### PR TITLE
fix(hub): mark queued sessions thinking before Codex task_start

### DIFF
--- a/hub/src/sync/aliveEvents.test.ts
+++ b/hub/src/sync/aliveEvents.test.ts
@@ -169,7 +169,13 @@ describe('alive incremental events', () => {
         cache.markMessageQueued(session.id, now + 10)
         events.length = 0
 
-        cache.handleSessionAlive({ sid: session.id, time: now + 2_000, thinking: false })
+        const originalNow = Date.now
+        Date.now = () => now + 2_000
+        try {
+            cache.handleSessionAlive({ sid: session.id, time: now + 2_000, thinking: false })
+        } finally {
+            Date.now = originalNow
+        }
 
         expect(cache.getSession(session.id)?.thinking).toBe(true)
         expect(events.find((event) => event.type === 'session-updated')).toBeUndefined()
@@ -193,6 +199,40 @@ describe('alive incremental events', () => {
         events.length = 0
 
         cache.handleSessionAlive({ sid: session.id, time: now + 16_000, thinking: false })
+
+        expect(cache.getSession(session.id)?.thinking).toBe(false)
+        const update = events.find((event) => event.type === 'session-updated')
+        expect(update).toBeDefined()
+        if (!update || update.type !== 'session-updated') {
+            return
+        }
+        expect(update.data).toEqual(expect.objectContaining({ thinking: false }))
+    })
+
+    it('expires queued thinking against hub time instead of client heartbeat time', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-queued-thinking-clock-skew',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            { requests: {}, completedRequests: {} },
+            'default'
+        )
+
+        cache.handleSessionAlive({ sid: session.id, time: now, thinking: false })
+        cache.markMessageQueued(session.id, now + 10)
+        events.length = 0
+
+        const originalNow = Date.now
+        Date.now = () => now + 16_000
+        try {
+            cache.handleSessionAlive({ sid: session.id, time: now - 60_000, thinking: false })
+        } finally {
+            Date.now = originalNow
+        }
 
         expect(cache.getSession(session.id)?.thinking).toBe(false)
         const update = events.find((event) => event.type === 'session-updated')

--- a/hub/src/sync/aliveEvents.test.ts
+++ b/hub/src/sync/aliveEvents.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'bun:test'
 import type { SyncEvent } from '@hapi/protocol/types'
 import { Store } from '../store'
+import { RpcRegistry } from '../socket/rpcRegistry'
 import type { EventPublisher } from './eventPublisher'
 import { MachineCache } from './machineCache'
 import { SessionCache } from './sessionCache'
+import { SyncEngine } from './syncEngine'
 
 function createPublisher(events: SyncEvent[]): EventPublisher {
     return {
@@ -60,5 +62,115 @@ describe('alive incremental events', () => {
         }
 
         expect(update.data).toEqual(expect.objectContaining({ id: machine.id, active: true }))
+    })
+
+    it('marks session thinking immediately when a user message is accepted by the hub', async () => {
+        const store = new Store(':memory:')
+        const emittedSocketUpdates: unknown[] = []
+        const io = {
+            of: () => ({
+                to: () => ({
+                    emit: (_event: string, payload: unknown) => {
+                        emittedSocketUpdates.push(payload)
+                    }
+                })
+            })
+        }
+        const engine = new SyncEngine(
+            store,
+            io as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+        const events: SyncEvent[] = []
+        const unsubscribe = engine.subscribe((event) => {
+            events.push(event)
+        })
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-send-thinking',
+                { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+                { requests: {}, completedRequests: {} },
+                'default'
+            )
+
+            engine.handleSessionAlive({ sid: session.id, time: Date.now(), thinking: false })
+            events.length = 0
+
+            await engine.sendMessage(session.id, {
+                text: 'hello from web',
+                sentFrom: 'webapp'
+            })
+
+            expect(engine.getSession(session.id)?.thinking).toBe(true)
+            expect(emittedSocketUpdates.length).toBeGreaterThan(0)
+
+            const update = events.find((event) => event.type === 'session-updated')
+            expect(update).toBeDefined()
+            if (!update || update.type !== 'session-updated') {
+                return
+            }
+
+            expect(update.data).toEqual(expect.objectContaining({
+                active: true,
+                thinking: true
+            }))
+            expect((update.data as { updatedAt?: unknown }).updatedAt).toEqual(expect.any(Number))
+        } finally {
+            unsubscribe()
+            engine.stop()
+        }
+    })
+
+    it('keeps queued thinking true across false heartbeats during the grace window', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now() - 30_000
+
+        const session = cache.getOrCreateSession(
+            'session-queued-thinking-grace',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            { requests: {}, completedRequests: {} },
+            'default'
+        )
+
+        cache.handleSessionAlive({ sid: session.id, time: now, thinking: false })
+        cache.markMessageQueued(session.id, now + 10)
+        events.length = 0
+
+        cache.handleSessionAlive({ sid: session.id, time: now + 2_000, thinking: false })
+
+        expect(cache.getSession(session.id)?.thinking).toBe(true)
+        expect(events.find((event) => event.type === 'session-updated')).toBeUndefined()
+    })
+
+    it('clears queued thinking after the grace window expires', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now() - 30_000
+
+        const session = cache.getOrCreateSession(
+            'session-queued-thinking-expire',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            { requests: {}, completedRequests: {} },
+            'default'
+        )
+
+        cache.handleSessionAlive({ sid: session.id, time: now, thinking: false })
+        cache.markMessageQueued(session.id, now + 10)
+        events.length = 0
+
+        cache.handleSessionAlive({ sid: session.id, time: now + 16_000, thinking: false })
+
+        expect(cache.getSession(session.id)?.thinking).toBe(false)
+        const update = events.find((event) => event.type === 'session-updated')
+        expect(update).toBeDefined()
+        if (!update || update.type !== 'session-updated') {
+            return
+        }
+        expect(update.data).toEqual(expect.objectContaining({ thinking: false }))
     })
 })

--- a/hub/src/sync/aliveEvents.test.ts
+++ b/hub/src/sync/aliveEvents.test.ts
@@ -96,6 +96,7 @@ describe('alive incremental events', () => {
             )
 
             engine.handleSessionAlive({ sid: session.id, time: Date.now(), thinking: false })
+            const activeAtBeforeSend = engine.getSession(session.id)?.activeAt
             events.length = 0
 
             await engine.sendMessage(session.id, {
@@ -104,6 +105,7 @@ describe('alive incremental events', () => {
             })
 
             expect(engine.getSession(session.id)?.thinking).toBe(true)
+            expect(engine.getSession(session.id)?.activeAt).toBe(activeAtBeforeSend)
             expect(emittedSocketUpdates.length).toBeGreaterThan(0)
 
             const update = events.find((event) => event.type === 'session-updated')
@@ -112,15 +114,42 @@ describe('alive incremental events', () => {
                 return
             }
 
-            expect(update.data).toEqual(expect.objectContaining({
-                active: true,
-                thinking: true
-            }))
+            expect(update.data).toEqual(expect.objectContaining({ thinking: true }))
+            expect(update.data).not.toHaveProperty('activeAt')
             expect((update.data as { updatedAt?: unknown }).updatedAt).toEqual(expect.any(Number))
         } finally {
             unsubscribe()
             engine.stop()
         }
+    })
+
+    it('does not revive inactive sessions or refresh liveness when marking queued thinking', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now() - 30_000
+
+        const session = cache.getOrCreateSession(
+            'session-queued-thinking-inactive',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            { requests: {}, completedRequests: {} },
+            'default'
+        )
+
+        cache.handleSessionAlive({ sid: session.id, time: now, thinking: false })
+        cache.handleSessionEnd({ sid: session.id, time: now + 1_000 })
+        const inactive = cache.getSession(session.id)
+        expect(inactive?.active).toBe(false)
+        const inactiveActiveAt = inactive?.activeAt
+
+        events.length = 0
+        cache.markMessageQueued(session.id, now + 2_000)
+
+        const updated = cache.getSession(session.id)
+        expect(updated?.active).toBe(false)
+        expect(updated?.thinking).toBe(false)
+        expect(updated?.activeAt).toBe(inactiveActiveAt)
+        expect(events.find((event) => event.type === 'session-updated')).toBeUndefined()
     })
 
     it('keeps queued thinking true across false heartbeats during the grace window', () => {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -6,12 +6,15 @@ import { EventPublisher } from './eventPublisher'
 import { extractTodoWriteTodosFromMessageContent, TodosSchema } from './todos'
 import { extractBackgroundTaskDelta } from './backgroundTasks'
 
+const QUEUED_MESSAGE_THINKING_GRACE_MS = 15_000
+
 export class SessionCache {
     private readonly sessions: Map<string, Session> = new Map()
     private readonly lastBroadcastAtBySessionId: Map<string, number> = new Map()
     private readonly todoBackfillAttemptedSessionIds: Set<string> = new Set()
     private readonly deduplicateInProgress: Set<string> = new Set()
     private readonly deduplicatePending: Set<string> = new Set()
+    private readonly pendingThinkingUntilBySessionId: Map<string, number> = new Map()
 
     constructor(
         private readonly store: Store,
@@ -75,6 +78,7 @@ export class SessionCache {
         let stored = this.store.sessions.getSession(sessionId)
         if (!stored) {
             const existed = this.sessions.delete(sessionId)
+            this.pendingThinkingUntilBySessionId.delete(sessionId)
             if (existed) {
                 this.publisher.emit({ type: 'session-removed', sessionId })
             }
@@ -181,11 +185,17 @@ export class SessionCache {
         const previousModelReasoningEffort = session.modelReasoningEffort
         const previousEffort = session.effort
         const previousCollaborationMode = session.collaborationMode
+        const pendingThinkingUntil = this.pendingThinkingUntilBySessionId.get(session.id) ?? 0
+        const requestedThinking = Boolean(payload.thinking)
+        const preserveQueuedThinking = !requestedThinking && pendingThinkingUntil > t
 
         session.active = true
         session.activeAt = Math.max(session.activeAt, t)
-        session.thinking = Boolean(payload.thinking)
+        session.thinking = requestedThinking || preserveQueuedThinking
         session.thinkingAt = t
+        if (requestedThinking || pendingThinkingUntil <= t) {
+            this.pendingThinkingUntilBySessionId.delete(session.id)
+        }
         if (payload.permissionMode !== undefined) {
             session.permissionMode = payload.permissionMode
         }
@@ -248,6 +258,41 @@ export class SessionCache {
         }
     }
 
+    markMessageQueued(sessionId: string, time: number = Date.now()): void {
+        const session = this.sessions.get(sessionId) ?? this.refreshSession(sessionId)
+        if (!session) return
+
+        const nextTime = clampAliveTime(time) ?? Date.now()
+        const wasActive = session.active
+        const wasThinking = session.thinking
+        const previousUpdatedAt = session.updatedAt
+
+        session.active = true
+        session.activeAt = Math.max(session.activeAt, nextTime)
+        session.thinking = true
+        session.thinkingAt = nextTime
+        session.updatedAt = Math.max(session.updatedAt, nextTime)
+        this.pendingThinkingUntilBySessionId.set(session.id, nextTime + QUEUED_MESSAGE_THINKING_GRACE_MS)
+
+        if (!wasActive && session.active) {
+            this.lastBroadcastAtBySessionId.delete(session.id)
+        }
+
+        if (!wasActive || !wasThinking || session.updatedAt !== previousUpdatedAt) {
+            this.lastBroadcastAtBySessionId.set(session.id, Date.now())
+            this.publisher.emit({
+                type: 'session-updated',
+                sessionId: session.id,
+                data: {
+                    active: true,
+                    activeAt: session.activeAt,
+                    thinking: true,
+                    updatedAt: session.updatedAt
+                }
+            })
+        }
+    }
+
     applyBackgroundTaskDelta(sessionId: string, delta: { started: number; completed: number }): void {
         const session = this.sessions.get(sessionId)
         if (!session) return
@@ -278,6 +323,7 @@ export class SessionCache {
         session.thinking = false
         session.thinkingAt = t
         session.backgroundTaskCount = 0
+        this.pendingThinkingUntilBySessionId.delete(session.id)
 
         this.publisher.emit({ type: 'session-updated', sessionId: session.id, data: { active: false, thinking: false, backgroundTaskCount: 0 } })
     }
@@ -291,6 +337,7 @@ export class SessionCache {
             if (now - session.activeAt <= sessionTimeoutMs) continue
             session.active = false
             session.thinking = false
+            this.pendingThinkingUntilBySessionId.delete(session.id)
             expired.push(session.id)
             this.publisher.emit({ type: 'session-updated', sessionId: session.id, data: { active: false } })
         }
@@ -402,6 +449,7 @@ export class SessionCache {
         this.sessions.delete(sessionId)
         this.lastBroadcastAtBySessionId.delete(sessionId)
         this.todoBackfillAttemptedSessionIds.delete(sessionId)
+        this.pendingThinkingUntilBySessionId.delete(sessionId)
 
         this.publisher.emit({ type: 'session-removed', sessionId, namespace: session.namespace })
     }

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -187,13 +187,14 @@ export class SessionCache {
         const previousCollaborationMode = session.collaborationMode
         const pendingThinkingUntil = this.pendingThinkingUntilBySessionId.get(session.id) ?? 0
         const requestedThinking = Boolean(payload.thinking)
-        const preserveQueuedThinking = !requestedThinking && pendingThinkingUntil > t
+        const hubNow = Date.now()
+        const preserveQueuedThinking = !requestedThinking && pendingThinkingUntil > hubNow
 
         session.active = true
         session.activeAt = Math.max(session.activeAt, t)
         session.thinking = requestedThinking || preserveQueuedThinking
         session.thinkingAt = t
-        if (requestedThinking || pendingThinkingUntil <= t) {
+        if (requestedThinking || pendingThinkingUntil <= hubNow) {
             this.pendingThinkingUntilBySessionId.delete(session.id)
         }
         if (payload.permissionMode !== undefined) {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -261,31 +261,23 @@ export class SessionCache {
     markMessageQueued(sessionId: string, time: number = Date.now()): void {
         const session = this.sessions.get(sessionId) ?? this.refreshSession(sessionId)
         if (!session) return
+        if (!session.active) return
 
         const nextTime = clampAliveTime(time) ?? Date.now()
-        const wasActive = session.active
         const wasThinking = session.thinking
         const previousUpdatedAt = session.updatedAt
 
-        session.active = true
-        session.activeAt = Math.max(session.activeAt, nextTime)
         session.thinking = true
         session.thinkingAt = nextTime
         session.updatedAt = Math.max(session.updatedAt, nextTime)
         this.pendingThinkingUntilBySessionId.set(session.id, nextTime + QUEUED_MESSAGE_THINKING_GRACE_MS)
 
-        if (!wasActive && session.active) {
-            this.lastBroadcastAtBySessionId.delete(session.id)
-        }
-
-        if (!wasActive || !wasThinking || session.updatedAt !== previousUpdatedAt) {
+        if (!wasThinking || session.updatedAt !== previousUpdatedAt) {
             this.lastBroadcastAtBySessionId.set(session.id, Date.now())
             this.publisher.emit({
                 type: 'session-updated',
                 sessionId: session.id,
                 data: {
-                    active: true,
-                    activeAt: session.activeAt,
                     thinking: true,
                     updatedAt: session.updatedAt
                 }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -272,6 +272,7 @@ export class SyncEngine {
         }
     ): Promise<void> {
         await this.messageService.sendMessage(sessionId, payload)
+        this.sessionCache.markMessageQueued(sessionId)
     }
 
     async approvePermission(


### PR DESCRIPTION
## Summary
- mark a session as `thinking=true` immediately after the hub accepts a user message
- keep that queued-thinking state through short `thinking=false` keepalive heartbeats until a real task start arrives or a short grace window expires
- add sync-layer regression coverage for immediate thinking, grace-window preservation, and expiry

## Problem
When a remote Codex message was sent from the web app, the UI could stay on `online` for a while even though the message had already been accepted by the hub. The status only switched later when Codex emitted `task_started` or a later alive update.

In practice this produced a visible delay where the message was already sent but the session state did not reflect that work had begun yet.

## Fix
The hub now sets queued sessions to `thinking=true` as soon as `sendMessage()` succeeds, and preserves that state across short false heartbeats from the CLI until either:
- a real `thinking=true` update arrives
- the grace window expires

This keeps the UI responsive without leaving sessions stuck in thinking forever.

## Tests
- `bun test src/sync/aliveEvents.test.ts`
- `bun test src/sync/sessionModel.test.ts`
