### PR TITLE
Persist new session agent and yolo preferences

### DIFF
--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -13,6 +13,12 @@ import { AgentSelector } from './AgentSelector'
 import { DirectorySection } from './DirectorySection'
 import { MachineSelector } from './MachineSelector'
 import { ModelSelector } from './ModelSelector'
+import {
+    loadPreferredAgent,
+    loadPreferredYoloMode,
+    savePreferredAgent,
+    savePreferredYoloMode,
+} from './preferences'
 import { SessionTypeSelector } from './SessionTypeSelector'
 import { YoloToggle } from './YoloToggle'
 
@@ -34,9 +40,9 @@ export function NewSession(props: {
     const [suppressSuggestions, setSuppressSuggestions] = useState(false)
     const [isDirectoryFocused, setIsDirectoryFocused] = useState(false)
     const [pathExistence, setPathExistence] = useState<Record<string, boolean>>({})
-    const [agent, setAgent] = useState<AgentType>('claude')
+    const [agent, setAgent] = useState<AgentType>(loadPreferredAgent)
     const [model, setModel] = useState('auto')
-    const [yoloMode, setYoloMode] = useState(false)
+    const [yoloMode, setYoloMode] = useState(loadPreferredYoloMode)
     const [sessionType, setSessionType] = useState<SessionType>('simple')
     const [worktreeName, setWorktreeName] = useState('')
     const [error, setError] = useState<string | null>(null)
@@ -51,6 +57,14 @@ export function NewSession(props: {
     useEffect(() => {
         setModel('auto')
     }, [agent])
+
+    useEffect(() => {
+        savePreferredAgent(agent)
+    }, [agent])
+
+    useEffect(() => {
+        savePreferredYoloMode(yoloMode)
+    }, [yoloMode])
 
     useEffect(() => {
         if (props.machines.length === 0) return

--- a/web/src/components/NewSession/preferences.test.ts
+++ b/web/src/components/NewSession/preferences.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+    loadPreferredAgent,
+    loadPreferredYoloMode,
+    savePreferredAgent,
+    savePreferredYoloMode,
+} from './preferences'
+
+describe('NewSession preferences', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('loads defaults when storage is empty', () => {
+        expect(loadPreferredAgent()).toBe('claude')
+        expect(loadPreferredYoloMode()).toBe(false)
+    })
+
+    it('loads saved values from storage', () => {
+        localStorage.setItem('hapi:newSession:agent', 'codex')
+        localStorage.setItem('hapi:newSession:yolo', 'true')
+
+        expect(loadPreferredAgent()).toBe('codex')
+        expect(loadPreferredYoloMode()).toBe(true)
+    })
+
+    it('falls back to default agent on invalid stored value', () => {
+        localStorage.setItem('hapi:newSession:agent', 'unknown-agent')
+
+        expect(loadPreferredAgent()).toBe('claude')
+    })
+
+    it('persists new values to storage', () => {
+        savePreferredAgent('gemini')
+        savePreferredYoloMode(true)
+
+        expect(localStorage.getItem('hapi:newSession:agent')).toBe('gemini')
+        expect(localStorage.getItem('hapi:newSession:yolo')).toBe('true')
+    })
+})

--- a/web/src/components/NewSession/preferences.ts
+++ b/web/src/components/NewSession/preferences.ts
@@ -1,0 +1,42 @@
+import type { AgentType } from './types'
+
+const AGENT_STORAGE_KEY = 'hapi:newSession:agent'
+const YOLO_STORAGE_KEY = 'hapi:newSession:yolo'
+
+const VALID_AGENTS: AgentType[] = ['claude', 'codex', 'gemini', 'opencode']
+
+export function loadPreferredAgent(): AgentType {
+    try {
+        const stored = localStorage.getItem(AGENT_STORAGE_KEY)
+        if (stored && VALID_AGENTS.includes(stored as AgentType)) {
+            return stored as AgentType
+        }
+    } catch {
+        // Ignore storage errors
+    }
+    return 'claude'
+}
+
+export function savePreferredAgent(agent: AgentType): void {
+    try {
+        localStorage.setItem(AGENT_STORAGE_KEY, agent)
+    } catch {
+        // Ignore storage errors
+    }
+}
+
+export function loadPreferredYoloMode(): boolean {
+    try {
+        return localStorage.getItem(YOLO_STORAGE_KEY) === 'true'
+    } catch {
+        return false
+    }
+}
+
+export function savePreferredYoloMode(enabled: boolean): void {
+    try {
+        localStorage.setItem(YOLO_STORAGE_KEY, enabled ? 'true' : 'false')
+    } catch {
+        // Ignore storage errors
+    }
+}


### PR DESCRIPTION
Persist New Session preferences in web: last selected `agent` + `yoloMode` now saved to `localStorage` and reused on next open. This makes the user experience of creating new sessions faster.