### PR TITLE
Fix Codex default approval policy for remote sessions

### DIFF
--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -27,6 +27,17 @@ describe('appServerConfig', () => {
         });
     });
 
+    it('uses on-request approvals for default Codex threads', () => {
+        const params = buildThreadStartParams({
+            cwd: '/workspace/project',
+            mode: { permissionMode: 'default', collaborationMode: 'default' },
+            mcpServers
+        });
+
+        expect(params.sandbox).toBe('workspace-write');
+        expect(params.approvalPolicy).toBe('on-request');
+    });
+
     it('ignores CLI overrides when permission mode is not default', () => {
         const params = buildThreadStartParams({
             cwd: '/workspace/project',

--- a/cli/src/codex/utils/permissionModeConfig.test.ts
+++ b/cli/src/codex/utils/permissionModeConfig.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCodexPermissionModeConfig } from './permissionModeConfig';
+
+describe('resolveCodexPermissionModeConfig', () => {
+    it('uses on-request approvals for default mode', () => {
+        expect(resolveCodexPermissionModeConfig('default')).toEqual({
+            approvalPolicy: 'on-request',
+            sandbox: 'workspace-write',
+            sandboxPolicy: { type: 'workspaceWrite' }
+        });
+    });
+
+    it('keeps safe-yolo escalation on failure', () => {
+        expect(resolveCodexPermissionModeConfig('safe-yolo')).toEqual({
+            approvalPolicy: 'on-failure',
+            sandbox: 'workspace-write',
+            sandboxPolicy: { type: 'workspaceWrite' }
+        });
+    });
+});

--- a/cli/src/codex/utils/permissionModeConfig.ts
+++ b/cli/src/codex/utils/permissionModeConfig.ts
@@ -11,7 +11,10 @@ export function resolveCodexPermissionModeConfig(mode: CodexPermissionMode): Cod
     switch (mode) {
         case 'default':
             return {
-                approvalPolicy: 'untrusted',
+                // Remote Codex sessions rely on HAPI's approval UI for sandbox escalation.
+                // `on-request` keeps workspace-write sandboxing while still surfacing a
+                // user-approvable elevation request when the model needs it.
+                approvalPolicy: 'on-request',
                 sandbox: 'workspace-write',
                 sandboxPolicy: { type: 'workspaceWrite' }
             };


### PR DESCRIPTION
## Summary
- switch Codex remote `default` mode from `approvalPolicy=untrusted` to `approvalPolicy=on-request`
- keep the existing `workspace-write` sandbox for default mode
- add regression coverage for the permission mode mapping and thread-start config

Closes #327

## Why
In the app, Codex remote sessions need to be able to surface sandbox escalation requests through HAPI's approval UI. With the current default mapping, `gpt-5.4` running in the sandbox can get stuck without a usable in-app escalation path.

## Testing
- `cd cli && bun run test -- src/codex/utils/permissionModeConfig.test.ts src/codex/utils/appServerConfig.test.ts src/codex/utils/permissionHandler.test.ts src/codex/codexLocalLauncher.test.ts`
- `cd cli && bunx vitest run src/claude/utils/sessionScanner.test.ts src/claude/utils/startHookServer.test.ts src/opencode/utils/startOpencodeHookServer.test.ts src/agent/backends/acp/AcpSdkBackend.test.ts`

Note: a full `cd cli && bun run test` still has pre-existing failures in `src/claude/utils/sessionScanner.test.ts` and `src/runner/runner.integration.test.ts` that are unrelated to this change.