### PR TITLE
feat(web): widen content area from 720px to 960px

### DIFF
--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -5,7 +5,7 @@ export default {
     theme: {
         extend: {
             maxWidth: {
-                content: '720px'
+                content: '960px'
             }
         }
     },


### PR DESCRIPTION
## Summary

Increase `max-w-content` from `720px` to `960px` in `tailwind.config.ts`. This single change affects all 21 uses across 10 files (chat thread, composer, header, settings, terminal, files, etc.), giving the content area ~33% more horizontal space on wide screens.

Narrow/mobile screens are unaffected — `w-full` still governs below the max-width threshold.

Closes #493

## Test plan

- [ ] Wide screen: verify chat area is noticeably wider
- [ ] Normal screen (~1200px): verify content still looks good
- [ ] Mobile/narrow: verify no overflow or layout breakage
- [ ] Settings page, terminal page, files page: verify they also look correct at the wider width