### PR TITLE
fix(cli): fix process exit handling deadlock and error masking in Claude SDK

### DIFF
--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -79,7 +79,16 @@ export async function claudeRemote(opts: {
     process.env.DISABLE_AUTOUPDATER = '1';
 
     // Get initial message
-    const initial = await opts.nextMessage();
+    let initial;
+    try {
+        initial = await opts.nextMessage();
+    } catch (e) {
+        if (e instanceof AbortError) {
+            logger.debug(`[claudeRemote] Aborted during initial message`);
+            return;
+        }
+        throw e;
+    }
     if (!initial) { // No initial message - exit
         return;
     }

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -363,7 +363,8 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                 } catch (e) {
                     logger.debug('[remote]: launch error', e);
                     if (!this.exitReason) {
-                        session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
+                        const detail = e instanceof Error ? e.message : String(e);
+                        session.client.sendSessionEvent({ type: 'message', message: `Process exited unexpectedly: ${detail}` });
                         continue;
                     }
                 } finally {

--- a/cli/src/claude/sdk/query.ts
+++ b/cli/src/claude/sdk/query.ts
@@ -88,6 +88,7 @@ export class Query implements AsyncIterableIterator<SDKMessage> {
      */
     private async readMessages(): Promise<void> {
         const rl = createInterface({ input: this.childStdout })
+        let hadError = false
 
         try {
             for await (const line of rl) {
@@ -118,9 +119,14 @@ export class Query implements AsyncIterableIterator<SDKMessage> {
             }
             await this.processExitPromise
         } catch (error) {
+            hadError = true
             this.inputStream.error(error as Error)
         } finally {
-            this.inputStream.done()
+            // Only call done() on clean exit - calling done() after error()
+            // would mask the error since Stream.next() checks isDone before hasError
+            if (!hadError) {
+                this.inputStream.done()
+            }
             this.cleanupControllers()
             rl.close()
         }
@@ -381,35 +387,50 @@ export function query(config: {
     process.on('exit', cleanup)
 
     // Handle process exit
-    const processExitPromise = new Promise<void>((resolve) => {
-        child.on('close', (code) => {
-            if (config.options?.abort?.aborted) {
-                query.setError(new AbortError('Claude Code process aborted by user'))
-            }
-            if (code !== 0) {
-                query.setError(new Error(`Claude Code process exited with code ${code}`))
-            } else {
-                resolve()
-            }
-        })
+    let resolveExit: () => void
+    let rejectExit: (error: Error) => void
+    const processExitPromise = new Promise<void>((resolve, reject) => {
+        resolveExit = resolve
+        rejectExit = reject
     })
 
-    // Create query instance
+    // Create query instance BEFORE registering close handler
+    // to avoid temporal dependency on `query` variable
     const query = new Query(childStdin, child.stdout, processExitPromise, canCallTool)
+
+    // Register close handler - query is safely defined now
+    child.on('close', (code) => {
+        if (config.options?.abort?.aborted) {
+            const err = new AbortError('Claude Code process aborted by user')
+            query.setError(err)
+            rejectExit(err)
+        } else if (code !== 0) {
+            const err = new Error(`Claude Code process exited with code ${code}`)
+            query.setError(err)
+            rejectExit(err)
+        } else {
+            resolveExit()
+        }
+    })
 
     // Handle process errors
     child.on('error', (error) => {
         cleanupMcpConfig?.()
         if (config.options?.abort?.aborted) {
-            query.setError(new AbortError('Claude Code process aborted by user'))
+            const err = new AbortError('Claude Code process aborted by user')
+            query.setError(err)
+            rejectExit(err)
         } else {
-            query.setError(new Error(`Failed to spawn Claude Code process: ${error.message}`))
+            const err = new Error(`Failed to spawn Claude Code process: ${error.message}`)
+            query.setError(err)
+            rejectExit(err)
         }
     })
 
-    // Cleanup on exit
-    processExitPromise.finally(() => {
+    // Cleanup on exit (catch rejection to avoid unhandled promise warning)
+    processExitPromise.catch(() => {}).finally(() => {
         cleanup()
+        process.removeListener('exit', cleanup)
         config.options?.abort?.removeEventListener('abort', cleanup)
         if (process.env.CLAUDE_SDK_MCP_SERVERS) {
             delete process.env.CLAUDE_SDK_MCP_SERVERS


### PR DESCRIPTION
## Summary

Fixes multiple critical bugs in the Claude Code SDK process exit handling that cause the "Process exited unexpectedly" error and silent error swallowing in remote sessions.

### Bugs Fixed

- **processExitPromise deadlock**: When the Claude Code process exits with a non-zero code, the promise only called `setError()` but never resolved or rejected. This caused `readMessages()` to hang at `await processExitPromise` indefinitely, preventing resource cleanup and leaving the session stuck.
- **Temporal initialization dependency**: The `close` event handler inside `processExitPromise` called `query.setError()`, but the `query` variable was assigned *after* the promise was created. If the child process exited quickly enough, this could cause a `ReferenceError`.
- **Stream error masking**: In `readMessages()`, `inputStream.done()` was called unconditionally in the `finally` block after `inputStream.error()` in the `catch` block. Since `Stream.next()` checks `isDone` before `hasError`, this caused process crash errors to be silently swallowed — consumers saw a clean stream end instead of the error.
- **Listener leak**: `process.on('exit', cleanup)` was registered on every `query()` call but never removed, causing unbounded listener accumulation in long-running remote launcher sessions.
- **AbortError not caught on startup**: The initial `nextMessage()` call in `claudeRemote()` was outside the `try/catch` block, so an `AbortError` during startup would propagate as "Process exited unexpectedly" instead of being handled gracefully.
- **Opaque error message**: "Process exited unexpectedly" now includes the actual error detail.

## Test plan

- [ ] Start a remote Claude Code session via the web interface
- [ ] Send messages and verify normal operation
- [ ] Abort a session mid-execution and verify clean shutdown without "Process exited unexpectedly"
- [ ] If Claude Code crashes (e.g., invalid config), verify the actual error message is shown instead of the generic message