### PR TITLE
fix(cli): match claude-code ≥2.1.120 AskUserQuestion answer shape

### DIFF
--- a/cli/src/claude/utils/permissionHandler.ts
+++ b/cli/src/claude/utils/permissionHandler.ts
@@ -101,23 +101,44 @@ function formatAskUserQuestionAnswers(answers: Record<string, string[]> | Record
 }
 
 function buildAskUserQuestionUpdatedInput(input: unknown, answers: Record<string, string[]> | Record<string, { answers: string[] }>): Record<string, unknown> {
-    // Normalize to flat format for AskUserQuestion
-    const flatAnswers: Record<string, string[]> = {};
+    // Normalize incoming answers (web sends Record<questionIndex, string[]>;
+    // codex pathway sends nested Record<id, { answers: string[] }>) into a
+    // single Record<index, string[]> shape we can iterate.
+    const indexedAnswers: Record<string, string[]> = {};
     for (const [key, value] of Object.entries(answers)) {
         if (Array.isArray(value)) {
-            flatAnswers[key] = value;
+            indexedAnswers[key] = value;
         } else if (value && typeof value === 'object' && 'answers' in value) {
-            flatAnswers[key] = value.answers;
+            indexedAnswers[key] = value.answers;
         }
     }
 
     if (!isObject(input)) {
-        return { answers: flatAnswers };
+        return { answers: {} };
+    }
+
+    // claude code 2.x's built-in AskUserQuestion tool expects
+    //   answers: Record<questionText, answerString>
+    // and joins multi-select answers with a comma; it then echoes them
+    // verbatim in the tool result (`mapToolResultToToolResultBlockParam`).
+    // Sending the index-keyed `string[]` shape we receive from the web
+    // makes claude's lookup miss every question, producing the empty
+    // "User has answered your questions: ." result that locks the turn.
+    const questions = Array.isArray(input.questions) ? input.questions : [];
+    const claudeShapedAnswers: Record<string, string> = {};
+    for (let i = 0; i < questions.length; i += 1) {
+        const q = questions[i];
+        if (!q || typeof q !== 'object') continue;
+        const questionText = (q as { question?: unknown }).question;
+        if (typeof questionText !== 'string' || questionText.length === 0) continue;
+        const selections = indexedAnswers[String(i)];
+        if (!selections || selections.length === 0) continue;
+        claudeShapedAnswers[questionText] = selections.join(',');
     }
 
     return {
         ...input,
-        answers: flatAnswers
+        answers: claudeShapedAnswers
     };
 }
 


### PR DESCRIPTION
## Problem

The built-in `AskUserQuestion` tool stops working with HAPI on `claude-code` ≥ 2.1.120. The option card renders in the web UI and the user can pick options, but the answers never reach Claude. The tool result arrives as the empty-template string

```
"User has answered your questions: . You can now continue with the user's answers in mind."
```

— a sentence with no answers — and the session hangs because Claude has nothing actionable.

## Root cause

`claude-code` 2.1.120 changed `AskUserQuestion`'s `mapToolResultToToolResultBlockParam` from `Object.entries(answers)` ("echo whatever you got") to `questions.map(q => answers[q.question])` (strict lookup by question text, missing entries filtered out). The schema (`y.record(y.string(), y.string())` + `strictObject`) is unchanged — the mismatch is in the result-building walk strategy, not the input validator.

```js
// 2.1.119 and earlier (OLD): walks answers entries, echoes any key/value
content: `User has answered your questions: ${
    Object.entries(answers).map(([k, v]) => `"${k}"="${v}"`).join(", ")
}.`

// 2.1.120 and later (NEW): walks questions, looks up by question text, drops misses
content: `User has answered your questions: ${
    questions.map(({question}) => {
        const a = answers[question];
        if (!a) return null;
        return `"${question}"="${a}"`;
    }).filter(x => x !== null).join(", ")
}.`
```

HAPI builds `updatedInput.answers` as `Record<questionIndex, string[]>`:

```
{ "0": ["选项A"], "1": ["选项B"] }
```

Pre-2.1.120 this happened to round-trip because `Object.entries(...)` echoed the indexed keys verbatim (`toString`-ing the array). Post-2.1.120 every `answers[question.question]` lookup misses, the filter drops them all, and the result is the empty echo above.

Bisected the transition by inspecting `Object.entries` ↔ strict-lookup in the published `cli.js` / `claude` binaries:

| Version | Walk strategy |
|---------|--------------|
| 2.1.85, 2.1.100, **2.1.119** | OLD `Object.entries(answers)` |
| **2.1.120**, 2.1.122, 2.1.126, 2.1.128, 2.1.131 | NEW strict lookup |

## Fix

Walk `input.questions` and rebuild `answers` keyed by question text, joining multi-select selections with commas:

```
{ "你想做什么?": "选项A,选项B" }
```

This shape works on both sides of the transition:

- **2.1.119 and earlier**: `Object.entries(answers)` echoes `"你想做什么?"="选项A,选项B"` — actually clearer than the previous `"0"="选项A"` echo because users now see the question text in the result.
- **2.1.120 and later**: `answers[question.question]` matches and echoes the same `"你想做什么?"="选项A,选项B"`.

So no version detection / fallback is needed; one shape is forward + backward compatible.

The codex `request_user_input` path keeps its existing nested-shape builder (different schema, different consumer).

## Screenshots

| Before — answers lost, session hangs | After — answers visible, turn continues |
|---|---|
| <img width="1216" height="512" alt="CleanShot 2026-05-06 at 18 12 40 2@2x" src="https://github.com/user-attachments/assets/8d207f51-c8d3-4fd0-b10a-f789327fcdf3" /> |  <img width="1084" height="390" alt="CleanShot 2026-05-06 at 18 32 10@2x" src="https://github.com/user-attachments/assets/e3c0c7f3-cd91-420c-94ff-4d6051f552b1" /> |

## Testing

- `bun typecheck` clean (cli)
- cli unit tests pass (`bun test runnerIdentity buildCliArgs`)
- End-to-end on `claude-code 2.1.131` + HAPI `0.17.3`: re-spawned a session, asked Claude to use `AskUserQuestion`, picked options in the web UI, the turn resumed with the answers visible in the tool result content