### PR TITLE
fix(web): localize runtime toasts and keep full session rows

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -239,14 +239,59 @@ function AppInner() {
         clearMessageWindow(event.sessionId)
         void fetchLatestMessages(api, event.sessionId)
     }, [api, selectedSessionId])
+    const translateIncomingToast = useCallback((title: string, body: string): { title: string; body: string } => {
+        const normalizedTitle = title.trim()
+        const normalizedBody = body.trim()
+
+        if (normalizedTitle === 'Ready for input') {
+            const waitingMatch = normalizedBody.match(/^(.+)\s+is waiting in\s+(.+)$/i)
+            if (waitingMatch) {
+                const agent = waitingMatch[1]?.trim() ?? ''
+                const sessionName = waitingMatch[2]?.trim() ?? ''
+                return {
+                    title: t('toast.ready.title'),
+                    body: t('toast.ready.body', { agent, session: sessionName })
+                }
+            }
+            return {
+                title: t('toast.ready.title'),
+                body: normalizedBody
+            }
+        }
+
+        if (normalizedTitle === 'Permission Request') {
+            return {
+                title: t('toast.permission.title'),
+                body: normalizedBody
+            }
+        }
+
+        if (normalizedTitle === 'Task completed') {
+            return {
+                title: t('toast.task.completed'),
+                body: normalizedBody
+            }
+        }
+
+        if (normalizedTitle === 'Task failed') {
+            return {
+                title: t('toast.task.failed'),
+                body: normalizedBody
+            }
+        }
+
+        return { title, body }
+    }, [t])
+
     const handleToast = useCallback((event: ToastEvent) => {
+        const localized = translateIncomingToast(event.data.title, event.data.body)
         addToast({
-            title: event.data.title,
-            body: event.data.body,
+            title: localized.title,
+            body: localized.body,
             sessionId: event.data.sessionId,
             url: event.data.url
         })
-    }, [addToast])
+    }, [addToast, translateIncomingToast])
 
     const eventSubscription = useMemo(() => {
         if (selectedSessionId) {

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -711,8 +711,8 @@ export function SessionList(props: {
     }
 
     const allSessions = useMemo(
-        () => deduplicateSessionsByAgentId(props.sessions, selectedSessionId),
-        [props.sessions, selectedSessionId]
+        () => props.sessions,
+        [props.sessions]
     )
     const visibleSessions = useMemo(
         () => isSearching

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -274,6 +274,12 @@ export default {
   // Send blocked
   'send.blocked.title': 'Cannot send message',
   'send.blocked.noConnection': 'Not connected to server',
+  'resume.failed.title': 'Resume failed',
+  'toast.ready.title': 'Ready for input',
+  'toast.ready.body': '{agent} is waiting in {session}',
+  'toast.permission.title': 'Permission Request',
+  'toast.task.completed': 'Task completed',
+  'toast.task.failed': 'Task failed',
 
   // Install prompt
   'install.title': 'Install HAPI',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -276,6 +276,12 @@ export default {
   // Send blocked
   'send.blocked.title': '无法发送消息',
   'send.blocked.noConnection': '未连接到服务器',
+  'resume.failed.title': '恢复会话失败',
+  'toast.ready.title': '等待输入',
+  'toast.ready.body': '{agent} 正在 {session} 等待你的输入',
+  'toast.permission.title': '权限请求',
+  'toast.task.completed': '任务完成',
+  'toast.task.failed': '任务失败',
 
   // Install prompt
   'install.title': '安装 HAPI',

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -276,9 +276,9 @@ function SessionPage() {
             try {
                 return await api.resumeSession(currentSessionId, { permissionMode: session.permissionMode ?? undefined })
             } catch (error) {
-                const message = error instanceof Error ? error.message : 'Resume failed'
+                const message = error instanceof Error ? error.message : t('dialog.error.default')
                 addToast({
-                    title: 'Resume failed',
+                    title: t('resume.failed.title'),
                     body: message,
                     sessionId: currentSessionId,
                     url: ''


### PR DESCRIPTION
## Background
I noticed two web UX issues while using Chinese UI:

1. Some runtime toasts still appear in English (for example: Ready for input).
2. Session groups can show fewer rows than expected because rows are deduplicated by gentSessionId before preview logic runs.

This makes the outline/list behavior feel inconsistent and can hide sessions users still expect to see.

## What I changed
- Localized hub-delivered runtime toasts in the web client:
  - Ready for input
  - Permission Request
  - Task completed / Task failed
- Localized resume-failure toast title via i18n key
- Stopped deduplicating session rows by gentSessionId in SessionList so row counts reflect user-visible sessions

## Why this approach
- I kept the change in web only to avoid protocol changes.
- Toast localization is handled at display time, which is the right layer for language-specific rendering.
- Removing pre-preview dedup keeps list behavior aligned with user expectation for row counts.

## Scope
- web/src/App.tsx
- web/src/router.tsx
- web/src/components/SessionList.tsx
- web/src/lib/locales/en.ts
- web/src/lib/locales/zh-CN.ts

## Risk and compatibility
- No hub/cli/shared protocol change
- Existing English behavior remains intact for English locale
- Main behavior change is intentional: session list no longer collapses rows by shared gentSessionId

## Validation plan
- [ ] Switch UI to Chinese and trigger ready/permission/task toasts; verify localized toast text
- [ ] Trigger resume failure; verify localized toast title
- [ ] Open a project group with many sessions sharing one gentSessionId; verify rows are no longer hidden by dedup