### PR TITLE
fix(cli): load configured API URL in auth status

### DIFF
--- a/cli/src/commands/auth.test.ts
+++ b/cli/src/commands/auth.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { configuration } from '@/configuration'
+
+const {
+    readSettingsMock,
+    clearMachineIdMock,
+    updateSettingsMock,
+    initializeApiUrlMock
+} = vi.hoisted(() => ({
+    readSettingsMock: vi.fn(),
+    clearMachineIdMock: vi.fn(),
+    updateSettingsMock: vi.fn(),
+    initializeApiUrlMock: vi.fn(async () => {
+        configuration._setApiUrl('https://hapi.example.com')
+    })
+}))
+
+vi.mock('@/persistence', () => ({
+    readSettings: readSettingsMock,
+    clearMachineId: clearMachineIdMock,
+    updateSettings: updateSettingsMock
+}))
+
+vi.mock('@/ui/apiUrlInit', () => ({
+    initializeApiUrl: initializeApiUrlMock
+}))
+
+import { handleAuthCommand } from './auth'
+
+function stripAnsi(value: string): string {
+    return value.replace(/\u001B\[[0-9;]*m/g, '')
+}
+
+describe('handleAuthCommand', () => {
+    beforeEach(() => {
+        configuration._setApiUrl('http://localhost:3006')
+        readSettingsMock.mockReset()
+        clearMachineIdMock.mockReset()
+        updateSettingsMock.mockReset()
+        initializeApiUrlMock.mockClear()
+    })
+
+    it('loads the configured api url before printing status', async () => {
+        readSettingsMock.mockResolvedValue({
+            apiUrl: 'https://hapi.example.com',
+            cliApiToken: 'token-from-settings',
+            machineId: 'machine-123'
+        })
+
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        try {
+            await handleAuthCommand(['status'])
+            expect(initializeApiUrlMock).toHaveBeenCalledOnce()
+
+            const output = logSpy.mock.calls
+                .map((call) => stripAnsi(String(call[0])))
+                .join('\n')
+
+            expect(output).toContain('HAPI_API_URL: https://hapi.example.com')
+            expect(output).toContain('CLI_API_TOKEN: set')
+            expect(output).toContain('Machine ID: machine-123')
+        } finally {
+            logSpy.mockRestore()
+        }
+    })
+})

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -4,6 +4,7 @@ import * as readline from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 import { configuration } from '@/configuration'
 import { readSettings, clearMachineId, updateSettings } from '@/persistence'
+import { initializeApiUrl } from '@/ui/apiUrlInit'
 import type { CommandDefinition } from './types'
 
 export async function handleAuthCommand(args: string[]): Promise<void> {
@@ -15,6 +16,7 @@ export async function handleAuthCommand(args: string[]): Promise<void> {
     }
 
     if (subcommand === 'status') {
+        await initializeApiUrl()
         const settings = await readSettings()
         const envToken = process.env.CLI_API_TOKEN
         const settingsToken = settings.cliApiToken


### PR DESCRIPTION
## Summary
- initialize the configured API URL before printing hapi auth status
- make auth status reflect the actual persisted/server URL instead of the default localhost fallback
- add a regression test that covers status output with a configured API URL

## Testing
- bun x vitest run src/commands/auth.test.ts
- bun run typecheck