### PR TITLE
feat(web): make content width responsive on wide screens

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -165,6 +165,13 @@ body {
     opacity: 1;
 }
 
+/* Scale content area to use available space on wide screens */
+@media (min-width: 1280px) {
+    :root {
+        --content-max-w: min(90%, 1200px);
+    }
+}
+
 /* Desktop sidebar: use custom width from CSS variable */
 @media (min-width: 1024px) {
     .desktop-scrollbar-left {

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -5,7 +5,7 @@ export default {
     theme: {
         extend: {
             maxWidth: {
-                content: '960px'
+                content: 'var(--content-max-w, 960px)'
             }
         }
     },


### PR DESCRIPTION
## Context

Follow-up to #493 which widened the content area from 720px → 960px. That was a great improvement, but on ultrawide or large monitors (≥1280px), there is still a lot of wasted horizontal space.

## Solution

Introduce a CSS custom property `--content-max-w` that the Tailwind `max-w-content` token reads from:

- **< 1280px**: keeps the existing 960px default — no visual change
- **≥ 1280px**: content scales to `min(90%, 1200px)`, filling more of the viewport without stretching to the edges

Only **2 files changed, +8 −1 lines**:

| File | Change |
|------|--------|
| `web/tailwind.config.ts` | Read max-width from CSS variable with 960px fallback |
| `web/src/index.css` | Set `--content-max-w` at the 1280px breakpoint |

## Benefits

- Better use of screen real estate on wide monitors
- The CSS variable approach makes it easy to extend later (e.g. sidebar-aware resizing) without touching the Tailwind config
- Zero impact on mobile/tablet layouts

## Screenshots

**Before (960px fixed)**:
Large empty margins on a 1920px-wide display.

**After (responsive)**:
Content fills ~90% of available width, capped at 1200px.

*(Happy to add screenshots if needed — my setup is macOS 1920×1080)*

Fixes #499