### PR TITLE
fix(web): 修复历史消息加载时的滚动位置恢复问题

### DIFF
--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -274,15 +274,17 @@ export function HappyThread(props: {
                 // Max attempts reached, give up and restore autoScroll state
                 pendingScrollRef.current = null
                 loadLockRef.current = false
-                setAutoScrollEnabled(prevAutoScrollEnabledRef.current)
+                // Use setTimeout to defer state update until after DOM operations complete
+                setTimeout(() => setAutoScrollEnabled(prevAutoScrollEnabledRef.current), 0)
                 return
             }
 
             viewport.scrollTop = pending.scrollTop + delta
             pendingScrollRef.current = null
             loadLockRef.current = false
-            // Restore previous autoScroll state instead of forcing it to true
-            setTimeout(() => setAutoScrollEnabled(prevAutoScrollEnabledRef.current), 50)
+            // Restore previous autoScroll state after DOM has settled
+            // Use longer delay to ensure all DOM operations are complete
+            setTimeout(() => setAutoScrollEnabled(prevAutoScrollEnabledRef.current), 100)
         }
 
         requestAnimationFrame(checkAndRestore)


### PR DESCRIPTION
## 问题描述

在加载历史消息时，自动滚动功能会干扰滚动位置的恢复。

## 修复内容

1. 防止 autoScroll 在历史加载时干扰滚动位置
2. 等待 DOM 更新完成后再恢复滚动位置

via [HAPI](https://hapi.run)

Co-Authored-By: HAPI <noreply@hapi.run>