### PR TITLE
fix(cli): prevent CLAUDE_CODE_ENTRYPOINT leak into local spawn

### DIFF
--- a/cli/src/claude/claudeLocal.ts
+++ b/cli/src/claude/claudeLocal.ts
@@ -76,8 +76,15 @@ export async function claudeLocal(opts: {
 
     // Prepare environment variables
     // Note: Local mode uses global Claude installation
+    //
+    // SDK metadata extraction (extractSDKMetadataAsync → query()) sets
+    // CLAUDE_CODE_ENTRYPOINT='sdk-ts' on the current process. If leaked
+    // into the local spawn, Claude Code thinks it was SDK-launched and
+    // excludes the session from `claude --resume`. Destructure it out
+    // so the child uses its own default entrypoint.
+    const { CLAUDE_CODE_ENTRYPOINT: _, ...cleanEnv } = process.env
     const env = {
-        ...process.env,
+        ...cleanEnv,
         DISABLE_AUTOUPDATER: '1',
         ...opts.claudeEnvVars
     }


### PR DESCRIPTION
## Summary

- Local-mode sessions started via `hapi` are invisible to `claude --resume` because the child process inherits `CLAUDE_CODE_ENTRYPOINT=sdk-ts` from the parent
- `extractSDKMetadataAsync()` → `query()` sets this env var on the current process for SDK metadata extraction; `claudeLocal()` then spreads `process.env` into the child, leaking it
- Fix: destructure out `CLAUDE_CODE_ENTRYPOINT` before building the child env so the local spawn uses its own default entrypoint

## Test plan

- [ ] Start a session via `hapi` locally (terminal mode)
- [ ] Send at least one message and get a response
- [ ] Exit the session
- [ ] Run `claude --resume` — the session should now appear in the list

Closes #450