### PR TITLE
fix(cli): correct Homebrew formula URL for Linux x64 baseline build

### DIFF
--- a/cli/scripts/update-homebrew-formula.ts
+++ b/cli/scripts/update-homebrew-formula.ts
@@ -87,7 +87,7 @@ class Hapi < Formula
       url "https://github.com/tiann/hapi/releases/download/v#{version}/hapi-linux-arm64.tar.gz"
       sha256 "${shas.linuxArm64}"
     else
-      url "https://github.com/tiann/hapi/releases/download/v#{version}/hapi-linux-x64.tar.gz"
+      url "https://github.com/tiann/hapi/releases/download/v#{version}/hapi-linux-x64-baseline.tar.gz"
       sha256 "${shas.linuxX64}"
     end
   end


### PR DESCRIPTION
## Summary

The release workflow produces `hapi-linux-x64-baseline.tar.gz` (from `bun-linux-x64-baseline` target), but the Homebrew formula generator hardcoded the URL as `hapi-linux-x64.tar.gz`. This causes `brew install tiann/tap/hapi` to fail on Linux x64 with a 404.

One-line fix: `hapi-linux-x64.tar.gz` → `hapi-linux-x64-baseline.tar.gz` in `cli/scripts/update-homebrew-formula.ts:90`.

Closes #365

## Test plan

- [x] Verified asset names match between `build-executable.ts` DEFAULT_TARGETS and the formula
- [ ] Next release will produce a correct Homebrew formula (the existing tap also needs a manual formula update for current versions)

via [HAPI](https://hapi.run)

Co-Authored-By: HAPI <noreply@hapi.run>