### PR TITLE
fix: block insert env param to gemini(eg: gemini_api_key form json co…

### DIFF
--- a/cli/src/gemini/utils/config.ts
+++ b/cli/src/gemini/utils/config.ts
@@ -107,25 +107,7 @@ export function buildGeminiEnv(opts: {
     hookSettingsPath?: string;
     cwd?: string;
 }): NodeJS.ProcessEnv {
-    const env: NodeJS.ProcessEnv = {
+    return {
         ...process.env
     };
-
-    if (opts.model) {
-        env[GEMINI_MODEL_ENV] = opts.model;
-    }
-
-    if (opts.token && !env[GEMINI_API_KEY_ENV] && !env[GOOGLE_API_KEY_ENV]) {
-        env[GEMINI_API_KEY_ENV] = opts.token;
-    }
-
-    if (opts.hookSettingsPath) {
-        env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = opts.hookSettingsPath;
-    }
-
-    if (opts.cwd) {
-        env.GEMINI_PROJECT_DIR = opts.cwd;
-    }
-
-    return env;
 }


### PR DESCRIPTION
GeminiCLI can automatically obtain authorization, whether by retrieving the API_KEY from environment variables or by logging in with a Google account. This statement indicates that the extracted GEMINI_API_KEY will override the normal account login, thereby significantly reducing the quota of paid versions (such as Google AI Pro).