### PR TITLE
fix(spawn): 稳定子进程 cwd 并统一错误映射

### DIFF
--- a/cli/src/utils/spawnHappyCLI.ts
+++ b/cli/src/utils/spawnHappyCLI.ts
@@ -63,10 +63,11 @@ export function getHappyCliCommand(args: string[]): HappyCliCommand {
   const isBunRuntime = Boolean((process.versions as Record<string, string | undefined>).bun);
 
   if (isBunRuntime) {
-    // Bun can run TypeScript directly
+    // Bun can run TypeScript directly. Force CLI project root as working directory
+    // so tsconfig path aliases (e.g. @/*) resolve correctly regardless of session cwd.
     return {
       command: process.execPath,
-      args: [entrypoint, ...args]
+      args: ['--cwd', projectRoot, entrypoint, ...args]
     };
   }
 

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -127,6 +127,12 @@ export class RpcGateway {
                 if (obj.type === 'error' && typeof obj.errorMessage === 'string') {
                     return { type: 'error', message: obj.errorMessage }
                 }
+                if (typeof obj.error === 'string') {
+                    return { type: 'error', message: obj.error }
+                }
+                if (obj.type === 'requestToApproveDirectoryCreation' && typeof obj.directory === 'string') {
+                    return { type: 'error', message: `Directory does not exist: ${obj.directory}` }
+                }
             }
             return { type: 'error', message: 'Unexpected spawn result' }
         } catch (error) {


### PR DESCRIPTION
## 背景
新建会话时，前端可能收到 `Unexpected spawn result`，根因是 CLI 子进程在容器/特定 cwd 下路径解析不稳定，以及 Hub 侧对部分 spawn 错误形态缺少归一化。

## 变更说明
- CLI 侧：为 bun 子进程显式设置 `--cwd projectRoot`，稳定路径解析行为。
- Hub 侧：扩展 spawn 错误归一化，覆盖 `error` 字段与目录审批请求形态，统一返回可消费错误。

## 影响范围
- 会话创建链路的错误可观测性与稳定性提升。
- 不涉及协议破坏性变更。

## 验证
- 手工验证：复现场景下不再出现前端 `Unexpected spawn result`。
- 回归检查：现有会话创建路径可正常工作。