### PR TITLE
fix(gemini): switch model mid-session via ACP RPC

### DIFF
--- a/cli/src/agent/backends/acp/AcpSdkBackend.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.ts
@@ -136,6 +136,23 @@ export class AcpSdkBackend implements AgentBackend {
         return sessionId;
     }
 
+    async setModel(sessionId: string, modelId: string): Promise<void> {
+        if (!this.transport) {
+            throw new Error('ACP transport not initialized');
+        }
+
+        // The launcher serializes setModel between turns, but defensively wait for any
+        // in-flight prompt to drain so we never interleave a switch with a session/prompt.
+        await this.waitForResponseComplete();
+
+        // Errors (including JSON-RPC 'method not found') propagate as rejections
+        // from the transport; the launcher's catch block handles them.
+        await this.transport.sendRequest('session/set_model', {
+            sessionId,
+            modelId
+        });
+    }
+
     async prompt(
         sessionId: string,
         content: PromptContent[],

--- a/cli/src/agent/sessionBase.ts
+++ b/cli/src/agent/sessionBase.ts
@@ -84,6 +84,10 @@ export class AgentSessionBase<Mode> {
         this.client.keepAlive(thinking, this.mode, this.getKeepAliveRuntime());
     };
 
+    pushKeepAlive = () => {
+        this.client.keepAlive(this.thinking, this.mode, this.getKeepAliveRuntime());
+    };
+
     onModeChange = (mode: 'local' | 'remote') => {
         this.mode = mode;
         this.client.keepAlive(this.thinking, mode, this.getKeepAliveRuntime());

--- a/cli/src/agent/types.ts
+++ b/cli/src/agent/types.ts
@@ -59,6 +59,7 @@ export type PermissionResponse =
 export interface AgentBackend {
     initialize(): Promise<void>;
     newSession(config: AgentSessionConfig): Promise<string>;
+    setModel?(sessionId: string, modelId: string): Promise<void>;
     prompt(sessionId: string, content: PromptContent[], onUpdate: (msg: AgentMessage) => void): Promise<void>;
     cancelPrompt(sessionId: string): Promise<void>;
     respondToPermission(sessionId: string, request: PermissionRequest, response: PermissionResponse): Promise<void>;

--- a/cli/src/gemini/geminiRemoteLauncher.test.ts
+++ b/cli/src/gemini/geminiRemoteLauncher.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MessageQueue2 } from '@/utils/MessageQueue2';
+import type { GeminiMode, PermissionMode } from './types';
+
+const harness = vi.hoisted(() => ({
+    setModelArgs: [] as Array<{ sessionId: string; modelId: string }>,
+    promptCount: 0,
+    events: [] as string[],
+    setModelImpl: null as null | ((sessionId: string, modelId: string) => Promise<void>)
+}));
+
+vi.mock('./utils/geminiBackend', () => ({
+    createGeminiBackend: vi.fn(() => ({
+        initialize: vi.fn(async () => {}),
+        newSession: vi.fn(async () => 'acp-session-1'),
+        loadSession: vi.fn(async () => 'acp-session-1'),
+        setModel: vi.fn(async (sessionId: string, modelId: string) => {
+            harness.events.push(`setModel:${modelId}`);
+            harness.setModelArgs.push({ sessionId, modelId });
+            if (harness.setModelImpl) {
+                await harness.setModelImpl(sessionId, modelId);
+            }
+        }),
+        prompt: vi.fn(async () => {
+            harness.events.push('prompt:start');
+            harness.promptCount++;
+            await new Promise<void>((resolve) => setImmediate(resolve));
+            harness.events.push('prompt:end');
+        }),
+        cancelPrompt: vi.fn(async () => {}),
+        respondToPermission: vi.fn(async () => {}),
+        onStderrError: vi.fn(),
+        onPermissionRequest: vi.fn(),
+        disconnect: vi.fn(async () => {})
+    }))
+}));
+
+vi.mock('@/codex/utils/buildHapiMcpBridge', () => ({
+    buildHapiMcpBridge: async () => ({
+        server: { stop: () => {} },
+        mcpServers: {}
+    })
+}));
+
+vi.mock('./utils/permissionHandler', () => ({
+    GeminiPermissionHandler: class {
+        async cancelAll(): Promise<void> {}
+    }
+}));
+
+vi.mock('./utils/config', () => ({
+    resolveGeminiRuntimeConfig: () => ({
+        model: 'gemini-3-flash-preview',
+        modelSource: 'default'
+    })
+}));
+
+vi.mock('@/ui/ink/GeminiDisplay', () => ({
+    GeminiDisplay: () => null
+}));
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn()
+    }
+}));
+
+import { geminiRemoteLauncher } from './geminiRemoteLauncher';
+
+function createMode(model?: string): GeminiMode {
+    return {
+        permissionMode: 'default' as PermissionMode,
+        model
+    };
+}
+
+function createSessionStub(items: Array<{ message: string; mode: GeminiMode }>) {
+    const queue = new MessageQueue2<GeminiMode>((mode) => JSON.stringify(mode));
+    items.forEach(({ message, mode }, index) => {
+        if (index === 0 && items.length > 1) {
+            queue.pushIsolateAndClear(message, mode);
+        } else {
+            queue.push(message, mode);
+        }
+    });
+    queue.close();
+
+    const sessionEvents: Array<{ type: string; [key: string]: unknown }> = [];
+    const rpcHandlers = new Map<string, (params: unknown) => unknown>();
+
+    const client = {
+        rpcHandlerManager: {
+            registerHandler(method: string, handler: (params: unknown) => unknown) {
+                rpcHandlers.set(method, handler);
+            }
+        },
+        sendAgentMessage(_message: unknown) {},
+        sendUserMessage(_text: string) {},
+        sendSessionEvent(event: { type: string; [key: string]: unknown }) {
+            sessionEvents.push(event);
+        }
+    };
+
+    const session = {
+        path: '/tmp/hapi-gemini-test',
+        logPath: '/tmp/hapi-gemini-test/test.log',
+        client,
+        queue,
+        sessionId: null as string | null,
+        thinking: false,
+        getPermissionMode() {
+            return 'default' as const;
+        },
+        setModel(_model: string | null) {},
+        onThinkingChange(thinking: boolean) {
+            session.thinking = thinking;
+        },
+        onSessionFound(id: string) {
+            session.sessionId = id;
+        },
+        sendAgentMessage(_message: unknown) {},
+        sendSessionEvent(event: { type: string; [key: string]: unknown }) {
+            client.sendSessionEvent(event);
+        },
+        sendUserMessage(_text: string) {}
+    };
+
+    return { session, sessionEvents, rpcHandlers };
+}
+
+describe('geminiRemoteLauncher inline model switch', () => {
+    afterEach(() => {
+        harness.setModelArgs = [];
+        harness.promptCount = 0;
+        harness.events = [];
+        harness.setModelImpl = null;
+    });
+
+    it('calls setModel between turns when the queued model differs from the running backend model', async () => {
+        const { session } = createSessionStub([
+            { message: 'first', mode: createMode('gemini-3-flash-preview') },
+            { message: 'second', mode: createMode('gemini-2.5-pro') }
+        ]);
+
+        await geminiRemoteLauncher(session as never, {});
+
+        expect(harness.setModelArgs).toEqual([
+            { sessionId: 'acp-session-1', modelId: 'gemini-2.5-pro' }
+        ]);
+        expect(harness.promptCount).toBe(2);
+    });
+
+    it('does not call setModel when the model is unchanged across turns', async () => {
+        const { session } = createSessionStub([
+            { message: 'first', mode: createMode('gemini-3-flash-preview') },
+            { message: 'second', mode: createMode('gemini-3-flash-preview') }
+        ]);
+
+        await geminiRemoteLauncher(session as never, {});
+
+        expect(harness.setModelArgs).toEqual([]);
+        expect(harness.promptCount).toBe(2);
+    });
+
+    it('latches inline switching off after a method-not-found response and notifies the user once', async () => {
+        harness.setModelImpl = async () => {
+            throw new Error('Method not found: session/set_model');
+        };
+        const { session, sessionEvents } = createSessionStub([
+            { message: 'first', mode: createMode('gemini-3-flash-preview') },
+            { message: 'second', mode: createMode('gemini-2.5-pro') },
+            { message: 'third', mode: createMode('gemini-2.5-flash') }
+        ]);
+
+        await geminiRemoteLauncher(session as never, {});
+
+        // Only one setModel attempt — latched off after the first method-not-found
+        expect(harness.setModelArgs).toEqual([
+            { sessionId: 'acp-session-1', modelId: 'gemini-2.5-pro' }
+        ]);
+        const unsupportedMessages = sessionEvents.filter(
+            (event) =>
+                event.type === 'message' &&
+                typeof event.message === 'string' &&
+                event.message.includes('does not support inline model switching')
+        );
+        expect(unsupportedMessages.length).toBe(1);
+        expect(harness.promptCount).toBe(3);
+    });
+
+    it('reports a transient setModel error and continues with the previous model', async () => {
+        let attempts = 0;
+        harness.setModelImpl = async () => {
+            attempts++;
+            throw new Error('Transient backend failure');
+        };
+        const { session, sessionEvents } = createSessionStub([
+            { message: 'first', mode: createMode('gemini-3-flash-preview') },
+            { message: 'second', mode: createMode('gemini-2.5-pro') }
+        ]);
+
+        await geminiRemoteLauncher(session as never, {});
+
+        expect(attempts).toBe(1);
+        const failureMessages = sessionEvents.filter(
+            (event) =>
+                event.type === 'message' &&
+                typeof event.message === 'string' &&
+                event.message.includes('Failed to switch model')
+        );
+        expect(failureMessages.length).toBe(1);
+        expect(failureMessages[0]?.message).toContain('gemini-2.5-pro');
+        expect(harness.promptCount).toBe(2);
+    });
+
+    it('serializes setModel after the previous prompt resolves', async () => {
+        const { session } = createSessionStub([
+            { message: 'first', mode: createMode('gemini-3-flash-preview') },
+            { message: 'second', mode: createMode('gemini-2.5-pro') }
+        ]);
+
+        await geminiRemoteLauncher(session as never, {});
+
+        // Order must be: prompt(1) start/end → setModel → prompt(2) start/end
+        expect(harness.events).toEqual([
+            'prompt:start',
+            'prompt:end',
+            'setModel:gemini-2.5-pro',
+            'prompt:start',
+            'prompt:end'
+        ]);
+    });
+});

--- a/cli/src/gemini/geminiRemoteLauncher.ts
+++ b/cli/src/gemini/geminiRemoteLauncher.ts
@@ -21,6 +21,8 @@ class GeminiRemoteLauncher extends RemoteLauncherBase {
     private abortController = new AbortController();
     private displayModel: string | null = null;
     private displayPermissionMode: PermissionMode | null = null;
+    private currentBackendModel: string | null = null;
+    private setModelSupported: boolean | undefined = undefined;
 
     constructor(session: GeminiSession, opts: { model?: string; hookSettingsPath?: string }) {
         super(process.env.DEBUG ? session.logPath : undefined);
@@ -102,7 +104,8 @@ class GeminiRemoteLauncher extends RemoteLauncherBase {
             backend,
             () => session.getPermissionMode() as PermissionMode | undefined
         );
-        this.applyDisplayMode(session.getPermissionMode() as PermissionMode, runtimeConfig.model);
+        this.currentBackendModel = runtimeConfig.model;
+        this.applyDisplayMode(session.getPermissionMode() as PermissionMode, this.currentBackendModel);
 
         this.setupAbortHandlers(session.client.rpcHandlerManager, {
             onAbort: () => this.handleAbort(),
@@ -120,6 +123,40 @@ class GeminiRemoteLauncher extends RemoteLauncherBase {
                     continue;
                 }
                 break;
+            }
+
+            // Inline model change via RPC. If the running gemini-cli build does not
+            // implement session/set_model, we learn that from the first method-not-found
+            // response and stop attempting it for the rest of this session.
+            if (batch.mode.model && batch.mode.model !== this.currentBackendModel) {
+                if (!backend.setModel || this.setModelSupported === false) {
+                    batch.mode.model = this.currentBackendModel!;
+                } else {
+                    logger.debug(`[gemini-remote] Switching model inline: ${this.currentBackendModel} -> ${batch.mode.model}`);
+                    try {
+                        await backend.setModel(acpSessionId, batch.mode.model);
+                        this.currentBackendModel = batch.mode.model;
+                        this.setModelSupported = true;
+                    } catch (error) {
+                        const message = error instanceof Error ? error.message : String(error);
+                        const methodNotFound = /method not found/i.test(message);
+                        if (methodNotFound && this.setModelSupported === undefined) {
+                            this.setModelSupported = false;
+                            logger.warn('[gemini-remote] Gemini CLI build does not support session/set_model; inline switching disabled for this session');
+                            session.sendSessionEvent({
+                                type: 'message',
+                                message: 'This Gemini CLI build does not support inline model switching. Restart the session to apply a different model.'
+                            });
+                        } else {
+                            logger.warn('[gemini-remote] Inline model switch failed', error);
+                            session.sendSessionEvent({
+                                type: 'message',
+                                message: `Failed to switch model to ${batch.mode.model}. Continuing with ${this.currentBackendModel}.`
+                            });
+                        }
+                        batch.mode.model = this.currentBackendModel!;
+                    }
+                }
             }
 
             this.applyDisplayMode(batch.mode.permissionMode, batch.mode.model);

--- a/cli/src/gemini/runGemini.test.ts
+++ b/cli/src/gemini/runGemini.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockGeminiSession = vi.hoisted(() => ({
     setModel: vi.fn(),
     setPermissionMode: vi.fn(),
+    pushKeepAlive: vi.fn(),
+    thinking: false,
     stopKeepAlive: vi.fn()
 }));
 
@@ -121,7 +123,7 @@ describe('runGemini', () => {
         expect(harness.geminiLoopArgs[0]?.model).toBe('gemini-3-pro-preview');
     });
 
-    it('does not persist the hardcoded default fallback model', async () => {
+    it('does not persist the hardcoded default fallback model so it floats with machine config', async () => {
         resolveGeminiRuntimeConfigMock.mockReturnValue({
             model: 'gemini-3-flash-preview',
             modelSource: 'default'
@@ -151,6 +153,27 @@ describe('runGemini', () => {
         const result = await handler({ model: 'gemini-2.5-flash' }) as Record<string, unknown>;
         const applied = result.applied as Record<string, unknown>;
         expect(applied.model).toBe('gemini-2.5-flash');
+    });
+
+    it('pushes a keepAlive immediately after a config change so the hub UI reflects it', async () => {
+        resolveGeminiRuntimeConfigMock.mockReturnValue({
+            model: 'gemini-3-flash-preview',
+            modelSource: 'default'
+        });
+
+        await runGemini({});
+
+        // Reset to ignore pushKeepAlive fired from initial onSessionReady setup
+        mockGeminiSession.pushKeepAlive.mockClear();
+
+        const registerCalls = harness.session.rpcHandlerManager.registerHandler.mock.calls;
+        const configHandler = registerCalls.find(
+            (call: unknown[]) => call[0] === 'set-session-config'
+        );
+        const handler = configHandler![1] as (payload: unknown) => Promise<unknown>;
+        await handler({ model: 'gemini-2.5-flash' });
+
+        expect(mockGeminiSession.pushKeepAlive).toHaveBeenCalledTimes(1);
     });
 
     it('rejects invalid model in set-session-config RPC', async () => {

--- a/cli/src/gemini/runGemini.ts
+++ b/cli/src/gemini/runGemini.ts
@@ -39,6 +39,10 @@ export async function runGemini(opts: {
 
     const machineDefault = resolveGeminiRuntimeConfig().model;
     const runtimeConfig = resolveGeminiRuntimeConfig({ model: opts.model });
+    // Persist only when the user (or env/local config) chose the model. The hardcoded
+    // default remains undefined in the DB so it floats with the machine config across
+    // gemini-cli upgrades. Mid-session selections are persisted by the hub via the
+    // set-session-config RPC, not by this initial bootstrap.
     const persistedModel = runtimeConfig.modelSource === 'default'
         ? undefined
         : runtimeConfig.model;
@@ -108,6 +112,10 @@ export async function runGemini(opts: {
         }
         sessionInstance.setPermissionMode(currentPermissionMode);
         sessionInstance.setModel(sessionModel);
+
+        // Notify hub immediately to reflect changes in UI
+        sessionInstance.pushKeepAlive();
+
         logger.debug(`[gemini] Synced session config for keepalive: permissionMode=${currentPermissionMode}, model=${resolvedModel}`);
     };
 


### PR DESCRIPTION
## Problem

When a user selects a different Gemini model from the Web UI mid-session, the running `gemini --experimental-acp` process keeps using the model it was launched with. The Web UI reflects the new selection, but the next response is still produced by the original model. There is also a smaller follow-on issue where, on resume, a previously-selected model can be lost if the session record never captured it.

## Solution

- **Backend (ACP)**: `AcpSdkBackend` now exposes a `setModel` method that wraps the `session/set_model` JSON-RPC request and waits for any in-flight prompt to drain first. JSON-RPC errors (including `method not found`) propagate as standard rejections, matching the pattern used by every other `sendRequest` call in this file.
- **Launcher**: `geminiRemoteLauncher` detects model changes in the message-queue batch and calls `backend.setModel` between turns, so the running ACP process picks up the new model without restarting and without reloading MCP servers. If the running gemini-cli build returns `method not found`, the launcher learns this once, surfaces a single advisory message to the user, and then silently honors the previous model for the rest of the session — no per-turn noise.
- **Synchronization**: Added a small `pushKeepAlive()` helper on `AgentSessionBase`. `runGemini` calls it from the `set-session-config` RPC handler so the new model is broadcast to the hub the moment it changes, instead of waiting for the next 2-second keepalive tick.
- **Concurrency**: Both layers serialize the switch — the launcher only attempts `setModel` between batches, and `AcpSdkBackend.setModel` additionally awaits `waitForResponseComplete()` defensively before issuing the RPC.

## Verification

- `session/set_model` is part of the gemini-cli Agent Client Protocol surface and was confirmed reachable against the local `gemini --experimental-acp` build with a small standalone harness that issued the request and observed the model swap reflected in subsequent `session/prompt` usage metadata.
- For builds that do not expose this RPC, the launcher's `method-not-found` latch makes the failure mode obvious and bounded (one user-visible message per session) rather than silent.

## Tests

- `cli/src/gemini/geminiRemoteLauncher.test.ts` (new): covers (a) `setModel` is called between turns when the batch model differs, (b) `setModel` is not called when the model is unchanged, (c) the latch behavior on `method-not-found`, (d) transient backend failures continue with the previous model and surface a per-occurrence message, and (e) `setModel` is serialized after the previous prompt resolves.
- `cli/src/gemini/runGemini.test.ts`: a new assertion verifies `pushKeepAlive` is invoked from the `set-session-config` handler. The existing default-persistence test is preserved (the hardcoded fallback model stays out of the DB so it floats with machine config across gemini-cli upgrades).
- Manually verified end-to-end against a live `gemini-cli` binary: switching models in the Web UI takes effect on the next turn without a process restart, and the usage metadata reflects the newly selected model.

## Known limitation

On a `setModel` failure, the launcher rolls back its local state to the previous backend model, but the hub-side state and Web UI dropdown will continue to show the user's most recent selection until the user changes it again. This was kept out of the current PR to avoid pulling a hub↔launcher rollback callback into the change. The user-visible session message indicates the failure, and the actual model used for the next turn is the previous (correct) one.