### PR TITLE
fix: respect Claude's defaultMode from settings.json as permission mode default

### DIFF
--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -20,6 +20,7 @@ import { formatMessageWithAttachments } from '@/utils/attachmentFormatter';
 import { normalizeClaudeSessionModel } from './model';
 import { normalizeClaudeSessionEffort } from './effort';
 import { getInvokedCwd } from '@/utils/invokedCwd';
+import { readClaudeSettings } from '@/claude/utils/claudeSettings';
 
 export interface StartOptions {
     model?: string
@@ -151,7 +152,9 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
     }));
 
     // Forward messages to the queue
-    let currentPermissionMode: PermissionMode = options.permissionMode ?? 'default';
+    const claudeSettings = readClaudeSettings();
+    const claudeDefaultMode = claudeSettings?.permissions?.defaultMode as PermissionMode | undefined;
+    let currentPermissionMode: PermissionMode = options.permissionMode ?? claudeDefaultMode ?? 'default';
     let currentModel: SessionModel = initialModel;
     let currentEffort: SessionEffort = initialEffort;
     let currentFallbackModel: string | undefined = undefined; // Track current fallback model


### PR DESCRIPTION
## Problem

When hapi spawns a Claude session (especially via runner), the `permissionMode` is hardcoded to `'default'`:

```typescript
// runClaude.ts
let currentPermissionMode: PermissionMode = options.permissionMode ?? 'default';
```

This ignores the user's `permissions.defaultMode` configured in `~/.claude/settings.json`. For example, users who set `"defaultMode": "auto"` in their Claude settings will find that hapi overrides it with `default`, causing unexpected permission prompts on every tool call.

## Fix

Use the existing `readClaudeSettings()` utility (already imported in the codebase for `includeCoAuthoredBy`) to read `permissions.defaultMode` from Claude's settings and use it as the fallback:

```typescript
const claudeSettings = readClaudeSettings();
const claudeDefaultMode = claudeSettings?.permissions?.defaultMode as PermissionMode | undefined;
let currentPermissionMode: PermissionMode = options.permissionMode ?? claudeDefaultMode ?? 'default';
```

Priority: explicit hapi `permissionMode` > Claude's `defaultMode` > `'default'`

## Test

1. Set `"permissions": { "defaultMode": "auto" }` in `~/.claude/settings.json`
2. Start a session via hapi runner
3. Verify the session runs with `permissionMode=auto` instead of `permissionMode=default`