### PR TITLE
fix(cli): hide Codex app-server console window on Windows

### DIFF
--- a/cli/src/codex/codexAppServerClient.ts
+++ b/cli/src/codex/codexAppServerClient.ts
@@ -84,7 +84,8 @@ export class CodexAppServerClient {
                 return acc;
             }, {} as Record<string, string>),
             stdio: ['pipe', 'pipe', 'pipe'],
-            shell: process.platform === 'win32'
+            shell: process.platform === 'win32',
+            windowsHide: process.platform === 'win32'
         });
 
         this.process.stdout.setEncoding('utf8');


### PR DESCRIPTION
## Background

I reproduced this on Windows 11 while creating a new HAPI session and selecting Codex.

The CLI launches Codex via `spawn('codex', ['app-server'])` and communicates over stdio JSON-RPC. On Windows, we keep `shell: true` so the `codex` command resolves reliably (including shim/batch execution paths), but this can surface visible `cmd.exe` console windows.

In this flow, extra `cmd` windows appeared; one often showed:
`[已退出进程，代码为 128 (0x00000080)]`

These windows were disruptive during normal session/model usage.

## Root cause

`codex app-server` was spawned with `shell: true` on Windows but without `windowsHide: true`, so the shell host could become visible as console windows.

## What I changed

- Added `windowsHide: process.platform === 'win32'` to the Codex app-server spawn options.
- Kept existing behavior for env/stdin/stdout/stderr and shell selection unchanged.

## Why this is safe

- Change is scoped to Windows process window behavior for Codex app-server startup.
- No protocol/API/schema/data-model changes.
- Execution semantics are unchanged; only suppresses intrusive visible shell windows.

## Scope

- Updated: `cli/src/codex/codexAppServerClient.ts`
- No changes in `hub/`, `web/`, or `shared/`

## Validation plan

- [x] **Manual (Windows 11):** New session → select Codex → model/turn flow works normally.
- [x] Confirm no stray `cmd` windows accumulate during startup/usage.