### PR TITLE
fix(web): stop rendering sidechain prompt as user message

### DIFF
--- a/web/src/chat/reducerTimeline.ts
+++ b/web/src/chat/reducerTimeline.ts
@@ -221,13 +221,8 @@ export function reduceTimeline(
                 }
 
                 if (c.type === 'sidechain') {
-                    blocks.push({
-                        kind: 'user-text',
-                        id: `${msg.id}:${idx}`,
-                        localId: null,
-                        createdAt: msg.createdAt,
-                        text: c.prompt
-                    })
+                    // Skip - the prompt is already visible in the parent Task tool call's input
+                    continue
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Sub-agent (sidechain) prompts were incorrectly converted to `user-text` blocks in `reducerTimeline.ts`, causing them to appear as standalone messages in the web chat UI
- The prompt text is already visible in the parent Task tool call's input, so this was a duplicate/misattributed display
- Fixed by skipping sidechain content blocks instead of creating `user-text` blocks

## Test plan

- [ ] Open a session that uses sub-agents (Agent tool) in the web UI
- [ ] Verify the sub-agent prompt no longer appears as a separate user message
- [ ] Verify the Task tool call still shows the prompt in its input parameters
- [ ] Verify sub-agent responses still render correctly as children of the Task tool call