### PR TITLE
fix(gemini): notify hub when session is aborted

### DIFF
--- a/cli/src/gemini/geminiRemoteLauncher.ts
+++ b/cli/src/gemini/geminiRemoteLauncher.ts
@@ -198,6 +198,7 @@ class GeminiRemoteLauncher extends RemoteLauncherBase {
             await backend.cancelPrompt(this.session.sessionId);
         }
         await this.permissionHandler?.cancelAll('User aborted');
+        this.session.sendSessionEvent({ type: 'message', message: 'Session aborted' });
         this.session.queue.reset();
         this.session.onThinkingChange(false);
         this.abortController.abort();


### PR DESCRIPTION
Explicitly send an abort event to the hub when a session is cancelled. This ensures that any active tool blocks or status indicators in the Web UI are properly cleared, resolving an issue where stale UI elements remained pinned after abortion. Matches the event pattern used in onStderrError.