### PR TITLE
fix(hub,web): raise request body limit for uploads and recover SSE on tab focus

### DIFF
--- a/hub/src/web/server.ts
+++ b/hub/src/web/server.ts
@@ -234,7 +234,7 @@ export async function startWebServer(options: {
         hostname: configuration.listenHost,
         port: configuration.listenPort,
         idleTimeout: Math.max(30, socketHandler.idleTimeout),
-        maxRequestBodySize: socketHandler.maxRequestBodySize,
+        maxRequestBodySize: Math.max(socketHandler.maxRequestBodySize, 100 * 1024 * 1024),
         websocket: socketHandler.websocket,
         fetch: (req, server) => {
             const url = new URL(req.url)

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -596,8 +596,22 @@ export function useSSE(options: {
             requestReconnect('heartbeat-timeout')
         }, HEARTBEAT_WATCHDOG_INTERVAL_MS)
 
+        // When the tab becomes visible again, check immediately whether the
+        // SSE connection went stale while hidden (the watchdog skips checks
+        // for hidden tabs).  This avoids the user having to wait up to
+        // HEARTBEAT_WATCHDOG_INTERVAL_MS after switching back.
+        const onVisibilityChange = () => {
+            if (getVisibilityState() !== 'visible') return
+            if (eventSourceRef.current !== eventSource) return
+            if (Date.now() - lastActivityAtRef.current >= HEARTBEAT_STALE_MS) {
+                requestReconnect('visibility-recovery')
+            }
+        }
+        document.addEventListener('visibilitychange', onVisibilityChange)
+
         return () => {
             clearInterval(watchdogTimer)
+            document.removeEventListener('visibilitychange', onVisibilityChange)
             if (invalidationTimerRef.current) {
                 clearTimeout(invalidationTimerRef.current)
                 invalidationTimerRef.current = null


### PR DESCRIPTION
## Problem 1: Image upload always fails

The Bun server's `maxRequestBodySize` inherits from Socket.IO's `maxHttpBufferSize` default (**1 MB**). The upload endpoint sends files as base64 in JSON, so any image > ~750 KB is rejected before reaching the route handler. The frontend allows 50 MB but the server silently blocks at 1 MB.

### Fix

```typescript
// Before: inherits Socket.IO's 1 MB default
maxRequestBodySize: socketHandler.maxRequestBodySize,

// After: at least 100 MB to accommodate 50 MB uploads with base64 overhead
maxRequestBodySize: Math.max(socketHandler.maxRequestBodySize, 100 * 1024 * 1024),
```

## Problem 2: Messages don't appear after switching back to tab

The SSE watchdog intentionally skips heartbeat checks while the tab is hidden. If the SSE connection dies in the background, the watchdog never detects it. When the user switches back, they see stale messages and have to wait up to 10s (next watchdog tick) or manually refresh.

### Fix

Add a `visibilitychange` event listener that checks heartbeat staleness immediately when the tab becomes visible. If the connection is stale, reconnect right away.

## Test plan

- [x] `tsc --noEmit` passes (web)
- [x] All 104 web tests pass
- [ ] Upload an image > 1 MB → should succeed
- [ ] Leave tab in background for > 90s, switch back → messages should appear immediately