### PR TITLE
fix(web): add visual indicator for sending message status

### DIFF
--- a/web/src/components/AssistantChat/messages/MessageStatusIndicator.tsx
+++ b/web/src/components/AssistantChat/messages/MessageStatusIndicator.tsx
@@ -10,10 +10,27 @@ function ErrorIcon() {
     )
 }
 
+function SendingIcon() {
+    return (
+        <svg className="h-[14px] w-[14px] animate-spin" viewBox="0 0 16 16" fill="none">
+            <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" opacity="0.3" />
+            <path d="M14 8a6 6 0 0 0-6-6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+    )
+}
+
 export function MessageStatusIndicator(props: {
     status?: MessageStatus
     onRetry?: () => void
 }) {
+    if (props.status === 'sending') {
+        return (
+            <span className="inline-flex items-center text-[var(--app-fg-muted)]">
+                <SendingIcon />
+            </span>
+        )
+    }
+
     if (props.status !== 'failed') {
         return null
     }


### PR DESCRIPTION
## Summary

- Messages in `sending` state had no visual indicator — `MessageStatusIndicator` only rendered for `failed` status, returning `null` for everything else
- Users could not distinguish between a message that was delivered vs one still in transit/queued, leading to confusion when messages appeared sent but were actually pending

Adds a spinning icon for `sending` status so users get immediate visual feedback that their message is still being delivered.

## Test plan

- [ ] Send a message from the web interface and verify the spinning indicator appears briefly
- [ ] Verify the indicator disappears once the message is confirmed by the hub
- [ ] Verify failed messages still show the error icon with retry button
- [ ] Test on mobile PWA to ensure the indicator renders correctly