### PR TITLE
fix(web): 修复新会话中斜杠命令自动补全

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -53,6 +53,8 @@ export function HappyComposer(props: {
     onTerminal?: () => void
     autocompletePrefixes?: string[]
     autocompleteSuggestions?: (query: string) => Promise<Suggestion[]>
+    onSlashEntry?: () => void
+    isFetchingSlashCommands?: boolean
     // Voice assistant props
     voiceStatus?: ConversationStatus
     voiceMicMuted?: boolean
@@ -77,6 +79,8 @@ export function HappyComposer(props: {
         onTerminal,
         autocompletePrefixes = ['@', '/', '$'],
         autocompleteSuggestions = defaultSuggestionHandler,
+        onSlashEntry,
+        isFetchingSlashCommands = false,
         voiceStatus = 'disconnected',
         voiceMicMuted = false,
         onVoiceToggle,
@@ -120,6 +124,8 @@ export function HappyComposer(props: {
 
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const prevControlledByUser = useRef(controlledByUser)
+    const prevActiveWordRef = useRef<string | null>(null)
+    const prevIsFetchingSlashCommandsRef = useRef(isFetchingSlashCommands)
 
     useEffect(() => {
         setInputState((prev) => {
@@ -147,6 +153,22 @@ export function HappyComposer(props: {
     const isIOSPWA = isIOS && isStandalone
     const bottomPaddingClass = isIOSPWA ? 'pb-0' : 'pb-3'
     const activeWord = useActiveWord(inputState.text, inputState.selection, autocompletePrefixes)
+
+    useEffect(() => {
+        const prevActiveWord = prevActiveWordRef.current
+        const isInSlashContext = activeWord?.startsWith('/') ?? false
+        const enteredSlashContext = isInSlashContext && !(prevActiveWord?.startsWith('/') ?? false)
+        const fetchingSettledInSlashContext = isInSlashContext && prevIsFetchingSlashCommandsRef.current && !isFetchingSlashCommands
+
+        const shouldTriggerSlashCompensation = (enteredSlashContext && !isFetchingSlashCommands) || fetchingSettledInSlashContext
+        if (shouldTriggerSlashCompensation) {
+            onSlashEntry?.()
+        }
+
+        prevActiveWordRef.current = activeWord
+        prevIsFetchingSlashCommandsRef.current = isFetchingSlashCommands
+    }, [activeWord, isFetchingSlashCommands, onSlashEntry])
+
     const [suggestions, selectedIndex, moveUp, moveDown, clearSuggestions] = useActiveSuggestions(
         activeWord,
         autocompleteSuggestions,

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -37,6 +37,8 @@ export function SessionChat(props: {
     onAtBottomChange: (atBottom: boolean) => void
     onRetryMessage?: (localId: string) => void
     autocompleteSuggestions?: (query: string) => Promise<Suggestion[]>
+    onSlashEntry?: () => void
+    isFetchingSlashCommands?: boolean
 }) {
     const { haptic } = usePlatform()
     const navigate = useNavigate()
@@ -322,6 +324,8 @@ export function SessionChat(props: {
                         onSwitchToRemote={handleSwitchToRemote}
                         onTerminal={props.session.active ? handleViewTerminal : undefined}
                         autocompleteSuggestions={props.autocompleteSuggestions}
+                        onSlashEntry={props.onSlashEntry}
+                        isFetchingSlashCommands={props.isFetchingSlashCommands}
                         voiceStatus={voice?.status}
                         voiceMicMuted={voice?.micMuted}
                         onVoiceToggle={voice ? handleVoiceToggle : undefined}

--- a/web/src/hooks/queries/useSlashCommands.test.ts
+++ b/web/src/hooks/queries/useSlashCommands.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import type { SlashCommand } from '@/types/api'
+import { mergeSlashCommands, shouldAttemptSlashEntryRefetch } from './useSlashCommands'
+
+describe('mergeSlashCommands', () => {
+    it('keeps builtin commands and appends allowed remote sources', () => {
+        const builtin: SlashCommand[] = [
+            { name: 'status', source: 'builtin' },
+            { name: 'clear', source: 'builtin' },
+        ]
+        const remote: SlashCommand[] = [
+            { name: 'project-sync', source: 'project' },
+            { name: 'plugin-action', source: 'plugin' },
+            { name: 'user-template', source: 'user' },
+        ]
+
+        const merged = mergeSlashCommands(builtin, remote)
+
+        expect(merged.map((item) => item.name)).toEqual([
+            'status',
+            'clear',
+            'project-sync',
+            'plugin-action',
+            'user-template',
+        ])
+    })
+
+    it('deduplicates command names case-insensitively', () => {
+        const builtin: SlashCommand[] = [{ name: 'status', source: 'builtin' }]
+        const remote: SlashCommand[] = [
+            { name: 'STATUS', source: 'project' },
+            { name: 'status', source: 'user' },
+            { name: 'Status', source: 'plugin' },
+            { name: 'fresh', source: 'project' },
+        ]
+
+        const merged = mergeSlashCommands(builtin, remote)
+
+        expect(merged.map((item) => item.name)).toEqual(['status', 'fresh'])
+    })
+
+    it('ignores unsupported command sources', () => {
+        const builtin: SlashCommand[] = [{ name: 'status', source: 'builtin' }]
+        const remote = [
+            { name: 'status-remote', source: 'builtin' },
+            { name: 'fresh', source: 'project' },
+        ] as SlashCommand[]
+
+        const merged = mergeSlashCommands(builtin, remote)
+
+        expect(merged.map((item) => item.name)).toEqual(['status', 'fresh'])
+    })
+})
+
+describe('shouldAttemptSlashEntryRefetch', () => {
+    it('returns true before first successful fetch', () => {
+        const result = shouldAttemptSlashEntryRefetch(
+            {
+                hasFetchedSuccessfully: false,
+                lastFetchError: null,
+                lastEntryRefetchAt: 1000,
+            },
+            1500,
+            4000
+        )
+
+        expect(result).toBe(true)
+    })
+
+    it('returns true when previous fetch failed', () => {
+        const result = shouldAttemptSlashEntryRefetch(
+            {
+                hasFetchedSuccessfully: true,
+                lastFetchError: 'network error',
+                lastEntryRefetchAt: 1000,
+            },
+            1500,
+            4000
+        )
+
+        expect(result).toBe(true)
+    })
+
+    it('returns false inside cooldown when last fetch succeeded', () => {
+        const result = shouldAttemptSlashEntryRefetch(
+            {
+                hasFetchedSuccessfully: true,
+                lastFetchError: null,
+                lastEntryRefetchAt: 1000,
+            },
+            4500,
+            4000
+        )
+
+        expect(result).toBe(false)
+    })
+
+    it('returns true after cooldown when last fetch succeeded', () => {
+        const result = shouldAttemptSlashEntryRefetch(
+            {
+                hasFetchedSuccessfully: true,
+                lastFetchError: null,
+                lastEntryRefetchAt: 1000,
+            },
+            5001,
+            4000
+        )
+
+        expect(result).toBe(true)
+    })
+
+    it('returns true exactly at cooldown boundary', () => {
+        const result = shouldAttemptSlashEntryRefetch(
+            {
+                hasFetchedSuccessfully: true,
+                lastFetchError: null,
+                lastEntryRefetchAt: 1000,
+            },
+            5000,
+            4000
+        )
+
+        expect(result).toBe(true)
+    })
+})

--- a/web/src/hooks/queries/useSlashCommands.ts
+++ b/web/src/hooks/queries/useSlashCommands.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { ApiClient } from '@/api/client'
-import type { SlashCommand } from '@/types/api'
+import type { SlashCommand, SlashCommandsResponse } from '@/types/api'
 import type { Suggestion } from '@/hooks/useActiveSuggestions'
 import { queryKeys } from '@/lib/query-keys'
 
@@ -53,6 +53,76 @@ const BUILTIN_COMMANDS: Record<string, SlashCommand[]> = {
     opencode: [],
 }
 
+type SlashFetchState = {
+    hasFetchedSuccessfully: boolean
+    lastFetchError: string | null
+    lastEntryRefetchAt: number
+}
+
+const SLASH_ENTRY_COOLDOWN_MS = 4000
+
+function getStateKey(sessionId: string | null, agentType: string): string {
+    return `${sessionId ?? 'unknown'}::${agentType}`
+}
+
+function getOrCreateSlashFetchState(map: Map<string, SlashFetchState>, key: string): SlashFetchState {
+    const existing = map.get(key)
+    if (existing) return existing
+    const created: SlashFetchState = {
+        hasFetchedSuccessfully: false,
+        lastFetchError: null,
+        lastEntryRefetchAt: 0,
+    }
+    map.set(key, created)
+    return created
+}
+
+function extractQueryError(queryError: unknown, queryData: SlashCommandsResponse | undefined): string | null {
+    if (queryError instanceof Error) {
+        return queryError.message
+    }
+    if (queryError) {
+        return 'Failed to load commands'
+    }
+    if (queryData && queryData.success === false) {
+        return queryData.error ?? 'Failed to load commands'
+    }
+    return null
+}
+
+export function mergeSlashCommands(
+    builtin: SlashCommand[],
+    remoteCommands: SlashCommand[] | undefined
+): SlashCommand[] {
+    const merged = [...builtin]
+    const seenNames = new Set(builtin.map((command) => command.name.toLowerCase()))
+
+    for (const command of remoteCommands ?? []) {
+        if (command.source !== 'user' && command.source !== 'plugin' && command.source !== 'project') {
+            continue
+        }
+        const normalizedName = command.name.toLowerCase()
+        if (seenNames.has(normalizedName)) {
+            continue
+        }
+        seenNames.add(normalizedName)
+        merged.push(command)
+    }
+
+    return merged
+}
+
+export function shouldAttemptSlashEntryRefetch(
+    state: SlashFetchState,
+    now: number,
+    cooldownMs: number = SLASH_ENTRY_COOLDOWN_MS
+): boolean {
+    if (!state.hasFetchedSuccessfully || state.lastFetchError !== null) {
+        return true
+    }
+    return now - state.lastEntryRefetchAt >= cooldownMs
+}
+
 export function useSlashCommands(
     api: ApiClient | null,
     sessionId: string | null,
@@ -61,13 +131,18 @@ export function useSlashCommands(
     commands: SlashCommand[]
     isLoading: boolean
     error: string | null
+    isFetchingCommands: boolean
     getSuggestions: (query: string) => Promise<Suggestion[]>
+    refetchCommands: () => Promise<void>
 } {
     const resolvedSessionId = sessionId ?? 'unknown'
+    const stateKey = getStateKey(sessionId, agentType)
+    const stateBySessionRef = useRef<Map<string, SlashFetchState>>(new Map())
+    const inFlightRefetchRef = useRef<Map<string, Promise<void>>>(new Map())
 
     // Fetch user-defined commands from the CLI (requires active session)
     const query = useQuery({
-        queryKey: queryKeys.slashCommands(resolvedSessionId),
+        queryKey: queryKeys.slashCommands(resolvedSessionId, agentType),
         queryFn: async () => {
             if (!api || !sessionId) {
                 throw new Error('Session unavailable')
@@ -80,21 +155,68 @@ export function useSlashCommands(
         retry: false, // Don't retry RPC failures
     })
 
+    useEffect(() => {
+        const state = getOrCreateSlashFetchState(stateBySessionRef.current, stateKey)
+
+        if (query.data?.success) {
+            state.hasFetchedSuccessfully = true
+            state.lastFetchError = null
+            return
+        }
+
+        state.lastFetchError = extractQueryError(query.error, query.data)
+    }, [query.data, query.error, stateKey])
+
     // Merge built-in commands with user-defined and plugin commands from API
     const commands = useMemo(() => {
         const builtin = BUILTIN_COMMANDS[agentType] ?? BUILTIN_COMMANDS['claude'] ?? []
 
-        // If API succeeded, add user-defined and plugin commands
         if (query.data?.success && query.data.commands) {
-            const extraCommands = query.data.commands.filter(
-                cmd => cmd.source === 'user' || cmd.source === 'plugin' || cmd.source === 'project'
-            )
-            return [...builtin, ...extraCommands]
+            return mergeSlashCommands(builtin, query.data.commands)
         }
 
         // Fallback to built-in commands only
         return builtin
     }, [agentType, query.data])
+
+    const refetchCommands = useCallback(async (): Promise<void> => {
+        if (!api || !sessionId) {
+            return
+        }
+
+        const state = getOrCreateSlashFetchState(stateBySessionRef.current, stateKey)
+        const now = Date.now()
+        if (!shouldAttemptSlashEntryRefetch(state, now)) {
+            return
+        }
+
+        const existingInFlight = inFlightRefetchRef.current.get(stateKey)
+        if (existingInFlight) {
+            await existingInFlight
+            return
+        }
+
+        state.lastEntryRefetchAt = now
+
+        const runRefetch = (async () => {
+            try {
+                const result = await query.refetch()
+                if (result.data?.success) {
+                    state.hasFetchedSuccessfully = true
+                    state.lastFetchError = null
+                } else {
+                    state.lastFetchError = extractQueryError(result.error, result.data)
+                }
+            } catch (error) {
+                state.lastFetchError = error instanceof Error ? error.message : 'Failed to load commands'
+            } finally {
+                inFlightRefetchRef.current.delete(stateKey)
+            }
+        })()
+
+        inFlightRefetchRef.current.set(stateKey, runRefetch)
+        await runRefetch
+    }, [api, query, sessionId, stateKey])
 
     const getSuggestions = useCallback(async (queryText: string): Promise<Suggestion[]> => {
         const searchTerm = queryText.startsWith('/')
@@ -141,7 +263,9 @@ export function useSlashCommands(
     return {
         commands,
         isLoading: query.isLoading,
-        error: query.error instanceof Error ? query.error.message : query.error ? 'Failed to load commands' : null,
+        error: extractQueryError(query.error, query.data),
+        isFetchingCommands: query.isFetching,
         getSuggestions,
+        refetchCommands,
     }
 }

--- a/web/src/lib/query-keys.ts
+++ b/web/src/lib/query-keys.ts
@@ -13,6 +13,6 @@ export const queryKeys = {
         path,
         staged ? 'staged' : 'unstaged'
     ] as const,
-    slashCommands: (sessionId: string) => ['slash-commands', sessionId] as const,
+    slashCommands: (sessionId: string, agentType: string) => ['slash-commands', sessionId, agentType] as const,
     skills: (sessionId: string) => ['skills', sessionId] as const,
 }

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -268,6 +268,8 @@ function SessionPage() {
     const agentType = session?.metadata?.flavor ?? 'claude'
     const {
         getSuggestions: getSlashSuggestions,
+        refetchCommands,
+        isFetchingCommands: isFetchingSlashCommands,
     } = useSlashCommands(api, sessionId, agentType)
     const {
         getSuggestions: getSkillSuggestions,
@@ -279,6 +281,10 @@ function SessionPage() {
         }
         return await getSlashSuggestions(query)
     }, [getSkillSuggestions, getSlashSuggestions])
+
+    const handleSlashEntry = useCallback(() => {
+        void refetchCommands()
+    }, [refetchCommands])
 
     const refreshSelectedSession = useCallback(() => {
         void refetchSession()
@@ -313,6 +319,8 @@ function SessionPage() {
             onAtBottomChange={setAtBottom}
             onRetryMessage={retryMessage}
             autocompleteSuggestions={getAutocompleteSuggestions}
+            onSlashEntry={handleSlashEntry}
+            isFetchingSlashCommands={isFetchingSlashCommands}
         />
     )
 }


### PR DESCRIPTION
## 背景
在新建会话场景下，斜杠命令候选可能未及时刷新，导致自动补全缺失或不稳定。

## 变更说明
- 修复会话切换/新建时斜杠命令刷新逻辑。
- 增强会话与 agent 维度的缓存与去重合并策略。
- 补充回归测试，覆盖新会话自动补全场景。

## 影响范围
- 仅影响 Web 端斜杠命令候选加载与展示。
- 不影响后端协议与数据结构。

## 验证
- 手工验证：新建会话后输入 `/` 可稳定出现候选。
- 自动化：相关新增测试通过。