### PR TITLE
Add GPT-5.3 options to Codex model selector

### DIFF
--- a/web/src/components/NewSession/types.ts
+++ b/web/src/components/NewSession/types.ts
@@ -9,6 +9,8 @@ export const MODEL_OPTIONS: Record<AgentType, { value: string; label: string }[]
     ],
     codex: [
         { value: 'auto', label: 'Auto' },
+        { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
+        { value: 'gpt-5.3', label: 'GPT-5.3' },
         { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex' },
         { value: 'gpt-5.2', label: 'GPT-5.2' },
         { value: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },


### PR DESCRIPTION
## Summary
- add `gpt-5.3-codex` to the New Session Codex model options
- add `gpt-5.3` to the New Session Codex model options
- keep existing ordering by placing 5.3 entries above 5.2

## Why
The latest Codex runtime accepts GPT-5.3 models, but the web dropdown currently only exposes 5.2/5.1 entries. This PR makes the latest options selectable from UI.

## Testing
- unable to run `bun run typecheck:web` locally in this environment because `bun` is not installed
- verified the change is a static update in `MODEL_OPTIONS` only
