### PR TITLE
fix(web): fix push notification click 404 on GitHub Pages

### DIFF
--- a/web/public/404.html
+++ b/web/public/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>HAPI</title>
+  <script>
+    sessionStorage.setItem('spaRedirect', window.location.pathname + window.location.search + window.location.hash)
+    window.location.replace('/')
+  </script>
+</head>
+<body></body>
+</html>

--- a/web/src/lib/spaRedirect.test.ts
+++ b/web/src/lib/spaRedirect.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { restoreSpaRedirect, storeSpaRedirect } from './spaRedirect'
+
+describe('spaRedirect', () => {
+    beforeEach(() => {
+        sessionStorage.clear()
+        vi.spyOn(window.history, 'replaceState')
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    describe('restoreSpaRedirect', () => {
+        it('restores stored path via replaceState', () => {
+            sessionStorage.setItem('spaRedirect', '/sessions/abc123')
+
+            restoreSpaRedirect()
+
+            expect(window.history.replaceState).toHaveBeenCalledWith(null, '', '/sessions/abc123')
+        })
+
+        it('removes spaRedirect from sessionStorage after restoring', () => {
+            sessionStorage.setItem('spaRedirect', '/sessions/abc123')
+
+            restoreSpaRedirect()
+
+            expect(sessionStorage.getItem('spaRedirect')).toBeNull()
+        })
+
+        it('does nothing when spaRedirect is not set', () => {
+            restoreSpaRedirect()
+
+            expect(window.history.replaceState).not.toHaveBeenCalled()
+        })
+
+        it('preserves query string and hash in restored path', () => {
+            sessionStorage.setItem('spaRedirect', '/sessions/abc123?foo=bar#section')
+
+            restoreSpaRedirect()
+
+            expect(window.history.replaceState).toHaveBeenCalledWith(null, '', '/sessions/abc123?foo=bar#section')
+        })
+    })
+
+    describe('storeSpaRedirect', () => {
+        it('stores the current pathname in sessionStorage', () => {
+            Object.defineProperty(window, 'location', {
+                value: { pathname: '/sessions/abc123', search: '', hash: '' },
+                configurable: true,
+            })
+
+            storeSpaRedirect()
+
+            expect(sessionStorage.getItem('spaRedirect')).toBe('/sessions/abc123')
+        })
+
+        it('stores pathname with search and hash', () => {
+            Object.defineProperty(window, 'location', {
+                value: { pathname: '/sessions/abc123', search: '?foo=bar', hash: '#section' },
+                configurable: true,
+            })
+
+            storeSpaRedirect()
+
+            expect(sessionStorage.getItem('spaRedirect')).toBe('/sessions/abc123?foo=bar#section')
+        })
+    })
+})

--- a/web/src/lib/spaRedirect.ts
+++ b/web/src/lib/spaRedirect.ts
@@ -1,0 +1,22 @@
+const SPA_REDIRECT_KEY = 'spaRedirect'
+
+/**
+ * Stores the current path in sessionStorage before GitHub Pages redirects to /.
+ * Called from public/404.html when GitHub Pages serves a 404 for SPA routes.
+ */
+export function storeSpaRedirect(): void {
+    const path = window.location.pathname + window.location.search + window.location.hash
+    sessionStorage.setItem(SPA_REDIRECT_KEY, path)
+}
+
+/**
+ * Restores the path stored by storeSpaRedirect() using replaceState,
+ * so TanStack Router initializes at the correct URL without a server round-trip.
+ */
+export function restoreSpaRedirect(): void {
+    const redirect = sessionStorage.getItem(SPA_REDIRECT_KEY)
+    if (redirect) {
+        sessionStorage.removeItem(SPA_REDIRECT_KEY)
+        window.history.replaceState(null, '', redirect)
+    }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,6 +10,7 @@ import { getTelegramWebApp, isTelegramEnvironment, loadTelegramSdk } from './hoo
 import { queryClient } from './lib/query-client'
 import { createAppRouter } from './router'
 import { I18nProvider } from './lib/i18n-context'
+import { restoreSpaRedirect } from './lib/spaRedirect'
 
 function getStartParam(): string | null {
     const query = new URLSearchParams(window.location.search)
@@ -39,6 +40,13 @@ async function bootstrap() {
     const isTelegram = isTelegramEnvironment()
     if (isTelegram) {
         await loadTelegramSdk()
+    }
+
+    // Handle GitHub Pages 404 redirect for SPA routing
+    // When GitHub Pages can't find a path (e.g. /sessions/xxx), it serves 404.html
+    // which stores the path in sessionStorage and redirects to /
+    if (!isTelegram) {
+        restoreSpaRedirect()
     }
 
     const updateSW = registerSW({


### PR DESCRIPTION
Fixes #321

## Problem

When running in relay mode (`hapi hub --relay`), the web app is served from `app.hapi.run` (GitHub Pages). Tapping a push notification opens `/sessions/:id` in a new tab. GitHub Pages has no file at that path, so it returns **404 Not Found** instead of serving the SPA.

This only affects relay mode. The hub's own static server (non-relay) has a proper SPA fallback and works correctly.

## Root Cause

The `notificationclick` handler in `sw.ts` calls `clients.openWindow('/sessions/:id')`. The relative URL resolves to `https://app.hapi.run/sessions/:id`. GitHub Pages serves 404 for any path that doesn't correspond to a real file.

## Solution

Standard GitHub Pages SPA routing workaround (no changes to service worker or notification payload needed):

- **`web/public/404.html`** — Stores the intended path in `sessionStorage`, then redirects to `/`
- **`web/src/lib/spaRedirect.ts`** — `restoreSpaRedirect()` reads sessionStorage before router init and calls `window.history.replaceState` with the stored path
- **`web/src/main.tsx`** — Calls `restoreSpaRedirect()` on bootstrap (skipped in Telegram environment which uses memory history)

TanStack Router initializes at the correct URL without any server round-trip, so the right session is rendered immediately.

## Tests

Added unit tests in `web/src/lib/spaRedirect.test.ts` covering:
- Restores stored path via `replaceState`
- Cleans up `sessionStorage` after restore
- No-op when no redirect is stored
- Preserves query string and hash
- `storeSpaRedirect` captures full path including search and hash

All 43 web tests pass.