### PR TITLE
fix(cli): set TERM, COLORTERM, and LANG defaults for terminal pty sessions

### DIFF
--- a/cli/src/terminal/TerminalManager.ts
+++ b/cli/src/terminal/TerminalManager.ts
@@ -75,7 +75,7 @@ function buildFilteredEnv(): NodeJS.ProcessEnv {
         env.COLORTERM = 'truecolor'
     }
     if (!env.LANG) {
-        env.LANG = 'en_US.UTF-8'
+        env.LANG = process.platform === 'darwin' ? 'en_US.UTF-8' : 'C.UTF-8'
     }
     return env
 }

--- a/cli/src/terminal/TerminalManager.ts
+++ b/cli/src/terminal/TerminalManager.ts
@@ -68,6 +68,15 @@ function buildFilteredEnv(): NodeJS.ProcessEnv {
         }
         env[key] = value
     }
+    if (!env.TERM) {
+        env.TERM = 'xterm-256color'
+    }
+    if (!env.COLORTERM) {
+        env.COLORTERM = 'truecolor'
+    }
+    if (!env.LANG) {
+        env.LANG = 'en_US.UTF-8'
+    }
     return env
 }
 


### PR DESCRIPTION
## Problem

When the hub process is started via **launchd** (macOS), **systemd**, or **Docker**, the spawned terminal PTY sessions inherit a stripped-down environment that is missing critical terminal variables:

| Variable | Missing behavior |
|----------|-----------------|
| `TERM` | Programs fall back to `dumb` mode — no colors, no cursor movement |
| `COLORTERM` | Shell prompts (e.g. Powerlevel10k) skip truecolor output |
| `LANG` | Non-ASCII glyphs (powerline symbols, emoji, CJK) render as replacement characters `�` |

This makes the web terminal nearly unusable for anyone running common shell setups like oh-my-zsh or p10k.

## Solution

Set sensible defaults in `buildFilteredEnv()` only when the variable is **not already present**, so explicit user overrides via the parent process are respected:

- `TERM=xterm-256color`
- `COLORTERM=truecolor`
- `LANG=en_US.UTF-8`

## Testing

- Verified on macOS (launchd-managed) and Docker (Ubuntu) deployments
- Confirmed p10k prompt renders correctly with powerline glyphs and truecolor
- Confirmed existing `TERM`/`LANG` values from parent env are preserved (not overwritten)

Fixes #498