### PR TITLE
fix(cli,hub): resolve typecheck errors in codex reasoning effort

### DIFF
--- a/cli/src/codex/codexLocalLauncher.test.ts
+++ b/cli/src/codex/codexLocalLauncher.test.ts
@@ -79,6 +79,7 @@ function createSessionStub(permissionMode: 'default' | 'read-only' | 'safe-yolo'
                 }
             },
             getPermissionMode: () => permissionMode,
+            getModelReasoningEffort: () => null,
             onSessionFound: () => {},
             sendSessionEvent: (event: { type: string; message?: string }) => {
                 sessionEvents.push(event);

--- a/cli/src/codex/codexLocalLauncher.ts
+++ b/cli/src/codex/codexLocalLauncher.ts
@@ -1,5 +1,6 @@
 import { logger } from '@/ui/logger';
 import { codexLocal } from './codexLocal';
+import type { ReasoningEffort } from './appServerTypes';
 import { CodexSession } from './session';
 import { createCodexSessionScanner } from './utils/codexSessionScanner';
 import { convertCodexEvent } from './utils/codexEventConverter';
@@ -42,7 +43,7 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
             await codexLocal({
                 path: session.path,
                 sessionId: resumeSessionId,
-                modelReasoningEffort: session.getModelReasoningEffort() ?? undefined,
+                modelReasoningEffort: (session.getModelReasoningEffort() ?? undefined) as ReasoningEffort | undefined,
                 onSessionFound: handleSessionFound,
                 abort: abortSignal,
                 codexArgs,

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -82,7 +82,7 @@ export async function runCodex(opts: {
         }
         const sessionModelReasoningEffort = sessionInstance.getModelReasoningEffort();
         if (sessionModelReasoningEffort !== undefined) {
-            currentModelReasoningEffort = sessionModelReasoningEffort ?? undefined;
+            currentModelReasoningEffort = (sessionModelReasoningEffort ?? undefined) as ReasoningEffort | undefined;
         }
         sessionInstance.setPermissionMode(currentPermissionMode);
         sessionInstance.setModel(currentModel ?? null);
@@ -106,7 +106,7 @@ export async function runCodex(opts: {
         }
         const sessionModelReasoningEffort = sessionWrapperRef.current?.getModelReasoningEffort();
         if (sessionModelReasoningEffort !== undefined) {
-            currentModelReasoningEffort = sessionModelReasoningEffort ?? undefined;
+            currentModelReasoningEffort = (sessionModelReasoningEffort ?? undefined) as ReasoningEffort | undefined;
         }
         const sessionCollaborationMode = sessionWrapperRef.current?.getCollaborationMode();
         if (sessionCollaborationMode) {

--- a/hub/src/notifications/notificationHub.test.ts
+++ b/hub/src/notifications/notificationHub.test.ts
@@ -58,6 +58,7 @@ function createSession(overrides: Partial<Session> = {}): Session {
         thinking: false,
         thinkingAt: 0,
         model: null,
+        modelReasoningEffort: null,
         effort: null,
         ...overrides
     }


### PR DESCRIPTION
## Summary

Fix 4 TypeScript errors introduced in 79a13d2 that have been failing CI on main since 2026-04-10.

## Problem

The reasoning effort resume logic passes `string | null` (from `SessionModelReasoningEffort`) into slots expecting the narrower `ReasoningEffort` union type. Additionally, the notification hub test helper was missing the newly required `modelReasoningEffort` field.

## Changes

| File | Fix |
|------|-----|
| `cli/src/codex/codexLocalLauncher.ts` | Cast `getModelReasoningEffort()` to `ReasoningEffort \| undefined` |
| `cli/src/codex/runCodex.ts` (×2) | Same cast at two sync-session-config sites |
| `hub/src/notifications/notificationHub.test.ts` | Add `modelReasoningEffort: null` to `createSession()` defaults |

After this fix, `bun run typecheck:cli` and `bun run typecheck:hub` both pass cleanly.