### PR TITLE
fixed codex resume session handling

### DIFF
--- a/cli/src/codex/loop.ts
+++ b/cli/src/codex/loop.ts
@@ -33,11 +33,12 @@ export async function loop(opts: LoopOptions): Promise<void> {
     const logPath = logger.getLogPath();
     const startedBy = opts.startedBy ?? 'terminal';
     const startingMode = opts.startingMode ?? 'local';
+    const resumeSessionId = opts.codexCliOverrides?.resumeSessionId ?? null;
     const session = new CodexSession({
         api: opts.api,
         client: opts.session,
         path: opts.path,
-        sessionId: null,
+        sessionId: resumeSessionId,
         logPath,
         messageQueue: opts.messageQueue,
         onModeChange: opts.onModeChange,

--- a/cli/src/codex/utils/codexCliOverrides.ts
+++ b/cli/src/codex/utils/codexCliOverrides.ts
@@ -1,6 +1,7 @@
 export type CodexCliOverrides = {
     sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
     approvalPolicy?: 'untrusted' | 'on-failure' | 'on-request' | 'never';
+    resumeSessionId?: string;
 };
 
 const SANDBOX_VALUES = new Set<CodexCliOverrides['sandbox']>([
@@ -20,6 +21,11 @@ export function parseCodexCliOverrides(args?: string[]): CodexCliOverrides {
     const overrides: CodexCliOverrides = {};
     if (!args || args.length === 0) {
         return overrides;
+    }
+
+    // Check for resume subcommand: `codex resume <session-id>`
+    if (args[0] === 'resume' && args.length > 1 && !args[1].startsWith('-')) {
+        overrides.resumeSessionId = args[1];
     }
 
     for (let i = 0; i < args.length; i++) {


### PR DESCRIPTION
noticed that `hapi codex resume` doesn't work so I added a similar behavior

tested it locally and seems to work, tests pass as well