### PR TITLE
feat: sync thinking state to session list view

### DIFF
--- a/server/src/web/routes/sessions.ts
+++ b/server/src/web/routes/sessions.ts
@@ -25,6 +25,7 @@ type SessionSummaryMetadata = {
 type SessionSummary = {
     id: string
     active: boolean
+    thinking: boolean
     activeAt: number
     updatedAt: number
     metadata: SessionSummaryMetadata | null
@@ -53,6 +54,7 @@ function toSessionSummary(session: Session): SessionSummary {
     return {
         id: session.id,
         active: session.active,
+        thinking: session.thinking,
         activeAt: session.activeAt,
         updatedAt: session.updatedAt,
         metadata,

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -193,6 +193,9 @@ function SessionItem(props: {
     })
 
     const sessionName = getSessionTitle(s)
+    const statusDotClass = s.active
+        ? (s.thinking ? 'bg-[#007AFF]' : 'bg-[var(--app-badge-success-text)]')
+        : 'bg-[var(--app-hint)]'
 
     return (
         <>
@@ -206,7 +209,7 @@ function SessionItem(props: {
                     <div className="flex items-center gap-2 min-w-0">
                         <span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">
                             <span
-                                className={`h-2 w-2 rounded-full ${s.active ? 'bg-[var(--app-badge-success-text)]' : 'bg-[var(--app-hint)]'}`}
+                                className={`h-2 w-2 rounded-full ${statusDotClass}`}
                             />
                         </span>
                         <div className="truncate text-sm font-medium">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -33,6 +33,7 @@ export type SessionSummaryMetadata = {
 export type SessionSummary = {
     id: string
     active: boolean
+    thinking: boolean
     activeAt: number
     updatedAt: number
     metadata: SessionSummaryMetadata | null


### PR DESCRIPTION
Think the blue dot state (thinking/working) to the session list page to help grab what's not done. It looks like this:

<img width="248" height="152" alt="image" src="https://github.com/user-attachments/assets/7b72ee9d-fc47-40a6-bab7-03c34714aa06" />
