### PR TITLE
fix: read host from settings.json in 'hapi auth status'

### DIFF
--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -25,7 +25,7 @@ export async function handleAuthCommand(args: string[]): Promise<void> {
         console.log(chalk.gray(`  CLI_API_TOKEN: ${hasToken ? 'set' : 'missing'}`))
         console.log(chalk.gray(`  Token Source: ${tokenSource}`))
         console.log(chalk.gray(`  Machine ID: ${settings.machineId ?? 'not set'}`))
-        console.log(chalk.gray(`  Host: ${os.hostname()}`))
+        console.log(chalk.gray(`  Host: ${settings.host ?? os.hostname()}`))
 
         if (!hasToken) {
             console.log('')

--- a/cli/src/persistence.ts
+++ b/cli/src/persistence.ts
@@ -19,6 +19,8 @@ interface Settings {
   cliApiToken?: string
   // Server URL for API connections (priority: env HAPI_SERVER_URL > this > default)
   serverUrl?: string
+  // Custom hostname to display in 'hapi auth status' (overrides os.hostname())
+  host?: string
 }
 
 const defaultSettings: Settings = {}


### PR DESCRIPTION
## Summary
- Add `host` field to Settings interface in persistence.ts
- Update `hapi auth status` to read host from settings, falling back to `os.hostname()`

## Problem
The `hapi auth status` command always displayed the system hostname via `os.hostname()`, ignoring any custom host configuration in `~/.hapi/settings.json`.

This was problematic for users using tunneling services (Cloudflare Tunnel, etc.) who wanted to display their custom domain instead of the auto-detected hostname.

## Solution
Read the `host` field from settings.json if configured, otherwise fall back to `os.hostname()`.

```typescript
// Before
console.log(chalk.gray(`  Host: ${os.hostname()}`))

// After  
console.log(chalk.gray(`  Host: ${settings.host ?? os.hostname()}`))
```

## Test plan
1. Without `host` in settings.json:
   - `hapi auth status` shows system hostname (unchanged behavior)

2. With `host` in settings.json:
   ```json
   { "host": "my-custom-domain.example.com" }
   ```
   - `hapi auth status` shows `Host: my-custom-domain.example.com`

Fixes #80