### PR TITLE
fix(web): move copy button to inline layout to prevent tool card overlap

### DIFF
--- a/web/src/components/AssistantChat/messages/AssistantMessage.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.tsx
@@ -53,21 +53,23 @@ export function HappyAssistantMessage() {
 
     return (
         <MessagePrimitive.Root className={`${rootClass} ${copyText ? 'group/msg' : ''}`}>
-            <div className={`relative min-w-0 ${copyText ? 'pr-8' : ''}`}>
-                {copyText && (
+            <div className="min-w-0">
+                <MessagePrimitive.Content components={MESSAGE_PART_COMPONENTS} />
+            </div>
+            {copyText && (
+                <div className="flex justify-end mt-1 opacity-60 sm:opacity-0 sm:group-hover/msg:opacity-100 transition-opacity">
                     <button
                         type="button"
                         title="Copy"
-                        className="absolute right-0 top-0 opacity-60 sm:opacity-0 sm:group-hover/msg:opacity-100 transition-[opacity,background-color] p-0.5 rounded hover:bg-[var(--app-subtle-bg)]"
+                        className="p-0.5 rounded hover:bg-[var(--app-subtle-bg)] transition-colors"
                         onClick={() => copy(copyText)}
                     >
                         {copied
                             ? <CheckIcon className="h-3.5 w-3.5 text-green-500" />
                             : <CopyIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />}
                     </button>
-                )}
-                <MessagePrimitive.Content components={MESSAGE_PART_COMPONENTS} />
-            </div>
+                </div>
+            )}
         </MessagePrimitive.Root>
     )
 }


### PR DESCRIPTION
## Problem

The assistant message copy button was absolutely positioned (`right-0 top-0`) over the entire message content area. When messages contain both text and tool calls (e.g. TodoWrite task list), the button overlapped the tool card UI, looking like a misplaced button on the task list.

## Root cause

`<button className="absolute right-0 top-0">` inside `<div className="relative pr-8">` pins the button to the top-right of the **whole** message block. When tool cards render below the text, the button visually sits on top of the first content element, which may be a tool card if text is short or absent.

## Fix

Move the copy button from absolute positioning inside the content wrapper to an **inline flex layout after the content**:

- Button renders at the bottom-right of the message, below all content (text + tool cards)
- Never overlaps tool cards regardless of content order
- Hover-to-reveal behavior preserved (`sm:opacity-0 sm:group-hover/msg:opacity-100`)
- `pr-8` padding removed (no longer needed for absolute positioning)
- `getAssistantCopyText` remains unchanged — mixed text+tool messages stay copyable

## Test plan

- [x] Typecheck passes
- [ ] Verify: pure text message shows copy button at bottom-right on hover
- [ ] Verify: text+tool message shows copy button below tool cards on hover
- [ ] Verify: tool-only message shows no copy button (no text to copy)