### PR TITLE
fix: prevent model parameter from being set to arbitrary strings

### DIFF
--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -140,8 +140,7 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
 
     // Forward messages to the queue
     let currentPermissionMode: PermissionMode = options.permissionMode ?? 'default';
-    let currentModel = options.model; // Track current model state
-    let currentModelMode: SessionModelMode = currentModel === 'sonnet' || currentModel === 'opus' ? currentModel : 'default';
+    let currentModelMode: SessionModelMode = options.model === 'sonnet' || options.model === 'opus' ? options.model : 'default';
     let currentFallbackModel: string | undefined = undefined; // Track current fallback model
     let currentCustomSystemPrompt: string | undefined = undefined; // Track current custom system prompt
     let currentAppendSystemPrompt: string | undefined = undefined; // Track current append system prompt
@@ -163,7 +162,7 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             currentPermissionMode = sessionPermissionMode as PermissionMode;
         }
         const messagePermissionMode = currentPermissionMode;
-        const messageModel = currentModel;
+        const messageModel = currentModelMode === 'default' ? undefined : currentModelMode;
         logger.debug(`[loop] User message received with permission mode: ${currentPermissionMode}, model: ${currentModelMode}`);
 
         // Resolve custom system prompt - use message.meta.customSystemPrompt if provided, otherwise use current
@@ -301,7 +300,6 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
         if (config.modelMode !== undefined) {
             const resolvedModelMode = resolveModelMode(config.modelMode);
             currentModelMode = resolvedModelMode;
-            currentModel = resolvedModelMode === 'default' ? undefined : resolvedModelMode;
         }
 
         syncSessionModes();


### PR DESCRIPTION
## Summary
- Remove the unvalidated `currentModel` variable which could contain arbitrary strings (like Linux usernames)
- Derive `messageModel` from the validated `currentModelMode` which only accepts 'sonnet', 'opus', or 'default'
- Ensures the `--model` CLI parameter cannot be injected with invalid values

## Problem
When using the Web UI to send messages, the `--model` parameter was being set to the Linux username (e.g., `marylewis9151`) instead of the correct model value like `opus`. This was caused by:
1. `currentModel` taking `options.model` without validation
2. `messageModel` using `currentModel` directly
3. Log printing `currentModelMode` while actual usage was `currentModel`, causing misleading debug info

## Solution
Single source of truth: derive model from validated `currentModelMode` only.

## Test plan
- [x] TypeScript type check passes
- [x] Build executable successfully
- [x] Runner starts and connects to bot
- [x] Session creation works without errors
- [x] Code reviewed by Codex (81/100) and Gemini (100/100)