### PR TITLE
fix(cli): hide Windows taskkill popups during process cleanup

### DIFF
--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -17,16 +17,31 @@ export function isProcessAlive(pid: number): boolean {
 }
 
 function killProcessWindows(pid: number, force: boolean): boolean {
+  if (!isProcessAlive(pid)) {
+    return true;
+  }
+
   const args = ['/T', '/PID', pid.toString()];
   if (force) {
     args.unshift('/F');
   }
   try {
-    const result = spawn.sync('taskkill', args, { stdio: 'pipe' });
+    const result = spawn.sync('taskkill', args, {
+      stdio: 'pipe',
+      windowsHide: true
+    });
     if (result.error) {
       return false;
     }
-    return result.status === 0;
+
+    if (result.status === 0) {
+      return true;
+    }
+
+    // Process teardown on Windows is racy: by the time taskkill runs, the target
+    // may already be gone, which commonly surfaces as non-zero exit codes
+    // (including 128 in some shells). Treat this as success if PID is no longer alive.
+    return !isProcessAlive(pid);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Background
I reproduced this on Windows 11 while using HAPI runner/session management.

When cleanup paths trigger process termination, Windows keeps opening 	askkill command windows showing:
[已退出进程，代码为 128 (0x00000080)]

In my case these are not transient flashes. The windows do not close automatically and keep accumulating, which is disruptive during normal use.

## Root cause
From my investigation, killProcessWindows() calls 	askkill without hiding the spawned console window.

Also, process teardown is racy on Windows: by the time 	askkill executes, the target PID may already be gone. That can return a non-zero status (including 128 in this environment) even though cleanup is already effectively complete.

## What I changed
- Set windowsHide: true for Windows 	askkill execution
- Return success early when the PID is already dead before invoking 	askkill
- If 	askkill returns non-zero, treat it as success when the PID is no longer alive after the call

## Why this is safe
- The change is limited to Windows process-kill handling in CLI utils
- No API/protocol/data model changes
- Kill semantics are preserved: alive process => still killed; already-dead process => treated as successful cleanup

## Scope
- Updated: cli/src/utils/process.ts
- No changes in hub/web/shared packages

## Validation plan
- [ ] On Windows 11, repeatedly start/stop runner and sessions, confirm no accumulating 	askkill windows
- [ ] Trigger timeout cleanup paths and verify cleanup still completes
- [ ] Verify normal stop flows still terminate target processes correctly
- [ ] Confirm non-Windows behavior is unchanged