### PR TITLE
feat: support codex runtime model updates from session model API

### DIFF
--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -50,7 +50,7 @@ export async function runCodex(opts: {
     const sessionWrapperRef: { current: CodexSession | null } = { current: null };
 
     let currentPermissionMode: PermissionMode = opts.permissionMode ?? 'default';
-    const currentModel = opts.model;
+    let currentModel: string | undefined = opts.model;
     let currentCollaborationMode: EnhancedMode['collaborationMode'];
 
     const lifecycle = createRunnerLifecycle({
@@ -114,11 +114,25 @@ export async function runCodex(opts: {
         return trimmed as EnhancedMode['collaborationMode'];
     };
 
+    const resolveModel = (value: unknown): string | undefined => {
+        if (value === null) {
+            return undefined;
+        }
+        if (typeof value !== 'string') {
+            throw new Error('Invalid model');
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+            throw new Error('Invalid model');
+        }
+        return trimmed;
+    };
+
     session.rpcHandlerManager.registerHandler('set-session-config', async (payload: unknown) => {
         if (!payload || typeof payload !== 'object') {
             throw new Error('Invalid session config payload');
         }
-        const config = payload as { permissionMode?: unknown; collaborationMode?: unknown };
+        const config = payload as { permissionMode?: unknown; collaborationMode?: unknown; model?: unknown };
 
         if (config.permissionMode !== undefined) {
             currentPermissionMode = resolvePermissionMode(config.permissionMode);
@@ -128,8 +142,18 @@ export async function runCodex(opts: {
             currentCollaborationMode = resolveCollaborationMode(config.collaborationMode);
         }
 
+        if (config.model !== undefined) {
+            currentModel = resolveModel(config.model);
+        }
+
         syncSessionMode();
-        return { applied: { permissionMode: currentPermissionMode, collaborationMode: currentCollaborationMode } };
+        return {
+            applied: {
+                permissionMode: currentPermissionMode,
+                collaborationMode: currentCollaborationMode,
+                model: currentModel
+            }
+        };
     });
 
     try {

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -94,6 +94,8 @@ export class RpcGateway {
         config: {
             permissionMode?: PermissionMode
             modelMode?: ModelMode
+            model?: string
+            collaborationMode?: string
         }
     ): Promise<unknown> {
         return await this.sessionRpc(sessionId, 'set-session-config', config)

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -282,19 +282,31 @@ export class SyncEngine {
         config: {
             permissionMode?: PermissionMode
             modelMode?: ModelMode
+            model?: string
+            collaborationMode?: string
         }
     ): Promise<void> {
         const result = await this.rpcGateway.requestSessionConfig(sessionId, config)
         if (!result || typeof result !== 'object') {
             throw new Error('Invalid response from session config RPC')
         }
-        const obj = result as { applied?: { permissionMode?: Session['permissionMode']; modelMode?: Session['modelMode'] } }
+        const obj = result as {
+            applied?: {
+                permissionMode?: Session['permissionMode']
+                modelMode?: Session['modelMode']
+                model?: string
+                collaborationMode?: string
+            }
+        }
         const applied = obj.applied
         if (!applied || typeof applied !== 'object') {
             throw new Error('Missing applied session config')
         }
 
-        this.sessionCache.applySessionConfig(sessionId, applied)
+        this.sessionCache.applySessionConfig(sessionId, {
+            permissionMode: applied.permissionMode,
+            modelMode: applied.modelMode
+        })
     }
 
     async spawnSession(

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -268,12 +268,35 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         }
 
         const body = await c.req.json().catch(() => null)
+        const flavor = sessionResult.session.metadata?.flavor ?? 'claude'
+
+        if (flavor === 'codex') {
+            const parsed = z.object({
+                model: z.string().min(1),
+                collaborationMode: z.string().min(1).optional().nullable()
+            }).safeParse(body)
+
+            if (!parsed.success) {
+                return c.json({ error: 'Invalid body' }, 400)
+            }
+
+            try {
+                await engine.applySessionConfig(sessionResult.sessionId, {
+                    model: parsed.data.model,
+                    collaborationMode: parsed.data.collaborationMode ?? undefined
+                })
+                return c.json({ ok: true })
+            } catch (error) {
+                const message = error instanceof Error ? error.message : 'Failed to apply codex model config'
+                return c.json({ error: message }, 409)
+            }
+        }
+
         const parsed = modelModeSchema.safeParse(body)
         if (!parsed.success) {
             return c.json({ error: 'Invalid body' }, 400)
         }
 
-        const flavor = sessionResult.session.metadata?.flavor ?? 'claude'
         if (!isModelModeAllowedForFlavor(parsed.data.model, flavor)) {
             return c.json({ error: 'Model mode is only supported for Claude sessions' }, 400)
         }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -313,10 +313,10 @@ export class ApiClient {
         })
     }
 
-    async setModelMode(sessionId: string, model: ModelMode): Promise<void> {
+    async setModelMode(sessionId: string, model: ModelMode | string, collaborationMode?: string): Promise<void> {
         await this.request(`/api/sessions/${encodeURIComponent(sessionId)}/model`, {
             method: 'POST',
-            body: JSON.stringify({ model })
+            body: JSON.stringify({ model, collaborationMode })
         })
     }
 


### PR DESCRIPTION
## What\n- allow Codex  to accept and apply  updates at runtime\n- extend hub RPC/sync config typing to pass  and  through\n- update  route:\n  - Claude sessions keep existing  behavior\n  - Codex sessions accept \n- widen web API client  to send string model + optional collaboration mode\n\n## Why\nHAPI currently blocks model switching for Codex sessions because  only accepts Claude model modes (). This allows selecting newer Codex models (e.g. gpt-5.3-codex) on active Codex sessions.\n\n## Notes\n- This PR focuses on backend/API capability.\n- Full Codex-specific UI model/thinking selector can be added in a follow-up PR.