### PR TITLE
fix(web): hide filesystem path and raw prompt in Skill tool card

### DIFF
--- a/web/src/components/ToolCard/knownTools.tsx
+++ b/web/src/components/ToolCard/knownTools.tsx
@@ -277,6 +277,14 @@ export const knownTools: Record<string, {
         subtitle: (opts) => formatChecklistCount(extractUpdatePlanChecklist(opts.input, opts.result), 'step'),
         minimal: (opts) => extractUpdatePlanChecklist(opts.input, opts.result).length === 0
     },
+    Skill: {
+        icon: () => <PuzzleIcon className={DEFAULT_ICON_CLASS} />,
+        title: (opts) => {
+            const skill = getInputStringAny(opts.input, ['skill'])
+            return skill ? `Skill: ${skill}` : 'Skill'
+        },
+        minimal: true
+    },
     CodexReasoning: {
         icon: () => <BulbIcon className={DEFAULT_ICON_CLASS} />,
         title: (opts) => getInputStringAny(opts.input, ['title']) ?? 'Reasoning',

--- a/web/src/components/ToolCard/views/_all.tsx
+++ b/web/src/components/ToolCard/views/_all.tsx
@@ -11,6 +11,7 @@ import { MultiEditFullView, MultiEditView } from '@/components/ToolCard/views/Mu
 import { TodoWriteView } from '@/components/ToolCard/views/TodoWriteView'
 import { UpdatePlanView } from '@/components/ToolCard/views/UpdatePlanView'
 import { WriteView } from '@/components/ToolCard/views/WriteView'
+import { getInputStringAny } from '@/lib/toolInputUtils'
 
 export type ToolViewProps = {
     block: ToolCallBlock
@@ -18,6 +19,15 @@ export type ToolViewProps = {
 }
 
 export type ToolViewComponent = ComponentType<ToolViewProps>
+
+const SkillFullView: ToolViewComponent = ({ block }: ToolViewProps) => {
+    const skillName = getInputStringAny(block.tool.input, ['skill'])
+    return (
+        <div className="text-sm text-[var(--app-fg)]">
+            {skillName ?? 'Unknown skill'}
+        </div>
+    )
+}
 
 export const toolViewRegistry: Record<string, ToolViewComponent> = {
     Edit: EditView,
@@ -39,6 +49,7 @@ export const toolFullViewRegistry: Record<string, ToolViewComponent> = {
     Write: WriteView,
     CodexDiff: CodexDiffFullView,
     CodexPatch: CodexPatchView,
+    Skill: SkillFullView,
     AskUserQuestion: AskUserQuestionView,
     ExitPlanMode: ExitPlanModeView,
     ask_user_question: AskUserQuestionView,

--- a/web/src/components/ToolCard/views/_results.tsx
+++ b/web/src/components/ToolCard/views/_results.tsx
@@ -520,9 +520,11 @@ const SkillResultView: ToolViewComponent = (props: ToolViewProps) => {
     // For errors, show the error text
     if (state === 'error') {
         const text = extractTextFromResult(result)
-        if (text) {
-            return <div className="text-sm text-red-600">{text}</div>
-        }
+        return (
+            <div className="text-sm text-red-600">
+                {text?.trim() ? text : 'Failed to load skill'}
+            </div>
+        )
     }
 
     // For successful loads, show just the skill name

--- a/web/src/components/ToolCard/views/_results.tsx
+++ b/web/src/components/ToolCard/views/_results.tsx
@@ -4,6 +4,7 @@ import { CodeBlock } from '@/components/CodeBlock'
 import { MarkdownRenderer } from '@/components/MarkdownRenderer'
 import { ChecklistList, extractTodoChecklist } from '@/components/ToolCard/checklist'
 import { basename, resolveDisplayPath } from '@/utils/path'
+import { getInputStringAny } from '@/lib/toolInputUtils'
 
 function parseToolUseError(message: string): { isToolUseError: boolean; errorMessage: string | null } {
     const regex = /<tool_use_error>(.*?)<\/tool_use_error>/s
@@ -506,6 +507,33 @@ const TodoWriteResultView: ToolViewComponent = (props: ToolViewProps) => {
     return <ChecklistList items={todos} />
 }
 
+const SkillResultView: ToolViewComponent = (props: ToolViewProps) => {
+    const { state, result, input } = props.block.tool
+
+    if (result === undefined || result === null) {
+        if (state === 'completed') {
+            return <div className="text-sm text-[var(--app-hint)]">Skill loaded</div>
+        }
+        return <div className="text-sm text-[var(--app-hint)]">{placeholderForState(state)}</div>
+    }
+
+    // For errors, show the error text
+    if (state === 'error') {
+        const text = extractTextFromResult(result)
+        if (text) {
+            return <div className="text-sm text-red-600">{text}</div>
+        }
+    }
+
+    // For successful loads, show just the skill name
+    const skillName = getInputStringAny(input, ['skill'])
+    return (
+        <div className="text-sm text-[var(--app-hint)]">
+            {skillName ? `Skill "${skillName}" loaded` : 'Skill loaded'}
+        </div>
+    )
+}
+
 const GenericResultView: ToolViewComponent = (props: ToolViewProps) => {
     const result = props.block.tool.result
 
@@ -566,6 +594,7 @@ export const toolResultViewRegistry: Record<string, ToolViewComponent> = {
     CodexReasoning: CodexReasoningResultView,
     CodexPatch: CodexPatchResultView,
     CodexDiff: CodexDiffResultView,
+    Skill: SkillResultView,
     AskUserQuestion: AskUserQuestionResultView,
     ExitPlanMode: MarkdownResultView,
     ask_user_question: AskUserQuestionResultView,


### PR DESCRIPTION
## Summary

- Register a dedicated `Skill` entry in `knownTools` with `PuzzleIcon` and a friendly title (`Skill: <name>`) instead of falling through to generic rendering
- Add `SkillResultView` in the result registry that displays `Skill "xxx" loaded` for success and error text for failures, hiding the full filesystem path and raw SKILL.md prompt content
- Set `minimal: true` so the card does not expand inline content

Closes #453

## Test plan

- [ ] Open a session in the web UI where a Skill tool is invoked
- [ ] Verify the card header shows `Skill: <skill-name>` with a puzzle icon
- [ ] Click the card to open the details dialog and verify the result section shows `Skill "xxx" loaded` instead of the raw path and prompt content
- [ ] Verify error states still display the error message in red