### PR TITLE
Support precise Codex session forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Run official Claude Code / Codex / Gemini / OpenCode sessions locally and contro
 ## Features
 
 - **Seamless Handoff** - Work locally, switch to remote when needed, switch back anytime. No context loss, no session restart.
+- **Codex Forking** - Fork an existing Codex conversation into a brand-new session from CLI or web.
 - **Native First** - HAPI wraps your AI agent instead of replacing it. Same terminal, same experience, same muscle memory.
 - **AFK Without Stopping** - Step away from your desk? Approve AI requests from your phone with one tap.
 - **Your AI, Your Choice** - Claude Code, Codex, Cursor Agent, Gemini, OpenCode—different models, one unified workflow.

--- a/cli/README.md
+++ b/cli/README.md
@@ -27,6 +27,7 @@ Run Claude Code, Codex, Cursor Agent, Gemini, or OpenCode sessions from your ter
 - `hapi` - Start a Claude Code session (passes through Claude CLI flags). See `src/index.ts`.
 - `hapi codex` - Start Codex mode. See `src/codex/runCodex.ts`.
 - `hapi codex resume <sessionId>` - Resume existing Codex session.
+- `hapi codex fork <sessionId>` - Fork existing Codex session into a new session.
 - `hapi cursor` - Start Cursor Agent mode. See `src/cursor/runCursor.ts`.
   Supports `hapi cursor resume <chatId>`, `hapi cursor --continue`, `--mode plan|ask`, `--yolo`, `--model`.
   Local and remote modes supported; remote uses `agent -p` with stream-json.

--- a/cli/src/agent/runners/runAgentSession.ts
+++ b/cli/src/agent/runners/runAgentSession.ts
@@ -51,7 +51,8 @@ export async function runAgentSession(opts: {
 
     const messageQueue = new MessageQueue2<Record<string, never>>(() => hashObject({}));
 
-    session.onUserMessage((message, localId) => {
+    session.onUserMessage((message, meta) => {
+        const localId = meta.localId
         const formattedText = formatMessageWithAttachments(message.content.text, message.content.attachments);
         messageQueue.push(formattedText, {}, localId);
     });

--- a/cli/src/api/apiMachine.ts
+++ b/cli/src/api/apiMachine.ts
@@ -299,7 +299,7 @@ export class ApiMachineClient {
 
     setRPCHandlers({ spawnSession, stopSession, requestShutdown }: MachineRpcHandlers): void {
         this.rpcHandlerManager.registerHandler('spawn-happy-session', async (params: any) => {
-            const { directory, sessionId, resumeSessionId, forkSessionId, machineId, approvedNewDirectoryCreation, agent, model, effort, modelReasoningEffort, yolo, permissionMode, token, sessionType, worktreeName } = params || {}
+            const { directory, sessionId, resumeSessionId, forkSessionId, forkHistory, machineId, approvedNewDirectoryCreation, agent, model, effort, modelReasoningEffort, yolo, permissionMode, token, sessionType, worktreeName } = params || {}
 
             if (!directory) {
                 throw new Error('Directory is required')
@@ -315,6 +315,7 @@ export class ApiMachineClient {
                 sessionId,
                 resumeSessionId,
                 forkSessionId,
+                forkHistory,
                 machineId,
                 approvedNewDirectoryCreation,
                 agent,

--- a/cli/src/api/apiMachine.ts
+++ b/cli/src/api/apiMachine.ts
@@ -299,7 +299,7 @@ export class ApiMachineClient {
 
     setRPCHandlers({ spawnSession, stopSession, requestShutdown }: MachineRpcHandlers): void {
         this.rpcHandlerManager.registerHandler('spawn-happy-session', async (params: any) => {
-            const { directory, sessionId, resumeSessionId, machineId, approvedNewDirectoryCreation, agent, model, effort, modelReasoningEffort, yolo, permissionMode, token, sessionType, worktreeName } = params || {}
+            const { directory, sessionId, resumeSessionId, forkSessionId, machineId, approvedNewDirectoryCreation, agent, model, effort, modelReasoningEffort, yolo, permissionMode, token, sessionType, worktreeName } = params || {}
 
             if (!directory) {
                 throw new Error('Directory is required')
@@ -314,6 +314,7 @@ export class ApiMachineClient {
                 directory,
                 sessionId,
                 resumeSessionId,
+                forkSessionId,
                 machineId,
                 approvedNewDirectoryCreation,
                 agent,

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -48,6 +48,11 @@ const SYSTEM_INJECTION_PREFIXES = [
     '<system-reminder>',
 ]
 
+export type UserMessageMeta = {
+    localId?: string
+    seq?: number | null
+}
+
 /**
  * Returns true if a JSONL message should be classified as a user-role message
  * (i.e., text typed by a real human) rather than an agent-role message.
@@ -79,8 +84,8 @@ export class ApiSessionClient extends EventEmitter {
     private agentState: AgentState | null
     private agentStateVersion: number
     private readonly socket: Socket<ServerToClientEvents, ClientToServerEvents>
-    private pendingMessages: { message: UserMessage; localId?: string }[] = []
-    private pendingMessageCallback: ((message: UserMessage, localId?: string) => void) | null = null
+    private pendingMessages: { message: UserMessage; meta: UserMessageMeta }[] = []
+    private pendingMessageCallback: ((message: UserMessage, meta: UserMessageMeta) => void) | null = null
     private cancelQueuedMessageCallback: ((localId: string) => boolean) | null = null
     private lastSeenMessageSeq: number | null = null
     private backfillInFlight: Promise<void> | null = null
@@ -254,11 +259,11 @@ export class ApiSessionClient extends EventEmitter {
         this.socket.connect()
     }
 
-    onUserMessage(callback: (data: UserMessage, localId?: string) => void): void {
+    onUserMessage(callback: (data: UserMessage, meta: UserMessageMeta) => void): void {
         this.pendingMessageCallback = callback
         while (this.pendingMessages.length > 0) {
             const pending = this.pendingMessages.shift()!
-            callback(pending.message, pending.localId)
+            callback(pending.message, pending.meta)
         }
     }
 
@@ -266,11 +271,11 @@ export class ApiSessionClient extends EventEmitter {
         this.cancelQueuedMessageCallback = callback
     }
 
-    private enqueueUserMessage(message: UserMessage, localId?: string): void {
+    private enqueueUserMessage(message: UserMessage, meta: UserMessageMeta): void {
         if (this.pendingMessageCallback) {
-            this.pendingMessageCallback(message, localId)
+            this.pendingMessageCallback(message, meta)
         } else {
-            this.pendingMessages.push({ message, localId })
+            this.pendingMessages.push({ message, meta })
         }
     }
 
@@ -285,7 +290,10 @@ export class ApiSessionClient extends EventEmitter {
 
         const userResult = UserMessageSchema.safeParse(message.content)
         if (userResult.success) {
-            this.enqueueUserMessage(userResult.data, message.localId ?? undefined)
+            this.enqueueUserMessage(userResult.data, {
+                localId: message.localId ?? undefined,
+                seq
+            })
             return
         }
 
@@ -511,6 +519,20 @@ export class ApiSessionClient extends EventEmitter {
     emitMessagesConsumed(localIds: string[]): void {
         if (localIds.length === 0) return
         this.socket.emit('messages-consumed', { sid: this.sessionId, localIds })
+    }
+
+    sendCodexHistoryItem(item: {
+        codexThreadId: string
+        turnId?: string | null
+        itemId: string
+        itemKind: 'user' | 'assistant' | 'tool' | 'event' | 'unknown'
+        messageSeq?: number | null
+        rawItem: unknown
+    }): void {
+        this.socket.emit('codex-history-item', {
+            sid: this.sessionId,
+            ...item
+        })
     }
 
     sendSessionDeath(reason?: SessionEndReason): void {

--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -170,7 +170,8 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
         sessionInstance.setEffort(currentEffort);
         logger.debug(`[loop] Synced session config for keepalive: permissionMode=${currentPermissionMode}, model=${currentModel ?? 'auto'}, effort=${currentEffort ?? 'auto'}`);
     };
-    session.onUserMessage((message, localId) => {
+    session.onUserMessage((message, meta) => {
+        const localId = meta.localId
         const sessionPermissionMode = currentSessionRef.current?.getPermissionMode();
         if (sessionPermissionMode && isPermissionModeAllowedForFlavor(sessionPermissionMode, 'claude')) {
             currentPermissionMode = sessionPermissionMode as PermissionMode;

--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -91,6 +91,29 @@ export interface ThreadResumeResponse {
     [key: string]: unknown;
 }
 
+export interface ThreadForkParams {
+    threadId: string;
+    path?: string;
+    model?: string;
+    modelProvider?: string;
+    cwd?: string;
+    approvalPolicy?: ApprovalPolicy;
+    sandbox?: SandboxMode;
+    config?: Record<string, unknown>;
+    baseInstructions?: string;
+    developerInstructions?: string;
+    ephemeral?: boolean;
+    persistExtendedHistory: boolean;
+}
+
+export interface ThreadForkResponse {
+    thread: {
+        id: string;
+    };
+    model: string;
+    [key: string]: unknown;
+}
+
 export type UserInput =
     | {
         type: 'text';

--- a/cli/src/codex/codexAppServerClient.ts
+++ b/cli/src/codex/codexAppServerClient.ts
@@ -10,6 +10,8 @@ import type {
     ThreadStartResponse,
     ThreadResumeParams,
     ThreadResumeResponse,
+    ThreadForkParams,
+    ThreadForkResponse,
     TurnStartParams,
     TurnStartResponse,
     TurnInterruptParams,
@@ -159,6 +161,14 @@ export class CodexAppServerClient {
             timeoutMs: CodexAppServerClient.DEFAULT_TIMEOUT_MS
         });
         return response as ThreadResumeResponse;
+    }
+
+    async forkThread(params: ThreadForkParams, options?: { signal?: AbortSignal }): Promise<ThreadForkResponse> {
+        const response = await this.sendRequest('thread/fork', params, {
+            signal: options?.signal,
+            timeoutMs: CodexAppServerClient.DEFAULT_TIMEOUT_MS
+        });
+        return response as ThreadForkResponse;
     }
 
     async startTurn(params: TurnStartParams, options?: { signal?: AbortSignal }): Promise<TurnStartResponse> {

--- a/cli/src/codex/codexLocal.test.ts
+++ b/cli/src/codex/codexLocal.test.ts
@@ -10,41 +10,53 @@ vi.mock('@/utils/spawnWithTerminalGuard', () => ({
 
 vi.mock('@/ui/logger', () => ({
     logger: {
-        debug: vi.fn()
+        debug: vi.fn(),
+        warn: vi.fn()
     }
 }));
 
-import { codexLocal, filterResumeSubcommand } from './codexLocal';
+import { codexLocal, filterManagedSessionSubcommand } from './codexLocal';
 
-describe('filterResumeSubcommand', () => {
+describe('filterManagedSessionSubcommand', () => {
     it('returns empty array unchanged', () => {
-        expect(filterResumeSubcommand([])).toEqual([]);
+        expect(filterManagedSessionSubcommand([])).toEqual([]);
     });
 
     it('passes through args when first arg is not resume', () => {
-        expect(filterResumeSubcommand(['--model', 'gpt-4'])).toEqual(['--model', 'gpt-4']);
-        expect(filterResumeSubcommand(['--sandbox', 'read-only'])).toEqual(['--sandbox', 'read-only']);
+        expect(filterManagedSessionSubcommand(['--model', 'gpt-4'])).toEqual(['--model', 'gpt-4']);
+        expect(filterManagedSessionSubcommand(['--sandbox', 'read-only'])).toEqual(['--sandbox', 'read-only']);
     });
 
     it('filters resume subcommand with session ID', () => {
-        expect(filterResumeSubcommand(['resume', 'abc-123'])).toEqual([]);
-        expect(filterResumeSubcommand(['resume', 'abc-123', '--model', 'gpt-4']))
+        expect(filterManagedSessionSubcommand(['resume', 'abc-123'])).toEqual([]);
+        expect(filterManagedSessionSubcommand(['resume', 'abc-123', '--model', 'gpt-4']))
             .toEqual(['--model', 'gpt-4']);
     });
 
     it('filters resume subcommand without session ID', () => {
-        expect(filterResumeSubcommand(['resume'])).toEqual([]);
-        expect(filterResumeSubcommand(['resume', '--model', 'gpt-4']))
+        expect(filterManagedSessionSubcommand(['resume'])).toEqual([]);
+        expect(filterManagedSessionSubcommand(['resume', '--model', 'gpt-4']))
+            .toEqual(['--model', 'gpt-4']);
+    });
+
+    it('filters fork subcommand with session ID', () => {
+        expect(filterManagedSessionSubcommand(['fork', 'abc-123'])).toEqual([]);
+        expect(filterManagedSessionSubcommand(['fork', 'abc-123', '--model', 'gpt-4']))
             .toEqual(['--model', 'gpt-4']);
     });
 
     it('does not filter resume when it appears as flag value', () => {
-        expect(filterResumeSubcommand(['--name', 'resume'])).toEqual(['--name', 'resume']);
+        expect(filterManagedSessionSubcommand(['--name', 'resume'])).toEqual(['--name', 'resume']);
     });
 
     it('does not filter resume in middle of args', () => {
-        expect(filterResumeSubcommand(['--model', 'gpt-4', 'resume', '123']))
+        expect(filterManagedSessionSubcommand(['--model', 'gpt-4', 'resume', '123']))
             .toEqual(['--model', 'gpt-4', 'resume', '123']);
+    });
+
+    it('does not filter fork in middle of args', () => {
+        expect(filterManagedSessionSubcommand(['--model', 'gpt-4', 'fork', '123']))
+            .toEqual(['--model', 'gpt-4', 'fork', '123']);
     });
 });
 
@@ -58,7 +70,7 @@ describe('codexLocal', () => {
 
         await codexLocal({
             abort: controller.signal,
-            sessionId: null,
+            resumeSessionId: null,
             path: 'C:\\workspace\\project',
             onSessionFound: vi.fn(),
             mcpServers: {

--- a/cli/src/codex/codexLocal.ts
+++ b/cli/src/codex/codexLocal.ts
@@ -9,27 +9,28 @@ import { codexSystemPrompt } from './utils/systemPrompt';
 import type { ReasoningEffort } from './appServerTypes';
 
 /**
- * Filter out 'resume' subcommand which is managed internally by hapi.
- * Codex CLI format is `codex resume <session-id>`, so subcommand is always first.
+ * Filter out HAPI-managed session subcommands which are handled internally.
+ * Codex CLI format is `codex <subcommand> <session-id>`, so the subcommand is always first.
  */
-export function filterResumeSubcommand(args: string[]): string[] {
-    if (args.length === 0 || args[0] !== 'resume') {
+export function filterManagedSessionSubcommand(args: string[]): string[] {
+    if (args.length === 0 || (args[0] !== 'resume' && args[0] !== 'fork')) {
         return args;
     }
 
-    // First arg is 'resume', filter it and optional session ID
+    // First arg is 'resume' or 'fork'; filter it and optional session ID
     if (args.length > 1 && !args[1].startsWith('-')) {
-        logger.debug(`[CodexLocal] Filtered 'resume ${args[1]}' - session managed by hapi`);
+        logger.debug(`[CodexLocal] Filtered '${args[0]} ${args[1]}' - session managed by hapi`);
         return args.slice(2);
     }
 
-    logger.debug(`[CodexLocal] Filtered 'resume' - session managed by hapi`);
+    logger.debug(`[CodexLocal] Filtered '${args[0]}' - session managed by hapi`);
     return args.slice(1);
 }
 
 export async function codexLocal(opts: {
     abort: AbortSignal;
-    sessionId: string | null;
+    resumeSessionId: string | null;
+    forkSessionId?: string;
     path: string;
     model?: string;
     modelReasoningEffort?: ReasoningEffort;
@@ -44,9 +45,11 @@ export async function codexLocal(opts: {
 }): Promise<void> {
     const args: string[] = [];
 
-    if (opts.sessionId) {
-        args.push('resume', opts.sessionId);
-        opts.onSessionFound(opts.sessionId);
+    if (opts.forkSessionId) {
+        args.push('fork', opts.forkSessionId);
+    } else if (opts.resumeSessionId) {
+        args.push('resume', opts.resumeSessionId);
+        opts.onSessionFound(opts.resumeSessionId);
     }
 
     if (opts.model) {
@@ -74,7 +77,7 @@ export async function codexLocal(opts: {
     args.push(...buildDeveloperInstructionsArg(codexSystemPrompt));
 
     if (opts.codexArgs) {
-        const safeArgs = filterResumeSubcommand(opts.codexArgs);
+        const safeArgs = filterManagedSessionSubcommand(opts.codexArgs);
         args.push(...safeArgs);
     }
 

--- a/cli/src/codex/codexLocalLauncher.ts
+++ b/cli/src/codex/codexLocalLauncher.ts
@@ -12,6 +12,7 @@ import { BaseLocalLauncher } from '@/modules/common/launcher/BaseLocalLauncher';
 
 export async function codexLocalLauncher(session: CodexSession): Promise<'switch' | 'exit'> {
     const resumeSessionId = session.sessionId;
+    const forkSessionId = session.forkSessionId;
     let primarySessionId = resumeSessionId;
     let primaryTranscriptPath: string | null = null;
     let scanner: CodexSessionScanner | null = null;
@@ -168,7 +169,8 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
         launch: async (abortSignal) => {
             await codexLocal({
                 path: session.path,
-                sessionId: resumeSessionId,
+                resumeSessionId,
+                forkSessionId,
                 modelReasoningEffort: (session.getModelReasoningEffort() ?? undefined) as ReasoningEffort | undefined,
                 onSessionFound: handleSessionFound,
                 abort: abortSignal,

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -39,7 +39,8 @@ const harness = vi.hoisted(() => ({
     emitCompletedChildTurnBeforeSuppressedParent: false,
     emitTurnAbortedOnInterrupt: false,
     bridgeOptions: [] as unknown[],
-    forkCalls: [] as unknown[]
+    forkCalls: [] as unknown[],
+    resumeShouldThrow: null as Error | null
 }));
 
 vi.mock('react', () => ({
@@ -92,6 +93,9 @@ vi.mock('./codexAppServerClient', () => {
             harness.resumeThreadCalls.push(params);
             if (harness.failResumeThreadIds.includes(id)) {
                 throw new Error('resume failed');
+            }
+            if (harness.resumeShouldThrow) {
+                throw harness.resumeShouldThrow;
             }
             return { thread: { id }, model: 'gpt-5.4' };
         }
@@ -822,6 +826,7 @@ describe('codexRemoteLauncher', () => {
         harness.emitTurnAbortedOnInterrupt = false;
         harness.bridgeOptions = [];
         harness.forkCalls = [];
+        harness.resumeShouldThrow = null;
     });
 
     it('finishes a turn and emits ready when task lifecycle events include turn_id', async () => {
@@ -1516,6 +1521,17 @@ describe('codexRemoteLauncher', () => {
             cwd: '/tmp/hapi-update'
         });
         expect(foundSessionIds[0]).toMatch(/^hapi-fork-/);
+    });
+
+    it('throws a descriptive error when thread/resume(history) is rejected by app-server', async () => {
+        harness.resumeShouldThrow = new Error('history not supported');
+        const forkHistory = [{ id: 'user-1', role: 'user' }];
+        const { session } = createSessionStub({ forkSessionId: 'thread-source', forkHistory });
+
+        await expect(codexRemoteLauncher(session as never)).rejects.toThrow(
+            /Codex historical fork failed: app-server rejected thread\/resume\(history\): history not supported/
+        );
+        expect(harness.resumeThreadCalls).toHaveLength(1);
     });
 
     it('records user raw history before completed app-server items', async () => {

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -37,7 +37,27 @@ const harness = vi.hoisted(() => ({
     emitRunningChildTurnBeforeSuppressedParent: false,
     emitCompletedChildTurnBeforeSuppressedParent: false,
     emitTurnAbortedOnInterrupt: false,
-    bridgeOptions: [] as unknown[]
+    bridgeOptions: [] as unknown[],
+    forkCalls: [] as unknown[]
+}));
+
+vi.mock('react', () => ({
+    default: {
+        createElement: () => ({})
+    }
+}));
+
+vi.mock('ink', () => ({
+    render: () => ({
+        unmount: () => {}
+    })
+}));
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: () => {},
+        warn: () => {}
+    }
 }));
 
 vi.mock('./codexAppServerClient', () => {
@@ -72,6 +92,11 @@ vi.mock('./codexAppServerClient', () => {
                 throw new Error('resume failed');
             }
             return { thread: { id }, model: 'gpt-5.4' };
+        }
+
+        async forkThread(params: unknown): Promise<{ thread: { id: string }; model: string }> {
+            harness.forkCalls.push(params);
+            return { thread: { id: 'thread-forked' }, model: 'gpt-5.4' };
         }
 
         async compactThread(params?: { threadId?: string }): Promise<Record<string, never>> {
@@ -643,7 +668,9 @@ function createMode(): EnhancedMode {
     };
 }
 
-function createSessionStub(messages = ['hello from launcher test']) {
+function createSessionStub(opts?: string[] | { messages?: string[]; forkSessionId?: string | null }) {
+    const options = Array.isArray(opts) ? { messages: opts } : opts;
+    const messages = options?.messages ?? ['hello from launcher test'];
     const queue = new MessageQueue2<EnhancedMode>((mode) => JSON.stringify(mode));
     messages.forEach((message, index) => {
         if (index === 0 && messages.length > 1) {
@@ -696,8 +723,12 @@ function createSessionStub(messages = ['hello from launcher test']) {
         codexArgs: undefined,
         codexCliOverrides: undefined,
         sessionId: null as string | null,
+        forkSessionId: options?.forkSessionId ?? undefined,
         thinking: false,
         getPermissionMode() {
+            return 'default' as const;
+        },
+        getCollaborationMode() {
             return 'default' as const;
         },
         setModel(nextModel: string | null) {
@@ -780,6 +811,7 @@ describe('codexRemoteLauncher', () => {
         harness.emitCompletedChildTurnBeforeSuppressedParent = false;
         harness.emitTurnAbortedOnInterrupt = false;
         harness.bridgeOptions = [];
+        harness.forkCalls = [];
     });
 
     it('finishes a turn and emits ready when task lifecycle events include turn_id', async () => {
@@ -971,7 +1003,7 @@ describe('codexRemoteLauncher', () => {
 
     it('does not start a fresh thread for the next queued message after thread-level systemError', async () => {
         harness.remainingThreadSystemErrors = 1;
-        const { session } = createSessionStub(['first message', 'second message']);
+        const { session } = createSessionStub({ messages: ['first message', 'second message'] });
 
         const exitReason = await codexRemoteLauncher(session as never);
 
@@ -1439,8 +1471,26 @@ describe('codexRemoteLauncher', () => {
         }));
     });
 
+    it('forks the source thread before starting a turn when forkSessionId is provided', async () => {
+        const {
+            session,
+            foundSessionIds
+        } = createSessionStub({ forkSessionId: 'thread-source' });
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.forkCalls).toHaveLength(1);
+        expect(harness.forkCalls[0]).toMatchObject({
+            threadId: 'thread-source',
+            cwd: '/tmp/hapi-update',
+            persistExtendedHistory: true
+        });
+        expect(foundSessionIds).toContain('thread-forked');
+    });
+
     it('clears codex thread state without starting a turn', async () => {
-        const { session, sessionEvents, resetThreadCalls } = createSessionStub(['/clear', 'next message']);
+        const { session, sessionEvents, resetThreadCalls } = createSessionStub({ messages: ['/clear', 'next message'] });
 
         const exitReason = await codexRemoteLauncher(session as never);
 
@@ -1457,7 +1507,7 @@ describe('codexRemoteLauncher', () => {
 
     it('interrupts an in-flight turn before clearing codex thread state', async () => {
         harness.suppressTurnCompletion = true;
-        const { session, sessionEvents, resetThreadCalls } = createSessionStub(['first message', '/clear']);
+        const { session, sessionEvents, resetThreadCalls } = createSessionStub({ messages: ['first message', '/clear'] });
 
         const exitReason = await codexRemoteLauncher(session as never);
 
@@ -1528,7 +1578,7 @@ describe('codexRemoteLauncher', () => {
     });
 
     it('compacts the current thread without starting a turn', async () => {
-        const { session, sessionEvents } = createSessionStub(['first message', '/compact']);
+        const { session, sessionEvents } = createSessionStub({ messages: ['first message', '/compact'] });
 
         const exitReason = await codexRemoteLauncher(session as never);
 
@@ -1548,7 +1598,7 @@ describe('codexRemoteLauncher', () => {
 
     it('interrupts an in-flight turn before compacting the current thread', async () => {
         harness.suppressTurnCompletion = true;
-        const { session, sessionEvents } = createSessionStub(['first message', '/compact']);
+        const { session, sessionEvents } = createSessionStub({ messages: ['first message', '/compact'] });
 
         const exitReason = await codexRemoteLauncher(session as never);
 
@@ -1565,7 +1615,7 @@ describe('codexRemoteLauncher', () => {
     });
 
     it('reports nothing to compact when no codex thread exists', async () => {
-        const { session, sessionEvents } = createSessionStub(['/compact']);
+        const { session, sessionEvents } = createSessionStub({ messages: ['/compact'] });
 
         const exitReason = await codexRemoteLauncher(session as never);
 
@@ -1580,7 +1630,7 @@ describe('codexRemoteLauncher', () => {
     });
 
     it('rejects argument-bearing codex slash commands without starting a turn', async () => {
-        const { session, sessionEvents } = createSessionStub(['/compact now']);
+        const { session, sessionEvents } = createSessionStub({ messages: ['/compact now'] });
 
         const exitReason = await codexRemoteLauncher(session as never);
 

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -8,6 +8,7 @@ const harness = vi.hoisted(() => ({
     initializeCalls: [] as unknown[],
     startThreadIds: [] as string[],
     resumeThreadIds: [] as string[],
+    resumeThreadCalls: [] as unknown[],
     startTurnThreadIds: [] as string[],
     interruptedTurns: [] as Array<{ threadId: string; turnId: string }>,
     compactThreadIds: [] as string[],
@@ -88,6 +89,7 @@ vi.mock('./codexAppServerClient', () => {
         async resumeThread(params?: { threadId?: string }): Promise<{ thread: { id: string }; model: string }> {
             const id = params?.threadId ?? 'thread-resumed';
             harness.resumeThreadIds.push(id);
+            harness.resumeThreadCalls.push(params);
             if (harness.failResumeThreadIds.includes(id)) {
                 throw new Error('resume failed');
             }
@@ -668,15 +670,16 @@ function createMode(): EnhancedMode {
     };
 }
 
-function createSessionStub(opts?: string[] | { messages?: string[]; forkSessionId?: string | null }) {
+function createSessionStub(opts?: string[] | { messages?: string[]; messageSeqs?: number[]; forkSessionId?: string | null; forkHistory?: unknown[] }) {
     const options = Array.isArray(opts) ? { messages: opts } : opts;
     const messages = options?.messages ?? ['hello from launcher test'];
     const queue = new MessageQueue2<EnhancedMode>((mode) => JSON.stringify(mode));
     messages.forEach((message, index) => {
+        const messageSeq = options?.messageSeqs?.[index] ?? null;
         if (index === 0 && messages.length > 1) {
-            queue.pushIsolateAndClear(message, createMode());
+            queue.pushIsolateAndClear(message, createMode(), undefined, messageSeq);
         } else {
-            queue.push(message, createMode());
+            queue.push(message, createMode(), undefined, messageSeq);
         }
     });
     queue.close();
@@ -684,6 +687,7 @@ function createSessionStub(opts?: string[] | { messages?: string[]; forkSessionI
     const sessionEvents: Array<{ type: string; [key: string]: unknown }> = [];
     const codexMessages: unknown[] = [];
     const summaryMessages: unknown[] = [];
+    const historyItems: unknown[] = [];
     const thinkingChanges: boolean[] = [];
     const foundSessionIds: string[] = [];
     const resetThreadCalls: string[] = [];
@@ -710,6 +714,9 @@ function createSessionStub(opts?: string[] | { messages?: string[]; forkSessionI
         sendClaudeSessionMessage(message: unknown) {
             summaryMessages.push(message);
         },
+        sendCodexHistoryItem(item: unknown) {
+            historyItems.push(item);
+        },
         sendSessionEvent(event: { type: string; [key: string]: unknown }) {
             sessionEvents.push(event);
         }
@@ -724,6 +731,7 @@ function createSessionStub(opts?: string[] | { messages?: string[]; forkSessionI
         codexCliOverrides: undefined,
         sessionId: null as string | null,
         forkSessionId: options?.forkSessionId ?? undefined,
+        forkHistory: options?.forkHistory ?? undefined,
         thinking: false,
         getPermissionMode() {
             return 'default' as const;
@@ -765,6 +773,7 @@ function createSessionStub(opts?: string[] | { messages?: string[]; forkSessionI
         sessionEvents,
         codexMessages,
         summaryMessages,
+        historyItems,
         thinkingChanges,
         foundSessionIds,
         resetThreadCalls,
@@ -781,6 +790,7 @@ describe('codexRemoteLauncher', () => {
         harness.initializeCalls = [];
         harness.startThreadIds = [];
         harness.resumeThreadIds = [];
+        harness.resumeThreadCalls = [];
         harness.startTurnThreadIds = [];
         harness.interruptedTurns = [];
         harness.compactThreadIds = [];
@@ -1487,6 +1497,52 @@ describe('codexRemoteLauncher', () => {
             persistExtendedHistory: true
         });
         expect(foundSessionIds).toContain('thread-forked');
+    });
+
+    it('resumes a new thread with raw history for historical fork', async () => {
+        const forkHistory = [{ id: 'user-1', role: 'user' }];
+        const {
+            session,
+            foundSessionIds
+        } = createSessionStub({ forkSessionId: 'thread-source', forkHistory });
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.forkCalls).toHaveLength(0);
+        expect(harness.resumeThreadCalls).toHaveLength(1);
+        expect(harness.resumeThreadCalls[0]).toMatchObject({
+            history: forkHistory,
+            cwd: '/tmp/hapi-update'
+        });
+        expect(foundSessionIds[0]).toMatch(/^hapi-fork-/);
+    });
+
+    it('records user raw history before completed app-server items', async () => {
+        const {
+            session,
+            historyItems
+        } = createSessionStub({ messages: ['hello from launcher test'], messageSeqs: [7] });
+
+        await codexRemoteLauncher(session as never);
+
+        expect(historyItems).toHaveLength(2);
+        expect(historyItems[0]).toMatchObject({
+            codexThreadId: 'thread-1',
+            itemId: 'hapi-user-7',
+            itemKind: 'user',
+            messageSeq: 7,
+            rawItem: {
+                id: 'hapi-user-7',
+                role: 'user'
+            }
+        });
+        expect(historyItems[1]).toMatchObject({
+            codexThreadId: 'thread-1',
+            turnId: 'turn-1',
+            itemId: 'cmd-1',
+            itemKind: 'tool'
+        });
     });
 
     it('clears codex thread state without starting a turn', async () => {

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -23,6 +23,7 @@ import {
     type RemoteLauncherDisplayContext,
     type RemoteLauncherExitReason
 } from '@/modules/common/remote/RemoteLauncherBase';
+import { isAbortError } from '@/utils/spawnWithAbort';
 
 type HappyServer = Awaited<ReturnType<typeof buildHapiMcpBridge>>['server'];
 type QueuedMessage = { message: string; mode: EnhancedMode; isolate: boolean; hash: string; messageSeqs: number[] };
@@ -2275,6 +2276,10 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 mcpServers,
                 cliOverrides: session.codexCliOverrides
             });
+            // Contract: Codex app-server `thread/resume` accepts an unknown threadId together with a
+            // `history` array and creates a fresh thread seeded with that history. The synthetic id
+            // here is required so we can later disambiguate this thread from the source. If a future
+            // app-server release rejects unknown ids, this is the call that breaks first.
             const historicalThreadId = `hapi-fork-${randomUUID()}`;
             let resumeResponse: unknown;
             try {
@@ -2301,20 +2306,29 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             applyResolvedModel(resumeRecord?.model);
             sendReady();
         } else if (session.forkSessionId) {
-            const forkResponse = await appServerClient.forkThread(buildThreadForkParams({
-                threadId: session.forkSessionId,
-                cwd: session.path,
-                mode: buildInitialMode(),
-                mcpServers,
-                cliOverrides: session.codexCliOverrides
-            }), {
-                signal: this.abortController.signal
-            });
+            let forkResponse: unknown;
+            try {
+                forkResponse = await appServerClient.forkThread(buildThreadForkParams({
+                    threadId: session.forkSessionId,
+                    cwd: session.path,
+                    mode: buildInitialMode(),
+                    mcpServers,
+                    cliOverrides: session.codexCliOverrides
+                }), {
+                    signal: this.abortController.signal
+                });
+            } catch (error) {
+                if (isAbortError(error)) {
+                    throw error;
+                }
+                const detail = error instanceof Error ? error.message : String(error);
+                throw new Error(`Codex fork failed: app-server rejected thread/fork: ${detail}`);
+            }
             const forkRecord = asRecord(forkResponse);
             const forkThread = forkRecord ? asRecord(forkRecord.thread) : null;
             const forkedThreadId = asString(forkThread?.id);
             if (!forkedThreadId) {
-                throw new Error('app-server thread/fork did not return thread.id');
+                throw new Error('Codex fork failed: app-server thread/fork did not return thread.id');
             }
             this.currentThreadId = forkedThreadId;
             session.onSessionFound(forkedThreadId);
@@ -2528,7 +2542,17 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                             applyResolvedModel(forkRecord?.model);
                             logger.debug(`[Codex] Forked app-server thread ${forkCandidate} -> ${threadId ?? 'unknown'}`);
                         } catch (error) {
-                            logger.warn(`[Codex] Failed to fork app-server thread ${forkCandidate}, starting new thread`, error);
+                            // Surface the fork failure to the user. Falling back silently to startThread
+                            // would lose the source thread's context without any indication.
+                            if (isAbortError(error)) {
+                                throw error;
+                            }
+                            const detail = error instanceof Error ? error.message : String(error);
+                            const message = `Fork failed (${forkCandidate}): ${detail}`;
+                            logger.warn(`[Codex] ${message}`);
+                            messageBuffer.addMessage(message, 'status');
+                            session.sendSessionEvent({ type: 'message', message });
+                            throw error;
                         }
                     } else if (resumeCandidate) {
                         try {
@@ -2620,12 +2644,12 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 }
             } catch (error) {
                 logger.warn('Error in codex session:', error);
-                const isAbortError = error instanceof Error && error.name === 'AbortError';
+                const aborted = isAbortError(error);
                 turnInFlight = false;
                 allowAnonymousTerminalEvent = false;
                 this.currentTurnId = null;
 
-                if (isAbortError) {
+                if (aborted) {
                     messageBuffer.addMessage('Aborted by user', 'status');
                     session.sendSessionEvent({ type: 'message', message: 'Aborted by user' });
                 } else {

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -14,7 +14,7 @@ import type { EnhancedMode } from './loop';
 import { hasCodexCliOverrides } from './utils/codexCliOverrides';
 import { AppServerEventConverter } from './utils/appServerEventConverter';
 import { registerAppServerPermissionHandlers } from './utils/appServerPermissionAdapter';
-import { buildThreadStartParams, buildTurnStartParams } from './utils/appServerConfig';
+import { buildThreadForkParams, buildThreadStartParams, buildTurnStartParams } from './utils/appServerConfig';
 import { shouldIgnoreTerminalEvent } from './utils/terminalEventGuard';
 import { parseCodexSpecialCommand } from './codexSpecialCommands';
 import {
@@ -2164,6 +2164,23 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             session.sendSessionEvent({ type: 'ready' });
         };
 
+        const buildInitialMode = (): EnhancedMode => {
+            const rawPermissionMode = session.getPermissionMode();
+            const permissionMode = rawPermissionMode === 'default'
+                || rawPermissionMode === 'read-only'
+                || rawPermissionMode === 'safe-yolo'
+                || rawPermissionMode === 'yolo'
+                ? rawPermissionMode
+                : 'default';
+            const rawCollaborationMode = session.getCollaborationMode?.();
+            const collaborationMode = rawCollaborationMode === 'plan' ? 'plan' : 'default';
+            return {
+                permissionMode,
+                model: session.getModel() ?? undefined,
+                collaborationMode
+            };
+        };
+
         await appServerClient.connect();
         await appServerClient.initialize({
             clientInfo: {
@@ -2177,6 +2194,29 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
 
         let hasThread = false;
         let pending: QueuedMessage | null = null;
+
+        if (session.forkSessionId) {
+            const forkResponse = await appServerClient.forkThread(buildThreadForkParams({
+                threadId: session.forkSessionId,
+                cwd: session.path,
+                mode: buildInitialMode(),
+                mcpServers,
+                cliOverrides: session.codexCliOverrides
+            }), {
+                signal: this.abortController.signal
+            });
+            const forkRecord = asRecord(forkResponse);
+            const forkThread = forkRecord ? asRecord(forkRecord.thread) : null;
+            const forkedThreadId = asString(forkThread?.id);
+            if (!forkedThreadId) {
+                throw new Error('app-server thread/fork did not return thread.id');
+            }
+            this.currentThreadId = forkedThreadId;
+            session.onSessionFound(forkedThreadId);
+            hasThread = true;
+            applyResolvedModel(forkRecord?.model);
+            sendReady();
+        }
 
         clearReadyAfterTurnTimer = () => {
             if (!readyAfterTurnTimer) {
@@ -2360,10 +2400,32 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                         cliOverrides: session.codexCliOverrides
                     });
 
-                    const resumeCandidate = session.sessionId ?? null;
+                    const forkCandidate = session.forkSessionId;
+                    const resumeCandidate = session.sessionId && session.sessionId !== invalidThreadId
+                        ? session.sessionId
+                        : null;
                     let threadId: string | null = null;
 
-                    if (resumeCandidate) {
+                    if (forkCandidate) {
+                        try {
+                            const forkResponse = await appServerClient.forkThread(buildThreadForkParams({
+                                threadId: forkCandidate,
+                                cwd: session.path,
+                                mode: message.mode,
+                                mcpServers,
+                                cliOverrides: session.codexCliOverrides
+                            }), {
+                                signal: this.abortController.signal
+                            });
+                            const forkRecord = asRecord(forkResponse);
+                            const forkThread = forkRecord ? asRecord(forkRecord.thread) : null;
+                            threadId = asString(forkThread?.id);
+                            applyResolvedModel(forkRecord?.model);
+                            logger.debug(`[Codex] Forked app-server thread ${forkCandidate} -> ${threadId ?? 'unknown'}`);
+                        } catch (error) {
+                            logger.warn(`[Codex] Failed to fork app-server thread ${forkCandidate}, starting new thread`, error);
+                        }
+                    } else if (resumeCandidate) {
                         try {
                             const resumeResponse = await appServerClient.resumeThread({
                                 threadId: resumeCandidate,

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -17,6 +17,7 @@ import { registerAppServerPermissionHandlers } from './utils/appServerPermission
 import { buildThreadForkParams, buildThreadStartParams, buildTurnStartParams } from './utils/appServerConfig';
 import { shouldIgnoreTerminalEvent } from './utils/terminalEventGuard';
 import { parseCodexSpecialCommand } from './codexSpecialCommands';
+import type { ResponseItem } from './appServerTypes';
 import {
     RemoteLauncherBase,
     type RemoteLauncherDisplayContext,
@@ -24,7 +25,7 @@ import {
 } from '@/modules/common/remote/RemoteLauncherBase';
 
 type HappyServer = Awaited<ReturnType<typeof buildHapiMcpBridge>>['server'];
-type QueuedMessage = { message: string; mode: EnhancedMode; isolate: boolean; hash: string };
+type QueuedMessage = { message: string; mode: EnhancedMode; isolate: boolean; hash: string; messageSeqs: number[] };
 type ChildAgentRuntime = {
     reasoningProcessor: ReasoningProcessor;
     diffProcessor: DiffProcessor;
@@ -219,6 +220,77 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
 
         const asString = (value: unknown): string | null => {
             return typeof value === 'string' && value.length > 0 ? value : null;
+        };
+
+        const extractHistoryItem = (params: unknown): Record<string, unknown> | null => {
+            const record = asRecord(params);
+            if (!record) return null;
+            return asRecord(record.item) ?? record;
+        };
+
+        const extractHistoryItemId = (params: unknown, item: Record<string, unknown>): string | null => {
+            const record = asRecord(params);
+            return asString(record?.itemId ?? record?.item_id ?? record?.id)
+                ?? asString(item.id ?? item.itemId ?? item.item_id);
+        };
+
+        const extractHistoryTurnId = (params: unknown): string | null => {
+            const record = asRecord(params);
+            return asString(record?.turnId ?? record?.turn_id) ?? this.currentTurnId;
+        };
+
+        const classifyHistoryItem = (item: Record<string, unknown>): 'user' | 'assistant' | 'tool' | 'event' | 'unknown' => {
+            if (item.role === 'user') return 'user';
+            if (item.role === 'assistant') return 'assistant';
+            const rawType = asString(item.type)?.toLowerCase() ?? '';
+            if (rawType.includes('tool') || rawType.includes('function') || rawType.includes('command')) return 'tool';
+            if (rawType.includes('message') || rawType.includes('reasoning')) return 'assistant';
+            if (rawType.includes('event')) return 'event';
+            return 'unknown';
+        };
+
+        const recordHistoryItem = (input: {
+            threadId: string;
+            turnId?: string | null;
+            itemId: string;
+            itemKind: 'user' | 'assistant' | 'tool' | 'event' | 'unknown';
+            messageSeq?: number | null;
+            rawItem: ResponseItem;
+        }): void => {
+            const historySender = (session.client as unknown as { sendCodexHistoryItem?: typeof session.client.sendCodexHistoryItem }).sendCodexHistoryItem;
+            if (!historySender) {
+                return;
+            }
+            historySender.call(session.client, {
+                codexThreadId: input.threadId,
+                turnId: input.turnId ?? null,
+                itemId: input.itemId,
+                itemKind: input.itemKind,
+                messageSeq: input.messageSeq ?? null,
+                rawItem: input.rawItem
+            });
+        };
+
+        const buildUserHistoryItem = (itemId: string, message: string): ResponseItem => ({
+            id: itemId,
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: message }]
+        });
+
+        const recordCompletedHistoryItem = (method: string, params: unknown): void => {
+            if (method !== 'item/completed' || !this.currentThreadId) return;
+            const item = extractHistoryItem(params);
+            if (!item) return;
+            const itemId = extractHistoryItemId(params, item);
+            if (!itemId) return;
+            recordHistoryItem({
+                threadId: this.currentThreadId,
+                turnId: extractHistoryTurnId(params),
+                itemId,
+                itemKind: classifyHistoryItem(item),
+                rawItem: item
+            });
         };
 
         const applyResolvedModel = (value: unknown): string | undefined => {
@@ -2126,6 +2198,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         });
 
         appServerClient.setNotificationHandler((method, params) => {
+            recordCompletedHistoryItem(method, params);
             const events = appServerEventConverter.handleNotification(method, params);
             for (const event of events) {
                 const eventRecord = asRecord(event) ?? { type: undefined };
@@ -2195,7 +2268,39 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         let hasThread = false;
         let pending: QueuedMessage | null = null;
 
-        if (session.forkSessionId) {
+        if (session.forkHistory) {
+            const threadParams = buildThreadStartParams({
+                cwd: session.path,
+                mode: buildInitialMode(),
+                mcpServers,
+                cliOverrides: session.codexCliOverrides
+            });
+            const historicalThreadId = `hapi-fork-${randomUUID()}`;
+            let resumeResponse: unknown;
+            try {
+                resumeResponse = await appServerClient.resumeThread({
+                    threadId: historicalThreadId,
+                    history: session.forkHistory,
+                    ...threadParams
+                }, {
+                    signal: this.abortController.signal
+                });
+            } catch (error) {
+                const detail = error instanceof Error ? error.message : String(error);
+                throw new Error(`Codex historical fork failed: app-server rejected thread/resume(history): ${detail}`);
+            }
+            const resumeRecord = asRecord(resumeResponse);
+            const resumeThread = resumeRecord ? asRecord(resumeRecord.thread) : null;
+            const resumedThreadId = asString(resumeThread?.id);
+            if (!resumedThreadId) {
+                throw new Error('Codex historical fork failed: app-server thread/resume(history) did not return thread.id');
+            }
+            this.currentThreadId = resumedThreadId;
+            session.onSessionFound(resumedThreadId);
+            hasThread = true;
+            applyResolvedModel(resumeRecord?.model);
+            sendReady();
+        } else if (session.forkSessionId) {
             const forkResponse = await appServerClient.forkThread(buildThreadForkParams({
                 threadId: session.forkSessionId,
                 cwd: session.path,
@@ -2487,6 +2592,17 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     },
                     cliOverrides: session.codexCliOverrides
                 });
+                const messageSeq = message.messageSeqs.length === 1 ? message.messageSeqs[0] : null;
+                if (typeof messageSeq === 'number' && this.currentThreadId) {
+                    const itemId = `hapi-user-${messageSeq}`;
+                    recordHistoryItem({
+                        threadId: this.currentThreadId,
+                        itemId,
+                        itemKind: 'user',
+                        messageSeq,
+                        rawItem: buildUserHistoryItem(itemId, message.message)
+                    });
+                }
                 turnInFlight = true;
                 allowAnonymousTerminalEvent = false;
                 const turnResponse = await appServerClient.startTurn(turnParams, {

--- a/cli/src/codex/loop.ts
+++ b/cli/src/codex/loop.ts
@@ -33,6 +33,7 @@ interface LoopOptions {
     modelReasoningEffort?: ReasoningEffort;
     collaborationMode?: CodexCollaborationMode;
     resumeSessionId?: string;
+    forkSessionId?: string;
     onSessionReady?: (session: CodexSession) => void;
 }
 
@@ -53,6 +54,7 @@ export async function loop(opts: LoopOptions): Promise<void> {
         startingMode,
         codexArgs: opts.codexArgs,
         codexCliOverrides: opts.codexCliOverrides,
+        forkSessionId: opts.forkSessionId,
         permissionMode: opts.permissionMode ?? 'default',
         model: opts.model,
         modelReasoningEffort: opts.modelReasoningEffort,

--- a/cli/src/codex/loop.ts
+++ b/cli/src/codex/loop.ts
@@ -6,7 +6,7 @@ import { codexLocalLauncher } from './codexLocalLauncher';
 import { codexRemoteLauncher } from './codexRemoteLauncher';
 import { ApiClient, ApiSessionClient } from '@/lib';
 import type { CodexCliOverrides } from './utils/codexCliOverrides';
-import type { ReasoningEffort } from './appServerTypes';
+import type { ReasoningEffort, ResponseItem } from './appServerTypes';
 import type { CodexCollaborationMode, CodexPermissionMode } from '@hapi/protocol/types';
 
 export type PermissionMode = CodexPermissionMode;
@@ -34,6 +34,7 @@ interface LoopOptions {
     collaborationMode?: CodexCollaborationMode;
     resumeSessionId?: string;
     forkSessionId?: string;
+    forkHistory?: ResponseItem[];
     onSessionReady?: (session: CodexSession) => void;
 }
 
@@ -55,6 +56,7 @@ export async function loop(opts: LoopOptions): Promise<void> {
         codexArgs: opts.codexArgs,
         codexCliOverrides: opts.codexCliOverrides,
         forkSessionId: opts.forkSessionId,
+        forkHistory: opts.forkHistory,
         permissionMode: opts.permissionMode ?? 'default',
         model: opts.model,
         modelReasoningEffort: opts.modelReasoningEffort,

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -193,6 +193,9 @@ export async function runCodex(opts: {
                     messageQueue.pushIsolateAndClear(isolatedCommandText, enhancedMode, localId, messageSeq);
                     return;
                 }
+                // Each user message starts its own turn so messageSeq → raw-history item is 1:1.
+                // Batching multiple messages into one turn would emit a single user item upstream
+                // and break historical-fork prefix reconstruction.
                 messageQueue.pushIsolated(text, enhancedMode, localId, messageSeq);
             } catch (error) {
                 logger.debug('[Codex] Failed to handle user message', error);

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -13,7 +13,7 @@ import { isPermissionModeAllowedForFlavor } from '@hapi/protocol';
 import { CodexCollaborationModeSchema, PermissionModeSchema } from '@hapi/protocol/schemas';
 import { formatMessageWithAttachments } from '@/utils/attachmentFormatter';
 import { getInvokedCwd } from '@/utils/invokedCwd';
-import type { ReasoningEffort } from './appServerTypes';
+import type { ReasoningEffort, ResponseItem } from './appServerTypes';
 import { parseCodexSpecialCommand } from './codexSpecialCommands';
 import { listSlashCommands } from '@/modules/common/slashCommands';
 import { resolveCodexSlashCommand } from './utils/slashCommands';
@@ -28,6 +28,7 @@ export async function runCodex(opts: {
     permissionMode?: PermissionMode;
     resumeSessionId?: string;
     forkSessionId?: string;
+    forkHistory?: ResponseItem[];
     model?: string;
     modelReasoningEffort?: ReasoningEffort;
 }): Promise<void> {
@@ -136,8 +137,10 @@ export async function runCodex(opts: {
     };
 
     let userMessageChain: Promise<void> = Promise.resolve();
-    session.onUserMessage((message, localId) => {
+    session.onUserMessage((message, meta) => {
         userMessageChain = userMessageChain.then(async () => {
+            const localId = meta.localId
+            const messageSeq = meta.seq ?? null
             try {
                 syncCurrentConfigFromSession();
                 let text = message.content.text;
@@ -187,10 +190,10 @@ export async function runCodex(opts: {
                     collaborationMode: currentCollaborationMode
                 };
                 if (isolatedCommandText) {
-                    messageQueue.pushIsolateAndClear(isolatedCommandText, enhancedMode, localId);
+                    messageQueue.pushIsolateAndClear(isolatedCommandText, enhancedMode, localId, messageSeq);
                     return;
                 }
-                messageQueue.push(text, enhancedMode, localId);
+                messageQueue.pushIsolated(text, enhancedMode, localId, messageSeq);
             } catch (error) {
                 logger.debug('[Codex] Failed to handle user message', error);
                 const enhancedMode: EnhancedMode = {
@@ -199,7 +202,7 @@ export async function runCodex(opts: {
                     modelReasoningEffort: currentModelReasoningEffort,
                     collaborationMode: currentCollaborationMode
                 };
-                messageQueue.push(formatMessageWithAttachments(message.content.text, message.content.attachments), enhancedMode, localId);
+                messageQueue.pushIsolated(formatMessageWithAttachments(message.content.text, message.content.attachments), enhancedMode, localId, messageSeq);
             }
         }).catch((error) => {
             logger.debug('[Codex] User message handler chain failed', error);
@@ -320,6 +323,7 @@ export async function runCodex(opts: {
             collaborationMode: currentCollaborationMode,
             resumeSessionId: opts.resumeSessionId,
             forkSessionId: opts.forkSessionId,
+            forkHistory: opts.forkHistory,
             onModeChange: createModeChangeHandler(session),
             onSessionReady: (instance) => {
                 sessionWrapperRef.current = instance;

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -27,6 +27,7 @@ export async function runCodex(opts: {
     codexArgs?: string[];
     permissionMode?: PermissionMode;
     resumeSessionId?: string;
+    forkSessionId?: string;
     model?: string;
     modelReasoningEffort?: ReasoningEffort;
 }): Promise<void> {
@@ -318,6 +319,7 @@ export async function runCodex(opts: {
             modelReasoningEffort: currentModelReasoningEffort,
             collaborationMode: currentCollaborationMode,
             resumeSessionId: opts.resumeSessionId,
+            forkSessionId: opts.forkSessionId,
             onModeChange: createModeChangeHandler(session),
             onSessionReady: (instance) => {
                 sessionWrapperRef.current = instance;

--- a/cli/src/codex/session.ts
+++ b/cli/src/codex/session.ts
@@ -15,6 +15,7 @@ export class CodexSession extends AgentSessionBase<EnhancedMode> {
     transcriptPath: string | null = null;
     readonly codexArgs?: string[];
     readonly codexCliOverrides?: CodexCliOverrides;
+    readonly forkSessionId?: string;
     readonly startedBy: 'runner' | 'terminal';
     readonly startingMode: 'local' | 'remote';
     localLaunchFailure: LocalLaunchFailure | null = null;
@@ -34,6 +35,7 @@ export class CodexSession extends AgentSessionBase<EnhancedMode> {
         startingMode: 'local' | 'remote';
         codexArgs?: string[];
         codexCliOverrides?: CodexCliOverrides;
+        forkSessionId?: string;
         permissionMode?: PermissionMode;
         model?: SessionModel;
         modelReasoningEffort?: SessionModelReasoningEffort;
@@ -62,6 +64,7 @@ export class CodexSession extends AgentSessionBase<EnhancedMode> {
 
         this.codexArgs = opts.codexArgs;
         this.codexCliOverrides = opts.codexCliOverrides;
+        this.forkSessionId = opts.forkSessionId;
         this.startedBy = opts.startedBy;
         this.startingMode = opts.startingMode;
         this.permissionMode = opts.permissionMode;

--- a/cli/src/codex/session.ts
+++ b/cli/src/codex/session.ts
@@ -5,6 +5,7 @@ import type { EnhancedMode, PermissionMode } from './loop';
 import type { CodexCliOverrides } from './utils/codexCliOverrides';
 import type { LocalLaunchExitReason } from '@/agent/localLaunchPolicy';
 import type { Metadata, SessionModel, SessionModelReasoningEffort } from '@/api/types';
+import type { ResponseItem } from './appServerTypes';
 
 type LocalLaunchFailure = {
     message: string;
@@ -16,6 +17,7 @@ export class CodexSession extends AgentSessionBase<EnhancedMode> {
     readonly codexArgs?: string[];
     readonly codexCliOverrides?: CodexCliOverrides;
     readonly forkSessionId?: string;
+    readonly forkHistory?: ResponseItem[];
     readonly startedBy: 'runner' | 'terminal';
     readonly startingMode: 'local' | 'remote';
     localLaunchFailure: LocalLaunchFailure | null = null;
@@ -36,6 +38,7 @@ export class CodexSession extends AgentSessionBase<EnhancedMode> {
         codexArgs?: string[];
         codexCliOverrides?: CodexCliOverrides;
         forkSessionId?: string;
+        forkHistory?: ResponseItem[];
         permissionMode?: PermissionMode;
         model?: SessionModel;
         modelReasoningEffort?: SessionModelReasoningEffort;
@@ -65,6 +68,7 @@ export class CodexSession extends AgentSessionBase<EnhancedMode> {
         this.codexArgs = opts.codexArgs;
         this.codexCliOverrides = opts.codexCliOverrides;
         this.forkSessionId = opts.forkSessionId;
+        this.forkHistory = opts.forkHistory;
         this.startedBy = opts.startedBy;
         this.startingMode = opts.startingMode;
         this.permissionMode = opts.permissionMode;

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { EnhancedMode } from '../loop';
 import {
+    buildThreadForkParams,
     buildThreadStartParams,
     buildTurnStartParams,
     codexCollaborationSpawnAgentInstructions,
@@ -103,6 +104,33 @@ describe('appServerConfig', () => {
             },
             developer_instructions: codexSystemPrompt,
             model_reasoning_effort: 'xhigh'
+        });
+    });
+
+    it('builds fork params from thread config defaults', () => {
+        const params = buildThreadForkParams({
+            threadId: 'thread-source',
+            cwd: '/workspace/project',
+            mode: { permissionMode: 'default', model: 'gpt-5.4', collaborationMode: 'default' },
+            mcpServers
+        });
+
+        expect(params).toEqual({
+            threadId: 'thread-source',
+            cwd: '/workspace/project',
+            approvalPolicy: 'on-request',
+            sandbox: 'workspace-write',
+            model: 'gpt-5.4',
+            baseInstructions: codexSystemPrompt,
+            developerInstructions: codexSystemPrompt,
+            config: {
+                'mcp_servers.hapi': {
+                    command: 'node',
+                    args: ['mcp']
+                },
+                developer_instructions: codexSystemPrompt
+            },
+            persistExtendedHistory: true
         });
     });
 

--- a/cli/src/codex/utils/appServerConfig.ts
+++ b/cli/src/codex/utils/appServerConfig.ts
@@ -6,6 +6,7 @@ import type {
     ApprovalPolicy,
     SandboxMode,
     SandboxPolicy,
+    ThreadForkParams,
     ThreadStartParams,
     TurnStartParams
 } from '../appServerTypes';
@@ -125,6 +126,37 @@ export function buildThreadStartParams(args: {
     }
 
     return params;
+}
+
+export function buildThreadForkParams(args: {
+    threadId: string;
+    cwd: string;
+    mode: EnhancedMode;
+    mcpServers: McpServersConfig;
+    cliOverrides?: CodexCliOverrides;
+    baseInstructions?: string;
+    developerInstructions?: string;
+}): ThreadForkParams {
+    const startParams = buildThreadStartParams({
+        cwd: args.cwd,
+        mode: args.mode,
+        mcpServers: args.mcpServers,
+        cliOverrides: args.cliOverrides,
+        baseInstructions: args.baseInstructions,
+        developerInstructions: args.developerInstructions
+    });
+
+    return {
+        threadId: args.threadId,
+        cwd: startParams.cwd,
+        approvalPolicy: startParams.approvalPolicy,
+        sandbox: startParams.sandbox,
+        config: startParams.config,
+        baseInstructions: startParams.baseInstructions,
+        developerInstructions: startParams.developerInstructions,
+        model: startParams.model,
+        persistExtendedHistory: true
+    };
 }
 
 export function buildTurnStartParams(args: {

--- a/cli/src/commands/codex.ts
+++ b/cli/src/commands/codex.ts
@@ -34,6 +34,7 @@ export const codexCommand: CommandDefinition = {
                 codexArgs?: string[]
                 permissionMode?: CodexPermissionMode
                 resumeSessionId?: string
+                forkSessionId?: string
                 model?: string
                 modelReasoningEffort?: ReasoningEffort
             } = {}
@@ -48,6 +49,15 @@ export const codexCommand: CommandDefinition = {
                         throw new Error('resume requires a session id')
                     }
                     options.resumeSessionId = candidate
+                    i += 1
+                    continue
+                }
+                if (i === 0 && arg === 'fork') {
+                    const candidate = commandArgs[i + 1]
+                    if (!candidate || candidate.startsWith('-')) {
+                        throw new Error('fork requires a session id')
+                    }
+                    options.forkSessionId = candidate
                     i += 1
                     continue
                 }

--- a/cli/src/commands/codex.ts
+++ b/cli/src/commands/codex.ts
@@ -5,7 +5,8 @@ import { maybeAutoStartServer } from '@/utils/autoStartServer'
 import type { CommandDefinition } from './types'
 import { CODEX_PERMISSION_MODES } from '@hapi/protocol/modes'
 import type { CodexPermissionMode } from '@hapi/protocol/types'
-import type { ReasoningEffort } from '@/codex/appServerTypes'
+import type { ReasoningEffort, ResponseItem } from '@/codex/appServerTypes'
+import { readFile } from 'node:fs/promises'
 import { assertCodexLocalSupported } from '@/codex/utils/codexVersion'
 
 function parseReasoningEffort(value: string): ReasoningEffort {
@@ -35,6 +36,7 @@ export const codexCommand: CommandDefinition = {
                 permissionMode?: CodexPermissionMode
                 resumeSessionId?: string
                 forkSessionId?: string
+                forkHistory?: ResponseItem[]
                 model?: string
                 modelReasoningEffort?: ReasoningEffort
             } = {}
@@ -86,6 +88,17 @@ export const codexCommand: CommandDefinition = {
                         throw new Error('Missing --model-reasoning-effort value')
                     }
                     options.modelReasoningEffort = parseReasoningEffort(effort)
+                } else if (arg === '--fork-history-file') {
+                    const file = commandArgs[++i]
+                    if (!file) {
+                        throw new Error('Missing --fork-history-file value')
+                    }
+                    const raw = await readFile(file, 'utf8')
+                    const parsed = JSON.parse(raw) as unknown
+                    if (!Array.isArray(parsed)) {
+                        throw new Error('--fork-history-file must contain a JSON array')
+                    }
+                    options.forkHistory = parsed as ResponseItem[]
                 } else {
                     unknownArgs.push(arg)
                 }

--- a/cli/src/commands/codex.ts
+++ b/cli/src/commands/codex.ts
@@ -6,7 +6,8 @@ import type { CommandDefinition } from './types'
 import { CODEX_PERMISSION_MODES } from '@hapi/protocol/modes'
 import type { CodexPermissionMode } from '@hapi/protocol/types'
 import type { ReasoningEffort, ResponseItem } from '@/codex/appServerTypes'
-import { readFile } from 'node:fs/promises'
+import { readFile, rm } from 'node:fs/promises'
+import { dirname } from 'node:path'
 import { assertCodexLocalSupported } from '@/codex/utils/codexVersion'
 
 function parseReasoningEffort(value: string): ReasoningEffort {
@@ -99,6 +100,7 @@ export const codexCommand: CommandDefinition = {
                         throw new Error('--fork-history-file must contain a JSON array')
                     }
                     options.forkHistory = parsed as ResponseItem[]
+                    void rm(dirname(file), { recursive: true, force: true }).catch(() => undefined)
                 } else {
                     unknownArgs.push(arg)
                 }

--- a/cli/src/commands/codex.ts
+++ b/cli/src/commands/codex.ts
@@ -7,7 +7,6 @@ import { CODEX_PERMISSION_MODES } from '@hapi/protocol/modes'
 import type { CodexPermissionMode } from '@hapi/protocol/types'
 import type { ReasoningEffort, ResponseItem } from '@/codex/appServerTypes'
 import { readFile, rm } from 'node:fs/promises'
-import { dirname } from 'node:path'
 import { assertCodexLocalSupported } from '@/codex/utils/codexVersion'
 
 function parseReasoningEffort(value: string): ReasoningEffort {
@@ -100,7 +99,7 @@ export const codexCommand: CommandDefinition = {
                         throw new Error('--fork-history-file must contain a JSON array')
                     }
                     options.forkHistory = parsed as ResponseItem[]
-                    void rm(dirname(file), { recursive: true, force: true }).catch(() => undefined)
+                    void rm(file, { force: true }).catch(() => undefined)
                 } else {
                     unknownArgs.push(arg)
                 }

--- a/cli/src/cursor/runCursor.ts
+++ b/cli/src/cursor/runCursor.ts
@@ -77,7 +77,8 @@ export async function runCursor(opts: {
         logger.debug(`[cursor] Synced session permission mode: ${currentPermissionMode}`);
     };
 
-    session.onUserMessage((message, localId) => {
+    session.onUserMessage((message, meta) => {
+        const localId = meta.localId
         const enhancedMode: EnhancedMode = {
             permissionMode: currentPermissionMode ?? 'default',
             model: currentModel

--- a/cli/src/gemini/runGemini.ts
+++ b/cli/src/gemini/runGemini.ts
@@ -119,7 +119,8 @@ export async function runGemini(opts: {
         logger.debug(`[gemini] Synced session config for keepalive: permissionMode=${currentPermissionMode}, model=${resolvedModel}`);
     };
 
-    session.onUserMessage((message, localId) => {
+    session.onUserMessage((message, meta) => {
+        const localId = meta.localId
         const formattedText = formatMessageWithAttachments(message.content.text, message.content.attachments);
         const mode: GeminiMode = {
             permissionMode: currentPermissionMode,

--- a/cli/src/modules/common/rpcTypes.ts
+++ b/cli/src/modules/common/rpcTypes.ts
@@ -3,6 +3,7 @@ export interface SpawnSessionOptions {
     directory: string
     sessionId?: string
     resumeSessionId?: string
+    forkSessionId?: string
     approvedNewDirectoryCreation?: boolean
     agent?: 'claude' | 'codex' | 'cursor' | 'gemini' | 'opencode'
     model?: string

--- a/cli/src/modules/common/rpcTypes.ts
+++ b/cli/src/modules/common/rpcTypes.ts
@@ -4,6 +4,7 @@ export interface SpawnSessionOptions {
     sessionId?: string
     resumeSessionId?: string
     forkSessionId?: string
+    forkHistory?: unknown[]
     approvedNewDirectoryCreation?: boolean
     agent?: 'claude' | 'codex' | 'cursor' | 'gemini' | 'opencode'
     model?: string

--- a/cli/src/opencode/runOpencode.ts
+++ b/cli/src/opencode/runOpencode.ts
@@ -99,7 +99,8 @@ export async function runOpencode(opts: {
         logger.debug(`[opencode] Synced session config for keepalive: permissionMode=${currentPermissionMode}, model=${sessionModel ?? '(default)'}`);
     };
 
-    session.onUserMessage((message, localId) => {
+    session.onUserMessage((message, meta) => {
+        const localId = meta.localId
         const formattedText = formatMessageWithAttachments(message.content.text, message.content.attachments);
         const mode: OpencodeMode = {
             permissionMode: currentPermissionMode,

--- a/cli/src/runner/run.ts
+++ b/cli/src/runner/run.ts
@@ -915,7 +915,9 @@ export function buildCliArgs(
           ? 'opencode'
           : 'claude';
   const args = [agentCommand];
-  if (options.resumeSessionId) {
+  if (options.forkSessionId && agent === 'codex') {
+    args.push('fork', options.forkSessionId);
+  } else if (options.resumeSessionId) {
     if (agent === 'codex') {
       args.push('resume', options.resumeSessionId);
     } else if (agent === 'cursor') {

--- a/cli/src/runner/run.ts
+++ b/cli/src/runner/run.ts
@@ -379,8 +379,9 @@ export async function startRunner(options: { workspaceRoots?: string[] } = {}): 
         }
 
         let forkHistoryFile: string | null = null;
+        let forkHistoryDir: string | null = null;
         if (agent === 'codex' && Array.isArray(options.forkHistory)) {
-          const forkHistoryDir = await fs.mkdtemp(join(os.tmpdir(), 'hapi-codex-history-'));
+          forkHistoryDir = await fs.mkdtemp(join(os.tmpdir(), 'hapi-codex-history-'));
           forkHistoryFile = join(forkHistoryDir, 'history.json');
           await fs.writeFile(forkHistoryFile, JSON.stringify(options.forkHistory));
         }
@@ -500,6 +501,10 @@ export async function startRunner(options: { workspaceRoots?: string[] } = {}): 
           logger.debug(`[RUNNER RUN] Child PID ${pid} exited with code ${code}, signal ${signal}`);
           if (code !== 0 || signal) {
             logStderrTail();
+          }
+          // Child normally deletes this dir after reading; clean up here in case it crashed first.
+          if (forkHistoryDir) {
+            void fs.rm(forkHistoryDir, { recursive: true, force: true }).catch(() => undefined);
           }
           const errorAwaiter = pidToErrorAwaiter.get(pid);
           if (errorAwaiter) {

--- a/cli/src/runner/run.ts
+++ b/cli/src/runner/run.ts
@@ -378,7 +378,17 @@ export async function startRunner(options: { workspaceRoots?: string[] } = {}): 
           };
         }
 
+        let forkHistoryFile: string | null = null;
+        if (agent === 'codex' && Array.isArray(options.forkHistory)) {
+          const forkHistoryDir = await fs.mkdtemp(join(os.tmpdir(), 'hapi-codex-history-'));
+          forkHistoryFile = join(forkHistoryDir, 'history.json');
+          await fs.writeFile(forkHistoryFile, JSON.stringify(options.forkHistory));
+        }
+
         const args = buildCliArgs(agent, options, yolo);
+        if (forkHistoryFile) {
+          args.push('--fork-history-file', forkHistoryFile);
+        }
 
         // sessionId reserved for future use
         const MAX_TAIL_CHARS = 4000;

--- a/cli/src/utils/MessageQueue2.ts
+++ b/cli/src/utils/MessageQueue2.ts
@@ -5,6 +5,7 @@ interface QueueItem<T> {
     mode: T;
     modeHash: string;
     localId?: string;
+    messageSeq?: number | null;
     isolate?: boolean; // If true, this message must be processed alone
 }
 
@@ -39,7 +40,7 @@ export class MessageQueue2<T> {
     /**
      * Push a message to the queue with a mode.
      */
-    push(message: string, mode: T, localId?: string): void {
+    push(message: string, mode: T, localId?: string, messageSeq?: number | null): void {
         if (this.closed) {
             throw new Error('Cannot push to closed queue');
         }
@@ -52,6 +53,7 @@ export class MessageQueue2<T> {
             mode,
             modeHash,
             localId,
+            messageSeq,
             isolate: false
         });
 
@@ -75,7 +77,7 @@ export class MessageQueue2<T> {
      * Push a message immediately without batching delay.
      * Does not clear the queue or enforce isolation.
      */
-    pushImmediate(message: string, mode: T, localId?: string): void {
+    pushImmediate(message: string, mode: T, localId?: string, messageSeq?: number | null): void {
         if (this.closed) {
             throw new Error('Cannot push to closed queue');
         }
@@ -88,6 +90,7 @@ export class MessageQueue2<T> {
             mode,
             modeHash,
             localId,
+            messageSeq,
             isolate: false
         });
 
@@ -112,7 +115,7 @@ export class MessageQueue2<T> {
      * Clears any pending messages and ensures this message is never batched with others.
      * Used for special commands that require dedicated processing.
      */
-    pushIsolateAndClear(message: string, mode: T, localId?: string): void {
+    pushIsolateAndClear(message: string, mode: T, localId?: string, messageSeq?: number | null): void {
         if (this.closed) {
             throw new Error('Cannot push to closed queue');
         }
@@ -128,6 +131,7 @@ export class MessageQueue2<T> {
             mode,
             modeHash,
             localId,
+            messageSeq,
             isolate: true
         });
 
@@ -145,6 +149,40 @@ export class MessageQueue2<T> {
         }
 
         logger.debug(`[MessageQueue2] pushIsolateAndClear() completed. Queue size: ${this.queue.length}`);
+    }
+
+    /**
+     * Push an isolated message without dropping already queued messages.
+     */
+    pushIsolated(message: string, mode: T, localId?: string, messageSeq?: number | null): void {
+        if (this.closed) {
+            throw new Error('Cannot push to closed queue');
+        }
+
+        const modeHash = this.modeHasher(mode);
+        logger.debug(`[MessageQueue2] pushIsolated() called with mode hash: ${modeHash}`);
+
+        this.queue.push({
+            message,
+            mode,
+            modeHash,
+            localId,
+            messageSeq,
+            isolate: true
+        });
+
+        if (this.onMessageHandler) {
+            this.onMessageHandler(message, mode);
+        }
+
+        if (this.waiter) {
+            logger.debug(`[MessageQueue2] Notifying waiter for isolated message`);
+            const waiter = this.waiter;
+            this.waiter = null;
+            waiter(true);
+        }
+
+        logger.debug(`[MessageQueue2] pushIsolated() completed. Queue size: ${this.queue.length}`);
     }
 
     /**
@@ -241,7 +279,7 @@ export class MessageQueue2<T> {
      * Wait for messages and return all messages with the same mode as a single string
      * Returns { message: string, mode: T } or null if aborted/closed
      */
-    async waitForMessagesAndGetAsString(abortSignal?: AbortSignal): Promise<{ message: string, mode: T, isolate: boolean, hash: string } | null> {
+    async waitForMessagesAndGetAsString(abortSignal?: AbortSignal): Promise<{ message: string, mode: T, isolate: boolean, hash: string, messageSeqs: number[] } | null> {
         // If we have messages, return them immediately
         if (this.queue.length > 0) {
             return this.collectBatch();
@@ -265,7 +303,7 @@ export class MessageQueue2<T> {
     /**
      * Collect a batch of messages with the same mode, respecting isolation requirements
      */
-    private collectBatch(): { message: string, mode: T, hash: string, isolate: boolean } | null {
+    private collectBatch(): { message: string, mode: T, hash: string, isolate: boolean, messageSeqs: number[] } | null {
         if (this.queue.length === 0) {
             return null;
         }
@@ -273,6 +311,7 @@ export class MessageQueue2<T> {
         const firstItem = this.queue[0];
         const sameModeMessages: string[] = [];
         const consumedLocalIds: string[] = [];
+        const consumedMessageSeqs: number[] = [];
         let mode = firstItem.mode;
         let isolate = firstItem.isolate ?? false;
         const targetModeHash = firstItem.modeHash;
@@ -282,6 +321,7 @@ export class MessageQueue2<T> {
             const item = this.queue.shift()!;
             sameModeMessages.push(item.message);
             if (item.localId) consumedLocalIds.push(item.localId);
+            if (typeof item.messageSeq === 'number') consumedMessageSeqs.push(item.messageSeq);
             logger.debug(`[MessageQueue2] Collected isolated message with mode hash: ${targetModeHash}`);
         } else {
             // Collect all messages with the same mode until we hit an isolated message
@@ -291,6 +331,7 @@ export class MessageQueue2<T> {
                 const item = this.queue.shift()!;
                 sameModeMessages.push(item.message);
                 if (item.localId) consumedLocalIds.push(item.localId);
+                if (typeof item.messageSeq === 'number') consumedMessageSeqs.push(item.messageSeq);
             }
             logger.debug(`[MessageQueue2] Collected batch of ${sameModeMessages.length} messages with mode hash: ${targetModeHash}`);
         }
@@ -306,7 +347,8 @@ export class MessageQueue2<T> {
             message: combinedMessage,
             mode,
             hash: targetModeHash,
-            isolate
+            isolate,
+            messageSeqs: consumedMessageSeqs
         };
     }
 

--- a/cli/src/utils/spawnWithAbort.ts
+++ b/cli/src/utils/spawnWithAbort.ts
@@ -6,7 +6,7 @@ import { killProcessByChildProcess } from '@/utils/process';
 const DEFAULT_ABORT_EXIT_CODES = [130, 137, 143];
 const DEFAULT_ABORT_SIGNALS: NodeJS.Signals[] = ['SIGTERM'];
 
-const isAbortError = (error: unknown): boolean => {
+export const isAbortError = (error: unknown): boolean => {
     if (!error || typeof error !== 'object') {
         return false;
     }

--- a/docs/plans/hapi-feature-codex-fork/design.md
+++ b/docs/plans/hapi-feature-codex-fork/design.md
@@ -1,0 +1,73 @@
+# Codex Fork Support Design Document
+
+## 1. Overview
+- Business requirement: HAPI needs first-class Codex fork support instead of only supporting resume.
+- Success criteria:
+  - CLI supports `hapi codex fork <sessionId>`
+  - Hub exposes a fork API and spawns a new HAPI session instead of merging into the old one
+  - Web can trigger fork for Codex sessions and navigate to the new forked session
+  - Codex remote launcher uses app-server `thread/fork`
+- Scope:
+  - `cli/` Codex launch + runner spawn arguments
+  - `hub/` session fork orchestration + HTTP route
+  - `web/` fork action + API client
+
+## 2. Module Interaction Flow
+1. User selects fork in CLI or Web.
+2. HAPI passes source Codex thread ID as `forkSessionId`.
+3. CLI local mode runs `codex fork <threadId>`.
+4. CLI remote mode calls Codex app-server `thread/fork`.
+5. Codex returns a new thread ID; HAPI stores it as the new session metadata `codexSessionId`.
+6. Hub returns the new HAPI session id to the Web client.
+
+## 3. Module Design Details
+
+### CLI
+
+#### 0. Metadata
+- Reuse existing `metadata.codexSessionId`
+- No new persisted schema field required for parent thread tracking in this change set
+
+#### 1. Interfaces
+- Add CLI parse path: `hapi codex fork <sessionId>`
+- Add app-server client method: `forkThread`
+- Add thread fork param builder: `buildThreadForkParams`
+
+#### 2. Local / Remote Launch
+- Local mode:
+  - invoke native `codex fork <threadId>`
+  - avoid pre-binding old thread id as current session id
+  - session scanner discovers the newly created Codex thread
+- Remote mode:
+  - if `forkSessionId` exists, call `thread/fork`
+  - otherwise keep existing resume/start behavior
+
+### Hub
+
+#### 1. Interfaces
+- Add `SyncEngine.forkSession(sessionId, namespace)`
+- Add HTTP route: `POST /api/sessions/:id/fork`
+- Extend machine spawn RPC payload with `forkSessionId`
+
+#### 2. Session Semantics
+- Fork differs from resume:
+  - resume reactivates or merges into prior conversation identity
+  - fork always creates a new HAPI session
+- Only Codex sessions are eligible
+
+### Web
+
+#### 1. Interfaces
+- Add `api.forkSession(sessionId)`
+- Add `useSessionActions().forkSession`
+- Add session action menu item `Fork`
+
+#### 2. UX
+- User clicks Fork on a Codex session
+- Web calls `/fork`
+- On success navigate to the new session detail page
+- On failure show toast
+
+## 4. Notes
+- Parent/child fork lineage is intentionally out of scope
+- Automatic inactive-message send still uses resume; fork remains an explicit action

--- a/docs/plans/hapi-feature-codex-fork/proposals/2026-04-02-12-24-codex-fork-support/deploy_modules.md
+++ b/docs/plans/hapi-feature-codex-fork/proposals/2026-04-02-12-24-codex-fork-support/deploy_modules.md
@@ -1,0 +1,3 @@
+cli
+hub
+web

--- a/docs/plans/hapi-feature-codex-fork/proposals/2026-04-02-12-24-codex-fork-support/design.md
+++ b/docs/plans/hapi-feature-codex-fork/proposals/2026-04-02-12-24-codex-fork-support/design.md
@@ -1,0 +1,16 @@
+# Codex Fork Support Proposal
+
+## Change Summary
+- Wire Codex fork through CLI, runner, hub, and web
+- Reuse upstream Codex app-server `thread/fork`
+- Keep resume semantics unchanged
+
+## Affected Modules
+- cli
+- hub
+- web
+
+## Behavior
+- `hapi codex fork <sessionId>` starts a new session forked from an existing Codex thread
+- Web adds a Fork action for Codex sessions
+- Hub exposes `POST /api/sessions/:id/fork`

--- a/hub/src/notifications/notificationHub.test.ts
+++ b/hub/src/notifications/notificationHub.test.ts
@@ -168,12 +168,12 @@ describe('NotificationHub', () => {
         hub.stop()
     })
 
-    it('suppresses the first ready notification for forked sessions only', async () => {
+    it('suppresses ready notifications for forked sessions during the ready cooldown', async () => {
         const engine = new FakeSyncEngine()
         const channel = new StubChannel()
         const hub = new NotificationHub(engine as unknown as SyncEngine, [channel], {
             permissionDebounceMs: 1,
-            readyCooldownMs: 1
+            readyCooldownMs: 30
         })
 
         const session = createSession({ id: 'forked-session' })
@@ -208,6 +208,11 @@ describe('NotificationHub', () => {
         expect(channel.readySessions).toHaveLength(0)
 
         await sleep(5)
+        engine.emit(readyEvent)
+        await sleep(5)
+        expect(channel.readySessions).toHaveLength(0)
+
+        await sleep(30)
         engine.emit(readyEvent)
         await sleep(5)
         expect(channel.readySessions).toHaveLength(1)

--- a/hub/src/notifications/notificationHub.test.ts
+++ b/hub/src/notifications/notificationHub.test.ts
@@ -168,7 +168,7 @@ describe('NotificationHub', () => {
         hub.stop()
     })
 
-    it('suppresses ready notifications for forked sessions during the ready cooldown', async () => {
+    it('suppresses the first ready notification for forked sessions', async () => {
         const engine = new FakeSyncEngine()
         const channel = new StubChannel()
         const hub = new NotificationHub(engine as unknown as SyncEngine, [channel], {
@@ -213,6 +213,10 @@ describe('NotificationHub', () => {
         expect(channel.readySessions).toHaveLength(0)
 
         await sleep(30)
+        engine.emit(readyEvent)
+        await sleep(5)
+        expect(channel.readySessions).toHaveLength(0)
+
         engine.emit(readyEvent)
         await sleep(5)
         expect(channel.readySessions).toHaveLength(1)

--- a/hub/src/notifications/notificationHub.test.ts
+++ b/hub/src/notifications/notificationHub.test.ts
@@ -168,6 +168,53 @@ describe('NotificationHub', () => {
         hub.stop()
     })
 
+    it('suppresses the first ready notification for forked sessions only', async () => {
+        const engine = new FakeSyncEngine()
+        const channel = new StubChannel()
+        const hub = new NotificationHub(engine as unknown as SyncEngine, [channel], {
+            permissionDebounceMs: 1,
+            readyCooldownMs: 1
+        })
+
+        const session = createSession({ id: 'forked-session' })
+        engine.setSession(session)
+
+        const readyEvent: SyncEvent = {
+            type: 'message-received',
+            sessionId: session.id,
+            message: {
+                id: 'message-1',
+                seq: 1,
+                localId: null,
+                createdAt: 0,
+                content: {
+                    role: 'agent',
+                    content: {
+                        id: 'event-1',
+                        type: 'event',
+                        data: { type: 'ready' }
+                    }
+                }
+            }
+        }
+
+        engine.emit({
+            type: 'session-forked',
+            sessionId: session.id,
+            sourceSessionId: 'source-session'
+        })
+        engine.emit(readyEvent)
+        await sleep(5)
+        expect(channel.readySessions).toHaveLength(0)
+
+        await sleep(5)
+        engine.emit(readyEvent)
+        await sleep(5)
+        expect(channel.readySessions).toHaveLength(1)
+
+        hub.stop()
+    })
+
     it('sends task notifications for task_notification system messages', async () => {
         const engine = new FakeSyncEngine()
         const channel = new StubChannel()

--- a/hub/src/notifications/notificationHub.ts
+++ b/hub/src/notifications/notificationHub.ts
@@ -10,7 +10,7 @@ export class NotificationHub {
     private readonly lastKnownRequests: Map<string, Set<string>> = new Map()
     private readonly notificationDebounce: Map<string, NodeJS.Timeout> = new Map()
     private readonly lastReadyNotificationAt: Map<string, number> = new Map()
-    private readonly suppressNextReadyNotification: Set<string> = new Set()
+    private readonly suppressReadyUntil: Map<string, number> = new Map()
     private unsubscribeSyncEvents: (() => void) | null = null
 
     constructor(
@@ -38,6 +38,7 @@ export class NotificationHub {
         this.notificationDebounce.clear()
         this.lastKnownRequests.clear()
         this.lastReadyNotificationAt.clear()
+        this.suppressReadyUntil.clear()
     }
 
     private handleSyncEvent(event: SyncEvent): void {
@@ -57,7 +58,7 @@ export class NotificationHub {
         }
 
         if (event.type === 'session-forked') {
-            this.suppressNextReadyNotification.add(event.sessionId)
+            this.suppressReadyUntil.set(event.sessionId, Date.now() + this.readyCooldownMs)
             return
         }
 
@@ -95,7 +96,7 @@ export class NotificationHub {
         }
         this.lastKnownRequests.delete(sessionId)
         this.lastReadyNotificationAt.delete(sessionId)
-        this.suppressNextReadyNotification.delete(sessionId)
+        this.suppressReadyUntil.delete(sessionId)
     }
 
     private getNotifiableSession(sessionId: string): Session | null {
@@ -160,11 +161,15 @@ export class NotificationHub {
             return
         }
 
-        if (this.suppressNextReadyNotification.delete(sessionId)) {
+        const now = Date.now()
+        const suppressUntil = this.suppressReadyUntil.get(sessionId) ?? 0
+        if (now < suppressUntil) {
             return
         }
+        if (suppressUntil > 0) {
+            this.suppressReadyUntil.delete(sessionId)
+        }
 
-        const now = Date.now()
         const last = this.lastReadyNotificationAt.get(sessionId) ?? 0
         if (now - last < this.readyCooldownMs) {
             return

--- a/hub/src/notifications/notificationHub.ts
+++ b/hub/src/notifications/notificationHub.ts
@@ -11,6 +11,7 @@ export class NotificationHub {
     private readonly notificationDebounce: Map<string, NodeJS.Timeout> = new Map()
     private readonly lastReadyNotificationAt: Map<string, number> = new Map()
     private readonly suppressReadyUntil: Map<string, number> = new Map()
+    private readonly forkedBootstrapReadySessions: Set<string> = new Set()
     private unsubscribeSyncEvents: (() => void) | null = null
 
     constructor(
@@ -39,6 +40,7 @@ export class NotificationHub {
         this.lastKnownRequests.clear()
         this.lastReadyNotificationAt.clear()
         this.suppressReadyUntil.clear()
+        this.forkedBootstrapReadySessions.clear()
     }
 
     private handleSyncEvent(event: SyncEvent): void {
@@ -59,6 +61,7 @@ export class NotificationHub {
 
         if (event.type === 'session-forked') {
             this.suppressReadyUntil.set(event.sessionId, Date.now() + this.readyCooldownMs)
+            this.forkedBootstrapReadySessions.add(event.sessionId)
             return
         }
 
@@ -74,6 +77,9 @@ export class NotificationHub {
         if (event.type === 'message-received' && event.sessionId) {
             const eventType = extractMessageEventType(event)
             if (eventType === 'ready') {
+                if (this.shouldSuppressForkedBootstrapReady(event.sessionId)) {
+                    return
+                }
                 this.sendReadyNotification(event.sessionId).catch((error) => {
                     console.error('[NotificationHub] Failed to send ready notification:', error)
                 })
@@ -97,6 +103,22 @@ export class NotificationHub {
         this.lastKnownRequests.delete(sessionId)
         this.lastReadyNotificationAt.delete(sessionId)
         this.suppressReadyUntil.delete(sessionId)
+        this.forkedBootstrapReadySessions.delete(sessionId)
+    }
+
+    private shouldSuppressForkedBootstrapReady(sessionId: string): boolean {
+        const suppressUntil = this.suppressReadyUntil.get(sessionId) ?? 0
+        if (Date.now() < suppressUntil) {
+            return true
+        }
+
+        if (!this.forkedBootstrapReadySessions.has(sessionId)) {
+            return false
+        }
+
+        this.forkedBootstrapReadySessions.delete(sessionId)
+        this.suppressReadyUntil.delete(sessionId)
+        return true
     }
 
     private getNotifiableSession(sessionId: string): Session | null {

--- a/hub/src/notifications/notificationHub.ts
+++ b/hub/src/notifications/notificationHub.ts
@@ -10,6 +10,7 @@ export class NotificationHub {
     private readonly lastKnownRequests: Map<string, Set<string>> = new Map()
     private readonly notificationDebounce: Map<string, NodeJS.Timeout> = new Map()
     private readonly lastReadyNotificationAt: Map<string, number> = new Map()
+    private readonly suppressNextReadyNotification: Set<string> = new Set()
     private unsubscribeSyncEvents: (() => void) | null = null
 
     constructor(
@@ -55,6 +56,11 @@ export class NotificationHub {
             return
         }
 
+        if (event.type === 'session-forked') {
+            this.suppressNextReadyNotification.add(event.sessionId)
+            return
+        }
+
         if (event.type === 'session-ended' && event.sessionId) {
             if (event.reason === 'completed') {
                 this.sendSessionCompletion(event.sessionId, event.reason).catch((error) => {
@@ -89,6 +95,7 @@ export class NotificationHub {
         }
         this.lastKnownRequests.delete(sessionId)
         this.lastReadyNotificationAt.delete(sessionId)
+        this.suppressNextReadyNotification.delete(sessionId)
     }
 
     private getNotifiableSession(sessionId: string): Session | null {
@@ -150,6 +157,10 @@ export class NotificationHub {
     private async sendReadyNotification(sessionId: string): Promise<void> {
         const session = this.getNotifiableSession(sessionId)
         if (!session) {
+            return
+        }
+
+        if (this.suppressNextReadyNotification.delete(sessionId)) {
             return
         }
 

--- a/hub/src/socket/handlers/cli/sessionHandlers.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.ts
@@ -44,6 +44,16 @@ const messageSchema = z.object({
     localId: z.string().optional()
 })
 
+const codexHistoryItemSchema = z.object({
+    sid: z.string(),
+    codexThreadId: z.string(),
+    turnId: z.string().nullable().optional(),
+    itemId: z.string(),
+    itemKind: z.enum(['user', 'assistant', 'tool', 'event', 'unknown']),
+    messageSeq: z.number().int().nullable().optional(),
+    rawItem: z.unknown()
+})
+
 const updateMetadataSchema = z.object({
     sid: z.string(),
     expectedVersion: z.number().int(),
@@ -154,6 +164,30 @@ export function registerSessionHandlers(socket: CliSocketWithData, deps: Session
                 createdAt: msg.createdAt,
                 invokedAt: msg.invokedAt
             }
+        })
+    })
+
+    socket.on('codex-history-item', (data: unknown) => {
+        const parsed = codexHistoryItemSchema.safeParse(data)
+        if (!parsed.success) {
+            return
+        }
+
+        const { sid } = parsed.data
+        const sessionAccess = resolveSessionAccess(sid)
+        if (!sessionAccess.ok) {
+            emitAccessError('session', sid, sessionAccess.reason)
+            return
+        }
+
+        store.codexHistory.addItem({
+            sessionId: sid,
+            codexThreadId: parsed.data.codexThreadId,
+            turnId: parsed.data.turnId ?? null,
+            itemId: parsed.data.itemId,
+            itemKind: parsed.data.itemKind,
+            messageSeq: parsed.data.messageSeq ?? null,
+            rawItem: parsed.data.rawItem
         })
     })
 

--- a/hub/src/socket/handlers/cli/sessionHandlers.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto'
 import type { CodexCollaborationMode, PermissionMode } from '@hapi/protocol/types'
 import type { Store, StoredSession } from '../../../store'
 import type { SyncEvent } from '../../../sync/syncEngine'
+import { mergeSessionMetadata } from '../../../sync/sessionMetadata'
 import { extractTodoWriteTodosFromMessageContent } from '../../../sync/todos'
 import { extractTeamStateFromMessageContent, applyTeamStateDelta } from '../../../sync/teams'
 import { extractBackgroundTaskDelta } from '../../../sync/backgroundTasks'
@@ -170,9 +171,12 @@ export function registerSessionHandlers(socket: CliSocketWithData, deps: Session
             return
         }
 
+        const currentSession = store.sessions.getSessionByNamespace(sid, sessionAccess.value.namespace)
+        const mergedMetadata = mergeSessionMetadata(currentSession?.metadata ?? null, metadata)
+
         const result = store.sessions.updateSessionMetadata(
             sid,
-            metadata,
+            mergedMetadata,
             expectedVersion,
             sessionAccess.value.namespace
         )
@@ -192,7 +196,7 @@ export function registerSessionHandlers(socket: CliSocketWithData, deps: Session
                 body: {
                     t: 'update-session' as const,
                     sid,
-                    metadata: { version: result.version, value: metadata },
+                    metadata: { version: result.version, value: mergedMetadata },
                     agentState: null
                 }
             }

--- a/hub/src/store/codexHistoryStore.test.ts
+++ b/hub/src/store/codexHistoryStore.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+
+import { Store } from './index'
+
+describe('CodexHistoryStore', () => {
+    it('creates v9 codex history table on fresh DB', () => {
+        const store = new Store(':memory:')
+        const db: Database = (store as any).db
+        const rows = db.prepare("PRAGMA table_info(codex_history_items)").all() as Array<{ name: string }>
+        const columns = rows.map((row) => row.name)
+
+        expect(columns).toContain('session_id')
+        expect(columns).toContain('codex_thread_id')
+        expect(columns).toContain('turn_id')
+        expect(columns).toContain('item_id')
+        expect(columns).toContain('message_seq')
+        expect(columns).toContain('raw_item')
+        expect(columns).toContain('seq')
+    })
+
+    it('returns raw history prefix before the selected user message', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')
+
+        store.codexHistory.addItem({
+            sessionId: session.id,
+            codexThreadId: 'thread-1',
+            itemId: 'user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'user-1', role: 'user' }
+        })
+        store.codexHistory.addItem({
+            sessionId: session.id,
+            codexThreadId: 'thread-1',
+            turnId: 'turn-1',
+            itemId: 'assistant-1',
+            itemKind: 'assistant',
+            rawItem: { id: 'assistant-1', role: 'assistant' }
+        })
+        store.codexHistory.addItem({
+            sessionId: session.id,
+            codexThreadId: 'thread-1',
+            itemId: 'user-2',
+            itemKind: 'user',
+            messageSeq: 3,
+            rawItem: { id: 'user-2', role: 'user' }
+        })
+
+        expect(store.codexHistory.getPrefixBeforeMessageSeq(session.id, 3)).toEqual([
+            { id: 'user-1', role: 'user' },
+            { id: 'assistant-1', role: 'assistant' }
+        ])
+        expect(store.codexHistory.getPrefixBeforeMessageSeq(session.id, 1)).toEqual([])
+        expect(store.codexHistory.getPrefixBeforeMessageSeq(session.id, 2)).toBeNull()
+    })
+
+    it('deletes codex history rows when deleting the session', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')
+        const db: Database = (store as any).db
+
+        store.codexHistory.addItem({
+            sessionId: session.id,
+            codexThreadId: 'thread-1',
+            itemId: 'user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'user-1', role: 'user' }
+        })
+
+        expect(db.prepare('SELECT COUNT(*) AS count FROM codex_history_items').get()).toEqual({ count: 1 })
+        store.sessions.deleteSession(session.id, 'default')
+        expect(db.prepare('SELECT COUNT(*) AS count FROM codex_history_items').get()).toEqual({ count: 0 })
+    })
+})

--- a/hub/src/store/codexHistoryStore.test.ts
+++ b/hub/src/store/codexHistoryStore.test.ts
@@ -56,6 +56,54 @@ describe('CodexHistoryStore', () => {
         expect(store.codexHistory.getPrefixBeforeMessageSeq(session.id, 2)).toBeNull()
     })
 
+    it('returns raw history through the selected user reply', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')
+
+        store.codexHistory.addItem({
+            sessionId: session.id,
+            codexThreadId: 'thread-1',
+            itemId: 'user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'user-1', role: 'user' }
+        })
+        store.codexHistory.addItem({
+            sessionId: session.id,
+            codexThreadId: 'thread-1',
+            itemId: 'assistant-1',
+            itemKind: 'assistant',
+            rawItem: { id: 'assistant-1', role: 'assistant' }
+        })
+        store.codexHistory.addItem({
+            sessionId: session.id,
+            codexThreadId: 'thread-1',
+            itemId: 'user-2',
+            itemKind: 'user',
+            messageSeq: 3,
+            rawItem: { id: 'user-2', role: 'user' }
+        })
+        store.codexHistory.addItem({
+            sessionId: session.id,
+            codexThreadId: 'thread-1',
+            itemId: 'assistant-2',
+            itemKind: 'assistant',
+            rawItem: { id: 'assistant-2', role: 'assistant' }
+        })
+
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(session.id, 1)).toEqual([
+            { id: 'user-1', role: 'user' },
+            { id: 'assistant-1', role: 'assistant' }
+        ])
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(session.id, 3)).toEqual([
+            { id: 'user-1', role: 'user' },
+            { id: 'assistant-1', role: 'assistant' },
+            { id: 'user-2', role: 'user' },
+            { id: 'assistant-2', role: 'assistant' }
+        ])
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(session.id, 2)).toBeNull()
+    })
+
     it('deletes codex history rows when deleting the session', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')

--- a/hub/src/store/codexHistoryStore.test.ts
+++ b/hub/src/store/codexHistoryStore.test.ts
@@ -183,6 +183,76 @@ describe('CodexHistoryStore', () => {
         ])
     })
 
+    it('preserves moved raw history when item ids collide', () => {
+        const store = new Store(':memory:')
+        const source = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')
+        const target = store.sessions.getOrCreateSession('s2', { flavor: 'codex' }, null, 'default')
+
+        store.codexHistory.addItem({
+            sessionId: source.id,
+            codexThreadId: 'thread-1',
+            itemId: 'hapi-user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'source-user', role: 'user' }
+        })
+        store.codexHistory.addItem({
+            sessionId: source.id,
+            codexThreadId: 'thread-1',
+            itemId: 'source-assistant-1',
+            itemKind: 'assistant',
+            rawItem: { id: 'source-assistant', role: 'assistant' }
+        })
+        store.codexHistory.addItem({
+            sessionId: target.id,
+            codexThreadId: 'thread-2',
+            itemId: 'hapi-user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'target-user', role: 'user' }
+        })
+
+        expect(store.codexHistory.moveSessionHistory(source.id, target.id, 2)).toBe(2)
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 1)).toEqual([
+            { id: 'source-user', role: 'user' },
+            { id: 'source-assistant', role: 'assistant' }
+        ])
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 3)).toEqual([
+            { id: 'source-user', role: 'user' },
+            { id: 'source-assistant', role: 'assistant' },
+            { id: 'target-user', role: 'user' }
+        ])
+    })
+
+    it('remaps target raw history even when source has no raw rows', () => {
+        const store = new Store(':memory:')
+        const source = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')
+        const target = store.sessions.getOrCreateSession('s2', { flavor: 'codex' }, null, 'default')
+
+        store.codexHistory.addItem({
+            sessionId: target.id,
+            codexThreadId: 'thread-2',
+            itemId: 'hapi-user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'target-user', role: 'user' }
+        })
+        store.codexHistory.addItem({
+            sessionId: target.id,
+            codexThreadId: 'thread-2',
+            itemId: 'target-assistant-1',
+            itemKind: 'assistant',
+            rawItem: { id: 'target-assistant', role: 'assistant' }
+        })
+
+        expect(store.codexHistory.moveSessionHistory(source.id, target.id, 2)).toBe(0)
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 1)).toBeNull()
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 3)).toEqual([
+            { id: 'target-user', role: 'user' },
+            { id: 'target-assistant', role: 'assistant' }
+        ])
+    })
+
     it('deletes codex history rows when deleting the session', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')

--- a/hub/src/store/codexHistoryStore.test.ts
+++ b/hub/src/store/codexHistoryStore.test.ts
@@ -141,6 +141,48 @@ describe('CodexHistoryStore', () => {
         expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 1)).toBeNull()
     })
 
+    it('moves raw history between sessions and remaps target user message seqs', () => {
+        const store = new Store(':memory:')
+        const source = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')
+        const target = store.sessions.getOrCreateSession('s2', { flavor: 'codex' }, null, 'default')
+
+        store.codexHistory.addItem({
+            sessionId: source.id,
+            codexThreadId: 'thread-1',
+            itemId: 'user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'user-1', role: 'user' }
+        })
+        store.codexHistory.addItem({
+            sessionId: source.id,
+            codexThreadId: 'thread-1',
+            itemId: 'assistant-1',
+            itemKind: 'assistant',
+            rawItem: { id: 'assistant-1', role: 'assistant' }
+        })
+        store.codexHistory.addItem({
+            sessionId: target.id,
+            codexThreadId: 'thread-2',
+            itemId: 'user-2',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'user-2', role: 'user' }
+        })
+
+        expect(store.codexHistory.moveSessionHistory(source.id, target.id, 2)).toBe(2)
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(source.id, 1)).toBeNull()
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 1)).toEqual([
+            { id: 'user-1', role: 'user' },
+            { id: 'assistant-1', role: 'assistant' }
+        ])
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 3)).toEqual([
+            { id: 'user-1', role: 'user' },
+            { id: 'assistant-1', role: 'assistant' },
+            { id: 'user-2', role: 'user' }
+        ])
+    })
+
     it('deletes codex history rows when deleting the session', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')

--- a/hub/src/store/codexHistoryStore.test.ts
+++ b/hub/src/store/codexHistoryStore.test.ts
@@ -104,6 +104,43 @@ describe('CodexHistoryStore', () => {
         expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(session.id, 2)).toBeNull()
     })
 
+    it('clones a raw history prefix and remaps user message seqs', () => {
+        const store = new Store(':memory:')
+        const source = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')
+        const target = store.sessions.getOrCreateSession('s2', { flavor: 'codex' }, null, 'default')
+
+        store.codexHistory.addItem({
+            sessionId: source.id,
+            codexThreadId: 'thread-1',
+            itemId: 'user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'user-1', role: 'user' }
+        })
+        store.codexHistory.addItem({
+            sessionId: source.id,
+            codexThreadId: 'thread-1',
+            itemId: 'assistant-1',
+            itemKind: 'assistant',
+            rawItem: { id: 'assistant-1', role: 'assistant' }
+        })
+        store.codexHistory.addItem({
+            sessionId: source.id,
+            codexThreadId: 'thread-1',
+            itemId: 'user-2',
+            itemKind: 'user',
+            messageSeq: 3,
+            rawItem: { id: 'user-2', role: 'user' }
+        })
+
+        expect(store.codexHistory.clonePrefixThroughReplyForUserMessageSeq(source.id, target.id, 1, 4)).toBe(2)
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 5)).toEqual([
+            { id: 'user-1', role: 'user' },
+            { id: 'assistant-1', role: 'assistant' }
+        ])
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 1)).toBeNull()
+    })
+
     it('deletes codex history rows when deleting the session', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')

--- a/hub/src/store/codexHistoryStore.test.ts
+++ b/hub/src/store/codexHistoryStore.test.ts
@@ -141,6 +141,43 @@ describe('CodexHistoryStore', () => {
         expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 1)).toBeNull()
     })
 
+    it('preserves cloned raw history when item ids collide', () => {
+        const store = new Store(':memory:')
+        const source = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')
+        const target = store.sessions.getOrCreateSession('s2', { flavor: 'codex' }, null, 'default')
+
+        store.codexHistory.addItem({
+            sessionId: source.id,
+            codexThreadId: 'thread-1',
+            itemId: 'hapi-user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'source-user', role: 'user' }
+        })
+        store.codexHistory.addItem({
+            sessionId: source.id,
+            codexThreadId: 'thread-1',
+            itemId: 'source-assistant-1',
+            itemKind: 'assistant',
+            rawItem: { id: 'source-assistant', role: 'assistant' }
+        })
+        store.codexHistory.addItem({
+            sessionId: target.id,
+            codexThreadId: 'thread-2',
+            itemId: 'hapi-user-1',
+            itemKind: 'user',
+            messageSeq: 1,
+            rawItem: { id: 'target-user', role: 'user' }
+        })
+
+        expect(store.codexHistory.clonePrefixThroughReplyForUserMessageSeq(source.id, target.id, 1, 2)).toBe(2)
+        expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(target.id, 3)).toEqual([
+            { id: 'target-user', role: 'user' },
+            { id: 'source-user', role: 'user' },
+            { id: 'source-assistant', role: 'assistant' }
+        ])
+    })
+
     it('moves raw history between sessions and remaps target user message seqs', () => {
         const store = new Store(':memory:')
         const source = store.sessions.getOrCreateSession('s1', { flavor: 'codex' }, null, 'default')

--- a/hub/src/store/codexHistoryStore.ts
+++ b/hub/src/store/codexHistoryStore.ts
@@ -48,6 +48,46 @@ export class CodexHistoryStore {
         })
     }
 
+    getPrefixThroughReplyForUserMessageSeq(sessionId: string, messageSeq: number): unknown[] | null {
+        const cut = this.db.prepare(`
+            SELECT seq
+            FROM codex_history_items
+            WHERE session_id = ?
+              AND message_seq = ?
+              AND item_kind = 'user'
+            ORDER BY seq ASC
+            LIMIT 1
+        `).get(sessionId, messageSeq) as { seq: number } | undefined
+
+        if (!cut) {
+            return null
+        }
+
+        const nextUser = this.db.prepare(`
+            SELECT seq
+            FROM codex_history_items
+            WHERE session_id = ?
+              AND item_kind = 'user'
+              AND seq > ?
+            ORDER BY seq ASC
+            LIMIT 1
+        `).get(sessionId, cut.seq) as { seq: number } | undefined
+
+        const beforeClause = nextUser ? 'AND seq < @nextUserSeq' : ''
+        const rows = this.db.prepare(`
+            SELECT raw_item
+            FROM codex_history_items
+            WHERE session_id = @sessionId
+              ${beforeClause}
+            ORDER BY seq ASC
+        `).all({
+            sessionId,
+            nextUserSeq: nextUser?.seq ?? null
+        }) as Array<{ raw_item: string }>
+
+        return rows.map((row) => safeJsonParse(row.raw_item))
+    }
+
     getPrefixBeforeMessageSeq(sessionId: string, beforeSeq: number): unknown[] | null {
         const cut = this.db.prepare(`
             SELECT seq

--- a/hub/src/store/codexHistoryStore.ts
+++ b/hub/src/store/codexHistoryStore.ts
@@ -23,17 +23,16 @@ export class CodexHistoryStore {
     }
 
     addItem(input: AddCodexHistoryItemInput): void {
-        const now = Date.now()
-        const row = this.db.prepare(
-            'SELECT COALESCE(MAX(seq), 0) + 1 AS nextSeq FROM codex_history_items WHERE session_id = ?'
-        ).get(input.sessionId) as { nextSeq: number }
-
-        this.db.prepare(`
+        // Compute seq atomically inside the INSERT so two concurrent addItem calls cannot read the
+        // same MAX(seq) and produce duplicate seq values for one session.
+        const result = this.db.prepare(`
             INSERT OR IGNORE INTO codex_history_items (
                 id, session_id, codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
-            ) VALUES (
-                @id, @session_id, @codex_thread_id, @turn_id, @item_id, @item_kind, @message_seq, @raw_item, @seq, @created_at
             )
+            SELECT
+                @id, @session_id, @codex_thread_id, @turn_id, @item_id, @item_kind, @message_seq, @raw_item,
+                COALESCE((SELECT MAX(seq) FROM codex_history_items WHERE session_id = @session_id), 0) + 1,
+                @created_at
         `).run({
             id: randomUUID(),
             session_id: input.sessionId,
@@ -43,9 +42,13 @@ export class CodexHistoryStore {
             item_kind: input.itemKind,
             message_seq: input.messageSeq ?? null,
             raw_item: JSON.stringify(input.rawItem),
-            seq: row.nextSeq,
-            created_at: now
+            created_at: Date.now()
         })
+        if (result.changes === 0) {
+            // INSERT OR IGNORE swallowed the row — most likely a duplicate (session_id, item_id),
+            // but any constraint failure lands here. Log enough to disambiguate during a later post-mortem.
+            console.warn(`[CodexHistoryStore] addItem inserted 0 rows sessionId=${input.sessionId} itemId=${input.itemId} (duplicate or constraint violation)`)
+        }
     }
 
     getPrefixThroughReplyForUserMessageSeq(sessionId: string, messageSeq: number): unknown[] | null {
@@ -75,7 +78,7 @@ export class CodexHistoryStore {
 
         const beforeClause = nextUser ? 'AND seq < @nextUserSeq' : ''
         const rows = this.db.prepare(`
-            SELECT raw_item
+            SELECT seq, raw_item
             FROM codex_history_items
             WHERE session_id = @sessionId
               ${beforeClause}
@@ -83,9 +86,9 @@ export class CodexHistoryStore {
         `).all({
             sessionId,
             nextUserSeq: nextUser?.seq ?? null
-        }) as Array<{ raw_item: string }>
+        }) as Array<{ seq: number; raw_item: string }>
 
-        return rows.map((row) => safeJsonParse(row.raw_item))
+        return parsePrefixRows(rows, sessionId)
     }
 
     getPrefixBeforeMessageSeq(sessionId: string, beforeSeq: number): unknown[] | null {
@@ -104,13 +107,28 @@ export class CodexHistoryStore {
         }
 
         const rows = this.db.prepare(`
-            SELECT raw_item
+            SELECT seq, raw_item
             FROM codex_history_items
             WHERE session_id = ?
               AND seq < ?
             ORDER BY seq ASC
-        `).all(sessionId, cut.seq) as Array<{ raw_item: string }>
+        `).all(sessionId, cut.seq) as Array<{ seq: number; raw_item: string }>
 
-        return rows.map((row) => safeJsonParse(row.raw_item))
+        return parsePrefixRows(rows, sessionId)
     }
+}
+
+// Throw on unparseable rows — forwarding null into thread/resume(history) would corrupt the prefix.
+function parsePrefixRows(rows: Array<{ seq: number; raw_item: string }>, sessionId: string): unknown[] {
+    const items: unknown[] = []
+    for (const row of rows) {
+        const parsed = safeJsonParse(row.raw_item)
+        if (parsed === null) {
+            const message = `[CodexHistoryStore] Corrupt history row sessionId=${sessionId} seq=${row.seq}`
+            console.error(message)
+            throw new Error(message)
+        }
+        items.push(parsed)
+    }
+    return items
 }

--- a/hub/src/store/codexHistoryStore.ts
+++ b/hub/src/store/codexHistoryStore.ts
@@ -1,0 +1,76 @@
+import type { Database } from 'bun:sqlite'
+import { randomUUID } from 'node:crypto'
+
+import { safeJsonParse } from './json'
+
+export type CodexHistoryItemKind = 'user' | 'assistant' | 'tool' | 'event' | 'unknown'
+
+export type AddCodexHistoryItemInput = {
+    sessionId: string
+    codexThreadId: string
+    turnId?: string | null
+    itemId: string
+    itemKind: CodexHistoryItemKind
+    messageSeq?: number | null
+    rawItem: unknown
+}
+
+export class CodexHistoryStore {
+    private readonly db: Database
+
+    constructor(db: Database) {
+        this.db = db
+    }
+
+    addItem(input: AddCodexHistoryItemInput): void {
+        const now = Date.now()
+        const row = this.db.prepare(
+            'SELECT COALESCE(MAX(seq), 0) + 1 AS nextSeq FROM codex_history_items WHERE session_id = ?'
+        ).get(input.sessionId) as { nextSeq: number }
+
+        this.db.prepare(`
+            INSERT OR IGNORE INTO codex_history_items (
+                id, session_id, codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
+            ) VALUES (
+                @id, @session_id, @codex_thread_id, @turn_id, @item_id, @item_kind, @message_seq, @raw_item, @seq, @created_at
+            )
+        `).run({
+            id: randomUUID(),
+            session_id: input.sessionId,
+            codex_thread_id: input.codexThreadId,
+            turn_id: input.turnId ?? null,
+            item_id: input.itemId,
+            item_kind: input.itemKind,
+            message_seq: input.messageSeq ?? null,
+            raw_item: JSON.stringify(input.rawItem),
+            seq: row.nextSeq,
+            created_at: now
+        })
+    }
+
+    getPrefixBeforeMessageSeq(sessionId: string, beforeSeq: number): unknown[] | null {
+        const cut = this.db.prepare(`
+            SELECT seq
+            FROM codex_history_items
+            WHERE session_id = ?
+              AND message_seq = ?
+              AND item_kind = 'user'
+            ORDER BY seq ASC
+            LIMIT 1
+        `).get(sessionId, beforeSeq) as { seq: number } | undefined
+
+        if (!cut) {
+            return null
+        }
+
+        const rows = this.db.prepare(`
+            SELECT raw_item
+            FROM codex_history_items
+            WHERE session_id = ?
+              AND seq < ?
+            ORDER BY seq ASC
+        `).all(sessionId, cut.seq) as Array<{ raw_item: string }>
+
+        return rows.map((row) => safeJsonParse(row.raw_item))
+    }
+}

--- a/hub/src/store/codexHistoryStore.ts
+++ b/hub/src/store/codexHistoryStore.ts
@@ -16,6 +16,7 @@ export type AddCodexHistoryItemInput = {
 }
 
 type CodexHistoryRow = {
+    id?: string
     codex_thread_id: string
     turn_id: string | null
     item_id: string
@@ -185,33 +186,82 @@ export class CodexHistoryStore {
     moveSessionHistory(fromSessionId: string, toSessionId: string, targetMessageSeqOffset: number): number {
         if (fromSessionId === toSessionId) return 0
 
-        const sourceMaxSeq = (this.db.prepare(
-            'SELECT COALESCE(MAX(seq), 0) AS maxSeq FROM codex_history_items WHERE session_id = ?'
-        ).get(fromSessionId) as { maxSeq: number } | undefined)?.maxSeq ?? 0
+        const sourceRows = this.db.prepare(`
+            SELECT id, codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
+            FROM codex_history_items
+            WHERE session_id = ?
+            ORDER BY seq ASC
+        `).all(fromSessionId) as Array<CodexHistoryRow & { id: string }>
 
         try {
             this.db.exec('BEGIN')
 
-            if (sourceMaxSeq > 0) {
+            if (targetMessageSeqOffset !== 0) {
                 this.db.prepare(`
                     UPDATE codex_history_items
-                    SET seq = seq + ?,
-                        message_seq = CASE
+                    SET message_seq = CASE
                             WHEN message_seq IS NULL THEN NULL
                             ELSE message_seq + ?
                         END
                     WHERE session_id = ?
-                `).run(sourceMaxSeq, targetMessageSeqOffset, toSessionId)
+                `).run(targetMessageSeqOffset, toSessionId)
             }
 
-            const result = this.db.prepare(`
-                UPDATE OR IGNORE codex_history_items
-                SET session_id = ?
-                WHERE session_id = ?
-            `).run(toSessionId, fromSessionId)
+            if (sourceRows.length === 0) {
+                this.db.exec('COMMIT')
+                return 0
+            }
+
+            const sourceMaxSeq = sourceRows[sourceRows.length - 1]?.seq ?? 0
+            if (sourceMaxSeq > 0) {
+                this.db.prepare(`
+                    UPDATE codex_history_items
+                    SET seq = seq + ?
+                    WHERE session_id = ?
+                `).run(sourceMaxSeq, toSessionId)
+            }
+
+            const existingItemIds = new Set(
+                (this.db.prepare(
+                    'SELECT item_id FROM codex_history_items WHERE session_id = ?'
+                ).all(toSessionId) as Array<{ item_id: string }>).map((row) => row.item_id)
+            )
+
+            const insert = this.db.prepare(`
+                INSERT INTO codex_history_items (
+                    id, session_id, codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
+                ) VALUES (
+                    @id, @session_id, @codex_thread_id, @turn_id, @item_id, @item_kind, @message_seq, @raw_item, @seq, @created_at
+                )
+            `)
+
+            let moved = 0
+            for (const row of sourceRows) {
+                const itemId = existingItemIds.has(row.item_id)
+                    ? `${row.item_id}:moved:${row.id}`
+                    : row.item_id
+                insert.run({
+                    id: randomUUID(),
+                    session_id: toSessionId,
+                    codex_thread_id: row.codex_thread_id,
+                    turn_id: row.turn_id,
+                    item_id: itemId,
+                    item_kind: row.item_kind,
+                    message_seq: row.message_seq,
+                    raw_item: row.raw_item,
+                    seq: row.seq,
+                    created_at: row.created_at
+                })
+                existingItemIds.add(itemId)
+                moved += 1
+            }
+
+            this.db.prepare(
+                'DELETE FROM codex_history_items WHERE session_id = ?'
+            ).run(fromSessionId)
 
             this.db.exec('COMMIT')
-            return result.changes
+            return moved
         } catch (error) {
             this.db.exec('ROLLBACK')
             throw error

--- a/hub/src/store/codexHistoryStore.ts
+++ b/hub/src/store/codexHistoryStore.ts
@@ -15,6 +15,17 @@ export type AddCodexHistoryItemInput = {
     rawItem: unknown
 }
 
+type CodexHistoryRow = {
+    codex_thread_id: string
+    turn_id: string | null
+    item_id: string
+    item_kind: CodexHistoryItemKind
+    message_seq: number | null
+    raw_item: string
+    seq: number
+    created_at: number
+}
+
 export class CodexHistoryStore {
     private readonly db: Database
 
@@ -115,6 +126,95 @@ export class CodexHistoryStore {
         `).all(sessionId, cut.seq) as Array<{ seq: number; raw_item: string }>
 
         return parsePrefixRows(rows, sessionId)
+    }
+
+    cloneSessionHistory(fromSessionId: string, toSessionId: string, messageSeqOffset: number): number {
+        const rows = this.db.prepare(`
+            SELECT codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
+            FROM codex_history_items
+            WHERE session_id = ?
+            ORDER BY seq ASC
+        `).all(fromSessionId) as CodexHistoryRow[]
+
+        return this.cloneRows(toSessionId, rows, messageSeqOffset)
+    }
+
+    clonePrefixThroughReplyForUserMessageSeq(
+        fromSessionId: string,
+        toSessionId: string,
+        messageSeq: number,
+        messageSeqOffset: number
+    ): number {
+        const cut = this.db.prepare(`
+            SELECT seq
+            FROM codex_history_items
+            WHERE session_id = ?
+              AND message_seq = ?
+              AND item_kind = 'user'
+            ORDER BY seq ASC
+            LIMIT 1
+        `).get(fromSessionId, messageSeq) as { seq: number } | undefined
+
+        if (!cut) return 0
+
+        const nextUser = this.db.prepare(`
+            SELECT seq
+            FROM codex_history_items
+            WHERE session_id = ?
+              AND item_kind = 'user'
+              AND seq > ?
+            ORDER BY seq ASC
+            LIMIT 1
+        `).get(fromSessionId, cut.seq) as { seq: number } | undefined
+
+        const beforeClause = nextUser ? 'AND seq < @nextUserSeq' : ''
+        const rows = this.db.prepare(`
+            SELECT codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
+            FROM codex_history_items
+            WHERE session_id = @fromSessionId
+              ${beforeClause}
+            ORDER BY seq ASC
+        `).all({
+            fromSessionId,
+            nextUserSeq: nextUser?.seq ?? null
+        }) as CodexHistoryRow[]
+
+        return this.cloneRows(toSessionId, rows, messageSeqOffset)
+    }
+
+    private cloneRows(toSessionId: string, rows: CodexHistoryRow[], messageSeqOffset: number): number {
+        if (rows.length === 0) return 0
+
+        const targetMaxSeq = (this.db.prepare(
+            'SELECT COALESCE(MAX(seq), 0) AS maxSeq FROM codex_history_items WHERE session_id = ?'
+        ).get(toSessionId) as { maxSeq: number } | undefined)?.maxSeq ?? 0
+
+        const insert = this.db.prepare(`
+            INSERT OR IGNORE INTO codex_history_items (
+                id, session_id, codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
+            ) VALUES (
+                @id, @session_id, @codex_thread_id, @turn_id, @item_id, @item_kind, @message_seq, @raw_item, @seq, @created_at
+            )
+        `)
+
+        let cloned = 0
+        for (const row of rows) {
+            const result = insert.run({
+                id: randomUUID(),
+                session_id: toSessionId,
+                codex_thread_id: row.codex_thread_id,
+                turn_id: row.turn_id,
+                item_id: row.item_id,
+                item_kind: row.item_kind,
+                message_seq: row.message_seq == null ? null : row.message_seq + messageSeqOffset,
+                raw_item: row.raw_item,
+                seq: targetMaxSeq + row.seq,
+                created_at: row.created_at
+            })
+            cloned += result.changes
+        }
+
+        return cloned
     }
 }
 

--- a/hub/src/store/codexHistoryStore.ts
+++ b/hub/src/store/codexHistoryStore.ts
@@ -131,7 +131,7 @@ export class CodexHistoryStore {
 
     cloneSessionHistory(fromSessionId: string, toSessionId: string, messageSeqOffset: number): number {
         const rows = this.db.prepare(`
-            SELECT codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
+            SELECT id, codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
             FROM codex_history_items
             WHERE session_id = ?
             ORDER BY seq ASC
@@ -170,7 +170,7 @@ export class CodexHistoryStore {
 
         const beforeClause = nextUser ? 'AND seq < @nextUserSeq' : ''
         const rows = this.db.prepare(`
-            SELECT codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
+            SELECT id, codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
             FROM codex_history_items
             WHERE session_id = @fromSessionId
               ${beforeClause}
@@ -275,8 +275,14 @@ export class CodexHistoryStore {
             'SELECT COALESCE(MAX(seq), 0) AS maxSeq FROM codex_history_items WHERE session_id = ?'
         ).get(toSessionId) as { maxSeq: number } | undefined)?.maxSeq ?? 0
 
+        const existingItemIds = new Set(
+            (this.db.prepare(
+                'SELECT item_id FROM codex_history_items WHERE session_id = ?'
+            ).all(toSessionId) as Array<{ item_id: string }>).map((row) => row.item_id)
+        )
+
         const insert = this.db.prepare(`
-            INSERT OR IGNORE INTO codex_history_items (
+            INSERT INTO codex_history_items (
                 id, session_id, codex_thread_id, turn_id, item_id, item_kind, message_seq, raw_item, seq, created_at
             ) VALUES (
                 @id, @session_id, @codex_thread_id, @turn_id, @item_id, @item_kind, @message_seq, @raw_item, @seq, @created_at
@@ -285,19 +291,23 @@ export class CodexHistoryStore {
 
         let cloned = 0
         for (const row of rows) {
-            const result = insert.run({
+            const itemId = existingItemIds.has(row.item_id)
+                ? `${row.item_id}:cloned:${row.id ?? randomUUID()}`
+                : row.item_id
+            insert.run({
                 id: randomUUID(),
                 session_id: toSessionId,
                 codex_thread_id: row.codex_thread_id,
                 turn_id: row.turn_id,
-                item_id: row.item_id,
+                item_id: itemId,
                 item_kind: row.item_kind,
                 message_seq: row.message_seq == null ? null : row.message_seq + messageSeqOffset,
                 raw_item: row.raw_item,
                 seq: targetMaxSeq + row.seq,
                 created_at: row.created_at
             })
-            cloned += result.changes
+            existingItemIds.add(itemId)
+            cloned += 1
         }
 
         return cloned

--- a/hub/src/store/codexHistoryStore.ts
+++ b/hub/src/store/codexHistoryStore.ts
@@ -182,6 +182,42 @@ export class CodexHistoryStore {
         return this.cloneRows(toSessionId, rows, messageSeqOffset)
     }
 
+    moveSessionHistory(fromSessionId: string, toSessionId: string, targetMessageSeqOffset: number): number {
+        if (fromSessionId === toSessionId) return 0
+
+        const sourceMaxSeq = (this.db.prepare(
+            'SELECT COALESCE(MAX(seq), 0) AS maxSeq FROM codex_history_items WHERE session_id = ?'
+        ).get(fromSessionId) as { maxSeq: number } | undefined)?.maxSeq ?? 0
+
+        try {
+            this.db.exec('BEGIN')
+
+            if (sourceMaxSeq > 0) {
+                this.db.prepare(`
+                    UPDATE codex_history_items
+                    SET seq = seq + ?,
+                        message_seq = CASE
+                            WHEN message_seq IS NULL THEN NULL
+                            ELSE message_seq + ?
+                        END
+                    WHERE session_id = ?
+                `).run(sourceMaxSeq, targetMessageSeqOffset, toSessionId)
+            }
+
+            const result = this.db.prepare(`
+                UPDATE OR IGNORE codex_history_items
+                SET session_id = ?
+                WHERE session_id = ?
+            `).run(toSessionId, fromSessionId)
+
+            this.db.exec('COMMIT')
+            return result.changes
+        } catch (error) {
+            this.db.exec('ROLLBACK')
+            throw error
+        }
+    }
+
     private cloneRows(toSessionId: string, rows: CodexHistoryRow[], messageSeqOffset: number): number {
         if (rows.length === 0) return 0
 

--- a/hub/src/store/index.ts
+++ b/hub/src/store/index.ts
@@ -7,6 +7,7 @@ import { MessageStore } from './messageStore'
 import { PushStore } from './pushStore'
 import { SessionStore } from './sessionStore'
 import { UserStore } from './userStore'
+import { CodexHistoryStore } from './codexHistoryStore'
 
 export type {
     StoredMachine,
@@ -22,14 +23,16 @@ export { MessageStore } from './messageStore'
 export { PushStore } from './pushStore'
 export { SessionStore } from './sessionStore'
 export { UserStore } from './userStore'
+export { CodexHistoryStore } from './codexHistoryStore'
 
-const SCHEMA_VERSION: number = 8
+const SCHEMA_VERSION: number = 9
 const REQUIRED_TABLES = [
     'sessions',
     'machines',
     'messages',
     'users',
-    'push_subscriptions'
+    'push_subscriptions',
+    'codex_history_items'
 ] as const
 
 export class Store {
@@ -41,6 +44,7 @@ export class Store {
     readonly messages: MessageStore
     readonly users: UserStore
     readonly push: PushStore
+    readonly codexHistory: CodexHistoryStore
 
     constructor(dbPath: string) {
         this.dbPath = dbPath
@@ -82,6 +86,7 @@ export class Store {
         this.messages = new MessageStore(this.db)
         this.users = new UserStore(this.db)
         this.push = new PushStore(this.db)
+        this.codexHistory = new CodexHistoryStore(this.db)
     }
 
     private initSchema(): void {
@@ -98,6 +103,7 @@ export class Store {
             5: () => this.migrateFromV5ToV6(),
             6: () => this.migrateFromV6ToV7(),
             7: () => this.migrateFromV7ToV8(),
+            8: () => this.migrateFromV8ToV9(),
         })
 
         if (currentVersion === 0) {
@@ -221,6 +227,26 @@ export class Store {
                 UNIQUE(namespace, endpoint)
             );
             CREATE INDEX IF NOT EXISTS idx_push_subscriptions_namespace ON push_subscriptions(namespace);
+
+            CREATE TABLE IF NOT EXISTS codex_history_items (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                codex_thread_id TEXT NOT NULL,
+                turn_id TEXT,
+                item_id TEXT NOT NULL,
+                item_kind TEXT NOT NULL,
+                message_seq INTEGER,
+                raw_item TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_codex_history_items_session_item
+                ON codex_history_items(session_id, item_id);
+            CREATE INDEX IF NOT EXISTS idx_codex_history_items_session_seq
+                ON codex_history_items(session_id, seq);
+            CREATE INDEX IF NOT EXISTS idx_codex_history_items_session_message_seq
+                ON codex_history_items(session_id, message_seq);
         `)
     }
 
@@ -375,6 +401,30 @@ export class Store {
         this.db.exec(`
             CREATE INDEX IF NOT EXISTS idx_messages_session_position
                 ON messages(session_id, COALESCE(invoked_at, created_at) DESC, seq DESC)
+        `)
+    }
+
+    private migrateFromV8ToV9(): void {
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS codex_history_items (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                codex_thread_id TEXT NOT NULL,
+                turn_id TEXT,
+                item_id TEXT NOT NULL,
+                item_kind TEXT NOT NULL,
+                message_seq INTEGER,
+                raw_item TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_codex_history_items_session_item
+                ON codex_history_items(session_id, item_id);
+            CREATE INDEX IF NOT EXISTS idx_codex_history_items_session_seq
+                ON codex_history_items(session_id, seq);
+            CREATE INDEX IF NOT EXISTS idx_codex_history_items_session_message_seq
+                ON codex_history_items(session_id, message_seq);
         `)
     }
 

--- a/hub/src/store/messageStore.ts
+++ b/hub/src/store/messageStore.ts
@@ -1,7 +1,7 @@
 import type { Database } from 'bun:sqlite'
 
 import type { StoredMessage } from './types'
-import { addMessage, cancelQueuedMessage, cloneSessionMessages, deleteQueuedMessageById, getMessageBySeq, lookupQueuedMessage, getMessages, getMessagesAfter, getMessagesByPosition, getUninvokedLocalMessages, markMessagesInvoked, mergeSessionMessages, type CancelQueuedMessageResult, type LookupQueuedMessageResult } from './messages'
+import { addMessage, cancelQueuedMessage, cloneSessionMessages, deleteQueuedMessageById, getMessageBySeq, getMessages, getMessagesAfter, getMessagesByPosition, getNextUserMessageSeq, getPreviousUserMessageSeq, getUninvokedLocalMessages, lookupQueuedMessage, markMessagesInvoked, mergeSessionMessages, type CancelQueuedMessageResult, type LookupQueuedMessageResult } from './messages'
 
 export class MessageStore {
     private readonly db: Database
@@ -44,6 +44,14 @@ export class MessageStore {
 
     getMessageBySeq(sessionId: string, seq: number): StoredMessage | null {
         return getMessageBySeq(this.db, sessionId, seq)
+    }
+
+    getNextUserMessageSeq(sessionId: string, afterSeq: number): number | null {
+        return getNextUserMessageSeq(this.db, sessionId, afterSeq)
+    }
+
+    getPreviousUserMessageSeq(sessionId: string, beforeSeq: number): number | null {
+        return getPreviousUserMessageSeq(this.db, sessionId, beforeSeq)
     }
 
     markMessagesInvoked(sessionId: string, localIds: string[], invokedAt: number): void {

--- a/hub/src/store/messageStore.ts
+++ b/hub/src/store/messageStore.ts
@@ -1,7 +1,7 @@
 import type { Database } from 'bun:sqlite'
 
 import type { StoredMessage } from './types'
-import { addMessage, cancelQueuedMessage, deleteQueuedMessageById, lookupQueuedMessage, getMessages, getMessagesAfter, getMessagesByPosition, getUninvokedLocalMessages, markMessagesInvoked, mergeSessionMessages, type CancelQueuedMessageResult, type LookupQueuedMessageResult } from './messages'
+import { addMessage, cancelQueuedMessage, cloneSessionMessages, deleteQueuedMessageById, lookupQueuedMessage, getMessages, getMessagesAfter, getMessagesByPosition, getUninvokedLocalMessages, markMessagesInvoked, mergeSessionMessages, type CancelQueuedMessageResult, type LookupQueuedMessageResult } from './messages'
 
 export class MessageStore {
     private readonly db: Database
@@ -48,5 +48,9 @@ export class MessageStore {
 
     mergeSessionMessages(fromSessionId: string, toSessionId: string): { moved: number; oldMaxSeq: number; newMaxSeq: number } {
         return mergeSessionMessages(this.db, fromSessionId, toSessionId)
+    }
+
+    cloneSessionMessages(fromSessionId: string, toSessionId: string): { cloned: number; sourceMaxSeq: number; targetMaxSeq: number } {
+        return cloneSessionMessages(this.db, fromSessionId, toSessionId)
     }
 }

--- a/hub/src/store/messageStore.ts
+++ b/hub/src/store/messageStore.ts
@@ -1,7 +1,7 @@
 import type { Database } from 'bun:sqlite'
 
 import type { StoredMessage } from './types'
-import { addMessage, cancelQueuedMessage, cloneSessionMessages, deleteQueuedMessageById, lookupQueuedMessage, getMessages, getMessagesAfter, getMessagesByPosition, getUninvokedLocalMessages, markMessagesInvoked, mergeSessionMessages, type CancelQueuedMessageResult, type LookupQueuedMessageResult } from './messages'
+import { addMessage, cancelQueuedMessage, cloneSessionMessages, deleteQueuedMessageById, getMessageBySeq, lookupQueuedMessage, getMessages, getMessagesAfter, getMessagesByPosition, getUninvokedLocalMessages, markMessagesInvoked, mergeSessionMessages, type CancelQueuedMessageResult, type LookupQueuedMessageResult } from './messages'
 
 export class MessageStore {
     private readonly db: Database
@@ -42,6 +42,10 @@ export class MessageStore {
         deleteQueuedMessageById(this.db, sessionId, messageId)
     }
 
+    getMessageBySeq(sessionId: string, seq: number): StoredMessage | null {
+        return getMessageBySeq(this.db, sessionId, seq)
+    }
+
     markMessagesInvoked(sessionId: string, localIds: string[], invokedAt: number): void {
         markMessagesInvoked(this.db, sessionId, localIds, invokedAt)
     }
@@ -50,7 +54,7 @@ export class MessageStore {
         return mergeSessionMessages(this.db, fromSessionId, toSessionId)
     }
 
-    cloneSessionMessages(fromSessionId: string, toSessionId: string): { cloned: number; sourceMaxSeq: number; targetMaxSeq: number } {
-        return cloneSessionMessages(this.db, fromSessionId, toSessionId)
+    cloneSessionMessages(fromSessionId: string, toSessionId: string, beforeSeq?: number): { cloned: number; sourceMaxSeq: number; targetMaxSeq: number } {
+        return cloneSessionMessages(this.db, fromSessionId, toSessionId, beforeSeq)
     }
 }

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite'
 import { randomUUID } from 'node:crypto'
+import { unwrapRoleWrappedRecordEnvelope } from '@hapi/protocol/messages'
 
 import type { StoredMessage } from './types'
 import { safeJsonParse } from './json'
@@ -112,6 +113,44 @@ export function getMessagesAfter(
     ).all(sessionId, safeAfterSeq, safeLimit) as DbMessageRow[]
 
     return rows.map(toStoredMessage)
+}
+
+export function getNextUserMessageSeq(
+    db: Database,
+    sessionId: string,
+    afterSeq: number
+): number | null {
+    const rows = db.prepare(
+        'SELECT * FROM messages WHERE session_id = ? AND seq > ? ORDER BY seq ASC'
+    ).all(sessionId, afterSeq) as DbMessageRow[]
+
+    for (const row of rows) {
+        const record = unwrapRoleWrappedRecordEnvelope(safeJsonParse(row.content))
+        if (record?.role === 'user') {
+            return row.seq
+        }
+    }
+
+    return null
+}
+
+export function getPreviousUserMessageSeq(
+    db: Database,
+    sessionId: string,
+    beforeSeq: number
+): number | null {
+    const rows = db.prepare(
+        'SELECT * FROM messages WHERE session_id = ? AND seq < ? ORDER BY seq DESC'
+    ).all(sessionId, beforeSeq) as DbMessageRow[]
+
+    for (const row of rows) {
+        const record = unwrapRoleWrappedRecordEnvelope(safeJsonParse(row.content))
+        if (record?.role === 'user') {
+            return row.seq
+        }
+    }
+
+    return null
 }
 
 /** Paginate messages by COALESCE(invoked_at, created_at) DESC, seq DESC.

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -347,3 +347,71 @@ export function mergeSessionMessages(
         throw error
     }
 }
+
+export function cloneSessionMessages(
+    db: Database,
+    fromSessionId: string,
+    toSessionId: string
+): { cloned: number; sourceMaxSeq: number; targetMaxSeq: number } {
+    if (fromSessionId === toSessionId) {
+        return { cloned: 0, sourceMaxSeq: 0, targetMaxSeq: getMaxSeq(db, toSessionId) }
+    }
+
+    const sourceRows = db.prepare(
+        'SELECT * FROM messages WHERE session_id = ? ORDER BY seq ASC'
+    ).all(fromSessionId) as DbMessageRow[]
+
+    if (sourceRows.length === 0) {
+        return { cloned: 0, sourceMaxSeq: 0, targetMaxSeq: getMaxSeq(db, toSessionId) }
+    }
+
+    const sourceMaxSeq = sourceRows[sourceRows.length - 1]?.seq ?? 0
+
+    try {
+        db.exec('BEGIN')
+
+        const targetMaxSeq = getMaxSeq(db, toSessionId)
+        const existingLocalIds = new Set<string>(
+            (db.prepare(
+                'SELECT local_id FROM messages WHERE session_id = ? AND local_id IS NOT NULL'
+            ).all(toSessionId) as Array<{ local_id: string }>).map((row) => row.local_id)
+        )
+
+        const insert = db.prepare(`
+            INSERT INTO messages (
+                id, session_id, content, created_at, seq, local_id
+            ) VALUES (
+                @id, @session_id, @content, @created_at, @seq, @local_id
+            )
+        `)
+
+        for (const row of sourceRows) {
+            const localId = row.local_id && !existingLocalIds.has(row.local_id)
+                ? row.local_id
+                : null
+
+            if (localId) {
+                existingLocalIds.add(localId)
+            }
+
+            insert.run({
+                id: randomUUID(),
+                session_id: toSessionId,
+                content: row.content,
+                created_at: row.created_at,
+                seq: targetMaxSeq + row.seq,
+                local_id: localId
+            })
+        }
+
+        db.exec('COMMIT')
+        return {
+            cloned: sourceRows.length,
+            sourceMaxSeq,
+            targetMaxSeq: targetMaxSeq + sourceMaxSeq
+        }
+    } catch (error) {
+        db.exec('ROLLBACK')
+        throw error
+    }
+}

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -421,6 +421,9 @@ export function cloneSessionMessages(
     try {
         db.exec('BEGIN')
 
+        // Cloned rows preserve relative ordering by reusing the source row's seq offset by
+        // targetMaxSeq. Source-side gaps (from a prior session merge) are inherited as-is; sort
+        // order remains correct but cloned rows are not guaranteed to be contiguous in seq.
         const targetMaxSeq = getMaxSeq(db, toSessionId)
         const existingLocalIds = new Set<string>(
             (db.prepare(
@@ -445,6 +448,11 @@ export function cloneSessionMessages(
                 existingLocalIds.add(localId)
             }
 
+            // Cloned messages are history, never queued work. Force a non-null invoked_at so a
+            // pending user message on the source (local_id set, invoked_at null) does not get
+            // re-delivered to the CLI on the forked session via getUninvokedLocalMessages.
+            const invokedAt = row.invoked_at ?? row.created_at
+
             insert.run({
                 id: randomUUID(),
                 session_id: toSessionId,
@@ -452,7 +460,7 @@ export function cloneSessionMessages(
                 created_at: row.created_at,
                 seq: targetMaxSeq + row.seq,
                 local_id: localId,
-                invoked_at: row.invoked_at
+                invoked_at: invokedAt
             })
         }
 

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -270,6 +270,13 @@ export function deleteQueuedMessageById(
     `).run(sessionId, messageId, messageId)
 }
 
+export function getMessageBySeq(db: Database, sessionId: string, seq: number): StoredMessage | null {
+    const row = db.prepare(
+        'SELECT * FROM messages WHERE session_id = ? AND seq = ? LIMIT 1'
+    ).get(sessionId, seq) as DbMessageRow | undefined
+    return row ? toStoredMessage(row) : null
+}
+
 /** Mark messages as invoked at the given server timestamp.
  *  Only updates rows whose local_id is in localIds.
  *  First-write-wins: rows with a non-NULL invoked_at are not updated.  A duplicate
@@ -351,15 +358,20 @@ export function mergeSessionMessages(
 export function cloneSessionMessages(
     db: Database,
     fromSessionId: string,
-    toSessionId: string
+    toSessionId: string,
+    beforeSeq?: number
 ): { cloned: number; sourceMaxSeq: number; targetMaxSeq: number } {
     if (fromSessionId === toSessionId) {
         return { cloned: 0, sourceMaxSeq: 0, targetMaxSeq: getMaxSeq(db, toSessionId) }
     }
 
-    const sourceRows = db.prepare(
-        'SELECT * FROM messages WHERE session_id = ? ORDER BY seq ASC'
-    ).all(fromSessionId) as DbMessageRow[]
+    const sourceRows = beforeSeq === undefined
+        ? db.prepare(
+            'SELECT * FROM messages WHERE session_id = ? ORDER BY seq ASC'
+        ).all(fromSessionId) as DbMessageRow[]
+        : db.prepare(
+            'SELECT * FROM messages WHERE session_id = ? AND seq < ? ORDER BY seq ASC'
+        ).all(fromSessionId, beforeSeq) as DbMessageRow[]
 
     if (sourceRows.length === 0) {
         return { cloned: 0, sourceMaxSeq: 0, targetMaxSeq: getMaxSeq(db, toSessionId) }
@@ -379,9 +391,9 @@ export function cloneSessionMessages(
 
         const insert = db.prepare(`
             INSERT INTO messages (
-                id, session_id, content, created_at, seq, local_id
+                id, session_id, content, created_at, seq, local_id, invoked_at
             ) VALUES (
-                @id, @session_id, @content, @created_at, @seq, @local_id
+                @id, @session_id, @content, @created_at, @seq, @local_id, @invoked_at
             )
         `)
 
@@ -400,7 +412,8 @@ export function cloneSessionMessages(
                 content: row.content,
                 created_at: row.created_at,
                 seq: targetMaxSeq + row.seq,
-                local_id: localId
+                local_id: localId,
+                invoked_at: row.invoked_at
             })
         }
 

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -145,6 +145,7 @@ export class RpcGateway {
         sessionType?: 'simple' | 'worktree',
         worktreeName?: string,
         resumeSessionId?: string,
+        forkSessionId?: string,
         effort?: string,
         permissionMode?: PermissionMode
     ): Promise<{ type: 'success'; sessionId: string } | { type: 'error'; message: string }> {
@@ -152,7 +153,20 @@ export class RpcGateway {
             const result = await this.machineRpc(
                 machineId,
                 'spawn-happy-session',
-                { type: 'spawn-in-directory', directory, agent, model, modelReasoningEffort, yolo, sessionType, worktreeName, resumeSessionId, effort, permissionMode }
+                {
+                    type: 'spawn-in-directory',
+                    directory,
+                    agent,
+                    model,
+                    modelReasoningEffort,
+                    yolo,
+                    sessionType,
+                    worktreeName,
+                    resumeSessionId,
+                    forkSessionId,
+                    effort,
+                    permissionMode
+                }
             )
             if (result && typeof result === 'object') {
                 const obj = result as Record<string, unknown>

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -147,7 +147,8 @@ export class RpcGateway {
         resumeSessionId?: string,
         forkSessionId?: string,
         effort?: string,
-        permissionMode?: PermissionMode
+        permissionMode?: PermissionMode,
+        forkHistory?: unknown[]
     ): Promise<{ type: 'success'; sessionId: string } | { type: 'error'; message: string }> {
         try {
             const result = await this.machineRpc(
@@ -164,6 +165,7 @@ export class RpcGateway {
                     worktreeName,
                     resumeSessionId,
                     forkSessionId,
+                    forkHistory,
                     effort,
                     permissionMode
                 }

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -3,6 +3,7 @@ import type { CodexCollaborationMode, PermissionMode, Session } from '@hapi/prot
 import type { Store } from '../store'
 import { clampAliveTime } from './aliveTime'
 import { EventPublisher } from './eventPublisher'
+import { mergeSessionMetadata } from './sessionMetadata'
 import { extractTodoWriteTodosFromMessageContent, TodosSchema } from './todos'
 import { extractBackgroundTaskDelta } from './backgroundTasks'
 
@@ -465,7 +466,7 @@ export class SessionCache {
             throw new Error('Session not found')
         }
 
-        const mergedMetadata = this.mergeSessionMetadata(source.metadata ?? null, target.metadata ?? null)
+        const mergedMetadata = mergeSessionMetadata(source.metadata ?? null, target.metadata ?? null)
         if (mergedMetadata === target.metadata) {
             return
         }
@@ -552,7 +553,7 @@ export class SessionCache {
             this.publisher.emit({ type: 'messages-invalidated', sessionId: newSessionId, namespace })
         }
 
-        const mergedMetadata = this.mergeSessionMetadata(oldStored.metadata, newStored.metadata)
+        const mergedMetadata = mergeSessionMetadata(oldStored.metadata, newStored.metadata)
         if (mergedMetadata !== null && mergedMetadata !== newStored.metadata) {
             for (let attempt = 0; attempt < 2; attempt += 1) {
                 const latest = this.store.sessions.getSessionByNamespace(newSessionId, namespace)
@@ -660,51 +661,6 @@ export class SessionCache {
             this.publisher.emit({ type: 'session-updated', sessionId: newSessionId, data: refreshed })
         }
     }
-
-    private mergeSessionMetadata(oldMetadata: unknown | null, newMetadata: unknown | null): unknown | null {
-        if (!oldMetadata || typeof oldMetadata !== 'object') {
-            return newMetadata
-        }
-        if (!newMetadata || typeof newMetadata !== 'object') {
-            return oldMetadata
-        }
-
-        const oldObj = oldMetadata as Record<string, unknown>
-        const newObj = newMetadata as Record<string, unknown>
-        const merged: Record<string, unknown> = { ...newObj }
-        let changed = false
-
-        if (typeof oldObj.name === 'string' && typeof newObj.name !== 'string') {
-            merged.name = oldObj.name
-            changed = true
-        }
-
-        const oldSummary = oldObj.summary as { text?: unknown; updatedAt?: unknown } | undefined
-        const newSummary = newObj.summary as { text?: unknown; updatedAt?: unknown } | undefined
-        const oldUpdatedAt = typeof oldSummary?.updatedAt === 'number' ? oldSummary.updatedAt : null
-        const newUpdatedAt = typeof newSummary?.updatedAt === 'number' ? newSummary.updatedAt : null
-        if (oldUpdatedAt !== null && (newUpdatedAt === null || oldUpdatedAt > newUpdatedAt)) {
-            merged.summary = oldSummary
-            changed = true
-        }
-
-        if (oldObj.worktree && !newObj.worktree) {
-            merged.worktree = oldObj.worktree
-            changed = true
-        }
-
-        if (typeof oldObj.path === 'string' && typeof newObj.path !== 'string') {
-            merged.path = oldObj.path
-            changed = true
-        }
-        if (typeof oldObj.host === 'string' && typeof newObj.host !== 'string') {
-            merged.host = oldObj.host
-            changed = true
-        }
-
-        return changed ? merged : newMetadata
-    }
-
     private mergeAgentState(oldState: unknown | null, newState: unknown | null): unknown | null {
         if (oldState === null) return newState
         if (newState === null) return oldState

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -458,6 +458,37 @@ export class SessionCache {
         this.refreshSession(sessionId)
     }
 
+    async inheritSessionMetadata(sourceSessionId: string, targetSessionId: string): Promise<void> {
+        const source = this.sessions.get(sourceSessionId) ?? this.refreshSession(sourceSessionId)
+        const target = this.sessions.get(targetSessionId) ?? this.refreshSession(targetSessionId)
+        if (!source || !target) {
+            throw new Error('Session not found')
+        }
+
+        const mergedMetadata = this.mergeSessionMetadata(source.metadata ?? null, target.metadata ?? null)
+        if (mergedMetadata === target.metadata) {
+            return
+        }
+
+        const result = this.store.sessions.updateSessionMetadata(
+            targetSessionId,
+            mergedMetadata,
+            target.metadataVersion,
+            target.namespace,
+            { touchUpdatedAt: false }
+        )
+
+        if (result.result === 'error') {
+            throw new Error('Failed to inherit session metadata')
+        }
+
+        if (result.result === 'version-mismatch') {
+            throw new Error('Session was modified concurrently. Please try again.')
+        }
+
+        this.refreshSession(targetSessionId)
+    }
+
     async deleteSession(sessionId: string): Promise<void> {
         const session = this.sessions.get(sessionId)
         if (!session) {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -461,33 +461,46 @@ export class SessionCache {
 
     async inheritSessionMetadata(sourceSessionId: string, targetSessionId: string): Promise<void> {
         const source = this.sessions.get(sourceSessionId) ?? this.refreshSession(sourceSessionId)
-        const target = this.sessions.get(targetSessionId) ?? this.refreshSession(targetSessionId)
-        if (!source || !target) {
+        if (!source) {
             throw new Error('Session not found')
         }
 
-        const mergedMetadata = mergeSessionMetadata(source.metadata ?? null, target.metadata ?? null)
-        if (mergedMetadata === target.metadata) {
-            return
+        // Retry on version-mismatch: by the time the fork's target session has become active, the CLI
+        // has typically already emitted update-metadata events that bumped metadataVersion. Re-read the
+        // latest snapshot and re-merge so a concurrent CLI write does not silently drop inheritance.
+        // Small backoff between attempts gives any in-flight CLI write room to land before we reread.
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+            if (attempt > 0) {
+                await new Promise((resolve) => setTimeout(resolve, 25 * attempt))
+            }
+            const target = this.refreshSession(targetSessionId)
+            if (!target) {
+                throw new Error('Session not found')
+            }
+
+            const mergedMetadata = mergeSessionMetadata(source.metadata ?? null, target.metadata ?? null)
+            if (mergedMetadata === target.metadata) {
+                return
+            }
+
+            const result = this.store.sessions.updateSessionMetadata(
+                targetSessionId,
+                mergedMetadata,
+                target.metadataVersion,
+                target.namespace,
+                { touchUpdatedAt: false }
+            )
+
+            if (result.result === 'success') {
+                this.refreshSession(targetSessionId)
+                return
+            }
+            if (result.result === 'error') {
+                throw new Error('Failed to inherit session metadata')
+            }
         }
 
-        const result = this.store.sessions.updateSessionMetadata(
-            targetSessionId,
-            mergedMetadata,
-            target.metadataVersion,
-            target.namespace,
-            { touchUpdatedAt: false }
-        )
-
-        if (result.result === 'error') {
-            throw new Error('Failed to inherit session metadata')
-        }
-
-        if (result.result === 'version-mismatch') {
-            throw new Error('Session was modified concurrently. Please try again.')
-        }
-
-        this.refreshSession(targetSessionId)
+        throw new Error('Session was modified concurrently. Please try again.')
     }
 
     async deleteSession(sessionId: string): Promise<void> {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -559,6 +559,10 @@ export class SessionCache {
         }
 
         const movedMessages = this.store.messages.mergeSessionMessages(oldSessionId, newSessionId)
+        const targetMessageSeqOffset = movedMessages.oldMaxSeq > 0 && movedMessages.newMaxSeq > 0
+            ? movedMessages.oldMaxSeq
+            : 0
+        this.store.codexHistory.moveSessionHistory(oldSessionId, newSessionId, targetMessageSeqOffset)
         if (movedMessages.moved > 0) {
             if (!options.deleteOldSession) {
                 this.publisher.emit({ type: 'messages-invalidated', sessionId: oldSessionId, namespace })

--- a/hub/src/sync/sessionMetadata.test.ts
+++ b/hub/src/sync/sessionMetadata.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test'
+import { mergeSessionMetadata } from './sessionMetadata'
+
+describe('mergeSessionMetadata', () => {
+    it('preserves custom name when new metadata omits it', () => {
+        expect(mergeSessionMetadata(
+            { path: '/tmp/project', host: 'localhost', name: '自定义标题' },
+            { path: '/tmp/project', host: 'localhost', codexSessionId: 'thread-2' }
+        )).toEqual({
+            path: '/tmp/project',
+            host: 'localhost',
+            codexSessionId: 'thread-2',
+            name: '自定义标题'
+        })
+    })
+
+    it('preserves newer summary when new metadata omits it', () => {
+        expect(mergeSessionMetadata(
+            {
+                path: '/tmp/project',
+                host: 'localhost',
+                summary: { text: '原标题', updatedAt: 200 }
+            },
+            { path: '/tmp/project', host: 'localhost', codexSessionId: 'thread-2' }
+        )).toEqual({
+            path: '/tmp/project',
+            host: 'localhost',
+            codexSessionId: 'thread-2',
+            summary: { text: '原标题', updatedAt: 200 }
+        })
+    })
+
+    it('keeps newer incoming summary when it is fresher', () => {
+        expect(mergeSessionMetadata(
+            {
+                path: '/tmp/project',
+                host: 'localhost',
+                summary: { text: '旧标题', updatedAt: 100 }
+            },
+            {
+                path: '/tmp/project',
+                host: 'localhost',
+                summary: { text: '新标题', updatedAt: 200 }
+            }
+        )).toEqual({
+            path: '/tmp/project',
+            host: 'localhost',
+            summary: { text: '新标题', updatedAt: 200 }
+        })
+    })
+})

--- a/hub/src/sync/sessionMetadata.ts
+++ b/hub/src/sync/sessionMetadata.ts
@@ -1,0 +1,43 @@
+export function mergeSessionMetadata(oldMetadata: unknown | null, newMetadata: unknown | null): unknown | null {
+    if (!oldMetadata || typeof oldMetadata !== 'object') {
+        return newMetadata
+    }
+    if (!newMetadata || typeof newMetadata !== 'object') {
+        return oldMetadata
+    }
+
+    const oldObj = oldMetadata as Record<string, unknown>
+    const newObj = newMetadata as Record<string, unknown>
+    const merged: Record<string, unknown> = { ...newObj }
+    let changed = false
+
+    if (typeof oldObj.name === 'string' && typeof newObj.name !== 'string') {
+        merged.name = oldObj.name
+        changed = true
+    }
+
+    const oldSummary = oldObj.summary as { text?: unknown; updatedAt?: unknown } | undefined
+    const newSummary = newObj.summary as { text?: unknown; updatedAt?: unknown } | undefined
+    const oldUpdatedAt = typeof oldSummary?.updatedAt === 'number' ? oldSummary.updatedAt : null
+    const newUpdatedAt = typeof newSummary?.updatedAt === 'number' ? newSummary.updatedAt : null
+    if (oldUpdatedAt !== null && (newUpdatedAt === null || oldUpdatedAt > newUpdatedAt)) {
+        merged.summary = oldSummary
+        changed = true
+    }
+
+    if (oldObj.worktree && !newObj.worktree) {
+        merged.worktree = oldObj.worktree
+        changed = true
+    }
+
+    if (typeof oldObj.path === 'string' && typeof newObj.path !== 'string') {
+        merged.path = oldObj.path
+        changed = true
+    }
+    if (typeof oldObj.host === 'string' && typeof newObj.host !== 'string') {
+        merged.host = oldObj.host
+        changed = true
+    }
+
+    return changed ? merged : newMetadata
+}

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1089,12 +1089,12 @@ describe('session model', () => {
             expect(await engine.forkSession(session.id, 'default', { beforeSeq: 2 })).toMatchObject({
                 type: 'error',
                 code: 'fork_unavailable',
-                message: '历史点 fork 只支持新版本会话'
+                message: 'Historical fork is only supported for sessions started with the new Codex history pipeline'
             })
             expect(await engine.forkSession(session.id, 'default', { beforeSeq: 1 })).toMatchObject({
                 type: 'error',
                 code: 'fork_unavailable',
-                message: '历史点 fork 只支持新版本会话'
+                message: 'Historical fork is only supported for sessions started with the new Codex history pipeline'
             })
         } finally {
             engine.stop()

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1260,4 +1260,80 @@ describe('session model', () => {
             expect(state.completedRequests?.['req-1']).toBeDefined()
         })
     })
+
+    it('clones existing messages into the forked session', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-codex-fork-history',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'codex',
+                    codexSessionId: 'codex-thread-1'
+                },
+                null,
+                'default',
+                'gpt-5.4'
+            )
+            engine.getOrCreateMachine(
+                'machine-1',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
+
+            store.messages.addMessage(session.id, {
+                role: 'user',
+                content: { type: 'text', text: 'old user message' }
+            })
+            store.messages.addMessage(session.id, {
+                role: 'assistant',
+                content: { type: 'text', text: 'old assistant message' }
+            })
+
+            let forkedSessionId = ''
+            ;(engine as any).rpcGateway.spawnSession = async () => {
+                const forkedSession = engine.getOrCreateSession(
+                    'forked-session-history',
+                    {
+                        path: '/tmp/project',
+                        host: 'localhost',
+                        machineId: 'machine-1',
+                        flavor: 'codex',
+                        codexSessionId: 'codex-thread-2'
+                    },
+                    null,
+                    'default',
+                    'gpt-5.4'
+                )
+                forkedSessionId = forkedSession.id
+                return { type: 'success', sessionId: forkedSessionId }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            const result = await engine.forkSession(session.id, 'default')
+
+            expect(result).toEqual({ type: 'success', sessionId: forkedSessionId })
+            expect(store.messages.getMessages(forkedSessionId, 10).map((message) => message.content)).toEqual([
+                { role: 'user', content: { type: 'text', text: 'old user message' } },
+                { role: 'assistant', content: { type: 'text', text: 'old assistant message' } }
+            ])
+            expect(store.messages.getMessages(session.id, 10).map((message) => message.content)).toEqual([
+                { role: 'user', content: { type: 'text', text: 'old user message' } },
+                { role: 'assistant', content: { type: 'text', text: 'old assistant message' } }
+            ])
+        } finally {
+            engine.stop()
+        }
+    })
 })

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -941,7 +941,7 @@ describe('session model', () => {
         }
     })
 
-    it('passes raw history instead of latest fork token for historical codex fork', async () => {
+    it('passes raw history through the selected user reply for historical codex fork', async () => {
         const store = new Store(':memory:')
         const engine = new SyncEngine(
             store,
@@ -975,6 +975,7 @@ describe('session model', () => {
             store.messages.addMessage(session.id, { role: 'user', content: { type: 'text', text: 'first' } })
             store.messages.addMessage(session.id, { role: 'assistant', content: { type: 'text', text: 'answer' } })
             store.messages.addMessage(session.id, { role: 'user', content: { type: 'text', text: 'second' } })
+            store.messages.addMessage(session.id, { role: 'assistant', content: { type: 'text', text: 'second answer' } })
             store.codexHistory.addItem({
                 sessionId: session.id,
                 codexThreadId: 'codex-thread-1',
@@ -997,6 +998,13 @@ describe('session model', () => {
                 itemKind: 'user',
                 messageSeq: 3,
                 rawItem: { id: 'user-3', role: 'user' }
+            })
+            store.codexHistory.addItem({
+                sessionId: session.id,
+                codexThreadId: 'codex-thread-1',
+                itemId: 'assistant-3',
+                itemKind: 'assistant',
+                rawItem: { id: 'assistant-3', role: 'assistant' }
             })
 
             let capturedForkSessionId: string | undefined
@@ -1036,7 +1044,7 @@ describe('session model', () => {
             }
             ;(engine as any).waitForSessionActive = async () => true
 
-            const result = await engine.forkSession(session.id, 'default', { beforeSeq: 3 })
+            const result = await engine.forkSession(session.id, 'default', { beforeSeq: 2 })
 
             expect(result).toEqual({ type: 'success', sessionId: forkedSessionId })
             expect(capturedForkSessionId).toBeUndefined()
@@ -1081,7 +1089,7 @@ describe('session model', () => {
             expect(await engine.forkSession(session.id, 'default', { beforeSeq: 2 })).toMatchObject({
                 type: 'error',
                 code: 'fork_unavailable',
-                message: 'Historical fork cut point must be a user message'
+                message: '历史点 fork 只支持新版本会话'
             })
             expect(await engine.forkSession(session.id, 'default', { beforeSeq: 1 })).toMatchObject({
                 type: 'error',

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1243,8 +1243,23 @@ describe('session model', () => {
                 'default'
             )
 
-            // Add a message to s1
-            store.messages.addMessage(s1.id, { type: 'text', text: 'hello from s1' }, 'local-1')
+            store.messages.addMessage(s1.id, { role: 'user', content: { type: 'text', text: 'hello from s1' } })
+            store.messages.addMessage(s1.id, { role: 'assistant', content: { type: 'text', text: 'answer from s1' } })
+            store.codexHistory.addItem({
+                sessionId: s1.id,
+                codexThreadId: 'thread-X',
+                itemId: 'user-1',
+                itemKind: 'user',
+                messageSeq: 1,
+                rawItem: { id: 'user-1', role: 'user' }
+            })
+            store.codexHistory.addItem({
+                sessionId: s1.id,
+                codexThreadId: 'thread-X',
+                itemId: 'assistant-1',
+                itemKind: 'assistant',
+                rawItem: { id: 'assistant-1', role: 'assistant' }
+            })
 
             const s2 = cache.getOrCreateSession(
                 'tag-2',
@@ -1262,6 +1277,10 @@ describe('session model', () => {
 
             const messages = store.messages.getMessages(s2.id, 100)
             expect(messages.length).toBeGreaterThanOrEqual(1)
+            expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(s2.id, 1)).toEqual([
+                { id: 'user-1', role: 'user' },
+                { id: 'assistant-1', role: 'assistant' }
+            ])
         })
 
         it('preserves sessions with different agent session IDs', async () => {

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -473,6 +473,7 @@ describe('session model', () => {
                 _sessionType?: string,
                 _worktreeName?: string,
                 _resumeSessionId?: string,
+                _forkSessionId?: string,
                 effort?: string
             ) => {
                 capturedModel = model
@@ -589,7 +590,8 @@ describe('session model', () => {
                 _yolo?: boolean,
                 _sessionType?: 'simple' | 'worktree',
                 _worktreeName?: string,
-                resumeSessionId?: string
+                resumeSessionId?: string,
+                _forkSessionId?: string
             ) => {
                 capturedResumeSessionId = resumeSessionId
                 return { type: 'success', sessionId: session.id }
@@ -847,6 +849,7 @@ describe('session model', () => {
                 _sessionType?: string,
                 _worktreeName?: string,
                 _resumeSessionId?: string,
+                _forkSessionId?: string,
                 _effort?: string,
                 permissionMode?: string
             ) => {
@@ -859,6 +862,67 @@ describe('session model', () => {
 
             expect(result).toEqual({ type: 'success', sessionId: session.id })
             expect(capturedPermissionMode).toBe('bypassPermissions')
+        } finally {
+            engine.stop()
+        }
+    })
+
+    it('passes fork session ID to rpc gateway when forking codex session', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-codex-fork',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'codex',
+                    codexSessionId: 'codex-thread-1'
+                },
+                null,
+                'default',
+                'gpt-5.4'
+            )
+            engine.getOrCreateMachine(
+                'machine-1',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
+
+            let capturedForkSessionId: string | undefined
+            let capturedModel: string | undefined
+            ;(engine as any).rpcGateway.spawnSession = async (
+                _machineId: string,
+                _directory: string,
+                _agent: string,
+                model?: string,
+                _modelReasoningEffort?: string,
+                _yolo?: boolean,
+                _sessionType?: 'simple' | 'worktree',
+                _worktreeName?: string,
+                _resumeSessionId?: string,
+                forkSessionId?: string
+            ) => {
+                capturedModel = model
+                capturedForkSessionId = forkSessionId
+                return { type: 'success', sessionId: 'forked-session' }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            const result = await engine.forkSession(session.id, 'default')
+
+            expect(result).toEqual({ type: 'success', sessionId: 'forked-session' })
+            expect(capturedForkSessionId).toBe('codex-thread-1')
+            expect(capturedModel).toBe('gpt-5.4')
         } finally {
             engine.stop()
         }

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -941,6 +941,158 @@ describe('session model', () => {
         }
     })
 
+    it('passes raw history instead of latest fork token for historical codex fork', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-codex-history-fork',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'codex',
+                    codexSessionId: 'codex-thread-1'
+                },
+                null,
+                'default',
+                'gpt-5.4'
+            )
+            engine.getOrCreateMachine(
+                'machine-1',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
+
+            store.messages.addMessage(session.id, { role: 'user', content: { type: 'text', text: 'first' } })
+            store.messages.addMessage(session.id, { role: 'assistant', content: { type: 'text', text: 'answer' } })
+            store.messages.addMessage(session.id, { role: 'user', content: { type: 'text', text: 'second' } })
+            store.codexHistory.addItem({
+                sessionId: session.id,
+                codexThreadId: 'codex-thread-1',
+                itemId: 'user-1',
+                itemKind: 'user',
+                messageSeq: 1,
+                rawItem: { id: 'user-1', role: 'user' }
+            })
+            store.codexHistory.addItem({
+                sessionId: session.id,
+                codexThreadId: 'codex-thread-1',
+                itemId: 'assistant-1',
+                itemKind: 'assistant',
+                rawItem: { id: 'assistant-1', role: 'assistant' }
+            })
+            store.codexHistory.addItem({
+                sessionId: session.id,
+                codexThreadId: 'codex-thread-1',
+                itemId: 'user-3',
+                itemKind: 'user',
+                messageSeq: 3,
+                rawItem: { id: 'user-3', role: 'user' }
+            })
+
+            let capturedForkSessionId: string | undefined
+            let capturedForkHistory: unknown[] | undefined
+            let forkedSessionId = ''
+            ;(engine as any).rpcGateway.spawnSession = async (
+                _machineId: string,
+                _directory: string,
+                _agent: string,
+                _model?: string,
+                _modelReasoningEffort?: string,
+                _yolo?: boolean,
+                _sessionType?: 'simple' | 'worktree',
+                _worktreeName?: string,
+                _resumeSessionId?: string,
+                forkSessionId?: string,
+                _effort?: string,
+                _permissionMode?: string,
+                forkHistory?: unknown[]
+            ) => {
+                capturedForkSessionId = forkSessionId
+                capturedForkHistory = forkHistory
+                const forkedSession = engine.getOrCreateSession(
+                    'forked-session-history-point',
+                    {
+                        path: '/tmp/project',
+                        host: 'localhost',
+                        machineId: 'machine-1',
+                        flavor: 'codex',
+                        codexSessionId: 'codex-thread-2'
+                    },
+                    null,
+                    'default'
+                )
+                forkedSessionId = forkedSession.id
+                return { type: 'success', sessionId: forkedSessionId }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            const result = await engine.forkSession(session.id, 'default', { beforeSeq: 3 })
+
+            expect(result).toEqual({ type: 'success', sessionId: forkedSessionId })
+            expect(capturedForkSessionId).toBeUndefined()
+            expect(capturedForkHistory).toEqual([
+                { id: 'user-1', role: 'user' },
+                { id: 'assistant-1', role: 'assistant' }
+            ])
+            expect(store.messages.getMessages(forkedSessionId, 10).map((message) => message.content)).toEqual([
+                { role: 'user', content: { type: 'text', text: 'first' } },
+                { role: 'assistant', content: { type: 'text', text: 'answer' } }
+            ])
+        } finally {
+            engine.stop()
+        }
+    })
+
+    it('rejects historical fork for non-user cut points or sessions without raw history', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-codex-history-fork-unavailable',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'codex',
+                    codexSessionId: 'codex-thread-1'
+                },
+                null,
+                'default'
+            )
+            store.messages.addMessage(session.id, { role: 'user', content: { type: 'text', text: 'first' } })
+            store.messages.addMessage(session.id, { role: 'assistant', content: { type: 'text', text: 'answer' } })
+
+            expect(await engine.forkSession(session.id, 'default', { beforeSeq: 2 })).toMatchObject({
+                type: 'error',
+                code: 'fork_unavailable',
+                message: 'Historical fork cut point must be a user message'
+            })
+            expect(await engine.forkSession(session.id, 'default', { beforeSeq: 1 })).toMatchObject({
+                type: 'error',
+                code: 'fork_unavailable',
+                message: '历史点 fork 只支持新版本会话'
+            })
+        } finally {
+            engine.stop()
+        }
+    })
+
     describe('session dedup by agent session ID', () => {
         it('merges duplicate when codexSessionId collides', async () => {
             const store = new Store(':memory:')

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1066,6 +1066,114 @@ describe('session model', () => {
         }
     })
 
+    it('forks before a selected user message by using the previous completed turn', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-codex-history-fork-before-user',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'codex',
+                    codexSessionId: 'codex-thread-1'
+                },
+                null,
+                'default'
+            )
+            engine.getOrCreateMachine(
+                'machine-1',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
+
+            store.messages.addMessage(session.id, { role: 'user', content: { type: 'text', text: 'first' } })
+            store.messages.addMessage(session.id, { role: 'assistant', content: { type: 'text', text: 'answer' } })
+            store.messages.addMessage(session.id, { role: 'user', content: { type: 'text', text: 'second' } })
+            store.codexHistory.addItem({
+                sessionId: session.id,
+                codexThreadId: 'codex-thread-1',
+                itemId: 'user-1',
+                itemKind: 'user',
+                messageSeq: 1,
+                rawItem: { id: 'user-1', role: 'user' }
+            })
+            store.codexHistory.addItem({
+                sessionId: session.id,
+                codexThreadId: 'codex-thread-1',
+                itemId: 'assistant-1',
+                itemKind: 'assistant',
+                rawItem: { id: 'assistant-1', role: 'assistant' }
+            })
+            store.codexHistory.addItem({
+                sessionId: session.id,
+                codexThreadId: 'codex-thread-1',
+                itemId: 'user-2',
+                itemKind: 'user',
+                messageSeq: 3,
+                rawItem: { id: 'user-2', role: 'user' }
+            })
+
+            let capturedForkHistory: unknown[] | undefined
+            let forkedSessionId = ''
+            ;(engine as any).rpcGateway.spawnSession = async (
+                _machineId: string,
+                _directory: string,
+                _agent: string,
+                _model?: string,
+                _modelReasoningEffort?: string,
+                _yolo?: boolean,
+                _sessionType?: 'simple' | 'worktree',
+                _worktreeName?: string,
+                _resumeSessionId?: string,
+                _forkSessionId?: string,
+                _effort?: string,
+                _permissionMode?: string,
+                forkHistory?: unknown[]
+            ) => {
+                capturedForkHistory = forkHistory
+                const forkedSession = engine.getOrCreateSession(
+                    'forked-session-before-user',
+                    {
+                        path: '/tmp/project',
+                        host: 'localhost',
+                        machineId: 'machine-1',
+                        flavor: 'codex',
+                        codexSessionId: 'codex-thread-2'
+                    },
+                    null,
+                    'default'
+                )
+                forkedSessionId = forkedSession.id
+                return { type: 'success', sessionId: forkedSessionId }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            const result = await engine.forkSession(session.id, 'default', { beforeSeq: 3 })
+
+            expect(result).toEqual({ type: 'success', sessionId: forkedSessionId })
+            expect(capturedForkHistory).toEqual([
+                { id: 'user-1', role: 'user' },
+                { id: 'assistant-1', role: 'assistant' }
+            ])
+            expect(store.messages.getMessages(forkedSessionId, 10).map((message) => message.content)).toEqual([
+                { role: 'user', content: { type: 'text', text: 'first' } },
+                { role: 'assistant', content: { type: 'text', text: 'answer' } }
+            ])
+        } finally {
+            engine.stop()
+        }
+    })
+
     it('rejects historical fork for non-user cut points or sessions without raw history', async () => {
         const store = new Store(':memory:')
         const engine = new SyncEngine(
@@ -1099,7 +1207,7 @@ describe('session model', () => {
             expect(await engine.forkSession(session.id, 'default', { beforeSeq: 1 })).toMatchObject({
                 type: 'error',
                 code: 'fork_unavailable',
-                message: 'Historical fork is only supported for sessions started with the new Codex history pipeline'
+                message: 'No earlier history to fork from'
             })
         } finally {
             engine.stop()

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -888,7 +888,9 @@ describe('session model', () => {
                 },
                 null,
                 'default',
-                'gpt-5.4'
+                'gpt-5.4',
+                undefined,
+                'xhigh'
             )
             engine.getOrCreateMachine(
                 'machine-1',
@@ -900,12 +902,13 @@ describe('session model', () => {
 
             let capturedForkSessionId: string | undefined
             let capturedModel: string | undefined
+            let capturedModelReasoningEffort: string | undefined
             ;(engine as any).rpcGateway.spawnSession = async (
                 _machineId: string,
                 _directory: string,
                 _agent: string,
                 model?: string,
-                _modelReasoningEffort?: string,
+                modelReasoningEffort?: string,
                 _yolo?: boolean,
                 _sessionType?: 'simple' | 'worktree',
                 _worktreeName?: string,
@@ -913,6 +916,7 @@ describe('session model', () => {
                 forkSessionId?: string
             ) => {
                 capturedModel = model
+                capturedModelReasoningEffort = modelReasoningEffort
                 capturedForkSessionId = forkSessionId
                 const forkedSession = engine.getOrCreateSession(
                     'forked-session',
@@ -936,6 +940,7 @@ describe('session model', () => {
             expect(result.type).toBe('success')
             expect(capturedForkSessionId).toBe('codex-thread-1')
             expect(capturedModel).toBe('gpt-5.4')
+            expect(capturedModelReasoningEffort).toBe('xhigh')
         } finally {
             engine.stop()
         }

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1336,4 +1336,68 @@ describe('session model', () => {
             engine.stop()
         }
     })
+
+    it('preserves custom session title when forking', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-codex-fork-title',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'codex',
+                    codexSessionId: 'codex-thread-1',
+                    name: '我的自定义标题'
+                },
+                null,
+                'default',
+                'gpt-5.4'
+            )
+            engine.getOrCreateMachine(
+                'machine-1',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
+
+            let forkedSessionId = ''
+            ;(engine as any).rpcGateway.spawnSession = async () => {
+                const forkedSession = engine.getOrCreateSession(
+                    'forked-session-title',
+                    {
+                        path: '/tmp/project',
+                        host: 'localhost',
+                        machineId: 'machine-1',
+                        flavor: 'codex',
+                        codexSessionId: 'codex-thread-2'
+                    },
+                    null,
+                    'default',
+                    'gpt-5.4'
+                )
+                forkedSessionId = forkedSession.id
+                return { type: 'success', sessionId: forkedSessionId }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            const result = await engine.forkSession(session.id, 'default')
+
+            expect(result).toEqual({ type: 'success', sessionId: forkedSessionId })
+            expect(engine.getSession(forkedSessionId)?.metadata?.name).toBe('我的自定义标题')
+            expect(store.sessions.getSession(forkedSessionId)?.metadata).toMatchObject({
+                name: '我的自定义标题'
+            })
+        } finally {
+            engine.stop()
+        }
+    })
 })

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -914,13 +914,26 @@ describe('session model', () => {
             ) => {
                 capturedModel = model
                 capturedForkSessionId = forkSessionId
-                return { type: 'success', sessionId: 'forked-session' }
+                const forkedSession = engine.getOrCreateSession(
+                    'forked-session',
+                    {
+                        path: '/tmp/project',
+                        host: 'localhost',
+                        machineId: 'machine-1',
+                        flavor: 'codex',
+                        codexSessionId: 'codex-thread-2'
+                    },
+                    null,
+                    'default',
+                    model
+                )
+                return { type: 'success', sessionId: forkedSession.id }
             }
             ;(engine as any).waitForSessionActive = async () => true
 
             const result = await engine.forkSession(session.id, 'default')
 
-            expect(result).toEqual({ type: 'success', sessionId: 'forked-session' })
+            expect(result.type).toBe('success')
             expect(capturedForkSessionId).toBe('codex-thread-1')
             expect(capturedModel).toBe('gpt-5.4')
         } finally {
@@ -1395,6 +1408,76 @@ describe('session model', () => {
             expect(engine.getSession(forkedSessionId)?.metadata?.name).toBe('我的自定义标题')
             expect(store.sessions.getSession(forkedSessionId)?.metadata).toMatchObject({
                 name: '我的自定义标题'
+            })
+        } finally {
+            engine.stop()
+        }
+    })
+
+    it('preserves summary title when forking', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-codex-fork-summary',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'codex',
+                    codexSessionId: 'codex-thread-1',
+                    summary: {
+                        text: '自动标题',
+                        updatedAt: 123456
+                    }
+                },
+                null,
+                'default',
+                'gpt-5.4'
+            )
+            engine.getOrCreateMachine(
+                'machine-1',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
+
+            let forkedSessionId = ''
+            ;(engine as any).rpcGateway.spawnSession = async () => {
+                const forkedSession = engine.getOrCreateSession(
+                    'forked-session-summary',
+                    {
+                        path: '/tmp/project',
+                        host: 'localhost',
+                        machineId: 'machine-1',
+                        flavor: 'codex',
+                        codexSessionId: 'codex-thread-2'
+                    },
+                    null,
+                    'default',
+                    'gpt-5.4'
+                )
+                forkedSessionId = forkedSession.id
+                return { type: 'success', sessionId: forkedSessionId }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            const result = await engine.forkSession(session.id, 'default')
+
+            expect(result).toEqual({ type: 'success', sessionId: forkedSessionId })
+            expect(engine.getSession(forkedSessionId)?.metadata?.summary?.text).toBe('自动标题')
+            expect(store.sessions.getSession(forkedSessionId)?.metadata).toMatchObject({
+                summary: {
+                    text: '自动标题',
+                    updatedAt: 123456
+                }
             })
         } finally {
             engine.stop()

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1014,6 +1014,7 @@ describe('session model', () => {
 
             let capturedForkSessionId: string | undefined
             let capturedForkHistory: unknown[] | undefined
+            let spawnCount = 0
             let forkedSessionId = ''
             ;(engine as any).rpcGateway.spawnSession = async (
                 _machineId: string,
@@ -1032,14 +1033,15 @@ describe('session model', () => {
             ) => {
                 capturedForkSessionId = forkSessionId
                 capturedForkHistory = forkHistory
+                spawnCount += 1
                 const forkedSession = engine.getOrCreateSession(
-                    'forked-session-history-point',
+                    `forked-session-history-point-${spawnCount}`,
                     {
                         path: '/tmp/project',
                         host: 'localhost',
                         machineId: 'machine-1',
                         flavor: 'codex',
-                        codexSessionId: 'codex-thread-2'
+                        codexSessionId: `codex-thread-fork-${spawnCount}`
                     },
                     null,
                     'default'
@@ -1053,13 +1055,27 @@ describe('session model', () => {
 
             expect(result).toEqual({ type: 'success', sessionId: forkedSessionId })
             expect(capturedForkSessionId).toBeUndefined()
-            expect(capturedForkHistory).toEqual([
+            expect(capturedForkHistory as unknown).toEqual([
                 { id: 'user-1', role: 'user' },
                 { id: 'assistant-1', role: 'assistant' }
             ])
             expect(store.messages.getMessages(forkedSessionId, 10).map((message) => message.content)).toEqual([
                 { role: 'user', content: { type: 'text', text: 'first' } },
                 { role: 'assistant', content: { type: 'text', text: 'answer' } }
+            ])
+
+            const firstForkedSessionId = forkedSessionId
+            capturedForkSessionId = undefined
+            capturedForkHistory = undefined
+
+            const chainedResult = await engine.forkSession(firstForkedSessionId, 'default', { beforeSeq: 2 })
+
+            expect(chainedResult).toEqual({ type: 'success', sessionId: forkedSessionId })
+            expect(forkedSessionId).not.toBe(firstForkedSessionId)
+            expect(capturedForkSessionId).toBeUndefined()
+            expect(capturedForkHistory as unknown).toEqual([
+                { id: 'user-1', role: 'user' },
+                { id: 'assistant-1', role: 'assistant' }
             ])
         } finally {
             engine.stop()

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1267,6 +1267,15 @@ describe('session model', () => {
                 null,
                 'default'
             )
+            store.messages.addMessage(s2.id, { role: 'user', content: { type: 'text', text: 'hello from s2' } })
+            store.codexHistory.addItem({
+                sessionId: s2.id,
+                codexThreadId: 'thread-X',
+                itemId: 'user-1',
+                itemKind: 'user',
+                messageSeq: 1,
+                rawItem: { id: 'target-user-1', role: 'user' }
+            })
 
             expect(s1.id).not.toBe(s2.id)
 
@@ -1280,6 +1289,11 @@ describe('session model', () => {
             expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(s2.id, 1)).toEqual([
                 { id: 'user-1', role: 'user' },
                 { id: 'assistant-1', role: 'assistant' }
+            ])
+            expect(store.codexHistory.getPrefixThroughReplyForUserMessageSeq(s2.id, 3)).toEqual([
+                { id: 'user-1', role: 'user' },
+                { id: 'assistant-1', role: 'assistant' },
+                { id: 'target-user-1', role: 'user' }
             ])
         })
 

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -664,10 +664,18 @@ export class SyncEngine {
             }
             const cutMessage = this.store.messages.getMessageBySeq(sessionId, opts.beforeSeq)
             const record = cutMessage ? unwrapRoleWrappedRecordEnvelope(cutMessage.content) : null
-            if (!cutMessage || record?.role !== 'user') {
-                return { type: 'error', message: 'Historical fork cut point must be a user message', code: 'fork_unavailable' }
+            const userMessageSeq = (() => {
+                if (!cutMessage || !record) return null
+                if (record.role === 'user') return opts.beforeSeq
+                if (record.role === 'agent' || record.role === 'assistant') {
+                    return this.store.messages.getPreviousUserMessageSeq(sessionId, opts.beforeSeq)
+                }
+                return null
+            })()
+            if (!userMessageSeq) {
+                return { type: 'error', message: 'Historical fork cut point must be an agent response', code: 'fork_unavailable' }
             }
-            const prefix = this.store.codexHistory.getPrefixBeforeMessageSeq(sessionId, opts.beforeSeq)
+            const prefix = this.store.codexHistory.getPrefixThroughReplyForUserMessageSeq(sessionId, userMessageSeq)
             if (!prefix) {
                 return {
                     type: 'error',
@@ -676,7 +684,7 @@ export class SyncEngine {
                 }
             }
             forkHistory = prefix
-            cloneBeforeSeq = opts.beforeSeq
+            cloneBeforeSeq = this.store.messages.getNextUserMessageSeq(sessionId, userMessageSeq) ?? undefined
         }
 
         const onlineMachines = this.machineCache.getOnlineMachinesByNamespace(namespace)

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -52,7 +52,7 @@ export type ResumeSessionResult =
     | { type: 'error'; message: string; code: 'session_not_found' | 'access_denied' | 'no_machine_online' | 'resume_unavailable' | 'resume_failed' }
 
 export type ForkSessionResult =
-    | { type: 'success'; sessionId: string }
+    | { type: 'success'; sessionId: string; warnings?: string[] }
     | { type: 'error'; message: string; code: 'session_not_found' | 'access_denied' | 'no_machine_online' | 'fork_unavailable' | 'fork_failed' }
 
 export class SyncEngine {
@@ -651,11 +651,6 @@ export class SyncEngine {
             return { type: 'error', message: 'Fork is only supported for Codex sessions', code: 'fork_unavailable' }
         }
 
-        const forkToken = metadata.codexSessionId
-        if (!forkToken) {
-            return { type: 'error', message: 'Fork session ID unavailable', code: 'fork_unavailable' }
-        }
-
         let forkHistory: unknown[] | undefined
         let cloneBeforeSeq: number | undefined
         if (opts?.beforeSeq !== undefined) {
@@ -679,12 +674,41 @@ export class SyncEngine {
             if (!prefix) {
                 return {
                     type: 'error',
-                    message: '历史点 fork 只支持新版本会话',
+                    message: 'Historical fork is only supported for sessions started with the new Codex history pipeline',
+                    code: 'fork_unavailable'
+                }
+            }
+            if (prefix.length === 0) {
+                // Defensive: a non-null but empty prefix means we located a user-message cut point
+                // but found zero raw history rows up to it — should be impossible by construction
+                // and indicates corruption rather than an old session.
+                return {
+                    type: 'error',
+                    message: 'Codex history prefix is empty; refusing to fork from missing history',
+                    code: 'fork_unavailable'
+                }
+            }
+            // Conservative cap below Socket.IO's 1 MiB default to leave room for the rest of the
+            // spawn payload (mcp config, permission mode, model, etc.). Without a guard the spawn
+            // RPC silently fails as an opaque socket timeout.
+            const FORK_HISTORY_MAX_BYTES = 512 * 1024
+            const prefixBytes = Buffer.byteLength(JSON.stringify(prefix), 'utf8')
+            if (prefixBytes > FORK_HISTORY_MAX_BYTES) {
+                return {
+                    type: 'error',
+                    message: `Historical fork payload too large (${prefixBytes} bytes, max ${FORK_HISTORY_MAX_BYTES})`,
                     code: 'fork_unavailable'
                 }
             }
             forkHistory = prefix
             cloneBeforeSeq = this.store.messages.getNextUserMessageSeq(sessionId, userMessageSeq) ?? undefined
+        }
+
+        // Whole-session fork needs the source's codex thread id; historical fork carries the prefix
+        // inline and does not.
+        const forkToken = metadata.codexSessionId
+        if (!forkHistory && !forkToken) {
+            return { type: 'error', message: 'Fork session ID unavailable', code: 'fork_unavailable' }
         }
 
         const onlineMachines = this.machineCache.getOnlineMachinesByNamespace(namespace)
@@ -728,6 +752,18 @@ export class SyncEngine {
             return { type: 'error', message: spawnResult.message, code: 'fork_failed' }
         }
 
+        const becameActive = await this.waitForSessionActive(spawnResult.sessionId)
+        if (!becameActive) {
+            // Spawn succeeded but the CLI never went active. Avoid the partial-success leak: do NOT
+            // clone messages, inherit metadata, or emit session-forked into a session the user
+            // can't actually use yet (skipping the emit also prevents notificationHub from leaking
+            // a never-cleaned entry for a session that may never emit session-end).
+            return { type: 'error', message: 'Session failed to become active', code: 'fork_failed' }
+        }
+
+        // Emit session-forked only after active. The CLI's `ready` event always lags `session-alive`
+        // by the time it takes to set up the codex thread, so notificationHub still gets the
+        // suppression entry installed before the ready arrives.
         this.eventPublisher.emit({
             type: 'session-forked',
             sessionId: spawnResult.sessionId,
@@ -735,15 +771,33 @@ export class SyncEngine {
             namespace
         })
 
-        const becameActive = await this.waitForSessionActive(spawnResult.sessionId)
-        if (!becameActive) {
-            return { type: 'error', message: 'Session failed to become active', code: 'fork_failed' }
+        // Best-effort post-conditions. If either fails the session itself is still valid; surface a
+        // warning back to the caller (and a log line) rather than reporting fork_failed.
+        const warnings: string[] = []
+        try {
+            // Observability for the residual ordering race: codex sessions don't normally write to
+            // the messages table before the first user turn, so the target should be empty here.
+            // If a future CLI change starts writing earlier, cloned history will land *after* those
+            // rows in the timeline; logging makes that regression obvious instead of silent.
+            const cloneResult = this.store.messages.cloneSessionMessages(sessionId, spawnResult.sessionId, cloneBeforeSeq)
+            const targetMaxSeqBefore = cloneResult.targetMaxSeq - cloneResult.sourceMaxSeq
+            if (targetMaxSeqBefore > 0) {
+                console.warn(`[SyncEngine] Forked session ${spawnResult.sessionId} already had ${targetMaxSeqBefore} messages before clone; cloned history will appear after them.`)
+            }
+        } catch (error) {
+            console.error(`[SyncEngine] Failed to clone messages into forked session ${spawnResult.sessionId}:`, error)
+            warnings.push('history could not be cloned')
+        }
+        try {
+            await this.sessionCache.inheritSessionMetadata(sessionId, spawnResult.sessionId)
+        } catch (error) {
+            console.error(`[SyncEngine] Failed to inherit metadata into forked session ${spawnResult.sessionId}:`, error)
+            warnings.push('title could not be inherited')
         }
 
-        this.store.messages.cloneSessionMessages(sessionId, spawnResult.sessionId, cloneBeforeSeq)
-        await this.sessionCache.inheritSessionMetadata(sessionId, spawnResult.sessionId)
-
-        return { type: 'success', sessionId: spawnResult.sessionId }
+        return warnings.length > 0
+            ? { type: 'success', sessionId: spawnResult.sessionId, warnings }
+            : { type: 'success', sessionId: spawnResult.sessionId }
     }
 
     async waitForSessionActive(sessionId: string, timeoutMs: number = 15_000): Promise<boolean> {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -55,6 +55,7 @@ export type ForkSessionResult =
     | { type: 'error'; message: string; code: 'session_not_found' | 'access_denied' | 'no_machine_online' | 'fork_unavailable' | 'fork_failed' }
 
 export class SyncEngine {
+    private readonly store: Store
     private readonly eventPublisher: EventPublisher
     private readonly sessionCache: SessionCache
     private readonly machineCache: MachineCache
@@ -68,6 +69,7 @@ export class SyncEngine {
         rpcRegistry: RpcRegistry,
         sseManager: SSEManager
     ) {
+        this.store = store
         this.eventPublisher = new EventPublisher(sseManager, (event) => this.resolveNamespace(event))
         this.sessionCache = new SessionCache(store, this.eventPublisher)
         this.machineCache = new MachineCache(store, this.eventPublisher)
@@ -695,6 +697,8 @@ export class SyncEngine {
         if (!becameActive) {
             return { type: 'error', message: 'Session failed to become active', code: 'fork_failed' }
         }
+
+        this.store.messages.cloneSessionMessages(sessionId, spawnResult.sessionId)
 
         return { type: 'success', sessionId: spawnResult.sessionId }
     }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -728,6 +728,13 @@ export class SyncEngine {
             return { type: 'error', message: spawnResult.message, code: 'fork_failed' }
         }
 
+        this.eventPublisher.emit({
+            type: 'session-forked',
+            sessionId: spawnResult.sessionId,
+            sourceSessionId: sessionId,
+            namespace
+        })
+
         const becameActive = await this.waitForSessionActive(spawnResult.sessionId)
         if (!becameActive) {
             return { type: 'error', message: 'Session failed to become active', code: 'fork_failed' }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -653,6 +653,7 @@ export class SyncEngine {
 
         let forkHistory: unknown[] | undefined
         let cloneBeforeSeq: number | undefined
+        let historicalForkUserMessageSeq: number | undefined
         if (opts?.beforeSeq !== undefined) {
             if (!Number.isInteger(opts.beforeSeq) || opts.beforeSeq <= 0) {
                 return { type: 'error', message: 'beforeSeq must be a positive integer', code: 'fork_unavailable' }
@@ -704,6 +705,7 @@ export class SyncEngine {
             }
             forkHistory = prefix
             cloneBeforeSeq = this.store.messages.getNextUserMessageSeq(sessionId, userMessageSeq) ?? undefined
+            historicalForkUserMessageSeq = userMessageSeq
         }
 
         // Whole-session fork needs the source's codex thread id; historical fork carries the prefix
@@ -776,12 +778,14 @@ export class SyncEngine {
         // Best-effort post-conditions. If either fails the session itself is still valid; surface a
         // warning back to the caller (and a log line) rather than reporting fork_failed.
         const warnings: string[] = []
+        let clonedMessageSeqOffset: number | null = null
         try {
             // Observability for the residual ordering race: codex sessions don't normally write to
             // the messages table before the first user turn, so the target should be empty here.
             // If a future CLI change starts writing earlier, cloned history will land *after* those
             // rows in the timeline; logging makes that regression obvious instead of silent.
             const cloneResult = this.store.messages.cloneSessionMessages(sessionId, spawnResult.sessionId, cloneBeforeSeq)
+            clonedMessageSeqOffset = cloneResult.targetMaxSeq - cloneResult.sourceMaxSeq
             const targetMaxSeqBefore = cloneResult.targetMaxSeq - cloneResult.sourceMaxSeq
             if (targetMaxSeqBefore > 0) {
                 console.warn(`[SyncEngine] Forked session ${spawnResult.sessionId} already had ${targetMaxSeqBefore} messages before clone; cloned history will appear after them.`)
@@ -789,6 +793,23 @@ export class SyncEngine {
         } catch (error) {
             console.error(`[SyncEngine] Failed to clone messages into forked session ${spawnResult.sessionId}:`, error)
             warnings.push('history could not be cloned')
+        }
+        if (clonedMessageSeqOffset != null) {
+            try {
+                if (historicalForkUserMessageSeq !== undefined) {
+                    this.store.codexHistory.clonePrefixThroughReplyForUserMessageSeq(
+                        sessionId,
+                        spawnResult.sessionId,
+                        historicalForkUserMessageSeq,
+                        clonedMessageSeqOffset
+                    )
+                } else {
+                    this.store.codexHistory.cloneSessionHistory(sessionId, spawnResult.sessionId, clonedMessageSeqOffset)
+                }
+            } catch (error) {
+                console.error(`[SyncEngine] Failed to clone Codex history into forked session ${spawnResult.sessionId}:`, error)
+                warnings.push('raw history could not be cloned')
+            }
         }
         try {
             await this.sessionCache.inheritSessionMetadata(sessionId, spawnResult.sessionId)

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -699,9 +699,7 @@ export class SyncEngine {
         }
 
         this.store.messages.cloneSessionMessages(sessionId, spawnResult.sessionId)
-        if (typeof session.metadata?.name === 'string' && session.metadata.name.length > 0) {
-            await this.sessionCache.renameSession(spawnResult.sessionId, session.metadata.name)
-        }
+        await this.sessionCache.inheritSessionMetadata(sessionId, spawnResult.sessionId)
 
         return { type: 'success', sessionId: spawnResult.sessionId }
     }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -661,14 +661,16 @@ export class SyncEngine {
             const record = cutMessage ? unwrapRoleWrappedRecordEnvelope(cutMessage.content) : null
             const userMessageSeq = (() => {
                 if (!cutMessage || !record) return null
-                if (record.role === 'user') return opts.beforeSeq
+                if (record.role === 'user') {
+                    return this.store.messages.getPreviousUserMessageSeq(sessionId, opts.beforeSeq)
+                }
                 if (record.role === 'agent' || record.role === 'assistant') {
                     return this.store.messages.getPreviousUserMessageSeq(sessionId, opts.beforeSeq)
                 }
                 return null
             })()
             if (!userMessageSeq) {
-                return { type: 'error', message: 'Historical fork cut point must be an agent response', code: 'fork_unavailable' }
+                return { type: 'error', message: 'No earlier history to fork from', code: 'fork_unavailable' }
             }
             const prefix = this.store.codexHistory.getPrefixThroughReplyForUserMessageSeq(sessionId, userMessageSeq)
             if (!prefix) {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -699,6 +699,9 @@ export class SyncEngine {
         }
 
         this.store.messages.cloneSessionMessages(sessionId, spawnResult.sessionId)
+        if (typeof session.metadata?.name === 'string' && session.metadata.name.length > 0) {
+            await this.sessionCache.renameSession(spawnResult.sessionId, session.metadata.name)
+        }
 
         return { type: 'success', sessionId: spawnResult.sessionId }
     }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -737,7 +737,7 @@ export class SyncEngine {
             metadata.path,
             'codex',
             session.model ?? undefined,
-            undefined,
+            session.modelReasoningEffort ?? undefined,
             undefined,
             undefined,
             undefined,

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -50,6 +50,10 @@ export type ResumeSessionResult =
     | { type: 'success'; sessionId: string }
     | { type: 'error'; message: string; code: 'session_not_found' | 'access_denied' | 'no_machine_online' | 'resume_unavailable' | 'resume_failed' }
 
+export type ForkSessionResult =
+    | { type: 'success'; sessionId: string }
+    | { type: 'error'; message: string; code: 'session_not_found' | 'access_denied' | 'no_machine_online' | 'fork_unavailable' | 'fork_failed' }
+
 export class SyncEngine {
     private readonly eventPublisher: EventPublisher
     private readonly sessionCache: SessionCache
@@ -409,6 +413,7 @@ export class SyncEngine {
         sessionType?: 'simple' | 'worktree',
         worktreeName?: string,
         resumeSessionId?: string,
+        forkSessionId?: string,
         effort?: string,
         permissionMode?: PermissionMode
     ): Promise<{ type: 'success'; sessionId: string } | { type: 'error'; message: string }> {
@@ -422,6 +427,7 @@ export class SyncEngine {
             sessionType,
             worktreeName,
             resumeSessionId,
+            forkSessionId,
             effort,
             permissionMode
         )
@@ -496,6 +502,7 @@ export class SyncEngine {
             undefined,
             undefined,
             resumeToken,
+            undefined,
             session.effort ?? undefined,
             effectivePermissionMode
         )
@@ -617,6 +624,79 @@ export class SyncEngine {
                 // best-effort: web-side safety net hides remaining duplicates
             })
         }
+    }
+
+    async forkSession(sessionId: string, namespace: string): Promise<ForkSessionResult> {
+        const access = this.sessionCache.resolveSessionAccess(sessionId, namespace)
+        if (!access.ok) {
+            return {
+                type: 'error',
+                message: access.reason === 'access-denied' ? 'Session access denied' : 'Session not found',
+                code: access.reason === 'access-denied' ? 'access_denied' : 'session_not_found'
+            }
+        }
+
+        const session = access.session
+        const metadata = session.metadata
+        if (!metadata || typeof metadata.path !== 'string') {
+            return { type: 'error', message: 'Session metadata missing path', code: 'fork_unavailable' }
+        }
+
+        if (metadata.flavor !== 'codex') {
+            return { type: 'error', message: 'Fork is only supported for Codex sessions', code: 'fork_unavailable' }
+        }
+
+        const forkToken = metadata.codexSessionId
+        if (!forkToken) {
+            return { type: 'error', message: 'Fork session ID unavailable', code: 'fork_unavailable' }
+        }
+
+        const onlineMachines = this.machineCache.getOnlineMachinesByNamespace(namespace)
+        if (onlineMachines.length === 0) {
+            return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
+        }
+
+        const targetMachine = (() => {
+            if (metadata.machineId) {
+                const exact = onlineMachines.find((machine) => machine.id === metadata.machineId)
+                if (exact) return exact
+            }
+            if (metadata.host) {
+                const hostMatch = onlineMachines.find((machine) => machine.metadata?.host === metadata.host)
+                if (hostMatch) return hostMatch
+            }
+            return null
+        })()
+
+        if (!targetMachine) {
+            return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
+        }
+
+        const spawnResult = await this.rpcGateway.spawnSession(
+            targetMachine.id,
+            metadata.path,
+            'codex',
+            session.model ?? undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            forkToken,
+            session.effort ?? undefined,
+            session.permissionMode ?? undefined
+        )
+
+        if (spawnResult.type !== 'success') {
+            return { type: 'error', message: spawnResult.message, code: 'fork_failed' }
+        }
+
+        const becameActive = await this.waitForSessionActive(spawnResult.sessionId)
+        if (!becameActive) {
+            return { type: 'error', message: 'Session failed to become active', code: 'fork_failed' }
+        }
+
+        return { type: 'success', sessionId: spawnResult.sessionId }
     }
 
     async waitForSessionActive(sessionId: string, timeoutMs: number = 15_000): Promise<boolean> {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -65,7 +65,7 @@ export class SyncEngine {
     private inactivityTimer: NodeJS.Timeout | null = null
 
     constructor(
-        private readonly store: Store,
+        store: Store,
         io: Server,
         rpcRegistry: RpcRegistry,
         sseManager: SSEManager

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CodexCollaborationMode, DecryptedMessage, PermissionMode, Session, SyncEvent } from '@hapi/protocol/types'
+import { unwrapRoleWrappedRecordEnvelope } from '@hapi/protocol/messages'
 import type { Server } from 'socket.io'
 import type { Store, CancelQueuedMessageResult } from '../store'
 import type { RpcRegistry } from '../socket/rpcRegistry'
@@ -417,7 +418,8 @@ export class SyncEngine {
         resumeSessionId?: string,
         forkSessionId?: string,
         effort?: string,
-        permissionMode?: PermissionMode
+        permissionMode?: PermissionMode,
+        forkHistory?: unknown[]
     ): Promise<{ type: 'success'; sessionId: string } | { type: 'error'; message: string }> {
         return await this.rpcGateway.spawnSession(
             machineId,
@@ -431,7 +433,8 @@ export class SyncEngine {
             resumeSessionId,
             forkSessionId,
             effort,
-            permissionMode
+            permissionMode,
+            forkHistory
         )
     }
 
@@ -628,7 +631,7 @@ export class SyncEngine {
         }
     }
 
-    async forkSession(sessionId: string, namespace: string): Promise<ForkSessionResult> {
+    async forkSession(sessionId: string, namespace: string, opts?: { beforeSeq?: number }): Promise<ForkSessionResult> {
         const access = this.sessionCache.resolveSessionAccess(sessionId, namespace)
         if (!access.ok) {
             return {
@@ -651,6 +654,29 @@ export class SyncEngine {
         const forkToken = metadata.codexSessionId
         if (!forkToken) {
             return { type: 'error', message: 'Fork session ID unavailable', code: 'fork_unavailable' }
+        }
+
+        let forkHistory: unknown[] | undefined
+        let cloneBeforeSeq: number | undefined
+        if (opts?.beforeSeq !== undefined) {
+            if (!Number.isInteger(opts.beforeSeq) || opts.beforeSeq <= 0) {
+                return { type: 'error', message: 'beforeSeq must be a positive integer', code: 'fork_unavailable' }
+            }
+            const cutMessage = this.store.messages.getMessageBySeq(sessionId, opts.beforeSeq)
+            const record = cutMessage ? unwrapRoleWrappedRecordEnvelope(cutMessage.content) : null
+            if (!cutMessage || record?.role !== 'user') {
+                return { type: 'error', message: 'Historical fork cut point must be a user message', code: 'fork_unavailable' }
+            }
+            const prefix = this.store.codexHistory.getPrefixBeforeMessageSeq(sessionId, opts.beforeSeq)
+            if (!prefix) {
+                return {
+                    type: 'error',
+                    message: '历史点 fork 只支持新版本会话',
+                    code: 'fork_unavailable'
+                }
+            }
+            forkHistory = prefix
+            cloneBeforeSeq = opts.beforeSeq
         }
 
         const onlineMachines = this.machineCache.getOnlineMachinesByNamespace(namespace)
@@ -684,9 +710,10 @@ export class SyncEngine {
             undefined,
             undefined,
             undefined,
-            forkToken,
+            forkHistory ? undefined : forkToken,
             session.effort ?? undefined,
-            session.permissionMode ?? undefined
+            session.permissionMode ?? undefined,
+            forkHistory
         )
 
         if (spawnResult.type !== 'success') {
@@ -698,7 +725,7 @@ export class SyncEngine {
             return { type: 'error', message: 'Session failed to become active', code: 'fork_failed' }
         }
 
-        this.store.messages.cloneSessionMessages(sessionId, spawnResult.sessionId)
+        this.store.messages.cloneSessionMessages(sessionId, spawnResult.sessionId, cloneBeforeSeq)
         await this.sessionCache.inheritSessionMetadata(sessionId, spawnResult.sessionId)
 
         return { type: 'success', sessionId: spawnResult.sessionId }

--- a/hub/src/web/routes/machines.ts
+++ b/hub/src/web/routes/machines.ts
@@ -61,6 +61,7 @@ export function createMachinesRoutes(getSyncEngine: () => SyncEngine | null): Ho
             parsed.data.sessionType,
             parsed.data.worktreeName,
             undefined,
+            undefined,
             parsed.data.effort
         )
         return c.json(result)

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -53,6 +53,7 @@ function createSession(overrides?: Partial<Session>): Session {
 function createApp(session: Session, opts?: {
     resumeSession?: (sessionId: string, namespace: string, resumeOpts?: { permissionMode?: string }) => Promise<{ type: string; sessionId?: string; message?: string; code?: string }>
     listSlashCommands?: SyncEngine['listSlashCommands']
+    forkSession?: (sessionId: string, namespace: string, forkOpts?: { beforeSeq?: number }) => Promise<{ type: string; sessionId?: string; message?: string; code?: string }>
 }) {
     const applySessionConfigCalls: Array<[string, Record<string, unknown>]> = []
     const applySessionConfig = async (sessionId: string, config: Record<string, unknown>) => {
@@ -73,12 +74,14 @@ function createApp(session: Session, opts?: {
         currentModelId: 'ollama/exaone:4.5-33b-q8'
     })
     const resumeSession = opts?.resumeSession ?? (async (sessionId: string) => ({ type: 'success', sessionId }))
+    const forkSession = opts?.forkSession ?? (async (sessionId: string) => ({ type: 'success', sessionId }))
     const engine = {
         resolveSessionAccess: () => ({ ok: true, sessionId: session.id, session }),
         applySessionConfig,
         listCodexModelsForSession,
         listOpencodeModelsForSession,
         resumeSession,
+        forkSession,
         listSlashCommands: opts?.listSlashCommands ?? (async () => ({
             success: true,
             commands: []
@@ -96,6 +99,26 @@ function createApp(session: Session, opts?: {
 }
 
 describe('sessions routes', () => {
+    it('returns conflict when fork is unavailable', async () => {
+        const { app } = createApp(createSession(), {
+            forkSession: async () => ({
+                type: 'error',
+                message: 'Fork is only supported for Codex sessions',
+                code: 'fork_unavailable'
+            })
+        })
+
+        const response = await app.request('/api/sessions/session-1/fork', {
+            method: 'POST'
+        })
+
+        expect(response.status).toBe(409)
+        expect(await response.json()).toEqual({
+            error: 'Fork is only supported for Codex sessions',
+            code: 'fork_unavailable'
+        })
+    })
+
     it('rejects collaboration mode changes for local Codex sessions', async () => {
         const session = createSession({
             agentState: {

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -190,7 +190,10 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         if (contentType.includes('application/json')) {
             const body = await c.req.json().catch(() => null) as { beforeSeq?: unknown } | null
             if (body && body.beforeSeq !== undefined) {
-                beforeSeq = typeof body.beforeSeq === 'number' ? body.beforeSeq : Number.NaN
+                if (typeof body.beforeSeq !== 'number' || !Number.isInteger(body.beforeSeq) || body.beforeSeq <= 0) {
+                    return c.json({ error: 'beforeSeq must be a positive integer', code: 'fork_unavailable' }, 400)
+                }
+                beforeSeq = body.beforeSeq
             }
         }
 
@@ -208,7 +211,9 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
             return c.json({ error: result.message, code: result.code }, status)
         }
 
-        return c.json({ type: 'success', sessionId: result.sessionId })
+        return c.json(result.warnings && result.warnings.length > 0
+            ? { type: 'success', sessionId: result.sessionId, warnings: result.warnings }
+            : { type: 'success', sessionId: result.sessionId })
     })
 
     app.post('/sessions/:id/upload', async (c) => {

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -185,8 +185,21 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
             return sessionResult
         }
 
+        let beforeSeq: number | undefined
+        const contentType = c.req.header('content-type') ?? ''
+        if (contentType.includes('application/json')) {
+            const body = await c.req.json().catch(() => null) as { beforeSeq?: unknown } | null
+            if (body && body.beforeSeq !== undefined) {
+                beforeSeq = typeof body.beforeSeq === 'number' ? body.beforeSeq : Number.NaN
+            }
+        }
+
         const namespace = c.get('namespace')
-        const result = await engine.forkSession(sessionResult.sessionId, namespace)
+        const result = await engine.forkSession(
+            sessionResult.sessionId,
+            namespace,
+            beforeSeq !== undefined ? { beforeSeq } : undefined
+        )
         if (result.type === 'error') {
             const status = result.code === 'no_machine_online' ? 503
                 : result.code === 'access_denied' ? 403

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -207,7 +207,8 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
             const status = result.code === 'no_machine_online' ? 503
                 : result.code === 'access_denied' ? 403
                     : result.code === 'session_not_found' ? 404
-                        : 500
+                        : result.code === 'fork_unavailable' ? 409
+                            : 500
             return c.json({ error: result.message, code: result.code }, status)
         }
 

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -174,6 +174,30 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         return c.json({ type: 'success', sessionId: result.sessionId })
     })
 
+    app.post('/sessions/:id/fork', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine)
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+
+        const namespace = c.get('namespace')
+        const result = await engine.forkSession(sessionResult.sessionId, namespace)
+        if (result.type === 'error') {
+            const status = result.code === 'no_machine_online' ? 503
+                : result.code === 'access_denied' ? 403
+                    : result.code === 'session_not_found' ? 404
+                        : 500
+            return c.json({ error: result.message, code: result.code }, status)
+        }
+
+        return c.json({ type: 'success', sessionId: result.sessionId })
+    })
+
     app.post('/sessions/:id/upload', async (c) => {
         const engine = requireSyncEngine(c, getSyncEngine)
         if (engine instanceof Response) {

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -222,6 +222,10 @@ export const SyncEventSchema = z.discriminatedUnion('type', [
         type: z.literal('session-ended'),
         reason: z.enum(['completed', 'terminated', 'error']).optional()
     }),
+    SessionChangedSchema.extend({
+        type: z.literal('session-forked'),
+        sourceSessionId: z.string()
+    }),
     MachineChangedSchema.extend({
         type: z.literal('machine-updated'),
         data: z.unknown().optional()

--- a/shared/src/socket.ts
+++ b/shared/src/socket.ts
@@ -150,6 +150,15 @@ export interface ServerToClientEvents {
 
 export interface ClientToServerEvents {
     message: (data: { sid: string; message: unknown; localId?: string }) => void
+    'codex-history-item': (data: {
+        sid: string
+        codexThreadId: string
+        turnId?: string | null
+        itemId: string
+        itemKind: 'user' | 'assistant' | 'tool' | 'event' | 'unknown'
+        messageSeq?: number | null
+        rawItem: unknown
+    }) => void
     'session-alive': (data: {
         sid: string
         time: number

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -297,8 +297,8 @@ export class ApiClient {
         return response.sessionId
     }
 
-    async forkSession(sessionId: string, opts?: { beforeSeq?: number }): Promise<string> {
-        const response = await this.request<{ sessionId: string }>(
+    async forkSession(sessionId: string, opts?: { beforeSeq?: number }): Promise<{ sessionId: string; warnings?: string[] }> {
+        const response = await this.request<{ sessionId: string; warnings?: string[] }>(
             `/api/sessions/${encodeURIComponent(sessionId)}/fork`,
             {
                 method: 'POST',
@@ -307,7 +307,7 @@ export class ApiClient {
                 })
             }
         )
-        return response.sessionId
+        return { sessionId: response.sessionId, warnings: response.warnings }
     }
 
     async sendMessage(sessionId: string, text: string, localId?: string | null, attachments?: AttachmentMetadata[]): Promise<void> {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -297,10 +297,15 @@ export class ApiClient {
         return response.sessionId
     }
 
-    async forkSession(sessionId: string): Promise<string> {
+    async forkSession(sessionId: string, opts?: { beforeSeq?: number }): Promise<string> {
         const response = await this.request<{ sessionId: string }>(
             `/api/sessions/${encodeURIComponent(sessionId)}/fork`,
-            { method: 'POST' }
+            {
+                method: 'POST',
+                ...(opts?.beforeSeq !== undefined && {
+                    body: JSON.stringify({ beforeSeq: opts.beforeSeq })
+                })
+            }
         )
         return response.sessionId
     }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -297,6 +297,14 @@ export class ApiClient {
         return response.sessionId
     }
 
+    async forkSession(sessionId: string): Promise<string> {
+        const response = await this.request<{ sessionId: string }>(
+            `/api/sessions/${encodeURIComponent(sessionId)}/fork`,
+            { method: 'POST' }
+        )
+        return response.sessionId
+    }
+
     async sendMessage(sessionId: string, text: string, localId?: string | null, attachments?: AttachmentMetadata[]): Promise<void> {
         await this.request(`/api/sessions/${encodeURIComponent(sessionId)}/messages`, {
             method: 'POST',

--- a/web/src/chat/normalize.ts
+++ b/web/src/chat/normalize.ts
@@ -10,6 +10,7 @@ export function normalizeDecryptedMessage(message: DecryptedMessage): Normalized
     if (!record) {
         return {
             id: message.id,
+            seq: message.seq,
             localId: message.localId,
             createdAt: message.createdAt,
             role: 'agent',
@@ -23,9 +24,10 @@ export function normalizeDecryptedMessage(message: DecryptedMessage): Normalized
     if (record.role === 'user') {
         const normalized = normalizeUserRecord(message.id, message.localId, message.createdAt, record.content, record.meta)
         return normalized
-            ? { ...normalized, status: message.status, originalText: message.originalText, invokedAt: message.invokedAt }
+            ? { ...normalized, seq: message.seq, status: message.status, originalText: message.originalText, invokedAt: message.invokedAt }
             : {
                 id: message.id,
+                seq: message.seq,
                 localId: message.localId,
                 createdAt: message.createdAt,
                 role: 'user',
@@ -46,9 +48,10 @@ export function normalizeDecryptedMessage(message: DecryptedMessage): Normalized
             return null
         }
         return normalized
-            ? { ...normalized, status: message.status, originalText: message.originalText, invokedAt: message.invokedAt }
+            ? { ...normalized, seq: message.seq, status: message.status, originalText: message.originalText, invokedAt: message.invokedAt }
             : {
                 id: message.id,
+                seq: message.seq,
                 localId: message.localId,
                 createdAt: message.createdAt,
                 role: 'agent',
@@ -63,6 +66,7 @@ export function normalizeDecryptedMessage(message: DecryptedMessage): Normalized
 
     return {
         id: message.id,
+        seq: message.seq,
         localId: message.localId,
         createdAt: message.createdAt,
         role: 'agent',

--- a/web/src/chat/normalizeUser.ts
+++ b/web/src/chat/normalizeUser.ts
@@ -37,6 +37,7 @@ export function normalizeUserRecord(
     if (typeof content === 'string') {
         return {
             id: messageId,
+            seq: null,
             localId,
             createdAt,
             role: 'user',
@@ -50,6 +51,7 @@ export function normalizeUserRecord(
         const attachments = parseAttachments(content.attachments)
         return {
             id: messageId,
+            seq: null,
             localId,
             createdAt,
             role: 'user',

--- a/web/src/chat/reconcile.test.ts
+++ b/web/src/chat/reconcile.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { reconcileChatBlocks } from './reconcile'
+import type { ChatBlock } from './types'
+
+describe('reconcileChatBlocks', () => {
+    it('replaces agent text blocks when seq changes', () => {
+        const previous: ChatBlock = {
+            kind: 'agent-text',
+            id: 'assistant:1',
+            seq: null,
+            localId: null,
+            createdAt: 1,
+            text: 'answer'
+        }
+        const prevById = new Map([[previous.id, previous]])
+        const next: ChatBlock = {
+            ...previous,
+            seq: 7
+        }
+
+        const result = reconcileChatBlocks([next], prevById)
+
+        expect(result.blocks[0]).toBe(next)
+        expect(result.blocks[0]).not.toBe(previous)
+    })
+
+    it('replaces agent reasoning blocks when seq changes', () => {
+        const previous: ChatBlock = {
+            kind: 'agent-reasoning',
+            id: 'assistant:reasoning:1',
+            seq: null,
+            localId: null,
+            createdAt: 1,
+            text: 'thinking'
+        }
+        const prevById = new Map([[previous.id, previous]])
+        const next: ChatBlock = {
+            ...previous,
+            seq: 7
+        }
+
+        const result = reconcileChatBlocks([next], prevById)
+
+        expect(result.blocks[0]).toBe(next)
+        expect(result.blocks[0]).not.toBe(previous)
+    })
+})

--- a/web/src/chat/reconcile.ts
+++ b/web/src/chat/reconcile.ts
@@ -108,6 +108,7 @@ function areUserTextBlocksEqual(left: UserTextBlock, right: UserTextBlock): bool
     return left.text === right.text
         && left.status === right.status
         && left.originalText === right.originalText
+        && left.seq === right.seq
         && left.localId === right.localId
         && left.createdAt === right.createdAt
         && left.meta === right.meta

--- a/web/src/chat/reconcile.ts
+++ b/web/src/chat/reconcile.ts
@@ -116,6 +116,7 @@ function areUserTextBlocksEqual(left: UserTextBlock, right: UserTextBlock): bool
 
 function areAgentTextBlocksEqual(left: AgentTextBlock, right: AgentTextBlock): boolean {
     return left.text === right.text
+        && left.seq === right.seq
         && left.localId === right.localId
         && left.createdAt === right.createdAt
         && left.meta === right.meta
@@ -123,6 +124,7 @@ function areAgentTextBlocksEqual(left: AgentTextBlock, right: AgentTextBlock): b
 
 function areAgentReasoningBlocksEqual(left: AgentReasoningBlock, right: AgentReasoningBlock): boolean {
     return left.text === right.text
+        && left.seq === right.seq
         && left.localId === right.localId
         && left.createdAt === right.createdAt
         && left.meta === right.meta

--- a/web/src/chat/reducerTimeline.ts
+++ b/web/src/chat/reducerTimeline.ts
@@ -720,6 +720,7 @@ export function reduceTimeline(
                     blocks.push({
                         kind: 'agent-text',
                         id: `${msg.id}:${idx}`,
+                        seq: msg.seq,
                         localId: msg.localId,
                         createdAt: msg.createdAt,
                         invokedAt: msg.invokedAt,
@@ -735,6 +736,7 @@ export function reduceTimeline(
                     blocks.push({
                         kind: 'agent-reasoning',
                         id: `${msg.id}:${idx}`,
+                        seq: msg.seq,
                         localId: msg.localId,
                         createdAt: msg.createdAt,
                         invokedAt: msg.invokedAt,

--- a/web/src/chat/reducerTimeline.ts
+++ b/web/src/chat/reducerTimeline.ts
@@ -648,6 +648,7 @@ export function reduceTimeline(
             blocks.push({
                 kind: 'user-text',
                 id: msg.id,
+                seq: msg.seq,
                 localId: msg.localId,
                 createdAt: msg.createdAt,
                 invokedAt: msg.invokedAt,

--- a/web/src/chat/types.ts
+++ b/web/src/chat/types.ts
@@ -137,6 +137,7 @@ export type UserTextBlock = {
 export type AgentTextBlock = {
     kind: 'agent-text'
     id: string
+    seq?: number | null
     localId: string | null
     createdAt: number
     invokedAt?: number | null
@@ -150,6 +151,7 @@ export type AgentTextBlock = {
 export type AgentReasoningBlock = {
     kind: 'agent-reasoning'
     id: string
+    seq?: number | null
     localId: string | null
     createdAt: number
     invokedAt?: number | null

--- a/web/src/chat/types.ts
+++ b/web/src/chat/types.ts
@@ -82,6 +82,7 @@ export type NormalizedMessage = ({
     content: AgentEvent
 }) & {
     id: string
+    seq?: number | null
     localId: string | null
     createdAt: number
     isSidechain: boolean
@@ -122,6 +123,7 @@ export type ChatToolCall = {
 export type UserTextBlock = {
     kind: 'user-text'
     id: string
+    seq?: number | null
     localId: string | null
     createdAt: number
     invokedAt?: number | null

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -246,6 +246,7 @@ export function HappyThread(props: {
     disabled: boolean
     onRefresh: () => void
     onRetryMessage?: (localId: string) => void
+    onForkBeforeMessage?: (seq: number) => void
     onFlushPending: () => void
     onAtBottomChange: (atBottom: boolean) => void
     isLoadingMessages: boolean
@@ -684,7 +685,8 @@ export function HappyThread(props: {
             onRetryMessage: props.onRetryMessage,
             hasMoreMessages: props.hasMoreMessages,
             isLoadingMoreMessages: props.isLoadingMoreMessages,
-            loadOlderMessagesPreservingScroll: loadOlderPreservingScroll
+            loadOlderMessagesPreservingScroll: loadOlderPreservingScroll,
+            onForkBeforeMessage: props.onForkBeforeMessage
         }}>
             <ThreadPrimitive.Root className="flex min-h-0 flex-1 flex-col relative">
                 <ThreadPrimitive.Viewport

--- a/web/src/components/AssistantChat/context.tsx
+++ b/web/src/components/AssistantChat/context.tsx
@@ -15,6 +15,7 @@ export type HappyChatContextValue = {
     hasMoreMessages: boolean
     isLoadingMoreMessages: boolean
     loadOlderMessagesPreservingScroll: () => Promise<boolean>
+    onForkBeforeMessage?: (seq: number) => void
 }
 
 const HappyChatContext = createContext<HappyChatContextValue | null>(null)

--- a/web/src/components/AssistantChat/messages/AssistantMessage.test.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { HappyChatProvider } from '@/components/AssistantChat/context'
+import { HappyAssistantMessage } from '@/components/AssistantChat/messages/AssistantMessage'
+
+const state = vi.hoisted(() => ({
+    message: {
+        role: 'assistant',
+        id: 'assistant:m1',
+        content: [{ type: 'text', text: 'answer' }],
+        metadata: { custom: { kind: 'assistant', seq: 8 } }
+    } as any
+}))
+
+vi.mock('@assistant-ui/react', () => ({
+    MessagePrimitive: {
+        Root: ({ children, ...props }: { children: ReactNode }) => <div {...props}>{children}</div>,
+        Content: () => <div>answer</div>
+    },
+    useAssistantState: (selector: (snapshot: { message: unknown }) => unknown) => selector({ message: state.message })
+}))
+
+vi.mock('@/components/assistant-ui/markdown-text', () => ({
+    MarkdownText: ({ text }: { text: string }) => <span>{text}</span>
+}))
+
+vi.mock('@/components/assistant-ui/reasoning', () => ({
+    Reasoning: ({ text }: { text: string }) => <span>{text}</span>,
+    ReasoningGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+function renderAssistantMessage(onForkBeforeMessage?: (seq: number) => void) {
+    return render(
+        <HappyChatProvider
+            value={{
+                api: {} as never,
+                sessionId: 's1',
+                metadata: null,
+                disabled: false,
+                onRefresh: vi.fn(),
+                onForkBeforeMessage
+            }}
+        >
+            <HappyAssistantMessage />
+        </HappyChatProvider>
+    )
+}
+
+describe('HappyAssistantMessage fork action', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: vi.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn()
+            }))
+        })
+        state.message = {
+            role: 'assistant',
+            id: 'assistant:m1',
+            content: [{ type: 'text', text: 'answer' }],
+            metadata: { custom: { kind: 'assistant', seq: 8 } }
+        } as any
+    })
+
+    it('shows fork action for assistant responses with a seq', () => {
+        const onForkBeforeMessage = vi.fn()
+        renderAssistantMessage(onForkBeforeMessage)
+
+        fireEvent.click(screen.getByTitle('Fork from this response'))
+
+        expect(onForkBeforeMessage).toHaveBeenCalledWith(8)
+    })
+
+    it('does not show fork action for tool-only assistant messages', () => {
+        state.message = {
+            role: 'assistant',
+            id: 'tool:m1',
+            content: [{ type: 'tool-call', toolCallId: 't1', toolName: 'Tool', argsText: '{}' }],
+            metadata: { custom: { kind: 'tool', toolCallId: 't1' } }
+        } as any
+
+        renderAssistantMessage(vi.fn())
+
+        expect(screen.queryByTitle('Fork from this response')).toBeNull()
+    })
+})

--- a/web/src/components/AssistantChat/messages/AssistantMessage.test.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.test.tsx
@@ -23,12 +23,16 @@ vi.mock('@assistant-ui/react', () => ({
 }))
 
 vi.mock('@/components/assistant-ui/markdown-text', () => ({
-    MarkdownText: ({ text }: { text: string }) => <span>{text}</span>
+    MarkdownText: () => null
 }))
 
 vi.mock('@/components/assistant-ui/reasoning', () => ({
-    Reasoning: ({ text }: { text: string }) => <span>{text}</span>,
-    ReasoningGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>
+    Reasoning: () => null,
+    ReasoningGroup: () => null
+}))
+
+vi.mock('@/components/AssistantChat/messages/ToolMessage', () => ({
+    HappyToolMessage: () => null
 }))
 
 function renderAssistantMessage(onForkBeforeMessage?: (seq: number) => void) {
@@ -75,7 +79,7 @@ describe('HappyAssistantMessage fork action', () => {
         } as any
     })
 
-    it('shows fork action for assistant responses with a seq', () => {
+    it('shows fork action for assistant messages with a seq', () => {
         const onForkBeforeMessage = vi.fn()
         renderAssistantMessage(onForkBeforeMessage)
 
@@ -84,13 +88,13 @@ describe('HappyAssistantMessage fork action', () => {
         expect(onForkBeforeMessage).toHaveBeenCalledWith(8)
     })
 
-    it('does not show fork action for tool-only assistant messages', () => {
+    it('does not show fork action without a seq', () => {
         state.message = {
             role: 'assistant',
-            id: 'tool:m1',
-            content: [{ type: 'tool-call', toolCallId: 't1', toolName: 'Tool', argsText: '{}' }],
-            metadata: { custom: { kind: 'tool', toolCallId: 't1' } }
-        } as any
+            id: 'assistant:m1',
+            content: [{ type: 'text', text: 'answer' }],
+            metadata: { custom: { kind: 'assistant' } }
+        }
 
         renderAssistantMessage(vi.fn())
 

--- a/web/src/components/AssistantChat/messages/AssistantMessage.test.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.test.tsx
@@ -42,8 +42,12 @@ function renderAssistantMessage(onForkBeforeMessage?: (seq: number) => void) {
                 api: {} as never,
                 sessionId: 's1',
                 metadata: null,
+                terminalToolDisplayMode: 'compact',
                 disabled: false,
                 onRefresh: vi.fn(),
+                hasMoreMessages: false,
+                isLoadingMoreMessages: false,
+                loadOlderMessagesPreservingScroll: async () => false,
                 onForkBeforeMessage
             }}
         >

--- a/web/src/components/AssistantChat/messages/AssistantMessage.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.tsx
@@ -161,7 +161,10 @@ export function HappyAssistantMessage() {
                                 type="button"
                                 title="Copy"
                                 className="inline-flex h-8 w-8 items-center justify-center rounded-md hover:bg-[var(--app-subtle-bg)] active:bg-[var(--app-subtle-bg)] transition-colors"
-                                onClick={() => copy(copyText)}
+                                onClick={(event) => {
+                                    event.stopPropagation()
+                                    copy(copyText)
+                                }}
                             >
                                 {copied
                                     ? <CheckIcon className="h-4 w-4 text-green-500" />
@@ -174,7 +177,10 @@ export function HappyAssistantMessage() {
                                 title="Fork from this response"
                                 aria-label="Fork from this response"
                                 className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] shadow-sm hover:bg-[var(--app-subtle-bg)] active:bg-[var(--app-subtle-bg)] transition-colors"
-                                onClick={() => ctx.onForkBeforeMessage!(seq)}
+                                onClick={(event) => {
+                                    event.stopPropagation()
+                                    ctx.onForkBeforeMessage!(seq)
+                                }}
                             >
                                 <ForkIcon className="h-4 w-4 text-[var(--app-fg)]" />
                             </button>

--- a/web/src/components/AssistantChat/messages/AssistantMessage.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.tsx
@@ -3,8 +3,9 @@ import { MessagePrimitive, useAssistantState } from '@assistant-ui/react'
 import { MarkdownText } from '@/components/assistant-ui/markdown-text'
 import { Reasoning, ReasoningGroup } from '@/components/assistant-ui/reasoning'
 import { HappyToolMessage } from '@/components/AssistantChat/messages/ToolMessage'
+import { useHappyChatContext } from '@/components/AssistantChat/context'
 import { CliOutputBlock } from '@/components/CliOutputBlock'
-import { CopyIcon, CheckIcon } from '@/components/icons'
+import { CopyIcon, CheckIcon, ForkIcon } from '@/components/icons'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import type { HappyChatMessageMetadata } from '@/lib/assistant-runtime'
 import { getAssistantCopyText } from '@/components/AssistantChat/messages/assistantCopyText'
@@ -24,6 +25,7 @@ const MESSAGE_PART_COMPONENTS = {
 } as const
 
 export function HappyAssistantMessage() {
+    const ctx = useHappyChatContext()
     const { copied, copy } = useCopyToClipboard()
     const [showMetadata, setShowMetadata] = useState(false)
     const toggleMetadata = useCallback((event: MouseEvent<HTMLElement>) => {
@@ -49,16 +51,21 @@ export function HappyAssistantMessage() {
         if (message.role !== 'assistant') return ''
         return getAssistantCopyText(message.content)
     })
-
     const invokedAt = useAssistantState(({ message }) => (message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined)?.invokedAt)
     const durationMs = useAssistantState(({ message }) => (message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined)?.durationMs)
     const usage = useAssistantState(({ message }) => (message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined)?.usage)
     const messageModel = useAssistantState(({ message }) => (message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined)?.model)
+    const seq = useAssistantState(({ message }) => {
+        if (message.role !== 'assistant') return null
+        const custom = message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined
+        return custom?.kind === 'assistant' && typeof custom.seq === 'number' ? custom.seq : null
+    })
 
     const hasMetadata = invokedAt != null
         || (typeof durationMs === 'number' && durationMs >= 0)
         || usage != null
         || (messageModel != null && messageModel !== '')
+    const canFork = typeof seq === 'number' && Boolean(ctx.onForkBeforeMessage)
 
     const onMetadataKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
         if (isNestedInteractiveEvent(event)) return
@@ -125,7 +132,7 @@ export function HappyAssistantMessage() {
     return (
         <MessagePrimitive.Root
             id={getConversationMessageAnchorId(messageId)}
-            className={`${rootClass} ${copyText ? 'group/msg' : ''} scroll-mt-4`}
+            className={`${rootClass} ${(copyText || canFork) ? 'group/msg' : ''} scroll-mt-4`}
         >
             <div className="flex items-start gap-2">
                 <div
@@ -147,18 +154,30 @@ export function HappyAssistantMessage() {
                         />
                     )}
                 </div>
-                {copyText ? (
+                {(copyText || canFork) ? (
                     <div className="happy-message-actions-first-line hidden sm:flex shrink-0 opacity-0 group-hover/msg:opacity-100 transition-opacity">
-                        <button
-                            type="button"
-                            title="Copy"
-                            className="p-0.5 rounded hover:bg-[var(--app-subtle-bg)] transition-colors"
-                            onClick={() => copy(copyText)}
-                        >
-                            {copied
-                                ? <CheckIcon className="h-3.5 w-3.5 text-green-500" />
-                                : <CopyIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />}
-                        </button>
+                        {copyText ? (
+                            <button
+                                type="button"
+                                title="Copy"
+                                className="p-0.5 rounded hover:bg-[var(--app-subtle-bg)] transition-colors"
+                                onClick={() => copy(copyText)}
+                            >
+                                {copied
+                                    ? <CheckIcon className="h-3.5 w-3.5 text-green-500" />
+                                    : <CopyIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />}
+                            </button>
+                        ) : null}
+                        {canFork ? (
+                            <button
+                                type="button"
+                                title="Fork from this response"
+                                className="p-0.5 rounded hover:bg-[var(--app-subtle-bg)] transition-colors"
+                                onClick={() => ctx.onForkBeforeMessage!(seq)}
+                            >
+                                <ForkIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />
+                            </button>
+                        ) : null}
                     </div>
                 ) : null}
             </div>

--- a/web/src/components/AssistantChat/messages/AssistantMessage.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.tsx
@@ -155,7 +155,7 @@ export function HappyAssistantMessage() {
                     )}
                 </div>
                 {(copyText || canFork) ? (
-                    <div className="happy-message-actions-first-line hidden sm:flex shrink-0 opacity-0 group-hover/msg:opacity-100 transition-opacity">
+                    <div className="happy-message-actions-first-line flex shrink-0 opacity-70 group-hover/msg:opacity-100 transition-opacity">
                         {copyText ? (
                             <button
                                 type="button"

--- a/web/src/components/AssistantChat/messages/AssistantMessage.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.tsx
@@ -155,27 +155,28 @@ export function HappyAssistantMessage() {
                     )}
                 </div>
                 {(copyText || canFork) ? (
-                    <div className="happy-message-actions-first-line flex shrink-0 opacity-70 group-hover/msg:opacity-100 transition-opacity">
+                    <div className="happy-message-actions-first-line flex shrink-0 gap-1 opacity-80 group-hover/msg:opacity-100 transition-opacity">
                         {copyText ? (
                             <button
                                 type="button"
                                 title="Copy"
-                                className="p-0.5 rounded hover:bg-[var(--app-subtle-bg)] transition-colors"
+                                className="inline-flex h-8 w-8 items-center justify-center rounded-md hover:bg-[var(--app-subtle-bg)] active:bg-[var(--app-subtle-bg)] transition-colors"
                                 onClick={() => copy(copyText)}
                             >
                                 {copied
-                                    ? <CheckIcon className="h-3.5 w-3.5 text-green-500" />
-                                    : <CopyIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />}
+                                    ? <CheckIcon className="h-4 w-4 text-green-500" />
+                                    : <CopyIcon className="h-4 w-4 text-[var(--app-hint)]" />}
                             </button>
                         ) : null}
                         {canFork ? (
                             <button
                                 type="button"
                                 title="Fork from this response"
-                                className="p-0.5 rounded hover:bg-[var(--app-subtle-bg)] transition-colors"
+                                aria-label="Fork from this response"
+                                className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] shadow-sm hover:bg-[var(--app-subtle-bg)] active:bg-[var(--app-subtle-bg)] transition-colors"
                                 onClick={() => ctx.onForkBeforeMessage!(seq)}
                             >
-                                <ForkIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />
+                                <ForkIcon className="h-4 w-4 text-[var(--app-fg)]" />
                             </button>
                         ) : null}
                     </div>

--- a/web/src/components/AssistantChat/messages/UserMessage.test.tsx
+++ b/web/src/components/AssistantChat/messages/UserMessage.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { HappyChatProvider } from '@/components/AssistantChat/context'
+import { HappyUserMessage } from '@/components/AssistantChat/messages/UserMessage'
+
+const state = vi.hoisted(() => ({
+    message: {
+        role: 'user',
+        id: 'user:m1',
+        content: [{ type: 'text', text: 'hello' }],
+        metadata: { custom: { kind: 'user', seq: 7, localId: null } }
+    } as any
+}))
+
+vi.mock('@assistant-ui/react', () => ({
+    MessagePrimitive: {
+        Root: ({ children, ...props }: { children: ReactNode }) => <div {...props}>{children}</div>
+    },
+    useAssistantState: (selector: (snapshot: { message: unknown }) => unknown) => selector({ message: state.message })
+}))
+
+vi.mock('@/components/LazyRainbowText', () => ({
+    LazyRainbowText: ({ text }: { text: string }) => <span>{text}</span>
+}))
+
+function renderUserMessage(onForkBeforeMessage?: (seq: number) => void) {
+    return render(
+        <HappyChatProvider
+            value={{
+                api: {} as never,
+                sessionId: 's1',
+                metadata: null,
+                disabled: false,
+                onRefresh: vi.fn(),
+                onForkBeforeMessage
+            }}
+        >
+            <HappyUserMessage />
+        </HappyChatProvider>
+    )
+}
+
+describe('HappyUserMessage fork action', () => {
+    afterEach(() => {
+        cleanup()
+    })
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: vi.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn()
+            }))
+        })
+        state.message = {
+            role: 'user',
+            id: 'user:m1',
+            content: [{ type: 'text', text: 'hello' }],
+            metadata: { custom: { kind: 'user', seq: 7, localId: null } }
+        } as any
+    })
+
+    it('shows Fork before here for user messages with a seq', () => {
+        const onForkBeforeMessage = vi.fn()
+        renderUserMessage(onForkBeforeMessage)
+
+        fireEvent.click(screen.getByTitle('Fork before here'))
+
+        expect(onForkBeforeMessage).toHaveBeenCalledWith(7)
+    })
+
+    it('does not show Fork before here for non-user messages', () => {
+        state.message = {
+            role: 'assistant',
+            id: 'assistant:m1',
+            content: [{ type: 'text', text: 'answer' }],
+            metadata: { custom: { kind: 'assistant' } }
+        }
+
+        renderUserMessage(vi.fn())
+
+        expect(screen.queryByTitle('Fork before here')).toBeNull()
+    })
+})

--- a/web/src/components/AssistantChat/messages/UserMessage.test.tsx
+++ b/web/src/components/AssistantChat/messages/UserMessage.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 
 import { HappyChatProvider } from '@/components/AssistantChat/context'
@@ -69,16 +69,15 @@ describe('HappyUserMessage fork action', () => {
         } as any
     })
 
-    it('shows Fork before here for user messages with a seq', () => {
+    it('does not show fork action for user messages with a seq', () => {
         const onForkBeforeMessage = vi.fn()
         renderUserMessage(onForkBeforeMessage)
 
-        fireEvent.click(screen.getByTitle('Fork before here'))
-
-        expect(onForkBeforeMessage).toHaveBeenCalledWith(7)
+        expect(screen.queryByTitle('Fork from this response')).toBeNull()
+        expect(onForkBeforeMessage).not.toHaveBeenCalled()
     })
 
-    it('does not show Fork before here for non-user messages', () => {
+    it('does not show fork action for non-user messages', () => {
         state.message = {
             role: 'assistant',
             id: 'assistant:m1',
@@ -88,6 +87,6 @@ describe('HappyUserMessage fork action', () => {
 
         renderUserMessage(vi.fn())
 
-        expect(screen.queryByTitle('Fork before here')).toBeNull()
+        expect(screen.queryByTitle('Fork from this response')).toBeNull()
     })
 })

--- a/web/src/components/AssistantChat/messages/UserMessage.test.tsx
+++ b/web/src/components/AssistantChat/messages/UserMessage.test.tsx
@@ -69,12 +69,12 @@ describe('HappyUserMessage fork action', () => {
         } as any
     })
 
-    it('does not show fork action for user messages with a seq', () => {
+    it('shows fork-before action for user messages with a seq', () => {
         const onForkBeforeMessage = vi.fn()
         renderUserMessage(onForkBeforeMessage)
 
-        expect(screen.queryByTitle('Fork from this response')).toBeNull()
-        expect(onForkBeforeMessage).not.toHaveBeenCalled()
+        screen.getByTitle('Fork before here').click()
+        expect(onForkBeforeMessage).toHaveBeenCalledWith(7)
     })
 
     it('does not show fork action for non-user messages', () => {
@@ -87,6 +87,6 @@ describe('HappyUserMessage fork action', () => {
 
         renderUserMessage(vi.fn())
 
-        expect(screen.queryByTitle('Fork from this response')).toBeNull()
+        expect(screen.queryByTitle('Fork before here')).toBeNull()
     })
 })

--- a/web/src/components/AssistantChat/messages/UserMessage.test.tsx
+++ b/web/src/components/AssistantChat/messages/UserMessage.test.tsx
@@ -32,8 +32,12 @@ function renderUserMessage(onForkBeforeMessage?: (seq: number) => void) {
                 api: {} as never,
                 sessionId: 's1',
                 metadata: null,
+                terminalToolDisplayMode: 'compact',
                 disabled: false,
                 onRefresh: vi.fn(),
+                hasMoreMessages: false,
+                isLoadingMoreMessages: false,
+                loadOlderMessagesPreservingScroll: async () => false,
                 onForkBeforeMessage
             }}
         >

--- a/web/src/components/AssistantChat/messages/UserMessage.tsx
+++ b/web/src/components/AssistantChat/messages/UserMessage.tsx
@@ -6,7 +6,7 @@ import { MessageStatusIndicator } from '@/components/AssistantChat/messages/Mess
 import { MessageAttachments } from '@/components/AssistantChat/messages/MessageAttachments'
 import { UserBubbleContent, getUserBubbleClassName, shouldShowMessageStatus } from '@/components/AssistantChat/messages/user-bubble'
 import { CliOutputBlock } from '@/components/CliOutputBlock'
-import { CopyIcon, CheckIcon } from '@/components/icons'
+import { CopyIcon, CheckIcon, ForkIcon } from '@/components/icons'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { getConversationMessageAnchorId } from '@/chat/outline'
 import { MessageMetadata } from '@/components/AssistantChat/messages/MessageMetadata'
@@ -35,6 +35,11 @@ export function HappyUserMessage() {
         if (message.role !== 'user') return null
         const custom = message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined
         return custom?.localId ?? null
+    })
+    const seq = useAssistantState(({ message }) => {
+        if (message.role !== 'user') return null
+        const custom = message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined
+        return typeof custom?.seq === 'number' ? custom.seq : null
     })
     const attachments = useAssistantState(({ message }) => {
         if (message.role !== 'user') return undefined
@@ -66,6 +71,7 @@ export function HappyUserMessage() {
     const canRetry = status === 'failed' && typeof localId === 'string' && Boolean(ctx.onRetryMessage)
     const onRetry = canRetry ? () => ctx.onRetryMessage!(localId) : undefined
     const showStatus = shouldShowMessageStatus(status)
+    const canForkBefore = typeof seq === 'number' && Boolean(ctx.onForkBeforeMessage)
 
     if (isCliOutput) {
         return (
@@ -114,7 +120,7 @@ export function HappyUserMessage() {
                         {hasText ? <UserBubbleContent text={text} /> : null}
                         {hasAttachments ? <MessageAttachments attachments={attachments} /> : null}
                     </div>
-                    {(hasText || showStatus) && (
+                    {(hasText || showStatus || canForkBefore) && (
                         <div className="happy-message-actions-first-line flex shrink-0 items-center gap-1">
                             {hasText && (
                                 <button
@@ -132,6 +138,19 @@ export function HappyUserMessage() {
                                 </button>
                             )}
                             {showStatus ? <MessageStatusIndicator status={status} onRetry={onRetry} /> : null}
+                            {canForkBefore && (
+                                <button
+                                    type="button"
+                                    title="Fork before here"
+                                    className="opacity-60 sm:opacity-0 sm:group-hover/msg:opacity-100 transition-[opacity,background-color] p-0.5 rounded hover:bg-[var(--app-subtle-bg)]"
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        ctx.onForkBeforeMessage!(seq)
+                                    }}
+                                >
+                                    <ForkIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />
+                                </button>
+                            )}
                         </div>
                     )}
                 </div>

--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -13,7 +13,9 @@ type SessionActionMenuProps = {
     isOpen: boolean
     onClose: () => void
     sessionActive: boolean
+    canFork?: boolean
     onRename: () => void
+    onFork?: () => void
     onArchive: () => void
     onDelete: () => void
     anchorPoint: { x: number; y: number }
@@ -61,6 +63,29 @@ function ArchiveIcon(props: { className?: string }) {
     )
 }
 
+function ForkIcon(props: { className?: string }) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={props.className}
+        >
+            <circle cx="6" cy="6" r="3" />
+            <circle cx="18" cy="6" r="3" />
+            <circle cx="18" cy="18" r="3" />
+            <path d="M8.6 7.5 15.4 7.5" />
+            <path d="M18 9v6" />
+        </svg>
+    )
+}
+
 function TrashIcon(props: { className?: string }) {
     return (
         <svg
@@ -96,7 +121,9 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         isOpen,
         onClose,
         sessionActive,
+        canFork,
         onRename,
+        onFork,
         onArchive,
         onDelete,
         anchorPoint,
@@ -116,6 +143,11 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
     const handleArchive = () => {
         onClose()
         onArchive()
+    }
+
+    const handleFork = () => {
+        onClose()
+        onFork?.()
     }
 
     const handleDelete = () => {
@@ -238,6 +270,18 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
                     <EditIcon className="text-[var(--app-hint)]" />
                     {t('session.action.rename')}
                 </button>
+
+                {canFork ? (
+                    <button
+                        type="button"
+                        role="menuitem"
+                        className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
+                        onClick={handleFork}
+                    >
+                        <ForkIcon className="text-[var(--app-hint)]" />
+                        {t('session.action.fork')}
+                    </button>
+                ) : null}
 
                 {sessionActive ? (
                     <button

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -418,7 +418,7 @@ export function SessionChat(props: {
 
     const handleForkBeforeMessage = useCallback(async (beforeSeq: number) => {
         try {
-            const newSessionId = await props.api.forkSession(props.session.id, { beforeSeq })
+            const { sessionId: newSessionId, warnings } = await props.api.forkSession(props.session.id, { beforeSeq })
             haptic.notification('success')
             addToast({
                 title: t('dialog.fork.successTitle'),
@@ -428,14 +428,20 @@ export function SessionChat(props: {
                 variant: 'success',
                 actionLabel: t('toast.action.openSession')
             })
+            if (warnings && warnings.length > 0) {
+                addToast({
+                    title: t('dialog.fork.partialTitle'),
+                    body: warnings.join('; '),
+                    variant: 'error'
+                })
+            }
         } catch (error) {
             haptic.notification('error')
             const message = error instanceof Error ? error.message : t('dialog.fork.failedDescription')
             addToast({
                 title: t('dialog.fork.failedTitle'),
                 body: message,
-                sessionId: props.session.id,
-                url: `/sessions/${props.session.id}`
+                variant: 'error'
             })
         }
     }, [addToast, haptic, props.api, props.session, t])

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -418,15 +418,12 @@ export function SessionChat(props: {
 
     const handleForkBeforeMessage = useCallback(async (beforeSeq: number) => {
         try {
-            const newSessionId = await props.api.forkSession(props.session.id, { beforeSeq })
+            await props.api.forkSession(props.session.id, { beforeSeq })
             haptic.notification('success')
             addToast({
                 title: t('dialog.fork.successTitle'),
                 body: t('dialog.fork.successDescription', { name: getOutlineTitle(props.session) }),
-                sessionId: newSessionId,
-                url: `/sessions/${newSessionId}`,
-                variant: 'success',
-                actionLabel: t('toast.action.openSession')
+                variant: 'success'
             })
         } catch (error) {
             haptic.notification('error')

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -33,6 +33,7 @@ import { useOpencodeModels } from '@/hooks/queries/useOpencodeModels'
 import { useVoiceOptional } from '@/lib/voice-context'
 import { RealtimeVoiceSession, registerSessionStore, registerVoiceHooksStore, voiceHooks } from '@/realtime'
 import { isRemoteTerminalSupported } from '@/utils/terminalSupport'
+import { useToast } from '@/lib/toast-context'
 
 function getOutlineTitle(session: Session): string {
     if (session.metadata?.name) {
@@ -87,6 +88,7 @@ export function SessionChat(props: {
 }) {
     const { haptic } = usePlatform()
     const { t } = useTranslation()
+    const { addToast } = useToast()
     const navigate = useNavigate()
     const sessionInactive = !props.session.active
     const terminalSupported = isRemoteTerminalSupported(props.session.metadata)
@@ -414,6 +416,34 @@ export function SessionChat(props: {
         setForceScrollToken((token) => token + 1)
     }, [props.onSend])
 
+    const handleForkBeforeMessage = useCallback(async (beforeSeq: number) => {
+        try {
+            const newSessionId = await props.api.forkSession(props.session.id, { beforeSeq })
+            haptic.notification('success')
+            addToast({
+                title: t('dialog.fork.successTitle'),
+                body: t('dialog.fork.successDescription', { name: getOutlineTitle(props.session) }),
+                sessionId: newSessionId,
+                url: `/sessions/${newSessionId}`,
+                variant: 'success',
+                actionLabel: t('toast.action.openSession')
+            })
+            navigate({
+                to: '/sessions/$sessionId',
+                params: { sessionId: newSessionId }
+            })
+        } catch (error) {
+            haptic.notification('error')
+            const message = error instanceof Error ? error.message : t('dialog.fork.failedDescription')
+            addToast({
+                title: t('dialog.fork.failedTitle'),
+                body: message,
+                sessionId: props.session.id,
+                url: `/sessions/${props.session.id}`
+            })
+        }
+    }, [addToast, haptic, navigate, props.api, props.session, t])
+
     const attachmentAdapter = useMemo(() => {
         if (!props.session.active) {
             return undefined
@@ -465,6 +495,7 @@ export function SessionChat(props: {
                         disabled={sessionInactive}
                         onRefresh={props.onRefresh}
                         onRetryMessage={props.onRetryMessage}
+                        onForkBeforeMessage={handleForkBeforeMessage}
                         onFlushPending={props.onFlushPending}
                         onAtBottomChange={props.onAtBottomChange}
                         isLoadingMessages={props.isLoadingMessages}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -497,7 +497,7 @@ export function SessionChat(props: {
                         disabled={sessionInactive}
                         onRefresh={props.onRefresh}
                         onRetryMessage={props.onRetryMessage}
-                        onForkBeforeMessage={handleForkBeforeMessage}
+                        onForkBeforeMessage={agentFlavor === 'codex' ? handleForkBeforeMessage : undefined}
                         onFlushPending={props.onFlushPending}
                         onAtBottomChange={props.onAtBottomChange}
                         isLoadingMessages={props.isLoadingMessages}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -418,12 +418,15 @@ export function SessionChat(props: {
 
     const handleForkBeforeMessage = useCallback(async (beforeSeq: number) => {
         try {
-            await props.api.forkSession(props.session.id, { beforeSeq })
+            const newSessionId = await props.api.forkSession(props.session.id, { beforeSeq })
             haptic.notification('success')
             addToast({
                 title: t('dialog.fork.successTitle'),
                 body: t('dialog.fork.successDescription', { name: getOutlineTitle(props.session) }),
-                variant: 'success'
+                sessionId: newSessionId,
+                url: `/sessions/${newSessionId}`,
+                variant: 'success',
+                actionLabel: t('toast.action.openSession')
             })
         } catch (error) {
             haptic.notification('error')

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -428,10 +428,6 @@ export function SessionChat(props: {
                 variant: 'success',
                 actionLabel: t('toast.action.openSession')
             })
-            navigate({
-                to: '/sessions/$sessionId',
-                params: { sessionId: newSessionId }
-            })
         } catch (error) {
             haptic.notification('error')
             const message = error instanceof Error ? error.message : t('dialog.fork.failedDescription')
@@ -442,7 +438,7 @@ export function SessionChat(props: {
                 url: `/sessions/${props.session.id}`
             })
         }
-    }, [addToast, haptic, navigate, props.api, props.session, t])
+    }, [addToast, haptic, props.api, props.session, t])
 
     const attachmentAdapter = useMemo(() => {
         if (!props.session.active) {

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -8,6 +8,8 @@ import { RenameSessionDialog } from '@/components/RenameSessionDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { getSessionModelLabel } from '@/lib/sessionModelLabel'
 import { useTranslation } from '@/lib/use-translation'
+import { useNavigate } from '@tanstack/react-router'
+import { useToast } from '@/lib/toast-context'
 
 function getSessionTitle(session: Session): string {
     if (session.metadata?.name) {
@@ -93,10 +95,13 @@ export function SessionHeader(props: {
     onSessionDeleted?: () => void
 }) {
     const { t } = useTranslation()
+    const navigate = useNavigate()
+    const { addToast } = useToast()
     const { session, api, onSessionDeleted } = props
     const title = useMemo(() => getSessionTitle(session), [session])
     const worktreeBranch = session.metadata?.worktree?.branch
     const modelLabel = getSessionModelLabel(session)
+    const canFork = session.metadata?.flavor === 'codex'
 
     const [menuOpen, setMenuOpen] = useState(false)
     const [menuAnchorPoint, setMenuAnchorPoint] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
@@ -106,7 +111,7 @@ export function SessionHeader(props: {
     const [archiveOpen, setArchiveOpen] = useState(false)
     const [deleteOpen, setDeleteOpen] = useState(false)
 
-    const { archiveSession, renameSession, deleteSession, isPending } = useSessionActions(
+    const { archiveSession, forkSession, renameSession, deleteSession, isPending } = useSessionActions(
         api,
         session.id,
         session.metadata?.flavor ?? null
@@ -123,6 +128,32 @@ export function SessionHeader(props: {
             setMenuAnchorPoint({ x: rect.right, y: rect.bottom })
         }
         setMenuOpen((open) => !open)
+    }
+
+    const handleFork = async () => {
+        try {
+            const newSessionId = await forkSession()
+            addToast({
+                title: t('dialog.fork.successTitle'),
+                body: t('dialog.fork.successDescription', { name: title }),
+                sessionId: newSessionId,
+                url: `/sessions/${newSessionId}`,
+                variant: 'success',
+                actionLabel: t('toast.action.openSession')
+            })
+            navigate({
+                to: '/sessions/$sessionId',
+                params: { sessionId: newSessionId }
+            })
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Fork failed'
+            addToast({
+                title: t('dialog.fork.failedTitle'),
+                body: message,
+                sessionId: session.id,
+                url: `/sessions/${session.id}`
+            })
+        }
     }
 
     // In Telegram, don't render header (Telegram provides its own)
@@ -219,7 +250,9 @@ export function SessionHeader(props: {
                 isOpen={menuOpen}
                 onClose={() => setMenuOpen(false)}
                 sessionActive={session.active}
+                canFork={canFork}
                 onRename={() => setRenameOpen(true)}
+                onFork={handleFork}
                 onArchive={() => setArchiveOpen(true)}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -9,7 +9,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { getSessionModelLabel } from '@/lib/sessionModelLabel'
 import { useTranslation } from '@/lib/use-translation'
 import { useNavigate } from '@tanstack/react-router'
-import { useToast } from '@/lib/toast-context'
+import { useForkWithFeedback } from '@/hooks/mutations/useForkWithFeedback'
 
 function getSessionTitle(session: Session): string {
     if (session.metadata?.name) {
@@ -96,7 +96,6 @@ export function SessionHeader(props: {
 }) {
     const { t } = useTranslation()
     const navigate = useNavigate()
-    const { addToast } = useToast()
     const { session, api, onSessionDeleted } = props
     const title = useMemo(() => getSessionTitle(session), [session])
     const worktreeBranch = session.metadata?.worktree?.branch
@@ -117,6 +116,8 @@ export function SessionHeader(props: {
         session.metadata?.flavor ?? null
     )
 
+    const handleFork = useForkWithFeedback(forkSession, session.id, title)
+
     const handleDelete = async () => {
         await deleteSession()
         onSessionDeleted?.()
@@ -128,32 +129,6 @@ export function SessionHeader(props: {
             setMenuAnchorPoint({ x: rect.right, y: rect.bottom })
         }
         setMenuOpen((open) => !open)
-    }
-
-    const handleFork = async () => {
-        try {
-            const newSessionId = await forkSession()
-            addToast({
-                title: t('dialog.fork.successTitle'),
-                body: t('dialog.fork.successDescription', { name: title }),
-                sessionId: newSessionId,
-                url: `/sessions/${newSessionId}`,
-                variant: 'success',
-                actionLabel: t('toast.action.openSession')
-            })
-            navigate({
-                to: '/sessions/$sessionId',
-                params: { sessionId: newSessionId }
-            })
-        } catch (error) {
-            const message = error instanceof Error ? error.message : 'Fork failed'
-            addToast({
-                title: t('dialog.fork.failedTitle'),
-                body: message,
-                sessionId: session.id,
-                url: `/sessions/${session.id}`
-            })
-        }
     }
 
     // In Telegram, don't render header (Telegram provides its own)
@@ -252,7 +227,10 @@ export function SessionHeader(props: {
                 sessionActive={session.active}
                 canFork={canFork}
                 onRename={() => setRenameOpen(true)}
-                onFork={handleFork}
+                onFork={() => handleFork((newId) => navigate({
+                    to: '/sessions/$sessionId',
+                    params: { sessionId: newId }
+                }))}
                 onArchive={() => setArchiveOpen(true)}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -8,7 +8,6 @@ import { RenameSessionDialog } from '@/components/RenameSessionDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { getSessionModelLabel } from '@/lib/sessionModelLabel'
 import { useTranslation } from '@/lib/use-translation'
-import { useNavigate } from '@tanstack/react-router'
 import { useForkWithFeedback } from '@/hooks/mutations/useForkWithFeedback'
 
 function getSessionTitle(session: Session): string {
@@ -95,7 +94,6 @@ export function SessionHeader(props: {
     onSessionDeleted?: () => void
 }) {
     const { t } = useTranslation()
-    const navigate = useNavigate()
     const { session, api, onSessionDeleted } = props
     const title = useMemo(() => getSessionTitle(session), [session])
     const worktreeBranch = session.metadata?.worktree?.branch
@@ -116,7 +114,7 @@ export function SessionHeader(props: {
         session.metadata?.flavor ?? null
     )
 
-    const handleFork = useForkWithFeedback(forkSession, session.id, title)
+    const handleFork = useForkWithFeedback(forkSession, title)
 
     const handleDelete = async () => {
         await deleteSession()
@@ -227,10 +225,7 @@ export function SessionHeader(props: {
                 sessionActive={session.active}
                 canFork={canFork}
                 onRename={() => setRenameOpen(true)}
-                onFork={() => handleFork((newId) => navigate({
-                    to: '/sessions/$sessionId',
-                    params: { sessionId: newId }
-                }))}
+                onFork={handleFork}
                 onArchive={() => setArchiveOpen(true)}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -583,7 +583,7 @@ function SessionItem(props: {
         s.metadata?.flavor ?? null
     )
 
-    const handleFork = useForkWithFeedback(forkSession, s.id, sessionName)
+    const handleFork = useForkWithFeedback(forkSession, sessionName)
 
     const longPressHandlers = useLongPress({
         onLongPress: (point) => {
@@ -649,7 +649,7 @@ function SessionItem(props: {
                 sessionActive={s.active}
                 canFork={canFork}
                 onRename={() => setRenameOpen(true)}
-                onFork={() => handleFork(onSelect)}
+                onFork={handleFork}
                 onArchive={() => setArchiveOpen(true)}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -10,7 +10,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { CopyIcon, CheckIcon } from '@/components/icons'
 import { cn } from '@/lib/utils'
 import { useTranslation } from '@/lib/use-translation'
-import { useToast } from '@/lib/toast-context'
+import { useForkWithFeedback } from '@/hooks/mutations/useForkWithFeedback'
 
 type SessionGroup = {
     key: string
@@ -566,7 +566,6 @@ function SessionItem(props: {
     selected?: boolean
 }) {
     const { t } = useTranslation()
-    const { addToast } = useToast()
     const { session: s, onSelect, showPath = true, api, selected = false } = props
     const { haptic } = usePlatform()
     const [menuOpen, setMenuOpen] = useState(false)
@@ -576,6 +575,7 @@ function SessionItem(props: {
     const [deleteOpen, setDeleteOpen] = useState(false)
 
     const canFork = s.metadata?.flavor === 'codex'
+    const sessionName = getSessionTitle(s)
 
     const { archiveSession, forkSession, renameSession, deleteSession, isPending } = useSessionActions(
         api,
@@ -583,28 +583,7 @@ function SessionItem(props: {
         s.metadata?.flavor ?? null
     )
 
-    const handleFork = async () => {
-        try {
-            const newSessionId = await forkSession()
-            addToast({
-                title: t('dialog.fork.successTitle'),
-                body: t('dialog.fork.successDescription', { name: sessionName }),
-                sessionId: newSessionId,
-                url: `/sessions/${newSessionId}`,
-                variant: 'success',
-                actionLabel: t('toast.action.openSession')
-            })
-            onSelect(newSessionId)
-        } catch (error) {
-            const message = error instanceof Error ? error.message : 'Fork failed'
-            addToast({
-                title: t('dialog.fork.failedTitle'),
-                body: message,
-                sessionId: s.id,
-                url: `/sessions/${s.id}`
-            })
-        }
-    }
+    const handleFork = useForkWithFeedback(forkSession, s.id, sessionName)
 
     const longPressHandlers = useLongPress({
         onLongPress: (point) => {
@@ -620,7 +599,6 @@ function SessionItem(props: {
         threshold: 500
     })
 
-    const sessionName = getSessionTitle(s)
     const todoProgress = getTodoProgress(s)
     return (
         <>
@@ -671,7 +649,7 @@ function SessionItem(props: {
                 sessionActive={s.active}
                 canFork={canFork}
                 onRename={() => setRenameOpen(true)}
-                onFork={handleFork}
+                onFork={() => handleFork(onSelect)}
                 onArchive={() => setArchiveOpen(true)}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -10,6 +10,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { CopyIcon, CheckIcon } from '@/components/icons'
 import { cn } from '@/lib/utils'
 import { useTranslation } from '@/lib/use-translation'
+import { useToast } from '@/lib/toast-context'
 
 type SessionGroup = {
     key: string
@@ -565,6 +566,7 @@ function SessionItem(props: {
     selected?: boolean
 }) {
     const { t } = useTranslation()
+    const { addToast } = useToast()
     const { session: s, onSelect, showPath = true, api, selected = false } = props
     const { haptic } = usePlatform()
     const [menuOpen, setMenuOpen] = useState(false)
@@ -573,11 +575,36 @@ function SessionItem(props: {
     const [archiveOpen, setArchiveOpen] = useState(false)
     const [deleteOpen, setDeleteOpen] = useState(false)
 
-    const { archiveSession, renameSession, deleteSession, isPending } = useSessionActions(
+    const canFork = s.metadata?.flavor === 'codex'
+
+    const { archiveSession, forkSession, renameSession, deleteSession, isPending } = useSessionActions(
         api,
         s.id,
         s.metadata?.flavor ?? null
     )
+
+    const handleFork = async () => {
+        try {
+            const newSessionId = await forkSession()
+            addToast({
+                title: t('dialog.fork.successTitle'),
+                body: t('dialog.fork.successDescription', { name: sessionName }),
+                sessionId: newSessionId,
+                url: `/sessions/${newSessionId}`,
+                variant: 'success',
+                actionLabel: t('toast.action.openSession')
+            })
+            onSelect(newSessionId)
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Fork failed'
+            addToast({
+                title: t('dialog.fork.failedTitle'),
+                body: message,
+                sessionId: s.id,
+                url: `/sessions/${s.id}`
+            })
+        }
+    }
 
     const longPressHandlers = useLongPress({
         onLongPress: (point) => {
@@ -642,7 +669,9 @@ function SessionItem(props: {
                 isOpen={menuOpen}
                 onClose={() => setMenuOpen(false)}
                 sessionActive={s.active}
+                canFork={canFork}
                 onRename={() => setRenameOpen(true)}
+                onFork={handleFork}
                 onArchive={() => setArchiveOpen(true)}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}

--- a/web/src/components/ToastContainer.tsx
+++ b/web/src/components/ToastContainer.tsx
@@ -12,7 +12,7 @@ export function ToastContainer() {
 
     return (
         <div
-            className="pointer-events-none fixed inset-x-0 top-[calc(env(safe-area-inset-top)+1rem)] z-50 flex flex-col items-center gap-2 px-3"
+            className="pointer-events-none fixed inset-x-0 top-[calc(env(safe-area-inset-top)+4rem)] z-50 flex flex-col items-center gap-2 px-3 sm:top-[calc(env(safe-area-inset-top)+1rem)]"
             aria-live="polite"
         >
             {toasts.map((toast) => (

--- a/web/src/components/ToastContainer.tsx
+++ b/web/src/components/ToastContainer.tsx
@@ -20,6 +20,8 @@ export function ToastContainer() {
                     key={toast.id}
                     title={toast.title}
                     body={toast.body}
+                    variant={toast.variant}
+                    actionLabel={toast.actionLabel}
                     className="cursor-pointer"
                     onClick={() => {
                         removeToast(toast.id)

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -60,3 +60,17 @@ export function CheckIcon(props: IconProps) {
         2
     )
 }
+
+export function ForkIcon(props: IconProps) {
+    return createIcon(
+        <>
+            <circle cx="6" cy="18" r="2" />
+            <circle cx="18" cy="6" r="2" />
+            <circle cx="18" cy="18" r="2" />
+            <path d="M8 18h4a4 4 0 0 0 4-4V8" />
+            <path d="M16 14a4 4 0 0 0-4-4H8" />
+        </>,
+        props,
+        2
+    )
+}

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -3,11 +3,12 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const toastVariants = cva(
-    'pointer-events-auto w-full max-w-sm rounded-lg border border-[var(--app-border)] bg-[var(--app-bg)] text-[var(--app-fg)] shadow-lg',
+    'pointer-events-auto w-full max-w-sm rounded-lg border text-[var(--app-fg)] shadow-lg transition-all',
     {
         variants: {
             variant: {
-                default: 'border-[var(--app-border)] bg-[var(--app-bg)]'
+                default: 'border-[var(--app-border)] bg-[var(--app-bg)]',
+                success: 'border-emerald-500/30 bg-emerald-500/10 shadow-emerald-500/10 ring-1 ring-emerald-500/20'
             }
         },
         defaultVariants: {
@@ -20,10 +21,31 @@ export type ToastProps = React.HTMLAttributes<HTMLDivElement> &
     VariantProps<typeof toastVariants> & {
     title: string
     body: string
+    actionLabel?: string
     onClose?: () => void
 }
 
-export function Toast({ title, body, onClose, className, variant, ...props }: ToastProps) {
+function ArrowRightIcon(props: { className?: string }) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={props.className}
+        >
+            <path d="M5 12h14" />
+            <path d="m12 5 7 7-7 7" />
+        </svg>
+    )
+}
+
+export function Toast({ title, body, actionLabel, onClose, className, variant, ...props }: ToastProps) {
     const handleClose = (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation()
         onClose?.()
@@ -35,6 +57,12 @@ export function Toast({ title, body, onClose, className, variant, ...props }: To
                 <div className="min-w-0 flex-1">
                     <div className="text-sm font-semibold leading-5">{title}</div>
                     <div className="mt-1 text-xs text-[var(--app-hint)]">{body}</div>
+                    {actionLabel ? (
+                        <div className="mt-2 inline-flex items-center gap-1 rounded-full bg-[var(--app-bg)]/80 px-2.5 py-1 text-[11px] font-medium text-emerald-700 ring-1 ring-emerald-500/20 dark:text-emerald-300">
+                            <span>{actionLabel}</span>
+                            <ArrowRightIcon className="h-3.5 w-3.5" />
+                        </div>
+                    ) : null}
                 </div>
                 {onClose ? (
                     <button

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -3,12 +3,12 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const toastVariants = cva(
-    'pointer-events-auto w-full max-w-sm rounded-lg border text-[var(--app-fg)] shadow-lg transition-all',
+    'pointer-events-auto w-full max-w-sm rounded-xl border text-[var(--app-fg)] shadow-lg transition-all',
     {
         variants: {
             variant: {
                 default: 'border-[var(--app-border)] bg-[var(--app-bg)]',
-                success: 'border-emerald-500/30 bg-emerald-500/10 shadow-emerald-500/10 ring-1 ring-emerald-500/20'
+                success: 'border-emerald-500/35 bg-emerald-50 text-emerald-950 shadow-emerald-500/10 ring-1 ring-emerald-500/15 dark:bg-emerald-950 dark:text-emerald-50'
             }
         },
         defaultVariants: {
@@ -53,12 +53,12 @@ export function Toast({ title, body, actionLabel, onClose, className, variant, .
 
     return (
         <div className={cn(toastVariants({ variant }), className)} role="status" {...props}>
-            <div className="flex items-start gap-3 p-3">
-                <div className="min-w-0 flex-1">
+            <div className="relative p-3 pr-10">
+                <div className="min-w-0">
                     <div className="text-sm font-semibold leading-5">{title}</div>
-                    <div className="mt-1 text-xs text-[var(--app-hint)]">{body}</div>
+                    <div className="mt-1 text-xs leading-5 text-[var(--app-hint)]">{body}</div>
                     {actionLabel ? (
-                        <div className="mt-2 inline-flex items-center gap-1 rounded-full bg-[var(--app-bg)]/80 px-2.5 py-1 text-[11px] font-medium text-emerald-700 ring-1 ring-emerald-500/20 dark:text-emerald-300">
+                        <div className="mt-2 inline-flex w-fit items-center gap-1 rounded-full bg-white/90 px-2.5 py-1 text-[11px] font-medium text-emerald-700 ring-1 ring-emerald-500/20 dark:bg-emerald-900/80 dark:text-emerald-200">
                             <span>{actionLabel}</span>
                             <ArrowRightIcon className="h-3.5 w-3.5" />
                         </div>
@@ -67,7 +67,7 @@ export function Toast({ title, body, actionLabel, onClose, className, variant, .
                 {onClose ? (
                     <button
                         type="button"
-                        className="text-xs text-[var(--app-hint)] hover:text-[var(--app-fg)]"
+                        className="absolute right-3 top-3 text-xs text-[var(--app-hint)] hover:text-[var(--app-fg)]"
                         onClick={handleClose}
                         aria-label="Dismiss"
                     >

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -17,6 +17,21 @@ const toastVariants = cva(
     }
 )
 
+const toastActionVariants = cva(
+    'mt-2 inline-flex w-fit items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium ring-1',
+    {
+        variants: {
+            variant: {
+                default: 'bg-[var(--app-secondary-bg)] text-[var(--app-fg)] ring-[var(--app-border)]',
+                success: 'bg-white/90 text-emerald-700 ring-emerald-500/20 dark:bg-emerald-900/80 dark:text-emerald-200'
+            }
+        },
+        defaultVariants: {
+            variant: 'default'
+        }
+    }
+)
+
 export type ToastProps = React.HTMLAttributes<HTMLDivElement> &
     VariantProps<typeof toastVariants> & {
     title: string
@@ -58,7 +73,7 @@ export function Toast({ title, body, actionLabel, onClose, className, variant, .
                     <div className="text-sm font-semibold leading-5">{title}</div>
                     <div className="mt-1 text-xs leading-5 text-[var(--app-hint)]">{body}</div>
                     {actionLabel ? (
-                        <div className="mt-2 inline-flex w-fit items-center gap-1 rounded-full bg-white/90 px-2.5 py-1 text-[11px] font-medium text-emerald-700 ring-1 ring-emerald-500/20 dark:bg-emerald-900/80 dark:text-emerald-200">
+                        <div className={toastActionVariants({ variant })}>
                             <span>{actionLabel}</span>
                             <ArrowRightIcon className="h-3.5 w-3.5" />
                         </div>

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -8,7 +8,8 @@ const toastVariants = cva(
         variants: {
             variant: {
                 default: 'border-[var(--app-border)] bg-[var(--app-bg)]',
-                success: 'border-emerald-500/35 bg-emerald-50 text-emerald-950 shadow-emerald-500/10 ring-1 ring-emerald-500/15 dark:bg-emerald-950 dark:text-emerald-50'
+                success: 'border-emerald-500/35 bg-emerald-50 text-emerald-950 shadow-emerald-500/10 ring-1 ring-emerald-500/15 dark:bg-emerald-950 dark:text-emerald-50',
+                error: 'border-red-500/35 bg-red-50 text-red-950 shadow-red-500/10 ring-1 ring-red-500/15 dark:bg-red-950 dark:text-red-50'
             }
         },
         defaultVariants: {
@@ -23,7 +24,8 @@ const toastActionVariants = cva(
         variants: {
             variant: {
                 default: 'bg-[var(--app-secondary-bg)] text-[var(--app-fg)] ring-[var(--app-border)]',
-                success: 'bg-white/90 text-emerald-700 ring-emerald-500/20 dark:bg-emerald-900/80 dark:text-emerald-200'
+                success: 'bg-white/90 text-emerald-700 ring-emerald-500/20 dark:bg-emerald-900/80 dark:text-emerald-200',
+                error: 'bg-white/90 text-red-700 ring-red-500/20 dark:bg-red-900/80 dark:text-red-200'
             }
         },
         defaultVariants: {

--- a/web/src/hooks/mutations/useForkWithFeedback.ts
+++ b/web/src/hooks/mutations/useForkWithFeedback.ts
@@ -2,16 +2,17 @@ import { useToast } from '@/lib/toast-context'
 import { useTranslation } from '@/lib/use-translation'
 
 export function useForkWithFeedback(
-    forkSession: () => Promise<string>,
-    sessionId: string,
+    forkSession: () => Promise<{ sessionId: string; warnings?: string[] }>,
     sessionName: string
 ) {
     const { addToast } = useToast()
     const { t } = useTranslation()
 
-    return async (onSuccess: (newSessionId: string) => void) => {
+    // Returns void: callers stay on the source session and rely on the toast's
+    // sessionId/actionLabel to surface a click-through to the new session.
+    return async () => {
         try {
-            const newSessionId = await forkSession()
+            const { sessionId: newSessionId, warnings } = await forkSession()
             addToast({
                 title: t('dialog.fork.successTitle'),
                 body: t('dialog.fork.successDescription', { name: sessionName }),
@@ -20,13 +21,21 @@ export function useForkWithFeedback(
                 variant: 'success',
                 actionLabel: t('toast.action.openSession')
             })
+            if (warnings && warnings.length > 0) {
+                addToast({
+                    title: t('dialog.fork.partialTitle'),
+                    body: warnings.join('; '),
+                    variant: 'error'
+                })
+            }
         } catch (error) {
             const message = error instanceof Error ? error.message : t('dialog.fork.failedDescription')
+            // No sessionId/url: clicking the toast on the page you're already on would just dismiss
+            // it, which is what the close affordance already does.
             addToast({
                 title: t('dialog.fork.failedTitle'),
                 body: message,
-                sessionId,
-                url: `/sessions/${sessionId}`
+                variant: 'error'
             })
         }
     }

--- a/web/src/hooks/mutations/useForkWithFeedback.ts
+++ b/web/src/hooks/mutations/useForkWithFeedback.ts
@@ -1,0 +1,34 @@
+import { useToast } from '@/lib/toast-context'
+import { useTranslation } from '@/lib/use-translation'
+
+export function useForkWithFeedback(
+    forkSession: () => Promise<string>,
+    sessionId: string,
+    sessionName: string
+) {
+    const { addToast } = useToast()
+    const { t } = useTranslation()
+
+    return async (onSuccess: (newSessionId: string) => void) => {
+        try {
+            const newSessionId = await forkSession()
+            addToast({
+                title: t('dialog.fork.successTitle'),
+                body: t('dialog.fork.successDescription', { name: sessionName }),
+                sessionId: newSessionId,
+                url: `/sessions/${newSessionId}`,
+                variant: 'success',
+                actionLabel: t('toast.action.openSession')
+            })
+            onSuccess(newSessionId)
+        } catch (error) {
+            const message = error instanceof Error ? error.message : t('dialog.fork.failedDescription')
+            addToast({
+                title: t('dialog.fork.failedTitle'),
+                body: message,
+                sessionId,
+                url: `/sessions/${sessionId}`
+            })
+        }
+    }
+}

--- a/web/src/hooks/mutations/useForkWithFeedback.ts
+++ b/web/src/hooks/mutations/useForkWithFeedback.ts
@@ -20,7 +20,6 @@ export function useForkWithFeedback(
                 variant: 'success',
                 actionLabel: t('toast.action.openSession')
             })
-            onSuccess(newSessionId)
         } catch (error) {
             const message = error instanceof Error ? error.message : t('dialog.fork.failedDescription')
             addToast({

--- a/web/src/hooks/mutations/useSessionActions.ts
+++ b/web/src/hooks/mutations/useSessionActions.ts
@@ -14,6 +14,7 @@ export function useSessionActions(
 ): {
     abortSession: () => Promise<void>
     archiveSession: () => Promise<void>
+    forkSession: () => Promise<string>
     switchSession: () => Promise<void>
     setPermissionMode: (mode: PermissionMode) => Promise<void>
     setCollaborationMode: (mode: CodexCollaborationMode) => Promise<void>
@@ -60,6 +61,16 @@ export function useSessionActions(
             await api.switchSession(sessionId)
         },
         onSuccess: () => void invalidateSession(),
+    })
+
+    const forkMutation = useMutation({
+        mutationFn: async () => {
+            if (!api || !sessionId) {
+                throw new Error('Session unavailable')
+            }
+            return await api.forkSession(sessionId)
+        },
+        onSuccess: () => void queryClient.invalidateQueries({ queryKey: queryKeys.sessions })
     })
 
     const permissionMutation = useMutation({
@@ -155,6 +166,7 @@ export function useSessionActions(
     return {
         abortSession: abortMutation.mutateAsync,
         archiveSession: archiveMutation.mutateAsync,
+        forkSession: forkMutation.mutateAsync,
         switchSession: switchMutation.mutateAsync,
         setPermissionMode: permissionMutation.mutateAsync,
         setCollaborationMode: collaborationMutation.mutateAsync,
@@ -165,6 +177,7 @@ export function useSessionActions(
         deleteSession: deleteMutation.mutateAsync,
         isPending: abortMutation.isPending
             || archiveMutation.isPending
+            || forkMutation.isPending
             || switchMutation.isPending
             || permissionMutation.isPending
             || collaborationMutation.isPending

--- a/web/src/hooks/mutations/useSessionActions.ts
+++ b/web/src/hooks/mutations/useSessionActions.ts
@@ -14,7 +14,7 @@ export function useSessionActions(
 ): {
     abortSession: () => Promise<void>
     archiveSession: () => Promise<void>
-    forkSession: () => Promise<string>
+    forkSession: () => Promise<{ sessionId: string; warnings?: string[] }>
     switchSession: () => Promise<void>
     setPermissionMode: (mode: PermissionMode) => Promise<void>
     setCollaborationMode: (mode: CodexCollaborationMode) => Promise<void>

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -56,6 +56,7 @@ function toThreadMessageLike(block: VisibleChatBlock): ThreadMessageLike {
             metadata: {
                 custom: {
                     kind: 'assistant',
+                    seq: block.seq,
                     invokedAt: block.invokedAt,
                     durationMs: block.durationMs,
                     usage: block.usage,
@@ -75,6 +76,7 @@ function toThreadMessageLike(block: VisibleChatBlock): ThreadMessageLike {
             metadata: {
                 custom: {
                     kind: 'assistant',
+                    seq: block.seq,
                     invokedAt: block.invokedAt,
                     durationMs: block.durationMs,
                     usage: block.usage,

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -11,6 +11,7 @@ import type { AttachmentMetadata, MessageStatus as HappyMessageStatus, Session }
 export type HappyChatMessageMetadata = {
     kind: 'user' | 'assistant' | 'tool' | 'event' | 'cli-output'
     status?: HappyMessageStatus
+    seq?: number | null
     localId?: string | null
     originalText?: string
     toolCallId?: string
@@ -35,6 +36,7 @@ function toThreadMessageLike(block: VisibleChatBlock): ThreadMessageLike {
                 custom: {
                     kind: 'user',
                     status: block.status,
+                    seq: block.seq,
                     localId: block.localId,
                     originalText: block.originalText,
                     attachments: block.attachments,

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -95,6 +95,7 @@ export default {
   'dialog.fork.successTitle': 'Fork created',
   'dialog.fork.successDescription': 'Created a new session from "{name}".',
   'dialog.fork.failedTitle': 'Fork failed',
+  'dialog.fork.failedDescription': 'Unable to fork session. Please try again.',
   'toast.action.openSession': 'Open new session',
   'dialog.delete.title': 'Delete Session',
   'dialog.delete.description': 'Are you sure you want to delete "{name}"? This action cannot be undone.',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -96,6 +96,7 @@ export default {
   'dialog.fork.successDescription': 'Created a new session from "{name}".',
   'dialog.fork.failedTitle': 'Fork failed',
   'dialog.fork.failedDescription': 'Unable to fork session. Please try again.',
+  'dialog.fork.partialTitle': 'Fork created with warnings',
   'toast.action.openSession': 'Open new session',
   'dialog.delete.title': 'Delete Session',
   'dialog.delete.description': 'Are you sure you want to delete "{name}"? This action cannot be undone.',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -77,6 +77,7 @@ export default {
 
   // Session actions
   'session.action.rename': 'Rename',
+  'session.action.fork': 'Fork',
   'session.action.archive': 'Archive',
   'session.action.delete': 'Delete',
   'session.action.copy': 'Copy',
@@ -91,6 +92,10 @@ export default {
   'dialog.archive.description': 'Are you sure you want to archive "{name}"? This will disconnect active session.',
   'dialog.archive.confirm': 'Archive',
   'dialog.archive.confirming': 'Archiving…',
+  'dialog.fork.successTitle': 'Fork created',
+  'dialog.fork.successDescription': 'Created a new session from "{name}".',
+  'dialog.fork.failedTitle': 'Fork failed',
+  'toast.action.openSession': 'Open new session',
   'dialog.delete.title': 'Delete Session',
   'dialog.delete.description': 'Are you sure you want to delete "{name}"? This action cannot be undone.',
   'dialog.delete.confirm': 'Delete',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -96,6 +96,7 @@ export default {
   'dialog.fork.successTitle': 'Fork 成功',
   'dialog.fork.successDescription': '已从 "{name}" 创建新会话。',
   'dialog.fork.failedTitle': 'Fork 失败',
+  'dialog.fork.failedDescription': '无法 Fork 会话，请重试。',
   'toast.action.openSession': '点击前往新会话',
 
   'dialog.delete.title': '删除会话',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -97,6 +97,7 @@ export default {
   'dialog.fork.successDescription': '已从 "{name}" 创建新会话。',
   'dialog.fork.failedTitle': 'Fork 失败',
   'dialog.fork.failedDescription': '无法 Fork 会话，请重试。',
+  'dialog.fork.partialTitle': 'Fork 已创建但存在警告',
   'toast.action.openSession': '点击前往新会话',
 
   'dialog.delete.title': '删除会话',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -77,6 +77,7 @@ export default {
 
   // Session actions
   'session.action.rename': '重命名',
+  'session.action.fork': 'Fork',
   'session.action.archive': '归档',
   'session.action.delete': '删除',
   'session.action.copy': '复制',
@@ -92,6 +93,10 @@ export default {
   'dialog.archive.description': '确定要归档 "{name}" 吗？这将断开活动会话。',
   'dialog.archive.confirm': '归档',
   'dialog.archive.confirming': '归档中…',
+  'dialog.fork.successTitle': 'Fork 成功',
+  'dialog.fork.successDescription': '已从 "{name}" 创建新会话。',
+  'dialog.fork.failedTitle': 'Fork 失败',
+  'toast.action.openSession': '点击前往新会话',
 
   'dialog.delete.title': '删除会话',
   'dialog.delete.description': '确定要删除 "{name}" 吗？此操作无法撤销。',

--- a/web/src/lib/toast-context.tsx
+++ b/web/src/lib/toast-context.tsx
@@ -7,6 +7,8 @@ export type Toast = {
     body: string
     sessionId: string
     url: string
+    variant?: 'default' | 'success'
+    actionLabel?: string
 }
 
 export type ToastContextValue = {

--- a/web/src/lib/toast-context.tsx
+++ b/web/src/lib/toast-context.tsx
@@ -7,7 +7,7 @@ export type Toast = {
     body: string
     sessionId?: string
     url?: string
-    variant?: 'default' | 'success'
+    variant?: 'default' | 'success' | 'error'
     actionLabel?: string
 }
 

--- a/web/src/lib/toast-context.tsx
+++ b/web/src/lib/toast-context.tsx
@@ -5,8 +5,8 @@ export type Toast = {
     id: string
     title: string
     body: string
-    sessionId: string
-    url: string
+    sessionId?: string
+    url?: string
     variant?: 'default' | 'success'
     actionLabel?: string
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -52,15 +52,14 @@ async function bootstrap() {
 
     const updateSW = registerSW({
         onNeedRefresh() {
-            if (confirm('New version available! Reload to update?')) {
-                updateSW(true)
-            }
+            updateSW(true)
         },
         onOfflineReady() {
             console.log('App ready for offline use')
         },
         onRegistered(registration) {
             if (registration) {
+                void registration.update()
                 setInterval(() => {
                     registration.update()
                 }, 60 * 60 * 1000)


### PR DESCRIPTION
## Summary

- Add end-to-end Codex session forking across the CLI runner, hub RPC/REST routes, and web session controls.
- Persist raw Codex history and message sequence metadata so forks can start from the current session, before a user message, or from an assistant response.
- Clone and move visible message history plus raw Codex history through fork and session merge/dedup paths, while preserving session metadata/title, model, permission mode, collaboration mode, and model reasoning effort.
- Harden the fork UX and error handling: expose fork actions only for Codex sessions, return a conflict for unavailable forks, keep feedback on the source session, and suppress bootstrap ready notifications for forked sessions.
- Fix review feedback so the user-message "Fork before here" action actually cuts before the selected user turn, covers that control in the web test, only removes the consumed fork-history file instead of its parent directory, supports chained precise forks from already-forked sessions, keeps raw history attached after duplicate-session merges, preserves moved/cloned raw rows when item ids collide, and remaps target raw message seqs even when the source has no raw rows.

## Verification

- `bun typecheck`
- `cd hub && bun test src/sync/sessionModel.test.ts src/web/routes/sessions.test.ts src/store/codexHistoryStore.test.ts src/sync/sessionMetadata.test.ts` (67 pass)
- `cd web && bunx vitest run src/components/AssistantChat/messages/AssistantMessage.test.tsx src/components/AssistantChat/messages/UserMessage.test.tsx` (4 pass)
- `cd cli && bunx vitest run src/commands/codex.test.ts src/codex/codexRemoteLauncher.test.ts src/codex/codexLocal.test.ts src/codex/utils/appServerConfig.test.ts` (41 pass)
- `git diff --check`

## Notes

- The branch was rebased on `main` and PR conflicts were resolved.
- Direct `bun test` for the web/cli Vitest files is not the right runner here because those tests use Vitest APIs such as `vi.hoisted`; the targeted web/cli checks above were run with Vitest.
