### PR TITLE
fix(hub): harden resume recovery and Codex model discovery

### DIFF
--- a/cli/src/utils/spawnHappyCLI.test.ts
+++ b/cli/src/utils/spawnHappyCLI.test.ts
@@ -1,7 +1,17 @@
 import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SpawnOptions } from 'child_process';
 
-const spawnMock = vi.fn((..._args: any[]) => ({ pid: 12345 } as any));
+const {
+  spawnMock,
+  existsSyncMock,
+  isBunCompiledMock,
+  projectPathMock
+} = vi.hoisted(() => ({
+  spawnMock: vi.fn((..._args: any[]) => ({ pid: 12345 }) as any),
+  existsSyncMock: vi.fn((path: string) => !path.includes('missing-hapi.exe')),
+  isBunCompiledMock: vi.fn(() => false),
+  projectPathMock: vi.fn(() => process.cwd())
+}));
 
 vi.mock('child_process', async () => {
   const actual = await vi.importActual<typeof import('child_process')>('child_process');
@@ -11,8 +21,22 @@ vi.mock('child_process', async () => {
   };
 });
 
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: existsSyncMock
+  };
+});
+
+vi.mock('@/projectPath', () => ({
+  isBunCompiled: isBunCompiledMock,
+  projectPath: projectPathMock
+}));
+
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
 const originalInvokedCwd = process.env.HAPI_INVOKED_CWD;
+const originalCliExecutable = process.env.HAPI_CLI_EXECUTABLE;
 
 function setPlatform(value: string) {
   Object.defineProperty(process, 'platform', {
@@ -40,10 +64,19 @@ describe('spawnHappyCLI windowsHide behavior', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.resetModules();
+    existsSyncMock.mockImplementation((path: string) => !path.includes('missing-hapi.exe'));
+    isBunCompiledMock.mockReturnValue(false);
+    projectPathMock.mockReturnValue(process.cwd());
     if (originalInvokedCwd === undefined) {
       delete process.env.HAPI_INVOKED_CWD;
     } else {
       process.env.HAPI_INVOKED_CWD = originalInvokedCwd;
+    }
+    if (originalCliExecutable === undefined) {
+      delete process.env.HAPI_CLI_EXECUTABLE;
+    } else {
+      process.env.HAPI_CLI_EXECUTABLE = originalCliExecutable;
     }
   });
 
@@ -104,11 +137,59 @@ describe('spawnHappyCLI windowsHide behavior', () => {
     expect(command.command).toBe(process.execPath);
     if (isBunRuntime) {
       expect(command.args[0]).toBe('--cwd');
-      expect(command.args[1].replace(/\\/g, '/')).toMatch(/\/hapi\/cli$/);
-      expect(command.args[2].replace(/\\/g, '/')).toMatch(/\/hapi\/cli\/src\/index\.ts$/);
+      expect(command.args[1].replace(/\\/g, '/')).toMatch(/\/cli$/);
+      expect(command.args[2].replace(/\\/g, '/')).toMatch(/\/cli\/src\/index\.ts$/);
     } else {
-      expect(command.args.some((arg) => arg.replace(/\\/g, '/').endsWith('/hapi/cli/src/index.ts'))).toBe(true);
+      expect(command.args.some((arg) => arg.replace(/\\/g, '/').endsWith('/cli/src/index.ts'))).toBe(true);
     }
+  });
+
+  it('uses an inherited compiled CLI executable override when it points to an existing binary', async () => {
+    isBunCompiledMock.mockReturnValue(true);
+    process.env.HAPI_CLI_EXECUTABLE = 'C:\\Users\\Administrator\\.hapi\\patched\\hapi.exe';
+    const { getHappyCliCommand, resolveHappyCliExecutable } = await import('./spawnHappyCLI');
+
+    const command = getHappyCliCommand(['mcp', '--url', 'http://127.0.0.1:1234/']);
+
+    expect(resolveHappyCliExecutable()).toBe(process.env.HAPI_CLI_EXECUTABLE);
+    expect(command.command).toBe(process.env.HAPI_CLI_EXECUTABLE);
+  });
+
+  it('falls back to a real argv0 executable before process.execPath in compiled mode', async () => {
+    isBunCompiledMock.mockReturnValue(true);
+    const previousArgv0 = process.argv[0];
+    process.argv[0] = 'C:\\Users\\Administrator\\.hapi\\patched\\resume-recovery-0.17.2\\hapi.exe';
+    const { resolveHappyCliExecutable } = await import('./spawnHappyCLI');
+
+    try {
+      expect(resolveHappyCliExecutable()).toBe(process.argv[0]);
+    } finally {
+      process.argv[0] = previousArgv0;
+    }
+  });
+
+  it('ignores an inherited compiled CLI executable override when the binary is missing', async () => {
+    isBunCompiledMock.mockReturnValue(true);
+    process.env.HAPI_CLI_EXECUTABLE = 'C:\\Users\\Administrator\\.hapi\\patched\\missing-hapi.exe';
+    const { getHappyCliCommand } = await import('./spawnHappyCLI');
+
+    const command = getHappyCliCommand(['mcp', '--url', 'http://127.0.0.1:1234/']);
+
+    expect(command.command).toBe(process.execPath);
+  });
+
+  it('passes the resolved compiled executable to child HAPI processes', async () => {
+    isBunCompiledMock.mockReturnValue(true);
+    process.env.HAPI_CLI_EXECUTABLE = 'C:\\Users\\Administrator\\.hapi\\patched\\hapi.exe';
+    const { spawnHappyCLI } = await import('./spawnHappyCLI');
+
+    spawnHappyCLI(['mcp', '--url', 'http://127.0.0.1:1234/'], {
+      stdio: 'ignore'
+    });
+
+    const [command, _args, options] = spawnMock.mock.calls[0] as unknown[] | undefined ?? [];
+    expect(command).toBe(process.env.HAPI_CLI_EXECUTABLE);
+    expect((options as SpawnOptions | undefined)?.env?.HAPI_CLI_EXECUTABLE).toBe(process.env.HAPI_CLI_EXECUTABLE);
   });
 
   it('passes invoked workspace cwd to child processes when cwd is provided', async () => {

--- a/cli/src/utils/spawnHappyCLI.ts
+++ b/cli/src/utils/spawnHappyCLI.ts
@@ -32,6 +32,8 @@ import { isBunCompiled, projectPath } from '@/projectPath';
 import { logger } from '@/ui/logger';
 import { existsSync } from 'node:fs';
 
+const HAPI_CLI_EXECUTABLE_ENV = 'HAPI_CLI_EXECUTABLE';
+
 /**
  * Resolve the TypeScript entrypoint for development mode.
  */
@@ -71,11 +73,30 @@ function resolveInvokedCwd(cwd: SpawnOptions['cwd']): string {
   return process.cwd();
 }
 
+export function resolveHappyCliExecutable(): string {
+  const override = process.env[HAPI_CLI_EXECUTABLE_ENV]?.trim();
+  if (override && isCrossPlatformAbsolutePath(override) && existsSync(override)) {
+    return override;
+  }
+
+  const argv0 = process.argv[0]?.trim();
+  if (argv0 && isCrossPlatformAbsolutePath(argv0) && existsSync(argv0)) {
+    return argv0;
+  }
+
+  const bunArgv0 = globalThis.Bun?.argv?.[0]?.trim();
+  if (bunArgv0 && isCrossPlatformAbsolutePath(bunArgv0) && existsSync(bunArgv0)) {
+    return bunArgv0;
+  }
+
+  return process.execPath;
+}
+
 export function getHappyCliCommand(args: string[]): HappyCliCommand {
   // Compiled binary mode: just use the executable directly
   if (isBunCompiled()) {
     return {
-      command: process.execPath,
+      command: resolveHappyCliExecutable(),
       args
     };
   }
@@ -118,10 +139,11 @@ export function spawnHappyCLI(args: string[], options: SpawnOptions = {}): Child
   const fullCommand = `hapi ${args.join(' ')}`;
   logger.debug(`[SPAWN HAPI CLI] Spawning: ${fullCommand} in ${directory}`);
   
+  const compiledMode = isBunCompiled();
   const { command: spawnCommand, args: spawnArgs } = getHappyCliCommand(args);
 
   // Sanity check that the entrypoint path exists
-  if (!isBunCompiled()) {
+  if (!compiledMode) {
     const entrypoint = spawnArgs.find((arg) => arg.endsWith('index.ts'));
     if (entrypoint && !existsSync(entrypoint)) {
       const errorMessage = `Entrypoint ${entrypoint} does not exist`;
@@ -133,8 +155,12 @@ export function spawnHappyCLI(args: string[], options: SpawnOptions = {}): Child
   // On Windows, detached processes allocate a new console window by default.
   // windowsHide: true suppresses this to prevent cmd windows from accumulating.
   const finalOptions: SpawnOptions = { ...options };
-  if (!isBunCompiled()) {
-    const finalEnv = { ...process.env, ...options.env };
+  const finalEnv = { ...process.env, ...options.env };
+  let shouldSetEnv = false;
+  if (compiledMode) {
+    finalEnv[HAPI_CLI_EXECUTABLE_ENV] = spawnCommand;
+    shouldSetEnv = true;
+  } else {
     const invokedCwd = finalEnv.HAPI_INVOKED_CWD?.trim();
     const hasExplicitCwd = 'cwd' in options && options.cwd !== undefined;
     finalEnv.HAPI_INVOKED_CWD = hasExplicitCwd
@@ -142,6 +168,9 @@ export function spawnHappyCLI(args: string[], options: SpawnOptions = {}): Child
       : invokedCwd && isCrossPlatformAbsolutePath(invokedCwd)
         ? invokedCwd
         : resolveInvokedCwd(options.cwd);
+    shouldSetEnv = true;
+  }
+  if (shouldSetEnv) {
     finalOptions.env = finalEnv;
   }
   if (process.platform === 'win32' && options.detached) {

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -12,6 +12,17 @@ export class MessageService {
     ) {
     }
 
+    getMessages(sessionId: string, limit: number = 200): DecryptedMessage[] {
+        const stored = this.store.messages.getMessages(sessionId, limit)
+        return stored.map((message) => ({
+            id: message.id,
+            seq: message.seq,
+            localId: message.localId,
+            content: message.content,
+            createdAt: message.createdAt
+        }))
+    }
+
     getMessagesPage(sessionId: string, options: { limit: number; beforeSeq: number | null }): {
         messages: DecryptedMessage[]
         page: {

--- a/hub/src/sync/rpcGateway.test.ts
+++ b/hub/src/sync/rpcGateway.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test'
+import type { Server } from 'socket.io'
+import type { RpcRegistry } from '../socket/rpcRegistry'
+import { RpcGateway } from './rpcGateway'
+
+function createGateway() {
+    const timeouts: number[] = []
+    const socket = {
+        timeout(timeoutMs: number) {
+            timeouts.push(timeoutMs)
+            return {
+                async emitWithAck(_event: string, payload: { method: string; params: string }) {
+                    return JSON.stringify({
+                        success: true,
+                        method: payload.method,
+                        params: JSON.parse(payload.params) as unknown
+                    })
+                }
+            }
+        }
+    }
+
+    const io = {
+        of() {
+            return {
+                sockets: {
+                    get() {
+                        return socket
+                    }
+                }
+            }
+        }
+    } as unknown as Server
+
+    const rpcRegistry = {
+        getSocketIdForMethod() {
+            return 'socket-1'
+        }
+    } as unknown as RpcRegistry
+
+    return {
+        gateway: new RpcGateway(io, rpcRegistry),
+        timeouts
+    }
+}
+
+describe('RpcGateway RPC timeouts', () => {
+    it('uses the default RPC timeout for regular machine RPCs', async () => {
+        const { gateway, timeouts } = createGateway()
+
+        await gateway.listMachineDirectory('machine-1', 'C:\\workspace')
+
+        expect(timeouts).toEqual([30_000])
+    })
+
+    it('uses an extended RPC timeout when listing Codex models', async () => {
+        const { gateway, timeouts } = createGateway()
+
+        await gateway.listCodexModelsForMachine('machine-1')
+
+        expect(timeouts).toEqual([120_000])
+    })
+})
+

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -2,6 +2,9 @@ import type { CodexCollaborationMode, PermissionMode } from '@hapi/protocol/type
 import type { Server } from 'socket.io'
 import type { RpcRegistry } from '../socket/rpcRegistry'
 
+const DEFAULT_RPC_TIMEOUT_MS = 30_000
+const MODEL_LIST_RPC_TIMEOUT_MS = 120_000
+
 export type RpcCommandResponse = {
     success: boolean
     stdout?: string
@@ -267,11 +270,11 @@ export class RpcGateway {
     }
 
     async listCodexModelsForSession(sessionId: string): Promise<RpcListCodexModelsResponse> {
-        return await this.sessionRpc(sessionId, 'listCodexModels', {}) as RpcListCodexModelsResponse
+        return await this.sessionRpc(sessionId, 'listCodexModels', {}, MODEL_LIST_RPC_TIMEOUT_MS) as RpcListCodexModelsResponse
     }
 
     async listCodexModelsForMachine(machineId: string): Promise<RpcListCodexModelsResponse> {
-        return await this.machineRpc(machineId, 'listCodexModels', {}) as RpcListCodexModelsResponse
+        return await this.machineRpc(machineId, 'listCodexModels', {}, MODEL_LIST_RPC_TIMEOUT_MS) as RpcListCodexModelsResponse
     }
 
     async listOpencodeModelsForSession(sessionId: string): Promise<RpcListOpencodeModelsResponse> {
@@ -282,15 +285,25 @@ export class RpcGateway {
         return await this.machineRpc(machineId, 'listOpencodeModelsForCwd', { cwd }) as RpcListOpencodeModelsResponse
     }
 
-    private async sessionRpc(sessionId: string, method: string, params: unknown): Promise<unknown> {
-        return await this.rpcCall(`${sessionId}:${method}`, params)
+    private async sessionRpc(
+        sessionId: string,
+        method: string,
+        params: unknown,
+        timeoutMs: number = DEFAULT_RPC_TIMEOUT_MS
+    ): Promise<unknown> {
+        return await this.rpcCall(`${sessionId}:${method}`, params, timeoutMs)
     }
 
-    private async machineRpc(machineId: string, method: string, params: unknown): Promise<unknown> {
-        return await this.rpcCall(`${machineId}:${method}`, params)
+    private async machineRpc(
+        machineId: string,
+        method: string,
+        params: unknown,
+        timeoutMs: number = DEFAULT_RPC_TIMEOUT_MS
+    ): Promise<unknown> {
+        return await this.rpcCall(`${machineId}:${method}`, params, timeoutMs)
     }
 
-    private async rpcCall(method: string, params: unknown): Promise<unknown> {
+    private async rpcCall(method: string, params: unknown, timeoutMs: number = DEFAULT_RPC_TIMEOUT_MS): Promise<unknown> {
         const socketId = this.rpcRegistry.getSocketIdForMethod(method)
         if (!socketId) {
             throw new Error(`RPC handler not registered: ${method}`)
@@ -301,7 +314,7 @@ export class RpcGateway {
             throw new Error(`RPC socket disconnected: ${method}`)
         }
 
-        const response = await socket.timeout(30_000).emitWithAck('rpc-request', {
+        const response = await socket.timeout(timeoutMs).emitWithAck('rpc-request', {
             method,
             params: JSON.stringify(params)
         }) as unknown

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -605,6 +605,120 @@ describe('session model', () => {
         }
     })
 
+    it('recovers claude resume session ID from stored messages when metadata is missing it', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-claude-resume-from-message',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'claude'
+                },
+                null,
+                'default',
+                'sonnet'
+            )
+            store.messages.addMessage(session.id, {
+                role: 'agent',
+                content: {
+                    type: 'output',
+                    data: {
+                        type: 'assistant',
+                        sessionId: '7f5cd4ee-3a76-4601-a7b4-f9eb976bf515'
+                    }
+                }
+            })
+            engine.getOrCreateMachine(
+                'machine-1',
+                { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
+
+            let capturedResumeSessionId: string | undefined
+            ;(engine as any).rpcGateway.spawnSession = async (
+                _machineId: string,
+                _directory: string,
+                _agent: string,
+                _model?: string,
+                _modelReasoningEffort?: string,
+                _yolo?: boolean,
+                _sessionType?: 'simple' | 'worktree',
+                _worktreeName?: string,
+                resumeSessionId?: string
+            ) => {
+                capturedResumeSessionId = resumeSessionId
+                return { type: 'success', sessionId: session.id }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            const result = await engine.resumeSession(session.id, 'default')
+
+            expect(result).toEqual({ type: 'success', sessionId: session.id })
+            expect(capturedResumeSessionId).toBe('7f5cd4ee-3a76-4601-a7b4-f9eb976bf515')
+            expect(store.sessions.getSession(session.id)?.metadata).toMatchObject({
+                claudeSessionId: '7f5cd4ee-3a76-4601-a7b4-f9eb976bf515'
+            })
+        } finally {
+            engine.stop()
+        }
+    })
+
+
+    it('does not recover a non-UUID sessionId from stored messages', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'session-claude-resume-no-token',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'claude'
+                },
+                null,
+                'default',
+                'sonnet'
+            )
+            store.messages.addMessage(session.id, {
+                role: 'agent',
+                content: {
+                    type: 'output',
+                    data: {
+                        sessionId: 'hapi-session-id-not-claude-uuid'
+                    }
+                }
+            })
+
+            const result = await engine.resumeSession(session.id, 'default')
+
+            expect(result).toEqual({
+                type: 'error',
+                message: 'Resume session ID unavailable',
+                code: 'resume_unavailable'
+            })
+        } finally {
+            engine.stop()
+        }
+    })
+
     it('passes the cached permissionMode when respawning a resumed session', async () => {
         const store = new Store(':memory:')
         const engine = new SyncEngine(

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -59,7 +59,7 @@ export class SyncEngine {
     private inactivityTimer: NodeJS.Timeout | null = null
 
     constructor(
-        store: Store,
+        private readonly store: Store,
         io: Server,
         rpcRegistry: RpcRegistry,
         sseManager: SSEManager
@@ -451,7 +451,7 @@ export class SyncEngine {
                     ? metadata.opencodeSessionId
                     : flavor === 'cursor'
                         ? metadata.cursorSessionId
-                        : metadata.claudeSessionId
+                        : (metadata.claudeSessionId ?? this.recoverClaudeSessionIdFromMessages(access.sessionId, namespace))
 
         if (!resumeToken) {
             return { type: 'error', message: 'Resume session ID unavailable', code: 'resume_unavailable' }
@@ -518,6 +518,78 @@ export class SyncEngine {
         }
 
         return { type: 'success', sessionId: spawnResult.sessionId }
+    }
+
+    private recoverClaudeSessionIdFromMessages(sessionId: string, namespace: string): string | null {
+        const messages = this.messageService.getMessages(sessionId, 200)
+        for (const message of messages) {
+            const found = this.extractClaudeSessionId(message.content)
+            if (!found) continue
+
+            this.persistRecoveredClaudeSessionId(sessionId, namespace, found)
+            return found
+        }
+        return null
+    }
+
+    private extractClaudeSessionId(value: unknown): string | null {
+        if (!value || typeof value !== 'object') {
+            return null
+        }
+
+        const obj = value as Record<string, unknown>
+        const direct = this.normalizeClaudeSessionId(obj.session_id) ?? this.normalizeClaudeSessionId(obj.sessionId)
+        if (direct) {
+            return direct
+        }
+
+        const content = obj.content
+        if (content && typeof content === 'object') {
+            const found = this.extractClaudeSessionId(content)
+            if (found) return found
+        }
+
+        const data = obj.data
+        if (data && typeof data === 'object') {
+            const found = this.extractClaudeSessionId(data)
+            if (found) return found
+        }
+
+        return null
+    }
+
+    private normalizeClaudeSessionId(value: unknown): string | null {
+        if (typeof value !== 'string') {
+            return null
+        }
+        const trimmed = value.trim()
+        return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmed)
+            ? trimmed
+            : null
+    }
+
+    private persistRecoveredClaudeSessionId(sessionId: string, namespace: string, claudeSessionId: string): void {
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+            const latest = this.sessionCache.getSessionByNamespace(sessionId, namespace)
+                ?? this.sessionCache.refreshSession(sessionId)
+            if (!latest?.metadata) return
+            if (latest.metadata.claudeSessionId === claudeSessionId) return
+
+            const result = this.store.sessions.updateSessionMetadata(
+                sessionId,
+                { ...latest.metadata, claudeSessionId },
+                latest.metadataVersion,
+                namespace,
+                { touchUpdatedAt: false }
+            )
+            if (result.result === 'success') {
+                this.sessionCache.refreshSession(sessionId)
+                return
+            }
+            if (result.result !== 'version-mismatch') {
+                return
+            }
+        }
     }
 
     private hasSameAgentSessionIds(


### PR DESCRIPTION
## Summary
- Recover Claude resume IDs from prior assistant/user message content so resumed sessions can reconnect to the original provider thread.
- Extend Codex model-list RPC acknowledgements to 120s while preserving the 30s default timeout for normal RPC calls.
- Keep compiled HAPI child processes on the same executable via `HAPI_CLI_EXECUTABLE`, avoiding fallback to a globally installed `hapi.exe`.
- Add regression coverage for resume recovery, RPC timeout selection, and compiled executable inheritance.

## Root cause
- Some resumed Claude sessions only had the provider resume identifier in message content, not in the newer metadata location, so resume could lose the original provider thread id.
- Codex model discovery can take longer than the generic 30s Socket.IO ack timeout during app-server startup or plugin sync, causing HTTP 500 `operation has timed out` even when the model list eventually becomes available.
- In compiled Windows runs, child CLI processes could resolve through `process.execPath` / PATH in a way that used a different global npm HAPI binary instead of the executable that launched the runner.

## Validation
- `bun run --cwd cli test:win src/utils/spawnHappyCLI.test.ts` -> 11 passed
- `bun run --cwd hub test src/sync/rpcGateway.test.ts` -> 2 passed
- `bun run typecheck:cli` -> exit 0
- `bun run typecheck:hub` -> exit 0
- `bun run build:single-exe` -> exit 0, Windows exe SHA256 `E2000B0576761F710F9BD28EB937185D9134DB6FA52AD2E23476F1B04DFD4BB9`
- Local live smoke: `/api/machines/:id/codex-models` returned success in ~3.3s with 4 models: `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2`
- Local live process check: hub, runner, Codex, Claude, and MCP HAPI child processes are now running from `C:\Users\Administrator\.hapi\patched\resume-recovery-0.17.2\hapi.exe`
