### PR TITLE
Fix create session page scrolling

### DIFF
--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -352,7 +352,7 @@ function NewSessionPage() {
     }, [navigate, queryClient])
 
     return (
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex h-full min-h-0 flex-col">
             <div className="flex items-center gap-2 border-b border-[var(--app-border)] bg-[var(--app-bg)] p-3 pt-[calc(0.75rem+env(safe-area-inset-top))]">
                 {!isTelegramApp() && (
                     <button
@@ -366,19 +366,21 @@ function NewSessionPage() {
                 <div className="flex-1 font-semibold">{t('newSession.title')}</div>
             </div>
 
-            {machinesError ? (
-                <div className="p-3 text-sm text-red-600">
-                    {machinesError}
-                </div>
-            ) : null}
+            <div className="flex-1 min-h-0 overflow-y-auto">
+                {machinesError ? (
+                    <div className="p-3 text-sm text-red-600">
+                        {machinesError}
+                    </div>
+                ) : null}
 
-            <NewSession
-                api={api}
-                machines={machines}
-                isLoading={machinesLoading}
-                onCancel={handleCancel}
-                onSuccess={handleSuccess}
-            />
+                <NewSession
+                    api={api}
+                    machines={machines}
+                    isLoading={machinesLoading}
+                    onCancel={handleCancel}
+                    onSuccess={handleSuccess}
+                />
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- keep the create session header outside the scrolling region
- move the form content into a height-constrained inner scroll container
- ensure the content pane can scroll when agent/model options make the page taller

## Problem
On the create session page, choosing agents like Codex adds enough options that the lower action buttons can become unreachable because the page cannot scroll vertically.

## Testing
- local manual verification of the create session page layout
- confirmed the scroll region starts below the header and can scroll through the full form