### PR TITLE
[codex] Reuse duplicate runner spawn targets

### DIFF
--- a/cli/src/runner/run.ts
+++ b/cli/src/runner/run.ts
@@ -24,6 +24,7 @@ import { join } from 'path';
 import { buildMachineMetadata } from '@/agent/sessionFactory';
 import { resolveWorkspaceRoot } from '@/utils/workspaceRoot';
 import { hashRunnerCliApiToken } from './runnerIdentity';
+import { buildRunnerSpawnKey, findReusableRunnerSpawnSession } from './spawnDedupe';
 
 export async function startRunner(options: { workspaceRoot?: string } = {}): Promise<void> {
   // We don't have cleanup function at the time of server construction
@@ -144,6 +145,7 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
     // Session spawning awaiter system
     const pidToAwaiter = new Map<number, (session: TrackedSession) => void>();
     const pidToErrorAwaiter = new Map<number, (errorMessage: string) => void>();
+    const spawnKeyToPendingSpawn = new Map<string, Promise<SpawnSessionResult>>();
     type SpawnFailureDetails = {
       message: string
       pid?: number
@@ -242,6 +244,46 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
       let spawnDirectory = directory;
       let worktreeInfo: WorktreeInfo | null = null;
       let happyProcess: ReturnType<typeof spawnHappyCLI> | null = null;
+      const spawnKey = buildRunnerSpawnKey(options);
+
+      if (spawnKey) {
+        const pendingSpawn = spawnKeyToPendingSpawn.get(spawnKey);
+        if (pendingSpawn) {
+          logger.debug('[RUNNER RUN] Waiting for existing in-flight spawn with the same target');
+          return await pendingSpawn;
+        }
+
+        const reusableSession = findReusableRunnerSpawnSession(
+          pidToTrackedSession.values(),
+          spawnKey,
+          isProcessAlive
+        );
+        if (reusableSession?.happySessionId) {
+          logger.debug(
+            `[RUNNER RUN] Reusing existing runner-spawned session ${reusableSession.happySessionId} ` +
+            `for duplicate spawn target (PID ${reusableSession.pid})`
+          );
+          reportSpawnOutcomeToHub?.({ type: 'success' });
+          return {
+            type: 'success',
+            sessionId: reusableSession.happySessionId
+          };
+        }
+      }
+      let resolvePendingSpawn: ((result: SpawnSessionResult) => void) | null = null;
+      if (spawnKey) {
+        const pendingSpawn = new Promise<SpawnSessionResult>((resolve) => {
+          resolvePendingSpawn = resolve;
+        });
+        spawnKeyToPendingSpawn.set(spawnKey, pendingSpawn);
+      }
+      const finishSpawnSession = (result: SpawnSessionResult): SpawnSessionResult => {
+        if (spawnKey && spawnKeyToPendingSpawn.has(spawnKey)) {
+          spawnKeyToPendingSpawn.delete(spawnKey);
+          resolvePendingSpawn?.(result);
+        }
+        return result;
+      };
 
       if (sessionType === 'simple') {
         try {
@@ -253,10 +295,10 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
           // Check if directory creation is approved
           if (!approvedNewDirectoryCreation) {
             logger.debug(`[RUNNER RUN] Directory creation not approved for: ${directory}`);
-            return {
+            return finishSpawnSession({
               type: 'requestToApproveDirectoryCreation',
               directory
-            };
+            });
           }
 
           try {
@@ -280,10 +322,10 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
             }
 
             logger.debug(`[RUNNER RUN] Directory creation failed: ${errorMessage}`);
-            return {
+            return finishSpawnSession({
               type: 'error',
               errorMessage
-            };
+            });
           }
         }
       } else {
@@ -292,10 +334,10 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
           logger.debug(`[RUNNER RUN] Worktree base directory exists: ${directory}`);
         } catch (error) {
           logger.debug(`[RUNNER RUN] Worktree base directory missing: ${directory}`);
-          return {
+          return finishSpawnSession({
             type: 'error',
             errorMessage: `Worktree sessions require an existing Git repository. Directory not found: ${directory}`
-          };
+          });
         }
       }
 
@@ -306,10 +348,10 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
         });
         if (!worktreeResult.ok) {
           logger.debug(`[RUNNER RUN] Worktree creation failed: ${worktreeResult.error}`);
-          return {
+          return finishSpawnSession({
             type: 'error',
             errorMessage: worktreeResult.error
-          };
+          });
         }
         worktreeInfo = worktreeResult.info;
         spawnDirectory = worktreeInfo.worktreePath;
@@ -435,10 +477,10 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
             }
           });
           await maybeCleanupWorktree('no-pid');
-          return {
+          return finishSpawnSession({
             type: 'error',
             errorMessage
-          };
+          });
         }
         happyProcess.removeListener('error', captureSpawnErrorBeforePidCheck);
 
@@ -478,6 +520,7 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
           startedBy: 'runner',
           pid,
           childProcess: happyProcess,
+          spawnKey: spawnKey ?? undefined,
           directoryCreated,
           message: directoryCreated ? `The path '${directory}' did not exist. We created a new folder and spawned a new session there.` : undefined
         };
@@ -586,7 +629,7 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
         } else {
           reportSpawnOutcomeToHub?.({ type: 'success' });
         }
-        return spawnResult;
+        return finishSpawnSession(spawnResult);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         logger.debug('[RUNNER RUN] Failed to spawn session:', error);
@@ -597,10 +640,10 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
             message: `Failed to spawn session: ${errorMessage}`
           }
         });
-        return {
+        return finishSpawnSession({
           type: 'error',
           errorMessage: `Failed to spawn session: ${errorMessage}`
-        };
+        });
       }
     };
 

--- a/cli/src/runner/spawnDedupe.test.ts
+++ b/cli/src/runner/spawnDedupe.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { buildRunnerSpawnKey, findReusableRunnerSpawnSession } from './spawnDedupe'
+
+describe('runner spawn dedupe helpers', () => {
+    it('builds the same key for the same simple runner target', () => {
+        const first = buildRunnerSpawnKey({
+            directory: './repo',
+            sessionId: 'hub-session-a',
+            machineId: 'machine-a',
+            agent: 'codex',
+            resumeSessionId: 'codex-thread-1',
+            model: 'gpt-5.5',
+            modelReasoningEffort: 'xhigh',
+            permissionMode: 'yolo',
+        })
+        const second = buildRunnerSpawnKey({
+            directory: './repo',
+            sessionId: 'hub-session-b',
+            machineId: 'machine-b',
+            agent: 'codex',
+            resumeSessionId: 'codex-thread-1',
+            model: 'gpt-5.5',
+            modelReasoningEffort: 'xhigh',
+            permissionMode: 'yolo',
+        })
+
+        expect(first).toBe(second)
+    })
+
+    it('separates different resume targets and auth tokens', () => {
+        const base = buildRunnerSpawnKey({
+            directory: './repo',
+            agent: 'codex',
+            resumeSessionId: 'codex-thread-1',
+            token: 'token-a',
+        })
+        const differentResume = buildRunnerSpawnKey({
+            directory: './repo',
+            agent: 'codex',
+            resumeSessionId: 'codex-thread-2',
+            token: 'token-a',
+        })
+        const differentToken = buildRunnerSpawnKey({
+            directory: './repo',
+            agent: 'codex',
+            resumeSessionId: 'codex-thread-1',
+            token: 'token-b',
+        })
+
+        expect(base).not.toBe(differentResume)
+        expect(base).not.toBe(differentToken)
+        expect(differentToken).not.toContain('token-b')
+    })
+
+    it('treats missing and false yolo as the same target', () => {
+        const withoutYolo = buildRunnerSpawnKey({
+            directory: './repo',
+            agent: 'codex',
+            resumeSessionId: 'codex-thread-1',
+        })
+        const falseYolo = buildRunnerSpawnKey({
+            directory: './repo',
+            agent: 'codex',
+            resumeSessionId: 'codex-thread-1',
+            yolo: false,
+        })
+
+        expect(withoutYolo).toBe(falseYolo)
+    })
+
+    it('finds only live runner-spawned sessions with the same key', () => {
+        const spawnKey = buildRunnerSpawnKey({
+            directory: './repo',
+            agent: 'codex',
+            resumeSessionId: 'codex-thread-1',
+        })
+        expect(spawnKey).not.toBeNull()
+        const liveSpawnKey = spawnKey!
+
+        const reusable = findReusableRunnerSpawnSession([
+            { startedBy: 'runner', pid: 10, spawnKey: 'other-key', happySessionId: 'other-session' },
+            { startedBy: 'hapi directly - likely by user from terminal', pid: 11, spawnKey: liveSpawnKey, happySessionId: 'terminal-session' },
+            { startedBy: 'runner', pid: 12, spawnKey: liveSpawnKey, happySessionId: 'dead-session' },
+            { startedBy: 'runner', pid: 13, spawnKey: liveSpawnKey, happySessionId: 'live-session' },
+        ], liveSpawnKey, (pid) => pid === 13)
+
+        expect(reusable?.happySessionId).toBe('live-session')
+    })
+})

--- a/cli/src/runner/spawnDedupe.ts
+++ b/cli/src/runner/spawnDedupe.ts
@@ -1,0 +1,67 @@
+import path from 'path';
+import { createHash } from 'crypto';
+
+import type { SpawnSessionOptions } from '@/modules/common/rpcTypes';
+import type { TrackedSession } from './types';
+
+function normalizePathForKey(directory: string): string {
+  const resolved = path.resolve(directory);
+  return process.platform === 'win32'
+    ? resolved.toLowerCase()
+    : resolved;
+}
+
+function valueOrEmpty(value: string | boolean | undefined): string {
+  if (typeof value === 'boolean') {
+    return value ? 'true' : '';
+  }
+  return value ?? '';
+}
+
+function hashSecret(value: string | undefined): string {
+  if (!value) {
+    return '';
+  }
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function buildRunnerSpawnKey(options: SpawnSessionOptions): string | null {
+  if ((options.sessionType ?? 'simple') !== 'simple') {
+    return null;
+  }
+
+  return JSON.stringify({
+    agent: options.agent ?? 'claude',
+    directory: normalizePathForKey(options.directory),
+    resumeSessionId: valueOrEmpty(options.resumeSessionId),
+    model: valueOrEmpty(options.model),
+    effort: valueOrEmpty(options.effort),
+    modelReasoningEffort: valueOrEmpty(options.modelReasoningEffort),
+    yolo: valueOrEmpty(options.yolo),
+    permissionMode: valueOrEmpty(options.permissionMode),
+    tokenHash: hashSecret(options.token)
+  });
+}
+
+export function findReusableRunnerSpawnSession(
+  sessions: Iterable<TrackedSession>,
+  spawnKey: string,
+  isAlive: (pid: number) => boolean
+): TrackedSession | null {
+  for (const session of sessions) {
+    if (session.startedBy !== 'runner') {
+      continue;
+    }
+    if (session.spawnKey !== spawnKey) {
+      continue;
+    }
+    if (!session.happySessionId) {
+      continue;
+    }
+    if (!isAlive(session.pid)) {
+      continue;
+    }
+    return session;
+  }
+  return null;
+}

--- a/cli/src/runner/types.ts
+++ b/cli/src/runner/types.ts
@@ -14,6 +14,7 @@ export interface TrackedSession {
   happySessionMetadataFromLocalWebhook?: Metadata;
   pid: number;
   childProcess?: ChildProcess;
+  spawnKey?: string;
   error?: string;
   directoryCreated?: boolean;
   message?: string;


### PR DESCRIPTION
## Summary

This PR prevents the runner from spawning duplicate simple sessions for the same target.

- add a runner spawn key for simple sessions based on agent, directory, resume target, model/effort, permission mode, and token hash
- reuse an existing live runner-spawned session when a duplicate target is requested
- make concurrent duplicate spawn requests wait for the first in-flight spawn result instead of launching another child process
- keep worktree sessions out of the dedupe path

## Root cause

Repeated remote spawn requests for the same Codex resume target could pass through the runner as independent child processes. On Windows this can leave multiple long-running `hapi codex resume ...` processes for the same conversation, increasing process/pipe pressure and making later agent turn startup less reliable.

## Validation

- `bunx --bun vitest run src/runner/spawnDedupe.test.ts`
- `bun run typecheck`
