### PR TITLE
fix(hub): pass resumeSessionId when resuming session

### DIFF
--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -180,4 +180,61 @@ describe('session model', () => {
             engine.stop()
         }
     })
+
+    it('passes resume session ID to rpc gateway when resuming claude session', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-claude-resume',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'claude',
+                    claudeSessionId: 'claude-session-1'
+                },
+                null,
+                'default',
+                'sonnet'
+            )
+            engine.getOrCreateMachine(
+                'machine-1',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
+
+            let capturedResumeSessionId: string | undefined
+            ;(engine as any).rpcGateway.spawnSession = async (
+                _machineId: string,
+                _directory: string,
+                _agent: string,
+                _model?: string,
+                _modelReasoningEffort?: string,
+                _yolo?: boolean,
+                _sessionType?: 'simple' | 'worktree',
+                _worktreeName?: string,
+                resumeSessionId?: string
+            ) => {
+                capturedResumeSessionId = resumeSessionId
+                return { type: 'success', sessionId: session.id }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            const result = await engine.resumeSession(session.id, 'default')
+
+            expect(result).toEqual({ type: 'success', sessionId: session.id })
+            expect(capturedResumeSessionId).toBe('claude-session-1')
+        } finally {
+            engine.stop()
+        }
+    })
 })

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -385,6 +385,7 @@ export class SyncEngine {
             undefined,
             undefined,
             undefined,
+            undefined,
             resumeToken
         )
 


### PR DESCRIPTION
## Summary
Fixes a resume argument wiring bug in `SyncEngine.resumeSession()` that prevents hub-triggered session resume from passing the actual resume token to the CLI spawn RPC.

## Root cause
`rpcGateway.spawnSession()` takes params in this order:

1. machineId
2. directory
3. agent
4. model
5. modelReasoningEffort
6. yolo
7. sessionType
8. worktreeName
9. resumeSessionId

In `hub/src/sync/syncEngine.ts`, `resumeToken` was passed as the 8th argument (worktreeName) instead of the 9th argument (resumeSessionId).

So for resume flow:
- hub found `metadata.claudeSessionId` (or other flavor token)
- but CLI never received `resumeSessionId`
- runner spawn command missed `--resume <id>`
- session could start as a new session instead of resuming the target one.

## Fix
In `hub/src/sync/syncEngine.ts`:
- add explicit `undefined` for `worktreeName`
- pass `resumeToken` as the 9th arg (`resumeSessionId`)

## Tests
Added regression test in `hub/src/sync/sessionModel.test.ts`:
- `passes resume session ID to rpc gateway when resuming claude session`
- verifies `engine.resumeSession()` forwards `metadata.claudeSessionId` into rpc `spawnSession(..., resumeSessionId)`

Also keeps existing model-forwarding resume test intact.

## Validation
- `cd hub && bun run test src/sync/sessionModel.test.ts`
- all tests in this file pass

## Impact
- fixes resume correctness for Claude (and same call path shared by other flavors)
- prevents silent new-session fallback caused by missing resume token at spawn RPC boundary
