### PR TITLE
fix: prevent /sessions/new from matching as dynamic sessionId route

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -114,7 +114,7 @@ function AppInner() {
     }, [goBack, pathname])
     const queryClient = useQueryClient()
     const sessionMatch = matchRoute({ to: '/sessions/$sessionId' })
-    const selectedSessionId = sessionMatch ? sessionMatch.sessionId : null
+    const selectedSessionId = sessionMatch && sessionMatch.sessionId !== 'new' ? sessionMatch.sessionId : null
     const { isSyncing, startSync, endSync } = useSyncingState()
     const [sseDisconnected, setSseDisconnected] = useState(false)
     const syncTokenRef = useRef(0)

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -108,7 +108,7 @@ function SessionsPage() {
 
     const projectCount = new Set(sessions.map(s => s.metadata?.worktree?.basePath ?? s.metadata?.path ?? 'Other')).size
     const sessionMatch = matchRoute({ to: '/sessions/$sessionId', fuzzy: true })
-    const selectedSessionId = sessionMatch ? sessionMatch.sessionId : null
+    const selectedSessionId = sessionMatch && sessionMatch.sessionId !== 'new' ? sessionMatch.sessionId : null
     const isSessionsIndex = pathname === '/sessions' || pathname === '/sessions/'
 
     return (


### PR DESCRIPTION
Fixes #163

## Problem

When navigating to `/sessions/new` (e.g. clicking the "New Session" button), a "Reconnecting..." banner appears at the top of the page. This happens because `useMatchRoute({ to: "/sessions/$sessionId" })` matches the static path segment `"new"` as a dynamic `sessionId` parameter.

This causes the SSE subscription in `App.tsx` to connect to `/api/events?sessionId=new`, which fails because no session with id `"new"` exists, triggering the reconnection error banner.

The same issue affects the session list sidebar in `router.tsx`, where the selected session highlight logic also incorrectly treats `"new"` as a valid session id.

## Fix

Filter out the reserved path segment `"new"` when extracting `selectedSessionId` from the route match in both:

- **`web/src/App.tsx`** — prevents the SSE subscription from using `"new"` as a session id, which was the direct cause of the "Reconnecting..." banner
- **`web/src/router.tsx`** — prevents the session list sidebar from highlighting a non-existent session when on the `/sessions/new` page