### PR TITLE
feat(cli): support HAPI_HOSTNAME env to override machine hostname

### DIFF
--- a/cli/src/agent/sessionFactory.ts
+++ b/cli/src/agent/sessionFactory.ts
@@ -35,7 +35,7 @@ export type SessionBootstrapResult = {
 
 export function buildMachineMetadata(): MachineMetadata {
     return {
-        host: os.hostname(),
+        host: process.env.HAPI_HOSTNAME || os.hostname(),
         platform: os.platform(),
         happyCliVersion: packageJson.version,
         homeDir: os.homedir(),


### PR DESCRIPTION
## Summary
Allow users without root privileges to customize machine hostname via environment variable `HAPI_HOSTNAME`.

## Changes
- `cli/src/agent/sessionFactory.ts`: Add `process.env.HAPI_HOSTNAME` fallback in `buildMachineMetadata()`

## Usage
```bash
HAPI_HOSTNAME="my-server" hapi runner start
```

## Motivation
On systems where users don't have root access, changing the OS hostname requires elevated privileges. This PR provides a simple workaround by allowing the hostname to be overridden via environment variable.