### PR TITLE
fix(cli): use getDefaultClaudeCodePath() in claudeRemote

### DIFF
--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -10,6 +10,7 @@ import { awaitFileExist } from "@/modules/watcher/awaitFileExist";
 import { systemPrompt } from "./utils/systemPrompt";
 import { PermissionResult } from "./sdk/types";
 import { getHapiBlobsDir } from "@/constants/uploadPaths";
+import { getDefaultClaudeCodePath } from "./sdk/utils";
 
 export async function claudeRemote(opts: {
 
@@ -122,7 +123,7 @@ export async function claudeRemote(opts: {
         disallowedTools: initial.mode.disallowedTools,
         canCallTool: (toolName: string, input: unknown, options: { signal: AbortSignal }) => opts.canCallTool(toolName, input, mode, options),
         abort: opts.signal,
-        pathToClaudeCodeExecutable: 'claude',
+        pathToClaudeCodeExecutable: getDefaultClaudeCodePath(),
         settingsPath: opts.hookSettingsPath,
         additionalDirectories: [getHapiBlobsDir()],
     }


### PR DESCRIPTION
## Summary

- Replace hardcoded `'claude'` string with `getDefaultClaudeCodePath()` in `claudeRemote.ts` to properly resolve the Claude Code executable path
- This makes `claudeRemote` consistent with `claudeLocal`, which already uses `getDefaultClaudeCodePath()`
- Ensures the `HAPI_CLAUDE_PATH` environment variable and global path detection are respected in remote mode

## Test plan

- [ ] Verify remote mode correctly finds the Claude Code executable when installed globally
- [ ] Verify `HAPI_CLAUDE_PATH` env var override works in remote mode
- [ ] Verify existing local mode behavior is unchanged