### PR TITLE
feat(web): float queued messages above composer until invocation

### DIFF
--- a/hub/src/socket/handlers/cli/sessionHandlers.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.ts
@@ -294,6 +294,30 @@ export function registerSessionHandlers(socket: CliSocketWithData, deps: Session
             emitAccessError('session', data.sid, sessionAccess.reason)
             return
         }
+
+        // Force-invoke any user messages that are still queued at session end.
+        // Without this, the floating bar pins the queued rows after the CLI is
+        // gone — there is no longer an ack path (no CLI to emit
+        // messages-consumed) so they would stay queued forever.
+        try {
+            const queued = store.messages.getUninvokedLocalMessages(data.sid)
+            const localIds = queued
+                .map((m) => m.localId)
+                .filter((id): id is string => typeof id === 'string')
+            if (localIds.length > 0) {
+                const invokedAt = Date.now()
+                store.messages.markMessagesInvoked(data.sid, localIds, invokedAt)
+                onWebappEvent?.({
+                    type: 'messages-consumed',
+                    sessionId: data.sid,
+                    localIds,
+                    invokedAt
+                })
+            }
+        } catch (err) {
+            console.error('session-end markMessagesInvoked failed', err)
+        }
+
         onSessionEnd?.(data)
     })
 }

--- a/hub/src/socket/handlers/cli/sessionHandlers.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.ts
@@ -150,7 +150,8 @@ export function registerSessionHandlers(socket: CliSocketWithData, deps: Session
                 seq: msg.seq,
                 localId: msg.localId,
                 content: msg.content,
-                createdAt: msg.createdAt
+                createdAt: msg.createdAt,
+                invokedAt: msg.invokedAt
             }
         })
     })

--- a/hub/src/socket/handlers/cli/sessionHandlers.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.ts
@@ -279,10 +279,14 @@ export function registerSessionHandlers(socket: CliSocketWithData, deps: Session
         try {
             store.messages.markMessagesInvoked(data.sid, localIds, invokedAt)
             onSessionActivity?.(data.sid, invokedAt)
+            // Emit only after the DB write succeeds. Otherwise a transient SQLite
+            // failure would broadcast an `invokedAt` that was never persisted —
+            // live clients would hide the queued rows while a refresh / secondary
+            // client would see them as queued again, diverging the state.
+            onWebappEvent?.({ type: 'messages-consumed', sessionId: data.sid, localIds, invokedAt })
         } catch (err) {
             console.error('markMessagesInvoked failed', err)
         }
-        onWebappEvent?.({ type: 'messages-consumed', sessionId: data.sid, localIds, invokedAt })
     })
 
     socket.on('session-end', (data: SessionEndPayload) => {

--- a/hub/src/socket/handlers/cli/sessionHandlers.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.ts
@@ -274,7 +274,14 @@ export function registerSessionHandlers(socket: CliSocketWithData, deps: Session
             emitAccessError('session', data.sid, sessionAccess.reason)
             return
         }
-        onWebappEvent?.({ type: 'messages-consumed', sessionId: data.sid, localIds })
+        const invokedAt = Date.now()
+        try {
+            store.messages.markMessagesInvoked(data.sid, localIds, invokedAt)
+            onSessionActivity?.(data.sid, invokedAt)
+        } catch (err) {
+            console.error('markMessagesInvoked failed', err)
+        }
+        onWebappEvent?.({ type: 'messages-consumed', sessionId: data.sid, localIds, invokedAt })
     })
 
     socket.on('session-end', (data: SessionEndPayload) => {

--- a/hub/src/store/index.ts
+++ b/hub/src/store/index.ts
@@ -176,6 +176,8 @@ export class Store {
             );
             CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, seq);
             CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_local_id ON messages(session_id, local_id) WHERE local_id IS NOT NULL;
+            CREATE INDEX IF NOT EXISTS idx_messages_session_position
+                ON messages(session_id, COALESCE(invoked_at, created_at) DESC, seq DESC);
 
             CREATE TABLE IF NOT EXISTS users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -330,6 +332,11 @@ export class Store {
         // Idempotent (WHERE invoked_at IS NULL); safe to re-run if a previous attempt
         // crashed between ALTER and UPDATE before user_version was bumped.
         this.db.exec('UPDATE messages SET invoked_at = created_at WHERE invoked_at IS NULL')
+        // Position index for byPosition pagination — idempotent via IF NOT EXISTS.
+        this.db.exec(`
+            CREATE INDEX IF NOT EXISTS idx_messages_session_position
+                ON messages(session_id, COALESCE(invoked_at, created_at) DESC, seq DESC)
+        `)
     }
 
     private getSessionColumnNames(): Set<string> {

--- a/hub/src/store/index.ts
+++ b/hub/src/store/index.ts
@@ -85,9 +85,35 @@ export class Store {
 
     private initSchema(): void {
         const currentVersion = this.getUserVersion()
+        // V1/V2/V3 entries cover legacy DBs that pre-date our migration ladder.
+        // Each step is idempotent (column-existence guards inside) so we can
+        // safely run the full V1→V8 chain in the legacy branch where the DB
+        // shape is unknown.
+        const buildStepMigrations = (legacy: boolean): Record<number, () => void> => ({
+            1: () => this.migrateFromV1ToV2(legacy),
+            2: () => this.migrateFromV2ToV3(),
+            3: () => this.migrateFromV3ToV4(),
+            4: () => this.migrateFromV4ToV5(),
+            5: () => this.migrateFromV5ToV6(),
+            6: () => this.migrateFromV6ToV7(),
+            7: () => this.migrateFromV7ToV8(),
+        })
+
         if (currentVersion === 0) {
             if (this.hasAnyUserTables()) {
                 this.migrateLegacySchemaIfNeeded()
+                // Run the full step ladder BEFORE createSchema so legacy tables
+                // pick up every later-version column (e.g. invoked_at) via ALTER
+                // TABLE.  Without this, createSchema below would try to build
+                // idx_messages_session_position over a column that does not
+                // exist yet, and CREATE TABLE IF NOT EXISTS would not add the
+                // missing column to the existing table.
+                const legacySteps = buildStepMigrations(true)
+                for (let v = 1; v < SCHEMA_VERSION; v++) {
+                    legacySteps[v]?.()
+                }
+                // Backfill any *missing* tables (sessions, machines, ...) that
+                // a partially-built legacy DB may not have yet.
                 this.createSchema()
                 this.setUserVersion(SCHEMA_VERSION)
                 return
@@ -98,13 +124,7 @@ export class Store {
             return
         }
 
-        const stepMigrations: Record<number, () => void> = {
-            4: () => this.migrateFromV4ToV5(),
-            5: () => this.migrateFromV5ToV6(),
-            6: () => this.migrateFromV6ToV7(),
-            7: () => this.migrateFromV7ToV8(),
-        }
-
+        const stepMigrations = buildStepMigrations(false)
         if (currentVersion < SCHEMA_VERSION && stepMigrations[currentVersion]) {
             for (let v = currentVersion; v < SCHEMA_VERSION; v++) {
                 const step = stepMigrations[v]
@@ -221,9 +241,14 @@ export class Store {
         }
     }
 
-    private migrateFromV1ToV2(): void {
+    private migrateFromV1ToV2(legacy: boolean = false): void {
         const columns = this.getMachineColumnNames()
         if (columns.size === 0) {
+            // In the legacy branch the table may not exist yet — createSchema
+            // will build the up-to-date one.  When invoked from the regular
+            // upgrade path (user_version >= 1), missing the machines table is
+            // still an error.
+            if (legacy) return
             throw new Error('SQLite schema missing machines table for v1 to v2 migration.')
         }
 
@@ -235,6 +260,7 @@ export class Store {
         }
 
         if (!hasDaemon) {
+            if (legacy) return
             throw new Error('SQLite schema missing daemon_state columns for v1 to v2 migration.')
         }
 
@@ -295,6 +321,11 @@ export class Store {
 
     private migrateFromV3ToV4(): void {
         const columns = this.getSessionColumnNames()
+        // When the legacy branch invokes the full step ladder, an upstream-only
+        // DB may not have the sessions table yet — createSchema runs after the
+        // ladder.  Skip ALTERs in that case; createSchema will build the table
+        // with the up-to-date columns.
+        if (columns.size === 0) return
         if (!columns.has('team_state')) {
             this.db.exec('ALTER TABLE sessions ADD COLUMN team_state TEXT')
         }
@@ -305,6 +336,7 @@ export class Store {
 
     private migrateFromV4ToV5(): void {
         const columns = this.getSessionColumnNames()
+        if (columns.size === 0) return
         if (!columns.has('model')) {
             this.db.exec('ALTER TABLE sessions ADD COLUMN model TEXT')
         }
@@ -312,6 +344,7 @@ export class Store {
 
     private migrateFromV5ToV6(): void {
         const columns = this.getSessionColumnNames()
+        if (columns.size === 0) return
         if (!columns.has('effort')) {
             this.db.exec('ALTER TABLE sessions ADD COLUMN effort TEXT')
         }
@@ -319,6 +352,7 @@ export class Store {
 
     private migrateFromV6ToV7(): void {
         const columns = this.getSessionColumnNames()
+        if (columns.size === 0) return
         if (!columns.has('model_reasoning_effort')) {
             this.db.exec('ALTER TABLE sessions ADD COLUMN model_reasoning_effort TEXT')
         }
@@ -326,6 +360,10 @@ export class Store {
 
     private migrateFromV7ToV8(): void {
         const columns = this.getMessageColumnNames()
+        if (columns.size === 0) {
+            // No messages table yet — createSchema will build the up-to-date one.
+            return
+        }
         if (!columns.has('invoked_at')) {
             this.db.exec('ALTER TABLE messages ADD COLUMN invoked_at INTEGER')
         }

--- a/hub/src/store/index.ts
+++ b/hub/src/store/index.ts
@@ -326,8 +326,10 @@ export class Store {
         const columns = this.getMessageColumnNames()
         if (!columns.has('invoked_at')) {
             this.db.exec('ALTER TABLE messages ADD COLUMN invoked_at INTEGER')
-            this.db.exec('UPDATE messages SET invoked_at = created_at WHERE invoked_at IS NULL')
         }
+        // Idempotent (WHERE invoked_at IS NULL); safe to re-run if a previous attempt
+        // crashed between ALTER and UPDATE before user_version was bumped.
+        this.db.exec('UPDATE messages SET invoked_at = created_at WHERE invoked_at IS NULL')
     }
 
     private getSessionColumnNames(): Set<string> {

--- a/hub/src/store/index.ts
+++ b/hub/src/store/index.ts
@@ -22,7 +22,7 @@ export { PushStore } from './pushStore'
 export { SessionStore } from './sessionStore'
 export { UserStore } from './userStore'
 
-const SCHEMA_VERSION: number = 7
+const SCHEMA_VERSION: number = 8
 const REQUIRED_TABLES = [
     'sessions',
     'machines',
@@ -98,60 +98,19 @@ export class Store {
             return
         }
 
-        if (currentVersion === 1 && SCHEMA_VERSION === 2) {
-            this.migrateFromV1ToV2()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
+        const stepMigrations: Record<number, () => void> = {
+            4: () => this.migrateFromV4ToV5(),
+            5: () => this.migrateFromV5ToV6(),
+            6: () => this.migrateFromV6ToV7(),
+            7: () => this.migrateFromV7ToV8(),
         }
 
-        if (currentVersion === 2 && SCHEMA_VERSION === 3) {
-            this.migrateFromV2ToV3()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 3 && SCHEMA_VERSION === 4) {
-            this.migrateFromV3ToV4()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 4 && SCHEMA_VERSION === 5) {
-            this.migrateFromV4ToV5()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 5 && SCHEMA_VERSION === 6) {
-            this.migrateFromV5ToV6()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 6 && SCHEMA_VERSION === 7) {
-            this.migrateFromV6ToV7()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 4 && SCHEMA_VERSION === 6) {
-            this.migrateFromV4ToV5()
-            this.migrateFromV5ToV6()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 4 && SCHEMA_VERSION === 7) {
-            this.migrateFromV4ToV5()
-            this.migrateFromV5ToV6()
-            this.migrateFromV6ToV7()
-            this.setUserVersion(SCHEMA_VERSION)
-            return
-        }
-
-        if (currentVersion === 5 && SCHEMA_VERSION === 7) {
-            this.migrateFromV5ToV6()
-            this.migrateFromV6ToV7()
+        if (currentVersion < SCHEMA_VERSION && stepMigrations[currentVersion]) {
+            for (let v = currentVersion; v < SCHEMA_VERSION; v++) {
+                const step = stepMigrations[v]
+                if (!step) throw this.buildSchemaMismatchError(currentVersion)
+                step()
+            }
             this.setUserVersion(SCHEMA_VERSION)
             return
         }
@@ -212,6 +171,7 @@ export class Store {
                 created_at INTEGER NOT NULL,
                 seq INTEGER NOT NULL,
                 local_id TEXT,
+                invoked_at INTEGER,
                 FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
             );
             CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, seq);
@@ -362,6 +322,14 @@ export class Store {
         }
     }
 
+    private migrateFromV7ToV8(): void {
+        const columns = this.getMessageColumnNames()
+        if (!columns.has('invoked_at')) {
+            this.db.exec('ALTER TABLE messages ADD COLUMN invoked_at INTEGER')
+            this.db.exec('UPDATE messages SET invoked_at = created_at WHERE invoked_at IS NULL')
+        }
+    }
+
     private getSessionColumnNames(): Set<string> {
         const rows = this.db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>
         return new Set(rows.map((row) => row.name))
@@ -369,6 +337,11 @@ export class Store {
 
     private getMachineColumnNames(): Set<string> {
         const rows = this.db.prepare('PRAGMA table_info(machines)').all() as Array<{ name: string }>
+        return new Set(rows.map((row) => row.name))
+    }
+
+    private getMessageColumnNames(): Set<string> {
+        const rows = this.db.prepare('PRAGMA table_info(messages)').all() as Array<{ name: string }>
         return new Set(rows.map((row) => row.name))
     }
 

--- a/hub/src/store/messageStore.ts
+++ b/hub/src/store/messageStore.ts
@@ -1,7 +1,7 @@
 import type { Database } from 'bun:sqlite'
 
 import type { StoredMessage } from './types'
-import { addMessage, getMessages, getMessagesAfter, markMessagesInvoked, mergeSessionMessages } from './messages'
+import { addMessage, getMessages, getMessagesAfter, getMessagesByPosition, markMessagesInvoked, mergeSessionMessages } from './messages'
 
 export class MessageStore {
     private readonly db: Database
@@ -20,6 +20,10 @@ export class MessageStore {
 
     getMessagesAfter(sessionId: string, afterSeq: number, limit: number = 200): StoredMessage[] {
         return getMessagesAfter(this.db, sessionId, afterSeq, limit)
+    }
+
+    getMessagesByPosition(sessionId: string, limit: number, before?: { at: number; seq: number }): StoredMessage[] {
+        return getMessagesByPosition(this.db, sessionId, limit, before)
     }
 
     markMessagesInvoked(sessionId: string, localIds: string[], invokedAt: number): void {

--- a/hub/src/store/messageStore.ts
+++ b/hub/src/store/messageStore.ts
@@ -1,7 +1,7 @@
 import type { Database } from 'bun:sqlite'
 
 import type { StoredMessage } from './types'
-import { addMessage, getMessages, getMessagesAfter, getMessagesByPosition, markMessagesInvoked, mergeSessionMessages } from './messages'
+import { addMessage, getMessages, getMessagesAfter, getMessagesByPosition, getUninvokedLocalMessages, markMessagesInvoked, mergeSessionMessages } from './messages'
 
 export class MessageStore {
     private readonly db: Database
@@ -24,6 +24,10 @@ export class MessageStore {
 
     getMessagesByPosition(sessionId: string, limit: number, before?: { at: number; seq: number }): StoredMessage[] {
         return getMessagesByPosition(this.db, sessionId, limit, before)
+    }
+
+    getUninvokedLocalMessages(sessionId: string): StoredMessage[] {
+        return getUninvokedLocalMessages(this.db, sessionId)
     }
 
     markMessagesInvoked(sessionId: string, localIds: string[], invokedAt: number): void {

--- a/hub/src/store/messageStore.ts
+++ b/hub/src/store/messageStore.ts
@@ -1,7 +1,7 @@
 import type { Database } from 'bun:sqlite'
 
 import type { StoredMessage } from './types'
-import { addMessage, getMessages, getMessagesAfter, mergeSessionMessages } from './messages'
+import { addMessage, getMessages, getMessagesAfter, markMessagesInvoked, mergeSessionMessages } from './messages'
 
 export class MessageStore {
     private readonly db: Database
@@ -20,6 +20,10 @@ export class MessageStore {
 
     getMessagesAfter(sessionId: string, afterSeq: number, limit: number = 200): StoredMessage[] {
         return getMessagesAfter(this.db, sessionId, afterSeq, limit)
+    }
+
+    markMessagesInvoked(sessionId: string, localIds: string[], invokedAt: number): void {
+        markMessagesInvoked(this.db, sessionId, localIds, invokedAt)
     }
 
     mergeSessionMessages(fromSessionId: string, toSessionId: string): { moved: number; oldMaxSeq: number; newMaxSeq: number } {

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -11,6 +11,7 @@ type DbMessageRow = {
     created_at: number
     seq: number
     local_id: string | null
+    invoked_at: number | null
 }
 
 function toStoredMessage(row: DbMessageRow): StoredMessage {
@@ -20,7 +21,8 @@ function toStoredMessage(row: DbMessageRow): StoredMessage {
         content: safeJsonParse(row.content),
         createdAt: row.created_at,
         seq: row.seq,
-        localId: row.local_id
+        localId: row.local_id,
+        invokedAt: row.invoked_at ?? null
     }
 }
 
@@ -51,9 +53,9 @@ export function addMessage(
 
     db.prepare(`
         INSERT INTO messages (
-            id, session_id, content, created_at, seq, local_id
+            id, session_id, content, created_at, seq, local_id, invoked_at
         ) VALUES (
-            @id, @session_id, @content, @created_at, @seq, @local_id
+            @id, @session_id, @content, @created_at, @seq, @local_id, NULL
         )
     `).run({
         id,
@@ -111,6 +113,21 @@ export function getMaxSeq(db: Database, sessionId: string): number {
         'SELECT COALESCE(MAX(seq), 0) AS maxSeq FROM messages WHERE session_id = ?'
     ).get(sessionId) as { maxSeq: number } | undefined
     return row?.maxSeq ?? 0
+}
+
+/** Mark messages as invoked at the given server timestamp.
+ *  Only updates rows whose local_id is in localIds. */
+export function markMessagesInvoked(
+    db: Database,
+    sessionId: string,
+    localIds: string[],
+    invokedAt: number
+): void {
+    if (localIds.length === 0) return
+    const placeholders = localIds.map(() => '?').join(', ')
+    db.prepare(
+        `UPDATE messages SET invoked_at = ? WHERE session_id = ? AND local_id IN (${placeholders})`
+    ).run(invokedAt, sessionId, ...localIds)
 }
 
 export function mergeSessionMessages(

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -165,7 +165,10 @@ export function getMaxSeq(db: Database, sessionId: string): number {
 }
 
 /** Mark messages as invoked at the given server timestamp.
- *  Only updates rows whose local_id is in localIds. */
+ *  Only updates rows whose local_id is in localIds.
+ *  First-write-wins: rows with a non-NULL invoked_at are not updated.  A duplicate
+ *  ack (e.g. a CLI re-emit) would otherwise re-stamp the timestamp and shuffle
+ *  the message's position in the byPosition-ordered thread. */
 export function markMessagesInvoked(
     db: Database,
     sessionId: string,
@@ -175,7 +178,11 @@ export function markMessagesInvoked(
     if (localIds.length === 0) return
     const placeholders = localIds.map(() => '?').join(', ')
     db.prepare(
-        `UPDATE messages SET invoked_at = ? WHERE session_id = ? AND local_id IN (${placeholders})`
+        `UPDATE messages
+         SET invoked_at = ?
+         WHERE session_id = ?
+           AND local_id IN (${placeholders})
+           AND invoked_at IS NULL`
     ).run(invokedAt, sessionId, ...localIds)
 }
 
@@ -211,8 +218,15 @@ export function mergeSessionMessages(
         if (collisions.length > 0) {
             const localIds = collisions.map((row) => row.local_id)
             const placeholders = localIds.map(() => '?').join(', ')
+            // Force-invoke the older copy: clearing local_id severs its ack path
+            // (markMessagesInvoked matches by local_id), so leaving invoked_at
+            // NULL would strand the row in the queued floating bar forever.
+            // Use COALESCE so an already-invoked row keeps its server timestamp.
             db.prepare(
-                `UPDATE messages SET local_id = NULL WHERE session_id = ? AND local_id IN (${placeholders})`
+                `UPDATE messages
+                 SET local_id = NULL,
+                     invoked_at = COALESCE(invoked_at, created_at)
+                 WHERE session_id = ? AND local_id IN (${placeholders})`
             ).run(fromSessionId, ...localIds)
         }
 

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -51,11 +51,16 @@ export function addMessage(
     const id = randomUUID()
     const json = JSON.stringify(content)
 
+    // Messages without a localId have no ack path (markMessagesInvoked matches by localId).
+    // Treat them as already-invoked at insert time so they land in the thread normally instead
+    // of being stuck in the queued floating bar forever.
+    const invokedAt = localId ? null : now
+
     db.prepare(`
         INSERT INTO messages (
             id, session_id, content, created_at, seq, local_id, invoked_at
         ) VALUES (
-            @id, @session_id, @content, @created_at, @seq, @local_id, NULL
+            @id, @session_id, @content, @created_at, @seq, @local_id, @invoked_at
         )
     `).run({
         id,
@@ -63,7 +68,8 @@ export function addMessage(
         content: json,
         created_at: now,
         seq: msgSeq,
-        local_id: localId ?? null
+        local_id: localId ?? null,
+        invoked_at: invokedAt
     })
 
     const row = db.prepare('SELECT * FROM messages WHERE id = ?').get(id) as DbMessageRow | undefined

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -114,6 +114,35 @@ export function getMessagesAfter(
     return rows.map(toStoredMessage)
 }
 
+/** Paginate messages by COALESCE(invoked_at, created_at) DESC, seq DESC.
+ *  Used for V8 byPosition mode.  Results are returned in ascending display order. */
+export function getMessagesByPosition(
+    db: Database,
+    sessionId: string,
+    limit: number,
+    before?: { at: number; seq: number }
+): StoredMessage[] {
+    const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.min(200, limit)) : 200
+    const beforeClause = before
+        ? 'AND (COALESCE(invoked_at, created_at) < @beforeAt OR (COALESCE(invoked_at, created_at) = @beforeAt AND seq < @beforeSeq))'
+        : ''
+    const rows = db.prepare(`
+        SELECT *, COALESCE(invoked_at, created_at) AS position_at
+        FROM messages
+        WHERE session_id = @sessionId
+          ${beforeClause}
+        ORDER BY position_at DESC, seq DESC
+        LIMIT @limit
+    `).all({
+        sessionId,
+        beforeAt: before?.at ?? null,
+        beforeSeq: before?.seq ?? null,
+        limit: safeLimit
+    }) as DbMessageRow[]
+    // Reverse so results are in ascending display order (oldest first)
+    return rows.reverse().map(toStoredMessage)
+}
+
 export function getMaxSeq(db: Database, sessionId: string): number {
     const row = db.prepare(
         'SELECT COALESCE(MAX(seq), 0) AS maxSeq FROM messages WHERE session_id = ?'

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -143,6 +143,20 @@ export function getMessagesByPosition(
     return rows.reverse().map(toStoredMessage)
 }
 
+/** Returns user messages that have a localId but no invoked_at.
+ *  Used to surface queued messages on refresh / secondary clients even when they
+ *  fall outside the latest position-ordered page (their position key is the send
+ *  time, but the floating bar still needs to render them). */
+export function getUninvokedLocalMessages(
+    db: Database,
+    sessionId: string
+): StoredMessage[] {
+    const rows = db.prepare(
+        'SELECT * FROM messages WHERE session_id = ? AND invoked_at IS NULL AND local_id IS NOT NULL ORDER BY seq ASC'
+    ).all(sessionId) as DbMessageRow[]
+    return rows.map(toStoredMessage)
+}
+
 export function getMaxSeq(db: Database, sessionId: string): number {
     const row = db.prepare(
         'SELECT COALESCE(MAX(seq), 0) AS maxSeq FROM messages WHERE session_id = ?'

--- a/hub/src/store/migration-v8.test.ts
+++ b/hub/src/store/migration-v8.test.ts
@@ -219,6 +219,39 @@ describe('Store V7→V8 migration: invoked_at column', () => {
         expect(sent.invokedAt).toBeNull()  // value at insert; row has been updated since
         expect(store.messages.getUninvokedLocalMessages(session.id)).toEqual([])
     })
+
+    // Mirrors the session-end handler's auto-invoke contract at the store
+    // layer: when a CLI exits, we sweep every queued message for the session
+    // (getUninvokedLocalMessages) and stamp them with a single timestamp
+    // (markMessagesInvoked). After the sweep, no queued ghosts may remain —
+    // otherwise the floating bar would survive across reloads even though the
+    // CLI is no longer running.
+    it('session-end pattern: getUninvokedLocalMessages + markMessagesInvoked clears all queued', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        store.messages.addMessage(session.id, 'q1', 'local-1')
+        store.messages.addMessage(session.id, 'q2', 'local-2')
+        store.messages.addMessage(session.id, 'q3', 'local-3')
+
+        const queuedBefore = store.messages.getUninvokedLocalMessages(session.id)
+        expect(queuedBefore).toHaveLength(3)
+        const localIds = queuedBefore
+            .map(m => m.localId)
+            .filter((id): id is string => id !== null)
+        expect(localIds).toHaveLength(3)
+
+        const ts = Date.now()
+        store.messages.markMessagesInvoked(session.id, localIds, ts)
+
+        const queuedAfter = store.messages.getUninvokedLocalMessages(session.id)
+        expect(queuedAfter).toHaveLength(0)
+        // And every row now carries the same invokedAt — a partial sweep would
+        // leave the floating bar half-cleared on the web client.
+        const allMessages = store.messages.getMessages(session.id)
+        for (const msg of allMessages) {
+            expect(msg.invokedAt).toBe(ts)
+        }
+    })
 })
 
 describe('Store V8 byPosition pagination', () => {
@@ -362,6 +395,56 @@ describe('Store V8 byPosition pagination', () => {
         } finally {
             rmSync(dir, { recursive: true, force: true })
         }
+    })
+
+    // The web client renders queued messages from the union of the latest
+    // page (getMessagesByPosition) and the uninvoked-local set
+    // (getUninvokedLocalMessages). This test pins that contract at the store
+    // layer: a low-position queued row must NOT appear in the latest page once
+    // it's been pushed out, but it must still be discoverable via the
+    // uninvoked set so the floating bar can render it.
+    it('latest page + uninvoked union: queued rows pushed out of the page are still surfaced', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+
+        // Queued message lands first → low createdAt; invoked_at stays NULL,
+        // so its position_at = createdAt (the lowest in the session).
+        const queued = store.messages.addMessage(session.id, 'queued', 'local-q')
+
+        // Add enough later (auto-invoked) messages to push the queued row out
+        // of a 3-row latest page.
+        for (let i = 0; i < 5; i++) {
+            store.messages.addMessage(session.id, `later-${i}`)
+        }
+
+        const pageRows = store.messages.getMessagesByPosition(session.id, 3)
+        expect(pageRows).toHaveLength(3)
+        expect(pageRows.find(m => m.id === queued.id)).toBeUndefined()
+
+        // ...but the uninvoked union still surfaces it.
+        const queuedRows = store.messages.getUninvokedLocalMessages(session.id)
+        expect(queuedRows.map(m => m.id)).toContain(queued.id)
+    })
+
+    // Pins the latest-page ordering contract used as the cursor anchor on the
+    // web side: page rows are returned in ascending position order, so
+    // pageRows[0] is the oldest row in the page and is the correct anchor for
+    // the next older fetch.
+    it('getMessagesByPosition ascending order: pageRows[0] is the oldest in the page', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        const m1 = store.messages.addMessage(session.id, 'm1')
+        const m2 = store.messages.addMessage(session.id, 'm2')
+        const m3 = store.messages.addMessage(session.id, 'm3')
+
+        const page = store.messages.getMessagesByPosition(session.id, 10)
+        expect(page).toHaveLength(3)
+        // Ascending by position_at, with seq as the tiebreaker — m1 is oldest,
+        // m3 is newest. If this ever flips, the web client's
+        // `oldestPositionAt = pageRows[0].position` would anchor to the wrong
+        // end of the page and the next loadMore would either gap or duplicate.
+        expect(page[0].id).toBe(m1.id)
+        expect(page[2].id).toBe(m3.id)
     })
 
     it('legacy DB (user_version=0 with V7-shape tables): step ladder backfills invoked_at and index', () => {

--- a/hub/src/store/migration-v8.test.ts
+++ b/hub/src/store/migration-v8.test.ts
@@ -167,7 +167,7 @@ describe('Store V7→V8 migration: invoked_at column', () => {
         expect(m2.invokedAt).toBeNull()
     })
 
-    it('markMessagesInvoked is idempotent (repeated call updates timestamp)', () => {
+    it('markMessagesInvoked is first-write-wins (subsequent calls are no-ops)', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
         store.messages.addMessage(session.id, 'hi', 'local-x')
@@ -175,11 +175,13 @@ describe('Store V7→V8 migration: invoked_at column', () => {
         const ts1 = 1000
         const ts2 = 2000
         store.messages.markMessagesInvoked(session.id, ['local-x'], ts1)
-        // calling again with different ts should overwrite (UPDATE is idempotent-safe)
+        // A duplicate ack (CLI re-emit) must not overwrite the original timestamp:
+        // re-stamping invoked_at would shuffle the message in the byPosition-ordered
+        // thread for every subscribed client.
         store.messages.markMessagesInvoked(session.id, ['local-x'], ts2)
 
         const msgs = store.messages.getMessages(session.id)
-        expect(msgs[0].invokedAt).toBe(ts2)
+        expect(msgs[0].invokedAt).toBe(ts1)
     })
 
     it('addMessage with localId leaves invoked_at NULL (ack path is messages-consumed)', () => {
@@ -352,6 +354,45 @@ describe('Store V8 byPosition pagination', () => {
             db.close()
 
             const store = new Store(dbPath)
+            const db2: Database = (store as any).db
+            const rows = db2.prepare(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_session_position'"
+            ).all() as Array<{ name: string }>
+            expect(rows).toHaveLength(1)
+        } finally {
+            rmSync(dir, { recursive: true, force: true })
+        }
+    })
+
+    it('legacy DB (user_version=0 with V7-shape tables): step ladder backfills invoked_at and index', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-legacy-v0-'))
+        const dbPath = join(dir, 'test.db')
+        try {
+            // Build a V7-shape schema but leave user_version = 0 (legacy DB
+            // predating the version stamping).  The legacy branch in initSchema
+            // must run the step ladder so the messages table picks up
+            // invoked_at + idx_messages_session_position.
+            const db = new Database(dbPath, { create: true, readwrite: true, strict: true })
+            db.exec('PRAGMA journal_mode = WAL')
+            db.exec('PRAGMA foreign_keys = ON')
+            createV7Schema(db)
+            // Intentionally do NOT set user_version — leaves it at 0.
+            db.exec(`INSERT INTO sessions (id, namespace, created_at, updated_at, seq)
+                     VALUES ('s1', 'default', 1000, 1000, 0)`)
+            db.exec(`INSERT INTO messages (id, session_id, content, created_at, seq)
+                     VALUES ('m1', 's1', '"hi"', 1500, 1)`)
+            db.close()
+
+            const store = new Store(dbPath)
+            const cols = getMessageColumns(store)
+            expect(cols).toContain('invoked_at')
+
+            // Backfill should have happened via V7→V8 step running in the legacy branch.
+            const msgs = store.messages.getMessages('s1')
+            expect(msgs).toHaveLength(1)
+            expect(msgs[0].invokedAt).toBe(1500)
+
+            // The position index must exist for byPosition pagination to work.
             const db2: Database = (store as any).db
             const rows = db2.prepare(
                 "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_session_position'"

--- a/hub/src/store/migration-v8.test.ts
+++ b/hub/src/store/migration-v8.test.ts
@@ -182,11 +182,18 @@ describe('Store V7→V8 migration: invoked_at column', () => {
         expect(msgs[0].invokedAt).toBe(ts2)
     })
 
-    it('addMessage sets invoked_at to NULL by default', () => {
+    it('addMessage with localId leaves invoked_at NULL (ack path is messages-consumed)', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        const msg = store.messages.addMessage(session.id, 'content', 'local-1')
+        expect(msg.invokedAt).toBeNull()
+    })
+
+    it('addMessage without localId sets invoked_at = created_at (no ack path)', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
         const msg = store.messages.addMessage(session.id, 'content')
-        expect(msg.invokedAt).toBeNull()
+        expect(msg.invokedAt).toBe(msg.createdAt)
     })
 })
 

--- a/hub/src/store/migration-v8.test.ts
+++ b/hub/src/store/migration-v8.test.ts
@@ -1,0 +1,514 @@
+import { describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Store } from './index'
+
+/**
+ * Tests for V7→V8 schema migration: adding invoked_at column to messages table.
+ * All migration tests open a real Store to exercise the actual migration code path.
+ */
+describe('Store V7→V8 migration: invoked_at column', () => {
+    it('fresh DB has invoked_at column in messages', () => {
+        const store = new Store(':memory:')
+        const cols = getMessageColumns(store)
+        expect(cols).toContain('invoked_at')
+    })
+
+    it('V7 DB migrates to V8 via Store: invoked_at added, existing rows backfilled to created_at', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-migration-v8-test-'))
+        const dbPath = join(dir, 'test.db')
+        try {
+            // Build a V7 DB on disk, insert rows, then open via Store to trigger migration
+            const db = new Database(dbPath, { create: true, readwrite: true, strict: true })
+            db.exec('PRAGMA journal_mode = WAL')
+            db.exec('PRAGMA foreign_keys = ON')
+            createV7Schema(db)
+            db.exec('PRAGMA user_version = 7')
+            db.exec(`INSERT INTO sessions (id, namespace, created_at, updated_at, seq)
+                     VALUES ('s1', 'default', 1000, 1000, 0)`)
+            db.exec(`INSERT INTO messages (id, session_id, content, created_at, seq)
+                     VALUES ('m1', 's1', '"hello"', 1000, 1)`)
+            db.exec(`INSERT INTO messages (id, session_id, content, created_at, seq)
+                     VALUES ('m2', 's1', '"world"', 2000, 2)`)
+            db.close()
+
+            // Open via Store — should auto-migrate V7→V8
+            const store = new Store(dbPath)
+            const cols = getMessageColumns(store)
+            expect(cols).toContain('invoked_at')
+
+            // Backfill: existing rows must have invoked_at == created_at (not NULL)
+            const msgs = store.messages.getMessages('s1')
+            expect(msgs).toHaveLength(2)
+            const m1 = msgs.find(m => m.id === 'm1')!
+            const m2 = msgs.find(m => m.id === 'm2')!
+            expect(m1.invokedAt).toBe(1000)
+            expect(m2.invokedAt).toBe(2000)
+        } finally {
+            rmSync(dir, { recursive: true, force: true })
+        }
+    })
+
+    it('V6 DB migrates to V8 (multi-hop)', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-migration-v6-test-'))
+        const dbPath = join(dir, 'test.db')
+        try {
+            const db = new Database(dbPath, { create: true, readwrite: true, strict: true })
+            db.exec('PRAGMA journal_mode = WAL')
+            db.exec('PRAGMA foreign_keys = ON')
+            createV6Schema(db)
+            db.exec('PRAGMA user_version = 6')
+            db.close()
+
+            const store = new Store(dbPath)
+            const cols = getMessageColumns(store)
+            expect(cols).toContain('invoked_at')
+            // sessions table should have model_reasoning_effort (added in V6→V7)
+            const sessionCols = getSessionColumns(store)
+            expect(sessionCols).toContain('model_reasoning_effort')
+        } finally {
+            rmSync(dir, { recursive: true, force: true })
+        }
+    })
+
+    it('V5 DB migrates to V8 (multi-hop)', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-migration-v5-test-'))
+        const dbPath = join(dir, 'test.db')
+        try {
+            const db = new Database(dbPath, { create: true, readwrite: true, strict: true })
+            db.exec('PRAGMA journal_mode = WAL')
+            db.exec('PRAGMA foreign_keys = ON')
+            createV5Schema(db)
+            db.exec('PRAGMA user_version = 5')
+            db.close()
+
+            const store = new Store(dbPath)
+            const cols = getMessageColumns(store)
+            expect(cols).toContain('invoked_at')
+        } finally {
+            rmSync(dir, { recursive: true, force: true })
+        }
+    })
+
+    it('V4 DB migrates to V8 (multi-hop)', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-migration-v4-test-'))
+        const dbPath = join(dir, 'test.db')
+        try {
+            const db = new Database(dbPath, { create: true, readwrite: true, strict: true })
+            db.exec('PRAGMA journal_mode = WAL')
+            db.exec('PRAGMA foreign_keys = ON')
+            createV4Schema(db)
+            db.exec('PRAGMA user_version = 4')
+            db.close()
+
+            const store = new Store(dbPath)
+            const cols = getMessageColumns(store)
+            expect(cols).toContain('invoked_at')
+        } finally {
+            rmSync(dir, { recursive: true, force: true })
+        }
+    })
+
+    it('V8 DB reopen is idempotent: schema unchanged', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-migration-v8-idempotent-'))
+        const dbPath = join(dir, 'test.db')
+        try {
+            const store1 = new Store(dbPath)
+            const cols1 = getMessageColumns(store1)
+            expect(cols1).toContain('invoked_at')
+
+            // Re-open same DB — version is already 8, must not throw or alter schema
+            const store2 = new Store(dbPath)
+            const cols2 = getMessageColumns(store2)
+            expect(cols2).toEqual(cols1)
+        } finally {
+            rmSync(dir, { recursive: true, force: true })
+        }
+    })
+
+    it('migrateFromV7ToV8 PRAGMA guard: invoked_at column appears exactly once', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-migration-v8-guard-'))
+        const dbPath = join(dir, 'test.db')
+        try {
+            const db = new Database(dbPath, { create: true, readwrite: true, strict: true })
+            db.exec('PRAGMA journal_mode = WAL')
+            db.exec('PRAGMA foreign_keys = ON')
+            createV7Schema(db)
+            db.exec('PRAGMA user_version = 7')
+            db.close()
+
+            const store = new Store(dbPath)
+            const cols = getMessageColumns(store)
+            const count = cols.filter(c => c === 'invoked_at').length
+            expect(count).toBe(1)
+        } finally {
+            rmSync(dir, { recursive: true, force: true })
+        }
+    })
+
+    it('markMessagesInvoked sets invoked_at on matching messages', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        const msg1 = store.messages.addMessage(session.id, 'hello', 'local-1')
+        const msg2 = store.messages.addMessage(session.id, 'world', 'local-2')
+
+        // Initially both have invokedAt = null (new messages added to fresh V8 DB)
+        expect(store.messages.getMessages(session.id).map(m => m.invokedAt)).toEqual([null, null])
+
+        const ts = Date.now()
+        store.messages.markMessagesInvoked(session.id, ['local-1'], ts)
+
+        const msgs = store.messages.getMessages(session.id)
+        const m1 = msgs.find(m => m.id === msg1.id)!
+        const m2 = msgs.find(m => m.id === msg2.id)!
+        expect(m1.invokedAt).toBe(ts)
+        expect(m2.invokedAt).toBeNull()
+    })
+
+    it('markMessagesInvoked is idempotent (repeated call updates timestamp)', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        store.messages.addMessage(session.id, 'hi', 'local-x')
+
+        const ts1 = 1000
+        const ts2 = 2000
+        store.messages.markMessagesInvoked(session.id, ['local-x'], ts1)
+        // calling again with different ts should overwrite (UPDATE is idempotent-safe)
+        store.messages.markMessagesInvoked(session.id, ['local-x'], ts2)
+
+        const msgs = store.messages.getMessages(session.id)
+        expect(msgs[0].invokedAt).toBe(ts2)
+    })
+
+    it('addMessage sets invoked_at to NULL by default', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        const msg = store.messages.addMessage(session.id, 'content')
+        expect(msg.invokedAt).toBeNull()
+    })
+})
+
+function getMessageColumns(store: Store): string[] {
+    // Access internal db via reflection — safe for test only
+    const db: Database = (store as any).db
+    const rows = db.prepare('PRAGMA table_info(messages)').all() as Array<{ name: string }>
+    return rows.map(r => r.name)
+}
+
+function getSessionColumns(store: Store): string[] {
+    const db: Database = (store as any).db
+    const rows = db.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>
+    return rows.map(r => r.name)
+}
+
+/** V7 schema: messages table without invoked_at */
+function createV7Schema(db: Database): void {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            tag TEXT,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            machine_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            metadata TEXT,
+            metadata_version INTEGER DEFAULT 1,
+            agent_state TEXT,
+            agent_state_version INTEGER DEFAULT 1,
+            model TEXT,
+            model_reasoning_effort TEXT,
+            effort TEXT,
+            todos TEXT,
+            todos_updated_at INTEGER,
+            team_state TEXT,
+            team_state_updated_at INTEGER,
+            active INTEGER DEFAULT 0,
+            active_at INTEGER,
+            seq INTEGER DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_sessions_tag ON sessions(tag);
+        CREATE INDEX IF NOT EXISTS idx_sessions_tag_namespace ON sessions(tag, namespace);
+
+        CREATE TABLE IF NOT EXISTS machines (
+            id TEXT PRIMARY KEY,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            metadata TEXT,
+            metadata_version INTEGER DEFAULT 1,
+            runner_state TEXT,
+            runner_state_version INTEGER DEFAULT 1,
+            active INTEGER DEFAULT 0,
+            active_at INTEGER,
+            seq INTEGER DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_machines_namespace ON machines(namespace);
+
+        CREATE TABLE IF NOT EXISTS messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            seq INTEGER NOT NULL,
+            local_id TEXT,
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, seq);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_local_id ON messages(session_id, local_id) WHERE local_id IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            platform TEXT NOT NULL,
+            platform_user_id TEXT NOT NULL,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            created_at INTEGER NOT NULL,
+            UNIQUE(platform, platform_user_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_users_platform ON users(platform);
+        CREATE INDEX IF NOT EXISTS idx_users_platform_namespace ON users(platform, namespace);
+
+        CREATE TABLE IF NOT EXISTS push_subscriptions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            namespace TEXT NOT NULL,
+            endpoint TEXT NOT NULL,
+            p256dh TEXT NOT NULL,
+            auth TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            UNIQUE(namespace, endpoint)
+        );
+        CREATE INDEX IF NOT EXISTS idx_push_subscriptions_namespace ON push_subscriptions(namespace);
+    `)
+}
+
+/** V6 schema: sessions without model_reasoning_effort; messages without invoked_at */
+function createV6Schema(db: Database): void {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            tag TEXT,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            machine_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            metadata TEXT,
+            metadata_version INTEGER DEFAULT 1,
+            agent_state TEXT,
+            agent_state_version INTEGER DEFAULT 1,
+            model TEXT,
+            effort TEXT,
+            todos TEXT,
+            todos_updated_at INTEGER,
+            team_state TEXT,
+            team_state_updated_at INTEGER,
+            active INTEGER DEFAULT 0,
+            active_at INTEGER,
+            seq INTEGER DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_sessions_tag ON sessions(tag);
+        CREATE INDEX IF NOT EXISTS idx_sessions_tag_namespace ON sessions(tag, namespace);
+
+        CREATE TABLE IF NOT EXISTS machines (
+            id TEXT PRIMARY KEY,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            metadata TEXT,
+            metadata_version INTEGER DEFAULT 1,
+            runner_state TEXT,
+            runner_state_version INTEGER DEFAULT 1,
+            active INTEGER DEFAULT 0,
+            active_at INTEGER,
+            seq INTEGER DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_machines_namespace ON machines(namespace);
+
+        CREATE TABLE IF NOT EXISTS messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            seq INTEGER NOT NULL,
+            local_id TEXT,
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, seq);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_local_id ON messages(session_id, local_id) WHERE local_id IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            platform TEXT NOT NULL,
+            platform_user_id TEXT NOT NULL,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            created_at INTEGER NOT NULL,
+            UNIQUE(platform, platform_user_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_users_platform ON users(platform);
+        CREATE INDEX IF NOT EXISTS idx_users_platform_namespace ON users(platform, namespace);
+
+        CREATE TABLE IF NOT EXISTS push_subscriptions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            namespace TEXT NOT NULL,
+            endpoint TEXT NOT NULL,
+            p256dh TEXT NOT NULL,
+            auth TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            UNIQUE(namespace, endpoint)
+        );
+        CREATE INDEX IF NOT EXISTS idx_push_subscriptions_namespace ON push_subscriptions(namespace);
+    `)
+}
+
+/** V5 schema: sessions without effort, model_reasoning_effort; messages without invoked_at */
+function createV5Schema(db: Database): void {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            tag TEXT,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            machine_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            metadata TEXT,
+            metadata_version INTEGER DEFAULT 1,
+            agent_state TEXT,
+            agent_state_version INTEGER DEFAULT 1,
+            model TEXT,
+            todos TEXT,
+            todos_updated_at INTEGER,
+            team_state TEXT,
+            team_state_updated_at INTEGER,
+            active INTEGER DEFAULT 0,
+            active_at INTEGER,
+            seq INTEGER DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_sessions_tag ON sessions(tag);
+        CREATE INDEX IF NOT EXISTS idx_sessions_tag_namespace ON sessions(tag, namespace);
+
+        CREATE TABLE IF NOT EXISTS machines (
+            id TEXT PRIMARY KEY,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            metadata TEXT,
+            metadata_version INTEGER DEFAULT 1,
+            runner_state TEXT,
+            runner_state_version INTEGER DEFAULT 1,
+            active INTEGER DEFAULT 0,
+            active_at INTEGER,
+            seq INTEGER DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_machines_namespace ON machines(namespace);
+
+        CREATE TABLE IF NOT EXISTS messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            seq INTEGER NOT NULL,
+            local_id TEXT,
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, seq);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_local_id ON messages(session_id, local_id) WHERE local_id IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            platform TEXT NOT NULL,
+            platform_user_id TEXT NOT NULL,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            created_at INTEGER NOT NULL,
+            UNIQUE(platform, platform_user_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_users_platform ON users(platform);
+        CREATE INDEX IF NOT EXISTS idx_users_platform_namespace ON users(platform, namespace);
+
+        CREATE TABLE IF NOT EXISTS push_subscriptions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            namespace TEXT NOT NULL,
+            endpoint TEXT NOT NULL,
+            p256dh TEXT NOT NULL,
+            auth TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            UNIQUE(namespace, endpoint)
+        );
+        CREATE INDEX IF NOT EXISTS idx_push_subscriptions_namespace ON push_subscriptions(namespace);
+    `)
+}
+
+/** V4 schema: sessions without model, effort, model_reasoning_effort; messages without invoked_at */
+function createV4Schema(db: Database): void {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            tag TEXT,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            machine_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            metadata TEXT,
+            metadata_version INTEGER DEFAULT 1,
+            agent_state TEXT,
+            agent_state_version INTEGER DEFAULT 1,
+            todos TEXT,
+            todos_updated_at INTEGER,
+            team_state TEXT,
+            team_state_updated_at INTEGER,
+            active INTEGER DEFAULT 0,
+            active_at INTEGER,
+            seq INTEGER DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_sessions_tag ON sessions(tag);
+        CREATE INDEX IF NOT EXISTS idx_sessions_tag_namespace ON sessions(tag, namespace);
+
+        CREATE TABLE IF NOT EXISTS machines (
+            id TEXT PRIMARY KEY,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            metadata TEXT,
+            metadata_version INTEGER DEFAULT 1,
+            runner_state TEXT,
+            runner_state_version INTEGER DEFAULT 1,
+            active INTEGER DEFAULT 0,
+            active_at INTEGER,
+            seq INTEGER DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_machines_namespace ON machines(namespace);
+
+        CREATE TABLE IF NOT EXISTS messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            seq INTEGER NOT NULL,
+            local_id TEXT,
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, seq);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_local_id ON messages(session_id, local_id) WHERE local_id IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            platform TEXT NOT NULL,
+            platform_user_id TEXT NOT NULL,
+            namespace TEXT NOT NULL DEFAULT 'default',
+            created_at INTEGER NOT NULL,
+            UNIQUE(platform, platform_user_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_users_platform ON users(platform);
+        CREATE INDEX IF NOT EXISTS idx_users_platform_namespace ON users(platform, namespace);
+
+        CREATE TABLE IF NOT EXISTS push_subscriptions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            namespace TEXT NOT NULL,
+            endpoint TEXT NOT NULL,
+            p256dh TEXT NOT NULL,
+            auth TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            UNIQUE(namespace, endpoint)
+        );
+        CREATE INDEX IF NOT EXISTS idx_push_subscriptions_namespace ON push_subscriptions(namespace);
+    `)
+}

--- a/hub/src/store/migration-v8.test.ts
+++ b/hub/src/store/migration-v8.test.ts
@@ -195,6 +195,28 @@ describe('Store V7→V8 migration: invoked_at column', () => {
         const msg = store.messages.addMessage(session.id, 'content')
         expect(msg.invokedAt).toBe(msg.createdAt)
     })
+
+    it('getUninvokedLocalMessages returns rows with localId and null invoked_at', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        const queued = store.messages.addMessage(session.id, 'q', 'local-q')
+        store.messages.addMessage(session.id, 'no-localid')          // invoked_at = createdAt, excluded
+        store.messages.addMessage(session.id, 'invoked', 'local-i')
+        store.messages.markMessagesInvoked(session.id, ['local-i'], Date.now())
+
+        const uninvoked = store.messages.getUninvokedLocalMessages(session.id)
+        expect(uninvoked.map(m => m.id)).toEqual([queued.id])
+    })
+
+    it('getUninvokedLocalMessages returns empty for session with no queued messages', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        store.messages.addMessage(session.id, 'plain')                                // invoked_at set
+        const sent = store.messages.addMessage(session.id, 'sent', 'local-s')
+        store.messages.markMessagesInvoked(session.id, ['local-s'], Date.now())
+        expect(sent.invokedAt).toBeNull()  // value at insert; row has been updated since
+        expect(store.messages.getUninvokedLocalMessages(session.id)).toEqual([])
+    })
 })
 
 describe('Store V8 byPosition pagination', () => {

--- a/hub/src/store/migration-v8.test.ts
+++ b/hub/src/store/migration-v8.test.ts
@@ -197,6 +197,150 @@ describe('Store V7→V8 migration: invoked_at column', () => {
     })
 })
 
+describe('Store V8 byPosition pagination', () => {
+    it('getMessagesByPosition returns messages in ascending order', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        const msg1 = store.messages.addMessage(session.id, 'a', 'loc-1')
+        const msg2 = store.messages.addMessage(session.id, 'b', 'loc-2')
+        const msg3 = store.messages.addMessage(session.id, 'c', 'loc-3')
+        // All start with null invokedAt; set different invokedAt values
+        store.messages.markMessagesInvoked(session.id, ['loc-1'], 1000)
+        store.messages.markMessagesInvoked(session.id, ['loc-2'], 2000)
+        store.messages.markMessagesInvoked(session.id, ['loc-3'], 3000)
+
+        const result = store.messages.getMessagesByPosition(session.id, 50)
+        expect(result.map(m => m.id)).toEqual([msg1.id, msg2.id, msg3.id])
+    })
+
+    it('getMessagesByPosition sorts by invokedAt DESC, seq DESC (latest first, reversed to ascending)', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        // Insert 3 messages: msg1 has low seq but high invokedAt (queued message that was consumed late)
+        const msg1 = store.messages.addMessage(session.id, 'queued', 'loc-q')
+        const msg2 = store.messages.addMessage(session.id, 'normal-1')  // no localId → invokedAt = createdAt
+        const msg3 = store.messages.addMessage(session.id, 'normal-2')  // no localId → invokedAt = createdAt
+
+        // Simulate: msg1 (seq=1) is invoked much later than msg2 and msg3
+        store.messages.markMessagesInvoked(session.id, ['loc-q'], msg3.createdAt + 10_000)
+
+        const result = store.messages.getMessagesByPosition(session.id, 50)
+        // Expected order by position_at ASC: msg2, msg3, msg1 (msg1 has highest invokedAt)
+        expect(result[result.length - 1].id).toBe(msg1.id)
+        expect(result[0].id).toBe(msg2.id)
+    })
+
+    it('getMessagesByPosition composite cursor: second page has no gap or duplicate', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        // Add 5 messages with distinct invokedAt timestamps
+        const messages = []
+        for (let i = 0; i < 5; i++) {
+            const msg = store.messages.addMessage(session.id, `msg-${i}`)
+            messages.push(msg)
+        }
+
+        // First page: limit=3 (gets last 3 by position DESC, reversed to ASC)
+        const page1 = store.messages.getMessagesByPosition(session.id, 3)
+        expect(page1).toHaveLength(3)
+
+        // Derive cursor from oldest in page1 (first element after reverse)
+        const oldest = page1[0]
+        const cursorAt = oldest.invokedAt ?? oldest.createdAt
+        const cursorSeq = oldest.seq
+
+        // Second page
+        const page2 = store.messages.getMessagesByPosition(session.id, 3, { at: cursorAt, seq: cursorSeq })
+        expect(page2).toHaveLength(2)
+
+        // No overlap between pages
+        const page1Ids = new Set(page1.map(m => m.id))
+        const page2Ids = new Set(page2.map(m => m.id))
+        for (const id of page2Ids) {
+            expect(page1Ids.has(id)).toBe(false)
+        }
+
+        // Together they cover all 5 messages
+        expect(page1Ids.size + page2Ids.size).toBe(5)
+    })
+
+    it('long session: low-seq late-invokedAt message appears in first page', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('test', { path: '/tmp' }, null, 'default')
+        // Insert many normal messages first (low invokedAt)
+        for (let i = 0; i < 10; i++) {
+            store.messages.addMessage(session.id, `normal-${i}`)
+        }
+        // Insert a queued message (low seq, but invoked much later)
+        const queued = store.messages.addMessage(session.id, 'queued', 'loc-q')
+        store.messages.markMessagesInvoked(session.id, ['loc-q'], Date.now() + 1_000_000)
+
+        // The queued message should appear in first page (highest position_at)
+        const page1 = store.messages.getMessagesByPosition(session.id, 5)
+        const ids = page1.map(m => m.id)
+        expect(ids).toContain(queued.id)
+        // It should be the last (most recent) in ascending result
+        expect(ids[ids.length - 1]).toBe(queued.id)
+    })
+
+    it('V7 mode getMessages is unchanged after V8 migration', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-v7-compat-'))
+        const dbPath = join(dir, 'test.db')
+        try {
+            const db = new Database(dbPath, { create: true, readwrite: true, strict: true })
+            db.exec('PRAGMA journal_mode = WAL')
+            db.exec('PRAGMA foreign_keys = ON')
+            createV7Schema(db)
+            db.exec('PRAGMA user_version = 7')
+            db.exec(`INSERT INTO sessions (id, namespace, created_at, updated_at, seq)
+                     VALUES ('s1', 'default', 1000, 1000, 0)`)
+            db.exec(`INSERT INTO messages (id, session_id, content, created_at, seq)
+                     VALUES ('m1', 's1', '"hello"', 1000, 1), ('m2', 's1', '"world"', 2000, 2)`)
+            db.close()
+
+            const store = new Store(dbPath)
+            // V7 getMessages (seq-based) must still work
+            const msgs = store.messages.getMessages('s1')
+            expect(msgs).toHaveLength(2)
+            expect(msgs[0].seq).toBe(1)
+            expect(msgs[1].seq).toBe(2)
+        } finally {
+            rmSync(dir, { recursive: true, force: true })
+        }
+    })
+
+    it('idx_messages_session_position index exists on fresh DB', () => {
+        const store = new Store(':memory:')
+        const db: Database = (store as any).db
+        const rows = db.prepare(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_session_position'"
+        ).all() as Array<{ name: string }>
+        expect(rows).toHaveLength(1)
+    })
+
+    it('idx_messages_session_position index exists after V7→V8 migration', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-index-v7-v8-'))
+        const dbPath = join(dir, 'test.db')
+        try {
+            const db = new Database(dbPath, { create: true, readwrite: true, strict: true })
+            db.exec('PRAGMA journal_mode = WAL')
+            db.exec('PRAGMA foreign_keys = ON')
+            createV7Schema(db)
+            db.exec('PRAGMA user_version = 7')
+            db.close()
+
+            const store = new Store(dbPath)
+            const db2: Database = (store as any).db
+            const rows = db2.prepare(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_session_position'"
+            ).all() as Array<{ name: string }>
+            expect(rows).toHaveLength(1)
+        } finally {
+            rmSync(dir, { recursive: true, force: true })
+        }
+    })
+})
+
 function getMessageColumns(store: Store): string[] {
     // Access internal db via reflection — safe for test only
     const db: Database = (store as any).db

--- a/hub/src/store/types.ts
+++ b/hub/src/store/types.ts
@@ -42,6 +42,7 @@ export type StoredMessage = {
     createdAt: number
     seq: number
     localId: string | null
+    invokedAt: number | null
 }
 
 export type StoredUser = {

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -54,6 +54,64 @@ export class MessageService {
         }
     }
 
+    getMessagesPageByPosition(
+        sessionId: string,
+        options: { limit: number; before?: { at: number; seq: number } | null }
+    ): {
+        messages: DecryptedMessage[]
+        page: {
+            limit: number
+            nextBeforeSeq: number | null
+            nextBeforeAt: number | null
+            hasMore: boolean
+        }
+    } {
+        const before = options.before ?? undefined
+        const stored = this.store.messages.getMessagesByPosition(sessionId, options.limit, before)
+        const messages: DecryptedMessage[] = stored.map((message) => ({
+            id: message.id,
+            seq: message.seq,
+            localId: message.localId,
+            content: message.content,
+            createdAt: message.createdAt,
+            invokedAt: message.invokedAt
+        }))
+
+        // oldest entry is at index 0 (ascending order after reverse)
+        let oldestSeq: number | null = null
+        let oldestPositionAt: number | null = null
+        for (const message of messages) {
+            if (typeof message.seq !== 'number') continue
+            if (oldestSeq === null || message.seq < oldestSeq) {
+                oldestSeq = message.seq
+                // position_at = invokedAt ?? createdAt
+                const raw = stored.find((s) => s.seq === message.seq)
+                if (raw) {
+                    oldestPositionAt = raw.invokedAt ?? raw.createdAt
+                }
+            }
+        }
+
+        const hasMore = oldestSeq !== null
+            && this.store.messages.getMessagesByPosition(
+                sessionId,
+                1,
+                oldestPositionAt !== null && oldestSeq !== null
+                    ? { at: oldestPositionAt, seq: oldestSeq }
+                    : undefined
+            ).length > 0
+
+        return {
+            messages,
+            page: {
+                limit: options.limit,
+                nextBeforeSeq: oldestSeq,
+                nextBeforeAt: oldestPositionAt,
+                hasMore
+            }
+        }
+    }
+
     getMessagesAfter(sessionId: string, options: { afterSeq: number; limit: number }): DecryptedMessage[] {
         const stored = this.store.messages.getMessagesAfter(sessionId, options.afterSeq, options.limit)
         return stored.map((message) => ({

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -27,7 +27,8 @@ export class MessageService {
             seq: message.seq,
             localId: message.localId,
             content: message.content,
-            createdAt: message.createdAt
+            createdAt: message.createdAt,
+            invokedAt: message.invokedAt
         }))
 
         let oldestSeq: number | null = null
@@ -60,7 +61,8 @@ export class MessageService {
             seq: message.seq,
             localId: message.localId,
             content: message.content,
-            createdAt: message.createdAt
+            createdAt: message.createdAt,
+            invokedAt: message.invokedAt
         }))
     }
 

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -67,7 +67,26 @@ export class MessageService {
         }
     } {
         const before = options.before ?? undefined
-        const stored = this.store.messages.getMessagesByPosition(sessionId, options.limit, before)
+        const pageRows = this.store.messages.getMessagesByPosition(sessionId, options.limit, before)
+
+        // Latest-page request (no cursor): also include uninvoked local user messages
+        // out-of-band, so refresh / secondary clients can still see queued rows even
+        // when their position key (createdAt) places them outside the latest page.
+        // The cursor stays anchored to pageRows so out-of-band rows don't affect
+        // pagination of older pages.
+        const queuedRows = before === undefined
+            ? this.store.messages.getUninvokedLocalMessages(sessionId)
+            : []
+
+        const byId = new Map<string, typeof pageRows[number]>()
+        for (const row of pageRows) byId.set(row.id, row)
+        for (const row of queuedRows) byId.set(row.id, row)
+
+        const stored = [...byId.values()].sort((a, b) => {
+            const at = (a.invokedAt ?? a.createdAt) - (b.invokedAt ?? b.createdAt)
+            return at !== 0 ? at : a.seq - b.seq
+        })
+
         const messages: DecryptedMessage[] = stored.map((message) => ({
             id: message.id,
             seq: message.seq,
@@ -77,10 +96,10 @@ export class MessageService {
             invokedAt: message.invokedAt
         }))
 
-        // The page is in ascending position order (oldest first), so the cursor for
-        // the next older fetch is the first row — picking the smallest `seq` instead
-        // would land on the wrong row whenever a low-seq row was invoked late.
-        const oldest = stored[0] ?? null
+        // The cursor is the oldest row in the actual position-ordered page (pageRows[0]).
+        // Out-of-band queued rows are not part of the cursor — they are pinned to
+        // every latest-page response.
+        const oldest = pageRows[0] ?? null
         const oldestSeq: number | null = oldest?.seq ?? null
         const oldestPositionAt: number | null = oldest
             ? oldest.invokedAt ?? oldest.createdAt

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -77,28 +77,20 @@ export class MessageService {
             invokedAt: message.invokedAt
         }))
 
-        // oldest entry is at index 0 (ascending order after reverse)
-        let oldestSeq: number | null = null
-        let oldestPositionAt: number | null = null
-        for (const message of messages) {
-            if (typeof message.seq !== 'number') continue
-            if (oldestSeq === null || message.seq < oldestSeq) {
-                oldestSeq = message.seq
-                // position_at = invokedAt ?? createdAt
-                const raw = stored.find((s) => s.seq === message.seq)
-                if (raw) {
-                    oldestPositionAt = raw.invokedAt ?? raw.createdAt
-                }
-            }
-        }
+        // The page is in ascending position order (oldest first), so the cursor for
+        // the next older fetch is the first row — picking the smallest `seq` instead
+        // would land on the wrong row whenever a low-seq row was invoked late.
+        const oldest = stored[0] ?? null
+        const oldestSeq: number | null = oldest?.seq ?? null
+        const oldestPositionAt: number | null = oldest
+            ? oldest.invokedAt ?? oldest.createdAt
+            : null
 
-        const hasMore = oldestSeq !== null
+        const hasMore = oldestSeq !== null && oldestPositionAt !== null
             && this.store.messages.getMessagesByPosition(
                 sessionId,
                 1,
-                oldestPositionAt !== null && oldestSeq !== null
-                    ? { at: oldestPositionAt, seq: oldestSeq }
-                    : undefined
+                { at: oldestPositionAt, seq: oldestSeq }
             ).length > 0
 
         return {

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -118,7 +118,8 @@ export class MessageService {
                 seq: msg.seq,
                 localId: msg.localId,
                 content: msg.content,
-                createdAt: msg.createdAt
+                createdAt: msg.createdAt,
+                invokedAt: msg.invokedAt
             }
         })
     }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -166,6 +166,21 @@ export class SyncEngine {
         return this.messageService.getMessagesPage(sessionId, options)
     }
 
+    getMessagesPageByPosition(
+        sessionId: string,
+        options: { limit: number; before?: { at: number; seq: number } | null }
+    ): {
+        messages: DecryptedMessage[]
+        page: {
+            limit: number
+            nextBeforeSeq: number | null
+            nextBeforeAt: number | null
+            hasMore: boolean
+        }
+    } {
+        return this.messageService.getMessagesPageByPosition(sessionId, options)
+    }
+
     getMessagesAfter(sessionId: string, options: { afterSeq: number; limit: number }): DecryptedMessage[] {
         return this.messageService.getMessagesAfter(sessionId, options)
     }

--- a/hub/src/web/routes/messages.ts
+++ b/hub/src/web/routes/messages.ts
@@ -7,7 +7,9 @@ import { requireSessionFromParam, requireSyncEngine } from './guards'
 
 const querySchema = z.object({
     limit: z.coerce.number().int().min(1).max(200).optional(),
-    beforeSeq: z.coerce.number().int().min(1).optional()
+    beforeSeq: z.coerce.number().int().min(1).optional(),
+    byPosition: z.string().optional(),
+    beforeAt: z.coerce.number().int().min(0).optional(),
 })
 
 const sendMessageBodySchema = z.object({
@@ -33,6 +35,18 @@ export function createMessagesRoutes(getSyncEngine: () => SyncEngine | null): Ho
 
         const parsed = querySchema.safeParse(c.req.query())
         const limit = parsed.success ? (parsed.data.limit ?? 50) : 50
+
+        // V8 byPosition mode: use composite (position_at, seq) cursor
+        if (parsed.success && parsed.data.byPosition === '1') {
+            const beforeAt = parsed.data.beforeAt
+            const beforeSeq = parsed.data.beforeSeq
+            const before = (beforeAt !== undefined && beforeSeq !== undefined)
+                ? { at: beforeAt, seq: beforeSeq }
+                : null
+            return c.json(engine.getMessagesPageByPosition(sessionId, { limit, before }))
+        }
+
+        // V7-compatible path: seq-based cursor
         const beforeSeq = parsed.success ? (parsed.data.beforeSeq ?? null) : null
         return c.json(engine.getMessagesPage(sessionId, { limit, beforeSeq }))
     })

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -154,7 +154,8 @@ export const DecryptedMessageSchema = z.object({
     seq: z.number().nullable(),
     localId: z.string().nullable(),
     content: z.unknown(),
-    createdAt: z.number()
+    createdAt: z.number(),
+    invokedAt: z.number().nullable().optional()
 })
 
 export type DecryptedMessage = z.infer<typeof DecryptedMessageSchema>

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -236,7 +236,8 @@ export const SyncEventSchema = z.discriminatedUnion('type', [
     }),
     SessionChangedSchema.extend({
         type: z.literal('messages-consumed'),
-        localIds: z.array(z.string())
+        localIds: z.array(z.string()),
+        invokedAt: z.number().optional()
     }),
     SessionEventBaseSchema.extend({
         type: z.literal('heartbeat'),

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -191,8 +191,22 @@ export class ApiClient {
         return await this.request<SessionResponse>(`/api/sessions/${encodeURIComponent(sessionId)}`)
     }
 
-    async getMessages(sessionId: string, options: { beforeSeq?: number | null; limit?: number }): Promise<MessagesResponse> {
+    async getMessages(
+        sessionId: string,
+        options: {
+            beforeSeq?: number | null
+            beforeAt?: number | null
+            byPosition?: boolean
+            limit?: number
+        }
+    ): Promise<MessagesResponse> {
         const params = new URLSearchParams()
+        if (options.byPosition || options.beforeAt !== undefined && options.beforeAt !== null) {
+            params.set('byPosition', '1')
+        }
+        if (options.beforeAt !== undefined && options.beforeAt !== null) {
+            params.set('beforeAt', `${options.beforeAt}`)
+        }
         if (options.beforeSeq !== undefined && options.beforeSeq !== null) {
             params.set('beforeSeq', `${options.beforeSeq}`)
         }

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useSyncExternalStore } from 'react'
+import { getMessageWindowState, subscribeMessageWindow } from '@/lib/message-window-store'
+import { isUserMessage } from '@/lib/messages'
+import { EMPTY_STATE } from '@/hooks/queries/useMessages'
+import { normalizeDecryptedMessage } from '@/chat/normalize'
+import type { DecryptedMessage } from '@/types/api'
+
+function ClockIcon() {
+    return (
+        <svg
+            className="h-[14px] w-[14px] shrink-0"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+        >
+            <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" />
+            <path
+                d="M8 5v3.5l2.5 1.5"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    )
+}
+
+/**
+ * Returns user messages that haven't been invoked yet (invokedAt == null and not sent/failed).
+ * Covers both optimistic (status='queued') and server-loaded (status=undefined, invokedAt=null) cases.
+ */
+function useQueuedMessages(sessionId: string): DecryptedMessage[] {
+    const state = useSyncExternalStore(
+        useCallback((listener) => subscribeMessageWindow(sessionId, listener), [sessionId]),
+        useCallback(() => getMessageWindowState(sessionId), [sessionId]),
+        () => EMPTY_STATE
+    )
+
+    const allMessages = [...state.messages, ...state.pending]
+    return allMessages.filter(
+        (m) =>
+            isUserMessage(m) &&
+            m.invokedAt == null &&
+            m.status !== 'sent' &&
+            m.status !== 'failed'
+    )
+}
+
+function getTextFromMessage(msg: DecryptedMessage): string {
+    const normalized = normalizeDecryptedMessage(msg)
+    if (!normalized || normalized.role !== 'user') {
+        return ''
+    }
+    return normalized.content.text ?? ''
+}
+
+/**
+ * Floating bar above the composer showing queued (pending invocation) messages.
+ * Disappears automatically when all queued messages are invoked or consumed.
+ *
+ * TODO PR 2: add cancel/edit buttons per item.
+ */
+export function QueuedMessagesBar({ sessionId }: { sessionId: string }) {
+    const queued = useQueuedMessages(sessionId)
+
+    if (queued.length === 0) {
+        return null
+    }
+
+    return (
+        <div
+            role="status"
+            aria-label={`${queued.length} queued message${queued.length === 1 ? '' : 's'} pending invocation`}
+            className="mx-auto w-full max-w-content mb-1"
+        >
+            <div className="px-3 py-2 text-sm text-[var(--app-fg-muted)]">
+                <div className="flex items-center gap-1.5 mb-1.5 text-xs font-medium text-[var(--app-hint)]">
+                    <ClockIcon />
+                    <span>Queued</span>
+                </div>
+                <ul
+                    className="flex flex-col gap-1.5 max-h-32 sm:max-h-48 overflow-y-auto"
+                    aria-label="Queued messages"
+                >
+                    {queued.map((msg) => {
+                        const text = getTextFromMessage(msg)
+                        return (
+                            <li
+                                key={msg.localId ?? msg.id}
+                                className="flex items-start gap-2 min-w-0 rounded-lg bg-[var(--app-secondary-bg)] px-3 py-2 shadow-sm"
+                            >
+                                <span className="line-clamp-3 whitespace-pre-wrap break-words text-[var(--app-fg)]">{text}</span>
+                                {/* TODO PR 2: cancel/edit buttons */}
+                            </li>
+                        )
+                    })}
+                </ul>
+            </div>
+        </div>
+    )
+}

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -36,12 +36,14 @@ function useQueuedMessages(sessionId: string): DecryptedMessage[] {
         () => EMPTY_STATE
     )
 
+    // `invokedAt` is the source of truth for invocation. `status === 'sent'` only
+    // means the REST write to the hub returned, not that the CLI consumed it; an
+    // optimistic 'sent' message with no `invokedAt` is still queued.
     const allMessages = [...state.messages, ...state.pending]
     return allMessages.filter(
         (m) =>
             isUserMessage(m) &&
             m.invokedAt == null &&
-            m.status !== 'sent' &&
             m.status !== 'failed'
     )
 }

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -38,12 +38,14 @@ function useQueuedMessages(sessionId: string): DecryptedMessage[] {
 
     // `invokedAt` is the source of truth for invocation. `status === 'sent'` only
     // means the REST write to the hub returned, not that the CLI consumed it; an
-    // optimistic 'sent' message with no `invokedAt` is still queued.
+    // optimistic 'sent' message with no `invokedAt` is still queued. Strict null
+    // check so a pre-V8 hub response that omits the field (`undefined`) is
+    // treated as already-invoked and stays out of the bar.
     const allMessages = [...state.messages, ...state.pending]
     return allMessages.filter(
         (m) =>
             isUserMessage(m) &&
-            m.invokedAt == null &&
+            m.invokedAt === null &&
             m.status !== 'failed'
     )
 }

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -48,7 +48,18 @@ function getTextFromMessage(msg: DecryptedMessage): string {
     if (!normalized || normalized.role !== 'user') {
         return ''
     }
-    return normalized.content.text ?? ''
+    const text = (normalized.content.text ?? '').trim()
+    if (text) {
+        return text
+    }
+    // Attachment-only sends: the composer / POST /messages allow empty text
+    // when attachments are present. Fall back to the filenames so the chip
+    // is not blank.
+    const attachments = normalized.content.attachments ?? []
+    if (attachments.length === 0) {
+        return ''
+    }
+    return attachments.map((a) => a.filename ?? 'attachment').join(', ')
 }
 
 /**

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useSyncExternalStore } from 'react'
 import { getMessageWindowState, subscribeMessageWindow } from '@/lib/message-window-store'
-import { isUserMessage } from '@/lib/messages'
+import { isQueuedForInvocation } from '@/lib/messages'
 import { EMPTY_STATE } from '@/hooks/queries/useMessages'
 import { normalizeDecryptedMessage } from '@/chat/normalize'
 import type { DecryptedMessage } from '@/types/api'
@@ -36,18 +36,11 @@ function useQueuedMessages(sessionId: string): DecryptedMessage[] {
         () => EMPTY_STATE
     )
 
-    // `invokedAt` is the source of truth for invocation. `status === 'sent'` only
-    // means the REST write to the hub returned, not that the CLI consumed it; an
-    // optimistic 'sent' message with no `invokedAt` is still queued. Strict null
-    // check so a pre-V8 hub response that omits the field (`undefined`) is
-    // treated as already-invoked and stays out of the bar.
+    // `invokedAt` is the source of truth for invocation; see isQueuedForInvocation
+    // (lib/messages) for the shared predicate used by the thread filter and the
+    // window store trim helpers.
     const allMessages = [...state.messages, ...state.pending]
-    return allMessages.filter(
-        (m) =>
-            isUserMessage(m) &&
-            m.invokedAt === null &&
-            m.status !== 'failed'
-    )
+    return allMessages.filter(isQueuedForInvocation)
 }
 
 function getTextFromMessage(msg: DecryptedMessage): string {

--- a/web/src/components/AssistantChat/messages/UserMessage.tsx
+++ b/web/src/components/AssistantChat/messages/UserMessage.tsx
@@ -47,7 +47,7 @@ export function HappyUserMessage() {
     const canRetry = status === 'failed' && typeof localId === 'string' && Boolean(ctx.onRetryMessage)
     const onRetry = canRetry ? () => ctx.onRetryMessage!(localId) : undefined
 
-    const userBubbleClass = `w-fit min-w-0 max-w-[92%] ml-auto rounded-xl bg-[var(--app-secondary-bg)] px-3 py-2 text-[var(--app-fg)] shadow-sm${status === 'queued' ? ' opacity-60' : ''}`
+    const userBubbleClass = `w-fit min-w-0 max-w-[92%] ml-auto rounded-xl bg-[var(--app-secondary-bg)] px-3 py-2 text-[var(--app-fg)] shadow-sm`
 
     if (isCliOutput) {
         return (

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -217,10 +217,11 @@ export function SessionChat(props: {
     // Exclude user messages that haven't been invoked yet — those appear in the
     // QueuedMessagesBar above the composer, not in the thread timeline. `invokedAt`
     // is the source of truth: `status === 'sent'` only means the REST write returned,
-    // not that the CLI consumed the message.
+    // not that the CLI consumed the message. Strict null check so a pre-V8 hub
+    // response that omits the field (`undefined`) is treated as already-invoked.
     const visibleMessages = useMemo(
         () => props.messages.filter(
-            (m) => !(isUserMessage(m) && m.invokedAt == null && m.status !== 'failed')
+            (m) => !(isUserMessage(m) && m.invokedAt === null && m.status !== 'failed')
         ),
         [props.messages]
     )

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -16,8 +16,10 @@ import { normalizeDecryptedMessage } from '@/chat/normalize'
 import { reduceChatBlocks } from '@/chat/reducer'
 import { reconcileChatBlocks } from '@/chat/reconcile'
 import { buildConversationOutline } from '@/chat/outline'
+import { isUserMessage } from '@/lib/messages'
 import { HappyComposer } from '@/components/AssistantChat/HappyComposer'
 import { HappyThread } from '@/components/AssistantChat/HappyThread'
+import { QueuedMessagesBar } from '@/components/AssistantChat/QueuedMessagesBar'
 import { useHappyRuntime } from '@/lib/assistant-runtime'
 import { createAttachmentAdapter } from '@/lib/attachmentAdapter'
 import { findUnsupportedCodexBuiltinSlashCommand } from '@/lib/codexSlashCommands'
@@ -212,6 +214,16 @@ export function SessionChat(props: {
         setOutlineOpen(false)
     }, [props.session.id])
 
+    // Exclude user messages that haven't been invoked yet (invokedAt == null, not sent/failed).
+    // Those appear in the QueuedMessagesBar above the composer, not in the thread timeline.
+    // This covers both optimistic (status='queued') and server-loaded (status=undefined, invokedAt=null) cases.
+    const visibleMessages = useMemo(
+        () => props.messages.filter(
+            (m) => !(isUserMessage(m) && m.invokedAt == null && m.status !== 'sent' && m.status !== 'failed')
+        ),
+        [props.messages]
+    )
+
     const normalizedMessages: NormalizedMessage[] = useMemo(() => {
         // Clear caches immediately when session changes (before useEffect runs)
         if (prevSessionIdRef.current !== null && prevSessionIdRef.current !== props.session.id) {
@@ -223,7 +235,7 @@ export function SessionChat(props: {
         const cache = normalizedCacheRef.current
         const normalized: NormalizedMessage[] = []
         const seen = new Set<string>()
-        for (const message of props.messages) {
+        for (const message of visibleMessages) {
             seen.add(message.id)
             const cached = cache.get(message.id)
             if (cached && cached.source === message) {
@@ -240,7 +252,7 @@ export function SessionChat(props: {
             }
         }
         return normalized
-    }, [props.messages])
+    }, [visibleMessages])
 
     const reduced = useMemo(
         () => reduceChatBlocks(normalizedMessages, props.session.agentState),
@@ -428,7 +440,7 @@ export function SessionChat(props: {
                         isLoadingMoreMessages={props.isLoadingMoreMessages}
                         onLoadMore={props.onLoadMore}
                         pendingCount={props.pendingCount}
-                        rawMessagesCount={props.messages.length}
+                        rawMessagesCount={visibleMessages.length}
                         normalizedMessagesCount={normalizedMessages.length}
                         messagesVersion={props.messagesVersion}
                         forceScrollToken={forceScrollToken}
@@ -445,6 +457,10 @@ export function SessionChat(props: {
                             </div>
                         </div>
                     ) : null}
+
+                    <div className="px-3">
+                        <QueuedMessagesBar sessionId={props.session.id} />
+                    </div>
 
                     <HappyComposer
                         key={props.session.id}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -214,12 +214,13 @@ export function SessionChat(props: {
         setOutlineOpen(false)
     }, [props.session.id])
 
-    // Exclude user messages that haven't been invoked yet (invokedAt == null, not sent/failed).
-    // Those appear in the QueuedMessagesBar above the composer, not in the thread timeline.
-    // This covers both optimistic (status='queued') and server-loaded (status=undefined, invokedAt=null) cases.
+    // Exclude user messages that haven't been invoked yet — those appear in the
+    // QueuedMessagesBar above the composer, not in the thread timeline. `invokedAt`
+    // is the source of truth: `status === 'sent'` only means the REST write returned,
+    // not that the CLI consumed the message.
     const visibleMessages = useMemo(
         () => props.messages.filter(
-            (m) => !(isUserMessage(m) && m.invokedAt == null && m.status !== 'sent' && m.status !== 'failed')
+            (m) => !(isUserMessage(m) && m.invokedAt == null && m.status !== 'failed')
         ),
         [props.messages]
     )

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -16,7 +16,7 @@ import { normalizeDecryptedMessage } from '@/chat/normalize'
 import { reduceChatBlocks } from '@/chat/reducer'
 import { reconcileChatBlocks } from '@/chat/reconcile'
 import { buildConversationOutline } from '@/chat/outline'
-import { isUserMessage } from '@/lib/messages'
+import { isQueuedForInvocation } from '@/lib/messages'
 import { HappyComposer } from '@/components/AssistantChat/HappyComposer'
 import { HappyThread } from '@/components/AssistantChat/HappyThread'
 import { QueuedMessagesBar } from '@/components/AssistantChat/QueuedMessagesBar'
@@ -215,14 +215,11 @@ export function SessionChat(props: {
     }, [props.session.id])
 
     // Exclude user messages that haven't been invoked yet — those appear in the
-    // QueuedMessagesBar above the composer, not in the thread timeline. `invokedAt`
-    // is the source of truth: `status === 'sent'` only means the REST write returned,
-    // not that the CLI consumed the message. Strict null check so a pre-V8 hub
-    // response that omits the field (`undefined`) is treated as already-invoked.
+    // QueuedMessagesBar above the composer, not in the thread timeline. The
+    // `isQueuedForInvocation` predicate is shared with the window store and the
+    // floating bar so the three views never disagree about queued state.
     const visibleMessages = useMemo(
-        () => props.messages.filter(
-            (m) => !(isUserMessage(m) && m.invokedAt === null && m.status !== 'failed')
-        ),
+        () => props.messages.filter((m) => !isQueuedForInvocation(m)),
         [props.messages]
     )
 

--- a/web/src/hooks/mutations/useSendMessage.ts
+++ b/web/src/hooks/mutations/useSendMessage.ts
@@ -44,6 +44,10 @@ function createOptimisticMessage(input: SendMessageInput, status: 'queued' | 'se
             }
         },
         createdAt: input.createdAt,
+        // Explicit null so the strict-null queued check matches. A pre-V8 hub
+        // response that omits the field entirely (`undefined`) is treated as
+        // already-invoked and stays in the thread, not the floating bar.
+        invokedAt: null,
         status,
         originalText: input.text,
     }

--- a/web/src/hooks/queries/useMessages.ts
+++ b/web/src/hooks/queries/useMessages.ts
@@ -12,7 +12,7 @@ import {
     type MessageWindowState,
 } from '@/lib/message-window-store'
 
-const EMPTY_STATE: MessageWindowState = {
+export const EMPTY_STATE: MessageWindowState = {
     sessionId: 'unknown',
     messages: [],
     pending: [],

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -498,7 +498,7 @@ export function useSSE(options: {
             }
 
             if (event.type === 'messages-consumed') {
-                markMessagesConsumed(event.sessionId, event.localIds)
+                markMessagesConsumed(event.sessionId, event.localIds, event.invokedAt)
             }
 
             if (event.type === 'message-received') {

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -268,14 +268,30 @@ function buildState(
     }
 }
 
+function isQueuedForInvocation(message: DecryptedMessage): boolean {
+    return isUserMessage(message) && message.invokedAt == null && message.status !== 'failed'
+}
+
 function trimVisible(messages: DecryptedMessage[], mode: 'append' | 'prepend'): DecryptedMessage[] {
     if (messages.length <= VISIBLE_WINDOW_SIZE) {
         return messages
     }
-    if (mode === 'prepend') {
-        return messages.slice(0, VISIBLE_WINDOW_SIZE)
+    // Queued messages must survive trimming. The `messages-consumed` SSE only
+    // carries localIds, so if a queued row is dropped before invocation the
+    // client cannot restore or reposition it without a full refetch.
+    const queued = messages.filter(isQueuedForInvocation)
+    if (queued.length === 0) {
+        return mode === 'prepend'
+            ? messages.slice(0, VISIBLE_WINDOW_SIZE)
+            : messages.slice(messages.length - VISIBLE_WINDOW_SIZE)
     }
-    return messages.slice(messages.length - VISIBLE_WINDOW_SIZE)
+    const queuedIds = new Set(queued.map((message) => message.id))
+    const regular = messages.filter((message) => !queuedIds.has(message.id))
+    const budget = Math.max(0, VISIBLE_WINDOW_SIZE - queued.length)
+    const trimmedRegular = mode === 'prepend'
+        ? regular.slice(0, budget)
+        : regular.slice(Math.max(0, regular.length - budget))
+    return mergeMessages(trimmedRegular, queued)
 }
 
 function trimPending(

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -638,8 +638,12 @@ export function markMessagesConsumed(sessionId: string, localIds: string[], invo
                 // Apply the ack even if the message is already 'sent' (optimistic) — otherwise
                 // a message that flipped to 'sent' before the consume event arrives would
                 // never receive `invokedAt` and keep sorting by send time.
+                // First-write-wins on `invokedAt`: mirror the hub's UPDATE guard so a
+                // duplicate `messages-consumed` (e.g. CLI re-emit) doesn't restamp a
+                // message and shuffle its byPosition slot on live clients while the
+                // DB still holds the original timestamp.
                 const needsStatus = message.status !== 'sent'
-                const needsInvokedAt = message.invokedAt !== effectiveInvokedAt
+                const needsInvokedAt = message.invokedAt == null
                 if (!needsStatus && !needsInvokedAt) {
                     return message
                 }

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -603,8 +603,11 @@ export function markMessagesConsumed(sessionId: string, localIds: string[], invo
                 return { ...message, ...update }
             })
         }
-        const messages = updateList(prev.messages)
-        const pending = updateList(prev.pending)
+        // After update, re-merge to re-sort by the position key (`invokedAt ?? createdAt`):
+        // a queued message that just received `invokedAt` should move to its invocation
+        // position, not stay at its original send-time slot until the next fetch.
+        const messages = mergeMessages([], updateList(prev.messages))
+        const pending = mergeMessages([], updateList(prev.pending))
         if (!changed) {
             return prev
         }

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -552,13 +552,23 @@ export function markMessagesConsumed(sessionId: string, localIds: string[], invo
                 if (!message.localId || !idSet.has(message.localId)) {
                     return message
                 }
-                // Only update if not already in a terminal state
-                if (message.status === 'sent' || message.status === 'failed') {
+                if (message.status === 'failed') {
+                    return message
+                }
+                // Apply the ack even if the message is already 'sent' (optimistic) — otherwise
+                // a message that flipped to 'sent' before the consume event arrives would
+                // never receive `invokedAt` and keep sorting by send time.
+                const needsStatus = message.status !== 'sent'
+                const needsInvokedAt = invokedAt != null && message.invokedAt !== invokedAt
+                if (!needsStatus && !needsInvokedAt) {
                     return message
                 }
                 changed = true
-                const update: Partial<DecryptedMessage> = { status: 'sent' as MessageStatus }
-                if (invokedAt != null) {
+                const update: Partial<DecryptedMessage> = {}
+                if (needsStatus) {
+                    update.status = 'sent' as MessageStatus
+                }
+                if (needsInvokedAt) {
                     update.invokedAt = invokedAt
                 }
                 return { ...message, ...update }

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -538,20 +538,30 @@ export function updateMessageStatus(sessionId: string, localId: string, status: 
     })
 }
 
-/** Transition the queued messages whose localIds match to 'sent'. Driven by the
- *  CLI ack (messages-consumed). Unmatched messages remain queued. */
-export function markMessagesConsumed(sessionId: string, localIds: string[]): void {
+/** Transition the queued messages whose localIds match to 'sent' and record invokedAt.
+ *  Driven by the CLI ack (messages-consumed). Unmatched messages remain queued.
+ *  Also handles server-loaded messages (status=undefined) that have a matching localId.
+ *  If invokedAt is undefined (V7 hub compat), only status is updated. */
+export function markMessagesConsumed(sessionId: string, localIds: string[], invokedAt: number | undefined): void {
     if (localIds.length === 0) return
     const idSet = new Set(localIds)
     updateState(sessionId, (prev) => {
         let changed = false
         const updateList = (list: DecryptedMessage[]) => {
             return list.map((message) => {
-                if (message.status !== 'queued' || !message.localId || !idSet.has(message.localId)) {
+                if (!message.localId || !idSet.has(message.localId)) {
+                    return message
+                }
+                // Only update if not already in a terminal state
+                if (message.status === 'sent' || message.status === 'failed') {
                     return message
                 }
                 changed = true
-                return { ...message, status: 'sent' as MessageStatus }
+                const update: Partial<DecryptedMessage> = { status: 'sent' as MessageStatus }
+                if (invokedAt != null) {
+                    update.invokedAt = invokedAt
+                }
+                return { ...message, ...update }
             })
         }
         const messages = updateList(prev.messages)

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -269,7 +269,10 @@ function buildState(
 }
 
 function isQueuedForInvocation(message: DecryptedMessage): boolean {
-    return isUserMessage(message) && message.invokedAt == null && message.status !== 'failed'
+    // Strict null: a pre-V8 hub response that omits the field (undefined) is
+    // treated as already-invoked. Optimistic messages set invokedAt: null
+    // explicitly to opt into the queued state.
+    return isUserMessage(message) && message.invokedAt === null && message.status !== 'failed'
 }
 
 function trimVisible(messages: DecryptedMessage[], mode: 'append' | 'prepend'): DecryptedMessage[] {
@@ -602,10 +605,14 @@ export function updateMessageStatus(sessionId: string, localId: string, status: 
 /** Transition the queued messages whose localIds match to 'sent' and record invokedAt.
  *  Driven by the CLI ack (messages-consumed). Unmatched messages remain queued.
  *  Also handles server-loaded messages (status=undefined) that have a matching localId.
- *  If invokedAt is undefined (V7 hub compat), only status is updated. */
+ *  V7 hub compat: if `invokedAt` is undefined the SyncEvent had no server timestamp,
+ *  so we fall back to client time — without it the row would stay queued forever
+ *  under the strict-null filter. The fallback only affects display ordering on
+ *  this client; the persisted server value is the authoritative one when present. */
 export function markMessagesConsumed(sessionId: string, localIds: string[], invokedAt: number | undefined): void {
     if (localIds.length === 0) return
     const idSet = new Set(localIds)
+    const effectiveInvokedAt = invokedAt ?? Date.now()
     updateState(sessionId, (prev) => {
         let changed = false
         const updateList = (list: DecryptedMessage[]) => {
@@ -620,7 +627,7 @@ export function markMessagesConsumed(sessionId: string, localIds: string[], invo
                 // a message that flipped to 'sent' before the consume event arrives would
                 // never receive `invokedAt` and keep sorting by send time.
                 const needsStatus = message.status !== 'sent'
-                const needsInvokedAt = invokedAt != null && message.invokedAt !== invokedAt
+                const needsInvokedAt = message.invokedAt !== effectiveInvokedAt
                 if (!needsStatus && !needsInvokedAt) {
                     return message
                 }
@@ -630,7 +637,7 @@ export function markMessagesConsumed(sessionId: string, localIds: string[], invo
                     update.status = 'sent' as MessageStatus
                 }
                 if (needsInvokedAt) {
-                    update.invokedAt = invokedAt
+                    update.invokedAt = effectiveInvokedAt
                 }
                 return { ...message, ...update }
             })

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -29,6 +29,11 @@ type InternalState = MessageWindowState & {
     pendingOverflowVisibleCount: number
     // V8 composite cursor: defined when hub responded with nextBeforeAt
     oldestPositionAt: number | null
+    // Paired with oldestPositionAt — the server returns both as a cursor; keep them
+    // together so we don't accidentally combine `nextBeforeAt` from the server with
+    // a recomputed minimum `seq` from the local window (those can refer to
+    // different rows after a low-seq message is invoked late).
+    oldestPositionSeq: number | null
 }
 
 type PendingVisibilityCacheEntry = {
@@ -141,6 +146,7 @@ function createState(sessionId: string): InternalState {
         hasMore: false,
         oldestSeq: null,
         oldestPositionAt: null,
+        oldestPositionSeq: null,
         newestSeq: null,
         isLoading: false,
         isLoadingMore: false,
@@ -218,6 +224,7 @@ function buildState(
         pendingOverflowVisibleCount?: number
         hasMore?: boolean
         oldestPositionAt?: number | null
+        oldestPositionSeq?: number | null
         isLoading?: boolean
         isLoadingMore?: boolean
         warning?: string | null
@@ -250,6 +257,7 @@ function buildState(
         pendingCount,
         oldestSeq,
         oldestPositionAt: updates.oldestPositionAt !== undefined ? updates.oldestPositionAt : prev.oldestPositionAt,
+        oldestPositionSeq: updates.oldestPositionSeq !== undefined ? updates.oldestPositionSeq : prev.oldestPositionSeq,
         newestSeq,
         hasMore: updates.hasMore !== undefined ? updates.hasMore : prev.hasMore,
         isLoading: updates.isLoading !== undefined ? updates.isLoading : prev.isLoading,
@@ -366,6 +374,7 @@ export function seedMessageWindowFromSession(fromSessionId: string, toSessionId:
         pendingOverflowVisibleCount: source.pendingOverflowVisibleCount,
         hasMore: source.hasMore,
         oldestPositionAt: source.oldestPositionAt,
+        oldestPositionSeq: source.oldestPositionSeq,
         warning: source.warning,
         atBottom: source.atBottom,
         isLoading: false,
@@ -386,10 +395,12 @@ export async function fetchLatestMessages(api: ApiClient, sessionId: string): Pr
         // returns the standard seq-based response (no nextBeforeAt field) — we fall back
         // to seq-cursor mode seamlessly.
         const response = await api.getMessages(sessionId, { byPosition: true, limit: PAGE_SIZE })
-        // Derive composite cursor if hub responded with nextBeforeAt (V8 mode)
+        // Derive composite cursor pair from server response. Both values come from
+        // the same row on the server; we keep them paired so the next older fetch
+        // doesn't mix `beforeAt` from the server with a recomputed minimum `seq`.
         const nextBeforeAt = response.page.nextBeforeAt ?? null
         const nextBeforeSeq = response.page.nextBeforeSeq ?? null
-        const oldestPositionAt = nextBeforeAt !== null ? nextBeforeAt : null
+        const isV8Cursor = nextBeforeAt !== null && nextBeforeSeq !== null
 
         updateState(sessionId, (prev) => {
             if (prev.atBottom) {
@@ -402,7 +413,8 @@ export async function fetchLatestMessages(api: ApiClient, sessionId: string): Pr
                     pendingVisibleCount: 0,
                     pendingOverflowVisibleCount: 0,
                     hasMore: response.page.hasMore,
-                    oldestPositionAt: nextBeforeSeq !== null ? oldestPositionAt : null,
+                    oldestPositionAt: isV8Cursor ? nextBeforeAt : null,
+                    oldestPositionSeq: isV8Cursor ? nextBeforeSeq : null,
                     isLoading: false,
                     warning: null,
                 })
@@ -434,19 +446,22 @@ export async function fetchOlderMessages(api: ApiClient, sessionId: string): Pro
     updateState(sessionId, (prev) => buildState(prev, { isLoadingMore: true }))
 
     try {
-        // Use composite cursor (V8 mode) when oldestPositionAt is available from previous response.
-        // Fall back to seq-only cursor for V7 hubs (oldestPositionAt === null).
-        const response = initial.oldestPositionAt !== null
+        // V8 mode: use the server-provided cursor pair as-is. Mixing `beforeAt` from
+        // the server with a recomputed minimum `seq` from the local window can refer
+        // to different rows after a low-seq message is invoked late.
+        const useV8Cursor = initial.oldestPositionAt !== null && initial.oldestPositionSeq !== null
+        const response = useV8Cursor
             ? await api.getMessages(sessionId, {
                 byPosition: true,
-                beforeAt: initial.oldestPositionAt,
-                beforeSeq: initial.oldestSeq,
+                beforeAt: initial.oldestPositionAt!,
+                beforeSeq: initial.oldestPositionSeq!,
                 limit: PAGE_SIZE
             })
             : await api.getMessages(sessionId, { beforeSeq: initial.oldestSeq, limit: PAGE_SIZE })
 
         const nextBeforeAt = response.page.nextBeforeAt ?? null
         const nextBeforeSeq = response.page.nextBeforeSeq ?? null
+        const isV8Cursor = nextBeforeAt !== null && nextBeforeSeq !== null
 
         updateState(sessionId, (prev) => {
             const merged = mergeMessages(response.messages, prev.messages)
@@ -454,7 +469,8 @@ export async function fetchOlderMessages(api: ApiClient, sessionId: string): Pro
             return buildState(prev, {
                 messages: trimmed,
                 hasMore: response.page.hasMore,
-                oldestPositionAt: nextBeforeSeq !== null && nextBeforeAt !== null ? nextBeforeAt : null,
+                oldestPositionAt: isV8Cursor ? nextBeforeAt : null,
+                oldestPositionSeq: isV8Cursor ? nextBeforeSeq : null,
                 isLoadingMore: false,
             })
         })

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -1,7 +1,7 @@
 import type { ApiClient } from '@/api/client'
 import type { DecryptedMessage, MessageStatus } from '@/types/api'
 import { normalizeDecryptedMessage } from '@/chat/normalize'
-import { isUserMessage, mergeMessages } from '@/lib/messages'
+import { isQueuedForInvocation, isUserMessage, mergeMessages } from '@/lib/messages'
 
 export type MessageWindowState = {
     sessionId: string
@@ -268,33 +268,44 @@ function buildState(
     }
 }
 
-function isQueuedForInvocation(message: DecryptedMessage): boolean {
-    // Strict null: a pre-V8 hub response that omits the field (undefined) is
-    // treated as already-invoked. Optimistic messages set invokedAt: null
-    // explicitly to opt into the queued state.
-    return isUserMessage(message) && message.invokedAt === null && message.status !== 'failed'
-}
-
-function trimVisible(messages: DecryptedMessage[], mode: 'append' | 'prepend'): DecryptedMessage[] {
-    if (messages.length <= VISIBLE_WINDOW_SIZE) {
-        return messages
+/** Trim `messages` down to `limit` while preserving every queued user message.
+ *  Queued rows must survive trimming on both windows: the `messages-consumed`
+ *  SSE only carries localIds, so a dropped queued row cannot be restored or
+ *  repositioned without a full refetch.  Returns the kept slice plus the list
+ *  of regular (non-queued) rows that were dropped, so the pending-overflow
+ *  warning counter can be advanced symmetrically. */
+function trimPreservingQueued(
+    messages: DecryptedMessage[],
+    limit: number,
+    mode: 'append' | 'prepend'
+): { kept: DecryptedMessage[]; dropped: DecryptedMessage[] } {
+    if (messages.length <= limit) {
+        return { kept: messages, dropped: [] }
     }
-    // Queued messages must survive trimming. The `messages-consumed` SSE only
-    // carries localIds, so if a queued row is dropped before invocation the
-    // client cannot restore or reposition it without a full refetch.
     const queued = messages.filter(isQueuedForInvocation)
     if (queued.length === 0) {
-        return mode === 'prepend'
-            ? messages.slice(0, VISIBLE_WINDOW_SIZE)
-            : messages.slice(messages.length - VISIBLE_WINDOW_SIZE)
+        const kept = mode === 'prepend'
+            ? messages.slice(0, limit)
+            : messages.slice(messages.length - limit)
+        const dropped = mode === 'prepend'
+            ? messages.slice(limit)
+            : messages.slice(0, messages.length - limit)
+        return { kept, dropped }
     }
     const queuedIds = new Set(queued.map((message) => message.id))
     const regular = messages.filter((message) => !queuedIds.has(message.id))
-    const budget = Math.max(0, VISIBLE_WINDOW_SIZE - queued.length)
+    const budget = Math.max(0, limit - queued.length)
     const trimmedRegular = mode === 'prepend'
         ? regular.slice(0, budget)
         : regular.slice(Math.max(0, regular.length - budget))
-    return mergeMessages(trimmedRegular, queued)
+    const droppedRegular = mode === 'prepend'
+        ? regular.slice(budget)
+        : regular.slice(0, Math.max(0, regular.length - budget))
+    return { kept: mergeMessages(trimmedRegular, queued), dropped: droppedRegular }
+}
+
+function trimVisible(messages: DecryptedMessage[], mode: 'append' | 'prepend'): DecryptedMessage[] {
+    return trimPreservingQueued(messages, VISIBLE_WINDOW_SIZE, mode).kept
 }
 
 function trimPending(
@@ -304,11 +315,12 @@ function trimPending(
     if (messages.length <= PENDING_WINDOW_SIZE) {
         return { pending: messages, dropped: 0, droppedVisible: 0 }
     }
-    const cutoff = messages.length - PENDING_WINDOW_SIZE
-    const droppedMessages = messages.slice(0, cutoff)
-    const pending = messages.slice(cutoff)
-    const droppedVisible = countVisiblePendingMessages(sessionId, droppedMessages)
-    return { pending, dropped: droppedMessages.length, droppedVisible }
+    // Symmetric with trimVisible: agents that overflow the pending window
+    // (200) must not evict queued user messages — the floating bar holds the
+    // only client-visible reference to them until the CLI ack arrives.
+    const { kept, dropped } = trimPreservingQueued(messages, PENDING_WINDOW_SIZE, 'append')
+    const droppedVisible = countVisiblePendingMessages(sessionId, dropped)
+    return { pending: kept, dropped: dropped.length, droppedVisible }
 }
 
 function filterPendingAgainstVisible(pending: DecryptedMessage[], visible: DecryptedMessage[]): DecryptedMessage[] {
@@ -642,11 +654,31 @@ export function markMessagesConsumed(sessionId: string, localIds: string[], invo
                 return { ...message, ...update }
             })
         }
+        // Migrate just-acked pending entries into the visible thread. Without
+        // this step, an at-bottom=false user that is stuck in pending never
+        // sees their own message at the invocation slot — it stays in the
+        // pending bucket until they scroll, even though the floating bar
+        // already cleared.  Identifying the migrated rows by (localId,
+        // invokedAt = effectiveInvokedAt) ensures we only move rows whose
+        // ack just arrived, not unrelated pending entries.
+        const updatedPending = updateList(prev.pending)
+        const consumedFromPending: DecryptedMessage[] = []
+        const remainingPending = updatedPending.filter((message) => {
+            if (
+                message.localId &&
+                idSet.has(message.localId) &&
+                message.invokedAt === effectiveInvokedAt
+            ) {
+                consumedFromPending.push(message)
+                return false
+            }
+            return true
+        })
         // After update, re-merge to re-sort by the position key (`invokedAt ?? createdAt`):
         // a queued message that just received `invokedAt` should move to its invocation
         // position, not stay at its original send-time slot until the next fetch.
-        const messages = mergeMessages([], updateList(prev.messages))
-        const pending = mergeMessages([], updateList(prev.pending))
+        const messages = mergeMessages(updateList(prev.messages), consumedFromPending)
+        const pending = mergeMessages([], remainingPending)
         if (!changed) {
             return prev
         }

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -27,6 +27,8 @@ type InternalState = MessageWindowState & {
     pendingOverflowCount: number
     pendingVisibleCount: number
     pendingOverflowVisibleCount: number
+    // V8 composite cursor: defined when hub responded with nextBeforeAt
+    oldestPositionAt: number | null
 }
 
 type PendingVisibilityCacheEntry = {
@@ -138,6 +140,7 @@ function createState(sessionId: string): InternalState {
         pendingOverflowVisibleCount: 0,
         hasMore: false,
         oldestSeq: null,
+        oldestPositionAt: null,
         newestSeq: null,
         isLoading: false,
         isLoadingMore: false,
@@ -214,6 +217,7 @@ function buildState(
         pendingVisibleCount?: number
         pendingOverflowVisibleCount?: number
         hasMore?: boolean
+        oldestPositionAt?: number | null
         isLoading?: boolean
         isLoadingMore?: boolean
         warning?: string | null
@@ -245,6 +249,7 @@ function buildState(
         pendingOverflowVisibleCount,
         pendingCount,
         oldestSeq,
+        oldestPositionAt: updates.oldestPositionAt !== undefined ? updates.oldestPositionAt : prev.oldestPositionAt,
         newestSeq,
         hasMore: updates.hasMore !== undefined ? updates.hasMore : prev.hasMore,
         isLoading: updates.isLoading !== undefined ? updates.isLoading : prev.isLoading,
@@ -360,6 +365,7 @@ export function seedMessageWindowFromSession(fromSessionId: string, toSessionId:
         pendingOverflowCount: source.pendingOverflowCount,
         pendingOverflowVisibleCount: source.pendingOverflowVisibleCount,
         hasMore: source.hasMore,
+        oldestPositionAt: source.oldestPositionAt,
         warning: source.warning,
         atBottom: source.atBottom,
         isLoading: false,
@@ -376,7 +382,15 @@ export async function fetchLatestMessages(api: ApiClient, sessionId: string): Pr
     updateState(sessionId, (prev) => buildState(prev, { isLoading: true, warning: null }))
 
     try {
-        const response = await api.getMessages(sessionId, { limit: PAGE_SIZE, beforeSeq: null })
+        // Always request byPosition mode (V8). If the hub is V7 it ignores byPosition and
+        // returns the standard seq-based response (no nextBeforeAt field) — we fall back
+        // to seq-cursor mode seamlessly.
+        const response = await api.getMessages(sessionId, { byPosition: true, limit: PAGE_SIZE })
+        // Derive composite cursor if hub responded with nextBeforeAt (V8 mode)
+        const nextBeforeAt = response.page.nextBeforeAt ?? null
+        const nextBeforeSeq = response.page.nextBeforeSeq ?? null
+        const oldestPositionAt = nextBeforeAt !== null ? nextBeforeAt : null
+
         updateState(sessionId, (prev) => {
             if (prev.atBottom) {
                 const merged = mergeMessages(prev.messages, [...prev.pending, ...response.messages])
@@ -388,6 +402,7 @@ export async function fetchLatestMessages(api: ApiClient, sessionId: string): Pr
                     pendingVisibleCount: 0,
                     pendingOverflowVisibleCount: 0,
                     hasMore: response.page.hasMore,
+                    oldestPositionAt: nextBeforeSeq !== null ? oldestPositionAt : null,
                     isLoading: false,
                     warning: null,
                 })
@@ -419,13 +434,27 @@ export async function fetchOlderMessages(api: ApiClient, sessionId: string): Pro
     updateState(sessionId, (prev) => buildState(prev, { isLoadingMore: true }))
 
     try {
-        const response = await api.getMessages(sessionId, { limit: PAGE_SIZE, beforeSeq: initial.oldestSeq })
+        // Use composite cursor (V8 mode) when oldestPositionAt is available from previous response.
+        // Fall back to seq-only cursor for V7 hubs (oldestPositionAt === null).
+        const response = initial.oldestPositionAt !== null
+            ? await api.getMessages(sessionId, {
+                byPosition: true,
+                beforeAt: initial.oldestPositionAt,
+                beforeSeq: initial.oldestSeq,
+                limit: PAGE_SIZE
+            })
+            : await api.getMessages(sessionId, { beforeSeq: initial.oldestSeq, limit: PAGE_SIZE })
+
+        const nextBeforeAt = response.page.nextBeforeAt ?? null
+        const nextBeforeSeq = response.page.nextBeforeSeq ?? null
+
         updateState(sessionId, (prev) => {
             const merged = mergeMessages(response.messages, prev.messages)
             const trimmed = trimVisible(merged, 'prepend')
             return buildState(prev, {
                 messages: trimmed,
                 hasMore: response.page.hasMore,
+                oldestPositionAt: nextBeforeSeq !== null && nextBeforeAt !== null ? nextBeforeAt : null,
                 isLoadingMore: false,
             })
         })

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -456,6 +456,12 @@ export async function fetchLatestMessages(api: ApiClient, sessionId: string): Pr
                 pendingVisibleCount: pendingResult.pendingVisibleCount,
                 pendingOverflowCount: pendingResult.pendingOverflowCount,
                 pendingOverflowVisibleCount: pendingResult.pendingOverflowVisibleCount,
+                // Persist the V8 cursor pair on the non-at-bottom path too. Without this
+                // a refresh while scrolled up dropped the composite cursor and the next
+                // loadMore fell back to V7 seq mode against a V8 hub — the same
+                // asymmetric class of bug the at-bottom branch already guards against.
+                oldestPositionAt: isV8Cursor ? nextBeforeAt : null,
+                oldestPositionSeq: isV8Cursor ? nextBeforeSeq : null,
                 isLoading: false,
                 warning: pendingResult.warning,
             })
@@ -643,7 +649,10 @@ export function markMessagesConsumed(sessionId: string, localIds: string[], invo
                 // message and shuffle its byPosition slot on live clients while the
                 // DB still holds the original timestamp.
                 const needsStatus = message.status !== 'sent'
-                const needsInvokedAt = message.invokedAt == null
+                // Strict null to stay consistent with isQueuedForInvocation and the rest
+                // of this file. The idSet filter already shields V7-stamped rows from
+                // this path, but the strict-null contract should not vary by call site.
+                const needsInvokedAt = message.invokedAt === null
                 if (!needsStatus && !needsInvokedAt) {
                     return message
                 }

--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -58,12 +58,18 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
     }
 
     // If we received stored messages with a localId, drop any optimistic bubbles with the same localId.
-    // Preserve client-side status (e.g. 'queued') on the replacing server message.
+    // Preserve client-side status (e.g. 'queued') and invokedAt on the replacing server message.
     if (incomingStoredLocalIds.size > 0) {
         const optimisticStatusByLocalId = new Map<string, DecryptedMessage['status']>()
+        const optimisticInvokedAtByLocalId = new Map<string, number | null | undefined>()
         for (const msg of merged) {
-            if (msg.localId && isOptimisticMessage(msg) && incomingStoredLocalIds.has(msg.localId) && msg.status) {
-                optimisticStatusByLocalId.set(msg.localId, msg.status)
+            if (msg.localId && isOptimisticMessage(msg) && incomingStoredLocalIds.has(msg.localId)) {
+                if (msg.status) {
+                    optimisticStatusByLocalId.set(msg.localId, msg.status)
+                }
+                if ('invokedAt' in msg) {
+                    optimisticInvokedAtByLocalId.set(msg.localId, (msg as any).invokedAt)
+                }
             }
         }
         merged = merged.filter((msg) => {
@@ -72,10 +78,18 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
             }
             return !isOptimisticMessage(msg)
         })
-        if (optimisticStatusByLocalId.size > 0) {
+        if (optimisticStatusByLocalId.size > 0 || optimisticInvokedAtByLocalId.size > 0) {
             merged = merged.map((msg) => {
-                if (msg.localId && optimisticStatusByLocalId.has(msg.localId) && !msg.status) {
-                    return { ...msg, status: optimisticStatusByLocalId.get(msg.localId) }
+                if (!msg.localId) return msg
+                const update: Partial<DecryptedMessage> = {}
+                if (optimisticStatusByLocalId.has(msg.localId) && !msg.status) {
+                    update.status = optimisticStatusByLocalId.get(msg.localId)
+                }
+                if (optimisticInvokedAtByLocalId.has(msg.localId) && !('invokedAt' in msg)) {
+                    ;(update as any).invokedAt = optimisticInvokedAtByLocalId.get(msg.localId)
+                }
+                if (Object.keys(update).length > 0) {
+                    return { ...msg, ...update }
                 }
                 return msg
             })

--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -26,8 +26,12 @@ function compareMessages(a: DecryptedMessage, b: DecryptedMessage): number {
         return aSeq - bSeq
     }
 
-    if (a.createdAt !== b.createdAt) {
-        return a.createdAt - b.createdAt
+    // Use invokedAt as position anchor for invoked user messages; fall back to createdAt.
+    const aTime = a.invokedAt ?? a.createdAt
+    const bTime = b.invokedAt ?? b.createdAt
+
+    if (aTime !== bTime) {
+        return aTime - bTime
     }
     return a.id.localeCompare(b.id)
 }
@@ -67,8 +71,8 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
                 if (msg.status) {
                     optimisticStatusByLocalId.set(msg.localId, msg.status)
                 }
-                if ('invokedAt' in msg) {
-                    optimisticInvokedAtByLocalId.set(msg.localId, (msg as any).invokedAt)
+                if (msg.invokedAt !== undefined) {
+                    optimisticInvokedAtByLocalId.set(msg.localId, msg.invokedAt)
                 }
             }
         }
@@ -85,8 +89,11 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
                 if (optimisticStatusByLocalId.has(msg.localId) && !msg.status) {
                     update.status = optimisticStatusByLocalId.get(msg.localId)
                 }
-                if (optimisticInvokedAtByLocalId.has(msg.localId) && !('invokedAt' in msg)) {
-                    ;(update as any).invokedAt = optimisticInvokedAtByLocalId.get(msg.localId)
+                if (optimisticInvokedAtByLocalId.has(msg.localId) && msg.invokedAt == null) {
+                    const optimisticInvokedAt = optimisticInvokedAtByLocalId.get(msg.localId)
+                    if (optimisticInvokedAt != null) {
+                        update.invokedAt = optimisticInvokedAt
+                    }
                 }
                 if (Object.keys(update).length > 0) {
                     return { ...msg, ...update }

--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -19,19 +19,18 @@ function isOptimisticMessage(msg: DecryptedMessage): boolean {
 }
 
 function compareMessages(a: DecryptedMessage, b: DecryptedMessage): number {
-    const aSeq = typeof a.seq === 'number' ? a.seq : null
-    const bSeq = typeof b.seq === 'number' ? b.seq : null
-
-    if (aSeq !== null && bSeq !== null && aSeq !== bSeq) {
-        return aSeq - bSeq
-    }
-
-    // Use invokedAt as position anchor for invoked user messages; fall back to createdAt.
     const aTime = a.invokedAt ?? a.createdAt
     const bTime = b.invokedAt ?? b.createdAt
 
     if (aTime !== bTime) {
         return aTime - bTime
+    }
+
+    const aSeq = typeof a.seq === 'number' ? a.seq : null
+    const bSeq = typeof b.seq === 'number' ? b.seq : null
+
+    if (aSeq !== null && bSeq !== null && aSeq !== bSeq) {
+        return aSeq - bSeq
     }
     return a.id.localeCompare(b.id)
 }

--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -1,5 +1,4 @@
-import type { InfiniteData } from '@tanstack/react-query'
-import type { DecryptedMessage, MessagesResponse } from '@/types/api'
+import type { DecryptedMessage } from '@/types/api'
 import { randomId } from '@/lib/randomId'
 
 export function makeClientSideId(prefix: string): string {
@@ -137,40 +136,4 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
 
     result.sort(compareMessages)
     return result
-}
-
-export function upsertMessagesInCache(
-    data: InfiniteData<MessagesResponse> | undefined,
-    incoming: DecryptedMessage[],
-): InfiniteData<MessagesResponse> {
-    const mergedIncoming = mergeMessages([], incoming)
-
-    if (!data || data.pages.length === 0) {
-        return {
-            pages: [
-                {
-                    messages: mergedIncoming,
-                    page: {
-                        limit: 50,
-                        beforeSeq: null,
-                        nextBeforeSeq: null,
-                        hasMore: false,
-                    },
-                },
-            ],
-            pageParams: [null],
-        }
-    }
-
-    const pages = data.pages.slice()
-    const first = pages[0]
-    pages[0] = {
-        ...first,
-        messages: mergeMessages(first.messages, mergedIncoming),
-    }
-
-    return {
-        ...data,
-        pages,
-    }
 }

--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -14,6 +14,15 @@ export function isUserMessage(msg: DecryptedMessage): boolean {
     return false
 }
 
+/** A user message that is still waiting for the CLI ack (messages-consumed).
+ *  Strict null on `invokedAt` so a pre-V8 hub response that omits the field
+ *  (`undefined`) is treated as already-invoked; only optimistic / V8-loaded
+ *  rows that explicitly carry `invokedAt: null` are queued. `failed` rows are
+ *  not queued either — they're surfaced as send errors, not pending work. */
+export function isQueuedForInvocation(msg: DecryptedMessage): boolean {
+    return isUserMessage(msg) && msg.invokedAt === null && msg.status !== 'failed'
+}
+
 function isOptimisticMessage(msg: DecryptedMessage): boolean {
     return Boolean(msg.localId && msg.id === msg.localId)
 }
@@ -110,9 +119,14 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
 
     for (const optimistic of optimisticMessages) {
         if (optimistic.status === 'sent') {
+            // Compare by the position key (invokedAt ?? createdAt). A late ack can
+            // attach `invokedAt` long after `createdAt`, so the optimistic copy and
+            // the server echo end up at the same byPosition slot — using
+            // `createdAt` alone misses that match and renders both as duplicates.
+            const optimisticTime = optimistic.invokedAt ?? optimistic.createdAt
             const hasServerUserMessage = nonOptimisticMessages.some((m) =>
                 isUserMessage(m) &&
-                Math.abs(m.createdAt - optimistic.createdAt) < 10_000
+                Math.abs((m.invokedAt ?? m.createdAt) - optimisticTime) < 10_000
             )
             if (hasServerUserMessage) {
                 continue

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -88,8 +88,9 @@ export type MessagesResponse = {
     messages: DecryptedMessage[]
     page: {
         limit: number
-        beforeSeq: number | null
+        beforeSeq?: number | null
         nextBeforeSeq: number | null
+        nextBeforeAt?: number | null
         hasMore: boolean
     }
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -40,6 +40,7 @@ export type MessageStatus = 'queued' | 'sending' | 'sent' | 'failed'
 export type DecryptedMessage = ProtocolDecryptedMessage & {
     status?: MessageStatus
     originalText?: string
+    invokedAt?: number | null
 }
 
 export type RunnerState = {


### PR DESCRIPTION
Following up on #492 — instead of showing queued messages inline in the timeline (with an opacity-60 dimming), surface them in a dedicated floating bar above the composer. When the CLI batch-invokes the messages, the bar disappears and the messages appear at their correct position in the thread.

**Problem**

After #492, a queued message sits at its *send* position in the thread, dimmed with `opacity-60`. When the agent is mid-response, this queued bubble interrupts the assistant output flow — the user sees their message sandwiched between tool-use blocks that haven't run yet. Claude Code / Gemini CLI terminals solve this by showing a separate "queued" affordance near the input and inserting the message into the transcript only when it is actually processed.

**Solution**

1. **Hub schema** (`invoked_at INTEGER`, V7→V8 migration, see "Migration" below for details): when the CLI emits `messages-consumed`, Hub records `Date.now()` as `invoked_at` on each consumed message row.

2. **SSE propagation**: `messages-consumed` payload now includes `invokedAt` (server timestamp, not client clock — avoids the clock-skew trap from #492 review).

3. **Web — floating bar** (`QueuedMessagesBar`): Subscribes to `message-window-store`, shows user messages where `invokedAt == null`. Renders a clock icon + text preview per item. Placed above `<HappyComposer>`. Disappears automatically when all queued messages are invoked.

4. **Web — thread filtering**: `visibleMessages` excludes user messages with `invokedAt == null` so they never appear inline. Sorting uses `invokedAt ?? createdAt` as the position key, so invoked messages land at the right spot in the timeline.

5. **Multi-device / refresh**: Because `invoked_at` is the server SSOT, any client that loads or reloads the session restores the correct state — `invokedAt == null` → floating bar, `invokedAt != null` → thread position.

**Visuals**

Captured against an isolated hub stack (fresh `HAPI_HOME` + Playwright). Mobile (375×667) variants are collapsed; click to expand.

_Floating bar — agent thinking, four queued chips of varying length (multi-line wraps inside the chip):_

![Desktop floating bar](https://github.com/user-attachments/assets/0e9e3a9d-1170-410c-be77-d15a6f94aa00)

<details><summary>Mobile</summary>

![Mobile floating bar](https://github.com/user-attachments/assets/c08b6dd7-095a-4b9f-b69c-ea15600f2c3d)

</details>

_Overflow guard — once chip count exceeds the budget (`max-h-32 sm:max-h-48`), the bar caps its height and scrolls internally; the thread is never pushed offscreen:_

![Desktop overflow](https://github.com/user-attachments/assets/100abf57-b460-409d-927b-93967b377e96)

<details><summary>Mobile</summary>

![Mobile overflow](https://github.com/user-attachments/assets/bb24c30c-4378-436e-ac7c-c784844d33b1)

</details>

_After CLI invocation — bar disappears, each message lands at its `invokedAt` position in the thread:_

![Desktop after invocation](https://github.com/user-attachments/assets/b1cb29b6-603a-45a0-a0d7-ac25c70320c1)

<details><summary>Mobile</summary>

![Mobile after invocation](https://github.com/user-attachments/assets/e2980a98-da14-49b3-8d77-432700da81b9)

</details>

**Migration**

This PR bumps the schema to version 8 and adds a single nullable `invoked_at INTEGER` column to the `messages` table.

- **Forward path (`migrateFromV7ToV8`)**:
    1. `ALTER TABLE messages ADD COLUMN invoked_at INTEGER`, guarded by a `PRAGMA table_info(messages)` check so re-running the migration on an already-V8 database is a no-op (idempotent).
    2. `UPDATE messages SET invoked_at = created_at WHERE invoked_at IS NULL` to backfill existing rows. Without this, the new web filter (`invokedAt == null` → floating bar) would pull every user message ever sent before the upgrade out of its thread on first load. The backfill makes pre-upgrade messages indistinguishable from invoked ones (which is what they semantically are — they were already processed by the agent).
- **Multi-hop coverage**: while at it, the dispatcher in `initSchema` is generalized from a per-pair branch matrix (V4→V6, V4→V7, V5→V7, plus the four new V*→V8 entries) into a single step ladder loop that walks `currentVersion → SCHEMA_VERSION` one step at a time. Future `SCHEMA_VERSION` bumps now require only a single `migrateFromV(N-1)ToVN` registration in the `stepMigrations` map. Fresh databases use `createSchema`, which now declares `invoked_at` directly.
- **Defaults for new rows**: `messages.addMessage` inserts `invoked_at = NULL`. Hub sets it to `Date.now()` only when the CLI emits `messages-consumed` for the row's `localId`. The write is wrapped in `try/catch` so a transient DB error never blocks the SSE event (the timestamp is server-canonical regardless).
- **Wire compatibility**: both `DecryptedMessageSchema.invokedAt` and the `messages-consumed` SyncEvent's `invokedAt` are optional. Older web clients ignore the field. The `message-received` SSE payload also carries `invokedAt` (always `null` at send time) so the optimistic-merge path on the web side has one consistent shape across echo and consume events.
- **Rollback**: `invoked_at` is purely additive (column adds, never removes data). Downgrading to a pre-V8 binary is not auto-supported — the older binary will refuse to start with a SchemaMismatch against `user_version = 8`. This matches the project's existing forward-only migration policy. Re-running a V8+ binary against the same DB resumes normal operation.

**Tests**

- `hub/src/store/migration-v8.test.ts` (new): instantiates `Store` against in-memory SQLite seeded at V4, V5, V6, and V7 and asserts the resulting V8 schema, the backfill (`invoked_at == created_at` for pre-existing rows), and re-open idempotency. `markMessagesInvoked` is covered in the same suite.
- Manually verified end-to-end against an isolated hub stack (fresh `HAPI_HOME` + Playwright) on desktop (1280×720) and mobile (375×667) viewports: send-while-thinking, ack arrival, page refresh restore, and multi-tab SSE sync.

**Follow-up** (not in this PR): cancel and inline-edit of queued messages via the floating bar.
