### PR TITLE
fix(web): restore conditional TTL guard on visibility refresh

### DIFF
--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -267,7 +267,7 @@ export function useAuth(authSource: AuthSource | null, baseUrl: string): {
         }
 
         const handleActive = () => {
-            void refreshAuth({ force: true })
+            void refreshAuth({ minTtlMs: 60_000 })
         }
 
         const handleVisibilityChange = () => {


### PR DESCRIPTION
## Summary

Follow-up to #442. Restore the `minTtlMs: 60_000` guard on the visibility/focus refresh handler.

## Problem

The `force: true` change in #442 triggers a full `/api/auth` round-trip on **every** tab focus/visibility event, even when the token has hours of TTL remaining. With the JWT lifetime now extended to 4 hours, this forced refresh is unnecessary and adds avoidable auth traffic.

## Fix

Revert to the original conditional guard: only refresh when the token has less than 60 seconds remaining. The 4-hour JWT lifetime is the effective fix for the background-tab logout issue.

1 line changed in `web/src/hooks/useAuth.ts`.