### PR TITLE
fix(web): improve UI performance on Windows with long conversations

### DIFF
--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -326,7 +326,7 @@ export function HappyThread(props: {
                                     ) : null}
                                 </>
                             )}
-                            <div className="flex flex-col gap-3">
+                            <div className="happy-thread-messages flex flex-col gap-3">
                                 <ThreadPrimitive.Messages components={THREAD_MESSAGE_COMPONENTS} />
                             </div>
                         </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -132,6 +132,16 @@ body {
     }
 }
 
+/*
+ * content-visibility: auto lets the browser skip layout/paint for messages
+ * scrolled out of the viewport. Big win on Windows with long conversations (#310).
+ * contain-intrinsic-size gives a rough height hint so scrollbar doesn't jump.
+ */
+.happy-thread-messages > * {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 80px;
+}
+
 /* Markdown styles */
 .markdown-content a { color: var(--app-link); text-decoration: underline; }
 .markdown-content code { background: var(--app-inline-code-bg); padding: 0.1em 0.3em; border-radius: 4px; font-size: 0.9em; }

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -38,6 +38,48 @@ const states = new Map<string, InternalState>()
 const listeners = new Map<string, Set<() => void>>()
 const pendingVisibilityCacheBySession = new Map<string, Map<string, PendingVisibilityCacheEntry>>()
 
+// Throttled notification: coalesce rapid state updates into at most one
+// notification per NOTIFY_THROTTLE_MS during streaming. This prevents
+// Windows UI jank caused by excessive React re-renders during SSE streaming.
+const NOTIFY_THROTTLE_MS = 150
+const pendingNotifySessionIds = new Set<string>()
+let notifyRafId: ReturnType<typeof requestAnimationFrame> | null = null
+let lastNotifyAt = 0
+
+function scheduleNotify(sessionId: string): void {
+    pendingNotifySessionIds.add(sessionId)
+    if (notifyRafId !== null) {
+        return
+    }
+    const elapsed = Date.now() - lastNotifyAt
+    if (elapsed >= NOTIFY_THROTTLE_MS) {
+        // Enough time has passed — flush on next animation frame
+        notifyRafId = requestAnimationFrame(flushNotifications)
+    } else {
+        // Too soon — delay until the throttle window expires, then use rAF
+        const remaining = NOTIFY_THROTTLE_MS - elapsed
+        setTimeout(() => {
+            notifyRafId = requestAnimationFrame(flushNotifications)
+        }, remaining)
+        // Use a sentinel so we don't double-schedule
+        notifyRafId = -1 as unknown as ReturnType<typeof requestAnimationFrame>
+    }
+}
+
+function flushNotifications(): void {
+    notifyRafId = null
+    lastNotifyAt = Date.now()
+    const sessionIds = Array.from(pendingNotifySessionIds)
+    pendingNotifySessionIds.clear()
+    for (const sessionId of sessionIds) {
+        const subs = listeners.get(sessionId)
+        if (!subs) continue
+        for (const listener of subs) {
+            listener()
+        }
+    }
+}
+
 function getPendingVisibilityCache(sessionId: string): Map<string, PendingVisibilityCacheEntry> {
     const existing = pendingVisibilityCacheBySession.get(sessionId)
     if (existing) {
@@ -117,6 +159,11 @@ function getState(sessionId: string): InternalState {
 }
 
 function notify(sessionId: string): void {
+    scheduleNotify(sessionId)
+}
+
+function notifyImmediate(sessionId: string): void {
+    // Bypass throttle for user-initiated actions (flush, clear, etc.)
     const subs = listeners.get(sessionId)
     if (!subs) return
     for (const listener of subs) {
@@ -124,16 +171,20 @@ function notify(sessionId: string): void {
     }
 }
 
-function setState(sessionId: string, next: InternalState): void {
+function setState(sessionId: string, next: InternalState, immediate?: boolean): void {
     states.set(sessionId, next)
-    notify(sessionId)
+    if (immediate) {
+        notifyImmediate(sessionId)
+    } else {
+        notify(sessionId)
+    }
 }
 
-function updateState(sessionId: string, updater: (prev: InternalState) => InternalState): void {
+function updateState(sessionId: string, updater: (prev: InternalState) => InternalState, immediate?: boolean): void {
     const prev = getState(sessionId)
     const next = updater(prev)
     if (next !== prev) {
-        setState(sessionId, next)
+        setState(sessionId, next, immediate)
     }
 }
 
@@ -294,7 +345,7 @@ export function clearMessageWindow(sessionId: string): void {
     if (!states.has(sessionId)) {
         return
     }
-    setState(sessionId, createState(sessionId))
+    setState(sessionId, createState(sessionId), true)
 }
 
 export function seedMessageWindowFromSession(fromSessionId: string, toSessionId: string): void {
@@ -438,7 +489,7 @@ export function flushPendingMessages(sessionId: string): boolean {
             pendingOverflowVisibleCount: 0,
             warning: needsRefresh ? (prev.warning ?? PENDING_OVERFLOW_WARNING) : prev.warning,
         })
-    })
+    }, true)
     return needsRefresh
 }
 
@@ -448,7 +499,7 @@ export function setAtBottom(sessionId: string, atBottom: boolean): void {
             return prev
         }
         return buildState(prev, { atBottom })
-    })
+    }, true)
 }
 
 export function appendOptimisticMessage(sessionId: string, message: DecryptedMessage): void {
@@ -457,7 +508,7 @@ export function appendOptimisticMessage(sessionId: string, message: DecryptedMes
         const trimmed = trimVisible(merged, 'append')
         const pending = filterPendingAgainstVisible(prev.pending, trimmed)
         return buildState(prev, { messages: trimmed, pending, atBottom: true })
-    })
+    }, true)
 }
 
 export function updateMessageStatus(sessionId: string, localId: string, status: MessageStatus): void {

--- a/web/src/lib/shiki.ts
+++ b/web/src/lib/shiki.ts
@@ -152,8 +152,9 @@ export function useShikiHighlighter(
             setHighlighted(rendered as ReactNode)
         }
 
-        // Debounce highlighting
-        const timer = setTimeout(highlight, 50)
+        // Debounce highlighting — 150ms reduces CPU pressure on Windows during
+        // streaming where code blocks update rapidly (see #310)
+        const timer = setTimeout(highlight, 150)
         return () => {
             cancelled = true
             clearTimeout(timer)


### PR DESCRIPTION
## Summary

Fixes #310 — Windows browsers become unresponsive after 10+ conversation turns due to excessive re-renders during SSE streaming.

**Root cause:** Each SSE `message-received` event triggers immediate React re-render of the entire message tree. Combined with markdown re-parsing and syntax highlighting on every update, this overwhelms Windows' graphics compositing (GDI/DirectComposition is slower than macOS Core Animation).

**Three strategies applied:**

- **Throttle message store notifications (150ms):** Coalesce rapid SSE streaming updates into fewer React re-renders via `requestAnimationFrame` + timer. User-initiated actions (send, scroll, flush) bypass the throttle for instant feedback.
- **Increase Shiki debounce (50ms → 150ms):** Reduce syntax highlight attempts from ~20/sec to ~7/sec per code block during streaming.
- **`content-visibility: auto` on messages:** Browser skips layout/paint for off-screen messages — significant win with many messages in long conversations.

## Files changed

| File | Change |
|------|--------|
| `web/src/lib/message-window-store.ts` | Add `scheduleNotify`/`flushNotifications` throttle; `notifyImmediate` for user actions |
| `web/src/lib/shiki.ts` | Debounce 50ms → 150ms |
| `web/src/index.css` | `content-visibility: auto` rule for `.happy-thread-messages > *` |
| `web/src/components/AssistantChat/HappyThread.tsx` | Add `happy-thread-messages` class to message container |

## Test plan

- [ ] Open a session with 10+ turns of conversation on Windows
- [ ] Verify streaming output no longer causes browser/OS jank
- [ ] Verify user input (typing, sending) remains instantly responsive
- [ ] Verify scrolling through long conversations is smooth
- [ ] Verify `content-visibility` doesn't cause scrollbar jumping
- [ ] Test on macOS/mobile to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)