### PR TITLE
fix(codex): improve reused session adoption

### DIFF
--- a/cli/src/codex/utils/codexSessionScanner.test.ts
+++ b/cli/src/codex/utils/codexSessionScanner.test.ts
@@ -202,4 +202,78 @@ describe('codexSessionScanner', () => {
         expect(events).toHaveLength(1);
         expect(events[0].type).toBe('response_item');
     });
+
+    it('does not adopt a reused session when first fresh matching activity is ambiguous', async () => {
+        const targetCwd = '/data/github/happy/hapi';
+        const startupTimestampMs = Date.now();
+        const now = new Date(startupTimestampMs);
+        const currentSessionsDir = join(
+            testDir,
+            'sessions',
+            String(now.getFullYear()),
+            String(now.getMonth() + 1).padStart(2, '0'),
+            String(now.getDate()).padStart(2, '0')
+        );
+        await mkdir(currentSessionsDir, { recursive: true });
+
+        const firstSessionId = 'session-reused-a';
+        const secondSessionId = 'session-reused-b';
+        const firstFile = join(currentSessionsDir, `codex-${firstSessionId}.jsonl`);
+        const secondFile = join(currentSessionsDir, `codex-${secondSessionId}.jsonl`);
+        const oldTimestamp = new Date(startupTimestampMs - 10 * 60 * 1000).toISOString();
+
+        await writeFile(
+            firstFile,
+            JSON.stringify({
+                type: 'session_meta',
+                payload: { id: firstSessionId, cwd: targetCwd, timestamp: oldTimestamp }
+            }) + '\n'
+        );
+        await writeFile(
+            secondFile,
+            JSON.stringify({
+                type: 'session_meta',
+                payload: { id: secondSessionId, cwd: targetCwd, timestamp: oldTimestamp }
+            }) + '\n'
+        );
+
+        let matchedSessionId: string | null = null;
+        scanner = await createCodexSessionScanner({
+            sessionId: null,
+            cwd: targetCwd,
+            startupTimestampMs,
+            onEvent: (event) => events.push(event),
+            onSessionFound: (sessionId) => {
+                matchedSessionId = sessionId;
+            }
+        });
+
+        await wait(150);
+        expect(matchedSessionId).toBeNull();
+
+        const firstNewLine = JSON.stringify({
+            type: 'response_item',
+            payload: { type: 'function_call', name: 'Tool', call_id: 'call-reused-a-1', arguments: '{}' }
+        });
+        const secondNewLine = JSON.stringify({
+            type: 'response_item',
+            payload: { type: 'function_call', name: 'Tool', call_id: 'call-reused-b-1', arguments: '{}' }
+        });
+        await appendFile(firstFile, firstNewLine + '\n');
+        await appendFile(secondFile, secondNewLine + '\n');
+
+        await wait(2300);
+        expect(matchedSessionId).toBeNull();
+        expect(events).toHaveLength(0);
+
+        const laterUniqueLine = JSON.stringify({
+            type: 'response_item',
+            payload: { type: 'function_call', name: 'Tool', call_id: 'call-reused-a-2', arguments: '{}' }
+        });
+        await appendFile(firstFile, laterUniqueLine + '\n');
+
+        await wait(2300);
+        expect(matchedSessionId).toBeNull();
+        expect(events).toHaveLength(0);
+    });
 });

--- a/cli/src/codex/utils/codexSessionScanner.ts
+++ b/cli/src/codex/utils/codexSessionScanner.ts
@@ -80,6 +80,9 @@ class CodexSessionScannerImpl extends BaseSessionScanner<CodexSessionEvent> {
     private matchFailed = false;
     private bestWithinWindow: Candidate | null = null;
     private readonly recentActivitySessionIds = new Set<string>();
+    private firstRecentActivityCandidateResolved = false;
+    private readonly firstRecentActivitySessionIds = new Set<string>();
+    private loggedAmbiguousRecentActivity = false;
 
     constructor(opts: CodexSessionScannerOptions, targetCwd: string | null) {
         super({ intervalMs: 2000 });
@@ -195,21 +198,47 @@ class CodexSessionScannerImpl extends BaseSessionScanner<CodexSessionEvent> {
             if (this.bestWithinWindow) {
                 logger.debug(`[CODEX_SESSION_SCANNER] Selected session ${this.bestWithinWindow.sessionId} within start window`);
                 this.setActiveSessionId(this.bestWithinWindow.sessionId);
-            } else if (this.recentActivitySessionIds.size === 1) {
-                const [sessionId] = this.recentActivitySessionIds;
-                if (sessionId) {
-                    logger.debug(`[CODEX_SESSION_SCANNER] Selected session ${sessionId} from recent matching activity`);
-                    this.setActiveSessionId(sessionId);
+            } else {
+                this.captureFirstRecentActivityCandidate();
+
+                if (this.firstRecentActivitySessionIds.size === 1) {
+                    const [sessionId] = this.firstRecentActivitySessionIds;
+                    if (sessionId) {
+                        logger.debug(`[CODEX_SESSION_SCANNER] Selected session ${sessionId} from first unique matching activity after startup`);
+                        this.setActiveSessionId(sessionId);
+                    }
+                } else if (
+                    !this.loggedAmbiguousRecentActivity
+                    && this.firstRecentActivityCandidateResolved
+                    && this.firstRecentActivitySessionIds.size > 1
+                ) {
+                    this.loggedAmbiguousRecentActivity = true;
+                    logger.debug('[CODEX_SESSION_SCANNER] First matching activity after startup was ambiguous; refusing reused-session adoption');
                 }
-            } else if (Date.now() > this.matchDeadlineMs) {
-                this.matchFailed = true;
-                this.pendingEventsByFile.clear();
-                const message = `No Codex session found within ${this.sessionStartWindowMs}ms for cwd ${this.targetCwd}; refusing fallback.`;
-                logger.warn(`[CODEX_SESSION_SCANNER] ${message}`);
-                this.onSessionMatchFailed?.(message);
-            } else if (this.pendingEventsByFile.size > 0) {
-                logger.debug('[CODEX_SESSION_SCANNER] No session candidate matched yet; pending events buffered');
+
+                if (!this.activeSessionId) {
+                    if (Date.now() > this.matchDeadlineMs) {
+                        this.matchFailed = true;
+                        this.pendingEventsByFile.clear();
+                        const message = `No Codex session found within ${this.sessionStartWindowMs}ms for cwd ${this.targetCwd}; refusing fallback.`;
+                        logger.warn(`[CODEX_SESSION_SCANNER] ${message}`);
+                        this.onSessionMatchFailed?.(message);
+                    } else if (this.pendingEventsByFile.size > 0) {
+                        logger.debug('[CODEX_SESSION_SCANNER] No session candidate matched yet; pending events buffered');
+                    }
+                }
             }
+        }
+    }
+
+    private captureFirstRecentActivityCandidate(): void {
+        if (this.firstRecentActivityCandidateResolved || this.recentActivitySessionIds.size === 0) {
+            return;
+        }
+
+        this.firstRecentActivityCandidateResolved = true;
+        for (const sessionId of this.recentActivitySessionIds) {
+            this.firstRecentActivitySessionIds.add(sessionId);
         }
     }
 


### PR DESCRIPTION
## Summary
- allow Codex session scanning to adopt a reused session file when matching activity appears after startup
- keep that fallback limited to activity that still matches the requested cwd
- refuse reused-session adoption when the first fresh matching activity is ambiguous across multiple sessions
- add regression tests for both the successful and ambiguous reuse cases

## Testing
- bun x vitest run src/codex/utils/codexSessionScanner.test.ts
- bun run typecheck