### PR TITLE
fix(web): show actual selected model for sessions

### DIFF
--- a/cli/src/agent/sessionFactory.ts
+++ b/cli/src/agent/sessionFactory.ts
@@ -20,6 +20,7 @@ export type SessionBootstrapOptions = {
     startedBy?: SessionStartedBy
     workingDirectory?: string
     tag?: string
+    model?: string
     agentState?: AgentState | null
 }
 
@@ -49,6 +50,7 @@ export function buildSessionMetadata(options: {
     startedBy: SessionStartedBy
     workingDirectory: string
     machineId: string
+    model?: string
     now?: number
 }): Metadata {
     const happyLibDir = runtimePath()
@@ -58,6 +60,7 @@ export function buildSessionMetadata(options: {
     return {
         path: options.workingDirectory,
         host: os.hostname(),
+        model: options.model?.trim() || undefined,
         version: packageJson.version,
         os: os.platform(),
         machineId: options.machineId,
@@ -118,7 +121,8 @@ export async function bootstrapSession(options: SessionBootstrapOptions): Promis
         flavor: options.flavor,
         startedBy,
         workingDirectory,
-        machineId
+        machineId,
+        model: options.model
     })
 
     const sessionInfo = await api.getOrCreateSession({

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -33,6 +33,7 @@ export async function runCodex(opts: {
         flavor: 'codex',
         startedBy,
         workingDirectory,
+        model: opts.model,
         agentState: state
     });
 

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -22,6 +22,7 @@ export type WorktreeMetadata = z.infer<typeof WorktreeMetadataSchema>
 export const MetadataSchema = z.object({
     path: z.string(),
     host: z.string(),
+    model: z.string().optional(),
     version: z.string().optional(),
     name: z.string().optional(),
     os: z.string().optional(),

--- a/shared/src/sessionSummary.ts
+++ b/shared/src/sessionSummary.ts
@@ -5,6 +5,7 @@ export type SessionSummaryMetadata = {
     name?: string
     path: string
     machineId?: string
+    model?: string
     summary?: { text: string }
     flavor?: string | null
     worktree?: WorktreeMetadata
@@ -29,6 +30,7 @@ export function toSessionSummary(session: Session): SessionSummary {
         name: session.metadata.name,
         path: session.metadata.path,
         machineId: session.metadata.machineId ?? undefined,
+        model: session.metadata.model ?? undefined,
         summary: session.metadata.summary ? { text: session.metadata.summary.text } : undefined,
         flavor: session.metadata.flavor ?? null,
         worktree: session.metadata.worktree

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -6,6 +6,7 @@ import { useSessionActions } from '@/hooks/mutations/useSessionActions'
 import { SessionActionMenu } from '@/components/SessionActionMenu'
 import { RenameSessionDialog } from '@/components/RenameSessionDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+import { getSessionModelLabel } from '@/lib/sessionModelLabel'
 import { useTranslation } from '@/lib/use-translation'
 
 function getSessionTitle(session: Session): string {
@@ -139,7 +140,7 @@ export function SessionHeader(props: {
                                 {session.metadata?.flavor?.trim() || 'unknown'}
                             </span>
                             <span>
-                                {t('session.item.modelMode')}: {session.modelMode || 'default'}
+                                {t('session.item.modelMode')}: {getSessionModelLabel(session)}
                             </span>
                             {worktreeBranch ? (
                                 <span>{t('session.item.worktree')}: {worktreeBranch}</span>

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -7,6 +7,7 @@ import { useSessionActions } from '@/hooks/mutations/useSessionActions'
 import { SessionActionMenu } from '@/components/SessionActionMenu'
 import { RenameSessionDialog } from '@/components/RenameSessionDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
+import { getSessionModelLabel } from '@/lib/sessionModelLabel'
 import { useTranslation } from '@/lib/use-translation'
 
 type SessionGroup = {
@@ -259,7 +260,7 @@ function SessionItem(props: {
                         </span>
                         {getAgentLabel(s)}
                     </span>
-                    <span>{t('session.item.modelMode')}: {s.modelMode || 'default'}</span>
+                    <span>{t('session.item.modelMode')}: {getSessionModelLabel(s)}</span>
                     {s.metadata?.worktree?.branch ? (
                         <span>{t('session.item.worktree')}: {s.metadata.worktree.branch}</span>
                     ) : null}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -46,7 +46,7 @@ export default {
   'session.item.path': 'path',
   'session.item.agent': 'agent',
   'session.item.model': 'model',
-  'session.item.modelMode': 'mode',
+  'session.item.modelMode': 'model',
   'session.item.worktree': 'worktree',
   'session.item.pending': 'pending',
   'session.item.thinking': 'thinking',

--- a/web/src/lib/sessionModelLabel.test.ts
+++ b/web/src/lib/sessionModelLabel.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { getSessionModelLabel } from './sessionModelLabel'
+
+describe('getSessionModelLabel', () => {
+    it('prefers the actual model name stored in session metadata', () => {
+        expect(getSessionModelLabel({
+            metadata: {
+                path: '/Users/test/project',
+                host: 'test-host',
+                model: 'gpt-5.4'
+            },
+            modelMode: 'default'
+        })).toBe('gpt-5.4')
+    })
+
+    it('falls back to modelMode when no actual model is stored', () => {
+        expect(getSessionModelLabel({
+            metadata: {
+                path: '/Users/test/project',
+                host: 'test-host'
+            },
+            modelMode: 'opus'
+        })).toBe('opus')
+    })
+
+    it('falls back to default when neither actual model nor model mode is available', () => {
+        expect(getSessionModelLabel({
+            metadata: {
+                path: '/Users/test/project',
+                host: 'test-host'
+            },
+            modelMode: undefined
+        })).toBe('default')
+    })
+})

--- a/web/src/lib/sessionModelLabel.ts
+++ b/web/src/lib/sessionModelLabel.ts
@@ -1,0 +1,13 @@
+import type { Session, SessionSummary } from '@/types/api'
+
+type SessionWithModelMetadata =
+    | Pick<Session, 'metadata' | 'modelMode'>
+    | Pick<SessionSummary, 'metadata' | 'modelMode'>
+
+export function getSessionModelLabel(session: SessionWithModelMetadata): string {
+    const actualModel = session.metadata?.model?.trim()
+    if (actualModel) {
+        return actualModel
+    }
+    return session.modelMode || 'default'
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -25,6 +25,7 @@ export type {
 export type SessionMetadataSummary = {
     path: string
     host: string
+    model?: string
     version?: string
     name?: string
     os?: string


### PR DESCRIPTION
## Summary
- persist the actual selected model in session metadata when a Codex session is spawned
- show that actual model in the session list and session header instead of always falling back to `default`
- keep the fallback to `modelMode` for sessions that do not store a concrete model

## Why
Issue #267 reports that creating a Codex session with `gpt-5.4` still shows `model: default` in the web UI. This PR addresses the confusing display part.

I intentionally did **not** bundle Codex effort controls into this PR, because that requires additional hub / session-config plumbing and is better handled separately.

## Validation
- `docker run --rm -v /root/sandbox/hapi-pr:/workspace -w /workspace oven/bun:1 sh -lc "bun install && cd cli && bun run typecheck && cd /workspace/web && bunx vitest run src/lib/sessionModelLabel.test.ts && bun run typecheck"`
