### PR TITLE
fix(web): show agent messages immediately regardless of scroll position

### DIFF
--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -8,7 +8,7 @@ export function makeClientSideId(prefix: string): string {
     return `${prefix}-${Date.now()}-${Math.random()}`
 }
 
-function isUserMessage(msg: DecryptedMessage): boolean {
+export function isUserMessage(msg: DecryptedMessage): boolean {
     const content = msg.content
     if (content && typeof content === 'object' && 'role' in content) {
         return (content as { role: string }).role === 'user'


### PR DESCRIPTION
When the user was scrolled up from the bottom, all incoming messages (including AI responses) were queued in the pending buffer and only flushed when the user scrolled back down or sent a new message.

This caused AI replies to appear delayed by N turns: each user message sent would flush one pending AI response rather than triggering a real response, creating the illusion that the AI was lagging 3 sentences behind.

Fix: in ingestIncomingMessages, bypass the atBottom gate for agent messages so they are always merged into the visible window immediately. User messages from other clients remain in the pending queue to avoid disrupting scroll position during history review.

#226 