### PR TITLE
fix(cli): preserve requested cwd for runner-spawned sessions

### DIFF
--- a/cli/src/utils/spawnHappyCLI.test.ts
+++ b/cli/src/utils/spawnHappyCLI.test.ts
@@ -124,12 +124,28 @@ describe('spawnHappyCLI windowsHide behavior', () => {
     expect(options.env?.HAPI_INVOKED_CWD).toBe(childCwd);
   });
 
-  it('keeps an existing absolute HAPI_INVOKED_CWD when provided explicitly', async () => {
+  it('prefers the explicit child cwd over an inherited HAPI_INVOKED_CWD', async () => {
+    const { spawnHappyCLI } = await import('./spawnHappyCLI');
+    const inheritedInvokedCwd = 'C:\\workspace\\other-project';
+    const childCwd = 'C:\\workspace\\project';
+
+    spawnHappyCLI(['runner', 'start-sync'], {
+      cwd: childCwd,
+      env: {
+        HAPI_INVOKED_CWD: inheritedInvokedCwd
+      },
+      stdio: 'ignore'
+    });
+
+    const options = getSpawnOptionsOrThrow();
+    expect(options.env?.HAPI_INVOKED_CWD).toBe(childCwd);
+  });
+
+  it('keeps an existing absolute HAPI_INVOKED_CWD when no child cwd is provided', async () => {
     const { spawnHappyCLI } = await import('./spawnHappyCLI');
     const inheritedInvokedCwd = 'C:\\workspace\\other-project';
 
     spawnHappyCLI(['runner', 'start-sync'], {
-      cwd: 'C:\\workspace\\project',
       env: {
         HAPI_INVOKED_CWD: inheritedInvokedCwd
       },

--- a/cli/src/utils/spawnHappyCLI.ts
+++ b/cli/src/utils/spawnHappyCLI.ts
@@ -136,9 +136,12 @@ export function spawnHappyCLI(args: string[], options: SpawnOptions = {}): Child
   if (!isBunCompiled()) {
     const finalEnv = { ...process.env, ...options.env };
     const invokedCwd = finalEnv.HAPI_INVOKED_CWD?.trim();
-    finalEnv.HAPI_INVOKED_CWD = invokedCwd && isCrossPlatformAbsolutePath(invokedCwd)
-      ? invokedCwd
-      : resolveInvokedCwd(options.cwd);
+    const hasExplicitCwd = 'cwd' in options && options.cwd !== undefined;
+    finalEnv.HAPI_INVOKED_CWD = hasExplicitCwd
+      ? resolveInvokedCwd(options.cwd)
+      : invokedCwd && isCrossPlatformAbsolutePath(invokedCwd)
+        ? invokedCwd
+        : resolveInvokedCwd(options.cwd);
     finalOptions.env = finalEnv;
   }
   if (process.platform === 'win32' && options.detached) {


### PR DESCRIPTION
## Summary
- let runner-spawned sessions keep the directory explicitly requested by the user
- stop an inherited `HAPI_INVOKED_CWD` value from overriding an explicit spawn cwd
- cover the precedence rule with tests

## Testing
- bunx vitest run src/utils/spawnHappyCLI.test.ts