### PR TITLE
fix: 修复编译后的二进制文件无法加载嵌入的 Web 资源

### DIFF
--- a/server/src/web/server.ts
+++ b/server/src/web/server.ts
@@ -163,8 +163,8 @@ export async function startWebServer(options: {
     jwtSecret: Uint8Array
     socketEngine: SocketEngine
 }): Promise<BunServer<WebSocketData>> {
-    const bunRuntime = (globalThis as typeof globalThis & { Bun?: { isCompiled?: boolean } }).Bun
-    const embeddedAssetMap = bunRuntime?.isCompiled ? await loadEmbeddedAssetMap() : null
+    const isCompiled = Bun.main?.startsWith('/$bunfs') ?? false
+    const embeddedAssetMap = isCompiled ? await loadEmbeddedAssetMap() : null
     const app = createWebApp({
         getSyncEngine: options.getSyncEngine,
         getSseManager: options.getSseManager,


### PR DESCRIPTION
### 问题现象

使用 GitHub Releases 下载的预编译二进制文件（如 `hapi-darwin-arm64`），在没有 `web/dist` 目录的位置启动 `hapi server` 时，访问网页会返回：

```
Mini App is not built.

Run:
  cd web
  bun install
  bun run build
```

### 复现步骤

1. 从 GitHub Releases 下载 `hapi-darwin-arm64.tar.gz`
2. 解压到任意目录（如 `~/Downloads`）
3. 运行 `./hapi server`
4. 访问 `http://localhost:3006/`
5. 页面显示 "Mini App is not built" 错误

### 问题原因

在 `server/src/web/server.ts` 第 166-167 行：

```typescript
const bunRuntime = (globalThis as typeof globalThis & { Bun?: { isCompiled?: boolean } }).Bun
const embeddedAssetMap = bunRuntime?.isCompiled ? await loadEmbeddedAssetMap() : null
```

代码使用 `Bun.isCompiled` 来检测是否是编译后的二进制文件，但 **`Bun.isCompiled` 这个 API 不存在**，始终返回 `undefined`。

这导致 `embeddedAssetMap` 始终为 `null`，服务器回退到查找本地 `web/dist` 目录，找不到时就返回错误。

### 解决方案

使用 `Bun.main?.startsWith('/$bunfs')` 来检测编译后的二进制文件。

编译后的 Bun 二进制使用虚拟文件系统，`Bun.main` 会返回类似 `/$bunfs/root/hapi` 的路径，以 `/$bunfs` 开头。

```typescript
const isCompiled = Bun.main?.startsWith('/$bunfs') ?? false
const embeddedAssetMap = isCompiled ? await loadEmbeddedAssetMap() : null
```

### 测试步骤

1. 构建包含 Web 资源的可执行文件：
   ```bash
   bun run build:single-exe
   ```

2. 从**没有 `web/dist` 目录**的位置启动：
   ```bash
   cd /tmp
   /path/to/hapi server
   ```

3. 访问 `http://localhost:3006/`

### 修复效果

| 修复前 | 修复后 |
|--------|--------|
| 返回 "Mini App is not built" 错误 | 正常显示 Web 页面 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)