### PR TITLE
fix: make TodoItemSchema tolerant of Claude's TodoWrite payload

### DIFF
--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -90,8 +90,9 @@ export type AgentState = z.infer<typeof AgentStateSchema>
 export const TodoItemSchema = z.object({
     content: z.string(),
     status: z.enum(['pending', 'in_progress', 'completed']),
-    priority: z.enum(['high', 'medium', 'low']),
-    id: z.string()
+    priority: z.enum(['high', 'medium', 'low']).optional().default('medium'),
+    id: z.string().optional().default(''),
+    activeForm: z.string().optional()
 })
 
 export type TodoItem = z.infer<typeof TodoItemSchema>


### PR DESCRIPTION
## Problem

Claude's `TodoWrite` tool sends todo items as:
```json
{ "content": "Fix the bug", "status": "in_progress", "activeForm": "Fixing the bug" }
```

But `TodoItemSchema` requires `priority` and `id` as mandatory fields:
```typescript
export const TodoItemSchema = z.object({
    content: z.string(),
    status: z.enum(['pending', 'in_progress', 'completed']),
    priority: z.enum(['high', 'medium', 'low']),  // ← required
    id: z.string()                                 // ← required
})
```

This causes `TodosSchema.safeParse()` to return `{ success: false }` in all three extraction paths (`extractTodosFromClaudeOutput`, `extractTodosFromCodexMessage`, `extractTodosFromAcpMessage`), so `session.todos` is never populated and the **web UI todo panel stays permanently empty**.

## Solution

Make `priority` and `id` optional with sensible defaults, and add `activeForm` as an optional field:

```typescript
export const TodoItemSchema = z.object({
    content: z.string(),
    status: z.enum(['pending', 'in_progress', 'completed']),
    priority: z.enum(['high', 'medium', 'low']).optional().default('medium'),
    id: z.string().optional().default(''),
    activeForm: z.string().optional()
})
```

**Backwards-compatible**: existing data with all fields present still parses correctly (Zod defaults only apply when the field is missing).

## Changes

| File | Change |
|------|--------|
| `shared/src/schemas.ts` | Make `priority` and `id` optional with defaults, add `activeForm` |

Fixes #501