### PR TITLE
fix(codex): pass session cwd to app-server

### DIFF
--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -593,6 +593,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             try {
                 if (!hasThread) {
                     const threadParams = buildThreadStartParams({
+                        cwd: session.path,
                         mode: message.mode,
                         mcpServers,
                         cliOverrides: session.codexCliOverrides
@@ -651,6 +652,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 const turnParams = buildTurnStartParams({
                     threadId: this.currentThreadId,
                     message: message.message,
+                    cwd: session.path,
                     mode: {
                         ...message.mode,
                         model: session.getModel() ?? message.mode.model

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -7,11 +7,13 @@ describe('appServerConfig', () => {
 
     it('applies CLI overrides when permission mode is default', () => {
         const params = buildThreadStartParams({
+            cwd: '/workspace/project',
             mode: { permissionMode: 'default', collaborationMode: 'default' },
             mcpServers,
             cliOverrides: { sandbox: 'danger-full-access', approvalPolicy: 'never' }
         });
 
+        expect(params.cwd).toBe('/workspace/project');
         expect(params.sandbox).toBe('danger-full-access');
         expect(params.approvalPolicy).toBe('never');
         expect(params.baseInstructions).toBe(codexSystemPrompt);
@@ -27,6 +29,7 @@ describe('appServerConfig', () => {
 
     it('ignores CLI overrides when permission mode is not default', () => {
         const params = buildThreadStartParams({
+            cwd: '/workspace/project',
             mode: { permissionMode: 'yolo', collaborationMode: 'default' },
             mcpServers,
             cliOverrides: { sandbox: 'read-only', approvalPolicy: 'never' }
@@ -38,6 +41,7 @@ describe('appServerConfig', () => {
 
     it('keeps on-failure approvals for safe-yolo threads', () => {
         const params = buildThreadStartParams({
+            cwd: '/workspace/project',
             mode: { permissionMode: 'safe-yolo', collaborationMode: 'default' },
             mcpServers
         });
@@ -48,6 +52,7 @@ describe('appServerConfig', () => {
 
     it('concatenates custom developer instructions after base instructions', () => {
         const params = buildThreadStartParams({
+            cwd: '/workspace/project',
             mode: { permissionMode: 'default', collaborationMode: 'default' },
             mcpServers,
             developerInstructions: 'Only respond in Chinese.'
@@ -66,6 +71,7 @@ describe('appServerConfig', () => {
 
     it('passes model reasoning effort via thread config', () => {
         const params = buildThreadStartParams({
+            cwd: '/workspace/project',
             mode: { permissionMode: 'default', modelReasoningEffort: 'xhigh', collaborationMode: 'default' },
             mcpServers
         });
@@ -84,10 +90,12 @@ describe('appServerConfig', () => {
         const params = buildTurnStartParams({
             threadId: 'thread-1',
             message: 'hello',
+            cwd: '/workspace/project',
             mode: { permissionMode: 'read-only', model: 'o3', collaborationMode: 'default' }
         });
 
         expect(params.threadId).toBe('thread-1');
+        expect(params.cwd).toBe('/workspace/project');
         expect(params.input).toEqual([{ type: 'text', text: 'hello' }]);
         expect(params.approvalPolicy).toBe('never');
         expect(params.sandboxPolicy).toEqual({ type: 'readOnly' });
@@ -105,6 +113,7 @@ describe('appServerConfig', () => {
         const params = buildTurnStartParams({
             threadId: 'thread-1',
             message: 'hello',
+            cwd: '/workspace/project',
             mode: { permissionMode: 'default', model: 'o3', collaborationMode: 'plan' }
         });
 
@@ -122,6 +131,7 @@ describe('appServerConfig', () => {
         const params = buildTurnStartParams({
             threadId: 'thread-1',
             message: 'hello',
+            cwd: '/workspace/project',
             mode: { permissionMode: 'default', model: 'o3', collaborationMode: 'plan' },
             developerInstructions: 'Only respond in Chinese.'
         });
@@ -139,6 +149,7 @@ describe('appServerConfig', () => {
         expect(() => buildTurnStartParams({
             threadId: 'thread-1',
             message: 'hello',
+            cwd: '/workspace/project',
             mode: { permissionMode: 'default', collaborationMode: 'plan' }
         })).toThrow("Collaboration mode 'plan' requires a resolved model");
     });
@@ -147,6 +158,7 @@ describe('appServerConfig', () => {
         const params = buildTurnStartParams({
             threadId: 'thread-1',
             message: 'hello',
+            cwd: '/workspace/project',
             mode: { permissionMode: 'default', model: 'o3', collaborationMode: 'default' },
             cliOverrides: { sandbox: 'danger-full-access', approvalPolicy: 'never' }
         });
@@ -166,6 +178,7 @@ describe('appServerConfig', () => {
         const params = buildTurnStartParams({
             threadId: 'thread-1',
             message: 'hello',
+            cwd: '/workspace/project',
             mode: { permissionMode: 'safe-yolo', model: 'o3', collaborationMode: 'default' },
             cliOverrides: { sandbox: 'read-only', approvalPolicy: 'never' }
         });
@@ -185,6 +198,7 @@ describe('appServerConfig', () => {
         const params = buildTurnStartParams({
             threadId: 'thread-1',
             message: 'hello',
+            cwd: '/workspace/project',
             mode: { permissionMode: 'default', collaborationMode: 'default' },
             overrides: { approvalPolicy: 'on-request', model: 'gpt-5' }
         });

--- a/cli/src/codex/utils/appServerConfig.ts
+++ b/cli/src/codex/utils/appServerConfig.ts
@@ -64,6 +64,7 @@ function resolveInstructions(args: {
 }
 
 export function buildThreadStartParams(args: {
+    cwd: string;
     mode: EnhancedMode;
     mcpServers: McpServersConfig;
     cliOverrides?: CodexCliOverrides;
@@ -89,6 +90,7 @@ export function buildThreadStartParams(args: {
     };
 
     const params: ThreadStartParams = {
+        cwd: args.cwd,
         approvalPolicy: resolvedApprovalPolicy,
         sandbox: resolvedSandbox,
         baseInstructions,
@@ -106,6 +108,7 @@ export function buildThreadStartParams(args: {
 export function buildTurnStartParams(args: {
     threadId: string;
     message: string;
+    cwd: string;
     mode?: EnhancedMode;
     cliOverrides?: CodexCliOverrides;
     baseInstructions?: string;
@@ -118,6 +121,7 @@ export function buildTurnStartParams(args: {
 }): TurnStartParams {
     const params: TurnStartParams = {
         threadId: args.threadId,
+        cwd: args.cwd,
         input: [{ type: 'text', text: args.message }]
     };
 


### PR DESCRIPTION
## Summary
- pass `session.path` into Codex app-server thread startup
- pass the same cwd into follow-up turn requests
- add tests for the generated app-server payload

## Testing
- bunx vitest run src/codex/utils/appServerConfig.test.ts