### PR TITLE
fix(cli): honor HAPI_HOSTNAME in session metadata

### DIFF
--- a/cli/src/agent/sessionFactory.test.ts
+++ b/cli/src/agent/sessionFactory.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { buildSessionMetadata } from './sessionFactory'
+
+describe('buildSessionMetadata', () => {
+    const originalHostname = process.env.HAPI_HOSTNAME
+
+    afterEach(() => {
+        if (originalHostname === undefined) {
+            delete process.env.HAPI_HOSTNAME
+        } else {
+            process.env.HAPI_HOSTNAME = originalHostname
+        }
+    })
+
+    it('uses HAPI_HOSTNAME for session metadata host when provided', () => {
+        process.env.HAPI_HOSTNAME = 'custom-session-host'
+
+        const metadata = buildSessionMetadata({
+            flavor: 'codex',
+            startedBy: 'terminal',
+            workingDirectory: '/tmp/project',
+            machineId: 'machine-1',
+            now: 123
+        })
+
+        expect(metadata.host).toBe('custom-session-host')
+    })
+})

--- a/cli/src/agent/sessionFactory.ts
+++ b/cli/src/agent/sessionFactory.ts
@@ -63,7 +63,7 @@ export function buildSessionMetadata(options: {
 
     return {
         path: options.workingDirectory,
-        host: os.hostname(),
+        host: process.env.HAPI_HOSTNAME || os.hostname(),
         version: packageJson.version,
         os: os.platform(),
         machineId: options.machineId,


### PR DESCRIPTION
## Summary
This small fix makes session metadata use `HAPI_HOSTNAME` the same way machine metadata already does.

## Problem
Today `HAPI_HOSTNAME` affects machine metadata, but session metadata still records `os.hostname()` directly.
That can be confusing in self-hosted setups where multiple clients share the same system hostname but are intentionally distinguished with `HAPI_HOSTNAME`.

## Change
- use `process.env.HAPI_HOSTNAME || os.hostname()` in `buildSessionMetadata()`
- add a focused test covering the env override

## Why
This keeps machine host and session host consistent, and improves host-based display / fallback behavior without changing default behavior for users who do not set `HAPI_HOSTNAME`.
