### PR TITLE
Security: Potential command injection on Windows due to `shell: true` with dynamic arguments

### DIFF
--- a/cli/src/opencode/opencodeLocal.ts
+++ b/cli/src/opencode/opencodeLocal.ts
@@ -9,6 +9,9 @@ export async function opencodeLocal(opts: {
 }): Promise<void> {
     const args: string[] = [];
     if (opts.sessionId) {
+        if (process.platform === 'win32' && /[&|<>^()%!"\r\n]/u.test(opts.sessionId)) {
+            throw new Error('Invalid sessionId');
+        }
         args.push('--session', opts.sessionId);
     }
 


### PR DESCRIPTION
## Problem

The process is spawned with `shell: process.platform === 'win32'` while including dynamic values (e.g., `opts.sessionId`) in `args`. On Windows, shell invocation can introduce command parsing/injection risks if arguments are not strictly validated/escaped.

**Severity**: `high`
**File**: `cli/src/opencode/opencodeLocal.ts`

## Solution

Avoid `shell: true` unless absolutely necessary. Prefer direct process spawning (`shell: false`) and pass validated arguments. If shell usage is required, strictly validate `sessionId` and escape for `cmd.exe` semantics.

## Changes

- `cli/src/opencode/opencodeLocal.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
