### PR TITLE
fix(web): use i18n for hardcoded Create Session strings

### DIFF
--- a/web/src/components/SpawnSession.tsx
+++ b/web/src/components/SpawnSession.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { usePlatform } from '@/hooks/usePlatform'
 import { useSpawnSession } from '@/hooks/mutations/useSpawnSession'
+import { useTranslation } from '@/lib/use-translation'
 
 type SessionType = 'simple' | 'worktree'
 
@@ -23,6 +24,7 @@ export function SpawnSession(props: {
     onCancel: () => void
 }) {
     const { haptic } = usePlatform()
+    const { t } = useTranslation()
     const [directory, setDirectory] = useState('')
     const [sessionType, setSessionType] = useState<SessionType>('simple')
     const [worktreeName, setWorktreeName] = useState('')
@@ -60,7 +62,7 @@ export function SpawnSession(props: {
         <div className="p-3">
             <Card>
                 <CardHeader className="pb-2">
-                    <CardTitle>Create Session</CardTitle>
+                    <CardTitle>{t('spawn.title')}</CardTitle>
                     <CardDescription className="truncate">
                         {machineTitle}
                     </CardDescription>
@@ -154,13 +156,13 @@ export function SpawnSession(props: {
                                 onClick={props.onCancel}
                                 disabled={isPending}
                             >
-                                Cancel
+                                {t('spawn.cancel')}
                             </Button>
                             <Button
                                 onClick={spawn}
                                 disabled={isPending || !directory.trim()}
                             >
-                                {isPending ? 'Creating…' : 'Create Session'}
+                                {isPending ? t('spawn.creating') : t('spawn.create')}
                             </Button>
                         </div>
                     </div>

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -91,6 +91,7 @@ export default {
   'button.paste': 'Paste',
 
   // New session form
+  'newSession.title': 'Create Session',
   'newSession.machine': 'Machine',
   'newSession.directory': 'Directory',
   'newSession.placeholder': '/path/to/project',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -93,6 +93,7 @@ export default {
   'button.paste': '粘贴',
 
   // New session form
+  'newSession.title': '创建会话',
   'newSession.machine': '机器',
   'newSession.directory': '目录',
   'newSession.placeholder': '/path/to/project',

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -332,6 +332,7 @@ function NewSessionPage() {
     const goBack = useAppGoBack()
     const queryClient = useQueryClient()
     const { machines, isLoading: machinesLoading, error: machinesError } = useMachines(api, true)
+    const { t } = useTranslation()
 
     const handleCancel = useCallback(() => {
         navigate({ to: '/sessions' })
@@ -362,7 +363,7 @@ function NewSessionPage() {
                         <BackIcon />
                     </button>
                 )}
-                <div className="flex-1 font-semibold">Create Session</div>
+                <div className="flex-1 font-semibold">{t('newSession.title')}</div>
             </div>
 
             {machinesError ? (


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings in `SpawnSession.tsx` with `t('spawn.*')` translation calls
- Replace hardcoded `"Create Session"` in `router.tsx` (`NewSessionPage`) with `t('newSession.title')` to match the `newSession.*` namespace
- Add `newSession.title` key to both `en.ts` and `zh-CN.ts` locale files

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] Verify UI renders correctly in English
- [x] Verify UI renders correctly in Chinese