### PR TITLE
fix(web): use explicit Manager+socket for terminal namespace connection

### DIFF
--- a/web/src/hooks/useTerminalSocket.ts
+++ b/web/src/hooks/useTerminalSocket.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { io, type Socket } from 'socket.io-client'
+import { Manager, type Socket } from 'socket.io-client'
 
 type TerminalConnectionState =
     | { status: 'idle' }
@@ -116,8 +116,7 @@ export function useTerminalSocket(options: UseTerminalSocketOptions): {
             return
         }
 
-        const socket = io(`${baseUrlRef.current}/terminal`, {
-            auth: { token },
+        const manager = new Manager(baseUrlRef.current, {
             path: '/socket.io/',
             reconnection: true,
             reconnectionAttempts: Infinity,
@@ -125,6 +124,9 @@ export function useTerminalSocket(options: UseTerminalSocketOptions): {
             reconnectionDelayMax: 5000,
             transports: ['polling', 'websocket'],
             autoConnect: false
+        })
+        const socket = manager.socket('/terminal', {
+            auth: { token }
         })
 
         socketRef.current = socket


### PR DESCRIPTION
## Summary

Replace `io("${baseUrl}/terminal", ...)` with explicit `new Manager(baseUrl, ...)` + `manager.socket('/terminal', ...)` to fix web terminal connection failures.

## Problem

The `io()` convenience function misparses the `/terminal` path component as part of the Engine.IO endpoint URL in some browser environments, producing HTTP requests to:

```
GET /terminal/socket.io/?EIO=4&transport=polling   ← wrong
```

instead of:

```
GET /socket.io/?EIO=4&transport=polling             ← correct
```

The hub only routes `/socket.io/` to the socket handler (`server.ts:241`), so `/terminal/socket.io/` falls through to the web app and returns HTML, causing `transport error` disconnects.

Telegram Mini App terminal is unaffected because it uses a different connection path.

## Fix

Use `Manager` + `socket()` to explicitly separate the transport URL from the Socket.IO namespace:

```ts
// Before
const socket = io(`${baseUrl}/terminal`, { auth, path: '/socket.io/', ... })

// After
const manager = new Manager(baseUrl, { path: '/socket.io/', ... })
const socket = manager.socket('/terminal', { auth })
```

This eliminates URL parsing ambiguity — Engine.IO always connects to `${baseUrl}/socket.io/`, and `/terminal` is handled purely at the Socket.IO protocol level.

Reported and verified by @L1meSn0w in #251.

Closes #251