### PR TITLE
fix(codex): Handle mcpServer/elicitation/request

### DIFF
--- a/cli/src/claude/utils/sessionScanner.test.ts
+++ b/cli/src/claude/utils/sessionScanner.test.ts
@@ -3,21 +3,26 @@ import { createSessionScanner } from './sessionScanner'
 import { RawJSONLines } from '../types'
 import { mkdir, writeFile, appendFile, rm, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { tmpdir, homedir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { existsSync } from 'node:fs'
 
 describe('sessionScanner', () => {
   let testDir: string
   let projectDir: string
+  let claudeConfigDir: string
   let collectedMessages: RawJSONLines[]
   let scanner: Awaited<ReturnType<typeof createSessionScanner>> | null = null
+  const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
   
   beforeEach(async () => {
     testDir = join(tmpdir(), `scanner-test-${Date.now()}`)
     await mkdir(testDir, { recursive: true })
+
+    claudeConfigDir = join(testDir, '.claude')
+    process.env.CLAUDE_CONFIG_DIR = claudeConfigDir
     
     const projectName = testDir.replace(/\//g, '-')
-    projectDir = join(homedir(), '.claude', 'projects', projectName)
+    projectDir = join(claudeConfigDir, 'projects', projectName)
     await mkdir(projectDir, { recursive: true })
     
     collectedMessages = []
@@ -35,6 +40,12 @@ describe('sessionScanner', () => {
     }
     if (existsSync(projectDir)) {
       await rm(projectDir, { recursive: true, force: true })
+    }
+
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
     }
   })
   

--- a/cli/src/claude/utils/startHookServer.test.ts
+++ b/cli/src/claude/utils/startHookServer.test.ts
@@ -1,117 +1,150 @@
 import { describe, it, expect } from 'vitest'
-import { request } from 'node:http'
-import { startHookServer, type SessionHookData } from './startHookServer'
+import { Readable } from 'node:stream'
+import { createHookRequestHandler, type SessionHookData } from './startHookServer'
 
-const sendHookRequest = async (port: number, body: string, token?: string): Promise<{ statusCode?: number; body: string }> => {
-    return await new Promise((resolve, reject) => {
-        const headers: Record<string, string | number> = {
-            'Content-Type': 'application/json',
-            'Content-Length': Buffer.byteLength(body)
+class MockRequest extends Readable {
+    headers: Record<string, string | string[] | undefined>
+    method: string
+    url: string
+    private sent = false
+
+    constructor(opts: {
+        body: string
+        path?: string
+        token?: string
+    }) {
+        super()
+        this.method = 'POST'
+        this.url = opts.path ?? '/hook/session-start'
+        this.headers = {
+            'content-type': 'application/json',
+            'content-length': `${Buffer.byteLength(opts.body)}`
         }
-        if (token) {
-            headers['x-hapi-hook-token'] = token
+        if (opts.token) {
+            this.headers['x-hapi-hook-token'] = opts.token
         }
+        this.body = opts.body
+    }
 
-        const req = request({
-            host: '127.0.0.1',
-            port,
-            path: '/hook/session-start',
-            method: 'POST',
-            headers
-        }, (res) => {
-            const chunks: Buffer[] = []
-            res.on('data', (chunk) => chunks.push(chunk as Buffer))
-            res.on('error', reject)
-            res.on('end', () => {
-                resolve({
-                    statusCode: res.statusCode,
-                    body: Buffer.concat(chunks).toString('utf-8')
-                })
-            })
-        })
+    private readonly body: string
 
-        req.on('error', reject)
-        req.end(body)
-    })
+    _read(): void {
+        if (this.sent) {
+            this.push(null)
+            return
+        }
+        this.sent = true
+        this.push(Buffer.from(this.body, 'utf-8'))
+        this.push(null)
+    }
+}
+
+class MockResponse {
+    statusCode: number | undefined
+    headersSent = false
+    writableEnded = false
+    body = ''
+
+    writeHead(statusCode: number): this {
+        this.statusCode = statusCode
+        this.headersSent = true
+        return this
+    }
+
+    end(body?: string): this {
+        if (body) {
+            this.body += body
+        }
+        this.writableEnded = true
+        return this
+    }
+}
+
+const sendHookRequest = async (
+    handler: ReturnType<typeof createHookRequestHandler>,
+    body: string,
+    token?: string
+): Promise<{ statusCode?: number; body: string }> => {
+    const req = new MockRequest({ body, token })
+    const res = new MockResponse()
+
+    await handler(req as never, res as never)
+
+    return {
+        statusCode: res.statusCode,
+        body: res.body
+    }
 }
 
 describe('startHookServer', () => {
     it('forwards session hook payload to callback', async () => {
         let received: { sessionId?: string; data?: SessionHookData } = {}
-        const server = await startHookServer({
+        const token = 'test-hook-token'
+        const handler = createHookRequestHandler({
+            token,
             onSessionHook: (sessionId, data) => {
                 received = { sessionId, data }
             }
         })
 
-        try {
-            const body = JSON.stringify({ session_id: 'session-123', extra: 'ok' })
-            const response = await sendHookRequest(server.port, body, server.token)
-            expect(response.statusCode).toBe(200)
-        } finally {
-            server.stop()
-        }
+        const body = JSON.stringify({ session_id: 'session-123', extra: 'ok' })
+        const response = await sendHookRequest(handler, body, token)
 
+        expect(response.statusCode).toBe(200)
         expect(received.sessionId).toBe('session-123')
         expect(received.data?.session_id).toBe('session-123')
     })
 
     it('returns 400 for invalid JSON payloads', async () => {
         let hookCalled = false
-        const server = await startHookServer({
+        const token = 'test-hook-token'
+        const handler = createHookRequestHandler({
+            token,
             onSessionHook: () => {
                 hookCalled = true
             }
         })
 
-        try {
-            const response = await sendHookRequest(server.port, '{"session_id":', server.token)
-            expect(response.statusCode).toBe(400)
-            expect(response.body).toBe('invalid json')
-        } finally {
-            server.stop()
-        }
+        const response = await sendHookRequest(handler, '{"session_id":', token)
 
+        expect(response.statusCode).toBe(400)
+        expect(response.body).toBe('invalid json')
         expect(hookCalled).toBe(false)
     })
 
     it('returns 422 when session_id is missing', async () => {
         let hookCalled = false
-        const server = await startHookServer({
+        const token = 'test-hook-token'
+        const handler = createHookRequestHandler({
+            token,
             onSessionHook: () => {
                 hookCalled = true
             }
         })
 
-        try {
-            const body = JSON.stringify({ extra: 'ok' })
-            const response = await sendHookRequest(server.port, body, server.token)
-            expect(response.statusCode).toBe(422)
-            expect(response.body).toBe('missing session_id')
-        } finally {
-            server.stop()
-        }
+        const body = JSON.stringify({ extra: 'ok' })
+        const response = await sendHookRequest(handler, body, token)
 
+        expect(response.statusCode).toBe(422)
+        expect(response.body).toBe('missing session_id')
         expect(hookCalled).toBe(false)
     })
 
     it('returns 401 when hook token is missing', async () => {
         let hookCalled = false
-        const server = await startHookServer({
+        const token = 'test-hook-token'
+        const handler = createHookRequestHandler({
+            token,
             onSessionHook: () => {
                 hookCalled = true
             }
         })
 
-        try {
-            const body = JSON.stringify({ session_id: 'session-123' })
-            const response = await sendHookRequest(server.port, body)
-            expect(response.statusCode).toBe(401)
-            expect(response.body).toBe('unauthorized')
-        } finally {
-            server.stop()
-        }
+        const body = JSON.stringify({ session_id: 'session-123' })
+        const response = await sendHookRequest(handler, body)
 
+        expect(response.statusCode).toBe(401)
+        expect(response.body).toBe('unauthorized')
         expect(hookCalled).toBe(false)
     })
 })

--- a/cli/src/claude/utils/startHookServer.ts
+++ b/cli/src/claude/utils/startHookServer.ts
@@ -46,91 +46,106 @@ function readHookToken(req: IncomingMessage): string | null {
     return header ?? null;
 }
 
+export function createHookRequestHandler(options: {
+    onSessionHook: (sessionId: string, data: SessionHookData) => void;
+    token: string;
+}): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+    const { onSessionHook, token: hookToken } = options;
+
+    return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+        const requestPath = req.url?.split('?')[0];
+        if (req.method === 'POST' && requestPath === '/hook/session-start') {
+            const providedToken = readHookToken(req);
+            if (providedToken !== hookToken) {
+                logger.debug('[hookServer] Unauthorized hook request');
+                res.writeHead(401, { 'Content-Type': 'text/plain' }).end('unauthorized');
+                req.resume();
+                return;
+            }
+
+            let timedOut = false;
+            const timeout = setTimeout(() => {
+                timedOut = true;
+                if (!res.headersSent) {
+                    logger.debug('[hookServer] Request timeout');
+                    res.writeHead(408).end('timeout');
+                }
+                req.destroy(new Error('Request timeout'));
+            }, 5000);
+
+            try {
+                const chunks: Buffer[] = [];
+                for await (const chunk of req) {
+                    chunks.push(chunk as Buffer);
+                }
+                clearTimeout(timeout);
+
+                if (timedOut || res.headersSent || res.writableEnded) {
+                    return;
+                }
+
+                const body = Buffer.concat(chunks).toString('utf-8');
+                logger.debug('[hookServer] Received session hook:', body);
+
+                let data: SessionHookData = {};
+                try {
+                    const parsed = JSON.parse(body);
+                    if (!parsed || typeof parsed !== 'object') {
+                        logger.debug('[hookServer] Parsed hook data is not an object');
+                        res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
+                        return;
+                    }
+                    data = parsed as SessionHookData;
+                } catch (parseError) {
+                    logger.debug('[hookServer] Failed to parse hook data as JSON:', parseError);
+                    res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
+                    return;
+                }
+
+                const sessionId = data.session_id || data.sessionId;
+                if (sessionId) {
+                    logger.debug(`[hookServer] Session hook received session ID: ${sessionId}`);
+                    onSessionHook(sessionId, data);
+                } else {
+                    logger.debug('[hookServer] Session hook received but no session_id found in data');
+                    res.writeHead(422, { 'Content-Type': 'text/plain' }).end('missing session_id');
+                    return;
+                }
+
+                if (!res.headersSent && !res.writableEnded) {
+                    res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ok');
+                }
+            } catch (error) {
+                clearTimeout(timeout);
+                if (timedOut) {
+                    return;
+                }
+                logger.debug('[hookServer] Error handling session hook:', error);
+                if (!res.headersSent && !res.writableEnded) {
+                    res.writeHead(500).end('error');
+                }
+            }
+            return;
+        }
+
+        res.writeHead(404).end('not found');
+    };
+}
+
 /**
  * Start a dedicated HTTP server for receiving Claude session hooks.
  */
 export async function startHookServer(options: HookServerOptions): Promise<HookServer> {
     const { onSessionHook } = options;
     const hookToken = options.token || randomBytes(16).toString('hex');
+    const handleRequest = createHookRequestHandler({
+        onSessionHook,
+        token: hookToken
+    });
 
     return new Promise((resolve, reject) => {
-        const server: Server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-            const requestPath = req.url?.split('?')[0];
-            if (req.method === 'POST' && requestPath === '/hook/session-start') {
-                const providedToken = readHookToken(req);
-                if (providedToken !== hookToken) {
-                    logger.debug('[hookServer] Unauthorized hook request');
-                    res.writeHead(401, { 'Content-Type': 'text/plain' }).end('unauthorized');
-                    req.resume();
-                    return;
-                }
-
-                let timedOut = false;
-                const timeout = setTimeout(() => {
-                    timedOut = true;
-                    if (!res.headersSent) {
-                        logger.debug('[hookServer] Request timeout');
-                        res.writeHead(408).end('timeout');
-                    }
-                    req.destroy(new Error('Request timeout'));
-                }, 5000);
-
-                try {
-                    const chunks: Buffer[] = [];
-                    for await (const chunk of req) {
-                        chunks.push(chunk as Buffer);
-                    }
-                    clearTimeout(timeout);
-
-                    if (timedOut || res.headersSent || res.writableEnded) {
-                        return;
-                    }
-
-                    const body = Buffer.concat(chunks).toString('utf-8');
-                    logger.debug('[hookServer] Received session hook:', body);
-
-                    let data: SessionHookData = {};
-                    try {
-                        const parsed = JSON.parse(body);
-                        if (!parsed || typeof parsed !== 'object') {
-                            logger.debug('[hookServer] Parsed hook data is not an object');
-                            res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
-                            return;
-                        }
-                        data = parsed as SessionHookData;
-                    } catch (parseError) {
-                        logger.debug('[hookServer] Failed to parse hook data as JSON:', parseError);
-                        res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
-                        return;
-                    }
-
-                    const sessionId = data.session_id || data.sessionId;
-                    if (sessionId) {
-                        logger.debug(`[hookServer] Session hook received session ID: ${sessionId}`);
-                        onSessionHook(sessionId, data);
-                    } else {
-                        logger.debug('[hookServer] Session hook received but no session_id found in data');
-                        res.writeHead(422, { 'Content-Type': 'text/plain' }).end('missing session_id');
-                        return;
-                    }
-
-                    if (!res.headersSent && !res.writableEnded) {
-                        res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ok');
-                    }
-                } catch (error) {
-                    clearTimeout(timeout);
-                    if (timedOut) {
-                        return;
-                    }
-                    logger.debug('[hookServer] Error handling session hook:', error);
-                    if (!res.headersSent && !res.writableEnded) {
-                        res.writeHead(500).end('error');
-                    }
-                }
-                return;
-            }
-
-            res.writeHead(404).end('not found');
+        const server: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
+            void handleRequest(req, res);
         });
 
         server.listen(0, '127.0.0.1', () => {

--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -149,6 +149,7 @@ export interface McpElicitationFormRequest {
     mode: 'form';
     message: string;
     requestedSchema: Record<string, unknown>;
+    _meta?: Record<string, unknown>;
 }
 
 export interface McpElicitationUrlRequest {
@@ -156,6 +157,7 @@ export interface McpElicitationUrlRequest {
     message: string;
     url: string;
     elicitationId: string;
+    _meta?: Record<string, unknown>;
 }
 
 export interface McpServerElicitationRequestParams {

--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -144,3 +144,28 @@ export interface TurnInterruptResponse {
     ok: boolean;
     [key: string]: unknown;
 }
+
+export interface McpElicitationFormRequest {
+    mode: 'form';
+    message: string;
+    requestedSchema: Record<string, unknown>;
+}
+
+export interface McpElicitationUrlRequest {
+    mode: 'url';
+    message: string;
+    url: string;
+    elicitationId: string;
+}
+
+export interface McpServerElicitationRequestParams {
+    threadId: string;
+    turnId: string | null;
+    serverName: string;
+    request: McpElicitationFormRequest | McpElicitationUrlRequest;
+}
+
+export interface McpServerElicitationResponse {
+    action: 'accept' | 'decline' | 'cancel';
+    content: unknown | null;
+}

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -231,6 +231,10 @@ describe('codexRemoteLauncher', () => {
                         properties: {
                             token: { type: 'string' }
                         }
+                    },
+                    _meta: {
+                        tool_title: 'Demo Tool',
+                        tool_description: 'Collect a token'
                     }
                 }
             }));
@@ -244,7 +248,11 @@ describe('codexRemoteLauncher', () => {
                 turnId: 'turn-1',
                 serverName: 'demo-server',
                 mode: 'form',
-                message: 'Need MCP input'
+                message: 'Need MCP input',
+                _meta: {
+                    tool_title: 'Demo Tool',
+                    tool_description: 'Collect a token'
+                }
             });
 
             const rpcHandler = rpcHandlers.get('mcp-elicitation-response');

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -223,12 +223,14 @@ describe('codexRemoteLauncher', () => {
                 threadId: 'thread-anonymous',
                 turnId: 'turn-1',
                 serverName: 'demo-server',
-                mode: 'form',
-                message: 'Need MCP input',
-                requestedSchema: {
-                    type: 'object',
-                    properties: {
-                        token: { type: 'string' }
+                request: {
+                    mode: 'form',
+                    message: 'Need MCP input',
+                    requestedSchema: {
+                        type: 'object',
+                        properties: {
+                            token: { type: 'string' }
+                        }
                     }
                 }
             }));
@@ -287,5 +289,90 @@ describe('codexRemoteLauncher', () => {
             },
             is_error: false
         });
+    });
+
+    it('bridges nested MCP URL elicitation requests and preserves URL metadata', async () => {
+        const {
+            session,
+            codexMessages,
+            rpcHandlers
+        } = createSessionStub();
+
+        harness.startTurnHook = async () => {
+            const elicitationHandler = harness.requestHandlers.get('mcpServer/elicitation/request');
+            expect(elicitationHandler).toBeTypeOf('function');
+
+            const elicitationResult = Promise.resolve(elicitationHandler?.({
+                threadId: 'thread-anonymous',
+                turnId: 'turn-2',
+                serverName: 'github-auth',
+                request: {
+                    mode: 'url',
+                    message: 'Sign in to continue',
+                    url: 'https://example.com/auth',
+                    elicitationId: 'elicitation-123'
+                }
+            }));
+
+            await Promise.resolve();
+
+            const requestMessage = codexMessages.find((message: any) => message?.name === 'CodexMcpElicitation') as any;
+            expect(requestMessage).toBeTruthy();
+            expect(requestMessage.input).toMatchObject({
+                threadId: 'thread-anonymous',
+                turnId: 'turn-2',
+                serverName: 'github-auth',
+                mode: 'url',
+                message: 'Sign in to continue',
+                url: 'https://example.com/auth',
+                elicitationId: 'elicitation-123'
+            });
+
+            const rpcHandler = rpcHandlers.get('mcp-elicitation-response');
+            expect(rpcHandler).toBeTypeOf('function');
+
+            await rpcHandler?.({
+                id: requestMessage.callId,
+                action: 'accept',
+                content: null
+            });
+
+            await expect(elicitationResult).resolves.toEqual({
+                action: 'accept',
+                content: null
+            });
+        };
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.registerRequestCalls).toContain('mcpServer/elicitation/request');
+    });
+
+    it('rejects malformed nested MCP elicitation payloads before bridging to the UI', async () => {
+        const {
+            session,
+            codexMessages
+        } = createSessionStub();
+
+        harness.startTurnHook = async () => {
+            const elicitationHandler = harness.requestHandlers.get('mcpServer/elicitation/request');
+            expect(elicitationHandler).toBeTypeOf('function');
+
+            await expect(Promise.resolve(elicitationHandler?.({
+                threadId: 'thread-anonymous',
+                turnId: 'turn-3',
+                serverName: 'broken-server',
+                request: {
+                    message: 'Missing mode'
+                }
+            }))).rejects.toThrow('Invalid MCP elicitation request: missing mode');
+
+            expect(codexMessages.find((message: any) => message?.name === 'CodexMcpElicitation')).toBeUndefined();
+        };
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
     });
 });

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -5,7 +5,9 @@ import type { EnhancedMode } from './loop';
 const harness = vi.hoisted(() => ({
     notifications: [] as Array<{ method: string; params: unknown }>,
     registerRequestCalls: [] as string[],
-    initializeCalls: [] as unknown[]
+    initializeCalls: [] as unknown[],
+    requestHandlers: new Map<string, (params: unknown) => Promise<unknown> | unknown>(),
+    startTurnHook: null as null | (() => Promise<void>)
 }));
 
 vi.mock('./codexAppServerClient', () => {
@@ -23,8 +25,9 @@ vi.mock('./codexAppServerClient', () => {
             this.notificationHandler = handler;
         }
 
-        registerRequestHandler(method: string): void {
+        registerRequestHandler(method: string, handler: (params: unknown) => Promise<unknown> | unknown): void {
             harness.registerRequestCalls.push(method);
+            harness.requestHandlers.set(method, handler);
         }
 
         async startThread(): Promise<{ thread: { id: string }; model: string }> {
@@ -36,6 +39,9 @@ vi.mock('./codexAppServerClient', () => {
         }
 
         async startTurn(): Promise<{ turn: Record<string, never> }> {
+            if (harness.startTurnHook) {
+                await harness.startTurnHook();
+            }
             const started = { turn: {} };
             harness.notifications.push({ method: 'turn/started', params: started });
             this.notificationHandler?.('turn/started', started);
@@ -168,6 +174,8 @@ describe('codexRemoteLauncher', () => {
         harness.notifications = [];
         harness.registerRequestCalls = [];
         harness.initializeCalls = [];
+        harness.requestHandlers.clear();
+        harness.startTurnHook = null;
     });
 
     it('finishes a turn and emits ready when task lifecycle events omit turn_id', async () => {
@@ -197,5 +205,89 @@ describe('codexRemoteLauncher', () => {
         expect(sessionEvents.filter((event) => event.type === 'ready').length).toBeGreaterThanOrEqual(1);
         expect(thinkingChanges).toContain(true);
         expect(session.thinking).toBe(false);
+    });
+
+    it('bridges MCP elicitation requests through the remote launcher RPC channel', async () => {
+        const {
+            session,
+            codexMessages,
+            rpcHandlers
+        } = createSessionStub();
+        let elicitationResult: Promise<unknown> | null = null;
+
+        harness.startTurnHook = async () => {
+            const elicitationHandler = harness.requestHandlers.get('mcpServer/elicitation/request');
+            expect(elicitationHandler).toBeTypeOf('function');
+
+            elicitationResult = Promise.resolve(elicitationHandler?.({
+                threadId: 'thread-anonymous',
+                turnId: 'turn-1',
+                serverName: 'demo-server',
+                request: {
+                    mode: 'form',
+                    message: 'Need MCP input',
+                    requestedSchema: {
+                        type: 'object',
+                        properties: {
+                            token: { type: 'string' }
+                        }
+                    }
+                }
+            }));
+
+            await Promise.resolve();
+
+            const requestMessage = codexMessages.find((message: any) => message?.name === 'CodexMcpElicitation') as any;
+            expect(requestMessage).toBeTruthy();
+            expect(requestMessage.input).toMatchObject({
+                threadId: 'thread-anonymous',
+                turnId: 'turn-1',
+                serverName: 'demo-server',
+                mode: 'form',
+                message: 'Need MCP input'
+            });
+
+            const rpcHandler = rpcHandlers.get('mcp-elicitation-response');
+            expect(rpcHandler).toBeTypeOf('function');
+
+            await rpcHandler?.({
+                id: requestMessage.callId,
+                action: 'accept',
+                content: {
+                    token: 'abc'
+                }
+            });
+
+            await expect(elicitationResult).resolves.toEqual({
+                action: 'accept',
+                content: {
+                    token: 'abc'
+                }
+            });
+        };
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(rpcHandlers.has('mcp-elicitation-response')).toBe(true);
+        expect(harness.registerRequestCalls).toContain('mcpServer/elicitation/request');
+
+        const requestMessage = codexMessages.find((message: any) => message?.name === 'CodexMcpElicitation') as any;
+        const resultMessage = codexMessages.find((message: any) => (
+            message?.type === 'tool-call-result' && message?.callId === requestMessage?.callId
+        )) as any;
+
+        expect(requestMessage).toBeTruthy();
+        expect(resultMessage).toMatchObject({
+            type: 'tool-call-result',
+            callId: requestMessage.callId,
+            output: {
+                action: 'accept',
+                content: {
+                    token: 'abc'
+                }
+            },
+            is_error: false
+        });
     });
 });

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -223,14 +223,12 @@ describe('codexRemoteLauncher', () => {
                 threadId: 'thread-anonymous',
                 turnId: 'turn-1',
                 serverName: 'demo-server',
-                request: {
-                    mode: 'form',
-                    message: 'Need MCP input',
-                    requestedSchema: {
-                        type: 'object',
-                        properties: {
-                            token: { type: 'string' }
-                        }
+                mode: 'form',
+                message: 'Need MCP input',
+                requestedSchema: {
+                    type: 'object',
+                    properties: {
+                        token: { type: 'string' }
                     }
                 }
             }));

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -262,6 +262,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             const requestedSchema = asRecord(requestRecord.requestedSchema);
             const url = asString(requestRecord.url);
             const elicitationId = asString(requestRecord.elicitationId);
+            const meta = asRecord(requestRecord._meta);
 
             if (mode !== 'form' && mode !== 'url') {
                 throw new Error('Invalid MCP elicitation request: missing mode');
@@ -286,7 +287,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 message,
                 requestedSchema: mode === 'form' ? requestedSchema : undefined,
                 url: mode === 'url' ? url : undefined,
-                elicitationId: mode === 'url' ? elicitationId : undefined
+                elicitationId: mode === 'url' ? elicitationId : undefined,
+                _meta: meta ?? undefined
             };
         };
 

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -256,19 +256,37 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         });
 
         const parseMcpElicitationRequest = (params: McpServerElicitationRequestParams) => {
-            const request = params.request;
-            const requestId = request.mode === 'url' ? request.elicitationId : randomUUID();
+            const paramsRecord = asRecord(params) ?? {};
+            const mode = asString(paramsRecord.mode);
+            const message = asString(paramsRecord.message) ?? '';
+            const requestedSchema = asRecord(paramsRecord.requestedSchema);
+            const url = asString(paramsRecord.url);
+            const elicitationId = asString(paramsRecord.elicitationId);
+
+            if (mode !== 'form' && mode !== 'url') {
+                throw new Error('Invalid MCP elicitation request: missing mode');
+            }
+
+            if (mode === 'form' && !requestedSchema) {
+                throw new Error('Invalid MCP elicitation form request: missing requestedSchema');
+            }
+
+            if (mode === 'url' && !url) {
+                throw new Error('Invalid MCP elicitation URL request: missing url');
+            }
+
+            const requestId = mode === 'url' ? (elicitationId ?? randomUUID()) : randomUUID();
 
             return {
                 requestId,
                 threadId: params.threadId,
                 turnId: params.turnId,
                 serverName: params.serverName,
-                mode: request.mode,
-                message: request.message,
-                requestedSchema: request.mode === 'form' ? request.requestedSchema : undefined,
-                url: request.mode === 'url' ? request.url : undefined,
-                elicitationId: request.mode === 'url' ? request.elicitationId : undefined
+                mode,
+                message,
+                requestedSchema: mode === 'form' ? requestedSchema : undefined,
+                url: mode === 'url' ? url : undefined,
+                elicitationId: mode === 'url' ? elicitationId : undefined
             };
         };
 

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -256,12 +256,12 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         });
 
         const parseMcpElicitationRequest = (params: McpServerElicitationRequestParams) => {
-            const paramsRecord = asRecord(params) ?? {};
-            const mode = asString(paramsRecord.mode);
-            const message = asString(paramsRecord.message) ?? '';
-            const requestedSchema = asRecord(paramsRecord.requestedSchema);
-            const url = asString(paramsRecord.url);
-            const elicitationId = asString(paramsRecord.elicitationId);
+            const requestRecord = asRecord(params.request) ?? {};
+            const mode = asString(requestRecord.mode);
+            const message = asString(requestRecord.message) ?? '';
+            const requestedSchema = asRecord(requestRecord.requestedSchema);
+            const url = asString(requestRecord.url);
+            const elicitationId = asString(requestRecord.elicitationId);
 
             if (mode !== 'form' && mode !== 'url') {
                 throw new Error('Invalid MCP elicitation request: missing mode');

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -11,6 +11,7 @@ import { buildHapiMcpBridge } from './utils/buildHapiMcpBridge';
 import { emitReadyIfIdle } from './utils/emitReadyIfIdle';
 import type { CodexSession } from './session';
 import type { EnhancedMode } from './loop';
+import type { McpServerElicitationRequestParams, McpServerElicitationResponse } from './appServerTypes';
 import { hasCodexCliOverrides } from './utils/codexCliOverrides';
 import { AppServerEventConverter } from './utils/appServerEventConverter';
 import { registerAppServerPermissionHandlers } from './utils/appServerPermissionAdapter';
@@ -24,6 +25,14 @@ import {
 
 type HappyServer = Awaited<ReturnType<typeof buildHapiMcpBridge>>['server'];
 type QueuedMessage = { message: string; mode: EnhancedMode; isolate: boolean; hash: string };
+type McpElicitationRpcResponse = {
+    id: string;
+    action: 'accept' | 'decline' | 'cancel';
+    content?: unknown | null;
+};
+type PendingMcpElicitationRequest = {
+    resolve: (response: McpServerElicitationResponse) => void;
+};
 
 class CodexRemoteLauncher extends RemoteLauncherBase {
     private readonly session: CodexSession;
@@ -35,6 +44,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
     private abortController: AbortController = new AbortController();
     private currentThreadId: string | null = null;
     private currentTurnId: string | null = null;
+    private readonly pendingMcpElicitationRequests = new Map<string, PendingMcpElicitationRequest>();
 
     constructor(session: CodexSession) {
         super(process.env.DEBUG ? session.logPath : undefined);
@@ -64,6 +74,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             this.abortController.abort();
             this.session.queue.reset();
             this.permissionHandler?.reset();
+            this.cancelPendingMcpElicitationRequests();
             this.reasoningProcessor?.abort();
             this.diffProcessor?.reset();
             logger.debug('[Codex] Abort completed - session remains active');
@@ -71,6 +82,16 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             logger.debug('[Codex] Error during abort:', error);
         } finally {
             this.abortController = new AbortController();
+        }
+    }
+
+    private cancelPendingMcpElicitationRequests(): void {
+        for (const [requestId, pending] of this.pendingMcpElicitationRequests.entries()) {
+            pending.resolve({
+                action: 'cancel',
+                content: null
+            });
+            this.pendingMcpElicitationRequests.delete(requestId);
         }
     }
 
@@ -228,6 +249,89 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         let clearReadyAfterTurnTimer: (() => void) | null = null;
         let turnInFlight = false;
         let allowAnonymousTerminalEvent = false;
+
+        const toMcpElicitationResponse = (response: McpElicitationRpcResponse): McpServerElicitationResponse => ({
+            action: response.action,
+            content: response.action === 'accept' ? response.content ?? null : null
+        });
+
+        const parseMcpElicitationRequest = (params: McpServerElicitationRequestParams) => {
+            const request = params.request;
+            const requestId = request.mode === 'url' ? request.elicitationId : randomUUID();
+
+            return {
+                requestId,
+                threadId: params.threadId,
+                turnId: params.turnId,
+                serverName: params.serverName,
+                mode: request.mode,
+                message: request.message,
+                requestedSchema: request.mode === 'form' ? request.requestedSchema : undefined,
+                url: request.mode === 'url' ? request.url : undefined,
+                elicitationId: request.mode === 'url' ? request.elicitationId : undefined
+            };
+        };
+
+        const waitForMcpElicitationResponse = async (requestId: string): Promise<McpServerElicitationResponse> => {
+            return await new Promise<McpServerElicitationResponse>((resolve) => {
+                this.pendingMcpElicitationRequests.set(requestId, { resolve });
+            });
+        };
+
+        const handleMcpElicitationResponse = async (response: unknown): Promise<void> => {
+            const record = asRecord(response) ?? {};
+            const requestId = asString(record.id);
+            const action = asString(record.action);
+            if (!requestId || (action !== 'accept' && action !== 'decline' && action !== 'cancel')) {
+                logger.debug('[Codex] Ignoring invalid MCP elicitation response payload', response);
+                return;
+            }
+
+            const pending = this.pendingMcpElicitationRequests.get(requestId);
+            if (!pending) {
+                logger.debug(`[Codex] No pending MCP elicitation request for id ${requestId}`);
+                return;
+            }
+
+            this.pendingMcpElicitationRequests.delete(requestId);
+            pending.resolve(toMcpElicitationResponse({
+                id: requestId,
+                action,
+                content: record.content
+            }));
+        };
+
+        const handleMcpElicitationRequest = async (
+            params: McpServerElicitationRequestParams
+        ): Promise<McpServerElicitationResponse> => {
+            const request = parseMcpElicitationRequest(params);
+
+            logger.debug('[Codex] Bridging MCP elicitation request', {
+                requestId: request.requestId,
+                mode: request.mode,
+                serverName: request.serverName
+            });
+
+            session.sendAgentMessage({
+                type: 'tool-call',
+                name: 'CodexMcpElicitation',
+                callId: request.requestId,
+                input: request,
+                id: randomUUID()
+            });
+
+            const result = await waitForMcpElicitationResponse(request.requestId);
+
+            session.sendAgentMessage({
+                type: 'tool-call-result',
+                callId: request.requestId,
+                output: result,
+                is_error: result.action !== 'accept',
+                id: randomUUID()
+            });
+
+            return result;
+        };
 
         const handleCodexEvent = (msg: Record<string, unknown>) => {
             const msgType = asString(msg.type);
@@ -495,7 +599,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
 
         registerAppServerPermissionHandlers({
             client: appServerClient,
-            permissionHandler
+            permissionHandler,
+            onMcpElicitationRequest: handleMcpElicitationRequest
         });
 
         appServerClient.setNotificationHandler((method, params) => {
@@ -513,6 +618,10 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             onAbort: () => this.handleAbort(),
             onSwitch: () => this.handleSwitchRequest()
         });
+        session.client.rpcHandlerManager.registerHandler<McpElicitationRpcResponse, void>(
+            'mcp-elicitation-response',
+            handleMcpElicitationResponse
+        );
 
         function logActiveHandles(tag: string) {
             if (!process.env.DEBUG) return;
@@ -725,6 +834,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         }
 
         this.permissionHandler?.reset();
+        this.cancelPendingMcpElicitationRequests();
         this.reasoningProcessor?.abort();
         this.diffProcessor?.reset();
         this.permissionHandler = null;

--- a/cli/src/codex/utils/appServerPermissionAdapter.test.ts
+++ b/cli/src/codex/utils/appServerPermissionAdapter.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { McpServerElicitationRequestParams } from '../appServerTypes';
+import { registerAppServerPermissionHandlers } from './appServerPermissionAdapter';
+
+const harness = vi.hoisted(() => ({
+    loggerDebug: vi.fn()
+}));
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: harness.loggerDebug
+    }
+}));
+
+function createPermissionHandlerStub() {
+    return {
+        handleToolCall: vi.fn(async () => ({ decision: 'approved' }))
+    };
+}
+
+function createClientStub() {
+    const handlers = new Map<string, (params: unknown) => Promise<unknown> | unknown>();
+
+    return {
+        client: {
+            registerRequestHandler(method: string, handler: (params: unknown) => Promise<unknown> | unknown) {
+                handlers.set(method, handler);
+            }
+        },
+        handlers
+    };
+}
+
+describe('registerAppServerPermissionHandlers', () => {
+    it('registers the MCP elicitation app-server handler', () => {
+        const { client, handlers } = createClientStub();
+
+        registerAppServerPermissionHandlers({
+            client: client as never,
+            permissionHandler: createPermissionHandlerStub() as never
+        });
+
+        expect(handlers.has('mcpServer/elicitation/request')).toBe(true);
+    });
+
+    it('cancels MCP elicitation requests when no handler is provided', async () => {
+        const { client, handlers } = createClientStub();
+
+        registerAppServerPermissionHandlers({
+            client: client as never,
+            permissionHandler: createPermissionHandlerStub() as never
+        });
+
+        const handler = handlers.get('mcpServer/elicitation/request');
+        expect(handler).toBeTypeOf('function');
+
+        await expect(handler?.({})).resolves.toEqual({
+            action: 'cancel',
+            content: null
+        });
+        expect(harness.loggerDebug).toHaveBeenCalledWith(
+            '[CodexAppServer] No MCP elicitation handler registered; cancelling request'
+        );
+    });
+
+    it('returns the MCP elicitation result shape unchanged', async () => {
+        const { client, handlers } = createClientStub();
+        const request: McpServerElicitationRequestParams = {
+            threadId: 'thread-1',
+            turnId: 'turn-1',
+            serverName: 'demo-server',
+            request: {
+                mode: 'form',
+                message: 'Need input',
+                requestedSchema: {
+                    type: 'object'
+                }
+            }
+        };
+        const onMcpElicitationRequest = vi.fn(async () => ({
+            action: 'accept' as const,
+            content: {
+                token: 'abc'
+            }
+        }));
+
+        registerAppServerPermissionHandlers({
+            client: client as never,
+            permissionHandler: createPermissionHandlerStub() as never,
+            onMcpElicitationRequest
+        });
+
+        const handler = handlers.get('mcpServer/elicitation/request');
+        expect(handler).toBeTypeOf('function');
+
+        await expect(handler?.(request)).resolves.toEqual({
+            action: 'accept',
+            content: {
+                token: 'abc'
+            }
+        });
+        expect(onMcpElicitationRequest).toHaveBeenCalledWith(request);
+    });
+});

--- a/cli/src/codex/utils/appServerPermissionAdapter.ts
+++ b/cli/src/codex/utils/appServerPermissionAdapter.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { logger } from '@/ui/logger';
+import type { McpServerElicitationRequestParams, McpServerElicitationResponse } from '../appServerTypes';
 import type { CodexPermissionHandler } from './permissionHandler';
 import type { CodexAppServerClient } from '../codexAppServerClient';
 
@@ -38,8 +39,11 @@ export function registerAppServerPermissionHandlers(args: {
     client: CodexAppServerClient;
     permissionHandler: CodexPermissionHandler;
     onUserInputRequest?: (request: unknown) => Promise<Record<string, string[]>>;
+    onMcpElicitationRequest?: (
+        request: McpServerElicitationRequestParams
+    ) => Promise<McpServerElicitationResponse>;
 }): void {
-    const { client, permissionHandler, onUserInputRequest } = args;
+    const { client, permissionHandler, onUserInputRequest, onMcpElicitationRequest } = args;
 
     client.registerRequestHandler('item/commandExecution/requestApproval', async (params) => {
         const record = asRecord(params) ?? {};
@@ -90,5 +94,17 @@ export function registerAppServerPermissionHandlers(args: {
             decision: 'accept',
             answers
         };
+    });
+
+    client.registerRequestHandler('mcpServer/elicitation/request', async (params) => {
+        if (!onMcpElicitationRequest) {
+            logger.debug('[CodexAppServer] No MCP elicitation handler registered; cancelling request');
+            return {
+                action: 'cancel',
+                content: null
+            } satisfies McpServerElicitationResponse;
+        }
+
+        return await onMcpElicitationRequest(params as McpServerElicitationRequestParams);
     });
 }

--- a/cli/src/opencode/utils/startOpencodeHookServer.test.ts
+++ b/cli/src/opencode/utils/startOpencodeHookServer.test.ts
@@ -1,65 +1,100 @@
 import { describe, it, expect } from 'vitest'
-import { request } from 'node:http'
-import { startOpencodeHookServer } from './startOpencodeHookServer'
+import { Readable } from 'node:stream'
+import { createOpencodeHookRequestHandler } from './startOpencodeHookServer'
+
+class MockRequest extends Readable {
+    headers: Record<string, string | string[] | undefined>
+    method: string
+    url: string
+    private sent = false
+
+    constructor(opts: {
+        body: string
+        path?: string
+        token?: string
+    }) {
+        super()
+        this.method = 'POST'
+        this.url = opts.path ?? '/hook/opencode'
+        this.headers = {
+            'content-type': 'application/json',
+            'content-length': `${Buffer.byteLength(opts.body)}`
+        }
+        if (opts.token) {
+            this.headers['x-hapi-hook-token'] = opts.token
+        }
+        this.body = opts.body
+    }
+
+    private readonly body: string
+
+    _read(): void {
+        if (this.sent) {
+            this.push(null)
+            return
+        }
+        this.sent = true
+        this.push(Buffer.from(this.body, 'utf-8'))
+        this.push(null)
+    }
+}
+
+class MockResponse {
+    statusCode: number | undefined
+    headersSent = false
+    writableEnded = false
+    body = ''
+
+    writeHead(statusCode: number): this {
+        this.statusCode = statusCode
+        this.headersSent = true
+        return this
+    }
+
+    end(body?: string): this {
+        if (body) {
+            this.body += body
+        }
+        this.writableEnded = true
+        return this
+    }
+}
 
 const sendHookRequest = async (
-    port: number,
+    handler: ReturnType<typeof createOpencodeHookRequestHandler>,
     body: string,
     token?: string
 ): Promise<{ statusCode?: number; body: string }> => {
-    return await new Promise((resolve, reject) => {
-        const headers: Record<string, string | number> = {
-            'Content-Type': 'application/json',
-            'Content-Length': Buffer.byteLength(body)
-        }
-        if (token) {
-            headers['x-hapi-hook-token'] = token
-        }
+    const req = new MockRequest({ body, token })
+    const res = new MockResponse()
 
-        const req = request({
-            host: '127.0.0.1',
-            port,
-            path: '/hook/opencode',
-            method: 'POST',
-            headers
-        }, (res) => {
-            const chunks: Buffer[] = []
-            res.on('data', (chunk) => chunks.push(chunk as Buffer))
-            res.on('error', reject)
-            res.on('end', () => {
-                resolve({
-                    statusCode: res.statusCode,
-                    body: Buffer.concat(chunks).toString('utf-8')
-                })
-            })
-        })
+    await handler(req as never, res as never)
 
-        req.on('error', reject)
-        req.end(body)
-    })
+    return {
+        statusCode: res.statusCode,
+        body: res.body
+    }
 }
 
 describe('startOpencodeHookServer', () => {
     it('forwards hook payload to callback', async () => {
         let received: { event?: string; payload?: unknown; sessionId?: string } = {}
-        const server = await startOpencodeHookServer({
+        const token = 'test-hook-token'
+        const handler = createOpencodeHookRequestHandler({
+            token,
             onEvent: (event) => {
                 received = event
             }
         })
 
-        try {
-            const body = JSON.stringify({
-                event: 'message.updated',
-                payload: { message: 'ok' },
-                sessionId: 'session-123'
-            })
-            const response = await sendHookRequest(server.port, body, server.token)
-            expect(response.statusCode).toBe(200)
-        } finally {
-            server.stop()
-        }
+        const body = JSON.stringify({
+            event: 'message.updated',
+            payload: { message: 'ok' },
+            sessionId: 'session-123'
+        })
+        const response = await sendHookRequest(handler, body, token)
 
+        expect(response.statusCode).toBe(200)
         expect(received.event).toBe('message.updated')
         expect(received.sessionId).toBe('session-123')
         expect(received.payload).toEqual({ message: 'ok' })
@@ -67,60 +102,54 @@ describe('startOpencodeHookServer', () => {
 
     it('returns 400 for invalid JSON payloads', async () => {
         let hookCalled = false
-        const server = await startOpencodeHookServer({
+        const token = 'test-hook-token'
+        const handler = createOpencodeHookRequestHandler({
+            token,
             onEvent: () => {
                 hookCalled = true
             }
         })
 
-        try {
-            const response = await sendHookRequest(server.port, '{"event":', server.token)
-            expect(response.statusCode).toBe(400)
-            expect(response.body).toBe('invalid json')
-        } finally {
-            server.stop()
-        }
+        const response = await sendHookRequest(handler, '{"event":', token)
 
+        expect(response.statusCode).toBe(400)
+        expect(response.body).toBe('invalid json')
         expect(hookCalled).toBe(false)
     })
 
     it('returns 422 when event is missing', async () => {
         let hookCalled = false
-        const server = await startOpencodeHookServer({
+        const token = 'test-hook-token'
+        const handler = createOpencodeHookRequestHandler({
+            token,
             onEvent: () => {
                 hookCalled = true
             }
         })
 
-        try {
-            const body = JSON.stringify({ payload: { ok: true } })
-            const response = await sendHookRequest(server.port, body, server.token)
-            expect(response.statusCode).toBe(422)
-            expect(response.body).toBe('missing event')
-        } finally {
-            server.stop()
-        }
+        const body = JSON.stringify({ payload: { ok: true } })
+        const response = await sendHookRequest(handler, body, token)
 
+        expect(response.statusCode).toBe(422)
+        expect(response.body).toBe('missing event')
         expect(hookCalled).toBe(false)
     })
 
     it('returns 401 when hook token is missing', async () => {
         let hookCalled = false
-        const server = await startOpencodeHookServer({
+        const token = 'test-hook-token'
+        const handler = createOpencodeHookRequestHandler({
+            token,
             onEvent: () => {
                 hookCalled = true
             }
         })
 
-        try {
-            const body = JSON.stringify({ event: 'message.updated', payload: { ok: true } })
-            const response = await sendHookRequest(server.port, body)
-            expect(response.statusCode).toBe(401)
-            expect(response.body).toBe('unauthorized')
-        } finally {
-            server.stop()
-        }
+        const body = JSON.stringify({ event: 'message.updated', payload: { ok: true } })
+        const response = await sendHookRequest(handler, body)
 
+        expect(response.statusCode).toBe(401)
+        expect(response.body).toBe('unauthorized')
         expect(hookCalled).toBe(false)
     })
 })

--- a/cli/src/opencode/utils/startOpencodeHookServer.ts
+++ b/cli/src/opencode/utils/startOpencodeHookServer.ts
@@ -22,87 +22,102 @@ function readHookToken(req: IncomingMessage): string | null {
     return header ?? null;
 }
 
-export async function startOpencodeHookServer(options: OpencodeHookServerOptions): Promise<OpencodeHookServer> {
-    const hookToken = options.token || randomBytes(16).toString('hex');
+export function createOpencodeHookRequestHandler(options: {
+    onEvent: (event: OpencodeHookEvent) => void;
+    token: string;
+}): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+    const { onEvent, token: hookToken } = options;
 
-    return new Promise((resolve, reject) => {
-        const server: Server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-            const requestPath = req.url?.split('?')[0];
-            if (req.method === 'POST' && requestPath === '/hook/opencode') {
-                const providedToken = readHookToken(req);
-                if (providedToken !== hookToken) {
-                    logger.debug('[opencode-hook] Unauthorized hook request');
-                    res.writeHead(401, { 'Content-Type': 'text/plain' }).end('unauthorized');
-                    req.resume();
-                    return;
-                }
-
-                let timedOut = false;
-                const timeout = setTimeout(() => {
-                    timedOut = true;
-                    if (!res.headersSent) {
-                        logger.debug('[opencode-hook] Request timeout');
-                        res.writeHead(408).end('timeout');
-                    }
-                    req.destroy(new Error('Request timeout'));
-                }, 5000);
-
-                try {
-                    const chunks: Buffer[] = [];
-                    for await (const chunk of req) {
-                        chunks.push(chunk as Buffer);
-                    }
-                    clearTimeout(timeout);
-
-                    if (timedOut || res.headersSent || res.writableEnded) {
-                        return;
-                    }
-
-                    const body = Buffer.concat(chunks).toString('utf-8');
-                    logger.debug('[opencode-hook] Received hook:', body);
-
-                    let data: Record<string, unknown> = {};
-                    try {
-                        const parsed = JSON.parse(body);
-                        if (!parsed || typeof parsed !== 'object') {
-                            logger.debug('[opencode-hook] Parsed hook data is not an object');
-                            res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
-                            return;
-                        }
-                        data = parsed as Record<string, unknown>;
-                    } catch (parseError) {
-                        logger.debug('[opencode-hook] Failed to parse hook data as JSON:', parseError);
-                        res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
-                        return;
-                    }
-
-                    const eventValue = data.event;
-                    if (typeof eventValue !== 'string' || eventValue.length === 0) {
-                        res.writeHead(422, { 'Content-Type': 'text/plain' }).end('missing event');
-                        return;
-                    }
-
-                    const payload = data.payload;
-                    const sessionId = typeof data.sessionId === 'string' ? data.sessionId : undefined;
-                    options.onEvent({ event: eventValue, payload, sessionId });
-
-                    if (!res.headersSent && !res.writableEnded) {
-                        res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ok');
-                    }
-                } catch (error) {
-                    clearTimeout(timeout);
-                    if (timedOut) {
-                        return;
-                    }
-                    logger.debug('[opencode-hook] Error handling hook:', error);
-                    if (!res.headersSent && !res.writableEnded) {
-                        res.writeHead(500).end('error');
-                    }
-                }
+    return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+        const requestPath = req.url?.split('?')[0];
+        if (req.method === 'POST' && requestPath === '/hook/opencode') {
+            const providedToken = readHookToken(req);
+            if (providedToken !== hookToken) {
+                logger.debug('[opencode-hook] Unauthorized hook request');
+                res.writeHead(401, { 'Content-Type': 'text/plain' }).end('unauthorized');
+                req.resume();
                 return;
             }
 
-            res.writeHead(404).end('not found');
+            let timedOut = false;
+            const timeout = setTimeout(() => {
+                timedOut = true;
+                if (!res.headersSent) {
+                    logger.debug('[opencode-hook] Request timeout');
+                    res.writeHead(408).end('timeout');
+                }
+                req.destroy(new Error('Request timeout'));
+            }, 5000);
+
+            try {
+                const chunks: Buffer[] = [];
+                for await (const chunk of req) {
+                    chunks.push(chunk as Buffer);
+                }
+                clearTimeout(timeout);
+
+                if (timedOut || res.headersSent || res.writableEnded) {
+                    return;
+                }
+
+                const body = Buffer.concat(chunks).toString('utf-8');
+                logger.debug('[opencode-hook] Received hook:', body);
+
+                let data: Record<string, unknown> = {};
+                try {
+                    const parsed = JSON.parse(body);
+                    if (!parsed || typeof parsed !== 'object') {
+                        logger.debug('[opencode-hook] Parsed hook data is not an object');
+                        res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
+                        return;
+                    }
+                    data = parsed as Record<string, unknown>;
+                } catch (parseError) {
+                    logger.debug('[opencode-hook] Failed to parse hook data as JSON:', parseError);
+                    res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
+                    return;
+                }
+
+                const eventValue = data.event;
+                if (typeof eventValue !== 'string' || eventValue.length === 0) {
+                    res.writeHead(422, { 'Content-Type': 'text/plain' }).end('missing event');
+                    return;
+                }
+
+                const payload = data.payload;
+                const sessionId = typeof data.sessionId === 'string' ? data.sessionId : undefined;
+                onEvent({ event: eventValue, payload, sessionId });
+
+                if (!res.headersSent && !res.writableEnded) {
+                    res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ok');
+                }
+            } catch (error) {
+                clearTimeout(timeout);
+                if (timedOut) {
+                    return;
+                }
+                logger.debug('[opencode-hook] Error handling hook:', error);
+                if (!res.headersSent && !res.writableEnded) {
+                    res.writeHead(500).end('error');
+                }
+            }
+            return;
+        }
+
+        res.writeHead(404).end('not found');
+    };
+}
+
+export async function startOpencodeHookServer(options: OpencodeHookServerOptions): Promise<OpencodeHookServer> {
+    const hookToken = options.token || randomBytes(16).toString('hex');
+    const handleRequest = createOpencodeHookRequestHandler({
+        onEvent: options.onEvent,
+        token: hookToken
+    });
+
+    return new Promise((resolve, reject) => {
+        const server: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
+            void handleRequest(req, res);
         });
 
         server.listen(0, '127.0.0.1', () => {

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -1,4 +1,5 @@
 import type { CodexCollaborationMode, PermissionMode } from '@hapi/protocol/types'
+import type { McpElicitationAction } from '@hapi/protocol/types'
 import type { Server } from 'socket.io'
 import type { RpcRegistry } from '../socket/rpcRegistry'
 
@@ -78,6 +79,19 @@ export class RpcGateway {
             id: requestId,
             approved: false,
             decision
+        })
+    }
+
+    async respondToMcpElicitation(
+        sessionId: string,
+        requestId: string,
+        action: McpElicitationAction,
+        content?: unknown | null
+    ): Promise<void> {
+        await this.sessionRpc(sessionId, 'mcp-elicitation-response', {
+            id: requestId,
+            action,
+            content: content ?? null
         })
     }
 

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CodexCollaborationMode, DecryptedMessage, PermissionMode, Session, SyncEvent } from '@hapi/protocol/types'
+import type { McpElicitationAction } from '@hapi/protocol/types'
 import type { Server } from 'socket.io'
 import type { Store } from '../store'
 import type { RpcRegistry } from '../socket/rpcRegistry'
@@ -263,6 +264,15 @@ export class SyncEngine {
         decision?: 'approved' | 'approved_for_session' | 'denied' | 'abort'
     ): Promise<void> {
         await this.rpcGateway.denyPermission(sessionId, requestId, decision)
+    }
+
+    async respondToMcpElicitation(
+        sessionId: string,
+        requestId: string,
+        action: McpElicitationAction,
+        content?: unknown | null
+    ): Promise<void> {
+        await this.rpcGateway.respondToMcpElicitation(sessionId, requestId, action, content)
     }
 
     async abortSession(sessionId: string): Promise<void> {

--- a/hub/src/web/routes/mcpElicitation.ts
+++ b/hub/src/web/routes/mcpElicitation.ts
@@ -1,0 +1,39 @@
+import { McpElicitationResponseSchema } from '@hapi/protocol/schemas'
+import { Hono } from 'hono'
+import type { SyncEngine } from '../../sync/syncEngine'
+import type { WebAppEnv } from '../middleware/auth'
+import { requireSessionFromParam, requireSyncEngine } from './guards'
+
+export function createMcpElicitationRoutes(getSyncEngine: () => SyncEngine | null): Hono<WebAppEnv> {
+    const app = new Hono<WebAppEnv>()
+
+    app.post('/sessions/:id/mcp-elicitation/:requestId/respond', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+
+        const requestId = c.req.param('requestId')
+        const json = await c.req.json().catch(() => null)
+        const parsed = McpElicitationResponseSchema.omit({ id: true }).safeParse(json ?? {})
+        if (!parsed.success) {
+            return c.json({ error: 'Invalid body' }, 400)
+        }
+
+        await engine.respondToMcpElicitation(
+            sessionResult.sessionId,
+            requestId,
+            parsed.data.action,
+            parsed.data.content ?? null
+        )
+
+        return c.json({ ok: true })
+    })
+
+    return app
+}

--- a/hub/src/web/server.ts
+++ b/hub/src/web/server.ts
@@ -14,6 +14,7 @@ import { createEventsRoutes } from './routes/events'
 import { createSessionsRoutes } from './routes/sessions'
 import { createMessagesRoutes } from './routes/messages'
 import { createPermissionsRoutes } from './routes/permissions'
+import { createMcpElicitationRoutes } from './routes/mcpElicitation'
 import { createMachinesRoutes } from './routes/machines'
 import { createGitRoutes } from './routes/git'
 import { createCliRoutes } from './routes/cli'
@@ -93,6 +94,7 @@ function createWebApp(options: {
     app.route('/api', createSessionsRoutes(options.getSyncEngine))
     app.route('/api', createMessagesRoutes(options.getSyncEngine))
     app.route('/api', createPermissionsRoutes(options.getSyncEngine))
+    app.route('/api', createMcpElicitationRoutes(options.getSyncEngine))
     app.route('/api', createMachinesRoutes(options.getSyncEngine))
     app.route('/api', createGitRoutes(options.getSyncEngine))
     app.route('/api', createPushRoutes(options.store, options.vapidPublicKey))

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -87,6 +87,17 @@ export const AgentStateSchema = z.object({
 
 export type AgentState = z.infer<typeof AgentStateSchema>
 
+export const McpElicitationActionSchema = z.enum(['accept', 'decline', 'cancel'])
+export type McpElicitationAction = z.infer<typeof McpElicitationActionSchema>
+
+export const McpElicitationResponseSchema = z.object({
+    id: z.string(),
+    action: McpElicitationActionSchema,
+    content: z.unknown().nullish()
+})
+
+export type McpElicitationResponse = z.infer<typeof McpElicitationResponseSchema>
+
 export const TodoItemSchema = z.object({
     content: z.string(),
     status: z.enum(['pending', 'in_progress', 'completed']),

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -5,6 +5,8 @@ export type {
     AttachmentMetadata,
     DecryptedMessage,
     Metadata,
+    McpElicitationAction,
+    McpElicitationResponse,
     Session,
     SyncEvent,
     TeamMember,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
     GitCommandResponse,
     MachinePathsExistsResponse,
     MachinesResponse,
+    McpElicitationAction,
     MessagesResponse,
     PermissionMode,
     PushSubscriptionPayload,
@@ -363,6 +364,20 @@ export class ApiClient {
         await this.request(`/api/sessions/${encodeURIComponent(sessionId)}/permissions/${encodeURIComponent(requestId)}/deny`, {
             method: 'POST',
             body: JSON.stringify(options ?? {})
+        })
+    }
+
+    async respondToMcpElicitation(
+        sessionId: string,
+        requestId: string,
+        payload: {
+            action: McpElicitationAction
+            content?: unknown | null
+        }
+    ): Promise<void> {
+        await this.request(`/api/sessions/${encodeURIComponent(sessionId)}/mcp-elicitation/${encodeURIComponent(requestId)}/respond`, {
+            method: 'POST',
+            body: JSON.stringify(payload)
         })
     }
 

--- a/web/src/chat/normalizeAgent.ts
+++ b/web/src/chat/normalizeAgent.ts
@@ -372,7 +372,7 @@ export function normalizeAgentRecord(
                     type: 'tool-result',
                     tool_use_id: data.callId,
                     content: data.output,
-                    is_error: false,
+                    is_error: Boolean(data.is_error),
                     uuid,
                     parentUUID: null
                 }],

--- a/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
+++ b/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { ApiClient } from '@/api/client'
+import type { ChatToolCall } from '@/chat/types'
+import { CodeBlock } from '@/components/CodeBlock'
+import { Spinner } from '@/components/Spinner'
+import {
+    isCodexMcpElicitationToolName,
+    parseCodexMcpElicitationInput
+} from '@/components/ToolCard/codexMcpElicitation'
+import { usePlatform } from '@/hooks/usePlatform'
+
+function ActionButton(props: {
+    label: string
+    tone: 'allow' | 'deny' | 'neutral'
+    loading?: boolean
+    disabled: boolean
+    onClick: () => void
+}) {
+    const base = 'flex w-full items-center justify-between rounded-md px-2 py-2 text-sm text-left transition-colors disabled:pointer-events-none disabled:opacity-50 hover:bg-[var(--app-subtle-bg)]'
+    const tone = props.tone === 'allow'
+        ? 'text-emerald-600'
+        : props.tone === 'deny'
+            ? 'text-red-600'
+            : 'text-[var(--app-link)]'
+
+    return (
+        <button
+            type="button"
+            className={`${base} ${tone}`}
+            disabled={props.disabled}
+            aria-busy={props.loading === true}
+            onClick={props.onClick}
+        >
+            <span className="flex-1">{props.label}</span>
+            {props.loading ? (
+                <span className="ml-2 shrink-0">
+                    <Spinner size="sm" label={null} className="text-current" />
+                </span>
+            ) : null}
+        </button>
+    )
+}
+
+export function CodexMcpElicitationFooter(props: {
+    api: ApiClient
+    sessionId: string
+    tool: ChatToolCall
+    disabled: boolean
+    onDone: () => void
+}) {
+    const { haptic } = usePlatform()
+    const parsed = useMemo(() => parseCodexMcpElicitationInput(props.tool.input), [props.tool.input])
+    const [jsonContent, setJsonContent] = useState('{}')
+    const [loading, setLoading] = useState<'accept' | 'decline' | 'cancel' | null>(null)
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        setLoading(null)
+        setError(null)
+        setJsonContent('{}')
+    }, [props.tool.id])
+
+    if (!isCodexMcpElicitationToolName(props.tool.name)) return null
+    if (!parsed) return null
+    if (props.tool.state !== 'running' && props.tool.state !== 'pending') return null
+
+    const run = async (action: () => Promise<void>) => {
+        if (props.disabled) return
+        setError(null)
+        try {
+            await action()
+            haptic.notification('success')
+            props.onDone()
+        } catch (e) {
+            haptic.notification('error')
+            setError(e instanceof Error ? e.message : 'Request failed')
+        }
+    }
+
+    const submitAccept = async () => {
+        if (loading) return
+        setLoading('accept')
+
+        let content: unknown | null = null
+        if (parsed.mode === 'form') {
+            try {
+                content = JSON.parse(jsonContent)
+            } catch {
+                setLoading(null)
+                setError('Form content must be valid JSON')
+                return
+            }
+        }
+
+        await run(() => props.api.respondToMcpElicitation(props.sessionId, parsed.requestId, {
+            action: 'accept',
+            content
+        }))
+        setLoading(null)
+    }
+
+    const submitSimple = async (action: 'decline' | 'cancel') => {
+        if (loading) return
+        setLoading(action)
+        await run(() => props.api.respondToMcpElicitation(props.sessionId, parsed.requestId, {
+            action,
+            content: null
+        }))
+        setLoading(null)
+    }
+
+    return (
+        <div className="mt-3 rounded-lg border border-[var(--app-border)] bg-[var(--app-bg)] p-3">
+            <div className="text-xs text-[var(--app-hint)]">
+                MCP elicitation request from {parsed.serverName}
+            </div>
+
+            {parsed.message ? (
+                <div className="mt-2 text-sm text-[var(--app-fg)] whitespace-pre-wrap">
+                    {parsed.message}
+                </div>
+            ) : null}
+
+            {parsed.mode === 'form' ? (
+                <div className="mt-3 flex flex-col gap-2">
+                    <div className="text-xs font-medium text-[var(--app-hint)]">Schema</div>
+                    <CodeBlock code={JSON.stringify(parsed.requestedSchema, null, 2)} language="json" />
+                    <div className="text-xs font-medium text-[var(--app-hint)]">Content JSON</div>
+                    <textarea
+                        value={jsonContent}
+                        onChange={(e) => setJsonContent(e.target.value)}
+                        disabled={props.disabled || loading !== null}
+                        spellCheck={false}
+                        className="min-h-[120px] w-full resize-y rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-2 font-mono text-sm text-[var(--app-fg)] focus:outline-none focus:ring-2 focus:ring-[var(--app-button)] focus:border-transparent disabled:opacity-50"
+                    />
+                </div>
+            ) : (
+                <div className="mt-3">
+                    <a
+                        href={parsed.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-[var(--app-link)] underline break-all"
+                    >
+                        {parsed.url}
+                    </a>
+                </div>
+            )}
+
+            {error ? (
+                <div className="mt-2 text-xs text-red-600">
+                    {error}
+                </div>
+            ) : null}
+
+            <div className="mt-3 flex flex-col gap-1">
+                <ActionButton
+                    label={parsed.mode === 'url' ? 'Open and continue' : 'Submit'}
+                    tone="allow"
+                    loading={loading === 'accept'}
+                    disabled={props.disabled || loading !== null}
+                    onClick={submitAccept}
+                />
+                <ActionButton
+                    label="Decline"
+                    tone="neutral"
+                    loading={loading === 'decline'}
+                    disabled={props.disabled || loading !== null}
+                    onClick={() => submitSimple('decline')}
+                />
+                <ActionButton
+                    label="Cancel"
+                    tone="deny"
+                    loading={loading === 'cancel'}
+                    disabled={props.disabled || loading !== null}
+                    onClick={() => submitSimple('cancel')}
+                />
+            </div>
+        </div>
+    )
+}

--- a/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
+++ b/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { ApiClient } from '@/api/client'
 import type { ChatToolCall } from '@/chat/types'
-import { CodeBlock } from '@/components/CodeBlock'
 import { Spinner } from '@/components/Spinner'
 import {
     isCodexMcpElicitationToolName,
@@ -50,14 +49,12 @@ export function CodexMcpElicitationFooter(props: {
 }) {
     const { haptic } = usePlatform()
     const parsed = useMemo(() => parseCodexMcpElicitationInput(props.tool.input), [props.tool.input])
-    const [jsonContent, setJsonContent] = useState('{}')
     const [loading, setLoading] = useState<'accept' | 'decline' | 'cancel' | null>(null)
     const [error, setError] = useState<string | null>(null)
 
     useEffect(() => {
         setLoading(null)
         setError(null)
-        setJsonContent('{}')
     }, [props.tool.id])
 
     if (!isCodexMcpElicitationToolName(props.tool.name)) return null
@@ -83,13 +80,7 @@ export function CodexMcpElicitationFooter(props: {
 
         let content: unknown | null = null
         if (parsed.mode === 'form') {
-            try {
-                content = JSON.parse(jsonContent)
-            } catch {
-                setLoading(null)
-                setError('Form content must be valid JSON')
-                return
-            }
+            content = {}
         }
 
         await run(() => props.api.respondToMcpElicitation(props.sessionId, parsed.requestId, {
@@ -111,49 +102,13 @@ export function CodexMcpElicitationFooter(props: {
 
     return (
         <div className="mt-3 rounded-lg border border-[var(--app-border)] bg-[var(--app-bg)] p-3">
-            <div className="text-xs text-[var(--app-hint)]">
-                MCP elicitation request from {parsed.serverName}
-            </div>
-
-            {parsed.message ? (
-                <div className="mt-2 text-sm text-[var(--app-fg)] whitespace-pre-wrap">
-                    {parsed.message}
-                </div>
-            ) : null}
-
-            {parsed.mode === 'form' ? (
-                <div className="mt-3 flex flex-col gap-2">
-                    <div className="text-xs font-medium text-[var(--app-hint)]">Schema</div>
-                    <CodeBlock code={JSON.stringify(parsed.requestedSchema, null, 2)} language="json" />
-                    <div className="text-xs font-medium text-[var(--app-hint)]">Content JSON</div>
-                    <textarea
-                        value={jsonContent}
-                        onChange={(e) => setJsonContent(e.target.value)}
-                        disabled={props.disabled || loading !== null}
-                        spellCheck={false}
-                        className="min-h-[120px] w-full resize-y rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-2 font-mono text-sm text-[var(--app-fg)] focus:outline-none focus:ring-2 focus:ring-[var(--app-button)] focus:border-transparent disabled:opacity-50"
-                    />
-                </div>
-            ) : (
-                <div className="mt-3">
-                    <a
-                        href={parsed.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sm text-[var(--app-link)] underline break-all"
-                    >
-                        {parsed.url}
-                    </a>
-                </div>
-            )}
-
             {error ? (
-                <div className="mt-2 text-xs text-red-600">
+                <div className="mb-2 text-xs text-red-600">
                     {error}
                 </div>
             ) : null}
 
-            <div className="mt-3 flex flex-col gap-1">
+            <div className="flex flex-col gap-1">
                 <ActionButton
                     label={parsed.mode === 'url' ? 'Open and continue' : 'Submit'}
                     tone="allow"

--- a/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
+++ b/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
@@ -49,7 +49,7 @@ export function CodexMcpElicitationFooter(props: {
 }) {
     const { haptic } = usePlatform()
     const parsed = useMemo(() => parseCodexMcpElicitationInput(props.tool.input), [props.tool.input])
-    const [loading, setLoading] = useState<'accept' | 'decline' | 'cancel' | null>(null)
+    const [loading, setLoading] = useState<'accept' | 'decline' | null>(null)
     const [error, setError] = useState<string | null>(null)
 
     useEffect(() => {
@@ -90,11 +90,11 @@ export function CodexMcpElicitationFooter(props: {
         setLoading(null)
     }
 
-    const submitSimple = async (action: 'decline' | 'cancel') => {
+    const submitDecline = async () => {
         if (loading) return
-        setLoading(action)
+        setLoading('decline')
         await run(() => props.api.respondToMcpElicitation(props.sessionId, parsed.requestId, {
-            action,
+            action: 'decline',
             content: null
         }))
         setLoading(null)
@@ -121,14 +121,7 @@ export function CodexMcpElicitationFooter(props: {
                     tone="neutral"
                     loading={loading === 'decline'}
                     disabled={props.disabled || loading !== null}
-                    onClick={() => submitSimple('decline')}
-                />
-                <ActionButton
-                    label="Cancel"
-                    tone="deny"
-                    loading={loading === 'cancel'}
-                    disabled={props.disabled || loading !== null}
-                    onClick={() => submitSimple('cancel')}
+                    onClick={submitDecline}
                 />
             </div>
         </div>

--- a/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
+++ b/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
@@ -3,8 +3,12 @@ import type { ApiClient } from '@/api/client'
 import type { ChatToolCall } from '@/chat/types'
 import { Spinner } from '@/components/Spinner'
 import {
+    buildCodexMcpElicitationFormContent,
+    createCodexMcpElicitationFormState,
     isCodexMcpElicitationToolName,
-    parseCodexMcpElicitationInput
+    normalizeCodexMcpElicitationFormSchema,
+    parseCodexMcpElicitationInput,
+    type CodexMcpElicitationFormField
 } from '@/components/ToolCard/codexMcpElicitation'
 import { usePlatform } from '@/hooks/usePlatform'
 
@@ -49,13 +53,21 @@ export function CodexMcpElicitationFooter(props: {
 }) {
     const { haptic } = usePlatform()
     const parsed = useMemo(() => parseCodexMcpElicitationInput(props.tool.input), [props.tool.input])
+    const formSchema = useMemo(() => {
+        if (!parsed || parsed.mode !== 'form') {
+            return null
+        }
+        return normalizeCodexMcpElicitationFormSchema(parsed.requestedSchema)
+    }, [parsed])
     const [loading, setLoading] = useState<'accept' | 'decline' | null>(null)
     const [error, setError] = useState<string | null>(null)
+    const [formState, setFormState] = useState<Record<string, string | boolean | null>>({})
 
     useEffect(() => {
         setLoading(null)
         setError(null)
-    }, [props.tool.id])
+        setFormState(formSchema ? createCodexMcpElicitationFormState(formSchema) : {})
+    }, [props.tool.id, formSchema])
 
     if (!isCodexMcpElicitationToolName(props.tool.name)) return null
     if (!parsed) return null
@@ -74,34 +86,149 @@ export function CodexMcpElicitationFooter(props: {
         }
     }
 
+    const updateField = (key: string, value: string | boolean | null) => {
+        setError(null)
+        setFormState((prev) => ({
+            ...prev,
+            [key]: value
+        }))
+    }
+
     const submitAccept = async () => {
         if (loading) return
-        setLoading('accept')
 
         let content: unknown | null = null
         if (parsed.mode === 'form') {
-            content = {}
+            if (!formSchema) {
+                haptic.notification('error')
+                setError('This MCP request requires a form schema before it can be submitted')
+                return
+            }
+
+            const submission = buildCodexMcpElicitationFormContent(formSchema, formState)
+            if (!submission.ok) {
+                haptic.notification('error')
+                setError(submission.error)
+                return
+            }
+
+            content = submission.content
         }
 
-        await run(() => props.api.respondToMcpElicitation(props.sessionId, parsed.requestId, {
-            action: 'accept',
-            content
-        }))
-        setLoading(null)
+        setLoading('accept')
+        try {
+            await run(() => props.api.respondToMcpElicitation(props.sessionId, parsed.requestId, {
+                action: 'accept',
+                content
+            }))
+        } finally {
+            setLoading(null)
+        }
     }
 
     const submitDecline = async () => {
         if (loading) return
         setLoading('decline')
-        await run(() => props.api.respondToMcpElicitation(props.sessionId, parsed.requestId, {
-            action: 'decline',
-            content: null
-        }))
-        setLoading(null)
+        try {
+            await run(() => props.api.respondToMcpElicitation(props.sessionId, parsed.requestId, {
+                action: 'decline',
+                content: null
+            }))
+        } finally {
+            setLoading(null)
+        }
     }
+
+    const renderField = (field: CodexMcpElicitationFormField) => {
+        const fieldId = `codex-mcp-elicitation-${parsed.requestId}-${field.key}`
+        const commonClassName = 'w-full rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-2 text-sm text-[var(--app-fg)] focus:border-transparent focus:outline-none focus:ring-2 focus:ring-[var(--app-button)] disabled:opacity-50'
+        const draftValue = formState[field.key]
+
+        return (
+            <div key={field.key} className="flex flex-col gap-1">
+                <label htmlFor={fieldId} className="text-xs font-medium text-[var(--app-hint)]">
+                    {field.label}
+                    {field.required ? ' *' : ''}
+                </label>
+                {field.description ? (
+                    <div className="text-xs text-[var(--app-hint)]">
+                        {field.description}
+                    </div>
+                ) : null}
+
+                {field.kind === 'boolean' ? (
+                    <div className="rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-2">
+                        <input
+                            id={fieldId}
+                            type="checkbox"
+                            className="h-4 w-4 rounded border-[var(--app-border)]"
+                            checked={draftValue === true}
+                            disabled={props.disabled || loading !== null}
+                            onChange={(e) => updateField(field.key, e.target.checked)}
+                        />
+                    </div>
+                ) : field.kind === 'enum' ? (
+                    <select
+                        id={fieldId}
+                        value={typeof draftValue === 'string' ? draftValue : ''}
+                        disabled={props.disabled || loading !== null}
+                        onChange={(e) => updateField(field.key, e.target.value)}
+                        className={commonClassName}
+                    >
+                        <option value="">Select an option</option>
+                        {field.options.map((option, index) => (
+                            <option key={`${field.key}-${index}`} value={`${index}`}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                ) : field.kind === 'json' ? (
+                    <textarea
+                        id={fieldId}
+                        value={typeof draftValue === 'string' ? draftValue : ''}
+                        disabled={props.disabled || loading !== null}
+                        onChange={(e) => updateField(field.key, e.target.value)}
+                        placeholder='{"key":"value"}'
+                        className={`${commonClassName} min-h-[88px] resize-y font-mono`}
+                    />
+                ) : (
+                    <input
+                        id={fieldId}
+                        type={field.kind === 'string' ? 'text' : 'number'}
+                        step={field.kind === 'integer' ? '1' : 'any'}
+                        value={typeof draftValue === 'string' ? draftValue : ''}
+                        disabled={props.disabled || loading !== null}
+                        onChange={(e) => updateField(field.key, e.target.value)}
+                        className={commonClassName}
+                    />
+                )}
+            </div>
+        )
+    }
+
+    const showsUnsupportedFormNotice = parsed.mode === 'form' && formSchema?.kind === 'unsupported'
+    const unsupportedFormReason = formSchema?.kind === 'unsupported' ? formSchema.reason : null
+    const formFields = parsed.mode === 'form' && formSchema?.kind === 'object'
+        ? formSchema.fields
+        : []
+    const acceptDisabled = props.disabled
+        || loading !== null
+        || showsUnsupportedFormNotice
 
     return (
         <div className="mt-3 rounded-lg border border-[var(--app-border)] bg-[var(--app-bg)] p-3">
+            {showsUnsupportedFormNotice ? (
+                <div className="mb-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700">
+                    {unsupportedFormReason}
+                </div>
+            ) : null}
+
+            {formFields.length > 0 ? (
+                <div className="mb-3 flex flex-col gap-3">
+                    {formFields.map((field) => renderField(field))}
+                </div>
+            ) : null}
+
             {error ? (
                 <div className="mb-2 text-xs text-red-600">
                     {error}
@@ -113,7 +240,7 @@ export function CodexMcpElicitationFooter(props: {
                     label={parsed.mode === 'url' ? 'Open and continue' : 'Submit'}
                     tone="allow"
                     loading={loading === 'accept'}
-                    disabled={props.disabled || loading !== null}
+                    disabled={acceptDisabled}
                     onClick={submitAccept}
                 />
                 <ActionButton

--- a/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
+++ b/web/src/components/ToolCard/CodexMcpElicitationFooter.tsx
@@ -67,7 +67,7 @@ export function CodexMcpElicitationFooter(props: {
         setLoading(null)
         setError(null)
         setFormState(formSchema ? createCodexMcpElicitationFormState(formSchema) : {})
-    }, [props.tool.id, formSchema])
+    }, [props.tool.id])
 
     if (!isCodexMcpElicitationToolName(props.tool.name)) return null
     if (!parsed) return null
@@ -113,6 +113,9 @@ export function CodexMcpElicitationFooter(props: {
             }
 
             content = submission.content
+        }
+        if (parsed.mode === 'url') {
+            window.open(parsed.url, '_blank', 'noopener,noreferrer')
         }
 
         setLoading('accept')

--- a/web/src/components/ToolCard/ToolCard.tsx
+++ b/web/src/components/ToolCard/ToolCard.tsx
@@ -11,7 +11,9 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { PermissionFooter } from '@/components/ToolCard/PermissionFooter'
 import { AskUserQuestionFooter } from '@/components/ToolCard/AskUserQuestionFooter'
 import { RequestUserInputFooter } from '@/components/ToolCard/RequestUserInputFooter'
+import { CodexMcpElicitationFooter } from '@/components/ToolCard/CodexMcpElicitationFooter'
 import { isAskUserQuestionToolName } from '@/components/ToolCard/askUserQuestion'
+import { isCodexMcpElicitationToolName } from '@/components/ToolCard/codexMcpElicitation'
 import { isRequestUserInputToolName } from '@/components/ToolCard/requestUserInput'
 import { getToolPresentation } from '@/components/ToolCard/knownTools'
 import { getToolFullViewComponent, getToolViewComponent } from '@/components/ToolCard/views/_all'
@@ -313,12 +315,16 @@ function ToolCardInner(props: ToolCardProps) {
     const permission = props.block.tool.permission
     const isAskUserQuestion = isAskUserQuestionToolName(toolName)
     const isRequestUserInput = isRequestUserInputToolName(toolName)
+    const isCodexMcpElicitation = isCodexMcpElicitationToolName(toolName)
     const isQuestionTool = isAskUserQuestion || isRequestUserInput
+    const showsMcpElicitationFooter = isCodexMcpElicitation && (
+        props.block.tool.state === 'pending' || props.block.tool.state === 'running'
+    )
     const showsPermissionFooter = Boolean(permission && (
         permission.status === 'pending'
         || ((permission.status === 'denied' || permission.status === 'canceled') && Boolean(permission.reason))
     ))
-    const hasBody = showInline || taskSummary !== null || showsPermissionFooter
+    const hasBody = showInline || taskSummary !== null || showsPermissionFooter || showsMcpElicitationFooter
     const stateColor = statusColorClass(props.block.tool.state)
     const { suppressFocusRing, onTriggerPointerDown, onTriggerKeyDown, onTriggerBlur } = usePointerFocusRing()
 
@@ -442,6 +448,14 @@ function ToolCardInner(props: ToolCardProps) {
                         />
                     ) : isRequestUserInput && permission?.status === 'pending' ? (
                         <RequestUserInputFooter
+                            api={props.api}
+                            sessionId={props.sessionId}
+                            tool={props.block.tool}
+                            disabled={props.disabled}
+                            onDone={props.onDone}
+                        />
+                    ) : isCodexMcpElicitation ? (
+                        <CodexMcpElicitationFooter
                             api={props.api}
                             sessionId={props.sessionId}
                             tool={props.block.tool}

--- a/web/src/components/ToolCard/codexMcpElicitation.test.tsx
+++ b/web/src/components/ToolCard/codexMcpElicitation.test.tsx
@@ -6,8 +6,10 @@ import { CodexMcpElicitationFooter } from '@/components/ToolCard/CodexMcpElicita
 import {
     buildCodexMcpElicitationFormContent,
     createCodexMcpElicitationFormState,
-    normalizeCodexMcpElicitationFormSchema
+    normalizeCodexMcpElicitationFormSchema,
+    parseCodexMcpElicitationInput
 } from '@/components/ToolCard/codexMcpElicitation'
+import { I18nProvider } from '@/lib/i18n-context'
 
 const platformMocks = vi.hoisted(() => ({
     impact: vi.fn(),
@@ -34,6 +36,24 @@ function makeTool(input: unknown): ChatToolCall {
         completedAt: null,
         description: null
     }
+}
+
+function renderFooter(props: {
+    api: ApiClient
+    tool: ChatToolCall
+    onDone?: () => void
+}) {
+    return render(
+        <I18nProvider>
+            <CodexMcpElicitationFooter
+                api={props.api}
+                sessionId="session-1"
+                tool={props.tool}
+                disabled={false}
+                onDone={props.onDone ?? (() => {})}
+            />
+        </I18nProvider>
+    )
 }
 
 const formInput = {
@@ -123,6 +143,21 @@ describe('normalizeCodexMcpElicitationFormSchema', () => {
             reason: expect.stringContaining('Only object forms are supported')
         })
     })
+
+    it('extracts tool metadata from _meta payload', () => {
+        expect(parseCodexMcpElicitationInput({
+            ...formInput,
+            _meta: {
+                tool_title: 'Demo Tool',
+                tool_description: 'Collect a token'
+            }
+        })).toMatchObject({
+            meta: {
+                toolTitle: 'Demo Tool',
+                toolDescription: 'Collect a token'
+            }
+        })
+    })
 })
 
 describe('buildCodexMcpElicitationFormContent', () => {
@@ -179,15 +214,11 @@ describe('CodexMcpElicitationFooter', () => {
             respondToMcpElicitation
         } as unknown as ApiClient
 
-        render(
-            <CodexMcpElicitationFooter
-                api={api}
-                sessionId="session-1"
-                tool={makeTool(formInput)}
-                disabled={false}
-                onDone={onDone}
-            />
-        )
+        renderFooter({
+            api,
+            tool: makeTool(formInput),
+            onDone
+        })
 
         fireEvent.change(screen.getByLabelText(/Access token/i), { target: { value: 'abc' } })
         fireEvent.change(screen.getByLabelText(/Count/i), { target: { value: '3' } })
@@ -218,34 +249,31 @@ describe('CodexMcpElicitationFooter', () => {
             respondToMcpElicitation: vi.fn().mockResolvedValue(undefined)
         } as unknown as ApiClient
 
-        const rendered = render(
-            <CodexMcpElicitationFooter
-                api={api}
-                sessionId="session-1"
-                tool={makeTool(formInput)}
-                disabled={false}
-                onDone={() => {}}
-            />
-        )
+        const rendered = renderFooter({
+            api,
+            tool: makeTool(formInput)
+        })
 
         fireEvent.change(screen.getByLabelText(/Access token/i), { target: { value: 'draft-token' } })
 
         rendered.rerender(
-            <CodexMcpElicitationFooter
-                api={api}
-                sessionId="session-1"
-                tool={makeTool({
-                    ...formInput,
-                    requestedSchema: {
-                        ...formInput.requestedSchema,
-                        properties: {
-                            ...formInput.requestedSchema.properties
+            <I18nProvider>
+                <CodexMcpElicitationFooter
+                    api={api}
+                    sessionId="session-1"
+                    tool={makeTool({
+                        ...formInput,
+                        requestedSchema: {
+                            ...formInput.requestedSchema,
+                            properties: {
+                                ...formInput.requestedSchema.properties
+                            }
                         }
-                    }
-                })}
-                disabled={false}
-                onDone={() => {}}
-            />
+                    })}
+                    disabled={false}
+                    onDone={() => {}}
+                />
+            </I18nProvider>
         )
 
         expect(screen.getByLabelText(/Access token/i)).toHaveValue('draft-token')
@@ -259,15 +287,11 @@ describe('CodexMcpElicitationFooter', () => {
         } as unknown as ApiClient
         const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
-        render(
-            <CodexMcpElicitationFooter
-                api={api}
-                sessionId="session-1"
-                tool={makeTool(urlInput)}
-                disabled={false}
-                onDone={onDone}
-            />
-        )
+        renderFooter({
+            api,
+            tool: makeTool(urlInput),
+            onDone
+        })
 
         fireEvent.click(screen.getByRole('button', { name: 'Open and continue' }))
 

--- a/web/src/components/ToolCard/codexMcpElicitation.test.tsx
+++ b/web/src/components/ToolCard/codexMcpElicitation.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '@/api/client'
+import type { ChatToolCall } from '@/chat/types'
+import { CodexMcpElicitationFooter } from '@/components/ToolCard/CodexMcpElicitationFooter'
+import {
+    buildCodexMcpElicitationFormContent,
+    createCodexMcpElicitationFormState,
+    normalizeCodexMcpElicitationFormSchema
+} from '@/components/ToolCard/codexMcpElicitation'
+
+const platformMocks = vi.hoisted(() => ({
+    impact: vi.fn(),
+    notification: vi.fn(),
+    selection: vi.fn()
+}))
+
+vi.mock('@/hooks/usePlatform', () => ({
+    usePlatform: () => ({
+        isTelegram: false,
+        isTouch: false,
+        haptic: platformMocks
+    })
+}))
+
+function makeTool(input: unknown): ChatToolCall {
+    return {
+        id: 'tool-1',
+        name: 'CodexMcpElicitation',
+        state: 'running',
+        input,
+        createdAt: 0,
+        startedAt: 0,
+        completedAt: null,
+        description: null
+    }
+}
+
+const formInput = {
+    requestId: 'request-1',
+    threadId: 'thread-1',
+    turnId: 'turn-1',
+    serverName: 'demo-server',
+    mode: 'form' as const,
+    message: 'Need MCP input',
+    requestedSchema: {
+        type: 'object',
+        properties: {
+            token: {
+                type: 'string',
+                title: 'Access token'
+            },
+            count: {
+                type: 'integer',
+                title: 'Count'
+            },
+            enabled: {
+                type: 'boolean',
+                title: 'Enabled'
+            },
+            mode: {
+                title: 'Mode',
+                enum: ['basic', 'advanced']
+            },
+            settings: {
+                type: 'object',
+                title: 'Settings',
+                properties: {
+                    theme: {
+                        type: 'string'
+                    }
+                }
+            }
+        },
+        required: ['token', 'count']
+    }
+}
+
+describe('normalizeCodexMcpElicitationFormSchema', () => {
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('maps common field types and falls back to json for complex fields', () => {
+        const schema = normalizeCodexMcpElicitationFormSchema(formInput.requestedSchema)
+        expect(schema.kind).toBe('object')
+        if (schema.kind !== 'object') {
+            throw new Error('expected object schema')
+        }
+
+        expect(schema.fields.map((field) => ({
+            key: field.key,
+            kind: field.kind,
+            required: field.required,
+            label: field.label
+        }))).toEqual([
+            { key: 'token', kind: 'string', required: true, label: 'Access token' },
+            { key: 'count', kind: 'integer', required: true, label: 'Count' },
+            { key: 'enabled', kind: 'boolean', required: false, label: 'Enabled' },
+            { key: 'mode', kind: 'enum', required: false, label: 'Mode' },
+            { key: 'settings', kind: 'json', required: false, label: 'Settings' }
+        ])
+    })
+
+    it('rejects unsupported non-object root schemas', () => {
+        expect(normalizeCodexMcpElicitationFormSchema({
+            type: 'array',
+            items: {
+                type: 'string'
+            }
+        })).toMatchObject({
+            kind: 'unsupported',
+            reason: expect.stringContaining('Only object forms are supported')
+        })
+    })
+})
+
+describe('buildCodexMcpElicitationFormContent', () => {
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('builds typed content for supported field kinds', () => {
+        const schema = normalizeCodexMcpElicitationFormSchema(formInput.requestedSchema)
+        const state = createCodexMcpElicitationFormState(schema)
+        state.token = 'abc'
+        state.count = '3'
+        state.enabled = true
+        state.mode = '1'
+        state.settings = '{"theme":"dark"}'
+
+        expect(buildCodexMcpElicitationFormContent(schema, state)).toEqual({
+            ok: true,
+            content: {
+                token: 'abc',
+                count: 3,
+                enabled: true,
+                mode: 'advanced',
+                settings: {
+                    theme: 'dark'
+                }
+            }
+        })
+    })
+
+    it('surfaces validation failures for invalid json fallback fields', () => {
+        const schema = normalizeCodexMcpElicitationFormSchema(formInput.requestedSchema)
+        const state = createCodexMcpElicitationFormState(schema)
+        state.token = 'abc'
+        state.count = '3'
+        state.settings = '{broken'
+
+        expect(buildCodexMcpElicitationFormContent(schema, state)).toMatchObject({
+            ok: false,
+            fieldKey: 'settings'
+        })
+    })
+})
+
+describe('CodexMcpElicitationFooter', () => {
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('submits collected form values instead of an empty object', async () => {
+        const respondToMcpElicitation = vi.fn().mockResolvedValue(undefined)
+        const onDone = vi.fn()
+        const api = {
+            respondToMcpElicitation
+        } as unknown as ApiClient
+
+        render(
+            <CodexMcpElicitationFooter
+                api={api}
+                sessionId="session-1"
+                tool={makeTool(formInput)}
+                disabled={false}
+                onDone={onDone}
+            />
+        )
+
+        fireEvent.change(screen.getByLabelText(/Access token/i), { target: { value: 'abc' } })
+        fireEvent.change(screen.getByLabelText(/Count/i), { target: { value: '3' } })
+        fireEvent.click(screen.getByLabelText(/Enabled/i))
+        fireEvent.change(screen.getByLabelText(/Mode/i), { target: { value: '1' } })
+        fireEvent.change(screen.getByLabelText(/Settings/i), { target: { value: '{"theme":"dark"}' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+        await waitFor(() => {
+            expect(respondToMcpElicitation).toHaveBeenCalledWith('session-1', 'request-1', {
+                action: 'accept',
+                content: {
+                    token: 'abc',
+                    count: 3,
+                    enabled: true,
+                    mode: 'advanced',
+                    settings: {
+                        theme: 'dark'
+                    }
+                }
+            })
+        })
+        expect(onDone).toHaveBeenCalled()
+    })
+})

--- a/web/src/components/ToolCard/codexMcpElicitation.test.tsx
+++ b/web/src/components/ToolCard/codexMcpElicitation.test.tsx
@@ -76,6 +76,16 @@ const formInput = {
     }
 }
 
+const urlInput = {
+    requestId: 'request-url-1',
+    threadId: 'thread-1',
+    turnId: 'turn-2',
+    serverName: 'auth-server',
+    mode: 'url' as const,
+    message: 'Open the login page',
+    url: 'https://example.com/login'
+}
+
 describe('normalizeCodexMcpElicitationFormSchema', () => {
     afterEach(() => {
         vi.clearAllMocks()
@@ -198,6 +208,74 @@ describe('CodexMcpElicitationFooter', () => {
                         theme: 'dark'
                     }
                 }
+            })
+        })
+        expect(onDone).toHaveBeenCalled()
+    })
+
+    it('preserves in-progress form values across rerenders for the same tool id', () => {
+        const api = {
+            respondToMcpElicitation: vi.fn().mockResolvedValue(undefined)
+        } as unknown as ApiClient
+
+        const rendered = render(
+            <CodexMcpElicitationFooter
+                api={api}
+                sessionId="session-1"
+                tool={makeTool(formInput)}
+                disabled={false}
+                onDone={() => {}}
+            />
+        )
+
+        fireEvent.change(screen.getByLabelText(/Access token/i), { target: { value: 'draft-token' } })
+
+        rendered.rerender(
+            <CodexMcpElicitationFooter
+                api={api}
+                sessionId="session-1"
+                tool={makeTool({
+                    ...formInput,
+                    requestedSchema: {
+                        ...formInput.requestedSchema,
+                        properties: {
+                            ...formInput.requestedSchema.properties
+                        }
+                    }
+                })}
+                disabled={false}
+                onDone={() => {}}
+            />
+        )
+
+        expect(screen.getByLabelText(/Access token/i)).toHaveValue('draft-token')
+    })
+
+    it('opens the URL before accepting URL-mode elicitations', async () => {
+        const respondToMcpElicitation = vi.fn().mockResolvedValue(undefined)
+        const onDone = vi.fn()
+        const api = {
+            respondToMcpElicitation
+        } as unknown as ApiClient
+        const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+        render(
+            <CodexMcpElicitationFooter
+                api={api}
+                sessionId="session-1"
+                tool={makeTool(urlInput)}
+                disabled={false}
+                onDone={onDone}
+            />
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open and continue' }))
+
+        await waitFor(() => {
+            expect(openSpy).toHaveBeenCalledWith('https://example.com/login', '_blank', 'noopener,noreferrer')
+            expect(respondToMcpElicitation).toHaveBeenCalledWith('session-1', 'request-url-1', {
+                action: 'accept',
+                content: null
             })
         })
         expect(onDone).toHaveBeenCalled()

--- a/web/src/components/ToolCard/codexMcpElicitation.ts
+++ b/web/src/components/ToolCard/codexMcpElicitation.ts
@@ -1,0 +1,101 @@
+import { isObject } from '@hapi/protocol'
+
+export type CodexMcpElicitationInput =
+    | {
+        requestId: string
+        threadId: string
+        turnId: string | null
+        serverName: string
+        mode: 'form'
+        message: string
+        requestedSchema: Record<string, unknown>
+        url?: undefined
+        elicitationId?: undefined
+    }
+    | {
+        requestId: string
+        threadId: string
+        turnId: string | null
+        serverName: string
+        mode: 'url'
+        message: string
+        url: string
+        elicitationId?: string
+        requestedSchema?: undefined
+    }
+
+export type CodexMcpElicitationResult = {
+    action: 'accept' | 'decline' | 'cancel'
+    content: unknown | null
+}
+
+export function isCodexMcpElicitationToolName(toolName: string): boolean {
+    return toolName === 'CodexMcpElicitation'
+}
+
+function asString(value: unknown): string | null {
+    return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+export function parseCodexMcpElicitationInput(input: unknown): CodexMcpElicitationInput | null {
+    if (!isObject(input)) return null
+
+    const requestId = asString(input.requestId)
+    const threadId = asString(input.threadId)
+    const serverName = asString(input.serverName)
+    const mode = input.mode
+    const message = asString(input.message) ?? ''
+    const turnId = typeof input.turnId === 'string' ? input.turnId : null
+
+    if (!requestId || !threadId || !serverName) return null
+
+    if (mode === 'form' && isObject(input.requestedSchema)) {
+        return {
+            requestId,
+            threadId,
+            turnId,
+            serverName,
+            mode,
+            message,
+            requestedSchema: input.requestedSchema as Record<string, unknown>
+        }
+    }
+
+    if (mode === 'url') {
+        const url = asString(input.url)
+        if (!url) return null
+        return {
+            requestId,
+            threadId,
+            turnId,
+            serverName,
+            mode,
+            message,
+            url,
+            elicitationId: asString(input.elicitationId) ?? undefined
+        }
+    }
+
+    return null
+}
+
+export function parseCodexMcpElicitationResult(result: unknown): CodexMcpElicitationResult | null {
+    if (typeof result === 'string') {
+        try {
+            return parseCodexMcpElicitationResult(JSON.parse(result))
+        } catch {
+            return null
+        }
+    }
+
+    if (!isObject(result)) return null
+    const action = result.action
+    if (action !== 'accept' && action !== 'decline' && action !== 'cancel') {
+        return null
+    }
+
+    return {
+        action,
+        content: result.content ?? null
+    }
+}

--- a/web/src/components/ToolCard/codexMcpElicitation.ts
+++ b/web/src/components/ToolCard/codexMcpElicitation.ts
@@ -9,6 +9,10 @@ export type CodexMcpElicitationInput =
         mode: 'form'
         message: string
         requestedSchema: Record<string, unknown>
+        meta?: {
+            toolTitle?: string
+            toolDescription?: string
+        }
         url?: undefined
         elicitationId?: undefined
     }
@@ -20,6 +24,10 @@ export type CodexMcpElicitationInput =
         mode: 'url'
         message: string
         url: string
+        meta?: {
+            toolTitle?: string
+            toolDescription?: string
+        }
         elicitationId?: string
         requestedSchema?: undefined
     }
@@ -46,6 +54,12 @@ export function parseCodexMcpElicitationInput(input: unknown): CodexMcpElicitati
     const mode = input.mode
     const message = asString(input.message) ?? ''
     const turnId = typeof input.turnId === 'string' ? input.turnId : null
+    const meta = isObject(input._meta)
+        ? {
+            toolTitle: asString(input._meta.tool_title) ?? undefined,
+            toolDescription: asString(input._meta.tool_description) ?? undefined
+        }
+        : undefined
 
     if (!requestId || !threadId || !serverName) return null
 
@@ -57,7 +71,8 @@ export function parseCodexMcpElicitationInput(input: unknown): CodexMcpElicitati
             serverName,
             mode,
             message,
-            requestedSchema: input.requestedSchema as Record<string, unknown>
+            requestedSchema: input.requestedSchema as Record<string, unknown>,
+            meta
         }
     }
 
@@ -72,6 +87,7 @@ export function parseCodexMcpElicitationInput(input: unknown): CodexMcpElicitati
             mode,
             message,
             url,
+            meta,
             elicitationId: asString(input.elicitationId) ?? undefined
         }
     }

--- a/web/src/components/ToolCard/codexMcpElicitation.ts
+++ b/web/src/components/ToolCard/codexMcpElicitation.ts
@@ -37,12 +37,329 @@ export type CodexMcpElicitationResult = {
     content: unknown | null
 }
 
+export type CodexMcpElicitationPrimitive = string | number | boolean
+
+type CodexMcpElicitationFormFieldBase = {
+    key: string
+    label: string
+    description?: string
+    required: boolean
+}
+
+export type CodexMcpElicitationFormField =
+    | (CodexMcpElicitationFormFieldBase & {
+        kind: 'string'
+    })
+    | (CodexMcpElicitationFormFieldBase & {
+        kind: 'number' | 'integer'
+    })
+    | (CodexMcpElicitationFormFieldBase & {
+        kind: 'boolean'
+    })
+    | (CodexMcpElicitationFormFieldBase & {
+        kind: 'enum'
+        options: Array<{
+            label: string
+            value: CodexMcpElicitationPrimitive
+        }>
+    })
+    | (CodexMcpElicitationFormFieldBase & {
+        kind: 'json'
+        schema: Record<string, unknown>
+    })
+
+export type CodexMcpElicitationFormSchema =
+    | {
+        kind: 'object'
+        fields: CodexMcpElicitationFormField[]
+    }
+    | {
+        kind: 'unsupported'
+        reason: string
+    }
+
+export type CodexMcpElicitationFormState = Record<string, string | boolean | null>
+
+export type CodexMcpElicitationFormSubmission =
+    | {
+        ok: true
+        content: Record<string, unknown>
+    }
+    | {
+        ok: false
+        error: string
+        fieldKey?: string
+    }
+
 export function isCodexMcpElicitationToolName(toolName: string): boolean {
     return toolName === 'CodexMcpElicitation'
 }
 
 function asString(value: unknown): string | null {
     return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function getSchemaTypes(schema: Record<string, unknown>): string[] {
+    const rawType = schema.type
+    const rawTypes = typeof rawType === 'string'
+        ? [rawType]
+        : Array.isArray(rawType)
+            ? rawType.filter((value): value is string => typeof value === 'string')
+            : []
+
+    return [...new Set(rawTypes.filter((value) => value !== 'null'))]
+}
+
+function isPrimitiveEnumValue(value: unknown): value is CodexMcpElicitationPrimitive {
+    return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+}
+
+function normalizeFormField(
+    key: string,
+    schema: unknown,
+    required: boolean
+): CodexMcpElicitationFormField {
+    const schemaRecord = isObject(schema) ? schema as Record<string, unknown> : null
+    const label = schemaRecord ? (asString(schemaRecord.title) ?? key) : key
+    const description = schemaRecord ? (asString(schemaRecord.description) ?? undefined) : undefined
+
+    const base = {
+        key,
+        label,
+        description,
+        required
+    }
+
+    if (!schemaRecord) {
+        return {
+            ...base,
+            kind: 'json',
+            schema: {}
+        }
+    }
+
+    const enumValues = Array.isArray(schemaRecord.enum)
+        ? schemaRecord.enum.filter(isPrimitiveEnumValue)
+        : []
+    if (enumValues.length > 0) {
+        return {
+            ...base,
+            kind: 'enum',
+            options: enumValues.map((value) => ({
+                label: String(value),
+                value
+            }))
+        }
+    }
+
+    const schemaTypes = getSchemaTypes(schemaRecord)
+    if (schemaTypes.length === 1) {
+        const schemaType = schemaTypes[0]
+        if (schemaType === 'string') {
+            return {
+                ...base,
+                kind: 'string'
+            }
+        }
+        if (schemaType === 'number' || schemaType === 'integer') {
+            return {
+                ...base,
+                kind: schemaType
+            }
+        }
+        if (schemaType === 'boolean') {
+            return {
+                ...base,
+                kind: 'boolean'
+            }
+        }
+    }
+
+    if (
+        schemaTypes.includes('object')
+        || schemaTypes.includes('array')
+        || isObject(schemaRecord.properties)
+        || schemaRecord.items !== undefined
+    ) {
+        return {
+            ...base,
+            kind: 'json',
+            schema: schemaRecord
+        }
+    }
+
+    return {
+        ...base,
+        kind: 'json',
+        schema: schemaRecord
+    }
+}
+
+export function normalizeCodexMcpElicitationFormSchema(
+    requestedSchema: Record<string, unknown>
+): CodexMcpElicitationFormSchema {
+    const rootTypes = getSchemaTypes(requestedSchema)
+    const properties = isObject(requestedSchema.properties)
+        ? requestedSchema.properties as Record<string, unknown>
+        : null
+    const isObjectRoot = rootTypes.includes('object') || properties !== null
+
+    if (!isObjectRoot || !properties) {
+        return {
+            kind: 'unsupported',
+            reason: 'This MCP request uses an unsupported root schema. Only object forms are supported right now.'
+        }
+    }
+
+    const requiredKeys = new Set(
+        Array.isArray(requestedSchema.required)
+            ? requestedSchema.required.filter((value): value is string => typeof value === 'string')
+            : []
+    )
+
+    return {
+        kind: 'object',
+        fields: Object.entries(properties).map(([key, schema]) => (
+            normalizeFormField(key, schema, requiredKeys.has(key))
+        ))
+    }
+}
+
+export function createCodexMcpElicitationFormState(
+    schema: CodexMcpElicitationFormSchema
+): CodexMcpElicitationFormState {
+    if (schema.kind !== 'object') {
+        return {}
+    }
+
+    const nextState: CodexMcpElicitationFormState = {}
+    for (const field of schema.fields) {
+        if (field.kind === 'boolean') {
+            nextState[field.key] = field.required ? false : null
+            continue
+        }
+        nextState[field.key] = ''
+    }
+    return nextState
+}
+
+function requiredFieldError(field: CodexMcpElicitationFormField): CodexMcpElicitationFormSubmission {
+    return {
+        ok: false,
+        error: `${field.label} is required`,
+        fieldKey: field.key
+    }
+}
+
+export function buildCodexMcpElicitationFormContent(
+    schema: CodexMcpElicitationFormSchema,
+    state: CodexMcpElicitationFormState
+): CodexMcpElicitationFormSubmission {
+    if (schema.kind !== 'object') {
+        return {
+            ok: false,
+            error: schema.reason
+        }
+    }
+
+    const content: Record<string, unknown> = {}
+
+    for (const field of schema.fields) {
+        const draftValue = state[field.key]
+
+        if (field.kind === 'string') {
+            const value = typeof draftValue === 'string' ? draftValue : ''
+            if (value.trim().length === 0) {
+                if (field.required) return requiredFieldError(field)
+                continue
+            }
+            content[field.key] = value
+            continue
+        }
+
+        if (field.kind === 'number' || field.kind === 'integer') {
+            const value = typeof draftValue === 'string' ? draftValue : ''
+            if (value.trim().length === 0) {
+                if (field.required) return requiredFieldError(field)
+                continue
+            }
+
+            const parsedNumber = Number(value)
+            if (!Number.isFinite(parsedNumber)) {
+                return {
+                    ok: false,
+                    error: `${field.label} must be a number`,
+                    fieldKey: field.key
+                }
+            }
+            if (field.kind === 'integer' && !Number.isInteger(parsedNumber)) {
+                return {
+                    ok: false,
+                    error: `${field.label} must be an integer`,
+                    fieldKey: field.key
+                }
+            }
+
+            content[field.key] = parsedNumber
+            continue
+        }
+
+        if (field.kind === 'boolean') {
+            if (typeof draftValue === 'boolean') {
+                content[field.key] = draftValue
+                continue
+            }
+            if (field.required) {
+                content[field.key] = false
+            }
+            continue
+        }
+
+        if (field.kind === 'enum') {
+            const selectedIndex = typeof draftValue === 'string' ? draftValue : ''
+            if (selectedIndex.length === 0) {
+                if (field.required) return requiredFieldError(field)
+                continue
+            }
+
+            const optionIndex = Number(selectedIndex)
+            if (
+                !Number.isInteger(optionIndex)
+                || optionIndex < 0
+                || optionIndex >= field.options.length
+            ) {
+                return {
+                    ok: false,
+                    error: `Please choose a valid value for ${field.label}`,
+                    fieldKey: field.key
+                }
+            }
+
+            content[field.key] = field.options[optionIndex]?.value
+            continue
+        }
+
+        const value = typeof draftValue === 'string' ? draftValue : ''
+        if (value.trim().length === 0) {
+            if (field.required) return requiredFieldError(field)
+            continue
+        }
+
+        try {
+            content[field.key] = JSON.parse(value)
+        } catch {
+            return {
+                ok: false,
+                error: `${field.label} must be valid JSON`,
+                fieldKey: field.key
+            }
+        }
+    }
+
+    return {
+        ok: true,
+        content
+    }
 }
 
 export function parseCodexMcpElicitationInput(input: unknown): CodexMcpElicitationInput | null {

--- a/web/src/components/ToolCard/knownTools.tsx
+++ b/web/src/components/ToolCard/knownTools.tsx
@@ -176,15 +176,19 @@ export const knownTools: Record<string, {
         title: (opts) => {
             const parsed = parseCodexMcpElicitationInput(opts.input)
             if (!parsed) return 'MCP elicitation'
+            const toolTitle = parsed.meta?.toolTitle
+            if (toolTitle) {
+                return parsed.mode === 'url' ? `Approve Sign-in: ${toolTitle}` : `Approve Tool: ${toolTitle}`
+            }
             return parsed.mode === 'url'
-                ? `MCP auth: ${parsed.serverName}`
-                : `MCP input: ${parsed.serverName}`
+                ? `Approve Sign-in: ${parsed.serverName}`
+                : `Approve Tool: ${parsed.serverName}`
         },
         subtitle: (opts) => {
             const parsed = parseCodexMcpElicitationInput(opts.input)
-            return parsed?.message ?? null
+            return parsed?.meta?.toolDescription ?? null
         },
-        minimal: false
+        minimal: true
     },
     shell_command: {
         icon: () => <TerminalIcon className={DEFAULT_ICON_CLASS} />,

--- a/web/src/components/ToolCard/knownTools.tsx
+++ b/web/src/components/ToolCard/knownTools.tsx
@@ -6,6 +6,7 @@ import type { ChecklistItem } from '@/components/ToolCard/checklist'
 import { extractTodoChecklist, extractUpdatePlanChecklist } from '@/components/ToolCard/checklist'
 import { basename, resolveDisplayPath } from '@/utils/path'
 import { getInputStringAny, truncate } from '@/lib/toolInputUtils'
+import { parseCodexMcpElicitationInput } from '@/components/ToolCard/codexMcpElicitation'
 
 const DEFAULT_ICON_CLASS = 'h-3.5 w-3.5'
 // Tool presentation registry for `hapi/web` (aligned with `hapi-app`).
@@ -169,6 +170,21 @@ export const knownTools: Record<string, {
         },
         subtitle: (opts) => getInputStringAny(opts.input, ['message', 'command']) ?? null,
         minimal: true
+    },
+    CodexMcpElicitation: {
+        icon: () => <PuzzleIcon className={DEFAULT_ICON_CLASS} />,
+        title: (opts) => {
+            const parsed = parseCodexMcpElicitationInput(opts.input)
+            if (!parsed) return 'MCP elicitation'
+            return parsed.mode === 'url'
+                ? `MCP auth: ${parsed.serverName}`
+                : `MCP input: ${parsed.serverName}`
+        },
+        subtitle: (opts) => {
+            const parsed = parseCodexMcpElicitationInput(opts.input)
+            return parsed?.message ?? null
+        },
+        minimal: false
     },
     shell_command: {
         icon: () => <TerminalIcon className={DEFAULT_ICON_CLASS} />,

--- a/web/src/components/ToolCard/views/CodexMcpElicitationView.tsx
+++ b/web/src/components/ToolCard/views/CodexMcpElicitationView.tsx
@@ -1,0 +1,62 @@
+import type { ToolViewProps } from '@/components/ToolCard/views/_all'
+import {
+    parseCodexMcpElicitationInput,
+    parseCodexMcpElicitationResult
+} from '@/components/ToolCard/codexMcpElicitation'
+import { CodeBlock } from '@/components/CodeBlock'
+
+export function CodexMcpElicitationView(props: ToolViewProps) {
+    const input = parseCodexMcpElicitationInput(props.block.tool.input)
+    const result = parseCodexMcpElicitationResult(props.block.tool.result)
+
+    if (!input) {
+        return null
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] p-3">
+                <div className="text-xs font-medium text-[var(--app-hint)]">Server</div>
+                <div className="mt-1 text-sm text-[var(--app-fg)]">{input.serverName}</div>
+                {input.message ? (
+                    <>
+                        <div className="mt-3 text-xs font-medium text-[var(--app-hint)]">Message</div>
+                        <div className="mt-1 whitespace-pre-wrap text-sm text-[var(--app-fg)]">{input.message}</div>
+                    </>
+                ) : null}
+                {input.mode === 'form' ? (
+                    <>
+                        <div className="mt-3 text-xs font-medium text-[var(--app-hint)]">Requested schema</div>
+                        <div className="mt-1">
+                            <CodeBlock code={JSON.stringify(input.requestedSchema, null, 2)} language="json" />
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        <div className="mt-3 text-xs font-medium text-[var(--app-hint)]">URL</div>
+                        <a
+                            href={input.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-1 block break-all text-sm text-[var(--app-link)] underline"
+                        >
+                            {input.url}
+                        </a>
+                    </>
+                )}
+            </div>
+
+            {result ? (
+                <div className="rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] p-3">
+                    <div className="text-xs font-medium text-[var(--app-hint)]">Response</div>
+                    <div className="mt-1 text-sm text-[var(--app-fg)]">{result.action}</div>
+                    {result.content !== null ? (
+                        <div className="mt-3">
+                            <CodeBlock code={JSON.stringify(result.content, null, 2)} language="json" />
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    )
+}

--- a/web/src/components/ToolCard/views/_all.tsx
+++ b/web/src/components/ToolCard/views/_all.tsx
@@ -5,6 +5,7 @@ import { CodexDiffCompactView, CodexDiffFullView } from '@/components/ToolCard/v
 import { CodexPatchView } from '@/components/ToolCard/views/CodexPatchView'
 import { EditView } from '@/components/ToolCard/views/EditView'
 import { AskUserQuestionView } from '@/components/ToolCard/views/AskUserQuestionView'
+import { CodexMcpElicitationView } from '@/components/ToolCard/views/CodexMcpElicitationView'
 import { RequestUserInputView } from '@/components/ToolCard/views/RequestUserInputView'
 import { ExitPlanModeView } from '@/components/ToolCard/views/ExitPlanModeView'
 import { MultiEditFullView, MultiEditView } from '@/components/ToolCard/views/MultiEditView'
@@ -30,7 +31,8 @@ export const toolViewRegistry: Record<string, ToolViewComponent> = {
     ExitPlanMode: ExitPlanModeView,
     ask_user_question: AskUserQuestionView,
     exit_plan_mode: ExitPlanModeView,
-    request_user_input: RequestUserInputView
+    request_user_input: RequestUserInputView,
+    CodexMcpElicitation: CodexMcpElicitationView
 }
 
 export const toolFullViewRegistry: Record<string, ToolViewComponent> = {
@@ -43,7 +45,8 @@ export const toolFullViewRegistry: Record<string, ToolViewComponent> = {
     ExitPlanMode: ExitPlanModeView,
     ask_user_question: AskUserQuestionView,
     exit_plan_mode: ExitPlanModeView,
-    request_user_input: RequestUserInputView
+    request_user_input: RequestUserInputView,
+    CodexMcpElicitation: CodexMcpElicitationView
 }
 
 export function getToolViewComponent(toolName: string): ToolViewComponent | null {

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,1 +1,54 @@
 import '@testing-library/jest-dom/vitest'
+
+function createMemoryStorage(): Storage {
+    const store = new Map<string, string>()
+
+    return {
+        get length() {
+            return store.size
+        },
+        clear() {
+            store.clear()
+        },
+        getItem(key: string) {
+            return store.get(key) ?? null
+        },
+        key(index: number) {
+            return Array.from(store.keys())[index] ?? null
+        },
+        removeItem(key: string) {
+            store.delete(key)
+        },
+        setItem(key: string, value: string) {
+            store.set(key, value)
+        }
+    }
+}
+
+function ensureStorage(name: 'localStorage' | 'sessionStorage') {
+    const current = globalThis[name]
+    const looksValid = current
+        && typeof current.getItem === 'function'
+        && typeof current.setItem === 'function'
+        && typeof current.removeItem === 'function'
+        && typeof current.clear === 'function'
+
+    if (looksValid) {
+        return
+    }
+
+    const storage = createMemoryStorage()
+    Object.defineProperty(globalThis, name, {
+        value: storage,
+        configurable: true
+    })
+    if (typeof window !== 'undefined') {
+        Object.defineProperty(window, name, {
+            value: storage,
+            configurable: true
+        })
+    }
+}
+
+ensureStorage('localStorage')
+ensureStorage('sessionStorage')

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -10,6 +10,8 @@ export type {
     AgentState,
     AttachmentMetadata,
     CodexCollaborationMode,
+    McpElicitationAction,
+    McpElicitationResponse,
     PermissionMode,
     Session,
     SessionSummary,


### PR DESCRIPTION
## problem
current codex service does not register the mcpServer/elicitation/request method, which causes MCP server-initiated elicitation requests to be rejected by default.

When an MCP server requires user confirmation (e.g., title modification MCPs, stdio MCPs, etc.), the requests are directly rejected or cancelled due to the absence of corresponding handling logic.

The related error log is as follows:
```
JSONRPCErrorError { code: -32601, message: "Method not found: mcpServer/elicitation/request" }
```
## change
To address this issue, this change implements support for handling mcpServer/elicitation/request, based on the Codex [documentation](https://github.com/openai/codex/tree/main/codex-rs/app-server#mcp-server-elicitations)

Related Issue: [tiann/hapi#287](https://github.com/tiann/hapi/issues/287)