### PR TITLE
fix(web): allow multiline input with modifier+Enter in composer

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -303,10 +303,18 @@ export function HappyComposer(props: {
             return // let default textarea behavior handle newline
         }
 
+        // Enter with suggestions visible: select the suggestion
+        if (key === 'Enter' && suggestions.length > 0) {
+            e.preventDefault()
+            const indexToSelect = selectedIndex >= 0 ? selectedIndex : 0
+            handleSuggestionSelect(indexToSelect)
+            return
+        }
+
         // Only plain Enter (no modifiers) sends; other modifier combos are ignored
         if (key === 'Enter') {
             e.preventDefault()
-            if (!e.ctrlKey && !e.altKey && !e.metaKey && canSend && suggestions.length === 0) {
+            if (!e.ctrlKey && !e.altKey && !e.metaKey && canSend) {
                 api.composer().send()
                 setShowContinueHint(false)
             }
@@ -324,7 +332,7 @@ export function HappyComposer(props: {
                 moveDown()
                 return
             }
-            if ((key === 'Enter' || key === 'Tab') && !e.shiftKey) {
+            if ((key === 'Tab') && !e.shiftKey) {
                 e.preventDefault()
                 const indexToSelect = selectedIndex >= 0 ? selectedIndex : 0
                 handleSuggestionSelect(indexToSelect)

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -298,15 +298,15 @@ export function HappyComposer(props: {
             return
         }
 
-        // Modifier+Enter inserts a newline (Shift, Ctrl, Alt, Cmd)
-        if (key === 'Enter' && (e.shiftKey || e.ctrlKey || e.altKey || e.metaKey)) {
+        // Shift+Enter inserts a newline (standard behavior)
+        if (key === 'Enter' && e.shiftKey) {
             return // let default textarea behavior handle newline
         }
 
-        // Plain Enter: send or no-op (never insert newline)
-        if (key === 'Enter' && suggestions.length === 0) {
+        // Only plain Enter (no modifiers) sends; other modifier combos are ignored
+        if (key === 'Enter') {
             e.preventDefault()
-            if (canSend) {
+            if (!e.ctrlKey && !e.altKey && !e.metaKey && canSend && suggestions.length === 0) {
                 api.composer().send()
                 setShowContinueHint(false)
             }

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -298,13 +298,13 @@ export function HappyComposer(props: {
             return
         }
 
-        // Shift+Enter inserts a newline (standard behavior)
-        if (key === 'Enter' && e.shiftKey) {
+        // Modifier+Enter inserts a newline (Shift, Ctrl, Alt, Cmd)
+        if (key === 'Enter' && (e.shiftKey || e.ctrlKey || e.altKey || e.metaKey)) {
             return // let default textarea behavior handle newline
         }
 
-        // Enter without shift: send or no-op (never insert newline)
-        if (key === 'Enter' && !e.shiftKey && suggestions.length === 0) {
+        // Plain Enter: send or no-op (never insert newline)
+        if (key === 'Enter' && suggestions.length === 0) {
             e.preventDefault()
             if (canSend) {
                 api.composer().send()
@@ -768,7 +768,7 @@ export function HappyComposer(props: {
                                 placeholder={showContinueHint ? t('misc.typeMessage') : t('misc.typeAMessage')}
                                 disabled={controlsDisabled}
                                 maxRows={5}
-                                submitOnEnter={!isTouch}
+                                submitOnEnter={false}
                                 cancelOnEscape={false}
                                 onChange={handleChange}
                                 onSelect={handleSelect}


### PR DESCRIPTION
## Summary

Prevent `Ctrl+Enter`, `Alt+Enter`, and `Cmd+Enter` from accidentally sending messages. Only **plain Enter** sends; **Shift+Enter** inserts a newline — unchanged from the original design.

## Problem

The `handleKeyDown` guard only checked `e.shiftKey`, so any other modifier+Enter (`Ctrl`, `Alt`, `Cmd`) fell through to the send path and triggered an unintended send.

Additionally, `submitOnEnter={!isTouch}` kept the library's internal Enter handler active alongside the custom one, creating two competing submit mechanisms. Setting it to `false` makes `handleKeyDown` the sole owner of Enter-key logic.

## Changes

| Key combo | Before | After |
|-----------|--------|-------|
| Enter | Send | Send (unchanged) |
| Shift+Enter | Newline | Newline (unchanged) |
| Ctrl+Enter | **Send (bug)** | No-op |
| Alt+Enter | **Send (bug)** | No-op |
| Cmd+Enter | **Send (bug)** | No-op |
| `submitOnEnter` | `{!isTouch}` | `{false}` |

No new shortcuts are added — this is a pure bug fix.

Closes #429