### PR TITLE
fix(cli): filter invisible system messages in local mode

### DIFF
--- a/cli/src/claude/claudeLocalLauncher.test.ts
+++ b/cli/src/claude/claudeLocalLauncher.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+    launches: [] as Array<Record<string, unknown>>,
+    scannerOnMessage: null as ((message: Record<string, unknown>) => void) | null
+}))
+
+vi.mock('./claudeLocal', () => ({
+    claudeLocal: async (opts: Record<string, unknown>) => {
+        harness.launches.push(opts)
+    }
+}))
+
+vi.mock('./utils/sessionScanner', () => ({
+    createSessionScanner: async (opts: { onMessage: (message: Record<string, unknown>) => void }) => {
+        harness.scannerOnMessage = opts.onMessage
+        return {
+            cleanup: async () => {},
+            onNewSession: () => {}
+        }
+    }
+}))
+
+vi.mock('@/modules/common/launcher/BaseLocalLauncher', () => ({
+    BaseLocalLauncher: class {
+        constructor(private readonly opts: { launch: (signal: AbortSignal) => Promise<void> }) {}
+        async run(): Promise<'exit'> {
+            await this.opts.launch(new AbortController().signal)
+            return 'exit'
+        }
+    }
+}))
+
+import { claudeLocalLauncher } from './claudeLocalLauncher'
+
+function createSessionStub() {
+    const sentMessages: Array<Record<string, unknown>> = []
+    return {
+        session: {
+            sessionId: 'test-session',
+            path: '/tmp/test',
+            startedBy: 'terminal' as const,
+            startingMode: 'local' as const,
+            claudeEnvVars: {},
+            claudeArgs: [],
+            mcpServers: [],
+            allowedTools: [],
+            hookSettingsPath: null,
+            queue: { size: () => 0, reset: () => {}, setOnMessage: () => {} },
+            client: {
+                sendClaudeSessionMessage: (msg: Record<string, unknown>) => { sentMessages.push(msg) },
+                rpcHandlerManager: { registerHandler: () => {} }
+            },
+            addSessionFoundCallback: () => {},
+            removeSessionFoundCallback: () => {},
+            consumeOneTimeFlags: () => {},
+            recordLocalLaunchFailure: () => {}
+        },
+        sentMessages
+    }
+}
+
+describe('claudeLocalLauncher message filtering', () => {
+    afterEach(() => {
+        harness.launches = []
+        harness.scannerOnMessage = null
+    })
+
+    it('filters out summary messages', async () => {
+        const { session, sentMessages } = createSessionStub()
+        await claudeLocalLauncher(session as never)
+
+        harness.scannerOnMessage!({ type: 'summary', leafUuid: '1' })
+
+        expect(sentMessages).toHaveLength(0)
+    })
+
+    it('filters out invisible system messages', async () => {
+        const { session, sentMessages } = createSessionStub()
+        await claudeLocalLauncher(session as never)
+
+        harness.scannerOnMessage!({ type: 'system', subtype: 'init', uuid: '1' })
+        harness.scannerOnMessage!({ type: 'system', subtype: 'stop_hook_summary', uuid: '2' })
+        harness.scannerOnMessage!({ type: 'system', uuid: '3' })
+
+        expect(sentMessages).toHaveLength(0)
+    })
+
+    it('forwards visible system messages', async () => {
+        const { session, sentMessages } = createSessionStub()
+        await claudeLocalLauncher(session as never)
+
+        harness.scannerOnMessage!({ type: 'system', subtype: 'api_error', uuid: '1' })
+        harness.scannerOnMessage!({ type: 'system', subtype: 'turn_duration', uuid: '2' })
+
+        expect(sentMessages).toHaveLength(2)
+    })
+
+    it('forwards normal conversation messages', async () => {
+        const { session, sentMessages } = createSessionStub()
+        await claudeLocalLauncher(session as never)
+
+        harness.scannerOnMessage!({ type: 'user', uuid: '1' })
+        harness.scannerOnMessage!({ type: 'assistant', uuid: '2' })
+
+        expect(sentMessages).toHaveLength(2)
+    })
+})

--- a/cli/src/claude/claudeLocalLauncher.ts
+++ b/cli/src/claude/claudeLocalLauncher.ts
@@ -1,6 +1,7 @@
 import { claudeLocal } from "./claudeLocal";
 import { Session } from "./session";
 import { createSessionScanner } from "./utils/sessionScanner";
+import { isClaudeChatVisibleMessage } from "./utils/chatVisibility";
 import { BaseLocalLauncher } from "@/modules/common/launcher/BaseLocalLauncher";
 
 export async function claudeLocalLauncher(session: Session): Promise<'switch' | 'exit'> {
@@ -9,11 +10,17 @@ export async function claudeLocalLauncher(session: Session): Promise<'switch' | 
     const scanner = await createSessionScanner({
         sessionId: session.sessionId,
         workingDirectory: session.path,
-        onMessage: (message) => { 
+        onMessage: (message) => {
             // Block SDK summary messages - we generate our own
-            if (message.type !== 'summary') {
-                session.client.sendClaudeSessionMessage(message)
+            if (message.type === 'summary') {
+                return
             }
+            // Filter out invisible system messages (e.g. init, stop_hook_summary)
+            // to avoid them showing as raw JSON in the web UI
+            if (!isClaudeChatVisibleMessage(message)) {
+                return
+            }
+            session.client.sendClaudeSessionMessage(message)
         }
     });
 


### PR DESCRIPTION
## Summary

Two related message filtering fixes for the local and remote Claude launchers:

### 1. Filter invisible system messages in local mode (Closes #313)

In local mode, the session scanner forwards all messages except `summary` to the hub/web. Internal system messages (`init`, `stop_hook_summary`, etc.) end up stored in the hub and displayed as raw JSON in the PWA, since the web normalizer has no renderers for these subtypes.

Apply the shared `isClaudeChatVisibleMessage` helper in the local launcher's `onMessage` callback. This is more precise than remote mode's blanket filter: it allows renderable system subtypes (`api_error`, `turn_duration`, `compact_boundary`, `microcompact_boundary`) through while blocking internal ones.

### 2. Filter isMeta messages in both local and remote mode (Relates to #235)

When Claude Code loads a skill, it injects the full skill content as a user message with `isMeta: true`. While the web normalizer checks `isMeta`, these messages were still being sent to the hub, stored in the database, and transmitted over SSE unnecessarily.

- **Local mode**: add `isMeta` check alongside the existing summary and system message filters
- **Remote mode**: the `OutgoingMessageQueue` only filtered `system` type messages — skill injections have `type: 'user'` with `isMeta: true` and slipped through. Add `isMeta` check.

## Test plan

- [x] Unit tests: verify summary, invisible system, isMeta, visible system, and conversation messages are all handled correctly (5 tests)
- [ ] Start a Claude session in local mode, use a skill, confirm skill content does not appear as chat text
- [ ] Confirm `api_error` and `turn_duration` system messages still display correctly