### PR TITLE
feat: include authentication token in Telegram bot Mini App URLs

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -189,7 +189,8 @@ async function main() {
             syncEngine,
             botToken: config.telegramBotToken,
             miniAppUrl: config.miniAppUrl,
-            store
+            store,
+            cliApiToken: config.cliApiToken
         })
         // Only add to notification channels if notifications are enabled
         if (config.telegramNotification) {

--- a/server/src/telegram/sessionView.ts
+++ b/server/src/telegram/sessionView.ts
@@ -38,7 +38,7 @@ export function formatSessionNotification(session: Session): string {
 /**
  * Create notification keyboard for quick actions
  */
-export function createNotificationKeyboard(session: Session, miniAppUrl: string): InlineKeyboard {
+export function createNotificationKeyboard(session: Session, miniAppUrl: string, cliApiToken?: string): InlineKeyboard {
     const keyboard = new InlineKeyboard()
     const requests = session.agentState?.requests ?? null
     const hasRequests = Boolean(requests && Object.keys(requests).length > 0)
@@ -55,14 +55,14 @@ export function createNotificationKeyboard(session: Session, miniAppUrl: string)
 
         keyboard.webApp(
             'Details',
-            buildMiniAppDeepLink(miniAppUrl, `session_${session.id}`)
+            buildMiniAppDeepLink(miniAppUrl, `session_${session.id}`, cliApiToken)
         )
         return keyboard
     }
 
     keyboard.webApp(
         'Open Session',
-        buildMiniAppDeepLink(miniAppUrl, `session_${session.id}`)
+        buildMiniAppDeepLink(miniAppUrl, `session_${session.id}`, cliApiToken)
     )
     return keyboard
 }
@@ -139,13 +139,20 @@ function formatToolArgumentsDetailed(tool: string, args: any): string {
     }
 }
 
-function buildMiniAppDeepLink(baseUrl: string, startParam: string): string {
+function buildMiniAppDeepLink(baseUrl: string, startParam: string, token?: string): string {
     try {
         const url = new URL(baseUrl)
         url.searchParams.set('startapp', startParam)
+        if (token) {
+            url.searchParams.set('token', token)
+        }
         return url.toString()
     } catch {
         const separator = baseUrl.includes('?') ? '&' : '?'
-        return `${baseUrl}${separator}startapp=${encodeURIComponent(startParam)}`
+        let result = `${baseUrl}${separator}startapp=${encodeURIComponent(startParam)}`
+        if (token) {
+            result += `&token=${encodeURIComponent(token)}`
+        }
+        return result
     }
 }


### PR DESCRIPTION
## Summary
- Include `cliApiToken` in all Telegram bot Mini App URLs
- Users no longer need to manually authenticate when opening via bot

## Changes
- Add `cliApiToken` to `HappyBotConfig` interface
- Add `buildAuthenticatedUrl()` helper method to `HappyBot` class
- Update `/start` and `/app` commands to include token in URLs
- Update notification keyboards to include token in URLs
- Update `sessionView.ts` to pass token to deep link builder

## Test plan
- [ ] Start server with `--relay` and bot token
- [ ] Send `/start` or `/app` to bot
- [ ] Click "Open App" button
- [ ] Mini App should open and auto-authenticate (no token prompt)
- [ ] Trigger a permission request notification
- [ ] Click "Open Session" or "Details" button
- [ ] Should auto-authenticate

Fixes #75