### PR TITLE
feat(hub): add ServerChan task notifications

### DIFF
--- a/cli/src/agent/runnerLifecycle.ts
+++ b/cli/src/agent/runnerLifecycle.ts
@@ -1,4 +1,5 @@
 import type { ApiSessionClient } from '@/api/apiSession'
+import type { SessionEndReason } from '@hapi/protocol'
 import { logger } from '@/ui/logger'
 import { restoreTerminalState } from '@/ui/terminalState'
 
@@ -13,6 +14,7 @@ type RunnerLifecycleOptions = {
 export type RunnerLifecycle = {
     setExitCode: (code: number) => void
     setArchiveReason: (reason: string) => void
+    setSessionEndReason: (reason: SessionEndReason) => void
     markCrash: (error: unknown) => void
     cleanup: () => Promise<void>
     cleanupAndExit: (codeOverride?: number) => Promise<void>
@@ -22,6 +24,7 @@ export type RunnerLifecycle = {
 export function createRunnerLifecycle(options: RunnerLifecycleOptions): RunnerLifecycle {
     let exitCode = 0
     let archiveReason = 'User terminated'
+    let sessionEndReason: SessionEndReason = 'terminated'
     let cleanupStarted = false
     let cleanupPromise: Promise<void> | null = null
 
@@ -36,7 +39,7 @@ export function createRunnerLifecycle(options: RunnerLifecycleOptions): RunnerLi
             archiveReason
         }))
 
-        options.session.sendSessionDeath()
+        options.session.sendSessionDeath(sessionEndReason)
         await options.session.flush()
         await options.session.close()
     }
@@ -90,10 +93,15 @@ export function createRunnerLifecycle(options: RunnerLifecycleOptions): RunnerLi
         archiveReason = reason
     }
 
+    const setSessionEndReason = (reason: SessionEndReason) => {
+        sessionEndReason = reason
+    }
+
     const markCrash = (error: unknown) => {
         logger.debug(`${logPrefix} Unhandled error:`, error)
         exitCode = 1
         archiveReason = 'Session crashed'
+        sessionEndReason = 'error'
     }
 
     const registerProcessHandlers = () => {
@@ -119,6 +127,7 @@ export function createRunnerLifecycle(options: RunnerLifecycleOptions): RunnerLi
     return {
         setExitCode,
         setArchiveReason,
+        setSessionEndReason,
         markCrash,
         cleanup,
         cleanupAndExit,

--- a/cli/src/agent/runners/runAgentSession.test.ts
+++ b/cli/src/agent/runners/runAgentSession.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+    sendSessionDeath: vi.fn(),
+    userMessageHandler: null as null | ((message: { content: { text: string; attachments: unknown[] } }, localId: string) => void),
+    promptError: null as Error | null,
+    cancelPrompt: vi.fn(async () => {}),
+    cancelAll: vi.fn(async () => {}),
+    stopServer: vi.fn(),
+    disconnect: vi.fn(async () => {})
+}))
+
+vi.mock('@/agent/sessionFactory', () => ({
+    bootstrapSession: vi.fn(async () => ({
+        session: {
+            updateAgentState: vi.fn(),
+            onUserMessage: vi.fn((handler) => {
+                harness.userMessageHandler = handler
+            }),
+            keepAlive: vi.fn(),
+            sendSessionEvent: vi.fn(),
+            sendAgentMessage: vi.fn(),
+            sendSessionDeath: harness.sendSessionDeath,
+            flush: vi.fn(async () => {}),
+            close: vi.fn(),
+            rpcHandlerManager: {
+                registerHandler: vi.fn()
+            }
+        },
+        sessionInfo: {
+            permissionMode: 'default'
+        }
+    }))
+}))
+
+vi.mock('@/agent/AgentRegistry', () => ({
+    AgentRegistry: {
+        create: vi.fn(() => ({
+            initialize: vi.fn(async () => {}),
+            newSession: vi.fn(async () => 'agent-session-1'),
+            prompt: vi.fn(async () => {
+                if (harness.promptError) {
+                    throw harness.promptError
+                }
+            }),
+            cancelPrompt: harness.cancelPrompt,
+            respondToPermission: vi.fn(async () => {}),
+            onPermissionRequest: vi.fn(),
+            disconnect: harness.disconnect
+        }))
+    }
+}))
+
+vi.mock('@/agent/permissionAdapter', () => ({
+    PermissionAdapter: vi.fn(function PermissionAdapter() {
+        return {
+            cancelAll: harness.cancelAll
+        }
+    })
+}))
+
+vi.mock('@/claude/utils/startHappyServer', () => ({
+    startHappyServer: vi.fn(async () => ({
+        url: 'http://127.0.0.1:1234',
+        stop: harness.stopServer
+    }))
+}))
+
+vi.mock('@/utils/spawnHappyCLI', () => ({
+    getHappyCliCommand: vi.fn(() => ({ command: 'hapi', args: [], env: [] }))
+}))
+
+vi.mock('@/claude/registerKillSessionHandler', () => ({
+    registerKillSessionHandler: vi.fn()
+}))
+
+vi.mock('@/utils/invokedCwd', () => ({
+    getInvokedCwd: vi.fn(() => '/tmp/project')
+}))
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: vi.fn(),
+        warn: vi.fn()
+    }
+}))
+
+vi.mock('@/utils/attachmentFormatter', () => ({
+    formatMessageWithAttachments: vi.fn((text: string) => text)
+}))
+
+import { runAgentSession } from './runAgentSession'
+
+describe('runAgentSession', () => {
+    beforeEach(() => {
+        harness.sendSessionDeath.mockClear()
+        harness.userMessageHandler = null
+        harness.promptError = null
+        harness.cancelPrompt.mockClear()
+        harness.cancelAll.mockClear()
+        harness.stopServer.mockClear()
+        harness.disconnect.mockClear()
+    })
+
+    it('reports unhandled ACP runner failures as error, not completed', async () => {
+        harness.cancelAll.mockImplementationOnce(async () => {
+            throw new Error('cancel failed')
+        })
+
+        const running = runAgentSession({ agentType: 'acp' })
+        for (let i = 0; i < 5; i++) {
+            await Promise.resolve()
+        }
+        expect(harness.userMessageHandler).not.toBeNull()
+        harness.userMessageHandler?.({ content: { text: 'hello', attachments: [] } }, 'local-1')
+
+        await expect(running).rejects.toThrow('cancel failed')
+
+        expect(harness.sendSessionDeath).toHaveBeenCalledWith('error')
+        expect(harness.sendSessionDeath).not.toHaveBeenCalledWith('completed')
+    })
+})

--- a/cli/src/agent/runners/runAgentSession.ts
+++ b/cli/src/agent/runners/runAgentSession.ts
@@ -14,6 +14,7 @@ import { formatMessageWithAttachments } from '@/utils/attachmentFormatter';
 import { getInvokedCwd } from '@/utils/invokedCwd';
 import { PermissionModeSchema } from '@hapi/protocol/schemas';
 import { isPermissionModeAllowedForFlavor } from '@hapi/protocol';
+import type { SessionEndReason } from '@hapi/protocol';
 
 function emitReadyIfIdle(props: {
     queueSize: () => number;
@@ -146,6 +147,7 @@ export async function runAgentSession(opts: {
 
     registerKillSessionHandler(session.rpcHandlerManager, handleKillSession);
 
+    let sessionEndReason: SessionEndReason = 'completed';
     try {
         while (!shouldExit) {
             waitAbortController = new AbortController();
@@ -191,10 +193,16 @@ export async function runAgentSession(opts: {
                 });
             }
         }
+        if (shouldExit) {
+            sessionEndReason = 'terminated';
+        }
+    } catch (error) {
+        sessionEndReason = 'error';
+        throw error;
     } finally {
         clearInterval(keepAliveInterval);
         await permissionAdapter.cancelAll('Session ended');
-        session.sendSessionDeath(shouldExit ? 'terminated' : 'completed');
+        session.sendSessionDeath(sessionEndReason);
         await session.flush();
         session.close();
         await backend.disconnect();

--- a/cli/src/agent/runners/runAgentSession.ts
+++ b/cli/src/agent/runners/runAgentSession.ts
@@ -194,7 +194,7 @@ export async function runAgentSession(opts: {
     } finally {
         clearInterval(keepAliveInterval);
         await permissionAdapter.cancelAll('Session ended');
-        session.sendSessionDeath();
+        session.sendSessionDeath(shouldExit ? 'terminated' : 'completed');
         await session.flush();
         session.close();
         await backend.disconnect();

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -10,6 +10,7 @@ import { AsyncLock } from '@/utils/lock'
 import type { RawJSONLines } from '@/claude/types'
 import { configuration } from '@/configuration'
 import { AGENT_MESSAGE_PAYLOAD_TYPE } from "@hapi/protocol"
+import type { SessionEndReason } from '@hapi/protocol'
 import type { ClientToServerEvents, ServerToClientEvents, Update } from '@hapi/protocol'
 import {
     TerminalClosePayloadSchema,
@@ -499,9 +500,9 @@ export class ApiSessionClient extends EventEmitter {
         this.socket.emit('messages-consumed', { sid: this.sessionId, localIds })
     }
 
-    sendSessionDeath(): void {
+    sendSessionDeath(reason?: SessionEndReason): void {
         void cleanupUploadDir(this.sessionId)
-        this.socket.emit('session-end', { sid: this.sessionId, time: Date.now() })
+        this.socket.emit('session-end', { sid: this.sessionId, time: Date.now(), reason })
     }
 
     updateMetadata(handler: (metadata: Metadata) => Metadata): void {

--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -390,11 +390,16 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
     if (localFailure?.exitReason === 'exit') {
         lifecycle.setExitCode(1);
         lifecycle.setArchiveReason(`Local launch failed: ${formatFailureReason(localFailure.message)}`);
+        lifecycle.setSessionEndReason('error');
     }
 
     if (loopFailed) {
         await lifecycle.cleanup();
         throw loopError;
+    }
+
+    if (!localFailure) {
+        lifecycle.setSessionEndReason('completed');
     }
 
     await lifecycle.cleanupAndExit();

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -224,6 +224,9 @@ export async function runCodex(opts: {
         if (localFailure?.exitReason === 'exit') {
             lifecycle.setExitCode(1);
             lifecycle.setArchiveReason(`Local launch failed: ${formatFailureReason(localFailure.message)}`);
+            lifecycle.setSessionEndReason('error');
+        } else {
+            lifecycle.setSessionEndReason('completed');
         }
         await lifecycle.cleanupAndExit();
     }

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -195,6 +195,8 @@ export async function runCodex(opts: {
         };
     });
 
+    let crashed = false;
+
     try {
         await loop({
             path: workingDirectory,
@@ -217,6 +219,7 @@ export async function runCodex(opts: {
             }
         });
     } catch (error) {
+        crashed = true;
         lifecycle.markCrash(error);
         logger.debug('[codex] Loop error:', error);
     } finally {
@@ -225,7 +228,7 @@ export async function runCodex(opts: {
             lifecycle.setExitCode(1);
             lifecycle.setArchiveReason(`Local launch failed: ${formatFailureReason(localFailure.message)}`);
             lifecycle.setSessionEndReason('error');
-        } else {
+        } else if (!crashed) {
             lifecycle.setSessionEndReason('completed');
         }
         await lifecycle.cleanupAndExit();

--- a/cli/src/cursor/runCursor.ts
+++ b/cli/src/cursor/runCursor.ts
@@ -108,6 +108,8 @@ export async function runCursor(opts: {
         return { applied: { permissionMode: currentPermissionMode } };
     });
 
+    let crashed = false;
+
     try {
         await loop({
             path: workingDirectory,
@@ -127,6 +129,7 @@ export async function runCursor(opts: {
             }
         });
     } catch (error) {
+        crashed = true;
         lifecycle.markCrash(error);
         logger.debug('[cursor] Loop error:', error);
     } finally {
@@ -135,7 +138,7 @@ export async function runCursor(opts: {
             lifecycle.setExitCode(1);
             lifecycle.setArchiveReason(`Local launch failed: ${formatFailureReason(localFailure.message)}`);
             lifecycle.setSessionEndReason('error');
-        } else {
+        } else if (!crashed) {
             lifecycle.setSessionEndReason('completed');
         }
         await lifecycle.cleanupAndExit();

--- a/cli/src/cursor/runCursor.ts
+++ b/cli/src/cursor/runCursor.ts
@@ -134,6 +134,9 @@ export async function runCursor(opts: {
         if (localFailure?.exitReason === 'exit') {
             lifecycle.setExitCode(1);
             lifecycle.setArchiveReason(`Local launch failed: ${formatFailureReason(localFailure.message)}`);
+            lifecycle.setSessionEndReason('error');
+        } else {
+            lifecycle.setSessionEndReason('completed');
         }
         await lifecycle.cleanupAndExit();
     }

--- a/cli/src/gemini/runGemini.test.ts
+++ b/cli/src/gemini/runGemini.test.ts
@@ -9,6 +9,7 @@ const mockGeminiSession = vi.hoisted(() => ({
 const harness = vi.hoisted(() => ({
     bootstrapArgs: [] as Array<Record<string, unknown>>,
     geminiLoopArgs: [] as Array<Record<string, unknown>>,
+    geminiLoopError: null as Error | null,
     session: {
         onUserMessage: vi.fn(),
         rpcHandlerManager: {
@@ -30,6 +31,9 @@ vi.mock('@/agent/sessionFactory', () => ({
 vi.mock('./loop', () => ({
     geminiLoop: vi.fn(async (options: Record<string, unknown>) => {
         harness.geminiLoopArgs.push(options);
+        if (harness.geminiLoopError) {
+            throw harness.geminiLoopError;
+        }
         const onSessionReady = options.onSessionReady as ((session: unknown) => void) | undefined;
         if (onSessionReady) {
             onSessionReady(mockGeminiSession);
@@ -41,15 +45,18 @@ vi.mock('@/claude/registerKillSessionHandler', () => ({
     registerKillSessionHandler: vi.fn()
 }));
 
+const lifecycleMock = vi.hoisted(() => ({
+    registerProcessHandlers: vi.fn(),
+    cleanupAndExit: vi.fn(async () => {}),
+    markCrash: vi.fn(),
+    setExitCode: vi.fn(),
+    setArchiveReason: vi.fn(),
+    setSessionEndReason: vi.fn()
+}));
+
 vi.mock('@/agent/runnerLifecycle', () => ({
     createModeChangeHandler: vi.fn(() => vi.fn()),
-    createRunnerLifecycle: vi.fn(() => ({
-        registerProcessHandlers: vi.fn(),
-        cleanupAndExit: vi.fn(async () => {}),
-        markCrash: vi.fn(),
-        setExitCode: vi.fn(),
-        setArchiveReason: vi.fn()
-    })),
+    createRunnerLifecycle: vi.fn(() => lifecycleMock),
     setControlledByUser: vi.fn()
 }));
 
@@ -88,10 +95,17 @@ describe('runGemini', () => {
     beforeEach(() => {
         harness.bootstrapArgs.length = 0;
         harness.geminiLoopArgs.length = 0;
+        harness.geminiLoopError = null;
         mockGeminiSession.setModel.mockReset();
         mockGeminiSession.setPermissionMode.mockReset();
         harness.session.onUserMessage.mockReset();
         harness.session.rpcHandlerManager.registerHandler.mockReset();
+        lifecycleMock.registerProcessHandlers.mockClear();
+        lifecycleMock.cleanupAndExit.mockClear();
+        lifecycleMock.markCrash.mockClear();
+        lifecycleMock.setExitCode.mockClear();
+        lifecycleMock.setArchiveReason.mockClear();
+        lifecycleMock.setSessionEndReason.mockClear();
         resolveGeminiRuntimeConfigMock.mockReset();
     });
 
@@ -251,5 +265,19 @@ describe('runGemini', () => {
         await runGemini({});
 
         expect(harness.geminiLoopArgs[0]?.resumeSessionId).toBeUndefined();
+    });
+
+    it('preserves crash session end reason instead of overwriting it as completed', async () => {
+        resolveGeminiRuntimeConfigMock.mockReturnValue({
+            model: 'gemini-2.5-pro',
+            modelSource: 'default'
+        });
+        harness.geminiLoopError = new Error('loop failed');
+
+        await runGemini({});
+
+        expect(lifecycleMock.markCrash).toHaveBeenCalledWith(harness.geminiLoopError);
+        expect(lifecycleMock.setSessionEndReason).not.toHaveBeenCalledWith('completed');
+        expect(lifecycleMock.cleanupAndExit).toHaveBeenCalled();
     });
 });

--- a/cli/src/gemini/runGemini.ts
+++ b/cli/src/gemini/runGemini.ts
@@ -186,6 +186,9 @@ export async function runGemini(opts: {
         if (localFailure?.exitReason === 'exit') {
             lifecycle.setExitCode(1);
             lifecycle.setArchiveReason(`Local launch failed: ${localFailure.message.slice(0, 200)}`);
+            lifecycle.setSessionEndReason('error');
+        } else {
+            lifecycle.setSessionEndReason('completed');
         }
         await lifecycle.cleanupAndExit();
     }

--- a/cli/src/gemini/runGemini.ts
+++ b/cli/src/gemini/runGemini.ts
@@ -160,6 +160,8 @@ export async function runGemini(opts: {
         return { applied };
     });
 
+    let crashed = false;
+
     try {
         await geminiLoop({
             path: workingDirectory,
@@ -179,6 +181,7 @@ export async function runGemini(opts: {
             }
         });
     } catch (error) {
+        crashed = true;
         lifecycle.markCrash(error);
         logger.debug('[gemini] Loop error:', error);
     } finally {
@@ -187,7 +190,7 @@ export async function runGemini(opts: {
             lifecycle.setExitCode(1);
             lifecycle.setArchiveReason(`Local launch failed: ${localFailure.message.slice(0, 200)}`);
             lifecycle.setSessionEndReason('error');
-        } else {
+        } else if (!crashed) {
             lifecycle.setSessionEndReason('completed');
         }
         await lifecycle.cleanupAndExit();

--- a/cli/src/opencode/runOpencode.ts
+++ b/cli/src/opencode/runOpencode.ts
@@ -114,6 +114,8 @@ export async function runOpencode(opts: {
         return { applied: { permissionMode: currentPermissionMode } };
     });
 
+    let crashed = false;
+
     try {
         await opencodeLoop({
             path: workingDirectory,
@@ -133,6 +135,7 @@ export async function runOpencode(opts: {
             }
         });
     } catch (error) {
+        crashed = true;
         lifecycle.markCrash(error);
         logger.debug('[opencode] Loop error:', error);
     } finally {
@@ -141,7 +144,7 @@ export async function runOpencode(opts: {
             lifecycle.setExitCode(1);
             lifecycle.setArchiveReason(`Local launch failed: ${localFailure.message.slice(0, 200)}`);
             lifecycle.setSessionEndReason('error');
-        } else {
+        } else if (!crashed) {
             lifecycle.setSessionEndReason('completed');
         }
         await lifecycle.cleanupAndExit();

--- a/cli/src/opencode/runOpencode.ts
+++ b/cli/src/opencode/runOpencode.ts
@@ -140,6 +140,9 @@ export async function runOpencode(opts: {
         if (localFailure?.exitReason === 'exit') {
             lifecycle.setExitCode(1);
             lifecycle.setArchiveReason(`Local launch failed: ${localFailure.message.slice(0, 200)}`);
+            lifecycle.setSessionEndReason('error');
+        } else {
+            lifecycle.setSessionEndReason('completed');
         }
         await lifecycle.cleanupAndExit();
     }

--- a/hub/src/config/serverSettings.ts
+++ b/hub/src/config/serverSettings.ts
@@ -13,6 +13,8 @@ import { getSettingsFile, readSettings, writeSettings } from './settings'
 export interface ServerSettings {
     telegramBotToken: string | null
     telegramNotification: boolean
+    serverChanSendKey: string | null
+    serverChanNotification: boolean
     listenHost: string
     listenPort: number
     publicUrl: string
@@ -24,6 +26,8 @@ export interface ServerSettingsResult {
     sources: {
         telegramBotToken: 'env' | 'file' | 'default'
         telegramNotification: 'env' | 'file' | 'default'
+        serverChanSendKey: 'env' | 'file' | 'default'
+        serverChanNotification: 'env' | 'file' | 'default'
         listenHost: 'env' | 'file' | 'default'
         listenPort: 'env' | 'file' | 'default'
         publicUrl: 'env' | 'file' | 'default'
@@ -87,6 +91,8 @@ export async function loadServerSettings(dataDir: string): Promise<ServerSetting
     const sources: ServerSettingsResult['sources'] = {
         telegramBotToken: 'default',
         telegramNotification: 'default',
+        serverChanSendKey: 'default',
+        serverChanNotification: 'default',
         listenHost: 'default',
         listenPort: 'default',
         publicUrl: 'default',
@@ -118,6 +124,34 @@ export async function loadServerSettings(dataDir: string): Promise<ServerSetting
     } else if (settings.telegramNotification !== undefined) {
         telegramNotification = settings.telegramNotification
         sources.telegramNotification = 'file'
+    }
+
+    // serverChanSendKey: env > file > null
+    let serverChanSendKey: string | null = null
+    if (process.env.SERVERCHAN_SENDKEY) {
+        serverChanSendKey = process.env.SERVERCHAN_SENDKEY
+        sources.serverChanSendKey = 'env'
+        if (settings.serverChanSendKey === undefined) {
+            settings.serverChanSendKey = serverChanSendKey
+            needsSave = true
+        }
+    } else if (settings.serverChanSendKey !== undefined) {
+        serverChanSendKey = settings.serverChanSendKey
+        sources.serverChanSendKey = 'file'
+    }
+
+    // serverChanNotification: env > file > true
+    let serverChanNotification = true
+    if (process.env.SERVERCHAN_NOTIFICATION !== undefined) {
+        serverChanNotification = process.env.SERVERCHAN_NOTIFICATION === 'true'
+        sources.serverChanNotification = 'env'
+        if (settings.serverChanNotification === undefined) {
+            settings.serverChanNotification = serverChanNotification
+            needsSave = true
+        }
+    } else if (settings.serverChanNotification !== undefined) {
+        serverChanNotification = settings.serverChanNotification
+        sources.serverChanNotification = 'file'
     }
 
     // listenHost: env > file (new or old name) > default
@@ -212,6 +246,8 @@ export async function loadServerSettings(dataDir: string): Promise<ServerSetting
         settings: {
             telegramBotToken,
             telegramNotification,
+            serverChanSendKey,
+            serverChanNotification,
             listenHost,
             listenPort,
             publicUrl,

--- a/hub/src/config/settings.ts
+++ b/hub/src/config/settings.ts
@@ -14,6 +14,8 @@ export interface Settings {
     // Server configuration (persisted from environment variables)
     telegramBotToken?: string
     telegramNotification?: boolean
+    serverChanSendKey?: string
+    serverChanNotification?: boolean
     listenHost?: string
     listenPort?: number
     publicUrl?: string

--- a/hub/src/configuration.ts
+++ b/hub/src/configuration.ts
@@ -9,6 +9,8 @@
  * - CLI_API_TOKEN: Shared secret for hapi CLI authentication (auto-generated if not set)
  * - TELEGRAM_BOT_TOKEN: Telegram Bot API token from @BotFather
  * - TELEGRAM_NOTIFICATION: Enable/disable Telegram notifications (default: true)
+ * - SERVERCHAN_SENDKEY: Server酱 SendKey/AppKey for push notifications
+ * - SERVERCHAN_NOTIFICATION: Enable/disable Server酱 notifications (default: true)
  * - HAPI_LISTEN_HOST: Host/IP to bind the HTTP service (default: 127.0.0.1)
  * - HAPI_LISTEN_PORT: Port for HTTP service (default: 3006)
  * - HAPI_PUBLIC_URL: Public URL for external access (e.g., Telegram Mini App)
@@ -33,6 +35,8 @@ export type ConfigSource = 'env' | 'file' | 'default'
 export interface ConfigSources {
     telegramBotToken: ConfigSource
     telegramNotification: ConfigSource
+    serverChanSendKey: ConfigSource
+    serverChanNotification: ConfigSource
     listenHost: ConfigSource
     listenPort: ConfigSource
     publicUrl: ConfigSource
@@ -49,6 +53,12 @@ class Configuration {
 
     /** Telegram notifications enabled */
     public readonly telegramNotification: boolean
+
+    /** Server酱 SendKey/AppKey */
+    public readonly serverChanSendKey: string | null
+
+    /** Server酱 notifications enabled */
+    public readonly serverChanNotification: boolean
 
     /** CLI auth token (shared secret) */
     public cliApiToken: string
@@ -98,6 +108,8 @@ class Configuration {
         this.telegramBotToken = serverSettings.telegramBotToken
         this.telegramEnabled = Boolean(this.telegramBotToken)
         this.telegramNotification = serverSettings.telegramNotification
+        this.serverChanSendKey = serverSettings.serverChanSendKey
+        this.serverChanNotification = serverSettings.serverChanNotification
         this.listenHost = serverSettings.listenHost
         this.listenPort = serverSettings.listenPort
         this.publicUrl = serverSettings.publicUrl

--- a/hub/src/index.ts
+++ b/hub/src/index.ts
@@ -24,6 +24,7 @@ import { PushNotificationChannel } from './push/pushNotificationChannel'
 import { VisibilityTracker } from './visibility/visibilityTracker'
 import { TunnelManager } from './tunnel'
 import { waitForTunnelTlsReady } from './tunnel/tlsGate'
+import { ServerChanChannel } from './serverchan/channel'
 import QRCode from 'qrcode'
 import type { Server as BunServer } from 'bun'
 import type { WebSocketData } from '@socket.io/bun-engine'
@@ -149,6 +150,14 @@ async function main() {
         const notificationSource = formatSource(config.sources.telegramNotification)
         console.log(`[Hub] Telegram notifications: ${config.telegramNotification ? 'enabled' : 'disabled'} (${notificationSource})`)
     }
+    if (config.serverChanSendKey) {
+        const source = formatSource(config.sources.serverChanSendKey)
+        const notificationSource = formatSource(config.sources.serverChanNotification)
+        console.log(`[Hub] ServerChan: enabled (${source})`)
+        console.log(`[Hub] ServerChan notifications: ${config.serverChanNotification ? 'enabled' : 'disabled'} (${notificationSource})`)
+    } else {
+        console.log('[Hub] ServerChan: disabled (no SERVERCHAN_SENDKEY)')
+    }
 
     // Display tunnel status
     if (relayFlag.enabled) {
@@ -188,6 +197,10 @@ async function main() {
     const notificationChannels: NotificationChannel[] = [
         new PushNotificationChannel(pushService, sseManager, visibilityTracker, config.publicUrl)
     ]
+
+    if (config.serverChanSendKey && config.serverChanNotification) {
+        notificationChannels.push(new ServerChanChannel(config.serverChanSendKey, config.publicUrl))
+    }
 
     // Initialize Telegram bot (optional)
     if (config.telegramEnabled && config.telegramBotToken) {

--- a/hub/src/notifications/eventParsing.test.ts
+++ b/hub/src/notifications/eventParsing.test.ts
@@ -138,6 +138,34 @@ describe('extractTaskNotification', () => {
         })
     })
 
+    it('extracts task notification from direct user output content payload', () => {
+        const event: SyncEvent = {
+            type: 'message-received',
+            sessionId: 'session-1',
+            message: {
+                id: 'message-task-user-direct',
+                seq: 6,
+                localId: null,
+                createdAt: 0,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'output',
+                        data: {
+                            type: 'user',
+                            content: '<task-notification> <summary>Direct done</summary> <status>completed</status> </task-notification>'
+                        }
+                    }
+                }
+            }
+        }
+
+        expect(extractTaskNotification(event)).toEqual({
+            status: 'completed',
+            summary: 'Direct done'
+        })
+    })
+
     it('returns null when task notification summary is missing', () => {
         const event: SyncEvent = {
             type: 'message-received',

--- a/hub/src/notifications/eventParsing.test.ts
+++ b/hub/src/notifications/eventParsing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import type { SyncEvent } from '../sync/syncEngine'
-import { extractMessageEventType } from './eventParsing'
+import { extractMessageEventType, extractTaskNotification } from './eventParsing'
 
 describe('extractMessageEventType', () => {
     it('returns the event type from a role-wrapped envelope', () => {
@@ -74,5 +74,94 @@ describe('extractMessageEventType', () => {
         }
 
         expect(extractMessageEventType(event)).toBeNull()
+    })
+})
+
+describe('extractTaskNotification', () => {
+    it('extracts task notification from system output payload', () => {
+        const event: SyncEvent = {
+            type: 'message-received',
+            sessionId: 'session-1',
+            message: {
+                id: 'message-task-system',
+                seq: 4,
+                localId: null,
+                createdAt: 0,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'output',
+                        data: {
+                            type: 'system',
+                            subtype: 'task_notification',
+                            status: 'completed',
+                            summary: 'Background command stopped'
+                        }
+                    }
+                }
+            }
+        }
+
+        expect(extractTaskNotification(event)).toEqual({
+            status: 'completed',
+            summary: 'Background command stopped'
+        })
+    })
+
+    it('extracts task notification from sidechain user output payload', () => {
+        const event: SyncEvent = {
+            type: 'message-received',
+            sessionId: 'session-1',
+            message: {
+                id: 'message-task-user',
+                seq: 5,
+                localId: null,
+                createdAt: 0,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'output',
+                        data: {
+                            type: 'user',
+                            message: {
+                                content: '<task-notification> <summary>Done</summary> <status>completed</status> </task-notification>'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        expect(extractTaskNotification(event)).toEqual({
+            status: 'completed',
+            summary: 'Done'
+        })
+    })
+
+    it('returns null when task notification summary is missing', () => {
+        const event: SyncEvent = {
+            type: 'message-received',
+            sessionId: 'session-1',
+            message: {
+                id: 'message-task-user-empty',
+                seq: 6,
+                localId: null,
+                createdAt: 0,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'output',
+                        data: {
+                            type: 'user',
+                            message: {
+                                content: '<task-notification> <status>killed</status> </task-notification>'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        expect(extractTaskNotification(event)).toBeNull()
     })
 })

--- a/hub/src/notifications/eventParsing.ts
+++ b/hub/src/notifications/eventParsing.ts
@@ -38,3 +38,84 @@ export function extractMessageEventType(event: SyncEvent): string | null {
     const eventType = data?.type
     return typeof eventType === 'string' ? eventType : null
 }
+
+export type TaskNotificationEvent = {
+    summary: string
+    status?: string
+}
+
+function extractTaskNotificationFromSystemOutput(message: unknown): TaskNotificationEvent | null {
+    if (!isObject(message) || message.type !== 'output') {
+        return null
+    }
+
+    const data = isObject(message.data) ? message.data : null
+    if (!data || data.type !== 'system' || data.subtype !== 'task_notification') {
+        return null
+    }
+
+    const summary = typeof data.summary === 'string' ? data.summary.trim() : ''
+    if (!summary) {
+        return null
+    }
+
+    const status = typeof data.status === 'string' ? data.status.trim() : undefined
+    return { summary, status }
+}
+
+function extractTaskNotificationFromUserOutput(message: unknown): TaskNotificationEvent | null {
+    if (!isObject(message) || message.type !== 'output') {
+        return null
+    }
+
+    const data = isObject(message.data) ? message.data : null
+    if (!data || data.type !== 'user') {
+        return null
+    }
+
+    const wrappedMessage = isObject(data.message) ? data.message : null
+    const content = wrappedMessage?.content
+    if (typeof content !== 'string') {
+        return null
+    }
+
+    const trimmed = content.trimStart()
+    if (!trimmed.startsWith('<task-notification>')) {
+        return null
+    }
+
+    const summary = trimmed.match(/<summary>([\s\S]*?)<\/summary>/)?.[1]?.trim()
+    if (!summary) {
+        return null
+    }
+
+    const status = trimmed.match(/<status>([\s\S]*?)<\/status>/)?.[1]?.trim() || undefined
+    return { summary, status }
+}
+
+export function extractTaskNotification(event: SyncEvent): TaskNotificationEvent | null {
+    if (event.type !== 'message-received') {
+        return null
+    }
+
+    const message = event.message?.content
+    if (!isObject(message)) {
+        return null
+    }
+
+    const roleWrapped = isObject(message.content) ? message.content : null
+    const candidates = roleWrapped ? [roleWrapped, message] : [message]
+    for (const candidate of candidates) {
+        const fromSystem = extractTaskNotificationFromSystemOutput(candidate)
+        if (fromSystem) {
+            return fromSystem
+        }
+
+        const fromUser = extractTaskNotificationFromUserOutput(candidate)
+        if (fromUser) {
+            return fromUser
+        }
+    }
+
+    return null
+}

--- a/hub/src/notifications/eventParsing.ts
+++ b/hub/src/notifications/eventParsing.ts
@@ -74,7 +74,9 @@ function extractTaskNotificationFromUserOutput(message: unknown): TaskNotificati
     }
 
     const wrappedMessage = isObject(data.message) ? data.message : null
-    const content = wrappedMessage?.content
+    const content = typeof data.content === 'string'
+        ? data.content
+        : wrappedMessage?.content
     if (typeof content !== 'string') {
         return null
     }

--- a/hub/src/notifications/notificationHub.test.ts
+++ b/hub/src/notifications/notificationHub.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import type { Session, SyncEvent, SyncEventListener, SyncEngine } from '../sync/syncEngine'
+import type { SessionEndReason } from '@hapi/protocol'
 import type { NotificationChannel, TaskNotification } from './notificationTypes'
 import { NotificationHub } from './notificationHub'
 
@@ -33,6 +34,7 @@ class StubChannel implements NotificationChannel {
     readonly readySessions: Session[] = []
     readonly permissionSessions: Session[] = []
     readonly taskNotifications: Array<{ session: Session; notification: TaskNotification }> = []
+    readonly sessionCompletions: Session[] = []
 
     async sendReady(session: Session): Promise<void> {
         this.readySessions.push(session)
@@ -44,6 +46,10 @@ class StubChannel implements NotificationChannel {
 
     async sendTaskNotification(session: Session, notification: TaskNotification): Promise<void> {
         this.taskNotifications.push({ session, notification })
+    }
+
+    async sendSessionCompletion(session: Session): Promise<void> {
+        this.sessionCompletions.push(session)
     }
 }
 
@@ -204,6 +210,37 @@ describe('NotificationHub', () => {
             status: 'completed',
             summary: 'Commit T4 finished'
         })
+
+        hub.stop()
+    })
+
+    it('sends session completion only for completed session-ended events', async () => {
+        const engine = new FakeSyncEngine()
+        const channel = new StubChannel()
+        const hub = new NotificationHub(engine as unknown as SyncEngine, [channel], {
+            permissionDebounceMs: 1,
+            readyCooldownMs: 20
+        })
+
+        const completedSession = createSession({ id: 'session-completed', active: false })
+        const terminatedSession = createSession({ id: 'session-terminated', active: false })
+        engine.setSession(completedSession)
+        engine.setSession(terminatedSession)
+
+        engine.emit({
+            type: 'session-ended',
+            sessionId: completedSession.id,
+            reason: 'completed' satisfies SessionEndReason
+        })
+        engine.emit({
+            type: 'session-ended',
+            sessionId: terminatedSession.id,
+            reason: 'terminated' satisfies SessionEndReason
+        })
+        await sleep(5)
+
+        expect(channel.sessionCompletions).toHaveLength(1)
+        expect(channel.sessionCompletions[0]?.id).toBe(completedSession.id)
 
         hub.stop()
     })

--- a/hub/src/notifications/notificationHub.test.ts
+++ b/hub/src/notifications/notificationHub.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import type { Session, SyncEvent, SyncEventListener, SyncEngine } from '../sync/syncEngine'
-import type { NotificationChannel } from './notificationTypes'
+import type { NotificationChannel, TaskNotification } from './notificationTypes'
 import { NotificationHub } from './notificationHub'
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -32,6 +32,7 @@ class FakeSyncEngine {
 class StubChannel implements NotificationChannel {
     readonly readySessions: Session[] = []
     readonly permissionSessions: Session[] = []
+    readonly taskNotifications: Array<{ session: Session; notification: TaskNotification }> = []
 
     async sendReady(session: Session): Promise<void> {
         this.readySessions.push(session)
@@ -39,6 +40,10 @@ class StubChannel implements NotificationChannel {
 
     async sendPermissionRequest(session: Session): Promise<void> {
         this.permissionSessions.push(session)
+    }
+
+    async sendTaskNotification(session: Session, notification: TaskNotification): Promise<void> {
+        this.taskNotifications.push({ session, notification })
     }
 }
 
@@ -153,6 +158,52 @@ describe('NotificationHub', () => {
         engine.emit(readyEvent)
         await sleep(5)
         expect(channel.readySessions).toHaveLength(2)
+
+        hub.stop()
+    })
+
+    it('sends task notifications for task_notification system messages', async () => {
+        const engine = new FakeSyncEngine()
+        const channel = new StubChannel()
+        const hub = new NotificationHub(engine as unknown as SyncEngine, [channel], {
+            permissionDebounceMs: 1,
+            readyCooldownMs: 20
+        })
+
+        const session = createSession()
+        engine.setSession(session)
+
+        const taskEvent: SyncEvent = {
+            type: 'message-received',
+            sessionId: session.id,
+            message: {
+                id: 'message-task',
+                seq: 2,
+                localId: null,
+                createdAt: 0,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'output',
+                        data: {
+                            type: 'system',
+                            subtype: 'task_notification',
+                            status: 'completed',
+                            summary: 'Commit T4 finished'
+                        }
+                    }
+                }
+            }
+        }
+
+        engine.emit(taskEvent)
+        await sleep(5)
+
+        expect(channel.taskNotifications).toHaveLength(1)
+        expect(channel.taskNotifications[0]?.notification).toEqual({
+            status: 'completed',
+            summary: 'Commit T4 finished'
+        })
 
         hub.stop()
     })

--- a/hub/src/notifications/notificationHub.ts
+++ b/hub/src/notifications/notificationHub.ts
@@ -1,4 +1,5 @@
 import type { Session, SyncEngine, SyncEvent } from '../sync/syncEngine'
+import type { SessionEndReason } from '@hapi/protocol'
 import type { NotificationChannel, NotificationHubOptions, TaskNotification } from './notificationTypes'
 import { extractMessageEventType, extractTaskNotification } from './eventParsing'
 
@@ -51,6 +52,15 @@ export class NotificationHub {
 
         if (event.type === 'session-removed' && event.sessionId) {
             this.clearSessionState(event.sessionId)
+            return
+        }
+
+        if (event.type === 'session-ended' && event.sessionId) {
+            if (event.reason === 'completed') {
+                this.sendSessionCompletion(event.sessionId, event.reason).catch((error) => {
+                    console.error('[NotificationHub] Failed to send session completion notification:', error)
+                })
+            }
             return
         }
 
@@ -162,6 +172,15 @@ export class NotificationHub {
         await this.notifyTask(session, notification)
     }
 
+    private async sendSessionCompletion(sessionId: string, reason: SessionEndReason): Promise<void> {
+        const session = this.syncEngine.getSession(sessionId)
+        if (!session) {
+            return
+        }
+
+        await this.notifySessionCompletion(session, reason)
+    }
+
     private async notifyReady(session: Session): Promise<void> {
         for (const channel of this.channels) {
             try {
@@ -188,6 +207,19 @@ export class NotificationHub {
                 await channel.sendTaskNotification(session, notification)
             } catch (error) {
                 console.error('[NotificationHub] Failed to send task notification:', error)
+            }
+        }
+    }
+
+    private async notifySessionCompletion(session: Session, reason: SessionEndReason): Promise<void> {
+        for (const channel of this.channels) {
+            if (typeof channel.sendSessionCompletion !== 'function') {
+                continue
+            }
+            try {
+                await channel.sendSessionCompletion(session, reason)
+            } catch (error) {
+                console.error('[NotificationHub] Failed to send session completion notification:', error)
             }
         }
     }

--- a/hub/src/notifications/notificationHub.ts
+++ b/hub/src/notifications/notificationHub.ts
@@ -1,6 +1,6 @@
 import type { Session, SyncEngine, SyncEvent } from '../sync/syncEngine'
-import type { NotificationChannel, NotificationHubOptions } from './notificationTypes'
-import { extractMessageEventType } from './eventParsing'
+import type { NotificationChannel, NotificationHubOptions, TaskNotification } from './notificationTypes'
+import { extractMessageEventType, extractTaskNotification } from './eventParsing'
 
 export class NotificationHub {
     private readonly channels: NotificationChannel[]
@@ -59,6 +59,13 @@ export class NotificationHub {
             if (eventType === 'ready') {
                 this.sendReadyNotification(event.sessionId).catch((error) => {
                     console.error('[NotificationHub] Failed to send ready notification:', error)
+                })
+            }
+
+            const taskNotification = extractTaskNotification(event)
+            if (taskNotification) {
+                this.sendTaskNotification(event.sessionId, taskNotification).catch((error) => {
+                    console.error('[NotificationHub] Failed to send task notification:', error)
                 })
             }
         }
@@ -146,6 +153,15 @@ export class NotificationHub {
         await this.notifyReady(session)
     }
 
+    private async sendTaskNotification(sessionId: string, notification: TaskNotification): Promise<void> {
+        const session = this.getNotifiableSession(sessionId)
+        if (!session) {
+            return
+        }
+
+        await this.notifyTask(session, notification)
+    }
+
     private async notifyReady(session: Session): Promise<void> {
         for (const channel of this.channels) {
             try {
@@ -162,6 +178,16 @@ export class NotificationHub {
                 await channel.sendPermissionRequest(session)
             } catch (error) {
                 console.error('[NotificationHub] Failed to send permission notification:', error)
+            }
+        }
+    }
+
+    private async notifyTask(session: Session, notification: TaskNotification): Promise<void> {
+        for (const channel of this.channels) {
+            try {
+                await channel.sendTaskNotification(session, notification)
+            } catch (error) {
+                console.error('[NotificationHub] Failed to send task notification:', error)
             }
         }
     }

--- a/hub/src/notifications/notificationTypes.ts
+++ b/hub/src/notifications/notificationTypes.ts
@@ -1,8 +1,14 @@
 import type { Session } from '../sync/syncEngine'
 
+export type TaskNotification = {
+    summary: string
+    status?: string
+}
+
 export type NotificationChannel = {
     sendReady: (session: Session) => Promise<void>
     sendPermissionRequest: (session: Session) => Promise<void>
+    sendTaskNotification: (session: Session, notification: TaskNotification) => Promise<void>
 }
 
 export type NotificationHubOptions = {

--- a/hub/src/notifications/notificationTypes.ts
+++ b/hub/src/notifications/notificationTypes.ts
@@ -1,4 +1,5 @@
 import type { Session } from '../sync/syncEngine'
+import type { SessionEndReason } from '@hapi/protocol'
 
 export type TaskNotification = {
     summary: string
@@ -9,6 +10,7 @@ export type NotificationChannel = {
     sendReady: (session: Session) => Promise<void>
     sendPermissionRequest: (session: Session) => Promise<void>
     sendTaskNotification: (session: Session, notification: TaskNotification) => Promise<void>
+    sendSessionCompletion?: (session: Session, reason: SessionEndReason) => Promise<void>
 }
 
 export type NotificationHubOptions = {

--- a/hub/src/push/pushNotificationChannel.test.ts
+++ b/hub/src/push/pushNotificationChannel.test.ts
@@ -44,4 +44,35 @@ describe('PushNotificationChannel', () => {
         expect(toasts).toHaveLength(1)
         expect(pushed).toHaveLength(0)
     })
+
+    it('does not reuse one replacement tag for all task notifications in a session', async () => {
+        const pushed: Array<{ namespace: string; payload: PushPayload }> = []
+        const channel = new PushNotificationChannel(
+            {
+                sendToNamespace: async (namespace: string, payload: PushPayload) => {
+                    pushed.push({ namespace, payload })
+                }
+            } as never,
+            {
+                sendToast: async () => 0
+            } as never,
+            {
+                hasVisibleConnection: () => false
+            } as never,
+            ''
+        )
+
+        await channel.sendTaskNotification(createSession(), {
+            status: 'completed',
+            summary: 'First task'
+        })
+        await channel.sendTaskNotification(createSession(), {
+            status: 'failed',
+            summary: 'Second task'
+        })
+
+        expect(pushed).toHaveLength(2)
+        expect(pushed[0].payload.tag).toBeUndefined()
+        expect(pushed[1].payload.tag).toBeUndefined()
+    })
 })

--- a/hub/src/push/pushNotificationChannel.test.ts
+++ b/hub/src/push/pushNotificationChannel.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import type { Session } from '../sync/syncEngine'
+import { PushNotificationChannel } from './pushNotificationChannel'
+import type { PushPayload } from './pushService'
+
+function createSession(overrides: Partial<Session> = {}): Session {
+    return {
+        id: 'session-task-toast',
+        namespace: 'default',
+        name: 'Demo task',
+        active: true,
+        metadata: { flavor: 'codex' },
+        ...overrides
+    } as Session
+}
+
+describe('PushNotificationChannel', () => {
+    it('sends task notifications to visible web clients before falling back to push', async () => {
+        const pushed: Array<{ namespace: string; payload: PushPayload }> = []
+        const toasts: unknown[] = []
+        const channel = new PushNotificationChannel(
+            {
+                sendToNamespace: async (namespace: string, payload: PushPayload) => {
+                    pushed.push({ namespace, payload })
+                }
+            } as never,
+            {
+                sendToast: async (_namespace: string, event: unknown) => {
+                    toasts.push(event)
+                    return 1
+                }
+            } as never,
+            {
+                hasVisibleConnection: () => true
+            } as never,
+            ''
+        )
+
+        await channel.sendTaskNotification(createSession(), {
+            status: 'completed',
+            summary: 'Background work finished'
+        })
+
+        expect(toasts).toHaveLength(1)
+        expect(pushed).toHaveLength(0)
+    })
+})

--- a/hub/src/push/pushNotificationChannel.ts
+++ b/hub/src/push/pushNotificationChannel.ts
@@ -108,7 +108,6 @@ export class PushNotificationChannel implements NotificationChannel {
         const payload: PushPayload = {
             title: isFailure ? 'Task failed' : 'Task completed',
             body: `${agentName} · ${name} · ${notification.summary}`,
-            tag: `task-${session.id}`,
             data: {
                 type: 'task-notification',
                 sessionId: session.id,

--- a/hub/src/push/pushNotificationChannel.ts
+++ b/hub/src/push/pushNotificationChannel.ts
@@ -116,6 +116,22 @@ export class PushNotificationChannel implements NotificationChannel {
             }
         }
 
+        const url = payload.data?.url ?? this.buildSessionPath(session.id)
+        if (this.visibilityTracker.hasVisibleConnection(session.namespace)) {
+            const delivered = await this.sseManager.sendToast(session.namespace, {
+                type: 'toast',
+                data: {
+                    title: payload.title,
+                    body: payload.body,
+                    sessionId: session.id,
+                    url
+                }
+            })
+            if (delivered > 0) {
+                return
+            }
+        }
+
         await this.pushService.sendToNamespace(session.namespace, payload)
     }
 

--- a/hub/src/push/pushNotificationChannel.ts
+++ b/hub/src/push/pushNotificationChannel.ts
@@ -1,5 +1,5 @@
 import type { Session } from '../sync/syncEngine'
-import type { NotificationChannel } from '../notifications/notificationTypes'
+import type { NotificationChannel, TaskNotification } from '../notifications/notificationTypes'
 import { getAgentName, getSessionName } from '../notifications/sessionInfo'
 import type { SSEManager } from '../sse/sseManager'
 import type { VisibilityTracker } from '../visibility/visibilityTracker'
@@ -86,6 +86,33 @@ export class PushNotificationChannel implements NotificationChannel {
             })
             if (delivered > 0) {
                 return
+            }
+        }
+
+        await this.pushService.sendToNamespace(session.namespace, payload)
+    }
+
+    async sendTaskNotification(session: Session, notification: TaskNotification): Promise<void> {
+        if (!session.active) {
+            return
+        }
+
+        const agentName = getAgentName(session)
+        const name = getSessionName(session)
+        const normalizedStatus = notification.status?.trim().toLowerCase()
+        const isFailure = normalizedStatus === 'failed'
+            || normalizedStatus === 'error'
+            || normalizedStatus === 'killed'
+            || normalizedStatus === 'aborted'
+
+        const payload: PushPayload = {
+            title: isFailure ? 'Task failed' : 'Task completed',
+            body: `${agentName} · ${name} · ${notification.summary}`,
+            tag: `task-${session.id}`,
+            data: {
+                type: 'task-notification',
+                sessionId: session.id,
+                url: this.buildSessionPath(session.id)
             }
         }
 

--- a/hub/src/serverchan/channel.test.ts
+++ b/hub/src/serverchan/channel.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, mock } from 'bun:test'
+import type { SessionEndReason } from '@hapi/protocol'
+import type { Session } from '../sync/syncEngine'
+import { ServerChanChannel } from './channel'
+
+function createSession(overrides: Partial<Session> = {}): Session {
+    return {
+        id: 'session-1',
+        namespace: 'default',
+        seq: 1,
+        createdAt: 0,
+        updatedAt: 0,
+        active: true,
+        activeAt: 0,
+        metadata: {
+            path: 'F:\\develop\\code\\usdt',
+            host: 'DESKTOP'
+        },
+        metadataVersion: 0,
+        agentState: null,
+        agentStateVersion: 0,
+        thinking: false,
+        thinkingAt: 0,
+        model: null,
+        modelReasoningEffort: null,
+        effort: null,
+        ...overrides
+    }
+}
+
+describe('ServerChanChannel', () => {
+    it('does not send completed task notifications', async () => {
+        const fetchMock = mock(async () => new Response('ok', { status: 200 }))
+        const originalFetch = globalThis.fetch
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        try {
+            const channel = new ServerChanChannel('SCT_TEST', 'https://hapi.example.com')
+            await channel.sendTaskNotification(createSession(), {
+                status: 'completed',
+                summary: 'Subtask finished'
+            })
+
+            expect(fetchMock).not.toHaveBeenCalled()
+        } finally {
+            globalThis.fetch = originalFetch
+        }
+    })
+
+    it('sends failed task notifications', async () => {
+        const fetchMock = mock(async () => new Response('ok', { status: 200 }))
+        const originalFetch = globalThis.fetch
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        try {
+            const channel = new ServerChanChannel('SCT_TEST', 'https://hapi.example.com')
+            await channel.sendTaskNotification(createSession(), {
+                status: 'failed',
+                summary: 'Subtask failed'
+            })
+
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+            const call = fetchMock.mock.calls[0] as unknown[] | undefined
+            const url = call?.[0]
+            const init = call?.[1] as RequestInit | undefined
+            expect(String(url)).toContain('https://sctapi.ftqq.com/SCT_TEST.send')
+            expect((init?.body as URLSearchParams).get('title')).toBe('HAPI Task failed')
+        } finally {
+            globalThis.fetch = originalFetch
+        }
+    })
+
+    it('sends session completion notifications', async () => {
+        const fetchMock = mock(async () => new Response('ok', { status: 200 }))
+        const originalFetch = globalThis.fetch
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        try {
+            const channel = new ServerChanChannel('SCT_TEST', 'https://hapi.example.com')
+            await channel.sendSessionCompletion(createSession({
+                id: 'session-complete',
+                metadata: {
+                    path: 'F:\\develop\\code\\usdt',
+                    host: 'DESKTOP',
+                    name: 'USDT review'
+                }
+            }), 'completed' satisfies SessionEndReason)
+
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+            const call = fetchMock.mock.calls[0] as unknown[] | undefined
+            const url = call?.[0]
+            const init = call?.[1] as RequestInit | undefined
+            expect(String(url)).toContain('https://sctapi.ftqq.com/SCT_TEST.send')
+            expect((init?.body as URLSearchParams).get('title')).toBe('HAPI Session completed')
+        } finally {
+            globalThis.fetch = originalFetch
+        }
+    })
+})

--- a/hub/src/serverchan/channel.ts
+++ b/hub/src/serverchan/channel.ts
@@ -1,0 +1,80 @@
+import type { Session } from '../sync/syncEngine'
+import type { NotificationChannel, TaskNotification } from '../notifications/notificationTypes'
+import { getAgentName, getSessionName } from '../notifications/sessionInfo'
+
+function buildSessionUrl(baseUrl: string, sessionId: string): string {
+    try {
+        return new URL(`/sessions/${sessionId}`, baseUrl).toString()
+    } catch {
+        const normalized = baseUrl.replace(/\/+$/, '')
+        return `${normalized}/sessions/${sessionId}`
+    }
+}
+
+export class ServerChanChannel implements NotificationChannel {
+    constructor(
+        private readonly sendKey: string,
+        private readonly publicUrl: string
+    ) {}
+
+    async sendReady(session: Session): Promise<void> {
+        if (!session.active) {
+            return
+        }
+
+        const agentName = getAgentName(session)
+        const name = getSessionName(session)
+        const url = buildSessionUrl(this.publicUrl, session.id)
+        await this.send('HAPI Ready for input', `${agentName} 正在等待输入\n\n会话：${name}\n\n${url}`)
+    }
+
+    async sendPermissionRequest(session: Session): Promise<void> {
+        if (!session.active) {
+            return
+        }
+
+        const name = getSessionName(session)
+        const request = session.agentState?.requests
+            ? Object.values(session.agentState.requests)[0]
+            : null
+        const toolName = request?.tool ? ` (${request.tool})` : ''
+        const url = buildSessionUrl(this.publicUrl, session.id)
+        await this.send('HAPI Permission Request', `${name}${toolName}\n\n${url}`)
+    }
+
+    async sendTaskNotification(session: Session, notification: TaskNotification): Promise<void> {
+        if (!session.active) {
+            return
+        }
+
+        const agentName = getAgentName(session)
+        const name = getSessionName(session)
+        const status = notification.status?.trim().toLowerCase()
+        const title = status === 'failed' || status === 'error' || status === 'killed' || status === 'aborted'
+            ? 'HAPI Task failed'
+            : 'HAPI Task completed'
+        const url = buildSessionUrl(this.publicUrl, session.id)
+        await this.send(title, `${agentName} · ${name}\n\n${notification.summary}\n\n${url}`)
+    }
+
+    private async send(title: string, desp: string): Promise<void> {
+        const url = `https://sctapi.ftqq.com/${this.sendKey}.send`
+        const body = new URLSearchParams({
+            title,
+            desp
+        })
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded'
+            },
+            body
+        })
+
+        if (!response.ok) {
+            const text = await response.text().catch(() => '')
+            throw new Error(`Server酱发送失败: HTTP ${response.status} ${response.statusText}${text ? ` - ${text}` : ''}`)
+        }
+    }
+}

--- a/hub/src/serverchan/channel.ts
+++ b/hub/src/serverchan/channel.ts
@@ -1,4 +1,5 @@
 import type { Session } from '../sync/syncEngine'
+import type { SessionEndReason } from '@hapi/protocol'
 import type { NotificationChannel, TaskNotification } from '../notifications/notificationTypes'
 import { getAgentName, getSessionName } from '../notifications/sessionInfo'
 
@@ -50,11 +51,19 @@ export class ServerChanChannel implements NotificationChannel {
         const agentName = getAgentName(session)
         const name = getSessionName(session)
         const status = notification.status?.trim().toLowerCase()
-        const title = status === 'failed' || status === 'error' || status === 'killed' || status === 'aborted'
-            ? 'HAPI Task failed'
-            : 'HAPI Task completed'
+        const isFailure = status === 'failed' || status === 'error' || status === 'killed' || status === 'aborted'
+        if (!isFailure) {
+            return
+        }
         const url = buildSessionUrl(this.publicUrl, session.id)
-        await this.send(title, `${agentName} · ${name}\n\n${notification.summary}\n\n${url}`)
+        await this.send('HAPI Task failed', `${agentName} · ${name}\n\n${notification.summary}\n\n${url}`)
+    }
+
+    async sendSessionCompletion(session: Session, _reason: SessionEndReason): Promise<void> {
+        const agentName = getAgentName(session)
+        const name = getSessionName(session)
+        const url = buildSessionUrl(this.publicUrl, session.id)
+        await this.send('HAPI Session completed', `${agentName} · ${name}\n\n会话已结束。\n\n${url}`)
     }
 
     private async send(title: string, desp: string): Promise<void> {

--- a/hub/src/socket/handlers/cli/sessionHandlers.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.ts
@@ -8,6 +8,7 @@ import { extractTodoWriteTodosFromMessageContent } from '../../../sync/todos'
 import { extractTeamStateFromMessageContent, applyTeamStateDelta } from '../../../sync/teams'
 import { extractBackgroundTaskDelta } from '../../../sync/backgroundTasks'
 import type { CliSocketWithData } from '../../socketTypes'
+import type { SessionEndReason } from '@hapi/protocol'
 import type { AccessErrorReason, AccessResult } from './types'
 
 type SessionAlivePayload = {
@@ -25,6 +26,7 @@ type SessionAlivePayload = {
 type SessionEndPayload = {
     sid: string
     time: number
+    reason?: SessionEndReason
 }
 
 type ResolveSessionAccess = (sessionId: string) => AccessResult<StoredSession>

--- a/hub/src/sync/aliveEvents.test.ts
+++ b/hub/src/sync/aliveEvents.test.ts
@@ -169,7 +169,13 @@ describe('alive incremental events', () => {
         cache.markMessageQueued(session.id, now + 10)
         events.length = 0
 
-        cache.handleSessionAlive({ sid: session.id, time: now + 2_000, thinking: false })
+        const originalNow = Date.now
+        Date.now = () => now + 2_000
+        try {
+            cache.handleSessionAlive({ sid: session.id, time: now + 2_000, thinking: false })
+        } finally {
+            Date.now = originalNow
+        }
 
         expect(cache.getSession(session.id)?.thinking).toBe(true)
         expect(events.find((event) => event.type === 'session-updated')).toBeUndefined()
@@ -193,6 +199,40 @@ describe('alive incremental events', () => {
         events.length = 0
 
         cache.handleSessionAlive({ sid: session.id, time: now + 16_000, thinking: false })
+
+        expect(cache.getSession(session.id)?.thinking).toBe(false)
+        const update = events.find((event) => event.type === 'session-updated')
+        expect(update).toBeDefined()
+        if (!update || update.type !== 'session-updated') {
+            return
+        }
+        expect(update.data).toEqual(expect.objectContaining({ thinking: false }))
+    })
+
+    it('expires queued thinking against hub time instead of client heartbeat time', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-queued-thinking-clock-skew',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            { requests: {}, completedRequests: {} },
+            'default'
+        )
+
+        cache.handleSessionAlive({ sid: session.id, time: now, thinking: false })
+        cache.markMessageQueued(session.id, now + 10)
+        events.length = 0
+
+        const originalNow = Date.now
+        Date.now = () => now + 16_000
+        try {
+            cache.handleSessionAlive({ sid: session.id, time: now - 60_000, thinking: false })
+        } finally {
+            Date.now = originalNow
+        }
 
         expect(cache.getSession(session.id)?.thinking).toBe(false)
         const update = events.find((event) => event.type === 'session-updated')

--- a/hub/src/sync/aliveEvents.test.ts
+++ b/hub/src/sync/aliveEvents.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'bun:test'
 import type { SyncEvent } from '@hapi/protocol/types'
 import { Store } from '../store'
+import { RpcRegistry } from '../socket/rpcRegistry'
 import type { EventPublisher } from './eventPublisher'
 import { MachineCache } from './machineCache'
 import { SessionCache } from './sessionCache'
+import { SyncEngine } from './syncEngine'
 
 function createPublisher(events: SyncEvent[]): EventPublisher {
     return {
@@ -60,5 +62,115 @@ describe('alive incremental events', () => {
         }
 
         expect(update.data).toEqual(expect.objectContaining({ id: machine.id, active: true }))
+    })
+
+    it('marks session thinking immediately when a user message is accepted by the hub', async () => {
+        const store = new Store(':memory:')
+        const emittedSocketUpdates: unknown[] = []
+        const io = {
+            of: () => ({
+                to: () => ({
+                    emit: (_event: string, payload: unknown) => {
+                        emittedSocketUpdates.push(payload)
+                    }
+                })
+            })
+        }
+        const engine = new SyncEngine(
+            store,
+            io as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+        const events: SyncEvent[] = []
+        const unsubscribe = engine.subscribe((event) => {
+            events.push(event)
+        })
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-send-thinking',
+                { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+                { requests: {}, completedRequests: {} },
+                'default'
+            )
+
+            engine.handleSessionAlive({ sid: session.id, time: Date.now(), thinking: false })
+            events.length = 0
+
+            await engine.sendMessage(session.id, {
+                text: 'hello from web',
+                sentFrom: 'webapp'
+            })
+
+            expect(engine.getSession(session.id)?.thinking).toBe(true)
+            expect(emittedSocketUpdates.length).toBeGreaterThan(0)
+
+            const update = events.find((event) => event.type === 'session-updated')
+            expect(update).toBeDefined()
+            if (!update || update.type !== 'session-updated') {
+                return
+            }
+
+            expect(update.data).toEqual(expect.objectContaining({
+                active: true,
+                thinking: true
+            }))
+            expect((update.data as { updatedAt?: unknown }).updatedAt).toEqual(expect.any(Number))
+        } finally {
+            unsubscribe()
+            engine.stop()
+        }
+    })
+
+    it('keeps queued thinking true across false heartbeats during the grace window', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now() - 30_000
+
+        const session = cache.getOrCreateSession(
+            'session-queued-thinking-grace',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            { requests: {}, completedRequests: {} },
+            'default'
+        )
+
+        cache.handleSessionAlive({ sid: session.id, time: now, thinking: false })
+        cache.markMessageQueued(session.id, now + 10)
+        events.length = 0
+
+        cache.handleSessionAlive({ sid: session.id, time: now + 2_000, thinking: false })
+
+        expect(cache.getSession(session.id)?.thinking).toBe(true)
+        expect(events.find((event) => event.type === 'session-updated')).toBeUndefined()
+    })
+
+    it('clears queued thinking after the grace window expires', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now() - 30_000
+
+        const session = cache.getOrCreateSession(
+            'session-queued-thinking-expire',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            { requests: {}, completedRequests: {} },
+            'default'
+        )
+
+        cache.handleSessionAlive({ sid: session.id, time: now, thinking: false })
+        cache.markMessageQueued(session.id, now + 10)
+        events.length = 0
+
+        cache.handleSessionAlive({ sid: session.id, time: now + 16_000, thinking: false })
+
+        expect(cache.getSession(session.id)?.thinking).toBe(false)
+        const update = events.find((event) => event.type === 'session-updated')
+        expect(update).toBeDefined()
+        if (!update || update.type !== 'session-updated') {
+            return
+        }
+        expect(update.data).toEqual(expect.objectContaining({ thinking: false }))
     })
 })

--- a/hub/src/sync/aliveEvents.test.ts
+++ b/hub/src/sync/aliveEvents.test.ts
@@ -96,6 +96,7 @@ describe('alive incremental events', () => {
             )
 
             engine.handleSessionAlive({ sid: session.id, time: Date.now(), thinking: false })
+            const activeAtBeforeSend = engine.getSession(session.id)?.activeAt
             events.length = 0
 
             await engine.sendMessage(session.id, {
@@ -104,6 +105,7 @@ describe('alive incremental events', () => {
             })
 
             expect(engine.getSession(session.id)?.thinking).toBe(true)
+            expect(engine.getSession(session.id)?.activeAt).toBe(activeAtBeforeSend)
             expect(emittedSocketUpdates.length).toBeGreaterThan(0)
 
             const update = events.find((event) => event.type === 'session-updated')
@@ -112,15 +114,42 @@ describe('alive incremental events', () => {
                 return
             }
 
-            expect(update.data).toEqual(expect.objectContaining({
-                active: true,
-                thinking: true
-            }))
+            expect(update.data).toEqual(expect.objectContaining({ thinking: true }))
+            expect(update.data).not.toHaveProperty('activeAt')
             expect((update.data as { updatedAt?: unknown }).updatedAt).toEqual(expect.any(Number))
         } finally {
             unsubscribe()
             engine.stop()
         }
+    })
+
+    it('does not revive inactive sessions or refresh liveness when marking queued thinking', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now() - 30_000
+
+        const session = cache.getOrCreateSession(
+            'session-queued-thinking-inactive',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            { requests: {}, completedRequests: {} },
+            'default'
+        )
+
+        cache.handleSessionAlive({ sid: session.id, time: now, thinking: false })
+        cache.handleSessionEnd({ sid: session.id, time: now + 1_000 })
+        const inactive = cache.getSession(session.id)
+        expect(inactive?.active).toBe(false)
+        const inactiveActiveAt = inactive?.activeAt
+
+        events.length = 0
+        cache.markMessageQueued(session.id, now + 2_000)
+
+        const updated = cache.getSession(session.id)
+        expect(updated?.active).toBe(false)
+        expect(updated?.thinking).toBe(false)
+        expect(updated?.activeAt).toBe(inactiveActiveAt)
+        expect(events.find((event) => event.type === 'session-updated')).toBeUndefined()
     })
 
     it('keeps queued thinking true across false heartbeats during the grace window', () => {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -6,12 +6,15 @@ import { EventPublisher } from './eventPublisher'
 import { extractTodoWriteTodosFromMessageContent, TodosSchema } from './todos'
 import { extractBackgroundTaskDelta } from './backgroundTasks'
 
+const QUEUED_MESSAGE_THINKING_GRACE_MS = 15_000
+
 export class SessionCache {
     private readonly sessions: Map<string, Session> = new Map()
     private readonly lastBroadcastAtBySessionId: Map<string, number> = new Map()
     private readonly todoBackfillAttemptedSessionIds: Set<string> = new Set()
     private readonly deduplicateInProgress: Set<string> = new Set()
     private readonly deduplicatePending: Set<string> = new Set()
+    private readonly pendingThinkingUntilBySessionId: Map<string, number> = new Map()
 
     constructor(
         private readonly store: Store,
@@ -75,6 +78,7 @@ export class SessionCache {
         let stored = this.store.sessions.getSession(sessionId)
         if (!stored) {
             const existed = this.sessions.delete(sessionId)
+            this.pendingThinkingUntilBySessionId.delete(sessionId)
             if (existed) {
                 this.publisher.emit({ type: 'session-removed', sessionId })
             }
@@ -181,11 +185,17 @@ export class SessionCache {
         const previousModelReasoningEffort = session.modelReasoningEffort
         const previousEffort = session.effort
         const previousCollaborationMode = session.collaborationMode
+        const pendingThinkingUntil = this.pendingThinkingUntilBySessionId.get(session.id) ?? 0
+        const requestedThinking = Boolean(payload.thinking)
+        const preserveQueuedThinking = !requestedThinking && pendingThinkingUntil > t
 
         session.active = true
         session.activeAt = Math.max(session.activeAt, t)
-        session.thinking = Boolean(payload.thinking)
+        session.thinking = requestedThinking || preserveQueuedThinking
         session.thinkingAt = t
+        if (requestedThinking || pendingThinkingUntil <= t) {
+            this.pendingThinkingUntilBySessionId.delete(session.id)
+        }
         if (payload.permissionMode !== undefined) {
             session.permissionMode = payload.permissionMode
         }
@@ -248,6 +258,41 @@ export class SessionCache {
         }
     }
 
+    markMessageQueued(sessionId: string, time: number = Date.now()): void {
+        const session = this.sessions.get(sessionId) ?? this.refreshSession(sessionId)
+        if (!session) return
+
+        const nextTime = clampAliveTime(time) ?? Date.now()
+        const wasActive = session.active
+        const wasThinking = session.thinking
+        const previousUpdatedAt = session.updatedAt
+
+        session.active = true
+        session.activeAt = Math.max(session.activeAt, nextTime)
+        session.thinking = true
+        session.thinkingAt = nextTime
+        session.updatedAt = Math.max(session.updatedAt, nextTime)
+        this.pendingThinkingUntilBySessionId.set(session.id, nextTime + QUEUED_MESSAGE_THINKING_GRACE_MS)
+
+        if (!wasActive && session.active) {
+            this.lastBroadcastAtBySessionId.delete(session.id)
+        }
+
+        if (!wasActive || !wasThinking || session.updatedAt !== previousUpdatedAt) {
+            this.lastBroadcastAtBySessionId.set(session.id, Date.now())
+            this.publisher.emit({
+                type: 'session-updated',
+                sessionId: session.id,
+                data: {
+                    active: true,
+                    activeAt: session.activeAt,
+                    thinking: true,
+                    updatedAt: session.updatedAt
+                }
+            })
+        }
+    }
+
     applyBackgroundTaskDelta(sessionId: string, delta: { started: number; completed: number }): void {
         const session = this.sessions.get(sessionId)
         if (!session) return
@@ -278,6 +323,7 @@ export class SessionCache {
         session.thinking = false
         session.thinkingAt = t
         session.backgroundTaskCount = 0
+        this.pendingThinkingUntilBySessionId.delete(session.id)
 
         this.publisher.emit({ type: 'session-updated', sessionId: session.id, data: { active: false, thinking: false, backgroundTaskCount: 0 } })
     }
@@ -291,6 +337,7 @@ export class SessionCache {
             if (now - session.activeAt <= sessionTimeoutMs) continue
             session.active = false
             session.thinking = false
+            this.pendingThinkingUntilBySessionId.delete(session.id)
             expired.push(session.id)
             this.publisher.emit({ type: 'session-updated', sessionId: session.id, data: { active: false } })
         }
@@ -402,6 +449,7 @@ export class SessionCache {
         this.sessions.delete(sessionId)
         this.lastBroadcastAtBySessionId.delete(sessionId)
         this.todoBackfillAttemptedSessionIds.delete(sessionId)
+        this.pendingThinkingUntilBySessionId.delete(sessionId)
 
         this.publisher.emit({ type: 'session-removed', sessionId, namespace: session.namespace })
     }

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -187,13 +187,14 @@ export class SessionCache {
         const previousCollaborationMode = session.collaborationMode
         const pendingThinkingUntil = this.pendingThinkingUntilBySessionId.get(session.id) ?? 0
         const requestedThinking = Boolean(payload.thinking)
-        const preserveQueuedThinking = !requestedThinking && pendingThinkingUntil > t
+        const hubNow = Date.now()
+        const preserveQueuedThinking = !requestedThinking && pendingThinkingUntil > hubNow
 
         session.active = true
         session.activeAt = Math.max(session.activeAt, t)
         session.thinking = requestedThinking || preserveQueuedThinking
         session.thinkingAt = t
-        if (requestedThinking || pendingThinkingUntil <= t) {
+        if (requestedThinking || pendingThinkingUntil <= hubNow) {
             this.pendingThinkingUntilBySessionId.delete(session.id)
         }
         if (payload.permissionMode !== undefined) {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -261,31 +261,23 @@ export class SessionCache {
     markMessageQueued(sessionId: string, time: number = Date.now()): void {
         const session = this.sessions.get(sessionId) ?? this.refreshSession(sessionId)
         if (!session) return
+        if (!session.active) return
 
         const nextTime = clampAliveTime(time) ?? Date.now()
-        const wasActive = session.active
         const wasThinking = session.thinking
         const previousUpdatedAt = session.updatedAt
 
-        session.active = true
-        session.activeAt = Math.max(session.activeAt, nextTime)
         session.thinking = true
         session.thinkingAt = nextTime
         session.updatedAt = Math.max(session.updatedAt, nextTime)
         this.pendingThinkingUntilBySessionId.set(session.id, nextTime + QUEUED_MESSAGE_THINKING_GRACE_MS)
 
-        if (!wasActive && session.active) {
-            this.lastBroadcastAtBySessionId.delete(session.id)
-        }
-
-        if (!wasActive || !wasThinking || session.updatedAt !== previousUpdatedAt) {
+        if (!wasThinking || session.updatedAt !== previousUpdatedAt) {
             this.lastBroadcastAtBySessionId.set(session.id, Date.now())
             this.publisher.emit({
                 type: 'session-updated',
                 sessionId: session.id,
                 data: {
-                    active: true,
-                    activeAt: session.activeAt,
                     thinking: true,
                     updatedAt: session.updatedAt
                 }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -205,8 +205,13 @@ export class SyncEngine {
         this.triggerDedupIfNeeded(payload.sid)
     }
 
-    handleSessionEnd(payload: { sid: string; time: number }): void {
+    handleSessionEnd(payload: { sid: string; time: number; reason?: 'completed' | 'terminated' | 'error' }): void {
         this.sessionCache.handleSessionEnd(payload)
+        this.eventPublisher.emit({
+            type: 'session-ended',
+            sessionId: payload.sid,
+            reason: payload.reason
+        })
         // Retry dedup now that this session is inactive — a prior dedup may have
         // skipped it because it was still active at the time.
         this.triggerDedupIfNeeded(payload.sid)

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -272,6 +272,7 @@ export class SyncEngine {
         }
     ): Promise<void> {
         await this.messageService.sendMessage(sessionId, payload)
+        this.sessionCache.markMessageQueued(sessionId)
     }
 
     async approvePermission(

--- a/hub/src/telegram/bot.ts
+++ b/hub/src/telegram/bot.ts
@@ -10,7 +10,7 @@ import { SyncEngine, Session } from '../sync/syncEngine'
 import { handleCallback, CallbackContext } from './callbacks'
 import { formatSessionNotification, createNotificationKeyboard } from './sessionView'
 import { getAgentName } from '../notifications/sessionInfo'
-import type { NotificationChannel } from '../notifications/notificationTypes'
+import type { NotificationChannel, TaskNotification } from '../notifications/notificationTypes'
 import type { Store } from '../store'
 
 export interface BotContext extends Context {
@@ -238,6 +238,36 @@ export class HappyBot implements NotificationChannel {
                 })
             } catch (error) {
                 console.error(`[HAPIBot] Failed to send notification to chat ${chatId}:`, error)
+            }
+        }
+    }
+
+    async sendTaskNotification(session: Session, notification: TaskNotification): Promise<void> {
+        if (!session.active) {
+            return
+        }
+
+        const agentName = getAgentName(session)
+        const status = notification.status?.trim().toLowerCase()
+        const prefix = status === 'failed' || status === 'error' || status === 'killed' || status === 'aborted'
+            ? 'Task failed'
+            : 'Task completed'
+        const url = buildMiniAppDeepLink(this.publicUrl, `session_${session.id}`)
+        const keyboard = new InlineKeyboard()
+            .webApp('Open Session', url)
+
+        const chatIds = this.getBoundChatIds(session.namespace)
+        if (chatIds.length === 0) {
+            return
+        }
+
+        for (const chatId of chatIds) {
+            try {
+                await this.bot.api.sendMessage(chatId, `${prefix}\n\n${agentName}: ${notification.summary}`, {
+                    reply_markup: keyboard
+                })
+            } catch (error) {
+                console.error(`[HAPIBot] Failed to send task notification to chat ${chatId}:`, error)
             }
         }
     }

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -217,6 +217,10 @@ export const SyncEventSchema = z.discriminatedUnion('type', [
     SessionChangedSchema.extend({
         type: z.literal('messages-invalidated')
     }),
+    SessionChangedSchema.extend({
+        type: z.literal('session-ended'),
+        reason: z.enum(['completed', 'terminated', 'error']).optional()
+    }),
     MachineChangedSchema.extend({
         type: z.literal('machine-updated'),
         data: z.unknown().optional()

--- a/shared/src/socket.ts
+++ b/shared/src/socket.ts
@@ -67,6 +67,8 @@ export const TerminalErrorPayloadSchema = z.object({
 })
 
 export type TerminalErrorPayload = z.infer<typeof TerminalErrorPayloadSchema>
+export const SessionEndReasonSchema = z.enum(['completed', 'terminated', 'error'])
+export type SessionEndReason = z.infer<typeof SessionEndReasonSchema>
 
 export const UpdateNewMessageBodySchema = z.object({
     t: z.literal('new-message'),
@@ -144,7 +146,7 @@ export interface ClientToServerEvents {
         effort?: string | null
         collaborationMode?: CodexCollaborationMode
     }) => void
-    'session-end': (data: { sid: string; time: number }) => void
+    'session-end': (data: { sid: string; time: number; reason?: SessionEndReason }) => void
     'messages-consumed': (data: { sid: string; localIds: string[] }) => void
     'update-metadata': (data: { sid: string; expectedVersion: number; metadata: unknown }, cb: (answer: {
         result: 'error'


### PR DESCRIPTION
## Summary
- add ServerChan notification channel configuration and wiring in hub startup
- route task_notification events through NotificationHub to push, Telegram, and ServerChan channels
- cover task notification parsing and hub dispatch with tests

## Testing
- bun run typecheck
- bun test src/notifications/eventParsing.test.ts src/notifications/notificationHub.test.ts
- bun run build
