### PR TITLE
Dispose terminal addons before teardown

### DIFF
--- a/web/src/components/Terminal/TerminalView.tsx
+++ b/web/src/components/Terminal/TerminalView.tsx
@@ -81,6 +81,9 @@ export function TerminalView(props: {
 
         return () => {
             observer.disconnect()
+            fitAddon.dispose()
+            webLinksAddon.dispose()
+            canvasAddon.dispose()
             terminal.dispose()
         }
     }, [fontProvider])


### PR DESCRIPTION
Fixes #57.\n\nDispose xterm addons before calling `terminal.dispose()` to avoid linkifier/renderer errors after terminal exit.