### PR TITLE
feat(hub): persist and apply permission mode on inactive session resume

### DIFF
--- a/hub/src/store/index.ts
+++ b/hub/src/store/index.ts
@@ -22,7 +22,7 @@ export { PushStore } from './pushStore'
 export { SessionStore } from './sessionStore'
 export { UserStore } from './userStore'
 
-const SCHEMA_VERSION: number = 7
+const SCHEMA_VERSION: number = 8
 const REQUIRED_TABLES = [
     'sessions',
     'machines',
@@ -98,60 +98,39 @@ export class Store {
             return
         }
 
-        if (currentVersion === 1 && SCHEMA_VERSION === 2) {
-            this.migrateFromV1ToV2()
+        if (currentVersion < 4) {
+            throw new Error(
+                `Database schema version ${currentVersion} is no longer auto-upgradable. ` +
+                'Please reinstall or contact maintainers.'
+            )
+        }
+
+        if (currentVersion === 7) {
+            this.migrateFromV7ToV8()
             this.setUserVersion(SCHEMA_VERSION)
             return
         }
 
-        if (currentVersion === 2 && SCHEMA_VERSION === 3) {
-            this.migrateFromV2ToV3()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 3 && SCHEMA_VERSION === 4) {
-            this.migrateFromV3ToV4()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 4 && SCHEMA_VERSION === 5) {
-            this.migrateFromV4ToV5()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 5 && SCHEMA_VERSION === 6) {
-            this.migrateFromV5ToV6()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 6 && SCHEMA_VERSION === 7) {
+        if (currentVersion === 6) {
             this.migrateFromV6ToV7()
+            this.migrateFromV7ToV8()
             this.setUserVersion(SCHEMA_VERSION)
             return
         }
 
-        if (currentVersion === 4 && SCHEMA_VERSION === 6) {
-            this.migrateFromV4ToV5()
+        if (currentVersion === 5) {
             this.migrateFromV5ToV6()
+            this.migrateFromV6ToV7()
+            this.migrateFromV7ToV8()
             this.setUserVersion(SCHEMA_VERSION)
             return
         }
 
-        if (currentVersion === 4 && SCHEMA_VERSION === 7) {
+        if (currentVersion === 4) {
             this.migrateFromV4ToV5()
             this.migrateFromV5ToV6()
             this.migrateFromV6ToV7()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 5 && SCHEMA_VERSION === 7) {
-            this.migrateFromV5ToV6()
-            this.migrateFromV6ToV7()
+            this.migrateFromV7ToV8()
             this.setUserVersion(SCHEMA_VERSION)
             return
         }
@@ -179,6 +158,7 @@ export class Store {
                 model TEXT,
                 model_reasoning_effort TEXT,
                 effort TEXT,
+                permission_mode TEXT,
                 todos TEXT,
                 todos_updated_at INTEGER,
                 team_state TEXT,
@@ -359,6 +339,13 @@ export class Store {
         const columns = this.getSessionColumnNames()
         if (!columns.has('model_reasoning_effort')) {
             this.db.exec('ALTER TABLE sessions ADD COLUMN model_reasoning_effort TEXT')
+        }
+    }
+
+    private migrateFromV7ToV8(): void {
+        const columns = this.getSessionColumnNames()
+        if (!columns.has('permission_mode')) {
+            this.db.exec('ALTER TABLE sessions ADD COLUMN permission_mode TEXT')
         }
     }
 

--- a/hub/src/store/sessionStore.ts
+++ b/hub/src/store/sessionStore.ts
@@ -11,6 +11,7 @@ import {
     setSessionEffort,
     setSessionModel,
     setSessionModelReasoningEffort,
+    setSessionPermissionMode,
     setSessionTeamState,
     setSessionTodos,
     touchSessionUpdatedAt,
@@ -79,6 +80,10 @@ export class SessionStore {
 
     setSessionEffort(id: string, effort: string | null, namespace: string, options?: { touchUpdatedAt?: boolean }): boolean {
         return setSessionEffort(this.db, id, effort, namespace, options)
+    }
+
+    setSessionPermissionMode(id: string, permissionMode: string | null, namespace: string): boolean {
+        return setSessionPermissionMode(this.db, id, permissionMode, namespace)
     }
 
     touchSessionUpdatedAt(id: string, updatedAt: number, namespace: string): boolean {

--- a/hub/src/store/sessions.ts
+++ b/hub/src/store/sessions.ts
@@ -19,6 +19,7 @@ type DbSessionRow = {
     model: string | null
     model_reasoning_effort: string | null
     effort: string | null
+    permission_mode: string | null
     todos: string | null
     todos_updated_at: number | null
     team_state: string | null
@@ -43,6 +44,7 @@ function toStoredSession(row: DbSessionRow): StoredSession {
         model: row.model,
         modelReasoningEffort: row.model_reasoning_effort,
         effort: row.effort,
+        permissionMode: row.permission_mode,
         todos: safeJsonParse(row.todos),
         todosUpdatedAt: row.todos_updated_at,
         teamState: safeJsonParse(row.team_state),
@@ -334,6 +336,31 @@ export function setSessionEffort(
             effort,
             updated_at: now,
             touch_updated_at: touchUpdatedAt ? 1 : 0
+        })
+
+        return result.changes === 1
+    } catch {
+        return false
+    }
+}
+
+export function setSessionPermissionMode(
+    db: Database,
+    id: string,
+    permissionMode: string | null,
+    namespace: string
+): boolean {
+    try {
+        const result = db.prepare(`
+            UPDATE sessions
+            SET permission_mode = @permission_mode,
+                seq = seq + 1
+            WHERE id = @id
+              AND namespace = @namespace
+        `).run({
+            id,
+            namespace,
+            permission_mode: permissionMode
         })
 
         return result.changes === 1

--- a/hub/src/store/types.ts
+++ b/hub/src/store/types.ts
@@ -12,6 +12,7 @@ export type StoredSession = {
     model: string | null
     modelReasoningEffort: string | null
     effort: string | null
+    permissionMode: string | null
     todos: unknown | null
     todosUpdatedAt: number | null
     teamState: unknown | null

--- a/hub/src/sync/aliveEvents.test.ts
+++ b/hub/src/sync/aliveEvents.test.ts
@@ -108,7 +108,9 @@ describe('alive incremental events', () => {
             expect(engine.getSession(session.id)?.activeAt).toBe(activeAtBeforeSend)
             expect(emittedSocketUpdates.length).toBeGreaterThan(0)
 
-            const update = events.find((event) => event.type === 'session-updated')
+            const update = events.find(
+                (event) => event.type === 'session-updated' && 'thinking' in (event.data ?? {})
+            )
             expect(update).toBeDefined()
             if (!update || update.type !== 'session-updated') {
                 return

--- a/hub/src/sync/aliveEvents.test.ts
+++ b/hub/src/sync/aliveEvents.test.ts
@@ -109,7 +109,8 @@ describe('alive incremental events', () => {
             expect(emittedSocketUpdates.length).toBeGreaterThan(0)
 
             const update = events.find(
-                (event) => event.type === 'session-updated' && 'thinking' in (event.data ?? {})
+                (event): event is Extract<SyncEvent, { type: 'session-updated' }> =>
+                    event.type === 'session-updated' && (event.data as { thinking?: boolean }).thinking === true
             )
             expect(update).toBeDefined()
             if (!update || update.type !== 'session-updated') {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -1,4 +1,4 @@
-import { AgentStateSchema, MetadataSchema, TeamStateSchema } from '@hapi/protocol/schemas'
+import { AgentStateSchema, MetadataSchema, PermissionModeSchema, TeamStateSchema } from '@hapi/protocol/schemas'
 import type { CodexCollaborationMode, PermissionMode, Session } from '@hapi/protocol/types'
 import type { Store } from '../store'
 import { clampAliveTime } from './aliveTime'
@@ -145,7 +145,7 @@ export class SessionCache {
             model: stored.model,
             modelReasoningEffort: stored.modelReasoningEffort,
             effort: stored.effort,
-            permissionMode: existing?.permissionMode,
+            permissionMode: existing?.permissionMode ?? PermissionModeSchema.safeParse(stored.permissionMode).data,
             collaborationMode: existing?.collaborationMode
         }
 
@@ -198,6 +198,9 @@ export class SessionCache {
             this.pendingThinkingUntilBySessionId.delete(session.id)
         }
         if (payload.permissionMode !== undefined) {
+            if (payload.permissionMode !== session.permissionMode) {
+                this.store.sessions.setSessionPermissionMode(payload.sid, payload.permissionMode, session.namespace)
+            }
             session.permissionMode = payload.permissionMode
         }
         if (payload.model !== undefined) {
@@ -388,6 +391,12 @@ export class SessionCache {
         }
 
         if (config.permissionMode !== undefined) {
+            if (config.permissionMode !== session.permissionMode) {
+                const updated = this.store.sessions.setSessionPermissionMode(sessionId, config.permissionMode, session.namespace)
+                if (!updated) {
+                    throw new Error('Failed to update session permission mode')
+                }
+            }
             session.permissionMode = config.permissionMode
         }
         if (config.model !== undefined) {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -145,7 +145,10 @@ export class SessionCache {
             model: stored.model,
             modelReasoningEffort: stored.modelReasoningEffort,
             effort: stored.effort,
-            permissionMode: existing?.permissionMode ?? PermissionModeSchema.safeParse(stored.permissionMode).data,
+            permissionMode: existing?.permissionMode ?? (() => {
+                const parsed = PermissionModeSchema.safeParse(stored.permissionMode)
+                return parsed.success ? parsed.data : undefined
+            })(),
             collaborationMode: existing?.collaborationMode
         }
 

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -202,7 +202,10 @@ export class SessionCache {
         }
         if (payload.permissionMode !== undefined) {
             if (payload.permissionMode !== session.permissionMode) {
-                this.store.sessions.setSessionPermissionMode(payload.sid, payload.permissionMode, session.namespace)
+                const persisted = this.store.sessions.setSessionPermissionMode(payload.sid, payload.permissionMode, session.namespace)
+                if (!persisted) {
+                    console.warn(`[sessionCache] failed to persist permissionMode for ${payload.sid} via keepalive`)
+                }
             }
             session.permissionMode = payload.permissionMode
         }

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -605,6 +605,93 @@ describe('session model', () => {
         }
     })
 
+    it('updates cache permissionMode when applySessionConfig is called on inactive session', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+
+        const session = cache.getOrCreateSession(
+            'session-inactive-perm-config',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude' },
+            null,
+            'default',
+            'sonnet'
+        )
+
+        // Simulate session going inactive
+        cache.handleSessionAlive({ sid: session.id, time: Date.now(), thinking: false })
+        // Force inactive by manipulating activeAt (simulating timeout or session-end)
+        // We test the cache layer directly: applySessionConfig should update permissionMode
+        // regardless of session active state.
+        cache.applySessionConfig(session.id, { permissionMode: 'bypassPermissions' })
+
+        expect(cache.getSession(session.id)?.permissionMode).toBe('bypassPermissions')
+    })
+
+    it('uses opts.permissionMode override when resuming inactive session', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-perm-override-resume',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-perm-ovr',
+                    flavor: 'claude',
+                    claudeSessionId: 'claude-perm-ovr-session'
+                },
+                null,
+                'default',
+                'sonnet'
+            )
+            engine.getOrCreateMachine(
+                'machine-perm-ovr',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-perm-ovr', time: Date.now() })
+
+            // Session starts inactive (no session-alive sent)
+            // Simulate: user toggled mode to 'bypassPermissions' via the route
+            // (after fix, route calls resumeSession with opts.permissionMode)
+
+            let capturedPermissionMode: string | undefined
+            ;(engine as any).rpcGateway.spawnSession = async (
+                _machineId: string,
+                _directory: string,
+                _agent: string,
+                _model?: string,
+                _modelReasoningEffort?: string,
+                _yolo?: boolean,
+                _sessionType?: string,
+                _worktreeName?: string,
+                _resumeSessionId?: string,
+                _effort?: string,
+                permissionMode?: string
+            ) => {
+                capturedPermissionMode = permissionMode
+                return { type: 'success', sessionId: session.id }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            // Call resumeSession with permissionMode override
+            const result = await engine.resumeSession(session.id, 'default', { permissionMode: 'bypassPermissions' })
+
+            expect(result).toEqual({ type: 'success', sessionId: session.id })
+            expect(capturedPermissionMode).toBe('bypassPermissions')
+        } finally {
+            engine.stop()
+        }
+    })
+
     it('passes the cached permissionMode when respawning a resumed session', async () => {
         const store = new Store(':memory:')
         const engine = new SyncEngine(

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -785,6 +785,57 @@ describe('session model', () => {
         expect(stored?.permissionMode).toBe('bypassPermissions')
     })
 
+    it('rejects resumeSession with opts.permissionMode if session became active before spawn', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-toctou-active',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-toctou',
+                    flavor: 'claude',
+                    claudeSessionId: 'claude-toctou'
+                },
+                null,
+                'default',
+                'sonnet'
+            )
+            engine.getOrCreateMachine(
+                'machine-toctou',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-toctou', time: Date.now() })
+
+            // Session starts inactive. Simulate it becoming active between resolve and spawn.
+            ;(engine as any).rpcGateway.spawnSession = async () => {
+                // Race: session becomes active right before spawn
+                engine.handleSessionAlive({ sid: session.id, time: Date.now(), thinking: false })
+                return { type: 'success', sessionId: session.id }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            // When opts.permissionMode is supplied and session became active mid-flight,
+            // the implementation must detect the race and abort the permissionMode write.
+            const result = await engine.resumeSession(session.id, 'default', { permissionMode: 'bypassPermissions' })
+
+            // The session is now active, so the result can be success, but
+            // the cache permissionMode must NOT have been overwritten.
+            expect(engine.getSession(session.id)?.permissionMode).not.toBe('bypassPermissions')
+        } finally {
+            engine.stop()
+        }
+    })
+
     it('does not mutate cache permissionMode when spawn fails', async () => {
         const store = new Store(':memory:')
         const engine = new SyncEngine(

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -765,6 +765,48 @@ describe('session model', () => {
         }
     })
 
+    it('persists permissionMode to SQLite when applySessionConfig is called', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+
+        const session = cache.getOrCreateSession(
+            'session-perm-persist',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude' },
+            null,
+            'default',
+            'sonnet'
+        )
+
+        cache.applySessionConfig(session.id, { permissionMode: 'bypassPermissions' })
+
+        // Must survive a cache eviction and re-load from SQLite
+        const stored = store.sessions.getSession(session.id)
+        expect(stored?.permissionMode).toBe('bypassPermissions')
+    })
+
+    it('restores permissionMode from SQLite when session is refreshed', () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+
+        const session = cache.getOrCreateSession(
+            'session-perm-refresh',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude' },
+            null,
+            'default',
+            'sonnet'
+        )
+
+        // Write directly to SQLite (simulating what applySessionConfig will do)
+        store.sessions.setSessionPermissionMode(session.id, 'bypassPermissions', session.namespace)
+
+        // Force a refresh from SQLite on the same cache (simulates hub restart / eviction)
+        const cache2 = new SessionCache(store, createPublisher([]))
+        const refreshed = cache2.refreshSession(session.id)
+        expect(refreshed?.permissionMode).toBe('bypassPermissions')
+    })
+
     describe('session dedup by agent session ID', () => {
         it('merges duplicate when codexSessionId collides', async () => {
             const store = new Store(':memory:')

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, spyOn } from 'bun:test'
 import { toSessionSummary } from '@hapi/protocol'
 import type { SyncEvent } from '@hapi/protocol/types'
 import { Store } from '../store'
@@ -7,6 +7,13 @@ import { registerSessionHandlers } from '../socket/handlers/cli/sessionHandlers'
 import type { EventPublisher } from './eventPublisher'
 import { SessionCache } from './sessionCache'
 import { SyncEngine } from './syncEngine'
+
+/** Exposes private SyncEngine internals for test stubs without `any` propagation. */
+type EngineInternals = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rpcGateway: { spawnSession: (...args: any[]) => Promise<{ type: 'success'; sessionId: string } | { type: 'error'; message: string }> }
+    sessionCache: SessionCache
+}
 
 function createPublisher(events: SyncEvent[]): EventPublisher {
     return {
@@ -463,7 +470,7 @@ describe('session model', () => {
             let capturedModel: string | undefined
             let capturedModelReasoningEffort: string | undefined
             let capturedEffort: string | undefined
-            ;(engine as any).rpcGateway.spawnSession = async (
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
                 _machineId: string,
                 _directory: string,
                 _agent: string,
@@ -480,7 +487,7 @@ describe('session model', () => {
                 capturedEffort = effort
                 return { type: 'success', sessionId: session.id }
             }
-            ;(engine as any).waitForSessionActive = async () => true
+            spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
 
             const result = await engine.resumeSession(session.id, 'default')
 
@@ -527,7 +534,7 @@ describe('session model', () => {
             engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
 
             let capturedModelReasoningEffort: string | undefined
-            ;(engine as any).rpcGateway.spawnSession = async (
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
                 _machineId: string,
                 _directory: string,
                 _agent: string,
@@ -537,7 +544,7 @@ describe('session model', () => {
                 capturedModelReasoningEffort = modelReasoningEffort
                 return { type: 'success', sessionId: session.id }
             }
-            ;(engine as any).waitForSessionActive = async () => true
+            spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
 
             const result = await engine.resumeSession(session.id, 'default')
 
@@ -580,7 +587,7 @@ describe('session model', () => {
             engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
 
             let capturedResumeSessionId: string | undefined
-            ;(engine as any).rpcGateway.spawnSession = async (
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
                 _machineId: string,
                 _directory: string,
                 _agent: string,
@@ -594,7 +601,7 @@ describe('session model', () => {
                 capturedResumeSessionId = resumeSessionId
                 return { type: 'success', sessionId: session.id }
             }
-            ;(engine as any).waitForSessionActive = async () => true
+            spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
 
             const result = await engine.resumeSession(session.id, 'default')
 
@@ -664,7 +671,7 @@ describe('session model', () => {
             // (after fix, route calls resumeSession with opts.permissionMode)
 
             let capturedPermissionMode: string | undefined
-            ;(engine as any).rpcGateway.spawnSession = async (
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
                 _machineId: string,
                 _directory: string,
                 _agent: string,
@@ -680,7 +687,7 @@ describe('session model', () => {
                 capturedPermissionMode = permissionMode
                 return { type: 'success', sessionId: session.id }
             }
-            ;(engine as any).waitForSessionActive = async () => true
+            spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
 
             // Call resumeSession with permissionMode override
             const result = await engine.resumeSession(session.id, 'default', { permissionMode: 'bypassPermissions' })
@@ -731,7 +738,7 @@ describe('session model', () => {
             engine.handleSessionEnd({ sid: session.id, time: Date.now() })
 
             let capturedPermissionMode: string | undefined
-            ;(engine as any).rpcGateway.spawnSession = async (
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
                 _machineId: string,
                 _directory: string,
                 _agent: string,
@@ -747,7 +754,7 @@ describe('session model', () => {
                 capturedPermissionMode = permissionMode
                 return { type: 'success', sessionId: session.id }
             }
-            ;(engine as any).waitForSessionActive = async () => true
+            spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
 
             const result = await engine.resumeSession(session.id, 'default')
 
@@ -981,7 +988,7 @@ describe('session model', () => {
 
                 // s1 is active, so dedup keeps its live record around
                 const events: SyncEvent[] = []
-                const cache = (engine as any).sessionCache as SessionCache
+                const cache = (engine as unknown as EngineInternals).sessionCache
                 await cache.deduplicateByAgentSessionId(s2.id)
                 expect(cache.getSession(s1.id)).toBeDefined()
 

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -785,6 +785,55 @@ describe('session model', () => {
         expect(stored?.permissionMode).toBe('bypassPermissions')
     })
 
+    it('does not mutate cache permissionMode when spawn fails', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-perm-spawn-fail',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-spawn-fail',
+                    flavor: 'claude',
+                    claudeSessionId: 'claude-spawn-fail'
+                },
+                null,
+                'default',
+                'sonnet'
+            )
+            engine.getOrCreateMachine(
+                'machine-spawn-fail',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-spawn-fail', time: Date.now() })
+
+            // Session starts with default permissionMode
+            expect(engine.getSession(session.id)?.permissionMode).toBeUndefined()
+
+            ;(engine as any).rpcGateway.spawnSession = async () => ({
+                type: 'error',
+                message: 'spawn failed'
+            })
+
+            const result = await engine.resumeSession(session.id, 'default', { permissionMode: 'bypassPermissions' })
+
+            expect(result.type).toBe('error')
+            // Cache must NOT have been mutated to bypassPermissions
+            expect(engine.getSession(session.id)?.permissionMode).toBeUndefined()
+        } finally {
+            engine.stop()
+        }
+    })
+
     it('restores permissionMode from SQLite when session is refreshed', () => {
         const store = new Store(':memory:')
         const events: SyncEvent[] = []

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -7,11 +7,11 @@ import { registerSessionHandlers } from '../socket/handlers/cli/sessionHandlers'
 import type { EventPublisher } from './eventPublisher'
 import { SessionCache } from './sessionCache'
 import { SyncEngine } from './syncEngine'
+import type { RpcGateway } from './rpcGateway'
 
 /** Exposes private SyncEngine internals for test stubs without `any` propagation. */
 type EngineInternals = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rpcGateway: { spawnSession: (...args: any[]) => Promise<{ type: 'success'; sessionId: string } | { type: 'error'; message: string }> }
+    rpcGateway: { spawnSession: RpcGateway['spawnSession'] }
     sessionCache: SessionCache
 }
 
@@ -470,21 +470,10 @@ describe('session model', () => {
             let capturedModel: string | undefined
             let capturedModelReasoningEffort: string | undefined
             let capturedEffort: string | undefined
-            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
-                _machineId: string,
-                _directory: string,
-                _agent: string,
-                model?: string,
-                modelReasoningEffort?: string,
-                _yolo?: boolean,
-                _sessionType?: string,
-                _worktreeName?: string,
-                _resumeSessionId?: string,
-                effort?: string
-            ) => {
-                capturedModel = model
-                capturedModelReasoningEffort = modelReasoningEffort
-                capturedEffort = effort
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (...args: Parameters<RpcGateway['spawnSession']>) => {
+                capturedModel = args[3]
+                capturedModelReasoningEffort = args[4]
+                capturedEffort = args[9]
                 return { type: 'success', sessionId: session.id }
             }
             spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
@@ -534,14 +523,8 @@ describe('session model', () => {
             engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
 
             let capturedModelReasoningEffort: string | undefined
-            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
-                _machineId: string,
-                _directory: string,
-                _agent: string,
-                _model?: string,
-                modelReasoningEffort?: string
-            ) => {
-                capturedModelReasoningEffort = modelReasoningEffort
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (...args: Parameters<RpcGateway['spawnSession']>) => {
+                capturedModelReasoningEffort = args[4]
                 return { type: 'success', sessionId: session.id }
             }
             spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
@@ -587,18 +570,8 @@ describe('session model', () => {
             engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
 
             let capturedResumeSessionId: string | undefined
-            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
-                _machineId: string,
-                _directory: string,
-                _agent: string,
-                _model?: string,
-                _modelReasoningEffort?: string,
-                _yolo?: boolean,
-                _sessionType?: 'simple' | 'worktree',
-                _worktreeName?: string,
-                resumeSessionId?: string
-            ) => {
-                capturedResumeSessionId = resumeSessionId
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (...args: Parameters<RpcGateway['spawnSession']>) => {
+                capturedResumeSessionId = args[8]
                 return { type: 'success', sessionId: session.id }
             }
             spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
@@ -671,20 +644,8 @@ describe('session model', () => {
             // (after fix, route calls resumeSession with opts.permissionMode)
 
             let capturedPermissionMode: string | undefined
-            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
-                _machineId: string,
-                _directory: string,
-                _agent: string,
-                _model?: string,
-                _modelReasoningEffort?: string,
-                _yolo?: boolean,
-                _sessionType?: string,
-                _worktreeName?: string,
-                _resumeSessionId?: string,
-                _effort?: string,
-                permissionMode?: string
-            ) => {
-                capturedPermissionMode = permissionMode
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (...args: Parameters<RpcGateway['spawnSession']>) => {
+                capturedPermissionMode = args[10]
                 return { type: 'success', sessionId: session.id }
             }
             spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
@@ -738,20 +699,8 @@ describe('session model', () => {
             engine.handleSessionEnd({ sid: session.id, time: Date.now() })
 
             let capturedPermissionMode: string | undefined
-            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (
-                _machineId: string,
-                _directory: string,
-                _agent: string,
-                _model?: string,
-                _modelReasoningEffort?: string,
-                _yolo?: boolean,
-                _sessionType?: string,
-                _worktreeName?: string,
-                _resumeSessionId?: string,
-                _effort?: string,
-                permissionMode?: string
-            ) => {
-                capturedPermissionMode = permissionMode
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async (...args: Parameters<RpcGateway['spawnSession']>) => {
+                capturedPermissionMode = args[10]
                 return { type: 'success', sessionId: session.id }
             }
             spyOn(engine, 'waitForSessionActive').mockResolvedValue(true)
@@ -817,12 +766,12 @@ describe('session model', () => {
             engine.handleMachineAlive({ machineId: 'machine-toctou', time: Date.now() })
 
             // Session starts inactive. Simulate it becoming active between resolve and spawn.
-            ;(engine as any).rpcGateway.spawnSession = async () => {
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async () => {
                 // Race: session becomes active right before spawn
                 engine.handleSessionAlive({ sid: session.id, time: Date.now(), thinking: false })
                 return { type: 'success', sessionId: session.id }
             }
-            ;(engine as any).waitForSessionActive = async () => true
+            ;(engine as unknown as { waitForSessionActive: () => Promise<boolean> }).waitForSessionActive = async () => true
 
             // When opts.permissionMode is supplied and session became active mid-flight,
             // the implementation must detect the race and abort the permissionMode write.
@@ -870,7 +819,7 @@ describe('session model', () => {
             // Session starts with default permissionMode
             expect(engine.getSession(session.id)?.permissionMode).toBeUndefined()
 
-            ;(engine as any).rpcGateway.spawnSession = async () => ({
+            ;(engine as unknown as EngineInternals).rpcGateway.spawnSession = async () => ({
                 type: 'error',
                 message: 'spawn failed'
             })

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -399,7 +399,7 @@ export class SyncEngine {
         )
     }
 
-    async resumeSession(sessionId: string, namespace: string): Promise<ResumeSessionResult> {
+    async resumeSession(sessionId: string, namespace: string, opts?: { permissionMode?: PermissionMode }): Promise<ResumeSessionResult> {
         const access = this.sessionCache.resolveSessionAccess(sessionId, namespace)
         if (!access.ok) {
             return {
@@ -457,6 +457,12 @@ export class SyncEngine {
             return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
         }
 
+        if (opts?.permissionMode !== undefined) {
+            this.sessionCache.applySessionConfig(sessionId, { permissionMode: opts.permissionMode })
+        }
+
+        const effectivePermissionMode = opts?.permissionMode ?? session.permissionMode ?? undefined
+
         const spawnResult = await this.rpcGateway.spawnSession(
             targetMachine.id,
             metadata.path,
@@ -468,7 +474,7 @@ export class SyncEngine {
             undefined,
             resumeToken,
             session.effort ?? undefined,
-            session.permissionMode ?? undefined
+            effectivePermissionMode
         )
 
         if (spawnResult.type !== 'success') {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -477,13 +477,29 @@ export class SyncEngine {
             return { type: 'error', message: spawnResult.message, code: 'resume_failed' }
         }
 
-        if (opts?.permissionMode !== undefined) {
-            this.sessionCache.applySessionConfig(sessionId, { permissionMode: opts.permissionMode })
-        }
-
         const becameActive = await this.waitForSessionActive(spawnResult.sessionId)
         if (!becameActive) {
             return { type: 'error', message: 'Session failed to become active', code: 'resume_failed' }
+        }
+
+        if (opts?.permissionMode !== undefined) {
+            // In the normal path, the keepalive received during waitForSessionActive already
+            // carries the mode that was injected into the spawn payload, so handleSessionAlive
+            // will have persisted it to the cache and DB. We only apply a manual fallback if
+            // the session has already gone inactive again before the keepalive arrived (a narrow
+            // race window: session became active enough to unblock waitForSessionActive but then
+            // immediately expired before the keepalive handler ran).
+            const currentSession = this.sessionCache.getSession(sessionId)
+            if (!currentSession?.active) {
+                try {
+                    this.sessionCache.applySessionConfig(sessionId, { permissionMode: opts.permissionMode })
+                } catch (err) {
+                    // Fallback write failed — the session state may be partially stale.
+                    // The next keepalive will self-correct via handleSessionAlive.
+                    const msg = err instanceof Error ? err.message : String(err)
+                    console.warn(`[resumeSession] TOCTOU fallback permissionMode write failed (self-healing via keepalive): ${msg}`)
+                }
+            }
         }
 
         if (spawnResult.sessionId !== access.sessionId) {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -457,10 +457,6 @@ export class SyncEngine {
             return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
         }
 
-        if (opts?.permissionMode !== undefined) {
-            this.sessionCache.applySessionConfig(sessionId, { permissionMode: opts.permissionMode })
-        }
-
         const effectivePermissionMode = opts?.permissionMode ?? session.permissionMode ?? undefined
 
         const spawnResult = await this.rpcGateway.spawnSession(
@@ -479,6 +475,10 @@ export class SyncEngine {
 
         if (spawnResult.type !== 'success') {
             return { type: 'error', message: spawnResult.message, code: 'resume_failed' }
+        }
+
+        if (opts?.permissionMode !== undefined) {
+            this.sessionCache.applySessionConfig(sessionId, { permissionMode: opts.permissionMode })
         }
 
         const becameActive = await this.waitForSessionActive(spawnResult.sessionId)

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -343,6 +343,13 @@ export class SyncEngine {
             collaborationMode?: CodexCollaborationMode
         }
     ): Promise<void> {
+        const session = this.sessionCache.getSession(sessionId)
+        if (!session?.active) {
+            // Session is inactive: update memory cache directly, skip RPC.
+            this.sessionCache.applySessionConfig(sessionId, config)
+            return
+        }
+
         const result = await this.rpcGateway.requestSessionConfig(sessionId, config)
         if (!result || typeof result !== 'object') {
             throw new Error('Invalid response from session config RPC')

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -55,6 +55,11 @@ function createApp(session: Session) {
     const applySessionConfig = async (sessionId: string, config: Record<string, unknown>) => {
         applySessionConfigCalls.push([sessionId, config])
     }
+    const resumeSessionCalls: Array<[string, string, Parameters<SyncEngine['resumeSession']>[2]]> = []
+    const resumeSession = async (sessionId: string, namespace: string, opts?: Parameters<SyncEngine['resumeSession']>[2]) => {
+        resumeSessionCalls.push([sessionId, namespace, opts])
+        return { type: 'success' as const, sessionId }
+    }
     const listCodexModelsForSession = async () => ({
         success: true,
         models: [
@@ -64,6 +69,7 @@ function createApp(session: Session) {
     const engine = {
         resolveSessionAccess: () => ({ ok: true, sessionId: session.id, session }),
         applySessionConfig,
+        resumeSession,
         listCodexModelsForSession
     } as Partial<SyncEngine>
 
@@ -74,7 +80,7 @@ function createApp(session: Session) {
     })
     app.route('/api', createSessionsRoutes(() => engine as SyncEngine))
 
-    return { app, applySessionConfigCalls }
+    return { app, applySessionConfigCalls, resumeSessionCalls }
 }
 
 describe('sessions routes', () => {
@@ -292,6 +298,48 @@ describe('sessions routes', () => {
                 { id: 'gpt-5.5', displayName: 'GPT-5.5', isDefault: true }
             ]
         })
+    })
+
+    it('forwards permissionMode from resume body to engine.resumeSession', async () => {
+        const session = createSession({ active: false })
+        const { app, resumeSessionCalls } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/resume', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ permissionMode: 'bypassPermissions' })
+        })
+
+        expect(response.status).toBe(200)
+        expect(resumeSessionCalls).toHaveLength(1)
+        expect(resumeSessionCalls[0][2]).toEqual({ permissionMode: 'bypassPermissions' })
+    })
+
+    it('accepts resume requests without a body (backward compatible)', async () => {
+        const session = createSession({ active: false })
+        const { app, resumeSessionCalls } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/resume', {
+            method: 'POST'
+        })
+
+        expect(response.status).toBe(200)
+        expect(resumeSessionCalls).toHaveLength(1)
+        expect(resumeSessionCalls[0][2]).toBeUndefined()
+    })
+
+    it('returns 400 when resume body is present but invalid', async () => {
+        const session = createSession({ active: false })
+        const { app, resumeSessionCalls } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/resume', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ permissionMode: 'not-a-valid-mode' })
+        })
+
+        expect(response.status).toBe(400)
+        expect(resumeSessionCalls).toHaveLength(0)
     })
 
     it('accepts permission-mode changes for inactive sessions and updates cache', async () => {

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -293,4 +293,24 @@ describe('sessions routes', () => {
             ]
         })
     })
+
+    it('accepts permission-mode changes for inactive sessions and updates cache', async () => {
+        const session = createSession({
+            active: false,
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'claude' }
+        })
+        const { app, applySessionConfigCalls } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/permission-mode', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ mode: 'bypassPermissions' })
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ ok: true })
+        expect(applySessionConfigCalls).toEqual([
+            ['session-1', { permissionMode: 'bypassPermissions' }]
+        ])
+    })
 })

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -300,8 +300,47 @@ describe('sessions routes', () => {
         })
     })
 
+    it('rejects resume with bypassPermissions for Codex sessions (flavor validation)', async () => {
+        const session = createSession({
+            active: false,
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'codex' }
+        })
+        const { app, resumeSessionCalls } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/resume', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ permissionMode: 'bypassPermissions' })
+        })
+
+        expect(response.status).toBe(400)
+        expect(await response.json()).toMatchObject({ error: expect.stringContaining('permission mode') })
+        expect(resumeSessionCalls).toHaveLength(0)
+    })
+
+    it('allows resume with a valid Codex permissionMode', async () => {
+        const session = createSession({
+            active: false,
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'codex' }
+        })
+        const { app, resumeSessionCalls } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/resume', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ permissionMode: 'yolo' })
+        })
+
+        expect(response.status).toBe(200)
+        expect(resumeSessionCalls).toHaveLength(1)
+        expect(resumeSessionCalls[0][2]).toEqual({ permissionMode: 'yolo' })
+    })
+
     it('forwards permissionMode from resume body to engine.resumeSession', async () => {
-        const session = createSession({ active: false })
+        const session = createSession({
+            active: false,
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'claude' }
+        })
         const { app, resumeSessionCalls } = createApp(session)
 
         const response = await app.request('/api/sessions/session-1/resume', {

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -1,5 +1,6 @@
 import { getPermissionModesForFlavor, isPermissionModeAllowedForFlavor, toSessionSummary } from '@hapi/protocol'
 import { CodexCollaborationModeSchema, PermissionModeSchema } from '@hapi/protocol/schemas'
+import type { PermissionMode } from '@hapi/protocol/types'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import type { SyncEngine, Session } from '../../sync/syncEngine'
@@ -8,6 +9,10 @@ import { requireSessionFromParam, requireSyncEngine } from './guards'
 
 const permissionModeSchema = z.object({
     mode: PermissionModeSchema
+})
+
+const resumeBodySchema = z.object({
+    permissionMode: PermissionModeSchema.optional()
 })
 
 const collaborationModeSchema = z.object({
@@ -107,7 +112,27 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         }
 
         const namespace = c.get('namespace')
-        const result = await engine.resumeSession(sessionResult.sessionId, namespace)
+        const body = await c.req.json().catch(() => null)
+        let requestedPermissionMode: PermissionMode | undefined = undefined
+        if (body !== null) {
+            const parsed = resumeBodySchema.safeParse(body)
+            if (!parsed.success) {
+                return c.json({ error: 'Invalid body' }, 400)
+            }
+            requestedPermissionMode = parsed.data.permissionMode
+        }
+
+        if (requestedPermissionMode !== undefined) {
+            const flavor = sessionResult.session.metadata?.flavor ?? 'claude'
+            if (!isPermissionModeAllowedForFlavor(requestedPermissionMode, flavor)) {
+                return c.json({ error: 'Invalid permission mode for session flavor' }, 400)
+            }
+        }
+
+        const opts = requestedPermissionMode !== undefined
+            ? { permissionMode: requestedPermissionMode }
+            : undefined
+        const result = await engine.resumeSession(sessionResult.sessionId, namespace, opts)
         if (result.type === 'error') {
             const status = result.code === 'no_machine_online' ? 503
                 : result.code === 'access_denied' ? 403

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -112,9 +112,15 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         }
 
         const namespace = c.get('namespace')
-        const body = await c.req.json().catch(() => null)
+        const rawBody = await c.req.text()
         let requestedPermissionMode: PermissionMode | undefined = undefined
-        if (body !== null) {
+        if (rawBody.trim() !== '') {
+            let body: unknown
+            try {
+                body = JSON.parse(rawBody) as unknown
+            } catch {
+                return c.json({ error: 'Invalid body' }, 400)
+            }
             const parsed = resumeBodySchema.safeParse(body)
             if (!parsed.success) {
                 return c.json({ error: 'Invalid body' }, 400)

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -236,7 +236,7 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
             return engine
         }
 
-        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        const sessionResult = requireSessionFromParam(c, engine)
         if (sessionResult instanceof Response) {
             return sessionResult
         }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -268,10 +268,15 @@ export class ApiClient {
         })
     }
 
-    async resumeSession(sessionId: string): Promise<string> {
+    async resumeSession(sessionId: string, opts?: { permissionMode?: PermissionMode }): Promise<string> {
         const response = await this.request<{ sessionId: string }>(
             `/api/sessions/${encodeURIComponent(sessionId)}/resume`,
-            { method: 'POST' }
+            {
+                method: 'POST',
+                ...(opts?.permissionMode !== undefined && {
+                    body: JSON.stringify({ permissionMode: opts.permissionMode })
+                })
+            }
         )
         return response.sessionId
     }

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -274,7 +274,8 @@ function SessionPage() {
                 return currentSessionId
             }
             try {
-                return await api.resumeSession(currentSessionId)
+                const permissionMode = session.permissionMode
+                return await api.resumeSession(currentSessionId, permissionMode !== undefined ? { permissionMode } : undefined)
             } catch (error) {
                 const message = error instanceof Error ? error.message : 'Resume failed'
                 addToast({


### PR DESCRIPTION
## Problem

When a user toggles the permission mode (e.g. to `bypassPermissions`) on an **inactive** session and then resumes it by sending a message, the session spawns with the default permission mode instead of the selected one.

Two gaps caused this:

1. `POST /sessions/:id/permission-mode` rejected inactive sessions with 409 (`requireActive: true` guard), so the in-memory cache was never updated.
2. `POST /sessions/:id/resume` accepted no body, so even if the cache held the right value, the web client had no way to signal the current UI-side toggle state at resume time.

## Solution

**Hub**

- `POST /sessions/:id/permission-mode`: removed the `requireActive` guard. When the session is inactive, the endpoint now updates the in-memory cache directly (via the existing `sessionCache.applySessionConfig`) and skips the RPC call. Active sessions continue to go through RPC as before.
- `syncEngine.applySessionConfig`: factored the active/inactive branch so inactive sessions update cache and return early without attempting RPC.
- `POST /sessions/:id/resume`: accepts an optional body `{ permissionMode?: PermissionMode }`. If provided, the value is validated against the session flavor (returning 400 on mismatch) and forwarded to `resumeSession()` as an override. A body is optional; an empty body or `{}` is treated as no override. A body that fails schema validation returns 400. The `/permission-mode` and `/resume` endpoints validate flavor independently; both reject incompatible modes before any state change.
- `resumeSession(sessionId, namespace, opts?)`: new optional third argument. If spawn fails, the in-memory cache and SQLite are not mutated; the failed spawn RPC may have transiently delivered the requested mode to the CLI, which will resynchronize on the next session-alive heartbeat. A live-check on `session.active` immediately before any fallback cache write prevents a TOCTOU race: in the normal path the keepalive carries the spawned mode and persists it via `handleSessionAlive`; the fallback only applies if the session drops inactive again before the keepalive arrives.
- `permissionMode` is now persisted to SQLite via a new `permission_mode` column (schema v8 migration). `applySessionConfig` calls `setSessionPermissionMode` and throws on failure; `handleSessionAlive` also persists the mode received in keepalives; `refreshSession` restores the value on hub restart.

**Web**

- `api.resumeSession()`: extended with `opts?: { permissionMode? }` — sends the body only when the value is defined, keeping the wire format backward-compatible.
- `router.tsx` resume callback: passes the current `session.permissionMode` (including `'default'`) so the toggle state always travels with the resume request.

**Test infrastructure**

- Replaced `(engine as any)` casts in tests with a typed `EngineInternals` helper and `spyOn`.

## Breaking Changes

- `POST /sessions/:id/permission-mode` now returns `200` for inactive sessions (previously `409`). Clients relying on `409` to detect session liveness must use `GET /sessions/:id` instead.
- `POST /sessions/:id/permission-mode` on inactive sessions now persists the mode change to both the in-memory cache and SQLite (schema v8). Previously, the request returned 409 without any state change. Clients that relied on 409 as an atomicity guarantee should not assume the call has no side effects.

## Usage

1. Start a session and let it become inactive.
2. Toggle the permission mode selector (e.g. switch to YOLO / `bypassPermissions`).
3. Send a message — the session resumes with the selected mode applied.

## Tests

- `hub/src/sync/sessionModel.test.ts`: tests for `opts.permissionMode` delivery to spawn payload; cache-not-mutated on spawn failure; TOCTOU guard; SQLite persistence and restore after refresh.
- `hub/src/web/routes/sessions.test.ts`: flavor rejection on `/resume` (400 for incompatible mode); valid flavor-compatible mode forwarded correctly; invalid body schema returns 400; inactive session permission-mode change returns 200.
- End-to-end behavior is exercised by the unit and route-level integration tests; behavior was additionally verified by hand against a local hub during development.

**Schema migration note**: Schema v8 migration covers v4–v7 paths consistent with the upstream pattern. v1–v3 databases were already not auto-upgradable in the prior code and remain so.
