### PR TITLE
feat(web): add copy button to assistant messages

### DIFF
--- a/web/src/components/AssistantChat/messages/AssistantMessage.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.tsx
@@ -3,7 +3,10 @@ import { MarkdownText } from '@/components/assistant-ui/markdown-text'
 import { Reasoning, ReasoningGroup } from '@/components/assistant-ui/reasoning'
 import { HappyToolMessage } from '@/components/AssistantChat/messages/ToolMessage'
 import { CliOutputBlock } from '@/components/CliOutputBlock'
+import { CopyIcon, CheckIcon } from '@/components/icons'
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import type { HappyChatMessageMetadata } from '@/lib/assistant-runtime'
+import { getAssistantCopyText } from '@/components/AssistantChat/messages/assistantCopyText'
 
 const TOOL_COMPONENTS = {
     Fallback: HappyToolMessage
@@ -17,6 +20,7 @@ const MESSAGE_PART_COMPONENTS = {
 } as const
 
 export function HappyAssistantMessage() {
+    const { copied, copy } = useCopyToClipboard()
     const isCliOutput = useAssistantState(({ message }) => {
         const custom = message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined
         return custom?.kind === 'cli-output'
@@ -31,6 +35,10 @@ export function HappyAssistantMessage() {
         const parts = message.content
         return parts.length > 0 && parts.every((part) => part.type === 'tool-call')
     })
+    const copyText = useAssistantState(({ message }) => {
+        if (message.role !== 'assistant') return ''
+        return getAssistantCopyText(message.content)
+    })
     const rootClass = toolOnly
         ? 'py-1 min-w-0 max-w-full overflow-x-hidden'
         : 'px-1 min-w-0 max-w-full overflow-x-hidden'
@@ -44,8 +52,22 @@ export function HappyAssistantMessage() {
     }
 
     return (
-        <MessagePrimitive.Root className={rootClass}>
-            <MessagePrimitive.Content components={MESSAGE_PART_COMPONENTS} />
+        <MessagePrimitive.Root className={`${rootClass} ${copyText ? 'group/msg' : ''}`}>
+            <div className={`relative min-w-0 ${copyText ? 'pr-8' : ''}`}>
+                {copyText && (
+                    <button
+                        type="button"
+                        title="Copy"
+                        className="absolute right-0 top-0 opacity-60 sm:opacity-0 sm:group-hover/msg:opacity-100 transition-[opacity,background-color] p-0.5 rounded hover:bg-[var(--app-subtle-bg)]"
+                        onClick={() => copy(copyText)}
+                    >
+                        {copied
+                            ? <CheckIcon className="h-3.5 w-3.5 text-green-500" />
+                            : <CopyIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />}
+                    </button>
+                )}
+                <MessagePrimitive.Content components={MESSAGE_PART_COMPONENTS} />
+            </div>
         </MessagePrimitive.Root>
     )
 }

--- a/web/src/components/AssistantChat/messages/assistantCopyText.test.ts
+++ b/web/src/components/AssistantChat/messages/assistantCopyText.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import type { ThreadAssistantMessagePart } from '@assistant-ui/react'
+import { getAssistantCopyText } from '@/components/AssistantChat/messages/assistantCopyText'
+
+describe('getAssistantCopyText', () => {
+    it('joins assistant text parts and ignores non-text parts', () => {
+        const parts = [
+            { type: 'text', text: 'First paragraph.' },
+            { type: 'reasoning', text: 'Hidden chain of thought' },
+            { type: 'tool-call', toolCallId: 'tool-1', toolName: 'search', args: {}, argsText: '{}' },
+            { type: 'text', text: 'Second paragraph.' }
+        ] satisfies ThreadAssistantMessagePart[]
+
+        expect(getAssistantCopyText(parts)).toBe('First paragraph.\n\nSecond paragraph.')
+    })
+
+    it('returns empty string when no assistant text exists', () => {
+        const parts = [
+            { type: 'reasoning', text: 'Thinking' },
+            { type: 'tool-call', toolCallId: 'tool-1', toolName: 'search', args: {}, argsText: '{}' }
+        ] satisfies ThreadAssistantMessagePart[]
+
+        expect(getAssistantCopyText(parts)).toBe('')
+    })
+})

--- a/web/src/components/AssistantChat/messages/assistantCopyText.ts
+++ b/web/src/components/AssistantChat/messages/assistantCopyText.ts
@@ -1,0 +1,9 @@
+import type { ThreadAssistantMessagePart } from '@assistant-ui/react'
+
+export function getAssistantCopyText(parts: readonly ThreadAssistantMessagePart[]): string {
+    return parts
+        .filter((part) => part.type === 'text')
+        .map((part) => part.text.trim())
+        .filter((text) => text.length > 0)
+        .join('\n\n')
+}


### PR DESCRIPTION
  ## Summary / 概述

<img width="1112" height="388" alt="image" src="https://github.com/user-attachments/assets/298ad96d-754e-46b0-9adb-ead6c10e5866" />


  This PR adds a copy button to assistant chat messages in the hub web UI.
  When a message contains visible reply text, a copy button appears on hover, matching the existing user-message interaction.

  这个 PR 为 hub 的 Web 聊天界面补充了 assistant 消息的复制按钮。
  当消息包含可见回复正文时，悬停会显示 copy 按钮，交互方式与现有 user 消息保持一致。

  ## Changes / 变更内容

  - Add a hover-only copy button to assistant messages
  - Reuse the existing clipboard hook and copied-state feedback
  - Extract assistant copy text into a small helper
  - Ignore tool cards, reasoning blocks, and CLI output when copying
  - Add focused unit tests for assistant copy-text extraction

  - 为 assistant 消息新增仅悬停显示的 copy 按钮
  - 复用现有剪贴板 hook 和复制成功反馈
  - 抽出 assistant 正文复制文本的辅助函数
  - 复制时忽略 tool card、reasoning 和 CLI output
  - 为 assistant 文本提取补充聚焦单测

  ## Verification / 验证

  - `bun run test -- src/components/AssistantChat/messages/assistantCopyText.test.ts`
  - `bun run typecheck`

  ## Notes / 说明

  This PR only includes assistant-side copy support.
  The existing user-message copy button remains unchanged.

  这个 PR 只补充 assistant 侧的复制能力。
  现有 user 消息复制按钮未改动。