### PR TITLE
fix(windows): use absolute path with shell:false for Claude spawn

### DIFF
--- a/cli/src/claude/claudeLocal.ts
+++ b/cli/src/claude/claudeLocal.ts
@@ -9,6 +9,7 @@ import { withBunRuntimeEnv } from "@/utils/bunRuntime";
 import { spawnWithAbort } from "@/utils/spawnWithAbort";
 import { getHapiBlobsDir } from "@/constants/uploadPaths";
 import { stripNewlinesForWindowsShellArg } from "@/utils/shellEscape";
+import { getDefaultClaudeCodePath } from "./sdk/utils";
 
 export async function claudeLocal(opts: {
     abort: AbortSignal,
@@ -84,11 +85,15 @@ export async function claudeLocal(opts: {
 
     logger.debug(`[ClaudeLocal] Spawning claude with args: ${JSON.stringify(args)}`);
 
+    // Get Claude executable path (absolute path on Windows for shell: false)
+    const claudeCommand = getDefaultClaudeCodePath();
+    logger.debug(`[ClaudeLocal] Using claude executable: ${claudeCommand}`);
+
     // Spawn the process
     try {
         process.stdin.pause();
         await spawnWithAbort({
-            command: 'claude',
+            command: claudeCommand,
             args,
             cwd: opts.path,
             env: withBunRuntimeEnv(env, { allowBunBeBun: false }),
@@ -98,7 +103,7 @@ export async function claudeLocal(opts: {
             installHint: 'Claude CLI',
             includeCause: true,
             logExit: true,
-            shell: process.platform === 'win32'
+            shell: false  // Use absolute path, no shell needed
         });
     } finally {
         cleanupMcpConfig?.();

--- a/cli/src/claude/sdk/query.ts
+++ b/cli/src/claude/sdk/query.ts
@@ -347,8 +347,9 @@ export function query(config: {
         stdio: ['pipe', 'pipe', 'pipe'],
         signal: config.options?.abort,
         env: spawnEnv,
-        // Use shell on Windows for command resolution
-        shell: process.platform === 'win32'
+        // Use shell: false with absolute path from getDefaultClaudeCodePath()
+        // This avoids cmd.exe resolution issues on Windows
+        shell: false
     }) as ChildProcessWithoutNullStreams
 
     // Handle stdin


### PR DESCRIPTION
On Windows, spawning Claude with shell: true causes the process to exit immediately with code 1. This happens because shell: true invokes cmd.exe /c claude <args>, and cmd.exe's PATH resolution differs from direct process creation, leading to environment inconsistencies.

This fix:
- Adds findWindowsClaudePath() to locate claude.exe absolute path
- Changes spawn to use absolute path with shell: false on Windows
- Maintains Unix behavior (command name works fine with shell: false)
- Adds HAPI_CLAUDE_PATH env var for user override

Tested on Windows 11 with Claude Code v2.1.29 and hapi v0.15.0.