### PR TITLE
Fix: mobile enter inserts newline

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -543,7 +543,7 @@ export function HappyComposer(props: {
                                 placeholder={showContinueHint ? t('misc.typeMessage') : t('misc.typeAMessage')}
                                 disabled={controlsDisabled}
                                 maxRows={5}
-                                submitOnEnter
+                                submitOnEnter={!isTouch}
                                 cancelOnEscape={false}
                                 onChange={handleChange}
                                 onSelect={handleSelect}


### PR DESCRIPTION
## Summary
- Mobile enter no longer sends; inserts newline instead

## Testing
- Not run (UI change only)
