### PR TITLE
fix(cli): prevent root rejection when using canCallTool with bypassPermissions

### DIFF
--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -361,7 +361,7 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                         session.client.sendSessionEvent({ type: 'message', message: 'Aborted by user' });
                     }
                 } catch (e) {
-                    logger.debug('[remote]: launch error', e);
+                    logger.debug('[remote]: launch error', e instanceof Error ? `${e.name}: ${e.message}\n${e.stack}` : JSON.stringify(e));
                     if (!this.exitReason) {
                         session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
                         continue;

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -361,12 +361,8 @@ export class SyncEngine {
                 const hostMatch = onlineMachines.find((machine) => machine.metadata?.host === metadata.host)
                 if (hostMatch) return hostMatch
             }
-            return null
+            return onlineMachines[0]
         })()
-
-        if (!targetMachine) {
-            return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
-        }
 
         const spawnResult = await this.rpcGateway.spawnSession(
             targetMachine.id,


### PR DESCRIPTION
## Summary

- **Root cause fix**: When running as root, Claude Code rejects `--dangerously-skip-permissions` (mapped from `--permission-mode bypassPermissions`). Since `canCallTool` already handles permission auto-approval via `--permission-prompt-tool stdio`, skip passing the redundant `--permission-mode` flag in that case.
- **Abort error fix**: Change `if`/`if` to `if`/`else if` in close handler to prevent exit code error from overwriting `AbortError`
- **Stderr capture**: Always log stderr via `logDebug()` instead of only when `DEBUG` env is set — critical for diagnosing silent Claude process exits
- **Remote launcher logging**: Log actual error name/message/stack instead of empty `{}` (Error objects don't JSON.stringify)
- **Sync engine fallback**: Fall back to first online machine instead of returning "No machine online" error when no host-specific match is found

## Context

When hapi runs as root (common in containerized/server deployments), the `--yolo` / `bypassPermissions` mode causes Claude Code to immediately exit with code 1 and the message `--dangerously-skip-permissions cannot be used with root/sudo privileges`. The remote launcher catches this as an empty error `{}` and shows "Process exited unexpectedly" to the user.

The fix recognizes that `canCallTool` + `--permission-prompt-tool stdio` already achieves the same effect as `bypassPermissions` — permissions are auto-approved app-side — so the redundant CLI flag can be safely omitted.

## Test plan

- [ ] Run hapi as root with `--yolo` mode and verify Claude sessions start successfully
- [ ] Verify non-root users are unaffected
- [ ] Verify abort (Ctrl-C) still works correctly and doesn't show spurious exit code errors
- [ ] Verify stderr from Claude process appears in hapi debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)