### PR TITLE
fix(hub): add PATCH to CORS allowMethods so session rename works

### DIFF
--- a/hub/src/web/server.ts
+++ b/hub/src/web/server.ts
@@ -77,7 +77,7 @@ function createWebApp(options: {
     const corsOriginOption = corsOrigins.includes('*') ? '*' : corsOrigins
     const corsMiddleware = cors({
         origin: corsOriginOption,
-        allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+        allowMethods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
         allowHeaders: ['authorization', 'content-type']
     })
     app.use('/api/*', corsMiddleware)


### PR DESCRIPTION
## Problem

The "Rename Session" dialog in the web UI always fails with "Failed to rename. Please try again."

### Root cause

The rename endpoint uses `PATCH /api/sessions/:id`, but the CORS middleware in `hub/src/web/server.ts` only allows:

```typescript
allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS']
```

`PATCH` is missing. Browsers send a preflight `OPTIONS` request before any `PATCH` request. The server's preflight response doesn't include `PATCH` in `Access-Control-Allow-Methods`, so the browser blocks the actual request — it never reaches the route handler.

### Fix

Add `'PATCH'` to `allowMethods`:

```typescript
allowMethods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS']
```

## Test plan

- [ ] Open web UI → click session menu → "Rename Session" → enter new name → Save → should succeed