### PR TITLE
fix(hub,web): extend JWT expiration and harden visibility refresh

### DIFF
--- a/hub/src/web/routes/auth.ts
+++ b/hub/src/web/routes/auth.ts
@@ -71,7 +71,7 @@ export function createAuthRoutes(jwtSecret: Uint8Array, store: Store): Hono<WebA
         const token = await new SignJWT({ uid: userId, ns: namespace })
             .setProtectedHeader({ alg: 'HS256' })
             .setIssuedAt()
-            .setExpirationTime('15m')
+            .setExpirationTime('4h')
             .sign(jwtSecret)
 
         return c.json({

--- a/hub/src/web/routes/bind.ts
+++ b/hub/src/web/routes/bind.ts
@@ -51,7 +51,7 @@ export function createBindRoutes(jwtSecret: Uint8Array, store: Store): Hono<WebA
         const token = await new SignJWT({ uid: userId, ns: namespace })
             .setProtectedHeader({ alg: 'HS256' })
             .setIssuedAt()
-            .setExpirationTime('15m')
+            .setExpirationTime('4h')
             .sign(jwtSecret)
 
         return c.json({

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -267,7 +267,7 @@ export function useAuth(authSource: AuthSource | null, baseUrl: string): {
         }
 
         const handleActive = () => {
-            void refreshAuth({ minTtlMs: 60_000 })
+            void refreshAuth({ force: true })
         }
 
         const handleVisibilityChange = () => {


### PR DESCRIPTION
## Summary

Fix unexpected auto-logout after ~15 minutes of inactivity by extending JWT lifetime and hardening the tab-visibility refresh mechanism.

Discussed and approved by @tiann in #412.

## Problem

The JWT token had a hardcoded 15-minute expiration. When a browser tab is backgrounded, JavaScript timers are throttled, so the scheduled refresh (set to fire 1 minute before expiry) often doesn't execute in time. When the user returns:

1. Token is already expired
2. Visibility refresh fires with `minTtlMs: 60_000` — but since TTL is negative, it proceeds to authenticate
3. If the auth request fails (even briefly), the expired-token check clears all auth state
4. User sees login screen

## Changes

| File | Change |
|------|--------|
| `hub/src/web/routes/auth.ts:74` | `'15m'` → `'4h'` |
| `hub/src/web/routes/bind.ts:54` | `'15m'` → `'4h'` |
| `web/src/hooks/useAuth.ts:270` | `{ minTtlMs: 60_000 }` → `{ force: true }` |

**JWT expiration extended to 4 hours** — long enough that background tabs won't expire during normal use. HAPI is self-hosted, so the security tradeoff is acceptable.

**Visibility refresh changed to forced** — returning to a backgrounded tab always re-authenticates, regardless of remaining token TTL. This eliminates the race condition between timer throttling and token expiration.

Closes #412