### PR TITLE
fix(cli): improve Windows process spawning and CLI discovery. fix #106

### DIFF
--- a/cli/src/claude/claudeLocal.ts
+++ b/cli/src/claude/claudeLocal.ts
@@ -97,8 +97,9 @@ export async function claudeLocal(opts: {
             spawnName: 'claude',
             installHint: 'Claude CLI',
             includeCause: true,
-            logExit: true,
-            shell: process.platform === 'win32'
+            logExit: true
+            // Note: shell option is omitted to let spawnWithAbort handle platform-specific logic
+            // On Windows, it will use shell=false with .cmd extension to avoid cmd.exe parsing issues
         });
     } finally {
         cleanupMcpConfig?.();

--- a/cli/src/codex/codexLocal.ts
+++ b/cli/src/codex/codexLocal.ts
@@ -80,8 +80,8 @@ export async function codexLocal(opts: {
             spawnName: 'codex',
             installHint: 'Codex CLI',
             includeCause: true,
-            logExit: true,
-            shell: process.platform === 'win32'
+            logExit: true
+            // Note: shell option omitted to let spawnWithAbort handle platform-specific logic
         });
     } finally {
         process.stdin.resume();

--- a/cli/src/gemini/geminiLocal.ts
+++ b/cli/src/gemini/geminiLocal.ts
@@ -44,12 +44,12 @@ export async function geminiLocal(opts: {
             cwd: opts.path,
             env,
             signal: opts.abort,
-            shell: process.platform === 'win32',
             logLabel: 'GeminiLocal',
             spawnName: 'gemini',
             installHint: 'Gemini CLI',
             includeCause: true,
             logExit: true
+            // Note: shell option omitted to let spawnWithAbort handle platform-specific logic
         });
     } finally {
         process.stdin.resume();

--- a/server/scripts/download-tunwg.ts
+++ b/server/scripts/download-tunwg.ts
@@ -7,6 +7,7 @@
 
 import { existsSync, mkdirSync, writeFileSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const TUNWG_RELEASES: Record<string, string> = {
     'x64-linux': 'https://github.com/tiann/tunwg/releases/latest/download/tunwg',
@@ -34,7 +35,7 @@ async function downloadFile(url: string, destPath: string): Promise<void> {
 }
 
 async function main(): Promise<void> {
-    const scriptDir = dirname(new URL(import.meta.url).pathname);
+    const scriptDir = dirname(fileURLToPath(import.meta.url));
     const toolsDir = join(scriptDir, '..', 'tools', 'tunwg');
 
     console.log('Downloading tunwg binaries...\n');


### PR DESCRIPTION
fix issues #106

- Let spawnWithAbort handle platform-specific shell logic and .cmd resolution
- Avoid cmd.exe argument parsing issues by preferring direct spawn with shell=false on Windows
- Enhance global Claude CLI detection using execSync options and where/which fallbacks
- Fix download-tunwg script path resolution under Windows using fileURLToPath