### PR TITLE
[codex] support GPT-5.5 model

### DIFF
--- a/cli/src/codex/runCodex.test.ts
+++ b/cli/src/codex/runCodex.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const harness = vi.hoisted(() => ({
+    rpcHandlers: new Map<string, (payload: unknown) => Promise<unknown> | unknown>(),
+    appliedConfig: undefined as unknown,
+    setModels: [] as Array<string | null>
+}));
+
+vi.mock('@/utils/invokedCwd', () => ({
+    getInvokedCwd: () => '/tmp/hapi-codex-test'
+}));
+
+vi.mock('@/agent/sessionFactory', () => ({
+    bootstrapSession: async () => ({
+        api: {},
+        session: {
+            rpcHandlerManager: {
+                registerHandler(method: string, handler: (payload: unknown) => Promise<unknown> | unknown) {
+                    harness.rpcHandlers.set(method, handler);
+                }
+            },
+            onUserMessage: () => {}
+        }
+    })
+}));
+
+vi.mock('@/agent/runnerLifecycle', () => ({
+    createModeChangeHandler: () => () => {},
+    createRunnerLifecycle: () => ({
+        registerProcessHandlers: () => {},
+        cleanupAndExit: async () => {},
+        markCrash: () => {},
+        setExitCode: () => {},
+        setArchiveReason: () => {}
+    }),
+    setControlledByUser: () => {}
+}));
+
+vi.mock('@/claude/registerKillSessionHandler', () => ({
+    registerKillSessionHandler: () => {}
+}));
+
+vi.mock('./loop', () => ({
+    loop: async (opts: {
+        onSessionReady?: (session: {
+            getModel: () => string | null | undefined;
+            getModelReasoningEffort: () => string | null | undefined;
+            setPermissionMode: (mode: string) => void;
+            setModel: (model: string | null) => void;
+            setModelReasoningEffort: (effort: string | null) => void;
+            setCollaborationMode: (mode: string) => void;
+        }) => void;
+    }) => {
+        opts.onSessionReady?.({
+            getModel: () => 'gpt-5.4',
+            getModelReasoningEffort: () => undefined,
+            setPermissionMode: () => {},
+            setModel: (model) => {
+                harness.setModels.push(model);
+            },
+            setModelReasoningEffort: () => {},
+            setCollaborationMode: () => {}
+        });
+
+        const handler = harness.rpcHandlers.get('set-session-config');
+        if (!handler) {
+            throw new Error('set-session-config handler not registered');
+        }
+        harness.appliedConfig = await handler({ model: 'gpt-5.5' });
+    }
+}));
+
+import { runCodex } from './runCodex';
+
+describe('runCodex', () => {
+    afterEach(() => {
+        harness.rpcHandlers.clear();
+        harness.appliedConfig = undefined;
+        harness.setModels = [];
+    });
+
+    it('applies runtime model config to the active Codex session wrapper', async () => {
+        await runCodex({});
+
+        expect(harness.appliedConfig).toEqual({
+            applied: {
+                permissionMode: 'default',
+                model: 'gpt-5.5',
+                modelReasoningEffort: null,
+                collaborationMode: 'default'
+            }
+        });
+        expect(harness.setModels).toEqual([null, 'gpt-5.5']);
+    });
+});

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -167,14 +167,37 @@ export async function runCodex(opts: {
         return value as ReasoningEffort;
     };
 
+    const resolveModel = (value: unknown): string | undefined => {
+        if (value === null) {
+            return undefined;
+        }
+        if (typeof value !== 'string') {
+            throw new Error('Invalid model');
+        }
+        const trimmedModel = value.trim();
+        if (!trimmedModel) {
+            throw new Error('Invalid model');
+        }
+        return trimmedModel;
+    };
+
     session.rpcHandlerManager.registerHandler('set-session-config', async (payload: unknown) => {
         if (!payload || typeof payload !== 'object') {
             throw new Error('Invalid session config payload');
         }
-        const config = payload as { permissionMode?: unknown; modelReasoningEffort?: unknown; collaborationMode?: unknown };
+        const config = payload as {
+            permissionMode?: unknown;
+            model?: unknown;
+            modelReasoningEffort?: unknown;
+            collaborationMode?: unknown;
+        };
 
         if (config.permissionMode !== undefined) {
             currentPermissionMode = resolvePermissionMode(config.permissionMode);
+        }
+
+        if (config.model !== undefined) {
+            currentModel = resolveModel(config.model);
         }
 
         if (config.modelReasoningEffort !== undefined) {
@@ -189,6 +212,7 @@ export async function runCodex(opts: {
         return {
             applied: {
                 permissionMode: currentPermissionMode,
+                model: currentModel ?? null,
                 modelReasoningEffort: currentModelReasoningEffort ?? null,
                 collaborationMode: currentCollaborationMode
             }

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -76,14 +76,6 @@ export async function runCodex(opts: {
         if (!sessionInstance) {
             return;
         }
-        const sessionModel = sessionInstance.getModel();
-        if (sessionModel !== undefined) {
-            currentModel = sessionModel ?? undefined;
-        }
-        const sessionModelReasoningEffort = sessionInstance.getModelReasoningEffort();
-        if (sessionModelReasoningEffort !== undefined) {
-            currentModelReasoningEffort = (sessionModelReasoningEffort ?? undefined) as ReasoningEffort | undefined;
-        }
         sessionInstance.setPermissionMode(currentPermissionMode);
         sessionInstance.setModel(currentModel ?? null);
         sessionInstance.setModelReasoningEffort(currentModelReasoningEffort ?? null);

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -133,6 +133,45 @@ describe('sessions routes', () => {
         ])
     })
 
+    it('rejects model changes for local Codex sessions', async () => {
+        const session = createSession({
+            agentState: {
+                controlledByUser: true,
+                requests: {},
+                completedRequests: {}
+            }
+        })
+        const { app, applySessionConfigCalls } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/model', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ model: 'gpt-5.5' })
+        })
+
+        expect(response.status).toBe(409)
+        expect(await response.json()).toEqual({
+            error: 'Model selection can only be changed for remote Codex sessions'
+        })
+        expect(applySessionConfigCalls).toEqual([])
+    })
+
+    it('applies GPT-5.5 model changes for remote Codex sessions', async () => {
+        const { app, applySessionConfigCalls } = createApp(createSession())
+
+        const response = await app.request('/api/sessions/session-1/model', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ model: 'gpt-5.5' })
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ ok: true })
+        expect(applySessionConfigCalls).toEqual([
+            ['session-1', { model: 'gpt-5.5' }]
+        ])
+    })
+
     it('rejects model reasoning effort changes for non-Codex sessions', async () => {
         const session = createSession({
             metadata: {

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -320,8 +320,11 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         }
 
         const flavor = sessionResult.session.metadata?.flavor ?? 'claude'
-        if (flavor !== 'claude' && flavor !== 'gemini') {
-            return c.json({ error: 'Model selection is only supported for Claude and Gemini sessions' }, 400)
+        if (flavor !== 'claude' && flavor !== 'gemini' && flavor !== 'codex') {
+            return c.json({ error: 'Model selection is only supported for Claude, Gemini, and Codex sessions' }, 400)
+        }
+        if (flavor === 'codex' && sessionResult.session.agentState?.controlledByUser === true) {
+            return c.json({ error: 'Model selection can only be changed for remote Codex sessions' }, 409)
         }
 
         try {

--- a/shared/src/flavors.test.ts
+++ b/shared/src/flavors.test.ts
@@ -22,8 +22,8 @@ describe('hasCapability', () => {
         expect(hasCapability('gemini', Capabilities.Effort)).toBe(false)
     })
 
-    test('codex has no capabilities', () => {
-        expect(hasCapability('codex', Capabilities.ModelChange)).toBe(false)
+    test('codex supports model-change but not effort', () => {
+        expect(hasCapability('codex', Capabilities.ModelChange)).toBe(true)
         expect(hasCapability('codex', Capabilities.Effort)).toBe(false)
     })
 
@@ -86,6 +86,7 @@ describe('convenience functions', () => {
     test('supportsModelChange matches hasCapability', () => {
         expect(supportsModelChange('claude')).toBe(true)
         expect(supportsModelChange('gemini')).toBe(true)
+        expect(supportsModelChange('codex')).toBe(true)
         expect(supportsModelChange('cursor')).toBe(false)
         expect(supportsModelChange(null)).toBe(false)
     })

--- a/shared/src/flavors.ts
+++ b/shared/src/flavors.ts
@@ -12,7 +12,7 @@ export type Capability = typeof Capabilities[keyof typeof Capabilities]
 const FLAVOR_CAPS: Record<AgentFlavor, ReadonlySet<Capability>> = {
     claude: new Set([Capabilities.ModelChange, Capabilities.Effort]),
     gemini: new Set([Capabilities.ModelChange]),
-    codex: new Set([]),
+    codex: new Set([Capabilities.ModelChange]),
     cursor: new Set([]),
     opencode: new Set([]),
 }

--- a/shared/src/models.test.ts
+++ b/shared/src/models.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from 'bun:test'
 import {
     CLAUDE_MODEL_PRESETS,
+    CODEX_MODEL_LABELS,
+    CODEX_MODEL_PRESETS,
     CLAUDE_MODEL_LABELS,
     DEFAULT_GEMINI_MODEL,
     GEMINI_MODEL_LABELS,
     GEMINI_MODEL_PRESETS,
     getClaudeModelLabel,
+    getCodexModelLabel,
     isClaudeModelPreset,
+    isCodexModelPreset,
 } from './models'
 
 describe('isClaudeModelPreset', () => {
@@ -47,10 +51,57 @@ describe('getClaudeModelLabel', () => {
     })
 })
 
+describe('isCodexModelPreset', () => {
+    test('accepts valid presets', () => {
+        for (const preset of CODEX_MODEL_PRESETS) {
+            expect(isCodexModelPreset(preset)).toBe(true)
+        }
+    })
+
+    test('accepts GPT-5.5', () => {
+        expect(isCodexModelPreset('gpt-5.5')).toBe(true)
+    })
+
+    test('rejects unknown model string', () => {
+        expect(isCodexModelPreset('gpt-unknown')).toBe(false)
+    })
+
+    test('rejects null and undefined', () => {
+        expect(isCodexModelPreset(null)).toBe(false)
+        expect(isCodexModelPreset(undefined)).toBe(false)
+    })
+})
+
+describe('getCodexModelLabel', () => {
+    test('returns label for known presets', () => {
+        expect(getCodexModelLabel('gpt-5.5')).toBe('GPT-5.5')
+        expect(getCodexModelLabel('gpt-5.4-mini')).toBe('GPT-5.4 Mini')
+    })
+
+    test('trims whitespace before lookup', () => {
+        expect(getCodexModelLabel('  gpt-5.5  ')).toBe('GPT-5.5')
+    })
+
+    test('returns null for unknown model', () => {
+        expect(getCodexModelLabel('gpt-unknown')).toBeNull()
+    })
+
+    test('returns null for empty/whitespace-only string', () => {
+        expect(getCodexModelLabel('')).toBeNull()
+        expect(getCodexModelLabel('   ')).toBeNull()
+    })
+})
+
 describe('model constants consistency', () => {
     test('every CLAUDE_MODEL_PRESET has a label', () => {
         for (const preset of CLAUDE_MODEL_PRESETS) {
             expect(CLAUDE_MODEL_LABELS[preset]).toBeDefined()
+        }
+    })
+
+    test('every CODEX_MODEL_PRESET has a label', () => {
+        for (const preset of CODEX_MODEL_PRESETS) {
+            expect(CODEX_MODEL_LABELS[preset]).toBeDefined()
         }
     })
 

--- a/shared/src/models.ts
+++ b/shared/src/models.ts
@@ -8,6 +8,20 @@ export const CLAUDE_MODEL_LABELS = {
 export type ClaudeModelPreset = keyof typeof CLAUDE_MODEL_LABELS
 export const CLAUDE_MODEL_PRESETS = Object.keys(CLAUDE_MODEL_LABELS) as ClaudeModelPreset[]
 
+export const CODEX_MODEL_LABELS = {
+    'gpt-5.5': 'GPT-5.5',
+    'gpt-5.4': 'GPT-5.4',
+    'gpt-5.4-mini': 'GPT-5.4 Mini',
+    'gpt-5.3-codex': 'GPT-5.3 Codex',
+    'gpt-5.2-codex': 'GPT-5.2 Codex',
+    'gpt-5.2': 'GPT-5.2',
+    'gpt-5.1-codex-max': 'GPT-5.1 Codex Max',
+    'gpt-5.1-codex-mini': 'GPT-5.1 Codex Mini',
+} as const
+
+export type CodexModelPreset = keyof typeof CODEX_MODEL_LABELS
+export const CODEX_MODEL_PRESETS = Object.keys(CODEX_MODEL_LABELS) as CodexModelPreset[]
+
 export const GEMINI_MODEL_LABELS = {
     'gemini-3.1-pro-preview': 'Gemini 3.1 Pro Preview',
     'gemini-3-flash-preview': 'Gemini 3 Flash Preview',
@@ -24,6 +38,10 @@ export function isClaudeModelPreset(model: string | null | undefined): model is 
     return typeof model === 'string' && Object.hasOwn(CLAUDE_MODEL_LABELS, model)
 }
 
+export function isCodexModelPreset(model: string | null | undefined): model is CodexModelPreset {
+    return typeof model === 'string' && Object.hasOwn(CODEX_MODEL_LABELS, model)
+}
+
 export function getClaudeModelLabel(model: string): string | null {
     const trimmedModel = model.trim()
     if (!trimmedModel) {
@@ -31,4 +49,13 @@ export function getClaudeModelLabel(model: string): string | null {
     }
 
     return CLAUDE_MODEL_LABELS[trimmedModel as ClaudeModelPreset] ?? null
+}
+
+export function getCodexModelLabel(model: string): string | null {
+    const trimmedModel = model.trim()
+    if (!trimmedModel) {
+        return null
+    }
+
+    return CODEX_MODEL_LABELS[trimmedModel as CodexModelPreset] ?? null
 }

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -32,4 +32,4 @@ export type {
     PermissionModeTone
 } from './modes'
 
-export type { ClaudeModelPreset, GeminiModelPreset } from './models'
+export type { ClaudeModelPreset, CodexModelPreset, GeminiModelPreset } from './models'

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -278,7 +278,7 @@ export function HappyComposer(props: {
         () => agentFlavor === 'codex' ? getCodexCollaborationModeOptions() : [],
         [agentFlavor]
     )
-    const claudeModelOptions = useMemo(
+    const modelOptions = useMemo(
         () => getModelOptionsForFlavor(agentFlavor, model),
         [agentFlavor, model]
     )
@@ -586,7 +586,7 @@ export function HappyComposer(props: {
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
                                     {t('misc.model')}
                                 </div>
-                                {claudeModelOptions.map((option) => (
+                                {modelOptions.map((option) => (
                                     <button
                                         key={option.value ?? 'auto'}
                                         type="button"
@@ -726,7 +726,7 @@ export function HappyComposer(props: {
         showModelSettings,
         showModelReasoningEffortSettings,
         showEffortSettings,
-        claudeModelOptions,
+        modelOptions,
         codexReasoningEffortOptions,
         claudeEffortOptions,
         suggestions,

--- a/web/src/components/AssistantChat/modelOptions.test.ts
+++ b/web/src/components/AssistantChat/modelOptions.test.ts
@@ -16,15 +16,33 @@ describe('getModelOptionsForFlavor', () => {
         expect(options.some((o) => o.value === 'opus')).toBe(true)
     })
 
+    it('returns Codex model options for codex flavor', () => {
+        const options = getModelOptionsForFlavor('codex')
+        expect(options[0]).toEqual({ value: null, label: 'Auto' })
+        expect(options[1]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5' })
+        expect(options.some((o) => o.value === 'gpt-5.4-mini')).toBe(true)
+    })
+
     it('includes custom Gemini model from env/config in options', () => {
         const options = getModelOptionsForFlavor('gemini', 'gemini-custom-experiment')
         expect(options.some((o) => o.value === 'gemini-custom-experiment')).toBe(true)
+    })
+
+    it('includes custom Codex model from an active session in options', () => {
+        const options = getModelOptionsForFlavor('codex', 'gpt-next-experiment')
+        expect(options).toContainEqual({ value: 'gpt-next-experiment', label: 'gpt-next-experiment' })
     })
 
     it('does not duplicate a preset Gemini model', () => {
         const options = getModelOptionsForFlavor('gemini', 'gemini-2.5-flash')
         const flashCount = options.filter((o) => o.value === 'gemini-2.5-flash').length
         expect(flashCount).toBe(1)
+    })
+
+    it('does not duplicate a preset Codex model', () => {
+        const options = getModelOptionsForFlavor('codex', 'gpt-5.5')
+        const count = options.filter((o) => o.value === 'gpt-5.5').length
+        expect(count).toBe(1)
     })
 })
 
@@ -37,5 +55,9 @@ describe('getNextModelForFlavor', () => {
     it('cycles Claude models', () => {
         const next = getNextModelForFlavor('claude', null)
         expect(next).not.toBeNull()
+    })
+
+    it('cycles Codex models', () => {
+        expect(getNextModelForFlavor('codex', null)).toBe('gpt-5.5')
     })
 })

--- a/web/src/components/AssistantChat/modelOptions.ts
+++ b/web/src/components/AssistantChat/modelOptions.ts
@@ -4,8 +4,8 @@ import type { ClaudeComposerModelOption } from './claudeModelOptions'
 
 export type ModelOption = ClaudeComposerModelOption
 
-function getGeminiModelOptions(currentModel?: string | null): ModelOption[] {
-    const options = MODEL_OPTIONS.gemini.map((m) => ({
+function getPresetModelOptions(flavor: 'codex' | 'gemini', currentModel?: string | null): ModelOption[] {
+    const options = MODEL_OPTIONS[flavor].map((m) => ({
         value: m.value === 'auto' ? null : m.value,
         label: m.label
     }))
@@ -16,8 +16,8 @@ function getGeminiModelOptions(currentModel?: string | null): ModelOption[] {
     return options
 }
 
-function getNextGeminiModel(currentModel?: string | null): string | null {
-    const options = getGeminiModelOptions(currentModel)
+function getNextPresetModel(flavor: 'codex' | 'gemini', currentModel?: string | null): string | null {
+    const options = getPresetModelOptions(flavor, currentModel)
     const currentIndex = options.findIndex((o) => o.value === (currentModel ?? null))
     if (currentIndex === -1) {
         return options[0]?.value ?? null
@@ -26,15 +26,21 @@ function getNextGeminiModel(currentModel?: string | null): string | null {
 }
 
 export function getModelOptionsForFlavor(flavor: string | undefined | null, currentModel?: string | null): ModelOption[] {
+    if (flavor === 'codex') {
+        return getPresetModelOptions('codex', currentModel)
+    }
     if (flavor === 'gemini') {
-        return getGeminiModelOptions(currentModel)
+        return getPresetModelOptions('gemini', currentModel)
     }
     return getClaudeComposerModelOptions(currentModel)
 }
 
 export function getNextModelForFlavor(flavor: string | undefined | null, currentModel?: string | null): string | null {
+    if (flavor === 'codex') {
+        return getNextPresetModel('codex', currentModel)
+    }
     if (flavor === 'gemini') {
-        return getNextGeminiModel(currentModel)
+        return getNextPresetModel('gemini', currentModel)
     }
     return getNextClaudeComposerModel(currentModel)
 }

--- a/web/src/components/NewSession/types.test.ts
+++ b/web/src/components/NewSession/types.test.ts
@@ -1,4 +1,4 @@
-import { CLAUDE_MODEL_PRESETS, getClaudeModelLabel } from '@hapi/protocol'
+import { CLAUDE_MODEL_PRESETS, CODEX_MODEL_PRESETS, getClaudeModelLabel } from '@hapi/protocol'
 import { describe, expect, it } from 'vitest'
 import { CLAUDE_EFFORT_OPTIONS, MODEL_OPTIONS } from './types'
 
@@ -28,5 +28,13 @@ describe('Claude effort options', () => {
             { value: 'high', label: 'High' },
             { value: 'max', label: 'Max' },
         ])
+    })
+})
+
+describe('Codex model options', () => {
+    it('includes GPT-5.5 first after auto', () => {
+        expect(MODEL_OPTIONS.codex[0]).toEqual({ value: 'auto', label: 'Auto' })
+        expect(MODEL_OPTIONS.codex[1]).toEqual({ value: 'gpt-5.5', label: 'GPT-5.5' })
+        expect(CODEX_MODEL_PRESETS[0]).toBe('gpt-5.5')
     })
 })

--- a/web/src/components/NewSession/types.ts
+++ b/web/src/components/NewSession/types.ts
@@ -1,4 +1,9 @@
-import { GEMINI_MODEL_PRESETS, GEMINI_MODEL_LABELS } from '@hapi/protocol'
+import {
+    CODEX_MODEL_LABELS,
+    CODEX_MODEL_PRESETS,
+    GEMINI_MODEL_LABELS,
+    GEMINI_MODEL_PRESETS,
+} from '@hapi/protocol'
 
 export type AgentType = 'claude' | 'codex' | 'cursor' | 'gemini' | 'opencode'
 export type SessionType = 'simple' | 'worktree'
@@ -15,13 +20,7 @@ export const MODEL_OPTIONS: Record<AgentType, { value: string; label: string }[]
     ],
     codex: [
         { value: 'auto', label: 'Auto' },
-        { value: 'gpt-5.4', label: 'GPT-5.4' },
-        { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
-        { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
-        { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex' },
-        { value: 'gpt-5.2', label: 'GPT-5.2' },
-        { value: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },
-        { value: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini' },
+        ...CODEX_MODEL_PRESETS.map(m => ({ value: m, label: CODEX_MODEL_LABELS[m] })),
     ],
     cursor: [],
     gemini: [

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -63,6 +63,7 @@ export function SessionChat(props: {
     const agentFlavor = props.session.metadata?.flavor ?? null
     const controlledByUser = props.session.agentState?.controlledByUser === true
     const codexCollaborationModeSupported = agentFlavor === 'codex' && !controlledByUser
+    const codexRemoteConfigSupported = agentFlavor === 'codex' && props.session.active && !controlledByUser
     const {
         abortSession,
         switchSession,
@@ -75,7 +76,7 @@ export function SessionChat(props: {
         props.api,
         props.session.id,
         agentFlavor,
-        codexCollaborationModeSupported
+        codexRemoteConfigSupported
     )
 
     // Voice assistant integration
@@ -405,14 +406,18 @@ export function SessionChat(props: {
                         contextSize={reduced.latestUsage?.contextSize}
                         controlledByUser={controlledByUser}
                         onCollaborationModeChange={
-                            codexCollaborationModeSupported && props.session.active && !controlledByUser
+                            codexRemoteConfigSupported
                                 ? handleCollaborationModeChange
                                 : undefined
                         }
                         onPermissionModeChange={handlePermissionModeChange}
-                        onModelChange={handleModelChange}
+                        onModelChange={
+                            agentFlavor === 'codex' && !codexRemoteConfigSupported
+                                ? undefined
+                                : handleModelChange
+                        }
                         onModelReasoningEffortChange={
-                            agentFlavor === 'codex' && props.session.active && !controlledByUser
+                            codexRemoteConfigSupported
                                 ? handleModelReasoningEffortChange
                                 : undefined
                         }


### PR DESCRIPTION
## Summary

- Add shared Codex model presets with GPT-5.5 as the first selectable option.
- Reuse the shared Codex model list in new-session and composer model controls.
- Allow remote Codex sessions to apply model changes through hub and CLI config RPC.

## Impact

Codex sessions can be started or remotely switched to `gpt-5.5`. Local Codex sessions still cannot be reconfigured from the web while controlled by the local user.

## Validation

- `bun test shared/src/models.test.ts shared/src/flavors.test.ts`
- `bun run test -- modelOptions.test.ts types.test.ts` in `web`
- `bun test src/web/routes/sessions.test.ts` in `hub`
- `bun run test -- runCodex.test.ts` in `cli`
- `bun run typecheck` in `cli`, `web`, and `hub`
- `git diff --check`