### PR TITLE
Add Codex clear and compact slash commands

### DIFF
--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -169,3 +169,11 @@ export interface TurnInterruptResponse {
     ok: boolean;
     [key: string]: unknown;
 }
+
+export interface ThreadCompactStartParams {
+    threadId: string;
+}
+
+export interface ThreadCompactStartResponse {
+    [key: string]: unknown;
+}

--- a/cli/src/codex/codexAppServerClient.ts
+++ b/cli/src/codex/codexAppServerClient.ts
@@ -13,7 +13,9 @@ import type {
     TurnStartParams,
     TurnStartResponse,
     TurnInterruptParams,
-    TurnInterruptResponse
+    TurnInterruptResponse,
+    ThreadCompactStartParams,
+    ThreadCompactStartResponse
 } from './appServerTypes';
 
 type JsonRpcLiteRequest = {
@@ -171,6 +173,17 @@ export class CodexAppServerClient {
             timeoutMs: 30_000
         });
         return response as TurnInterruptResponse;
+    }
+
+    async compactThread(
+        params: ThreadCompactStartParams,
+        options?: { signal?: AbortSignal }
+    ): Promise<ThreadCompactStartResponse> {
+        const response = await this.sendRequest('thread/compact/start', params, {
+            signal: options?.signal,
+            timeoutMs: CodexAppServerClient.DEFAULT_TIMEOUT_MS
+        });
+        return response as ThreadCompactStartResponse;
     }
 
     async disconnect(): Promise<void> {

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -9,6 +9,7 @@ const harness = vi.hoisted(() => ({
     startThreadIds: [] as string[],
     resumeThreadIds: [] as string[],
     startTurnThreadIds: [] as string[],
+    compactThreadIds: [] as string[],
     remainingThreadSystemErrors: 0
 }));
 
@@ -73,6 +74,11 @@ vi.mock('./codexAppServerClient', () => {
             return {};
         }
 
+        async compactThread(params?: { threadId?: string }): Promise<Record<string, never>> {
+            harness.compactThreadIds.push(params?.threadId ?? 'thread-unknown');
+            return {};
+        }
+
         async disconnect(): Promise<void> {}
     }
 
@@ -117,6 +123,7 @@ function createSessionStub(messages = ['hello from launcher test']) {
     const codexMessages: unknown[] = [];
     const thinkingChanges: boolean[] = [];
     const foundSessionIds: string[] = [];
+    const resetThreadCalls: string[] = [];
     let currentModel: string | null | undefined;
     let agentState: FakeAgentState = {
         requests: {},
@@ -168,6 +175,10 @@ function createSessionStub(messages = ['hello from launcher test']) {
             session.sessionId = id;
             foundSessionIds.push(id);
         },
+        resetCodexThread() {
+            resetThreadCalls.push(session.sessionId ?? 'none');
+            session.sessionId = null;
+        },
         sendAgentMessage(message: unknown) {
             client.sendAgentMessage(message);
         },
@@ -185,6 +196,7 @@ function createSessionStub(messages = ['hello from launcher test']) {
         codexMessages,
         thinkingChanges,
         foundSessionIds,
+        resetThreadCalls,
         rpcHandlers,
         getModel: () => currentModel,
         getAgentState: () => agentState
@@ -199,6 +211,7 @@ describe('codexRemoteLauncher', () => {
         harness.startThreadIds = [];
         harness.resumeThreadIds = [];
         harness.startTurnThreadIds = [];
+        harness.compactThreadIds = [];
         harness.remainingThreadSystemErrors = 0;
     });
 
@@ -259,5 +272,70 @@ describe('codexRemoteLauncher', () => {
         expect(harness.startTurnThreadIds).toEqual(['thread-1', 'thread-2']);
         expect(session.sessionId).toBe('thread-2');
         expect(session.thinking).toBe(false);
+    });
+
+    it('clears codex thread state without starting a turn', async () => {
+        const { session, sessionEvents, resetThreadCalls } = createSessionStub(['/clear', 'next message']);
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(resetThreadCalls).toEqual(['none']);
+        expect(harness.startThreadIds).toEqual(['thread-1']);
+        expect(harness.startTurnThreadIds).toEqual(['thread-1']);
+        expect(sessionEvents).toContainEqual({
+            type: 'message',
+            message: 'Context was reset'
+        });
+        expect(session.sessionId).toBe('thread-1');
+    });
+
+    it('compacts the current thread without starting a turn', async () => {
+        const { session, sessionEvents } = createSessionStub(['first message', '/compact']);
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.startThreadIds).toEqual(['thread-1']);
+        expect(harness.startTurnThreadIds).toEqual(['thread-1']);
+        expect(harness.compactThreadIds).toEqual(['thread-1']);
+        expect(sessionEvents).toContainEqual({
+            type: 'message',
+            message: 'Compaction started'
+        });
+        expect(sessionEvents).toContainEqual({
+            type: 'message',
+            message: 'Compaction completed'
+        });
+    });
+
+    it('reports nothing to compact when no codex thread exists', async () => {
+        const { session, sessionEvents } = createSessionStub(['/compact']);
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.startThreadIds).toEqual([]);
+        expect(harness.startTurnThreadIds).toEqual([]);
+        expect(harness.compactThreadIds).toEqual([]);
+        expect(sessionEvents).toContainEqual({
+            type: 'message',
+            message: 'Nothing to compact'
+        });
+    });
+
+    it('rejects argument-bearing codex slash commands without starting a turn', async () => {
+        const { session, sessionEvents } = createSessionStub(['/compact now']);
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.startThreadIds).toEqual([]);
+        expect(harness.startTurnThreadIds).toEqual([]);
+        expect(harness.compactThreadIds).toEqual([]);
+        expect(sessionEvents).toContainEqual({
+            type: 'message',
+            message: '/compact does not accept arguments'
+        });
     });
 });

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -9,7 +9,9 @@ const harness = vi.hoisted(() => ({
     startThreadIds: [] as string[],
     resumeThreadIds: [] as string[],
     startTurnThreadIds: [] as string[],
+    interruptedTurns: [] as Array<{ threadId: string; turnId: string }>,
     compactThreadIds: [] as string[],
+    suppressTurnCompletion: false,
     remainingThreadSystemErrors: 0
 }));
 
@@ -63,6 +65,10 @@ vi.mock('./codexAppServerClient', () => {
                 return { turn: { id: turnId } };
             }
 
+            if (harness.suppressTurnCompletion) {
+                return { turn: { id: turnId } };
+            }
+
             const completed = { status: 'Completed', turn: { id: turnId } };
             harness.notifications.push({ method: 'turn/completed', params: completed });
             this.notificationHandler?.('turn/completed', completed);
@@ -70,7 +76,11 @@ vi.mock('./codexAppServerClient', () => {
             return { turn: { id: turnId } };
         }
 
-        async interruptTurn(): Promise<Record<string, never>> {
+        async interruptTurn(params?: { threadId?: string; turnId?: string }): Promise<Record<string, never>> {
+            harness.interruptedTurns.push({
+                threadId: params?.threadId ?? 'thread-unknown',
+                turnId: params?.turnId ?? 'turn-unknown'
+            });
             return {};
         }
 
@@ -211,7 +221,9 @@ describe('codexRemoteLauncher', () => {
         harness.startThreadIds = [];
         harness.resumeThreadIds = [];
         harness.startTurnThreadIds = [];
+        harness.interruptedTurns = [];
         harness.compactThreadIds = [];
+        harness.suppressTurnCompletion = false;
         harness.remainingThreadSystemErrors = 0;
     });
 
@@ -290,6 +302,24 @@ describe('codexRemoteLauncher', () => {
         expect(session.sessionId).toBe('thread-1');
     });
 
+    it('interrupts an in-flight turn before clearing codex thread state', async () => {
+        harness.suppressTurnCompletion = true;
+        const { session, sessionEvents, resetThreadCalls } = createSessionStub(['first message', '/clear']);
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.startThreadIds).toEqual(['thread-1']);
+        expect(harness.startTurnThreadIds).toEqual(['thread-1']);
+        expect(harness.interruptedTurns).toEqual([{ threadId: 'thread-1', turnId: 'turn-1' }]);
+        expect(resetThreadCalls).toEqual(['thread-1']);
+        expect(sessionEvents).toContainEqual({
+            type: 'message',
+            message: 'Context was reset'
+        });
+        expect(session.thinking).toBe(false);
+    });
+
     it('compacts the current thread without starting a turn', async () => {
         const { session, sessionEvents } = createSessionStub(['first message', '/compact']);
 
@@ -307,6 +337,24 @@ describe('codexRemoteLauncher', () => {
             type: 'message',
             message: 'Compaction completed'
         });
+    });
+
+    it('interrupts an in-flight turn before compacting the current thread', async () => {
+        harness.suppressTurnCompletion = true;
+        const { session, sessionEvents } = createSessionStub(['first message', '/compact']);
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.startThreadIds).toEqual(['thread-1']);
+        expect(harness.startTurnThreadIds).toEqual(['thread-1']);
+        expect(harness.interruptedTurns).toEqual([{ threadId: 'thread-1', turnId: 'turn-1' }]);
+        expect(harness.compactThreadIds).toEqual(['thread-1']);
+        expect(sessionEvents).toContainEqual({
+            type: 'message',
+            message: 'Compaction completed'
+        });
+        expect(session.thinking).toBe(false);
     });
 
     it('reports nothing to compact when no codex thread exists', async () => {

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -16,6 +16,7 @@ import { AppServerEventConverter } from './utils/appServerEventConverter';
 import { registerAppServerPermissionHandlers } from './utils/appServerPermissionAdapter';
 import { buildThreadStartParams, buildTurnStartParams } from './utils/appServerConfig';
 import { shouldIgnoreTerminalEvent } from './utils/terminalEventGuard';
+import { parseCodexSpecialCommand } from './codexSpecialCommands';
 import {
     RemoteLauncherBase,
     type RemoteLauncherDisplayContext,
@@ -609,6 +610,106 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             readyAfterTurnTimer.unref?.();
         };
 
+        const sendVisibleStatus = (message: string) => {
+            messageBuffer.addMessage(message, 'status');
+            session.sendSessionEvent({ type: 'message', message });
+        };
+
+        const resetCurrentTurnState = () => {
+            turnInFlight = false;
+            allowAnonymousTerminalEvent = false;
+            this.currentTurnId = null;
+            permissionHandler.reset();
+            reasoningProcessor.abort();
+            diffProcessor.reset();
+            appServerEventConverter.reset();
+            session.onThinkingChange(false);
+        };
+
+        const resumeExistingThreadForCompact = async (mode: EnhancedMode): Promise<string | null> => {
+            if (this.currentThreadId && this.currentThreadId !== invalidThreadId) {
+                hasThread = true;
+                return this.currentThreadId;
+            }
+
+            const resumeCandidate = session.sessionId && session.sessionId !== invalidThreadId
+                ? session.sessionId
+                : null;
+            if (!resumeCandidate) {
+                return null;
+            }
+
+            const threadParams = buildThreadStartParams({
+                cwd: session.path,
+                mode,
+                mcpServers,
+                cliOverrides: session.codexCliOverrides
+            });
+
+            try {
+                const resumeResponse = await appServerClient.resumeThread({
+                    threadId: resumeCandidate,
+                    ...threadParams
+                }, {
+                    signal: this.abortController.signal
+                });
+                const resumeRecord = asRecord(resumeResponse);
+                const resumeThread = resumeRecord ? asRecord(resumeRecord.thread) : null;
+                const threadId = asString(resumeThread?.id) ?? resumeCandidate;
+                applyResolvedModel(resumeRecord?.model);
+                this.currentThreadId = threadId;
+                session.onSessionFound(threadId);
+                hasThread = true;
+                logger.debug(`[Codex] Resumed app-server thread ${threadId} for /compact`);
+                return threadId;
+            } catch (error) {
+                logger.warn(`[Codex] Failed to resume app-server thread ${resumeCandidate} for /compact`, error);
+                return null;
+            }
+        };
+
+        const handleSpecialCommand = async (message: QueuedMessage): Promise<boolean> => {
+            const specialCommand = parseCodexSpecialCommand(message.message);
+            if (!specialCommand.type) {
+                return false;
+            }
+
+            if (specialCommand.type === 'invalid') {
+                resetCurrentTurnState();
+                sendVisibleStatus(specialCommand.message);
+                return true;
+            }
+
+            if (specialCommand.type === 'clear') {
+                resetCurrentTurnState();
+                this.currentThreadId = null;
+                invalidThreadId = null;
+                hasThread = false;
+                session.resetCodexThread();
+                sendVisibleStatus('Context was reset');
+                return true;
+            }
+
+            resetCurrentTurnState();
+            const threadId = await resumeExistingThreadForCompact(message.mode);
+            if (!threadId) {
+                sendVisibleStatus('Nothing to compact');
+                return true;
+            }
+
+            sendVisibleStatus('Compaction started');
+            try {
+                await appServerClient.compactThread({ threadId }, {
+                    signal: this.abortController.signal
+                });
+                sendVisibleStatus('Compaction completed');
+            } catch (error) {
+                const detail = error instanceof Error ? error.message : String(error);
+                sendVisibleStatus(`Compaction failed: ${detail}`);
+            }
+            return true;
+        };
+
         while (!this.shouldExit) {
             logActiveHandles('loop-top');
             let message: QueuedMessage | null = pending;
@@ -634,6 +735,10 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             messageBuffer.addMessage(message.message, 'user');
 
             try {
+                if (await handleSpecialCommand(message)) {
+                    continue;
+                }
+
                 if (!hasThread) {
                     const threadParams = buildThreadStartParams({
                         cwd: session.path,

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -626,6 +626,20 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             session.onThinkingChange(false);
         };
 
+        const interruptActiveTurn = async () => {
+            const threadId = this.currentThreadId;
+            const turnId = this.currentTurnId;
+            if (!threadId || !turnId) {
+                return;
+            }
+
+            try {
+                await appServerClient.interruptTurn({ threadId, turnId });
+            } catch (error) {
+                logger.debug('[Codex] Error interrupting app-server turn for slash command:', error);
+            }
+        };
+
         const resumeExistingThreadForCompact = async (mode: EnhancedMode): Promise<string | null> => {
             if (this.currentThreadId && this.currentThreadId !== invalidThreadId) {
                 hasThread = true;
@@ -675,12 +689,14 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             }
 
             if (specialCommand.type === 'invalid') {
+                await interruptActiveTurn();
                 resetCurrentTurnState();
                 sendVisibleStatus(specialCommand.message);
                 return true;
             }
 
             if (specialCommand.type === 'clear') {
+                await interruptActiveTurn();
                 resetCurrentTurnState();
                 this.currentThreadId = null;
                 invalidThreadId = null;
@@ -690,6 +706,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 return true;
             }
 
+            await interruptActiveTurn();
             resetCurrentTurnState();
             const threadId = await resumeExistingThreadForCompact(message.mode);
             if (!threadId) {

--- a/cli/src/codex/codexSpecialCommands.test.ts
+++ b/cli/src/codex/codexSpecialCommands.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { parseCodexSpecialCommand } from './codexSpecialCommands';
+
+describe('parseCodexSpecialCommand', () => {
+    it('accepts exact /clear and /compact commands', () => {
+        expect(parseCodexSpecialCommand('  /clear  ')).toEqual({ type: 'clear' });
+        expect(parseCodexSpecialCommand('/compact')).toEqual({ type: 'compact' });
+    });
+
+    it('rejects argument-bearing special commands without treating them as prompts', () => {
+        expect(parseCodexSpecialCommand('/clear now')).toEqual({
+            type: 'invalid',
+            command: 'clear',
+            message: '/clear does not accept arguments'
+        });
+        expect(parseCodexSpecialCommand('/compact summarize this')).toEqual({
+            type: 'invalid',
+            command: 'compact',
+            message: '/compact does not accept arguments'
+        });
+    });
+
+    it('ignores regular slash-like messages', () => {
+        expect(parseCodexSpecialCommand('/clearing')).toEqual({ type: null });
+        expect(parseCodexSpecialCommand('please /clear')).toEqual({ type: null });
+    });
+});

--- a/cli/src/codex/codexSpecialCommands.ts
+++ b/cli/src/codex/codexSpecialCommands.ts
@@ -1,0 +1,29 @@
+export type CodexSpecialCommand =
+    | { type: 'clear' | 'compact' }
+    | { type: 'invalid'; command: 'clear' | 'compact'; message: string }
+    | { type: null };
+
+export function parseCodexSpecialCommand(message: string): CodexSpecialCommand {
+    const trimmed = message.trim();
+    if (trimmed === '/clear') {
+        return { type: 'clear' };
+    }
+    if (trimmed === '/compact') {
+        return { type: 'compact' };
+    }
+    if (trimmed.startsWith('/clear ')) {
+        return {
+            type: 'invalid',
+            command: 'clear',
+            message: '/clear does not accept arguments'
+        };
+    }
+    if (trimmed.startsWith('/compact ')) {
+        return {
+            type: 'invalid',
+            command: 'compact',
+            message: '/compact does not accept arguments'
+        };
+    }
+    return { type: null };
+}

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -13,6 +13,7 @@ import { CodexCollaborationModeSchema, PermissionModeSchema } from '@hapi/protoc
 import { formatMessageWithAttachments } from '@/utils/attachmentFormatter';
 import { getInvokedCwd } from '@/utils/invokedCwd';
 import type { ReasoningEffort } from './appServerTypes';
+import { parseCodexSpecialCommand } from './codexSpecialCommands';
 
 export { emitReadyIfIdle } from './utils/emitReadyIfIdle';
 
@@ -120,6 +121,13 @@ export async function runCodex(opts: {
             modelReasoningEffort: currentModelReasoningEffort,
             collaborationMode: currentCollaborationMode
         };
+        const specialCommand = parseCodexSpecialCommand(message.content.text);
+        if (specialCommand.type) {
+            logger.debug(`[Codex] Detected special command: ${specialCommand.type}`);
+            messageQueue.pushIsolateAndClear(message.content.text.trim(), enhancedMode, localId);
+            return;
+        }
+
         const formattedText = formatMessageWithAttachments(message.content.text, message.content.attachments);
         messageQueue.push(formattedText, enhancedMode, localId);
     });

--- a/cli/src/codex/session.ts
+++ b/cli/src/codex/session.ts
@@ -4,7 +4,7 @@ import { AgentSessionBase } from '@/agent/sessionBase';
 import type { EnhancedMode, PermissionMode } from './loop';
 import type { CodexCliOverrides } from './utils/codexCliOverrides';
 import type { LocalLaunchExitReason } from '@/agent/localLaunchPolicy';
-import type { SessionModel, SessionModelReasoningEffort } from '@/api/types';
+import type { Metadata, SessionModel, SessionModelReasoningEffort } from '@/api/types';
 
 type LocalLaunchFailure = {
     message: string;
@@ -93,6 +93,16 @@ export class CodexSession extends AgentSessionBase<EnhancedMode> {
 
     resetTranscriptPath(): void {
         this.transcriptPath = null;
+    }
+
+    resetCodexThread(): void {
+        this.sessionId = null;
+        this.resetTranscriptPath();
+        this.client.updateMetadata((metadata: Metadata) => {
+            const updated = { ...metadata };
+            delete updated.codexSessionId;
+            return updated;
+        });
     }
 
     setPermissionMode = (mode: PermissionMode): void => {

--- a/cli/src/modules/common/slashCommands.test.ts
+++ b/cli/src/modules/common/slashCommands.test.ts
@@ -6,19 +6,25 @@ import { listSlashCommands } from './slashCommands'
 
 describe('listSlashCommands', () => {
     const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
+    const originalCodexHome = process.env.CODEX_HOME
     let sandboxDir: string
     let claudeConfigDir: string
+    let codexHome: string
     let projectDir: string
 
     beforeEach(async () => {
         sandboxDir = await mkdtemp(join(tmpdir(), 'hapi-slash-commands-'))
         claudeConfigDir = join(sandboxDir, 'global-claude')
+        codexHome = join(sandboxDir, 'global-codex')
         projectDir = join(sandboxDir, 'project')
 
         process.env.CLAUDE_CONFIG_DIR = claudeConfigDir
+        process.env.CODEX_HOME = codexHome
 
         await mkdir(join(claudeConfigDir, 'commands'), { recursive: true })
+        await mkdir(join(codexHome, 'prompts'), { recursive: true })
         await mkdir(join(projectDir, '.claude', 'commands'), { recursive: true })
+        await mkdir(join(projectDir, '.codex', 'prompts'), { recursive: true })
     })
 
     afterEach(async () => {
@@ -26,6 +32,11 @@ describe('listSlashCommands', () => {
             delete process.env.CLAUDE_CONFIG_DIR
         } else {
             process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
+        }
+        if (originalCodexHome === undefined) {
+            delete process.env.CODEX_HOME
+        } else {
+            process.env.CODEX_HOME = originalCodexHome
         }
 
         await rm(sandboxDir, { recursive: true, force: true })
@@ -97,5 +108,26 @@ describe('listSlashCommands', () => {
         const nonExistentProjectDir = join(sandboxDir, 'not-exists')
 
         await expect(listSlashCommands('claude', nonExistentProjectDir)).resolves.toBeDefined()
+    })
+
+    it('lists supported codex built-ins', async () => {
+        const commands = await listSlashCommands('codex', projectDir)
+
+        expect(commands.filter(cmd => cmd.source === 'builtin').map(cmd => cmd.name)).toEqual(['clear', 'compact'])
+    })
+
+    it('lets project codex prompts override same-name built-ins', async () => {
+        await writeFile(
+            join(projectDir, '.codex', 'prompts', 'clear.md'),
+            ['---', 'description: Project clear', '---', '', 'Project clear prompt'].join('\n')
+        )
+
+        const commands = await listSlashCommands('codex', projectDir)
+        const clearCommands = commands.filter(cmd => cmd.name === 'clear')
+
+        expect(clearCommands).toHaveLength(1)
+        expect(clearCommands[0]?.source).toBe('project')
+        expect(clearCommands[0]?.description).toBe('Project clear')
+        expect(clearCommands[0]?.content).toBe('Project clear prompt')
     })
 })

--- a/cli/src/modules/common/slashCommands.ts
+++ b/cli/src/modules/common/slashCommands.ts
@@ -32,7 +32,10 @@ const BUILTIN_COMMANDS: Record<string, SlashCommand[]> = {
         { name: 'cost', description: 'Show session cost', source: 'builtin' },
         { name: 'plan', description: 'Toggle plan mode', source: 'builtin' },
     ],
-    codex: [],
+    codex: [
+        { name: 'clear', description: 'Clear current Codex thread context', source: 'builtin' },
+        { name: 'compact', description: 'Compact current Codex thread context', source: 'builtin' },
+    ],
     gemini: [
         { name: 'about', description: 'About Gemini', source: 'builtin' },
         { name: 'clear', description: 'Clear conversation', source: 'builtin' },

--- a/hub/src/sync/aliveEvents.test.ts
+++ b/hub/src/sync/aliveEvents.test.ts
@@ -108,7 +108,12 @@ describe('alive incremental events', () => {
             expect(engine.getSession(session.id)?.activeAt).toBe(activeAtBeforeSend)
             expect(emittedSocketUpdates.length).toBeGreaterThan(0)
 
-            const update = events.find((event) => event.type === 'session-updated')
+            const update = events.find((event) => {
+                return event.type === 'session-updated'
+                    && typeof event.data === 'object'
+                    && event.data !== null
+                    && (event.data as { thinking?: unknown }).thinking === true
+            })
             expect(update).toBeDefined()
             if (!update || update.type !== 'session-updated') {
                 return

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -20,7 +20,7 @@ import { HappyComposer } from '@/components/AssistantChat/HappyComposer'
 import { HappyThread } from '@/components/AssistantChat/HappyThread'
 import { useHappyRuntime } from '@/lib/assistant-runtime'
 import { createAttachmentAdapter } from '@/lib/attachmentAdapter'
-import { findUnsupportedCodexBuiltinSlashCommand } from '@/lib/codexSlashCommands'
+import { findCodexCustomPromptExpansion, findUnsupportedCodexBuiltinSlashCommand } from '@/lib/codexSlashCommands'
 import { useToast } from '@/lib/toast-context'
 import { useTranslation } from '@/lib/use-translation'
 import { SessionHeader } from '@/components/SessionHeader'
@@ -349,7 +349,16 @@ export function SessionChat(props: {
     }, [navigate, props.session.id])
 
     const handleSend = useCallback((text: string, attachments?: AttachmentMetadata[]) => {
+        let textToSend = text
         if (agentFlavor === 'codex') {
+            const customPrompt = findCodexCustomPromptExpansion(
+                text,
+                props.availableSlashCommands ?? []
+            )
+            if (customPrompt) {
+                textToSend = customPrompt
+            }
+
             const unsupportedCommand = findUnsupportedCodexBuiltinSlashCommand(
                 text,
                 props.availableSlashCommands ?? []
@@ -366,7 +375,7 @@ export function SessionChat(props: {
             }
         }
 
-        props.onSend(text, attachments)
+        props.onSend(textToSend, attachments)
         setForceScrollToken((token) => token + 1)
     }, [agentFlavor, props.availableSlashCommands, props.onSend, props.session.id, addToast, haptic, t])
 

--- a/web/src/hooks/queries/useSlashCommands.ts
+++ b/web/src/hooks/queries/useSlashCommands.ts
@@ -4,7 +4,7 @@ import type { ApiClient } from '@/api/client'
 import type { SlashCommand } from '@/types/api'
 import type { Suggestion } from '@/hooks/useActiveSuggestions'
 import { queryKeys } from '@/lib/query-keys'
-import { getBuiltinSlashCommands } from '@/lib/codexSlashCommands'
+import { getBuiltinSlashCommands, mergeSlashCommands } from '@/lib/codexSlashCommands'
 
 function levenshteinDistance(a: string, b: string): number {
     if (a.length === 0) return b.length
@@ -58,7 +58,7 @@ export function useSlashCommands(
             const extraCommands = query.data.commands.filter(
                 cmd => cmd.source === 'user' || cmd.source === 'plugin' || cmd.source === 'project'
             )
-            return [...builtin, ...extraCommands]
+            return mergeSlashCommands([...builtin, ...extraCommands])
         }
 
         // Fallback to built-in commands only

--- a/web/src/lib/codexSlashCommands.test.ts
+++ b/web/src/lib/codexSlashCommands.test.ts
@@ -1,9 +1,49 @@
 import { describe, expect, it } from 'vitest'
-import { findUnsupportedCodexBuiltinSlashCommand, getBuiltinSlashCommands } from './codexSlashCommands'
+import {
+    findCodexCustomPromptExpansion,
+    findUnsupportedCodexBuiltinSlashCommand,
+    getBuiltinSlashCommands,
+    mergeSlashCommands
+} from './codexSlashCommands'
 
 describe('getBuiltinSlashCommands', () => {
-    it('does not expose codex built-ins in remote web mode', () => {
-        expect(getBuiltinSlashCommands('codex')).toEqual([])
+    it('exposes supported codex built-ins in remote web mode', () => {
+        expect(getBuiltinSlashCommands('codex').map(command => command.name)).toEqual(['clear', 'compact'])
+    })
+})
+
+describe('mergeSlashCommands', () => {
+    it('lets custom commands override same-name built-ins', () => {
+        const commands = mergeSlashCommands([
+            { name: 'clear', source: 'builtin' },
+            { name: 'compact', source: 'builtin' },
+            { name: 'clear', source: 'project', content: 'project clear prompt' }
+        ])
+
+        expect(commands).toEqual([
+            { name: 'compact', source: 'builtin' },
+            { name: 'clear', source: 'project', content: 'project clear prompt' }
+        ])
+    })
+})
+
+describe('findCodexCustomPromptExpansion', () => {
+    it('expands exact custom codex prompt commands', () => {
+        expect(findCodexCustomPromptExpansion('  /clear  ', [
+            { name: 'clear', source: 'builtin' },
+            { name: 'clear', source: 'project', content: 'custom clear prompt' }
+        ])).toBe('custom clear prompt')
+    })
+
+    it('ignores built-ins and commands with arguments', () => {
+        const commands = [
+            { name: 'compact', source: 'project', content: 'custom compact prompt' }
+        ] as const
+
+        expect(findCodexCustomPromptExpansion('/compact now', commands)).toBeNull()
+        expect(findCodexCustomPromptExpansion('/clear', [
+            { name: 'clear', source: 'builtin' }
+        ])).toBeNull()
     })
 })
 

--- a/web/src/lib/codexSlashCommands.ts
+++ b/web/src/lib/codexSlashCommands.ts
@@ -11,9 +11,10 @@ const BUILTIN_COMMANDS: Record<string, SlashCommand[]> = {
         { name: 'stats', description: 'Show your Claude Code usage statistics and activity', source: 'builtin' },
         { name: 'status', description: 'Show Claude Code status including version, model, account, and API connectivity', source: 'builtin' },
     ],
-    // Codex remote turns send slash-prefixed input as plain text to app-server.
-    // Hide built-ins here until remote slash command execution is implemented end-to-end.
-    codex: [],
+    codex: [
+        { name: 'clear', description: 'Clear current Codex thread context', source: 'builtin' },
+        { name: 'compact', description: 'Compact current Codex thread context', source: 'builtin' },
+    ],
     gemini: [
         { name: 'about', description: 'Show version info', source: 'builtin' },
         { name: 'clear', description: 'Clear the screen and conversation history', source: 'builtin' },
@@ -34,6 +35,42 @@ const UNSUPPORTED_CODEX_BUILTIN_COMMANDS = new Set([
 
 export function getBuiltinSlashCommands(agentType: string): SlashCommand[] {
     return BUILTIN_COMMANDS[agentType] ?? BUILTIN_COMMANDS.claude ?? []
+}
+
+export function mergeSlashCommands(commands: readonly SlashCommand[]): SlashCommand[] {
+    const commandMap = new Map<string, SlashCommand>()
+    for (const command of commands) {
+        const key = command.name.toLowerCase()
+        if (commandMap.has(key)) {
+            commandMap.delete(key)
+        }
+        commandMap.set(key, command)
+    }
+    return Array.from(commandMap.values())
+}
+
+export function findCodexCustomPromptExpansion(
+    text: string,
+    availableCommands: readonly SlashCommand[]
+): string | null {
+    const trimmed = text.trim()
+    const match = /^\/([a-z0-9:_-]+)$/i.exec(trimmed)
+    if (!match) {
+        return null
+    }
+
+    const commandName = match[1]?.toLowerCase()
+    if (!commandName) {
+        return null
+    }
+
+    const command = availableCommands.find(
+        candidate => candidate.source !== 'builtin'
+            && candidate.name.toLowerCase() === commandName
+            && typeof candidate.content === 'string'
+            && candidate.content.length > 0
+    )
+    return command?.content ?? null
 }
 
 export function findUnsupportedCodexBuiltinSlashCommand(


### PR DESCRIPTION
## Summary
- expose supported Codex `/clear` and `/compact` slash commands in CLI and web command lists
- handle Codex remote `/clear` by resetting the current app-server thread while keeping the HAPI session
- handle Codex remote `/compact` via app-server `thread/compact/start` instead of sending it as a prompt
- let custom `.codex/prompts/*.md` commands override built-ins and expand exact manual custom commands

## Tests
- `bun run typecheck`
- `bun run test`