### PR TITLE
尝试修复 #53: 偶现消息会一直出现在最底部的问题

### DIFF
--- a/server/src/socket/handlers/cli/sessionHandlers.ts
+++ b/server/src/socket/handlers/cli/sessionHandlers.ts
@@ -98,7 +98,7 @@ export function registerSessionHandlers(socket: SocketWithData, deps: SessionHan
 
         const update = {
             id: randomUUID(),
-            seq: Date.now(),
+            seq: msg.seq,
             createdAt: Date.now(),
             body: {
                 t: 'new-message' as const,

--- a/server/src/sync/messageService.ts
+++ b/server/src/sync/messageService.ts
@@ -84,7 +84,7 @@ export class MessageService {
 
         const update = {
             id: msg.id,
-            seq: Date.now(),
+            seq: msg.seq,
             createdAt: msg.createdAt,
             body: {
                 t: 'new-message' as const,


### PR DESCRIPTION
修复 #53: 偶现消息会一直出现在最底部

**问题**：多轮对话后，部分消息会重复出现在聊天底部。

**原因**：发现socket更新中的seq值用了`Date.now()`而不是数据库seq，导致同一消息在不同渠道（API/SSE/Socket）的seq不一致，前端排序混乱。

**修复**：将两处`seq: Date.now()`改为`seq: msg.seq`：
1. `server/src/sync/messageService.ts:87`
2. `server/src/socket/handlers/cli/sessionHandlers.ts:101`

**效果**：统一了seq值，消息排序应该会更稳定。

**注意**：这是尝试性修复，可能不能完全解决问题，还需要进一步测试观察。