### PR TITLE
docs: add Quick Start guide and Chinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ npm install -g @twsxtd/hapi
 
 Download from [Releases](https://github.com/tiann/hapi/releases).
 
+**macOS users**: Remove the quarantine attribute before running:
+
+```bash
+xattr -d com.apple.quarantine ./hapi
+```
+
 ## Quickstart
 
 1. Start the server on a machine you control:
@@ -63,6 +69,22 @@ hapi
 ```
 
 4. Open the UI in a browser at the server URL and log in with `CLI_API_TOKEN`.
+
+### Finding Your Access Token
+
+On first run, an Access Token is automatically generated and saved to `~/.hapi/settings.json`.
+
+View your token:
+
+```bash
+cat ~/.hapi/settings.json | grep cliApiToken
+```
+
+Or set your own via environment variable (takes priority over generated token):
+
+```bash
+export CLI_API_TOKEN="your-secret-token"
+```
 
 ## Telegram Mini App (optional)
 


### PR DESCRIPTION
## Summary

- Add language switch link at top of README (English ↔ Chinese)
- Add macOS quarantine fix instructions
- Document Access Token location and usage
- Create README.zh-CN.md with same structure as English version

## Why this PR?

There are several common pitfalls that new users encounter:

### 1. macOS Quarantine Issue
Downloaded binaries from the internet are quarantined by macOS Gatekeeper, causing "cannot be opened" errors. Users need to run:
```bash
xattr -d com.apple.quarantine ./hapi
```

### 2. Access Token Discovery
On first run, the server auto-generates an Access Token and saves it to `~/.hapi/settings.json`. However, users don't know where to find it when the web UI asks for a token. This PR documents how to view it:
```bash
cat ~/.hapi/settings.json | grep cliApiToken
```

### 3. Telegram vs Web Authentication
- **Web access**: Requires the `CLI_API_TOKEN` from settings.json
- **Telegram Mini App**: Uses Telegram's own authentication (initData), no token needed, but Chat ID must be in `ALLOWED_CHAT_IDS`

This distinction wasn't clear before, causing confusion.

### 4. Telegram HTTPS Requirement
Telegram Mini Apps only work over HTTPS. Users trying to use `http://localhost` for Telegram will fail. This is now explicitly documented.

## Test plan

- [x] Verify README.md renders correctly on GitHub
- [x] Verify README.zh-CN.md renders correctly on GitHub
- [x] Verify language switch links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)