### PR TITLE
fix(web): 修复切换会话时消息乱序问题

### DIFF
--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -141,12 +141,22 @@ export function SessionChat(props: {
         voice.toggleMic()
     }, [voice])
 
+    // Track session id to clear caches when it changes
+    const prevSessionIdRef = useRef<string | null>(null)
+
     useEffect(() => {
         normalizedCacheRef.current.clear()
         blocksByIdRef.current.clear()
     }, [props.session.id])
 
     const normalizedMessages: NormalizedMessage[] = useMemo(() => {
+        // Clear caches immediately when session changes (before useEffect runs)
+        if (prevSessionIdRef.current !== null && prevSessionIdRef.current !== props.session.id) {
+            normalizedCacheRef.current.clear()
+            blocksByIdRef.current.clear()
+        }
+        prevSessionIdRef.current = props.session.id
+
         const cache = normalizedCacheRef.current
         const normalized: NormalizedMessage[] = []
         const seen = new Set<string>()

--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -23,9 +23,11 @@ function isOptimisticMessage(msg: DecryptedMessage): boolean {
 function compareMessages(a: DecryptedMessage, b: DecryptedMessage): number {
     const aSeq = typeof a.seq === 'number' ? a.seq : null
     const bSeq = typeof b.seq === 'number' ? b.seq : null
+
     if (aSeq !== null && bSeq !== null && aSeq !== bSeq) {
         return aSeq - bSeq
     }
+
     if (a.createdAt !== b.createdAt) {
         return a.createdAt - b.createdAt
     }


### PR DESCRIPTION
## 问题描述

切换会话或加载分页消息时，旧的工具卡片会混入当前消息中，导致显示顺序混乱。

Closes #148

## 根本原因

`reduceChatBlocks` 函数会为 `agentState.requests` 中的所有权限请求创建工具卡片，包括那些比当前消息页面更早的权限。这些旧的卡片（`createdAt` 更早）会与新消息混在一起显示。

**具体表现**：
- `normalizedMessages` 的最早 `createdAt` 是 `1770052048406`
- 但 `reduced.blocks` 的最早 `createdAt` 是 `1770050601586`（早了约 24 分钟）
- 这些早期的 blocks 来自 `agentState` 中的权限请求，而非当前页面的消息

## 修复方案

1. **reducer.ts**: 如果权限的 `createdAt` 早于当前视图中最早的消息，则跳过创建该权限的工具卡片
2. **SessionChat.tsx**: 在 `useMemo` 中同步清理缓存，因为 `useEffect` 在渲染后才执行

## 调试过程中的弯路

1. **最初怀疑数据库问题**：通过 SSH 连接服务器查询 SQLite 数据库，确认 `seq` 字段是连续正确的
2. **怀疑前端排序逻辑**：在 `compareMessages` 和 `mergeMessages` 函数中添加调试日志，发现排序逻辑没问题
3. **怀疑缓存清理时机**：发现 `useEffect` 在 `useMemo` 之后执行，尝试在 `useMemo` 中同步清理缓存，但问题依然存在
4. **最终定位到 agentState**：通过对比 `normalizedMessages` 和 `reduced.blocks` 的 `createdAt`，发现 `reduced.blocks` 包含了不在 `normalizedMessages` 中的旧数据，最终定位到 `reduceChatBlocks` 中从 `agentState` 创建权限卡片的逻辑

## MCP 调试的便捷性

这个问题是在晚上发现的，本来以为需要第二天到公司才能处理。但发现通过 MCP (Playwright) 工具，其实可以直接在手机上远程调试：

- 使用 Playwright MCP 导航到问题页面
- 查看浏览器控制台日志
- 远程部署代码到服务器并验证修复

虽然最终还是在公司电脑上完成的，但 MCP 提供了一种新的可能性——紧急问题可以随时随地响应，不必等到回到工位。

<img width="1694" height="1810" alt="image" src="https://github.com/user-attachments/assets/486ef701-b839-4f64-aa74-fc7318172014" />
<img width="1768" height="1150" alt="image" src="https://github.com/user-attachments/assets/36237902-2798-4657-87cc-01bfbe245434" />


---

via [HAPI](https://hapi.run)

Co-Authored-By: HAPI <noreply@hapi.run>