### PR TITLE
feat: Render question text and options with markdown

### DIFF
--- a/web/src/components/ToolCard/AskUserQuestionFooter.tsx
+++ b/web/src/components/ToolCard/AskUserQuestionFooter.tsx
@@ -41,10 +41,12 @@ function OptionRow(props: {
         >
             <SelectionMark checked={props.checked} mode={props.mode} />
             <span className="min-w-0 flex-1">
-                <div className="font-medium text-[var(--app-fg)] break-words">{props.title}</div>
+                <div className="[&_.aui-md]:font-medium [&_.aui-md]:text-sm [&_.aui-md]:text-[var(--app-fg)]">
+                    <MarkdownRenderer content={props.title} />
+                </div>
                 {props.description ? (
-                    <div className="mt-0.5 text-xs text-[var(--app-hint)] break-words">
-                        {props.description}
+                    <div className="mt-0.5 [&_.aui-md]:text-xs [&_.aui-md]:text-[var(--app-hint)]">
+                        <MarkdownRenderer content={props.description} />
                     </div>
                 ) : null}
             </span>

--- a/web/src/components/ToolCard/RequestUserInputFooter.tsx
+++ b/web/src/components/ToolCard/RequestUserInputFooter.tsx
@@ -43,10 +43,12 @@ function OptionRow(props: {
         >
             <SelectionMark checked={props.checked} />
             <span className="min-w-0 flex-1">
-                <div className="font-medium text-[var(--app-fg)] break-words">{props.title}</div>
+                <div className="[&_.aui-md]:font-medium [&_.aui-md]:text-sm [&_.aui-md]:text-[var(--app-fg)]">
+                    <MarkdownRenderer content={props.title} />
+                </div>
                 {props.description ? (
-                    <div className="mt-0.5 text-xs text-[var(--app-hint)] break-words">
-                        {props.description}
+                    <div className="mt-0.5 [&_.aui-md]:text-xs [&_.aui-md]:text-[var(--app-hint)]">
+                        <MarkdownRenderer content={props.description} />
                     </div>
                 ) : null}
             </span>

--- a/web/src/components/ToolCard/views/AskUserQuestionView.tsx
+++ b/web/src/components/ToolCard/views/AskUserQuestionView.tsx
@@ -167,16 +167,16 @@ export function AskUserQuestionView(props: ToolViewProps) {
                                                 )}
                                                 <div className="min-w-0 flex-1">
                                                     <div className={cn(
-                                                        "text-sm break-words",
+                                                        "[&_.aui-md]:text-sm",
                                                         isSelected
-                                                            ? "text-emerald-700 dark:text-emerald-300 font-medium"
-                                                            : "text-[var(--app-fg)]"
+                                                            ? "[&_.aui-md]:text-emerald-700 dark:[&_.aui-md]:text-emerald-300 [&_.aui-md]:font-medium"
+                                                            : "[&_.aui-md]:text-[var(--app-fg)]"
                                                     )}>
-                                                        {opt.label}
+                                                        <MarkdownRenderer content={opt.label} />
                                                     </div>
                                                     {opt.description ? (
-                                                        <div className="mt-0.5 text-xs text-[var(--app-hint)] break-words">
-                                                            {opt.description}
+                                                        <div className="mt-0.5 [&_.aui-md]:text-xs [&_.aui-md]:text-[var(--app-hint)]">
+                                                            <MarkdownRenderer content={opt.description} />
                                                         </div>
                                                     ) : null}
                                                 </div>

--- a/web/src/components/ToolCard/views/RequestUserInputView.tsx
+++ b/web/src/components/ToolCard/views/RequestUserInputView.tsx
@@ -93,16 +93,16 @@ export function RequestUserInputView(props: ToolViewProps) {
                                                 )}
                                                 <div className="min-w-0 flex-1">
                                                     <div className={cn(
-                                                        "text-sm break-words",
+                                                        "[&_.aui-md]:text-sm",
                                                         isSelected
-                                                            ? "text-emerald-700 dark:text-emerald-300 font-medium"
-                                                            : "text-[var(--app-fg)]"
+                                                            ? "[&_.aui-md]:text-emerald-700 dark:[&_.aui-md]:text-emerald-300 [&_.aui-md]:font-medium"
+                                                            : "[&_.aui-md]:text-[var(--app-fg)]"
                                                     )}>
-                                                        {opt.label}
+                                                        <MarkdownRenderer content={opt.label} />
                                                     </div>
                                                     {opt.description ? (
-                                                        <div className="mt-0.5 text-xs text-[var(--app-hint)] break-words">
-                                                            {opt.description}
+                                                        <div className="mt-0.5 [&_.aui-md]:text-xs [&_.aui-md]:text-[var(--app-hint)]">
+                                                            <MarkdownRenderer content={opt.description} />
                                                         </div>
                                                     ) : null}
                                                 </div>


### PR DESCRIPTION
  ## Summary

  Render markdown in CLI-started question UIs so question prompts and option content display consistently with the main session output.

  This updates both question tool variants:
  - `AskUserQuestion` / `ask_user_question`
  - `request_user_input`

  And it covers both states:
  - pending interaction footers
  - read-only/history views

  ## Changes

  - render question body text with the existing shared markdown renderer
  - render option labels with the existing shared markdown renderer
  - render option descriptions with the existing shared markdown renderer
  - keep option values, answer matching, and selection logic unchanged

  ### Before
  
![before](https://github.com/user-attachments/assets/59c847ee-7a84-4aed-9c1d-b51e19e17e15)

  ### After

  
![after](https://github.com/user-attachments/assets/b82b2bd5-d619-4f8f-a6cb-045f7a8f3b5f)


  ## Scope

  Intentionally narrow patch:
  - web-only
  - no hub / CLI / shared schema changes
  - no transport changes
  - no shared markdown renderer API changes

  ## Testing

  - `bun run typecheck:web`

  ## Notes

  - This reuses the app's existing markdown stack, so behavior matches current frontend markdown support.
  - Unrelated local `bun.lock` changes were not included in this branch.