### PR TITLE
fix(hub): deliver message-received events to all:true SSE connections

### DIFF
--- a/hub/src/sse/sseManager.ts
+++ b/hub/src/sse/sseManager.ts
@@ -156,7 +156,7 @@ export class SSEManager {
         }
 
         if (event.type === 'message-received') {
-            return connection.sessionId === event.sessionId
+            return connection.all || connection.sessionId === event.sessionId
         }
 
         if (event.type === 'connection-changed') {


### PR DESCRIPTION
## Summary

The `message-received` branch of `shouldSend()` in `hub/src/sse/sseManager.ts` checks only `connection.sessionId === event.sessionId`, ignoring the `connection.all` flag. As a result, any SSE connection subscribed with `all: true` silently never receives `message-received` events, even though every other event type below this branch honors `connection.all`.

## Change

```diff
 if (event.type === 'message-received') {
-    return connection.sessionId === event.sessionId
+    return connection.all || connection.sessionId === event.sessionId
 }
```

One-line fix — the branch now behaves consistently with the rest of the dispatch logic further down in the same function.

## Impact

Any feature that relies on an `all:true` SSE subscription to observe messages across sessions (cross-session unread indicators, global notification logic, etc.) starts working again. No behavioral change for session-scoped connections.

Closes #506

## Test plan

- [x] Reviewed that other event branches in `shouldSend()` all honor `connection.all`, confirming this was an inconsistency rather than an intentional restriction
- [x] Verified no other usages of `message-received` event filtering exist in `hub/`