### PR TITLE
fix: filter rate_limit_event from Claude Remote/Local chat paths

### DIFF
--- a/cli/src/claude/utils/chatVisibility.test.ts
+++ b/cli/src/claude/utils/chatVisibility.test.ts
@@ -20,4 +20,8 @@ describe('isClaudeChatVisibleMessage', () => {
         expect(isClaudeChatVisibleMessage({ type: 'assistant' })).toBe(true)
         expect(isClaudeChatVisibleMessage({ type: 'summary' })).toBe(true)
     })
+
+    it('hides rate_limit_event messages from chat delivery', () => {
+        expect(isClaudeChatVisibleMessage({ type: 'rate_limit_event' } as any)).toBe(false)
+    })
 })

--- a/cli/src/claude/utils/sdkToLogConverter.test.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.test.ts
@@ -340,6 +340,31 @@ describe('SDKToLogConverter', () => {
 
             expect(assistant!.parentUuid).toBe(user!.uuid)
         })
+
+        it('should chain parent correctly when rate_limit_event is converted', () => {
+            const user = converter.convert({
+                type: 'user',
+                message: { role: 'user', content: 'hi' }
+            } as SDKUserMessage)
+
+            const warning = converter.convert({
+                type: 'rate_limit_event',
+                rate_limit_info: {
+                    status: 'allowed_warning',
+                    resetsAt: 1775559600,
+                    utilization: 0.8,
+                    rateLimitType: 'five_hour'
+                }
+            } as unknown as SDKMessage)
+
+            const assistant = converter.convert({
+                type: 'assistant',
+                message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] }
+            } as SDKAssistantMessage)
+
+            expect(warning!.parentUuid).toBe(user!.uuid)
+            expect(assistant!.parentUuid).toBe(warning!.uuid)
+        })
     })
 
     describe('Convenience function', () => {

--- a/cli/src/claude/utils/sdkToLogConverter.test.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.test.ts
@@ -269,6 +269,41 @@ describe('SDKToLogConverter', () => {
         })
     })
 
+    describe('Internal event filtering', () => {
+        it('should drop rate_limit_event messages', () => {
+            const sdkMessage = {
+                type: 'rate_limit_event',
+                rate_limit_info: {
+                    status: 'allowed',
+                    resetsAt: 1775559600,
+                    rateLimitType: 'five_hour'
+                }
+            } as unknown as SDKMessage
+
+            const logMessage = converter.convert(sdkMessage)
+
+            expect(logMessage).toBeNull()
+        })
+
+        it('should not break parent chain when rate_limit_event is dropped', () => {
+            const user = converter.convert({
+                type: 'user',
+                message: { role: 'user', content: 'hi' }
+            } as SDKUserMessage)
+
+            converter.convert({
+                type: 'rate_limit_event',
+            } as unknown as SDKMessage)
+
+            const assistant = converter.convert({
+                type: 'assistant',
+                message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] }
+            } as SDKAssistantMessage)
+
+            expect(assistant!.parentUuid).toBe(user!.uuid)
+        })
+    })
+
     describe('Convenience function', () => {
         it('should convert single message without state', () => {
             const sdkMessage: SDKUserMessage = {

--- a/cli/src/claude/utils/sdkToLogConverter.test.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.test.ts
@@ -270,7 +270,7 @@ describe('SDKToLogConverter', () => {
     })
 
     describe('Internal event filtering', () => {
-        it('should drop rate_limit_event messages', () => {
+        it('should suppress rate_limit_event with allowed status', () => {
             const sdkMessage = {
                 type: 'rate_limit_event',
                 rate_limit_info: {
@@ -280,12 +280,49 @@ describe('SDKToLogConverter', () => {
                 }
             } as unknown as SDKMessage
 
-            const logMessage = converter.convert(sdkMessage)
-
-            expect(logMessage).toBeNull()
+            expect(converter.convert(sdkMessage)).toBeNull()
         })
 
-        it('should not break parent chain when rate_limit_event is dropped', () => {
+        it('should convert allowed_warning to pipe-delimited text', () => {
+            const sdkMessage = {
+                type: 'rate_limit_event',
+                rate_limit_info: {
+                    status: 'allowed_warning',
+                    resetsAt: 1775559600,
+                    utilization: 0.85,
+                    rateLimitType: 'five_hour'
+                }
+            } as unknown as SDKMessage
+
+            const logMessage = converter.convert(sdkMessage)
+
+            expect(logMessage).not.toBeNull()
+            expect(logMessage!.type).toBe('assistant')
+            expect((logMessage as any).message.content[0].text).toBe(
+                'Claude AI usage limit warning|1775559600|85|five_hour'
+            )
+        })
+
+        it('should convert rejected to pipe-delimited text', () => {
+            const sdkMessage = {
+                type: 'rate_limit_event',
+                rate_limit_info: {
+                    status: 'rejected',
+                    resetsAt: 1775559600,
+                    rateLimitType: 'five_hour'
+                }
+            } as unknown as SDKMessage
+
+            const logMessage = converter.convert(sdkMessage)
+
+            expect(logMessage).not.toBeNull()
+            expect(logMessage!.type).toBe('assistant')
+            expect((logMessage as any).message.content[0].text).toBe(
+                'Claude AI usage limit reached|1775559600|five_hour'
+            )
+        })
+
+        it('should not break parent chain when rate_limit_event is suppressed', () => {
             const user = converter.convert({
                 type: 'user',
                 message: { role: 'user', content: 'hi' }
@@ -293,6 +330,7 @@ describe('SDKToLogConverter', () => {
 
             converter.convert({
                 type: 'rate_limit_event',
+                rate_limit_info: { status: 'allowed' }
             } as unknown as SDKMessage)
 
             const assistant = converter.convert({

--- a/cli/src/claude/utils/sdkToLogConverter.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.ts
@@ -114,12 +114,13 @@ export class SDKToLogConverter {
             return null
         }
 
+        const parentUuid = this.lastUuid
         const uuid = randomUUID()
         const timestamp = new Date().toISOString()
         this.lastUuid = uuid
 
         return {
-            parentUuid: this.lastUuid,
+            parentUuid,
             isSidechain: false,
             userType: 'external' as const,
             cwd: this.context.cwd,

--- a/cli/src/claude/utils/sdkToLogConverter.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.ts
@@ -90,6 +90,8 @@ export class SDKToLogConverter {
      * Convert SDK message to log format
      */
     convert(sdkMessage: SDKMessage): RawJSONLines | null {
+        if (sdkMessage.type === 'rate_limit_event') return null
+
         const uuid = randomUUID()
         const timestamp = new Date().toISOString()
         let parentUuid = this.lastUuid;

--- a/cli/src/claude/utils/sdkToLogConverter.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.ts
@@ -87,10 +87,62 @@ export class SDKToLogConverter {
     }
 
     /**
+     * Convert rate_limit_event to pipe-delimited text matching the ACP path format,
+     * or suppress if the status does not need display (e.g. 'allowed').
+     * Must not mutate converter state (UUID chain) so dropped events are invisible.
+     */
+    private convertRateLimitEvent(sdkMessage: SDKMessage): RawJSONLines | null {
+        const info = (sdkMessage as any).rate_limit_info
+        if (typeof info !== 'object' || info === null) return null
+
+        const { status, resetsAt, utilization, rateLimitType } = info
+
+        if (status === 'allowed') return null
+        if (typeof resetsAt !== 'number') return null
+
+        const resetsAtInt = Math.round(resetsAt)
+        let text: string
+
+        if (status === 'allowed_warning') {
+            const pct = typeof utilization === 'number' ? Math.round(utilization * 100) : 0
+            const limitType = typeof rateLimitType === 'string' ? rateLimitType : ''
+            text = `Claude AI usage limit warning|${resetsAtInt}|${pct}|${limitType}`
+        } else if (status === 'rejected') {
+            const limitType = typeof rateLimitType === 'string' ? rateLimitType : ''
+            text = `Claude AI usage limit reached|${resetsAtInt}|${limitType}`
+        } else {
+            return null
+        }
+
+        const uuid = randomUUID()
+        const timestamp = new Date().toISOString()
+        this.lastUuid = uuid
+
+        return {
+            parentUuid: this.lastUuid,
+            isSidechain: false,
+            userType: 'external' as const,
+            cwd: this.context.cwd,
+            sessionId: this.context.sessionId,
+            version: this.context.version,
+            gitBranch: this.context.gitBranch,
+            uuid,
+            timestamp,
+            type: 'assistant',
+            message: {
+                role: 'assistant',
+                content: [{ type: 'text', text }]
+            }
+        } as RawJSONLines
+    }
+
+    /**
      * Convert SDK message to log format
      */
     convert(sdkMessage: SDKMessage): RawJSONLines | null {
-        if (sdkMessage.type === 'rate_limit_event') return null
+        if (sdkMessage.type === 'rate_limit_event') {
+            return this.convertRateLimitEvent(sdkMessage)
+        }
 
         const uuid = randomUUID()
         const timestamp = new Date().toISOString()

--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -39,6 +39,10 @@ export function isClaudeChatVisibleSystemSubtype(subtype: unknown): subtype is s
 }
 
 export function isClaudeChatVisibleMessage(message: { type: unknown; subtype?: unknown }): boolean {
+    if (message.type === 'rate_limit_event') {
+        return false
+    }
+
     if (message.type !== 'system') {
         return true
     }


### PR DESCRIPTION
## Summary

PR #388 handled `rate_limit_event` display for the ACP path, but Claude Remote (SDK) and Local (JSONL scanner) paths still leak the raw JSON into the web UI chat.

This adds filtering at two layers:

- **`sdkToLogConverter.convert()`** — early return before UUID generation and sidechain bookkeeping, preventing the event from reaching the web via the remote SDK path
- **`isClaudeChatVisibleMessage()`** — marks `rate_limit_event` as non-visible, covering the local session scanner path and acting as a second line of defense

## Test plan

- [x] Unit: `rate_limit_event` returns `null` from converter
- [x] Unit: dropped event does not break parent UUID chain
- [x] Unit: `isClaudeChatVisibleMessage({ type: 'rate_limit_event' })` returns `false`
- [x] E2E: start a new Claude session, send a message, verify no raw JSON in chat