### PR TITLE
feat(web): add copy button to user messages

### DIFF
--- a/web/src/components/AssistantChat/messages/UserMessage.tsx
+++ b/web/src/components/AssistantChat/messages/UserMessage.tsx
@@ -73,7 +73,7 @@ export function HappyUserMessage() {
                             <button
                                 type="button"
                                 title="Copy"
-                                className="opacity-60 sm:opacity-0 sm:group-hover/msg:opacity-100 transition-[opacity,colors] p-0.5 rounded hover:bg-[var(--app-subtle-bg)]"
+                                className="opacity-60 sm:opacity-0 sm:group-hover/msg:opacity-100 transition-[opacity,background-color] p-0.5 rounded hover:bg-[var(--app-subtle-bg)]"
                                 onClick={() => copy(text)}
                             >
                                 {copied


### PR DESCRIPTION
## Summary

- Add a small copy button to user message bubbles for easy text copying
- Especially useful on mobile where selecting message text is difficult
- Mobile: button always visible at low opacity; Desktop: appears on hover
- Reuses existing `useCopyToClipboard` hook (with haptic feedback) and `CopyIcon`/`CheckIcon`
- Conditionally rendered to avoid empty container spacing when there's no text

## Test plan

- [ ] Verify copy button appears on user messages with text content
- [ ] Verify clicking copies the message text to clipboard
- [ ] Verify icon changes to green checkmark after copying
- [ ] Verify button is always visible on mobile, hover-only on desktop
- [ ] Verify no copy button on attachment-only messages
- [ ] Verify status indicator (sending/failed) still displays correctly alongside copy button