### PR TITLE
fix(runner): prevent ghost sessions from orphaned spawn webhooks

### DIFF
--- a/cli/src/runner/run.ts
+++ b/cli/src/runner/run.ts
@@ -204,14 +204,14 @@ export async function startRunner(): Promise<void> {
           logger.debug(
             `[RUNNER RUN] Ignoring late webhook from orphaned runner-spawned PID ${pid} (session ${sessionId}). Terminating child.`
           );
-          try {
-            process.kill(pid, 'SIGTERM');
-          } catch (err) {
-            logger.debug(
-              `[RUNNER RUN] Failed to SIGTERM orphaned runner child PID ${pid}:`,
-              err
-            );
-          }
+          // Use killProcess (SIGTERM → SIGKILL escalation) rather than a
+          // bare process.kill() so the orphan is reliably reaped even if
+          // it ignores SIGTERM.  We don't have a ChildProcess reference
+          // here (tracking entry was already removed by the timeout
+          // handler), so tree-kill via killProcessByChildProcess is not
+          // available — but the timeout handler should have already
+          // tree-killed the process group; this is defence-in-depth.
+          void killProcess(pid);
           return;
         }
 
@@ -557,19 +557,23 @@ export async function startRunner(): Promise<void> {
             // ghost session by onHappySessionWebhook().
             pidToTrackedSession.delete(pid);
 
-            // Best-effort terminate the orphan child. Without this, children
-            // spawned with `detached: true` keep running past the webhook
-            // deadline, eventually report back, and are turned into ghost
-            // sessions in the web UI. A single SIGTERM gives them a chance
-            // to clean up; even if the signal is ignored we already removed
-            // their tracking entry above, so they cannot be promoted.
-            try {
-              happyProcess?.kill('SIGTERM');
-            } catch (err) {
-              logger.debug(
-                `[RUNNER RUN] Failed to SIGTERM orphaned PID ${pid} after webhook timeout:`,
-                err
-              );
+            // Terminate the entire process tree (wrapper + agent
+            // grandchildren).  Using killProcessByChildProcess instead of
+            // a bare SIGTERM ensures that detached grandchild processes
+            // (the actual claude/codex agent) are also reaped, and that
+            // SIGTERM → SIGKILL escalation kicks in if needed.
+            if (happyProcess) {
+              void killProcessByChildProcess(happyProcess);
+            }
+
+            // If this was a worktree session, the worktree can only be
+            // safely removed after the child has actually exited (the
+            // child may still be writing to it).  Register a one-shot
+            // exit listener so cleanup happens once the tree-kill lands.
+            if (worktreeInfo && happyProcess) {
+              happyProcess.once('exit', () => {
+                void cleanupWorktree();
+              });
             }
 
             logger.debug(`[RUNNER RUN] Session webhook timeout for PID ${pid}`);

--- a/cli/src/runner/run.ts
+++ b/cli/src/runner/run.ts
@@ -127,6 +127,18 @@ export async function startRunner(): Promise<void> {
     // Setup state - key by PID
     const pidToTrackedSession = new Map<number, TrackedSession>();
 
+    // Webhook timeout tolerance. Opus 1M + --resume can legitimately take
+    // longer than the default 15s to reach the "Session started" webhook
+    // (observed real-world durations of 30s – 60min under rate-limit /
+    // heavy session restore). Allow advanced users to raise this ceiling
+    // so that slow starts no longer leave orphaned child processes which
+    // later report back as ghost sessions.
+    const envWebhookTimeout = Number(process.env.HAPI_RUNNER_WEBHOOK_TIMEOUT_MS);
+    const webhookTimeoutMs =
+      Number.isFinite(envWebhookTimeout) && envWebhookTimeout > 0
+        ? envWebhookTimeout
+        : 15_000;
+
     // Session spawning awaiter system
     const pidToAwaiter = new Map<number, (session: TrackedSession) => void>();
     const pidToErrorAwaiter = new Map<number, (errorMessage: string) => void>();
@@ -178,7 +190,32 @@ export async function startRunner(): Promise<void> {
           logger.debug(`[RUNNER RUN] Resolved session awaiter for PID ${pid}`);
         }
       } else if (!existingSession) {
-        // New session started externally
+        // No tracked session for this PID. Two possibilities:
+        //  1. The child was spawned externally from a terminal (legitimate).
+        //  2. The child was runner-spawned but already had its tracking
+        //     entry removed because its webhook arrived after the timeout
+        //     (orphaned / ghost-session case).
+        //
+        // Differentiate via the webhook's own `startedBy` field: genuine
+        // terminal-launched children report `startedBy: 'terminal'`, so
+        // anything claiming `'runner'` here must be the second case and
+        // should be ignored + terminated instead of silently promoted.
+        if (sessionMetadata.startedBy === 'runner') {
+          logger.debug(
+            `[RUNNER RUN] Ignoring late webhook from orphaned runner-spawned PID ${pid} (session ${sessionId}). Terminating child.`
+          );
+          try {
+            process.kill(pid, 'SIGTERM');
+          } catch (err) {
+            logger.debug(
+              `[RUNNER RUN] Failed to SIGTERM orphaned runner child PID ${pid}:`,
+              err
+            );
+          }
+          return;
+        }
+
+        // New session started externally (terminal)
         const trackedSession: TrackedSession = {
           startedBy: 'hapi directly - likely by user from terminal',
           happySessionId: sessionId,
@@ -508,19 +545,40 @@ export async function startRunner(): Promise<void> {
         logger.debug(`[RUNNER RUN] Waiting for session webhook for PID ${pid}`);
 
         const spawnResult = await new Promise<SpawnSessionResult>((resolve) => {
-          // Set timeout for webhook
+          // Set timeout for webhook. Default is 15s but can be raised via
+          // HAPI_RUNNER_WEBHOOK_TIMEOUT_MS for users on slow models
+          // (e.g. opus[1m] --resume).
           const timeout = setTimeout(() => {
             pidToAwaiter.delete(pid);
             pidToErrorAwaiter.delete(pid);
+
+            // Remove the tracked session entry so a late-arriving webhook
+            // from this orphaned PID cannot be silently promoted into a
+            // ghost session by onHappySessionWebhook().
+            pidToTrackedSession.delete(pid);
+
+            // Best-effort terminate the orphan child. Without this, children
+            // spawned with `detached: true` keep running past the webhook
+            // deadline, eventually report back, and are turned into ghost
+            // sessions in the web UI. A single SIGTERM gives them a chance
+            // to clean up; even if the signal is ignored we already removed
+            // their tracking entry above, so they cannot be promoted.
+            try {
+              happyProcess?.kill('SIGTERM');
+            } catch (err) {
+              logger.debug(
+                `[RUNNER RUN] Failed to SIGTERM orphaned PID ${pid} after webhook timeout:`,
+                err
+              );
+            }
+
             logger.debug(`[RUNNER RUN] Session webhook timeout for PID ${pid}`);
             logStderrTail();
             resolve({
               type: 'error',
               errorMessage: buildWebhookFailureMessage('timeout')
             });
-            // 15 second timeout - I have seen timeouts on 10 seconds
-            // even though session was still created successfully in ~2 more seconds
-          }, 15_000);
+          }, webhookTimeoutMs);
 
           // Register awaiter
           pidToAwaiter.set(pid, (completedSession) => {


### PR DESCRIPTION
## Summary

`spawnSession()` in `cli/src/runner/run.ts` currently registers a tracked session entry **before** the child's `Session started` webhook arrives. If the 15-second webhook timeout fires, only `pidToAwaiter` / `pidToErrorAwaiter` are cleaned; the `pidToTrackedSession` entry is **left in place** and the detached child keeps running. When the child eventually starts and reports its webhook, `onHappySessionWebhook()` finds the stale tracking entry and silently promotes the orphan into a normal runner-managed session — a message-less "ghost session" shows up on the web UI, and the user has no idea where it came from.

## Reproduction

Seen repeatedly on `opus[1m] --resume` on a macOS machine running the current Homebrew build (`0.16.6`). Concretely:

1. Tap **Resume** on a session whose claude-code child takes >15s to boot (observed real start delays up to **~60 minutes** under rate-limit + large session restore).
2. The hub returns `POST /api/sessions/:id/resume 500` after ~15s.
3. The user, getting 500s, taps Resume a few more times — each click spawns a fresh detached child. All of them eventually finish booting and report their webhook together, creating one ghost session per attempt.

In one user's dashboard this produced **four** ghost `Obsidian1210` sessions from a single troubled session, all rooted at the same `--resume <sessionId>`.

Relevant log excerpt:

```
18:19:35  Spawning session (...)  PID 63881  → webhook timeout 15s later
18:20:02  Spawning session (...)  PID 63921  → webhook timeout
18:20:14  Spawning session (...)  PID 63997  → webhook timeout
19:13:45  Spawning session (...)  PID 70231  → webhook timeout
19:20:16  PID 63921 webhook arrives → promoted to ghost session ab2799dd
19:20:16  PID 70231 webhook arrives → promoted to ghost session 778d408c
19:20:17  PID 63997 webhook arrives → promoted to ghost session 69cdf975
19:20:17  PID 63881 webhook arrives → promoted to ghost session 5996f036
```

Note the ~60-minute gap between `Waiting for session webhook` and the children actually reporting in — far beyond the current hard-coded 15s ceiling.

## Fix

Three small, composable changes in `cli/src/runner/run.ts`:

1. **Make the webhook timeout configurable** via `HAPI_RUNNER_WEBHOOK_TIMEOUT_MS` (default unchanged at `15_000`). Users on slow models / large resumes can raise the ceiling so the timeout never fires in the first place. Zero behaviour change for existing users.

2. **On timeout, clean `pidToTrackedSession` and `SIGTERM` the child.** Without this, the orphan's late webhook can still be silently promoted into a live session by `onHappySessionWebhook()`.

3. **Defence in depth** in `onHappySessionWebhook()`: if a webhook arrives for a PID that has no tracked session but its payload claims `startedBy: 'runner'`, treat it as an orphan — log it, `SIGTERM` the child, and return without registering the session. Genuine terminal-launched children correctly report `startedBy: 'terminal'` (see `commands/claude.ts`, `codex/loop.ts`, `opencode/runOpencode.ts`), so this branch cannot false-positive on them.

The original hard-coded timeout even carried a `// I have seen timeouts on 10 seconds even though session was still created successfully in ~2 more seconds` comment — the race it describes is the same race exploited in (2) and (3).

## Out of scope / follow-ups

- No new tests added in this PR. `runner.integration.test.ts` covers most of this flow but exercising the 60-min late-webhook window requires wall-clock mocking. Happy to add a regression test if reviewers prefer — just say the word and I'll wire one in with `vi.useFakeTimers()`.
- Docs: I did not touch `cli/src/runner/README.md` or `docs/`; let me know if you'd like `HAPI_RUNNER_WEBHOOK_TIMEOUT_MS` documented there.

## Verification

Manually reviewed against:

- `spawnSession()` (spawn → awaiter Promise)
- `onHappySessionWebhook()` (webhook dispatch)
- `stopSession()` / `onChildExited()` (cleanup paths — no new leaks)
- `controlServer.ts` (webhook payload shape — `startedBy` is always present)

Built locally is not currently possible on the submitter's machine (`bun` not installed), but each change is small enough to be reviewed by eye and the CI will catch any typecheck slip. I can provide a local smoke-test log from a Homebrew-replaced binary after merge if useful.

## Why this matters

Until the fix ships, every slow `--resume` on a slow-starting model produces a compounding pile of ghost sessions that the user can only clean up manually via `DELETE /api/sessions/:id` (and only after first `POST .../archive` to clear the `active` flag). The underlying bug has been latent since `detached: true` was introduced; it only becomes visible when the model's boot time crosses the 15s ceiling, which `opus[1m]` does routinely.

Thanks for maintaining HAPI 🙏