### PR TITLE
fix(cli): include ~/.codex/skills in user skill discovery

### DIFF
--- a/cli/src/modules/common/skills.test.ts
+++ b/cli/src/modules/common/skills.test.ts
@@ -69,14 +69,15 @@ describe('listSkills', () => {
         expect(skills.find((s) => s.name === 'alpha')?.description).toBe('Alpha from agents')
     })
 
-    it('ignores legacy ~/.codex skills', async () => {
+    it('lists user skills from ~/.codex/skills', async () => {
         await writeSkill(join(homeDir, '.agents', 'skills', 'amis'), 'amis', 'AMIS guide')
         await writeSkill(join(homeDir, '.codex', 'skills', 'hello-agents'), 'helloagents', 'Main skill')
+        // Hidden directories (starting with .) are skipped
         await writeSkill(join(homeDir, '.codex', 'skills', '.system', 'skill-creator'), 'skill-creator', 'Create skills')
 
         const skills = await listSkills()
 
-        expect(skills.map((skill) => skill.name)).toEqual(['amis'])
+        expect(skills.map((skill) => skill.name)).toEqual(['amis', 'helloagents'])
     })
 
     it('falls back to directory name when frontmatter is missing', async () => {

--- a/cli/src/modules/common/skills.ts
+++ b/cli/src/modules/common/skills.ts
@@ -26,6 +26,7 @@ function getUserSkillsRoots(): string[] {
     return [
         join(home, '.agents', 'skills'),
         join(home, '.claude', 'skills'),
+        join(home, '.codex', 'skills'),
     ];
 }
 


### PR DESCRIPTION
## Summary

- Add `~/.codex/skills` to `getUserSkillsRoots()` so Codex users' skills are discovered by the web UI `$` autocomplete
- Previously, only `~/.agents/skills` and `~/.claude/skills` were scanned; `~/.codex/skills` was intentionally excluded as "legacy" but users actively store skills there
- Hidden directories (`.system/` etc.) inside skills roots are still skipped by the existing `entry.name.startsWith('.')` check
- Priority order: `.agents` > `.claude` > `.codex` (first found wins for duplicate names)

Closes #482

## Test plan

- [ ] Updated test: `~/.codex/skills` skills are now included in listing
- [ ] Hidden subdirectories (`.system/`) are still excluded
- [ ] Existing `~/.agents/skills` and `~/.claude/skills` behavior unchanged