### PR TITLE
fix(hub,web): apply selected permission mode when resuming inactive sessions

### DIFF
--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -343,6 +343,15 @@ export class SyncEngine {
             collaborationMode?: CodexCollaborationMode
         }
     ): Promise<void> {
+        const session = this.sessionCache.getSession(sessionId)
+        if (!session?.active) {
+            // For inactive sessions, update the in-memory cache directly without
+            // an RPC call — the CLI is not running yet. The updated value will be
+            // passed to the spawned process when the session is resumed.
+            this.sessionCache.applySessionConfig(sessionId, config)
+            return
+        }
+
         const result = await this.rpcGateway.requestSessionConfig(sessionId, config)
         if (!result || typeof result !== 'object') {
             throw new Error('Invalid response from session config RPC')
@@ -392,7 +401,7 @@ export class SyncEngine {
         )
     }
 
-    async resumeSession(sessionId: string, namespace: string): Promise<ResumeSessionResult> {
+    async resumeSession(sessionId: string, namespace: string, opts?: { permissionMode?: PermissionMode }): Promise<ResumeSessionResult> {
         const access = this.sessionCache.resolveSessionAccess(sessionId, namespace)
         if (!access.ok) {
             return {
@@ -450,6 +459,7 @@ export class SyncEngine {
             return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
         }
 
+        const effectivePermissionMode = opts?.permissionMode ?? session.permissionMode ?? undefined
         const spawnResult = await this.rpcGateway.spawnSession(
             targetMachine.id,
             metadata.path,
@@ -461,7 +471,7 @@ export class SyncEngine {
             undefined,
             resumeToken,
             session.effort ?? undefined,
-            session.permissionMode ?? undefined
+            effectivePermissionMode
         )
 
         if (spawnResult.type !== 'success') {

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -50,7 +50,9 @@ function createSession(overrides?: Partial<Session>): Session {
     }
 }
 
-function createApp(session: Session) {
+function createApp(session: Session, opts?: {
+    resumeSession?: (sessionId: string, namespace: string, resumeOpts?: { permissionMode?: string }) => Promise<{ type: string; sessionId?: string; message?: string; code?: string }>
+}) {
     const applySessionConfigCalls: Array<[string, Record<string, unknown>]> = []
     const applySessionConfig = async (sessionId: string, config: Record<string, unknown>) => {
         applySessionConfigCalls.push([sessionId, config])
@@ -61,10 +63,12 @@ function createApp(session: Session) {
             { id: 'gpt-5.5', displayName: 'GPT-5.5', isDefault: true }
         ]
     })
+    const resumeSession = opts?.resumeSession ?? (async (sessionId: string) => ({ type: 'success', sessionId }))
     const engine = {
         resolveSessionAccess: () => ({ ok: true, sessionId: session.id, session }),
         applySessionConfig,
-        listCodexModelsForSession
+        listCodexModelsForSession,
+        resumeSession
     } as Partial<SyncEngine>
 
     const app = new Hono<WebAppEnv>()
@@ -292,5 +296,64 @@ describe('sessions routes', () => {
                 { id: 'gpt-5.5', displayName: 'GPT-5.5', isDefault: true }
             ]
         })
+    })
+
+    it('applies permission mode changes for inactive sessions', async () => {
+        const session = createSession({
+            active: false,
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'claude' }
+        })
+        const { app, applySessionConfigCalls } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/permission-mode', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ mode: 'bypassPermissions' })
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ ok: true })
+        expect(applySessionConfigCalls).toEqual([
+            ['session-1', { permissionMode: 'bypassPermissions' }]
+        ])
+    })
+
+    it('rejects unsupported permission mode for flavor via resume body', async () => {
+        const session = createSession({
+            active: false,
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'codex' }
+        })
+        const { app } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/resume', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ permissionMode: 'bypassPermissions' })
+        })
+
+        expect(response.status).toBe(400)
+    })
+
+    it('passes permissionMode from resume body to resumeSession', async () => {
+        const session = createSession({
+            active: false,
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'claude' }
+        })
+        let capturedResumeOpts: { permissionMode?: string } | undefined
+        const { app } = createApp(session, {
+            resumeSession: async (sessionId, _namespace, resumeOpts) => {
+                capturedResumeOpts = resumeOpts
+                return { type: 'success', sessionId }
+            }
+        })
+
+        const response = await app.request('/api/sessions/session-1/resume', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ permissionMode: 'bypassPermissions' })
+        })
+
+        expect(response.status).toBe(200)
+        expect(capturedResumeOpts).toEqual({ permissionMode: 'bypassPermissions' })
     })
 })

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -10,6 +10,10 @@ const permissionModeSchema = z.object({
     mode: PermissionModeSchema
 })
 
+const resumeBodySchema = z.object({
+    permissionMode: PermissionModeSchema.optional()
+})
+
 const collaborationModeSchema = z.object({
     mode: CodexCollaborationModeSchema
 })
@@ -106,8 +110,26 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
             return sessionResult
         }
 
+        const body = await c.req.json().catch(() => null)
+        const parsed = body ? resumeBodySchema.safeParse(body) : { success: true as const, data: {} }
+        if (!parsed.success) {
+            return c.json({ error: 'Invalid body' }, 400)
+        }
+
+        const { permissionMode } = parsed.data
+        if (permissionMode !== undefined) {
+            const flavor = sessionResult.session.metadata?.flavor ?? 'claude'
+            if (!isPermissionModeAllowedForFlavor(permissionMode, flavor)) {
+                return c.json({ error: 'Invalid permission mode for session flavor' }, 400)
+            }
+        }
+
         const namespace = c.get('namespace')
-        const result = await engine.resumeSession(sessionResult.sessionId, namespace)
+        const result = await engine.resumeSession(
+            sessionResult.sessionId,
+            namespace,
+            permissionMode !== undefined ? { permissionMode } : undefined
+        )
         if (result.type === 'error') {
             const status = result.code === 'no_machine_online' ? 503
                 : result.code === 'access_denied' ? 403
@@ -236,7 +258,7 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
             return engine
         }
 
-        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        const sessionResult = requireSessionFromParam(c, engine)
         if (sessionResult instanceof Response) {
             return sessionResult
         }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -268,10 +268,15 @@ export class ApiClient {
         })
     }
 
-    async resumeSession(sessionId: string): Promise<string> {
+    async resumeSession(sessionId: string, opts?: { permissionMode?: string }): Promise<string> {
         const response = await this.request<{ sessionId: string }>(
             `/api/sessions/${encodeURIComponent(sessionId)}/resume`,
-            { method: 'POST' }
+            {
+                method: 'POST',
+                ...(opts?.permissionMode !== undefined && {
+                    body: JSON.stringify({ permissionMode: opts.permissionMode })
+                })
+            }
         )
         return response.sessionId
     }

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -274,7 +274,7 @@ function SessionPage() {
                 return currentSessionId
             }
             try {
-                return await api.resumeSession(currentSessionId)
+                return await api.resumeSession(currentSessionId, { permissionMode: session.permissionMode ?? undefined })
             } catch (error) {
                 const message = error instanceof Error ? error.message : 'Resume failed'
                 addToast({


### PR DESCRIPTION
## Problem

When a session is inactive (the CLI is not running), toggling the permission mode in the web UI has no visible effect: the `POST /sessions/:id/permission-mode` endpoint returned **409** because it required the session to be active (`requireActive: true`), so the in-memory cache was never updated. As a result, resuming the session always spawned the CLI with the stored default mode, ignoring the user's selection.

## Solution

Three coordinated changes close the gap:

1. **`POST /sessions/:id/permission-mode`** – remove the `requireActive` guard so inactive sessions are accepted. In `SyncEngine.applySessionConfig` an inactive-session branch is added that updates the in-memory cache directly (skipping the RPC call, which requires a running CLI).

2. **`POST /sessions/:id/resume`** – accept an optional `{ permissionMode }` body. The value is validated against the session flavor before being forwarded to `resumeSession`. This lets the web client pass the currently displayed mode at resume time as a safety net.

3. **Web client** – `api.resumeSession` passes `session.permissionMode` in the request body; `SyncEngine.resumeSession` accepts an optional `opts.permissionMode` that takes precedence over the cached value when building the spawn payload.

The in-memory-only approach is intentional: persisting the value across Hub restarts is a separate concern tracked elsewhere.

## Tests

New cases in `hub/src/web/routes/sessions.test.ts`:

- `POST /sessions/:id/permission-mode` returns 200 for inactive sessions and calls `applySessionConfig` with the requested mode.
- `POST /sessions/:id/resume` passes `permissionMode` from the request body through to `resumeSession`.
- `POST /sessions/:id/resume` returns 400 when the requested mode is not supported by the session flavor.