### PR TITLE
fix(web): add Shift+Enter to send messages on iPadOS

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -258,6 +258,15 @@ export function HappyComposer(props: {
             return
         }
 
+        // Shift+Enter sends the message (works on all platforms including iPadOS with keyboard)
+        if (key === 'Enter' && e.shiftKey) {
+            e.preventDefault()
+            if (!canSend) return
+            api.composer().send()
+            setShowContinueHint(false)
+            return
+        }
+
         if (suggestions.length > 0) {
             if (key === 'ArrowUp') {
                 e.preventDefault()
@@ -308,6 +317,8 @@ export function HappyComposer(props: {
         onPermissionModeChange,
         permissionMode,
         permissionModes,
+        canSend,
+        api,
         haptic
     ])
 


### PR DESCRIPTION
## Summary
- Adds Shift+Enter as a keyboard shortcut to send messages, fixing the inability to send via keyboard on iPadOS with a hardware keyboard (#175)
- Preserves existing desktop behavior (Enter still sends) — no breaking changes
- PR #178 attempted this fix on the stale `dev` branch; this applies the correct approach to `main`

## What changed
In `HappyComposer.tsx`:
- Added a `Shift+Enter` keydown handler that calls `api.composer().send()` when `canSend` is true
- Placed before the autocomplete suggestion handler so it fires even when suggestions are open
- Added `canSend` and `api` to the `useCallback` dependency array

## Why PR #178 didn't work
1. It was merged into the `dev` branch which is stuck at v0.7.3 — never reached `main` (v0.15.2)
2. It changed `submitOnEnter` to `false` everywhere, breaking desktop Enter-to-send behavior

## Behavior after this fix

| Platform | Enter | Shift+Enter |
|---|---|---|
| Desktop | Sends (unchanged) | Sends (new) |
| iPadOS + keyboard | Newline (unchanged) | **Sends (fixes #175)** |
| Touch (no keyboard) | Newline (unchanged) | N/A (use send button) |

## Test plan
- [ ] Desktop: Enter still sends messages
- [ ] Desktop: Shift+Enter also sends messages
- [ ] Desktop with autocomplete open: Enter selects suggestion, Shift+Enter sends
- [ ] iPadOS with hardware keyboard: Shift+Enter sends messages
- [ ] IME (CJK) input: no interference during composition
- [ ] Empty input: Shift+Enter does nothing when canSend is false

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)