### PR TITLE
fix(web): hide assistant message copy button on mobile

### DIFF
--- a/web/src/components/AssistantChat/messages/AssistantMessage.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.tsx
@@ -57,7 +57,7 @@ export function HappyAssistantMessage() {
                 <MessagePrimitive.Content components={MESSAGE_PART_COMPONENTS} />
             </div>
             {copyText && (
-                <div className="flex justify-end mt-1 opacity-60 sm:opacity-0 sm:group-hover/msg:opacity-100 transition-opacity">
+                <div className="hidden sm:flex justify-end mt-1 opacity-0 group-hover/msg:opacity-100 transition-opacity">
                     <button
                         type="button"
                         title="Copy"


### PR DESCRIPTION
## Summary

- Hide the assistant message copy button on mobile screens (`hidden sm:flex`) — it was always visible at `opacity-60`, floating as a detached row below the message content
- On desktop (`sm:` and above), keep the existing hover-only behavior (`opacity-0 group-hover/msg:opacity-100`)
- Mobile users can still copy text via native long-press text selection, which is the standard iOS/Android pattern

Closes #456

## Test plan

- [ ] Open the app on iPhone PWA — verify copy buttons no longer appear on assistant messages
- [ ] Long-press on assistant message text — verify native text selection and copy works
- [ ] On desktop, hover over an assistant message — verify copy button appears on hover
- [ ] Click the copy button on desktop — verify text is copied successfully
- [ ] Verify user message copy button is unaffected (inline inside bubble)