### PR TITLE
fix(web): show metadata slash commands

### DIFF
--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -52,6 +52,7 @@ function createSession(overrides?: Partial<Session>): Session {
 
 function createApp(session: Session, opts?: {
     resumeSession?: (sessionId: string, namespace: string, resumeOpts?: { permissionMode?: string }) => Promise<{ type: string; sessionId?: string; message?: string; code?: string }>
+    listSlashCommands?: SyncEngine['listSlashCommands']
 }) {
     const applySessionConfigCalls: Array<[string, Record<string, unknown>]> = []
     const applySessionConfig = async (sessionId: string, config: Record<string, unknown>) => {
@@ -77,7 +78,11 @@ function createApp(session: Session, opts?: {
         applySessionConfig,
         listCodexModelsForSession,
         listOpencodeModelsForSession,
-        resumeSession
+        resumeSession,
+        listSlashCommands: opts?.listSlashCommands ?? (async () => ({
+            success: true,
+            commands: []
+        }))
     } as Partial<SyncEngine>
 
     const app = new Hono<WebAppEnv>()
@@ -457,4 +462,66 @@ describe('sessions routes', () => {
         expect(response.status).toBe(200)
         expect(capturedResumeOpts).toEqual({ permissionMode: 'bypassPermissions' })
     })
+
+    it('falls back to metadata slash commands when RPC listing fails', async () => {
+        const session = createSession({
+            metadata: {
+                path: '/tmp/project',
+                host: 'localhost',
+                flavor: 'claude',
+                slashCommands: ['help', 'memory', 'status']
+            }
+        })
+        const { app } = createApp(session, {
+            listSlashCommands: async () => {
+                throw new Error('RPC unavailable')
+            }
+        })
+
+        const response = await app.request('/api/sessions/session-1/slash-commands')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+            success: true,
+            commands: [
+                { name: 'help', source: 'builtin' },
+                { name: 'memory', source: 'builtin' },
+                { name: 'status', source: 'builtin' }
+            ]
+        })
+    })
+
+    it('merges RPC and metadata slash commands without hiding built-ins', async () => {
+        const session = createSession({
+            metadata: {
+                path: '/tmp/project',
+                host: 'localhost',
+                flavor: 'claude',
+                slashCommands: ['help', 'memory']
+            }
+        })
+        const { app } = createApp(session, {
+            listSlashCommands: async () => ({
+                success: true,
+                commands: [
+                    { name: 'clear', source: 'builtin' },
+                    { name: 'project-only', source: 'project', content: 'Project prompt' }
+                ]
+            })
+        })
+
+        const response = await app.request('/api/sessions/session-1/slash-commands')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+            success: true,
+            commands: [
+                { name: 'help', source: 'builtin' },
+                { name: 'memory', source: 'builtin' },
+                { name: 'clear', source: 'builtin' },
+                { name: 'project-only', source: 'project', content: 'Project prompt' }
+            ]
+        })
+    })
+
 })

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -46,6 +46,39 @@ const uploadDeleteSchema = z.object({
 
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 
+
+type SlashCommand = {
+    name: string
+    description?: string
+    source: 'builtin' | 'user' | 'plugin' | 'project'
+    content?: string
+    pluginName?: string
+}
+
+function commandsFromMetadataSlashCommands(names: readonly string[] | undefined): SlashCommand[] {
+    if (!names?.length) {
+        return []
+    }
+
+    return names
+        .filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
+        .map((name) => ({
+            name,
+            source: 'builtin'
+        }))
+}
+
+function mergeSlashCommands(
+    primary: readonly SlashCommand[],
+    fallback: readonly SlashCommand[]
+): SlashCommand[] {
+    const commandMap = new Map<string, SlashCommand>()
+    for (const command of [...fallback, ...primary]) {
+        commandMap.set(command.name, command)
+    }
+    return Array.from(commandMap.values())
+}
+
 function estimateBase64Bytes(base64: string): number {
     const len = base64.length
     if (len === 0) return 0
@@ -498,10 +531,29 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         // Get agent type from session metadata, default to 'claude'
         const agent = sessionResult.session.metadata?.flavor ?? 'claude'
 
+        const metadataCommands = commandsFromMetadataSlashCommands(
+            sessionResult.session.metadata?.slashCommands
+        )
+
         try {
             const result = await engine.listSlashCommands(sessionResult.sessionId, agent)
+            if (result.success && result.commands) {
+                return c.json({
+                    ...result,
+                    commands: mergeSlashCommands(result.commands, metadataCommands)
+                })
+            }
+
+            if (metadataCommands.length > 0) {
+                return c.json({ success: true, commands: metadataCommands })
+            }
+
             return c.json(result)
         } catch (error) {
+            if (metadataCommands.length > 0) {
+                return c.json({ success: true, commands: metadataCommands })
+            }
+
             return c.json({
                 success: false,
                 error: error instanceof Error ? error.message : 'Failed to list slash commands'

--- a/web/src/lib/codexSlashCommands.test.ts
+++ b/web/src/lib/codexSlashCommands.test.ts
@@ -33,6 +33,24 @@ describe('mergeSlashCommands', () => {
             { name: 'clear', source: 'project', content: 'project clear prompt' }
         ])
     })
+
+    it('keeps API-provided built-ins while de-duplicating by name', () => {
+        const commands = mergeSlashCommands([
+            { name: 'clear', source: 'builtin' },
+            { name: 'status', source: 'builtin' },
+            { name: 'help', source: 'builtin' },
+            { name: 'status', source: 'builtin', description: 'Captured status' },
+            { name: 'project-only', source: 'project', content: 'Project prompt' }
+        ])
+
+        expect(commands).toEqual([
+            { name: 'clear', source: 'builtin' },
+            { name: 'help', source: 'builtin' },
+            { name: 'status', source: 'builtin', description: 'Captured status' },
+            { name: 'project-only', source: 'project', content: 'Project prompt' }
+        ])
+    })
+
 })
 
 describe('findCodexCustomPromptExpansion', () => {


### PR DESCRIPTION
## Summary

- merge slash commands captured in session metadata into the `/api/sessions/:id/slash-commands` response
- fall back to metadata-provided slash commands when live RPC listing fails
- add regression coverage for metadata fallback and API-provided built-in command preservation

## Why

Claude sessions can persist a `metadata.slashCommands` snapshot at startup. The web UI previously depended on live RPC listing for slash-command suggestions, so commands captured in metadata could disappear when the active RPC path was unavailable or incomplete. This made the remote `/` menu show fewer commands than the session had already captured.

## Validation

- `cd hub && bun test src/web/routes/sessions.test.ts`
- `cd web && bun test src/lib/codexSlashCommands.test.ts`
