### PR TITLE
fix(web): restore session history UX and hydrate full outline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ execplan/
 # Generated npm bundle output (local)
 cli/npm/main/
 .ace-tool/
+
+
+.specstory

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run official Claude Code / Codex / Gemini / OpenCode sessions locally and contro
 - **Your AI, Your Choice** - Claude Code, Codex, Cursor Agent, Gemini, OpenCode—different models, one unified workflow.
 - **Terminal Anywhere** - Run commands from your phone or browser, directly connected to the working machine.
 - **Voice Control** - Talk to your AI agent hands-free using the built-in voice assistant.
-- **Workspace Browser** - Opt-in via `hapi runner start --workspace-root <path>`: browse a scoped file tree from the web and start sessions in any subdirectory.
+- **Workspace Browser** - Opt-in via one or more `hapi runner start --workspace-root <path>` flags: browse scoped file trees from the web and start sessions in allowed subdirectories.
 
 ## Demo
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -52,10 +52,10 @@ See `src/commands/auth.ts`.
 - `hapi runner stop-session <sessionId>` - Terminate specific session.
 - `hapi runner logs` - Print path to latest runner log file.
 
-Both `start` and `start-sync` accept `--workspace-root <path>` (or `--workspace-root=<path>`). When set:
+Both `start` and `start-sync` accept repeatable `--workspace-root <path>` (or `--workspace-root=<path>`). When set:
 
-- The web `/browse` page surfaces a scoped file tree rooted at that path.
-- The runner refuses `list-directory` and `spawn-session` requests for paths outside the root.
+- The web `/browse` page surfaces scoped file trees rooted at those paths.
+- The runner refuses `list-directory` and `spawn-session` requests for paths outside the configured roots.
 - `~` and `~/foo` are expanded.
 
 Omitting the flag keeps the legacy behavior: no scoping, no `/browse` feature.

--- a/cli/src/agent/sessionFactory.ts
+++ b/cli/src/agent/sessionFactory.ts
@@ -38,7 +38,7 @@ export type SessionBootstrapResult = {
     workingDirectory: string
 }
 
-export function buildMachineMetadata(options?: { workspaceRoot?: string }): MachineMetadata {
+export function buildMachineMetadata(options?: { workspaceRoots?: string[] }): MachineMetadata {
     return {
         host: process.env.HAPI_HOSTNAME || os.hostname(),
         platform: os.platform(),
@@ -46,7 +46,7 @@ export function buildMachineMetadata(options?: { workspaceRoot?: string }): Mach
         homeDir: os.homedir(),
         happyHomeDir: configuration.happyHomeDir,
         happyLibDir: runtimePath(),
-        workspaceRoot: options?.workspaceRoot
+        workspaceRoots: options?.workspaceRoots
     }
 }
 

--- a/cli/src/api/api.ts
+++ b/cli/src/api/api.ts
@@ -142,7 +142,7 @@ export class ApiClient {
         return new ApiSessionClient(this.token, session)
     }
 
-    machineSyncClient(machine: Machine, options?: { workspaceRoot?: string }): ApiMachineClient {
-        return new ApiMachineClient(this.token, machine, options?.workspaceRoot)
+    machineSyncClient(machine: Machine, options?: { workspaceRoots?: string[] }): ApiMachineClient {
+        return new ApiMachineClient(this.token, machine, options?.workspaceRoots)
     }
 }

--- a/cli/src/api/apiMachine.test.ts
+++ b/cli/src/api/apiMachine.test.ts
@@ -62,12 +62,12 @@ describe('ApiMachineClient listOpencodeModelsForCwd handler', () => {
 
     it('rejects cwd outside the workspace root with the standard error shape', async () => {
         const machine = makeMachine('machine-1')
-        const client = new ApiMachineClient('cli-token', machine, workspaceRoot)
+        const client = new ApiMachineClient('cli-token', machine, [workspaceRoot])
 
         const outsideCwd = mkdtempSync(join(tmpdir(), 'hapi-outside-'))
         try {
             const result = await callListOpencodeModels(client, machine.id, outsideCwd)
-            expect(result).toEqual({ success: false, error: 'Path is outside workspace root' })
+            expect(result).toEqual({ success: false, error: 'Path is outside workspace roots' })
             expect(listOpencodeModelsForCwdMock).not.toHaveBeenCalled()
         } finally {
             rmSync(outsideCwd, { recursive: true, force: true })
@@ -77,7 +77,7 @@ describe('ApiMachineClient listOpencodeModelsForCwd handler', () => {
 
     it('rejects empty cwd with cwd-required error', async () => {
         const machine = makeMachine('machine-2')
-        const client = new ApiMachineClient('cli-token', machine, workspaceRoot)
+        const client = new ApiMachineClient('cli-token', machine, [workspaceRoot])
 
         try {
             const result = await callListOpencodeModels(client, machine.id, '')
@@ -90,7 +90,7 @@ describe('ApiMachineClient listOpencodeModelsForCwd handler', () => {
 
     it('forwards a workspace-internal cwd to listOpencodeModelsForCwd', async () => {
         const machine = makeMachine('machine-3')
-        const client = new ApiMachineClient('cli-token', machine, workspaceRoot)
+        const client = new ApiMachineClient('cli-token', machine, [workspaceRoot])
 
         const innerDir = join(workspaceRoot, 'inner-project')
         mkdirSync(innerDir)
@@ -112,6 +112,31 @@ describe('ApiMachineClient listOpencodeModelsForCwd handler', () => {
             // The handler should pass the resolved (realpath'd) cwd to the lower layer.
             expect(listOpencodeModelsForCwdMock).toHaveBeenCalledWith(expect.stringContaining('inner-project'))
         } finally {
+            client.shutdown()
+        }
+    })
+
+    it('accepts cwd inside any configured workspace root', async () => {
+        const machine = makeMachine('machine-4')
+        const secondWorkspaceRoot = mkdtempSync(join(tmpdir(), 'hapi-machine-ws-2-'))
+        const client = new ApiMachineClient('cli-token', machine, [workspaceRoot, secondWorkspaceRoot])
+
+        listOpencodeModelsForCwdMock.mockResolvedValueOnce({
+            success: true,
+            availableModels: [{ modelId: 'x/y' }],
+            currentModelId: 'x/y'
+        })
+
+        try {
+            const result = await callListOpencodeModels(client, machine.id, secondWorkspaceRoot)
+            expect(result).toEqual({
+                success: true,
+                availableModels: [{ modelId: 'x/y' }],
+                currentModelId: 'x/y'
+            })
+            expect(listOpencodeModelsForCwdMock).toHaveBeenCalledWith(secondWorkspaceRoot)
+        } finally {
+            rmSync(secondWorkspaceRoot, { recursive: true, force: true })
             client.shutdown()
         }
     })

--- a/cli/src/api/apiMachine.ts
+++ b/cli/src/api/apiMachine.ts
@@ -90,31 +90,52 @@ interface ListMachineDirectoryResponse {
     error?: string
 }
 
+function normalizeWorkspaceRoots(paths?: string[]): string[] | undefined {
+    if (!paths?.length) {
+        return undefined
+    }
+
+    const normalized = Array.from(new Set(paths.map((path) => {
+        try {
+            return realpathSync(path)
+        } catch {
+            return resolvePath(path)
+        }
+    })))
+
+    return normalized.length > 0 ? normalized : undefined
+}
+
+function workspaceRootsEqual(left?: string[], right?: string[]): boolean {
+    const normalizedLeft = left ?? []
+    const normalizedRight = right ?? []
+    if (normalizedLeft.length !== normalizedRight.length) {
+        return false
+    }
+
+    return normalizedLeft.every((value, index) => value === normalizedRight[index])
+}
+
+function formatWorkspaceRoots(paths?: string[]): string {
+    return paths?.length ? paths.join(', ') : '(none)'
+}
+
 export class ApiMachineClient {
     private socket!: Socket<ServerToRunnerEvents, RunnerToServerEvents>
     private keepAliveInterval: NodeJS.Timeout | null = null
     private rpcHandlerManager: RpcHandlerManager
 
-    private readonly normalizedWorkspaceRoot: string | undefined
+    private readonly normalizedWorkspaceRoots: string[] | undefined
 
     constructor(
         private readonly token: string,
         private readonly machine: Machine,
-        private readonly workspaceRoot?: string
+        private readonly workspaceRoots?: string[]
     ) {
-        // realpath the root once so all subsequent comparisons are against
-        // the canonical, symlink-resolved path. Falls back to a lexical
-        // resolve if realpath fails (e.g. unusual permission setup) so we
-        // still get *some* protection rather than skipping the check.
-        if (workspaceRoot) {
-            try {
-                this.normalizedWorkspaceRoot = realpathSync(workspaceRoot)
-            } catch {
-                this.normalizedWorkspaceRoot = resolvePath(workspaceRoot)
-            }
-        } else {
-            this.normalizedWorkspaceRoot = undefined
-        }
+        // Realpath roots once so all subsequent comparisons are against
+        // canonical, symlink-resolved locations. Falls back to lexical
+        // resolution if realpath fails so we still get protection.
+        this.normalizedWorkspaceRoots = normalizeWorkspaceRoots(workspaceRoots)
 
         this.rpcHandlerManager = new RpcHandlerManager({
             scopePrefix: this.machine.id,
@@ -143,7 +164,7 @@ export class ApiMachineClient {
         })
 
         this.rpcHandlerManager.registerHandler<ListMachineDirectoryRequest, ListMachineDirectoryResponse>('list-directory', async (params) => {
-            if (!this.normalizedWorkspaceRoot) {
+            if (!this.normalizedWorkspaceRoots?.length) {
                 return { success: false, error: 'Workspace browsing is not enabled for this machine' }
             }
 
@@ -153,8 +174,8 @@ export class ApiMachineClient {
             }
 
             const targetPath = await this.resolveForWorkspaceCheck(rawPath)
-            if (!this.isWithinWorkspaceRoot(targetPath)) {
-                return { success: false, error: 'Path is outside workspace root' }
+            if (!this.isWithinWorkspaceRoots(targetPath)) {
+                return { success: false, error: 'Path is outside workspace roots' }
             }
 
             try {
@@ -228,8 +249,8 @@ export class ApiMachineClient {
                 }
 
                 const resolvedCwd = await this.resolveForWorkspaceCheck(rawCwd)
-                if (!this.isWithinWorkspaceRoot(resolvedCwd)) {
-                    return { success: false, error: 'Path is outside workspace root' }
+                if (!this.isWithinWorkspaceRoots(resolvedCwd)) {
+                    return { success: false, error: 'Path is outside workspace roots' }
                 }
 
                 return await listOpencodeModelsForCwd(resolvedCwd)
@@ -237,10 +258,12 @@ export class ApiMachineClient {
         )
     }
 
-    private isWithinWorkspaceRoot(absolutePath: string): boolean {
-        if (!this.normalizedWorkspaceRoot) return true
-        const rel = relative(this.normalizedWorkspaceRoot, absolutePath)
-        return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+    private isWithinWorkspaceRoots(absolutePath: string): boolean {
+        if (!this.normalizedWorkspaceRoots?.length) return true
+        return this.normalizedWorkspaceRoots.some((workspaceRoot) => {
+            const rel = relative(workspaceRoot, absolutePath)
+            return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+        })
     }
 
     /**
@@ -283,8 +306,8 @@ export class ApiMachineClient {
             }
 
             const resolvedDirectory = await this.resolveForWorkspaceCheck(directory)
-            if (!this.isWithinWorkspaceRoot(resolvedDirectory)) {
-                return { type: 'error', errorMessage: 'Directory is outside this machine\'s workspace root' }
+            if (!this.isWithinWorkspaceRoots(resolvedDirectory)) {
+                return { type: 'error', errorMessage: 'Directory is outside this machine\'s workspace roots' }
             }
 
             const result = await spawnSession({
@@ -428,31 +451,33 @@ export class ApiMachineClient {
                 logger.debug('[API MACHINE] Failed to update runner state on connect', error)
             })
 
-            const hubWorkspaceRoot = this.machine.metadata?.workspaceRoot
-            const desiredWorkspaceRoot = this.workspaceRoot
-            if (desiredWorkspaceRoot !== hubWorkspaceRoot) {
-                if (desiredWorkspaceRoot) {
-                    console.log(`[HAPI] Syncing workspace root to hub: ${desiredWorkspaceRoot} (current hub value: ${hubWorkspaceRoot ?? 'none'})`)
+            const hubWorkspaceRoots = this.machine.metadata?.workspaceRoots
+            const desiredWorkspaceRoots = this.workspaceRoots
+            if (!workspaceRootsEqual(desiredWorkspaceRoots, hubWorkspaceRoots)) {
+                if (desiredWorkspaceRoots?.length) {
+                    console.log(`[HAPI] Syncing workspace roots to hub: ${formatWorkspaceRoots(desiredWorkspaceRoots)} (current hub value: ${formatWorkspaceRoots(hubWorkspaceRoots)})`)
                 } else {
-                    console.log(`[HAPI] Clearing workspace root on hub (was: ${hubWorkspaceRoot})`)
+                    console.log(`[HAPI] Clearing workspace roots on hub (was: ${formatWorkspaceRoots(hubWorkspaceRoots)})`)
                 }
                 this.updateMachineMetadata((current) => {
                     const base = current ?? this.machine.metadata
                     if (!base) {
-                        return { workspaceRoot: desiredWorkspaceRoot } as MachineMetadata
+                        return { workspaceRoots: desiredWorkspaceRoots } as MachineMetadata
                     }
-                    if (desiredWorkspaceRoot) {
-                        return { ...base, workspaceRoot: desiredWorkspaceRoot }
+                    if (desiredWorkspaceRoots?.length) {
+                        return { ...base, workspaceRoots: desiredWorkspaceRoots }
                     }
-                    const { workspaceRoot: _omit, ...rest } = base
+                    const { workspaceRoot: _legacyWorkspaceRoot, workspaceRoots: _workspaceRoots, ...rest } = base as MachineMetadata & {
+                        workspaceRoot?: string
+                    }
                     return rest as MachineMetadata
                 }).then(() => {
-                    console.log(`[HAPI] Workspace root synced: ${this.machine.metadata?.workspaceRoot ?? '(none)'}`)
+                    console.log(`[HAPI] Workspace roots synced: ${formatWorkspaceRoots(this.machine.metadata?.workspaceRoots)}`)
                 }).catch((error) => {
-                    console.error('[HAPI] Failed to sync workspace root:', error instanceof Error ? error.message : error)
+                    console.error('[HAPI] Failed to sync workspace roots:', error instanceof Error ? error.message : error)
                 })
-            } else if (desiredWorkspaceRoot) {
-                console.log(`[HAPI] Workspace root already up to date on hub: ${desiredWorkspaceRoot}`)
+            } else if (desiredWorkspaceRoots?.length) {
+                console.log(`[HAPI] Workspace roots already up to date on hub: ${formatWorkspaceRoots(desiredWorkspaceRoots)}`)
             }
 
             this.startKeepAlive()

--- a/cli/src/api/types.ts
+++ b/cli/src/api/types.ts
@@ -37,7 +37,21 @@ export const MachineMetadataSchema = z.object({
     homeDir: z.string(),
     happyHomeDir: z.string(),
     happyLibDir: z.string(),
-    workspaceRoot: z.string().optional()
+    workspaceRoot: z.string().optional(),
+    workspaceRoots: z.array(z.string()).optional()
+}).transform(({ workspaceRoot, workspaceRoots, ...rest }) => {
+    const normalizedWorkspaceRoots = Array.from(new Set(
+        Array.isArray(workspaceRoots)
+            ? workspaceRoots.filter((path): path is string => typeof path === 'string' && path.trim().length > 0)
+            : workspaceRoot
+                ? [workspaceRoot]
+                : []
+    ))
+
+    return {
+        ...rest,
+        workspaceRoots: normalizedWorkspaceRoots.length > 0 ? normalizedWorkspaceRoots : undefined
+    }
 })
 
 export type MachineMetadata = z.infer<typeof MachineMetadataSchema>

--- a/cli/src/commands/runner.ts
+++ b/cli/src/commands/runner.ts
@@ -16,15 +16,18 @@ import { initializeToken } from '@/ui/tokenInit'
 import type { CommandDefinition } from './types'
 
 /**
- * Parses `--workspace-root <path>` / `--workspace-root=<path>` from the
- * runner's positional args. Returns the resolved absolute path or exits
+ * Parses repeated `--workspace-root <path>` / `--workspace-root=<path>` from
+ * the runner's positional args. Returns resolved absolute paths or exits
  * the process with a clear error. Mutates `args` to remove the consumed
  * entries so subcommand dispatch still works.
  */
-function extractWorkspaceRootArg(args: string[]): string | undefined {
-    for (let i = 0; i < args.length; i++) {
+function extractWorkspaceRootArgs(args: string[]): string[] | undefined {
+    const workspaceRoots: string[] = []
+
+    for (let i = 0; i < args.length;) {
         const arg = args[i]
         let value: string | undefined
+        let consumed = 0
         if (arg === '--workspace-root') {
             const next = args[i + 1]
             if (next === undefined || next.startsWith('--')) {
@@ -32,12 +35,15 @@ function extractWorkspaceRootArg(args: string[]): string | undefined {
                 process.exit(1)
             }
             value = next
-            args.splice(i, 2)
+            consumed = 2
         } else if (arg?.startsWith('--workspace-root=')) {
             value = arg.slice('--workspace-root='.length)
-            args.splice(i, 1)
+            consumed = 1
         }
-        if (value === undefined) continue
+        if (value === undefined) {
+            i += 1
+            continue
+        }
 
         const trimmed = value.trim()
         if (!trimmed) {
@@ -56,9 +62,12 @@ function extractWorkspaceRootArg(args: string[]): string | undefined {
             console.error(`--workspace-root path does not exist or is not a directory: ${absolute}`)
             process.exit(1)
         }
-        return absolute
+        workspaceRoots.push(absolute)
+        args.splice(i, consumed)
     }
-    return undefined
+
+    const uniqueWorkspaceRoots = Array.from(new Set(workspaceRoots))
+    return uniqueWorkspaceRoots.length > 0 ? uniqueWorkspaceRoots : undefined
 }
 
 export const runnerCommand: CommandDefinition = {
@@ -66,7 +75,7 @@ export const runnerCommand: CommandDefinition = {
     requiresRuntimeAssets: true,
     run: async ({ commandArgs }) => {
         const mutableArgs = [...commandArgs]
-        const workspaceRoot = extractWorkspaceRootArg(mutableArgs)
+        const workspaceRoots = extractWorkspaceRootArgs(mutableArgs)
         const runnerSubcommand = mutableArgs[0]
 
         if (runnerSubcommand === 'list') {
@@ -103,8 +112,10 @@ export const runnerCommand: CommandDefinition = {
 
         if (runnerSubcommand === 'start') {
             const childArgs = ['runner', 'start-sync']
-            if (workspaceRoot) {
-                childArgs.push('--workspace-root', workspaceRoot)
+            if (workspaceRoots?.length) {
+                for (const workspaceRoot of workspaceRoots) {
+                    childArgs.push('--workspace-root', workspaceRoot)
+                }
             }
             const child = spawnHappyCLI(childArgs, {
                 detached: true,
@@ -133,7 +144,7 @@ export const runnerCommand: CommandDefinition = {
 
         if (runnerSubcommand === 'start-sync') {
             await initializeToken()
-            await startRunner({ workspaceRoot })
+            await startRunner({ workspaceRoots })
             process.exit(0)
         }
 
@@ -168,7 +179,8 @@ ${chalk.bold('Usage:')}
 
 ${chalk.bold('Options:')}
   --workspace-root <path>        Restrict the runner to this directory.
-                                 Browse & spawn will reject paths outside it.
+                                 Repeat to allow multiple directories/drives.
+                                 Browse & spawn reject paths outside them.
                                  Supports \`~\` / \`~/foo\` expansion.
                                  Omit to leave browsing off (legacy mode).
 

--- a/cli/src/runner/run.ts
+++ b/cli/src/runner/run.ts
@@ -22,10 +22,10 @@ import { startRunnerControlServer } from './controlServer';
 import { createWorktree, removeWorktree, type WorktreeInfo } from './worktree';
 import { join } from 'path';
 import { buildMachineMetadata } from '@/agent/sessionFactory';
-import { resolveWorkspaceRoot } from '@/utils/workspaceRoot';
+import { resolveWorkspaceRoots } from '@/utils/workspaceRoot';
 import { hashRunnerCliApiToken } from './runnerIdentity';
 
-export async function startRunner(options: { workspaceRoot?: string } = {}): Promise<void> {
+export async function startRunner(options: { workspaceRoots?: string[] } = {}): Promise<void> {
   // We don't have cleanup function at the time of server construction
   // Control flow is:
   // 1. Create promise that will resolve when shutdown is requested
@@ -685,14 +685,14 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
     // Create API client
     const api = await ApiClient.create();
 
-    const workspaceRoot = resolveWorkspaceRoot(options.workspaceRoot);
-    logger.debug(`[RUNNER RUN] Workspace root: ${workspaceRoot ?? '(not set)'}`);
+    const workspaceRoots = resolveWorkspaceRoots(options.workspaceRoots);
+    logger.debug(`[RUNNER RUN] Workspace roots: ${workspaceRoots?.join(', ') ?? '(not set)'}`);
 
     // Get or create machine (with retry for transient connection errors)
     const machine = await withRetry(
       () => api.getOrCreateMachine({
         machineId,
-        metadata: buildMachineMetadata({ workspaceRoot }),
+        metadata: buildMachineMetadata({ workspaceRoots }),
         runnerState: initialRunnerState
       }),
       {
@@ -709,7 +709,7 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
     logger.debug(`[RUNNER RUN] Machine registered: ${machine.id}`);
 
     // Create realtime machine session
-    const apiMachine = api.machineSyncClient(machine, { workspaceRoot });
+    const apiMachine = api.machineSyncClient(machine, { workspaceRoots });
 
     // Set RPC handlers
     apiMachine.setRPCHandlers({
@@ -725,7 +725,7 @@ export async function startRunner(options: { workspaceRoot?: string } = {}): Pro
     // regardless of the verbose/quiet logger setting.
     console.log('');
     console.log('Hapi runner started.');
-    console.log(`  Workspace root: ${workspaceRoot ?? '(not set — browse disabled; pass --workspace-root to enable)'}`);
+    console.log(`  Workspace roots: ${workspaceRoots?.join(', ') ?? '(not set — browse disabled; pass --workspace-root to enable)'}`);
     console.log(`  Hub URL:        ${configuration.apiUrl}`);
     console.log(`  Machine ID:     ${machine.id}`);
     console.log(`  Control port:   ${controlPort}`);

--- a/cli/src/utils/workspaceRoot.ts
+++ b/cli/src/utils/workspaceRoot.ts
@@ -1,17 +1,22 @@
 import { isAbsolute } from 'node:path'
 
 /**
- * Resolves the runner's workspace root — the directory tree the runner is
+ * Resolves the runner's workspace roots — the directory trees the runner is
  * allowed to browse and spawn sessions in. Returns `undefined` when the
  * user hasn't explicitly opted in; in that case the runner behaves like
- * the legacy hapi (no scoping, no /browse feature surfaced in the web UI).
+ * legacy hapi (no scoping, no /browse feature surfaced in the web UI).
  *
  * The only signal is the `explicit` argument — typically the resolved
- * `--workspace-root` flag. Non-absolute values are ignored.
+ * `--workspace-root` flag values. Non-absolute values are ignored.
  */
-export function resolveWorkspaceRoot(explicit?: string): string | undefined {
-    if (explicit && isAbsolute(explicit)) {
-        return explicit
+export function resolveWorkspaceRoots(explicit?: string[]): string[] | undefined {
+    if (!explicit?.length) {
+        return undefined
     }
-    return undefined
+
+    const uniqueRoots = Array.from(
+        new Set(explicit.filter((path): path is string => typeof path === 'string' && isAbsolute(path)))
+    )
+
+    return uniqueRoots.length > 0 ? uniqueRoots : undefined
 }

--- a/docs/superpowers/plans/2026-05-06-web-outline-full-hydration.md
+++ b/docs/superpowers/plans/2026-05-06-web-outline-full-hydration.md
@@ -1,0 +1,96 @@
+# Web Outline Full Hydration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a web-only conversation outline pipeline that hydrates full outline history in the background and can locate unloaded old items by paging the thread on demand.
+
+**Architecture:** Keep the chat thread on the existing message window store. Add a separate outline store keyed by session id, hydrate it from the existing paginated `/messages` endpoint, and expose it through a React hook. When the user selects an old outline item, load older thread pages until the target message enters the thread DOM, then scroll to it.
+
+**Tech Stack:** React 19, TypeScript strict, custom external-store pattern, existing `ApiClient.getMessages`, Vitest.
+
+---
+
+### Task 1: Add low-level outline extraction helpers
+
+**Files:**
+- Modify: `web/src/chat/outline.ts`
+- Test: `web/src/chat/outline.test.ts`
+
+- [ ] Add pure helpers that can derive a `ConversationOutlineItem` from `NormalizedMessage` / `DecryptedMessage`-derived user text without going through full chat block reduction.
+- [ ] Preserve current truncation, whitespace collapsing, and target anchor conventions.
+- [ ] Add tests for user-text extraction, non-user filtering, and duplicate-safe stable ids.
+
+### Task 2: Build outline store
+
+**Files:**
+- Create: `web/src/lib/outline-store.ts`
+- Test: `web/src/lib/outline-store.test.ts`
+
+- [ ] Implement per-session outline state with subscribe/get/reset semantics similar to `message-window-store`.
+- [ ] Implement `hydrateOutline(api, sessionId, seedItems?)` using existing `ApiClient.getMessages(... byPosition ...)` paging until `hasMore=false`, with single-flight protection and duplicate filtering.
+- [ ] Implement incremental append for newly received user messages and invalidation/reset for `messages-invalidated`.
+- [ ] Implement locating flags (`isLocating`, `locatingTargetMessageId`) and exported setters for UI.
+- [ ] Cover success, pagination, duplicate pages, invalidation, and single-flight behavior in tests.
+
+### Task 3: Add React hook for outline state
+
+**Files:**
+- Create: `web/src/hooks/queries/useConversationOutline.ts`
+- Test: `web/src/hooks/queries/useConversationOutline.test.ts` (or fold into component tests if lighter)
+
+- [ ] Wrap the outline store with `useSyncExternalStore`.
+- [ ] Expose `items`, `status`, `complete`, `error`, `isLocating`, `startHydrating`, `retryHydrating`, `markInvalidated`, `ingestIncomingMessage`.
+- [ ] Accept seed outline items from current thread blocks so the panel can render immediately before background hydration completes.
+
+### Task 4: Wire SSE events into outline cache
+
+**Files:**
+- Modify: `web/src/hooks/useSSE.ts`
+- Possibly Modify: `web/src/App.tsx` (only if event ownership fits better there)
+- Test: existing SSE-adjacent tests if any; otherwise store-level tests only
+
+- [ ] On `message-received`, incrementally append user outline items to a complete outline cache.
+- [ ] On `messages-invalidated` / session removal, reset the matching outline cache.
+- [ ] Keep this logic side-effect-light so it does not disturb existing message window flow.
+
+### Task 5: Use outline hook in SessionChat
+
+**Files:**
+- Modify: `web/src/components/SessionChat.tsx`
+- Test: `web/src/components/AssistantChat/HappyThread.test.tsx` or a new `SessionChat` test if needed
+
+- [ ] Seed immediate outline items from current `reconciled.blocks`.
+- [ ] Replace direct `buildConversationOutline(reconciled.blocks)` consumption with `useConversationOutline(...)`.
+- [ ] When outline opens, trigger background hydration if needed.
+- [ ] Provide async selection handler that can load older thread pages until the target message is present before asking `HappyThread` to scroll.
+
+### Task 6: Extend HappyThread outline UI states
+
+**Files:**
+- Modify: `web/src/components/AssistantChat/HappyThread.tsx`
+- Test: `web/src/components/AssistantChat/HappyThread.test.tsx`
+
+- [ ] Extend `ConversationOutlinePanel` props for loading/complete/error/locating states.
+- [ ] Show “正在补全大纲… / 已完整 / 重试补全 / 正在定位…” style states without cluttering the panel.
+- [ ] Allow async `onSelect`; disable repeated actions while locating.
+- [ ] Preserve existing in-thread scroll behavior for already-loaded targets.
+
+### Task 7: Verify locate-old-item flow end to end
+
+**Files:**
+- Modify tests only as needed
+- Test: `web/src/lib/outline-store.test.ts`, `web/src/components/AssistantChat/HappyThread.test.tsx`, possible `SessionChat` test
+
+- [ ] Add a regression test for selecting a target outside the current thread window and repeatedly calling `onLoadMore` until found.
+- [ ] Add a regression test for keeping cached outline items across session page unmount/remount.
+- [ ] Run targeted tests, then full `web` test suite and `typecheck`.
+
+### Task 8: Final verification
+
+**Files:**
+- No source changes unless fixes are needed
+
+- [ ] Run: `cd web && bun run test`
+- [ ] Run: `cd web && bun run typecheck`
+- [ ] Manually sanity check long-session UX if a local environment is available.
+- [ ] Summarize behavior changes and any remaining trade-offs.

--- a/docs/superpowers/specs/2026-05-06-web-outline-full-hydration-design.md
+++ b/docs/superpowers/specs/2026-05-06-web-outline-full-hydration-design.md
@@ -1,0 +1,204 @@
+# Web 会话大纲全量补全设计
+
+- 日期：2026-05-06
+- 范围：`web/`
+- 背景版本：CLI `0.17.3`
+
+## 目标
+
+在不放大聊天线程渲染负担的前提下，恢复并增强 Web 会话大纲体验：
+
+1. 打开大纲时，先立即展示当前线程已加载部分。
+2. 后台独立扫描完整历史，逐步补全大纲直到全量。
+3. 点击未加载到当前线程的老大纲项时，自动补拉历史消息并定位。
+4. 会话切换后保留大纲缓存，避免重复全量扫描。
+
+## 非目标
+
+1. 不修改 hub / store / API 协议。
+2. 不把聊天线程改成全量加载。
+3. 不做 localStorage / IndexedDB 持久化。
+4. 不改消息规范化主链路与现有分页协议。
+
+## 现状问题
+
+### 当前大纲来源
+
+当前大纲完全依赖：
+
+`messages -> normalize -> reduce/reconcile -> buildConversationOutline`
+
+因此大纲只覆盖当前 thread window 中的消息；首屏只拿最新窗口，老历史不在窗口里，大纲天然不完整。
+
+### 点击定位问题
+
+现有点击行为假设目标消息已在当前 DOM 中；若目标消息未被当前线程加载，则无法定位。
+
+### 缓存问题
+
+消息窗口缓存已改成会话级内存保留；但 outline 仍然没有独立缓存，无法复用后台扫描结果。
+
+## 方案概览
+
+拆成三条独立数据流：
+
+### 1. 线程流（保留现状）
+
+- 继续使用 `useMessages` + `message-window-store`
+- 负责聊天区渲染与轻量滚动窗口
+- 不负责大纲完整性
+
+### 2. 大纲流（新增）
+
+- 新增独立 `outline-store`
+- 打开大纲面板时启动后台分页扫描
+- 直接从分页得到的 `DecryptedMessage[]` 中提取 user outline 项
+- 逐页累加到 outline cache
+- 扫描结束后标记 `complete=true`
+
+### 3. 定位流（新增）
+
+- 点击大纲项时先检查当前 thread 是否已包含目标消息
+- 若已包含：直接滚动定位
+- 若未包含：串行调用现有 `onLoadMore` 补拉旧消息，直到命中目标或历史耗尽
+- 命中后等待 DOM 渲染完成，再执行滚动
+
+## 状态设计
+
+按 `sessionId` 维护独立 outline state：
+
+- `items`: `ConversationOutlineItem[]`
+- `status`: `idle | loading | ready | error`
+- `complete`: boolean
+- `hasMore`: boolean
+- `cursorBeforeAt`: number | null
+- `cursorBeforeSeq`: number | null
+- `loadedMessageIds`: Set<string>
+- `error`: string | null
+- `isLocating`: boolean
+- `locatingTargetMessageId`: string | null
+
+补充约束：
+
+- 仅采集可见 user 文本消息。
+- 同一 message id 只提取一次，避免翻页重叠或 SSE 回补导致重复。
+- `items` 按消息创建/调用顺序稳定追加，最终与会话时间线一致。
+
+## 数据提取策略
+
+新增一个更底层的 outline 提取纯函数，避免依赖完整 block/reconcile：
+
+- 输入：`DecryptedMessage` 或 `NormalizedMessage`
+- 输出：`ConversationOutlineItem | null`
+
+规则：
+
+1. 仅处理 `role === 'user'`
+2. 仅处理可见文本内容
+3. label 继续复用现有截断/折叠空白逻辑
+4. `targetMessageId` 继续使用现有 anchor 规范，保证与 thread DOM 定位兼容
+
+这样 outline 全量扫描不需要执行整套 reducer / timeline / tool tree 逻辑。
+
+## 缓存策略
+
+### 保留策略
+
+- outline cache 存于内存，生命周期与页面一致
+- 切出会话不清空
+- 再次进入同一会话：
+  - 立即展示缓存项
+  - 若 `complete=false`，后台继续从上次 cursor 扫描
+
+### 失效策略
+
+- 收到 `messages-invalidated` 时，重置该会话 outline cache 为 `idle`
+- 若当前会话正打开 outline 面板，自动重新开始扫描
+- 收到新 `message-received` 且是新的 user 消息时：
+  - 若 outline 已 complete，增量 append 新 outline 项
+  - 若 outline 正在扫描，仍允许扫描链路继续，依靠 `loadedMessageIds` 去重
+
+## 交互细节
+
+### 打开 outline 面板
+
+1. 先显示当前线程已生成的 outline 项
+2. 若缓存为空或未 complete：显示“正在补全大纲…”
+3. 每完成一页扫描，面板增量展示更多项
+4. 扫描结束后显示“已完整”
+5. 扫描失败时显示轻量错误与“重试补全”按钮
+
+### 点击大纲项
+
+#### 目标已在当前线程中
+- 直接 `scrollIntoView`
+- 关闭面板
+
+#### 目标不在当前线程中
+- 面板进入 `isLocating=true`
+- 禁用重复点击
+- 循环执行：
+  1. 检查 `props.messages` 是否已含目标 id
+  2. 若没有且 `hasMoreMessages=true`，调用 `onLoadMore()`
+  3. 等待本轮消息渲染完成，再继续检查
+- 命中后滚动定位并关闭面板
+- 若 `hasMoreMessages=false` 仍未命中，给出“未能定位到该消息”提示
+
+## 文件改动
+
+### 新增
+
+- `web/src/lib/outline-store.ts`
+  - 独立 outline state / subscribe / hydrate / retry / locate 状态
+- `web/src/hooks/queries/useConversationOutline.ts`
+  - React hook 封装订阅与操作
+
+### 修改
+
+- `web/src/chat/outline.ts`
+  - 增加 message/normalized-message 级 outline 提取函数
+- `web/src/components/SessionChat.tsx`
+  - 接入新 hook；outline 打开时触发 hydrate；点击时触发 locate
+- `web/src/components/AssistantChat/HappyThread.tsx`
+  - 面板展示 loading/complete/error/locating 状态；支持 async select
+- `web/src/App.tsx` 或 `web/src/hooks/useSSE.ts`
+  - 在消息失效/新增事件上驱动 outline cache 失效或增量更新
+
+## 错误处理
+
+1. 扫描分页失败：记录错误状态，不影响聊天线程。
+2. 点击定位失败：恢复 `isLocating=false`，展示 toast 或面板内提示。
+3. 会话切换中断：通过 sessionId guard 丢弃过期扫描结果。
+4. 并发打开/重试：同一 session 只允许一个 hydrate promise 在飞。
+
+## 验证方案
+
+### 功能
+
+1. 长会话打开 outline：立即看到部分项，随后逐步补全到全量。
+2. 切换会话再回来：outline 直接复用缓存。
+3. 点最新项：直接滚动定位。
+4. 点很老的项：自动补拉数页后命中并定位。
+5. 消息失效后再次打开：outline 重新补全。
+
+### 回归
+
+1. 聊天线程首屏加载速度无明显回退。
+2. 现有向上加载历史能力不退化。
+3. message-window 缓存与 outline 缓存不互相干扰。
+
+## 风险与权衡
+
+### 风险
+
+- 超长会话首次补全 outline 仍需后台扫多页
+- 点击极老项时，仍需串行补拉线程历史
+
+### 权衡
+
+- 这是最小侵入方案；只改 web，不碰 hub
+- 后续若仍需进一步提速，可演进为 hub 侧独立 outline endpoint
+
+## 决策结论
+
+采用“线程轻量 + outline 独立全量补全 + 点击按需补拉定位”的 web 侧方案；先修体验，再决定是否演进 hub API。

--- a/hub/src/sync/machineCache.ts
+++ b/hub/src/sync/machineCache.ts
@@ -11,7 +11,8 @@ const machineMetadataSchema = z.object({
     homeDir: z.string().optional(),
     happyHomeDir: z.string().optional(),
     happyLibDir: z.string().optional(),
-    workspaceRoot: z.string().optional()
+    workspaceRoot: z.string().optional(),
+    workspaceRoots: z.array(z.string()).optional()
 })
 
 export interface Machine {
@@ -30,7 +31,7 @@ export interface Machine {
         homeDir?: string
         happyHomeDir?: string
         happyLibDir?: string
-        workspaceRoot?: string
+        workspaceRoots?: string[]
     } | null
     metadataVersion: number
     runnerState: unknown | null
@@ -103,8 +104,23 @@ export class MachineCache {
             const homeDir = typeof data.homeDir === 'string' ? data.homeDir : undefined
             const happyHomeDir = typeof data.happyHomeDir === 'string' ? data.happyHomeDir : undefined
             const happyLibDir = typeof data.happyLibDir === 'string' ? data.happyLibDir : undefined
-            const workspaceRoot = typeof data.workspaceRoot === 'string' ? data.workspaceRoot : undefined
-            return { host, platform, happyCliVersion, displayName, homeDir, happyHomeDir, happyLibDir, workspaceRoot }
+            const workspaceRoots = Array.from(new Set(
+                Array.isArray(data.workspaceRoots)
+                    ? data.workspaceRoots.filter((path): path is string => typeof path === 'string' && path.trim().length > 0)
+                    : typeof data.workspaceRoot === 'string'
+                        ? [data.workspaceRoot]
+                        : []
+            ))
+            return {
+                host,
+                platform,
+                happyCliVersion,
+                displayName,
+                homeDir,
+                happyHomeDir,
+                happyLibDir,
+                workspaceRoots: workspaceRoots.length > 0 ? workspaceRoots : undefined
+            }
         })()
 
         const storedActiveAt = stored.activeAt ?? stored.createdAt

--- a/web/src/chat/outline.test.ts
+++ b/web/src/chat/outline.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import type { AgentEvent, ChatBlock } from '@/chat/types'
-import { buildConversationOutline, truncateOutlineLabel } from '@/chat/outline'
+import type { AgentEvent, ChatBlock, NormalizedMessage } from '@/chat/types'
+import type { DecryptedMessage } from '@/types/api'
+import {
+    buildConversationOutline,
+    decryptedMessageToOutlineItem,
+    mergeConversationOutlineItems,
+    normalizedMessageToOutlineItem,
+    truncateOutlineLabel
+} from '@/chat/outline'
 
 function userBlock(id: string, text: string, createdAt: number): ChatBlock {
     return {
@@ -64,6 +71,103 @@ describe('conversation outline', () => {
         expect(items.map((item) => item.id)).toEqual([
             'outline:user:first',
             'outline:user:second'
+        ])
+    })
+
+    it('builds outline items from normalized user messages', () => {
+        const normalized: NormalizedMessage = {
+            id: 'm1',
+            localId: null,
+            createdAt: 123,
+            role: 'user',
+            isSidechain: false,
+            content: {
+                type: 'text',
+                text: 'Outline me'
+            }
+        }
+
+        expect(normalizedMessageToOutlineItem(normalized)).toEqual({
+            id: 'outline:user:m1',
+            targetMessageId: 'user:m1',
+            kind: 'user',
+            label: 'Outline me',
+            createdAt: 123
+        })
+    })
+
+    it('ignores non-user normalized messages', () => {
+        const normalized: NormalizedMessage = {
+            id: 'a1',
+            localId: null,
+            createdAt: 123,
+            role: 'agent',
+            isSidechain: false,
+            content: [{
+                type: 'text',
+                text: 'Ignore me',
+                uuid: 'a1',
+                parentUUID: null
+            }]
+        }
+
+        expect(normalizedMessageToOutlineItem(normalized)).toBeNull()
+    })
+
+    it('builds outline items from decrypted user messages', () => {
+        const message: DecryptedMessage = {
+            id: 'server-1',
+            seq: 1,
+            localId: null,
+            createdAt: 456,
+            invokedAt: null,
+            content: {
+                role: 'user',
+                content: {
+                    type: 'text',
+                    text: 'Hydrated outline'
+                }
+            }
+        }
+
+        expect(decryptedMessageToOutlineItem(message)).toEqual({
+            id: 'outline:user:server-1',
+            targetMessageId: 'user:server-1',
+            kind: 'user',
+            label: 'Hydrated outline',
+            createdAt: 456
+        })
+    })
+
+    it('merges outline items without duplicates and keeps chronological order', () => {
+        const merged = mergeConversationOutlineItems([
+            {
+                id: 'outline:user:newer',
+                targetMessageId: 'user:newer',
+                kind: 'user',
+                label: 'Newer',
+                createdAt: 200
+            }
+        ], [
+            {
+                id: 'outline:user:older',
+                targetMessageId: 'user:older',
+                kind: 'user',
+                label: 'Older',
+                createdAt: 100
+            },
+            {
+                id: 'outline:user:newer-duplicate',
+                targetMessageId: 'user:newer',
+                kind: 'user',
+                label: 'Duplicate',
+                createdAt: 200
+            }
+        ])
+
+        expect(merged.map((item) => item.targetMessageId)).toEqual([
+            'user:older',
+            'user:newer'
         ])
     })
 })

--- a/web/src/chat/outline.ts
+++ b/web/src/chat/outline.ts
@@ -1,4 +1,6 @@
-import type { ChatBlock, UserTextBlock } from '@/chat/types'
+import { normalizeDecryptedMessage } from '@/chat/normalize'
+import type { ChatBlock, NormalizedMessage, UserTextBlock } from '@/chat/types'
+import type { DecryptedMessage } from '@/types/api'
 
 export type ConversationOutlineItem = {
     id: string
@@ -22,15 +24,72 @@ export function truncateOutlineLabel(value: string, maxLength = MAX_OUTLINE_LABE
     return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`
 }
 
-function userBlockToOutlineItem(block: UserTextBlock): ConversationOutlineItem {
+export function toConversationOutlineTargetMessageId(messageId: string): string {
+    return `user:${messageId}`
+}
+
+export function userBlockToOutlineItem(block: UserTextBlock): ConversationOutlineItem {
     const label = truncateOutlineLabel(block.text) || 'Empty message'
     return {
         id: `outline:user:${block.id}`,
-        targetMessageId: `user:${block.id}`,
+        targetMessageId: toConversationOutlineTargetMessageId(block.id),
         kind: 'user',
         label,
         createdAt: block.createdAt
     }
+}
+
+export function normalizedMessageToOutlineItem(message: NormalizedMessage): ConversationOutlineItem | null {
+    if (message.role !== 'user' || message.content.type !== 'text') {
+        return null
+    }
+
+    return userBlockToOutlineItem({
+        kind: 'user-text',
+        id: message.id,
+        localId: message.localId,
+        createdAt: message.createdAt,
+        invokedAt: message.invokedAt,
+        text: message.content.text,
+        attachments: message.content.attachments,
+        status: message.status,
+        originalText: message.originalText,
+        meta: message.meta
+    })
+}
+
+export function decryptedMessageToOutlineItem(message: DecryptedMessage): ConversationOutlineItem | null {
+    const normalized = normalizeDecryptedMessage(message)
+    if (!normalized) {
+        return null
+    }
+    return normalizedMessageToOutlineItem(normalized)
+}
+
+export function mergeConversationOutlineItems(
+    existing: readonly ConversationOutlineItem[],
+    incoming: readonly ConversationOutlineItem[]
+): ConversationOutlineItem[] {
+    if (incoming.length === 0) {
+        return [...existing]
+    }
+
+    const merged = new Map<string, ConversationOutlineItem>()
+    for (const item of existing) {
+        merged.set(item.targetMessageId, item)
+    }
+    for (const item of incoming) {
+        if (!merged.has(item.targetMessageId)) {
+            merged.set(item.targetMessageId, item)
+        }
+    }
+
+    return [...merged.values()].sort((left, right) => {
+        if (left.createdAt !== right.createdAt) {
+            return left.createdAt - right.createdAt
+        }
+        return left.id.localeCompare(right.id)
+    })
 }
 
 export function buildConversationOutline(blocks: readonly ChatBlock[]): ConversationOutlineItem[] {

--- a/web/src/components/AssistantChat/HappyThread.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.test.tsx
@@ -47,9 +47,15 @@ function renderPanel(props: Partial<ComponentProps<typeof ConversationOutlinePan
             <ConversationOutlinePanel
                 title="project"
                 items={outlineItems}
+                status="ready"
+                complete={false}
+                error={null}
+                locateError={null}
+                isLocating={false}
                 hasMoreMessages={false}
                 isLoadingMoreMessages={false}
                 onLoadMore={vi.fn()}
+                onRetryHydration={vi.fn()}
                 onSelect={vi.fn()}
                 onClose={vi.fn()}
                 {...props}
@@ -81,6 +87,38 @@ describe('ConversationOutlinePanel', () => {
         renderPanel({ items: [] })
 
         expect(screen.getByText('No outline items in loaded messages')).toBeInTheDocument()
+    })
+
+    it('shows hydration and locating statuses', () => {
+        renderPanel({
+            status: 'loading',
+            complete: false,
+            isLocating: true
+        })
+
+        expect(screen.getByText('Completing outline…')).toBeInTheDocument()
+        expect(screen.getByText('Locating message…')).toBeInTheDocument()
+    })
+
+    it('shows completion status', () => {
+        renderPanel({
+            complete: true,
+        })
+
+        expect(screen.getByText('Outline complete')).toBeInTheDocument()
+    })
+
+    it('shows retry action on outline error', () => {
+        const onRetryHydration = vi.fn()
+        renderPanel({
+            status: 'error',
+            error: 'Failed to hydrate outline',
+            onRetryHydration
+        })
+
+        fireEvent.click(screen.getByText('Retry hydration'))
+
+        expect(onRetryHydration).toHaveBeenCalledTimes(1)
     })
 })
 
@@ -146,6 +184,21 @@ describe('scroll anchor helpers', () => {
 
         expect(intent).toMatchObject({
             distanceFromBottom: 182,
+            isScrollingUp: true
+        })
+        expect(shouldCancelInitialScrollSettling(intent)).toBe(true)
+    })
+
+    it('cancels initial scroll settling on deliberate upward scrolling even near the bottom', () => {
+        const intent = getScrollIntent({
+            scrollTop: 690,
+            previousScrollTop: 702,
+            scrollHeight: 1232,
+            clientHeight: 530
+        })
+
+        expect(intent).toMatchObject({
+            distanceFromBottom: 12,
             isScrollingUp: true
         })
         expect(shouldCancelInitialScrollSettling(intent)).toBe(true)

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -24,6 +24,11 @@ type PendingScrollRestore = {
     scrollHeight: number
 }
 
+type PendingLoadCompletion = {
+    reject: (error: unknown) => void
+    resolve: (loaded: boolean) => void
+}
+
 const MESSAGE_ANCHOR_SELECTOR = '.happy-thread-messages > [id]'
 const AUTO_SCROLL_RESUME_THRESHOLD_PX = 120
 const MANUAL_SCROLL_EPSILON_PX = 1
@@ -299,7 +304,10 @@ export function HappyThread(props: {
     outlineIsLocating: boolean
     onRetryOutlineHydration: () => Promise<void> | void
     onOutlineOpenChange: (open: boolean) => void
-    onOutlineItemClick?: (item: ConversationOutlineItem) => Promise<boolean> | boolean
+    onOutlineItemClick?: (
+        item: ConversationOutlineItem,
+        helpers: { loadMore: () => Promise<boolean> }
+    ) => Promise<boolean> | boolean
 }) {
     const { t } = useTranslation()
     const viewportRef = useRef<HTMLDivElement | null>(null)
@@ -309,6 +317,7 @@ export function HappyThread(props: {
     const pendingScrollRef = useRef<PendingScrollRestore | null>(null)
     const prevLoadingMoreRef = useRef(false)
     const loadStartedRef = useRef(false)
+    const pendingLoadCompletionRef = useRef<PendingLoadCompletion | null>(null)
     const isLoadingMoreRef = useRef(props.isLoadingMoreMessages)
     const hasMoreMessagesRef = useRef(props.hasMoreMessages)
     const isLoadingMessagesRef = useRef(props.isLoadingMessages)
@@ -507,46 +516,61 @@ export function HappyThread(props: {
         scrollToBottom()
     }, [props.forceScrollToken, scrollToBottom])
 
-    const handleLoadMore = useCallback(() => {
+    const loadMorePreservingScroll = useCallback(async (): Promise<boolean> => {
         if (
             isLoadingMessagesRef.current
             || !hasMoreMessagesRef.current
             || isLoadingMoreRef.current
             || loadLockRef.current
         ) {
-            return
+            return false
         }
         const viewport = viewportRef.current
         if (!viewport) {
-            return
+            return false
         }
-        pendingScrollRef.current = {
-            anchor: captureScrollAnchor(viewport),
-            scrollTop: viewport.scrollTop,
-            scrollHeight: viewport.scrollHeight
-        }
-        autoScrollEnabledRef.current = false
-        loadLockRef.current = true
-        loadStartedRef.current = false
-        let loadPromise: Promise<unknown>
-        try {
-            loadPromise = onLoadMoreRef.current()
-        } catch (error) {
-            pendingScrollRef.current = null
-            loadLockRef.current = false
-            throw error
-        }
-        void loadPromise.catch((error) => {
-            pendingScrollRef.current = null
-            loadLockRef.current = false
-            console.error('Failed to load older messages:', error)
-        }).finally(() => {
-            if (!loadStartedRef.current && !isLoadingMoreRef.current && pendingScrollRef.current) {
+        return await new Promise<boolean>((resolve, reject) => {
+            pendingScrollRef.current = {
+                anchor: captureScrollAnchor(viewport),
+                scrollTop: viewport.scrollTop,
+                scrollHeight: viewport.scrollHeight
+            }
+            autoScrollEnabledRef.current = false
+            loadLockRef.current = true
+            loadStartedRef.current = false
+            pendingLoadCompletionRef.current = { resolve, reject }
+            let loadPromise: Promise<unknown>
+            try {
+                loadPromise = onLoadMoreRef.current()
+            } catch (error) {
                 pendingScrollRef.current = null
                 loadLockRef.current = false
+                pendingLoadCompletionRef.current = null
+                reject(error)
+                return
             }
+            void loadPromise.catch((error) => {
+                pendingScrollRef.current = null
+                loadLockRef.current = false
+                const pending = pendingLoadCompletionRef.current
+                pendingLoadCompletionRef.current = null
+                pending?.reject(error)
+                console.error('Failed to load older messages:', error)
+            }).finally(() => {
+                if (!loadStartedRef.current && !isLoadingMoreRef.current && pendingScrollRef.current) {
+                    pendingScrollRef.current = null
+                    loadLockRef.current = false
+                    const pending = pendingLoadCompletionRef.current
+                    pendingLoadCompletionRef.current = null
+                    pending?.resolve(false)
+                }
+            })
         })
     }, [])
+
+    const handleLoadMore = useCallback(() => {
+        void loadMorePreservingScroll()
+    }, [loadMorePreservingScroll])
 
     const handleOutlineSelect = useCallback(async (item: ConversationOutlineItem) => {
         const target = document.getElementById(getConversationMessageAnchorId(item.targetMessageId))
@@ -557,12 +581,12 @@ export function HappyThread(props: {
             return
         }
         if (props.onOutlineItemClick) {
-            const handled = await props.onOutlineItemClick(item)
+            const handled = await props.onOutlineItemClick(item, { loadMore: loadMorePreservingScroll })
             if (handled !== false) {
                 props.onOutlineOpenChange(false)
             }
         }
-    }, [props.onOutlineItemClick, props.onOutlineOpenChange])
+    }, [loadMorePreservingScroll, props.onOutlineItemClick, props.onOutlineOpenChange])
 
     useEffect(() => {
         handleLoadMoreRef.current = handleLoadMore
@@ -629,6 +653,9 @@ export function HappyThread(props: {
             lastScrollTopRef.current = viewport.scrollTop
             pendingScrollRef.current = null
             loadLockRef.current = false
+            const pendingLoad = pendingLoadCompletionRef.current
+            pendingLoadCompletionRef.current = null
+            pendingLoad?.resolve(true)
             return
         }
         if (atBottomRef.current && autoScrollEnabledRef.current) {
@@ -644,6 +671,9 @@ export function HappyThread(props: {
         if (prevLoadingMoreRef.current && !props.isLoadingMoreMessages && pendingScrollRef.current) {
             pendingScrollRef.current = null
             loadLockRef.current = false
+            const pendingLoad = pendingLoadCompletionRef.current
+            pendingLoadCompletionRef.current = null
+            pendingLoad?.resolve(true)
         }
         prevLoadingMoreRef.current = props.isLoadingMoreMessages
     }, [props.isLoadingMoreMessages])

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -53,7 +53,7 @@ export function getScrollIntent(params: {
 }
 
 export function shouldCancelInitialScrollSettling(intent: ScrollIntent): boolean {
-    return intent.isScrollingUp && intent.distanceFromBottom > MANUAL_SCROLL_EPSILON_PX
+    return intent.isScrollingUp
 }
 
 export function captureScrollAnchor(viewport: HTMLElement): ScrollAnchor | null {
@@ -130,10 +130,16 @@ const THREAD_MESSAGE_COMPONENTS = {
 export function ConversationOutlinePanel(props: {
     title: string
     items: readonly ConversationOutlineItem[]
+    status: 'idle' | 'loading' | 'ready' | 'error'
+    complete: boolean
+    error: string | null
+    locateError: string | null
+    isLocating: boolean
     hasMoreMessages: boolean
     isLoadingMoreMessages: boolean
     onLoadMore: () => void
-    onSelect: (item: ConversationOutlineItem) => void
+    onRetryHydration: () => void
+    onSelect: (item: ConversationOutlineItem) => Promise<void> | void
     onClose: () => void
 }) {
     const { t } = useTranslation()
@@ -184,6 +190,51 @@ export function ConversationOutlinePanel(props: {
                 </div>
             ) : null}
 
+            {props.status === 'loading' && !props.complete ? (
+                <div className="border-b border-[var(--app-border)] px-3 py-2 text-xs text-[var(--app-hint)]">
+                    <div className="flex items-center gap-2">
+                        <Spinner size="sm" label={null} className="text-current" />
+                        <span>{t('session.outline.hydrating')}</span>
+                    </div>
+                </div>
+            ) : null}
+
+            {props.complete ? (
+                <div className="border-b border-[var(--app-border)] px-3 py-2 text-xs text-[var(--app-hint)]">
+                    {t('session.outline.complete')}
+                </div>
+            ) : null}
+
+            {props.error ? (
+                <div className="border-b border-[var(--app-border)] p-3">
+                    <div className="rounded-md bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-300">
+                        <div>{props.error}</div>
+                        <button
+                            type="button"
+                            onClick={props.onRetryHydration}
+                            className="mt-2 text-[var(--app-link)] underline underline-offset-2"
+                        >
+                            {t('session.outline.retry')}
+                        </button>
+                    </div>
+                </div>
+            ) : null}
+
+            {props.isLocating ? (
+                <div className="border-b border-[var(--app-border)] px-3 py-2 text-xs text-[var(--app-hint)]">
+                    <div className="flex items-center gap-2">
+                        <Spinner size="sm" label={null} className="text-current" />
+                        <span>{t('session.outline.locating')}</span>
+                    </div>
+                </div>
+            ) : null}
+
+            {props.locateError ? (
+                <div className="border-b border-[var(--app-border)] px-3 py-2 text-xs text-red-600">
+                    {props.locateError}
+                </div>
+            ) : null}
+
             <div className="app-scroll-y min-h-0 flex-1 p-2">
                 {props.items.length === 0 ? (
                     <div className="px-2 py-8 text-center text-sm text-[var(--app-hint)]">
@@ -196,7 +247,8 @@ export function ConversationOutlinePanel(props: {
                                 <button
                                     key={item.id}
                                     type="button"
-                                    onClick={() => props.onSelect(item)}
+                                    onClick={() => void props.onSelect(item)}
+                                    disabled={props.isLocating}
                                     className="group flex w-full min-w-0 items-start gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-[var(--app-subtle-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
                                 >
                                     <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-[var(--app-button)]" aria-hidden="true" />
@@ -240,8 +292,14 @@ export function HappyThread(props: {
     outlineOpen: boolean
     outlineTitle: string
     outlineItems: readonly ConversationOutlineItem[]
+    outlineStatus: 'idle' | 'loading' | 'ready' | 'error'
+    outlineComplete: boolean
+    outlineError: string | null
+    outlineLocateError: string | null
+    outlineIsLocating: boolean
+    onRetryOutlineHydration: () => Promise<void> | void
     onOutlineOpenChange: (open: boolean) => void
-    onOutlineItemClick?: (item: ConversationOutlineItem) => void
+    onOutlineItemClick?: (item: ConversationOutlineItem) => Promise<boolean> | boolean
 }) {
     const { t } = useTranslation()
     const viewportRef = useRef<HTMLDivElement | null>(null)
@@ -451,8 +509,7 @@ export function HappyThread(props: {
 
     const handleLoadMore = useCallback(() => {
         if (
-            isInitialScrollSettling()
-            || isLoadingMessagesRef.current
+            isLoadingMessagesRef.current
             || !hasMoreMessagesRef.current
             || isLoadingMoreRef.current
             || loadLockRef.current
@@ -489,16 +546,22 @@ export function HappyThread(props: {
                 loadLockRef.current = false
             }
         })
-    }, [isInitialScrollSettling])
+    }, [])
 
-    const handleOutlineSelect = useCallback((item: ConversationOutlineItem) => {
+    const handleOutlineSelect = useCallback(async (item: ConversationOutlineItem) => {
         const target = document.getElementById(getConversationMessageAnchorId(item.targetMessageId))
         if (target) {
             target.scrollIntoView({ block: 'start', behavior: 'smooth' })
             autoScrollEnabledRef.current = false
+            props.onOutlineOpenChange(false)
+            return
         }
-        props.onOutlineItemClick?.(item)
-        props.onOutlineOpenChange(false)
+        if (props.onOutlineItemClick) {
+            const handled = await props.onOutlineItemClick(item)
+            if (handled !== false) {
+                props.onOutlineOpenChange(false)
+            }
+        }
     }, [props.onOutlineItemClick, props.onOutlineOpenChange])
 
     useEffect(() => {
@@ -669,9 +732,15 @@ export function HappyThread(props: {
                         <ConversationOutlinePanel
                             title={props.outlineTitle}
                             items={props.outlineItems}
+                            status={props.outlineStatus}
+                            complete={props.outlineComplete}
+                            error={props.outlineError}
+                            locateError={props.outlineLocateError}
+                            isLocating={props.outlineIsLocating}
                             hasMoreMessages={props.hasMoreMessages}
                             isLoadingMoreMessages={props.isLoadingMoreMessages}
                             onLoadMore={handleLoadMore}
+                            onRetryHydration={props.onRetryOutlineHydration}
                             onSelect={handleOutlineSelect}
                             onClose={() => props.onOutlineOpenChange(false)}
                         />

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -290,11 +290,11 @@ export function NewSession(props: {
     }, [suggestions, selectedIndex, moveUp, moveDown, clearSuggestions, handleSuggestionSelect])
 
     const chooseFolderCallback = props.onChooseFolder
-    const workspaceRootAvailable = Boolean(selectedMachine?.metadata?.workspaceRoot)
+    const workspaceRootsAvailable = Boolean(selectedMachine?.metadata?.workspaceRoots?.length)
     const handleChooseFolder = useMemo(() => {
-        if (!chooseFolderCallback || !workspaceRootAvailable) return undefined
+        if (!chooseFolderCallback || !workspaceRootsAvailable) return undefined
         return () => chooseFolderCallback({ machineId, directory: trimmedDirectory })
-    }, [chooseFolderCallback, workspaceRootAvailable, machineId, trimmedDirectory])
+    }, [chooseFolderCallback, workspaceRootsAvailable, machineId, trimmedDirectory])
 
     async function handleCreate() {
         if (!machineId || !trimmedDirectory) return

--- a/web/src/components/SessionChat.test.ts
+++ b/web/src/components/SessionChat.test.ts
@@ -6,6 +6,7 @@ describe('loadOutlineTarget', () => {
         let loaded = false
         const loadMore = vi.fn(async () => {
             loaded = true
+            return true
         })
 
         const found = await loadOutlineTarget({
@@ -20,7 +21,7 @@ describe('loadOutlineTarget', () => {
     })
 
     it('stops when no older pages remain', async () => {
-        const loadMore = vi.fn()
+        const loadMore = vi.fn(async () => false)
 
         const found = await loadOutlineTarget({
             findTarget: () => null,

--- a/web/src/components/SessionChat.test.ts
+++ b/web/src/components/SessionChat.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadOutlineTarget } from '@/components/SessionChat'
+
+describe('loadOutlineTarget', () => {
+    it('keeps loading older pages until the target is found', async () => {
+        let loaded = false
+        const loadMore = vi.fn(async () => {
+            loaded = true
+        })
+
+        const found = await loadOutlineTarget({
+            findTarget: () => (loaded ? document.body : null),
+            hasMore: () => !loaded,
+            loadMore,
+            maxAttempts: 3,
+        })
+
+        expect(found).toBe(true)
+        expect(loadMore).toHaveBeenCalledTimes(1)
+    })
+
+    it('stops when no older pages remain', async () => {
+        const loadMore = vi.fn()
+
+        const found = await loadOutlineTarget({
+            findTarget: () => null,
+            hasMore: () => false,
+            loadMore,
+        })
+
+        expect(found).toBe(false)
+        expect(loadMore).not.toHaveBeenCalled()
+    })
+})

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -56,7 +56,7 @@ function waitForNextPaint(): Promise<void> {
 export async function loadOutlineTarget(options: {
     findTarget: () => HTMLElement | null
     hasMore: () => boolean
-    loadMore: () => Promise<unknown>
+    loadMore: () => Promise<boolean>
     maxAttempts?: number
 }): Promise<boolean> {
     if (options.findTarget()) {
@@ -68,7 +68,10 @@ export async function loadOutlineTarget(options: {
 
     while (options.hasMore() && attempts < maxAttempts) {
         attempts += 1
-        await options.loadMore()
+        const loaded = await options.loadMore()
+        if (!loaded) {
+            break
+        }
         await waitForNextPaint()
         if (options.findTarget()) {
             return true
@@ -427,7 +430,10 @@ export function SessionChat(props: {
         setForceScrollToken((token) => token + 1)
     }, [props.onSend])
 
-    const handleOutlineItemClick = useCallback(async (item: ConversationOutlineItem) => {
+    const handleOutlineItemClick = useCallback(async (
+        item: ConversationOutlineItem,
+        helpers: { loadMore: () => Promise<boolean> }
+    ) => {
         const anchorId = getConversationMessageAnchorId(item.targetMessageId)
         const findTarget = () => document.getElementById(anchorId)
 
@@ -440,7 +446,7 @@ export function SessionChat(props: {
             const found = await loadOutlineTarget({
                 findTarget,
                 hasMore: () => hasMoreMessagesRef.current,
-                loadMore: () => onLoadMoreRef.current(),
+                loadMore: helpers.loadMore,
             })
             if (!found) {
                 outlineState.setLocating(null, t('session.outline.locateFailed'))

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -15,7 +15,7 @@ import type { Suggestion } from '@/hooks/useActiveSuggestions'
 import { normalizeDecryptedMessage } from '@/chat/normalize'
 import { reduceChatBlocks } from '@/chat/reducer'
 import { reconcileChatBlocks } from '@/chat/reconcile'
-import { buildConversationOutline } from '@/chat/outline'
+import { buildConversationOutline, getConversationMessageAnchorId, type ConversationOutlineItem } from '@/chat/outline'
 import { isQueuedForInvocation } from '@/lib/messages'
 import { HappyComposer } from '@/components/AssistantChat/HappyComposer'
 import { HappyThread } from '@/components/AssistantChat/HappyThread'
@@ -28,6 +28,7 @@ import { TeamPanel } from '@/components/TeamPanel'
 import { usePlatform } from '@/hooks/usePlatform'
 import { useSessionActions } from '@/hooks/mutations/useSessionActions'
 import { useCodexModels } from '@/hooks/queries/useCodexModels'
+import { useConversationOutline } from '@/hooks/queries/useConversationOutline'
 import { useOpencodeModels } from '@/hooks/queries/useOpencodeModels'
 import { useVoiceOptional } from '@/lib/voice-context'
 import { RealtimeVoiceSession, registerSessionStore, registerVoiceHooksStore, voiceHooks } from '@/realtime'
@@ -44,6 +45,37 @@ function getOutlineTitle(session: Session): string {
         return session.metadata.path
     }
     return session.id.slice(0, 8)
+}
+
+function waitForNextPaint(): Promise<void> {
+    return new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
+}
+
+export async function loadOutlineTarget(options: {
+    findTarget: () => HTMLElement | null
+    hasMore: () => boolean
+    loadMore: () => Promise<unknown>
+    maxAttempts?: number
+}): Promise<boolean> {
+    if (options.findTarget()) {
+        return true
+    }
+
+    const maxAttempts = options.maxAttempts ?? 200
+    let attempts = 0
+
+    while (options.hasMore() && attempts < maxAttempts) {
+        attempts += 1
+        await options.loadMore()
+        await waitForNextPaint()
+        if (options.findTarget()) {
+            return true
+        }
+    }
+
+    return options.findTarget() !== null
 }
 
 export function SessionChat(props: {
@@ -76,6 +108,8 @@ export function SessionChat(props: {
     const blocksByIdRef = useRef<Map<string, ChatBlock>>(new Map())
     const [forceScrollToken, setForceScrollToken] = useState(0)
     const [outlineOpen, setOutlineOpen] = useState(false)
+    const hasMoreMessagesRef = useRef(props.hasMoreMessages)
+    const onLoadMoreRef = useRef(props.onLoadMore)
     const agentFlavor = props.session.metadata?.flavor ?? null
     const controlledByUser = props.session.agentState?.controlledByUser === true
     const codexCollaborationModeSupported = agentFlavor === 'codex' && !controlledByUser
@@ -283,11 +317,27 @@ export function SessionChat(props: {
         () => buildConversationOutline(reconciled.blocks),
         [reconciled.blocks]
     )
+    const outlineState = useConversationOutline(props.api, props.session.id, outlineItems)
 
     const outlineTitle = useMemo(
         () => getOutlineTitle(props.session),
         [props.session]
     )
+
+    useEffect(() => {
+        hasMoreMessagesRef.current = props.hasMoreMessages
+    }, [props.hasMoreMessages])
+
+    useEffect(() => {
+        onLoadMoreRef.current = props.onLoadMore
+    }, [props.onLoadMore])
+
+    useEffect(() => {
+        if (!outlineOpen || outlineState.complete || outlineState.status === 'loading' || outlineState.status === 'error') {
+            return
+        }
+        void outlineState.startHydrating()
+    }, [outlineOpen, outlineState.complete, outlineState.startHydrating, outlineState.status])
 
     // Permission mode change handler
     const handlePermissionModeChange = useCallback(async (mode: PermissionMode) => {
@@ -377,6 +427,42 @@ export function SessionChat(props: {
         setForceScrollToken((token) => token + 1)
     }, [props.onSend])
 
+    const handleOutlineItemClick = useCallback(async (item: ConversationOutlineItem) => {
+        const anchorId = getConversationMessageAnchorId(item.targetMessageId)
+        const findTarget = () => document.getElementById(anchorId)
+
+        if (findTarget()) {
+            return true
+        }
+
+        outlineState.setLocating(item.targetMessageId, null)
+        try {
+            const found = await loadOutlineTarget({
+                findTarget,
+                hasMore: () => hasMoreMessagesRef.current,
+                loadMore: () => onLoadMoreRef.current(),
+            })
+            if (!found) {
+                outlineState.setLocating(null, t('session.outline.locateFailed'))
+                return false
+            }
+
+            const target = findTarget()
+            if (!target) {
+                outlineState.setLocating(null, t('session.outline.locateFailed'))
+                return false
+            }
+
+            target.scrollIntoView({ block: 'start', behavior: 'smooth' })
+            outlineState.setLocating(null, null)
+            return true
+        } catch (error) {
+            const message = error instanceof Error ? error.message : t('session.outline.locateFailed')
+            outlineState.setLocating(null, message)
+            return false
+        }
+    }, [outlineState, t])
+
     const attachmentAdapter = useMemo(() => {
         if (!props.session.active) {
             return undefined
@@ -441,8 +527,15 @@ export function SessionChat(props: {
                         forceScrollToken={forceScrollToken}
                         outlineOpen={outlineOpen}
                         outlineTitle={outlineTitle}
-                        outlineItems={outlineItems}
+                        outlineItems={outlineState.items}
+                        outlineStatus={outlineState.status}
+                        outlineComplete={outlineState.complete}
+                        outlineError={outlineState.error}
+                        outlineLocateError={outlineState.locateError}
+                        outlineIsLocating={outlineState.isLocating}
+                        onRetryOutlineHydration={outlineState.retryHydrating}
                         onOutlineOpenChange={setOutlineOpen}
+                        onOutlineItemClick={handleOutlineItemClick}
                     />
 
                     {codexCollaborationModeSupported && codexModelsState.error ? (

--- a/web/src/components/WorkspaceBrowser.tsx
+++ b/web/src/components/WorkspaceBrowser.tsx
@@ -58,33 +58,85 @@ function getMachineTitle(machine: Machine): string {
     return machine.id.slice(0, 8)
 }
 
+function getMachineRootsSummary(machine: Machine): string {
+    const roots = machine.metadata?.workspaceRoots ?? []
+    if (roots.length === 0) return ''
+    if (roots.length === 1) return roots[0]
+    return `${roots[0]} (+${roots.length - 1})`
+}
+
+function isWindowsStylePath(path: string): boolean {
+    return /^[A-Za-z]:[\\/]/.test(path) || path.includes('\\')
+}
+
+function getPathSeparator(path: string): '/' | '\\' {
+    return isWindowsStylePath(path) ? '\\' : '/'
+}
+
+function normalizePathForComparison(path: string): string {
+    const normalized = path.replace(/[\\/]+/g, '/')
+    if (/^[A-Za-z]:\/$/.test(normalized) || normalized === '/') {
+        return normalized
+    }
+    if (/^[A-Za-z]:$/.test(normalized)) {
+        return `${normalized}/`
+    }
+    return normalized.replace(/\/+$/, '')
+}
+
+function denormalizePath(path: string, sample: string): string {
+    return getPathSeparator(sample) === '\\'
+        ? path.replace(/\//g, '\\')
+        : path
+}
+
 function joinPath(base: string, name: string): string {
-    return base.endsWith('/') ? base + name : base + '/' + name
+    const normalizedBase = normalizePathForComparison(base)
+    const joined = normalizedBase === '/' || /^[A-Za-z]:\/$/.test(normalizedBase)
+        ? `${normalizedBase}${name}`
+        : `${normalizedBase}/${name}`
+    return denormalizePath(joined, base)
 }
 
 function parentPath(path: string): string {
-    const stripped = path.replace(/\/+$/, '')
-    const idx = stripped.lastIndexOf('/')
-    if (idx <= 0) return '/'
-    return stripped.slice(0, idx)
+    const normalizedPath = normalizePathForComparison(path)
+    if (normalizedPath === '/' || /^[A-Za-z]:\/$/.test(normalizedPath)) {
+        return denormalizePath(normalizedPath, path)
+    }
+
+    const idx = normalizedPath.lastIndexOf('/')
+    const parent = idx <= 0 ? '/' : normalizedPath.slice(0, idx)
+    const resolvedParent = /^[A-Za-z]:$/.test(parent) ? `${parent}/` : parent
+    return denormalizePath(resolvedParent, path)
 }
 
 function isPathWithin(candidate: string, root: string): boolean {
-    const c = candidate.replace(/\/+$/, '') || '/'
-    const r = root.replace(/\/+$/, '') || '/'
-    return c === r || c.startsWith(r + '/')
+    const c = normalizePathForComparison(candidate)
+    const r = normalizePathForComparison(root)
+    return c === r || c.startsWith(r.endsWith('/') ? r : `${r}/`)
 }
 
 function buildBreadcrumbs(currentPath: string, root: string): { label: string; path: string }[] {
-    const rootTrimmed = root.replace(/\/+$/, '')
-    const relative = currentPath.slice(rootTrimmed.length).replace(/^\/+/, '')
-    const crumbs: { label: string; path: string }[] = [{ label: rootTrimmed.split('/').pop() || '/', path: rootTrimmed || '/' }]
+    const normalizedRoot = normalizePathForComparison(root)
+    const normalizedCurrent = normalizePathForComparison(currentPath)
+    const rootLabel = (() => {
+        if (normalizedRoot === '/') return '/'
+        if (/^[A-Za-z]:\/$/.test(normalizedRoot)) return normalizedRoot.slice(0, 2)
+        return normalizedRoot.split('/').pop() || normalizedRoot
+    })()
+    const relative = normalizedCurrent.slice(normalizedRoot.length).replace(/^\/+/, '')
+    const crumbs: { label: string; path: string }[] = [{
+        label: rootLabel,
+        path: denormalizePath(normalizedRoot, root)
+    }]
     if (!relative) return crumbs
     const parts = relative.split('/').filter(Boolean)
-    let acc = rootTrimmed
+    let acc = normalizedRoot
     for (const part of parts) {
-        acc = acc + '/' + part
-        crumbs.push({ label: part, path: acc })
+        acc = acc === '/' || /^[A-Za-z]:\/$/.test(acc)
+            ? `${acc}${part}`
+            : `${acc}/${part}`
+        crumbs.push({ label: part, path: denormalizePath(acc, root) })
     }
     return crumbs
 }
@@ -101,6 +153,7 @@ export function WorkspaceBrowser(props: {
     const queryClient = useQueryClient()
 
     const [machineId, setMachineId] = useState<string | null>(initialMachineId ?? null)
+    const [selectedRoot, setSelectedRoot] = useState<string | null>(null)
     const [currentPath, setCurrentPath] = useState<string | null>(null)
     const [entries, setEntries] = useState<MachineDirectoryEntry[]>([])
     const [isLoading, setIsLoading] = useState(false)
@@ -131,7 +184,7 @@ export function WorkspaceBrowser(props: {
         () => machineId ? machines.find(m => m.id === machineId) ?? null : null,
         [machineId, machines]
     )
-    const workspaceRoot = selectedMachine?.metadata?.workspaceRoot ?? null
+    const workspaceRoots = selectedMachine?.metadata?.workspaceRoots ?? []
 
     const loadDirectory = useCallback(async (path: string) => {
         if (!machineId) return
@@ -144,7 +197,7 @@ export function WorkspaceBrowser(props: {
                 setCurrentPath(path)
             } else {
                 setError(result.error ?? 'Failed to list directory')
-                // CLI may have just pushed new metadata (e.g. a workspaceRoot)
+                // CLI may have just pushed new metadata (e.g. workspaceRoots)
                 // that we haven't picked up yet — refetch so the UI can
                 // transition out of the no-root state if applicable.
                 void queryClient.invalidateQueries({ queryKey: queryKeys.machines })
@@ -157,15 +210,25 @@ export function WorkspaceBrowser(props: {
         }
     }, [api, machineId, queryClient])
 
-    // Auto-load workspace root when a machine with a root is selected
     useEffect(() => {
-        if (!machineId || !workspaceRoot) return
-        if (currentPath && isPathWithin(currentPath, workspaceRoot)) return
-        void loadDirectory(workspaceRoot)
-    }, [machineId, workspaceRoot, currentPath, loadDirectory])
+        if (workspaceRoots.length === 0) {
+            if (selectedRoot !== null) setSelectedRoot(null)
+            return
+        }
+        if (selectedRoot && workspaceRoots.includes(selectedRoot)) return
+        setSelectedRoot(workspaceRoots[0] ?? null)
+    }, [workspaceRoots, selectedRoot])
+
+    // Auto-load selected root when a machine/root is selected
+    useEffect(() => {
+        if (!machineId || !selectedRoot) return
+        if (currentPath && isPathWithin(currentPath, selectedRoot)) return
+        void loadDirectory(selectedRoot)
+    }, [machineId, selectedRoot, currentPath, loadDirectory])
 
     // If switching machines, reset view
     useEffect(() => {
+        setSelectedRoot(null)
         setCurrentPath(null)
         setEntries([])
         setError(null)
@@ -177,12 +240,12 @@ export function WorkspaceBrowser(props: {
     }, [currentPath, loadDirectory])
 
     const handleGoUp = useCallback(() => {
-        if (!currentPath || !workspaceRoot) return
-        if (currentPath.replace(/\/+$/, '') === workspaceRoot.replace(/\/+$/, '')) return
+        if (!currentPath || !selectedRoot) return
+        if (normalizePathForComparison(currentPath) === normalizePathForComparison(selectedRoot)) return
         const parent = parentPath(currentPath)
-        if (!isPathWithin(parent, workspaceRoot)) return
+        if (!isPathWithin(parent, selectedRoot)) return
         void loadDirectory(parent)
-    }, [currentPath, workspaceRoot, loadDirectory])
+    }, [currentPath, selectedRoot, loadDirectory])
 
     const handleRefresh = useCallback(() => {
         if (currentPath) void loadDirectory(currentPath)
@@ -194,12 +257,12 @@ export function WorkspaceBrowser(props: {
     }, [machineId, currentPath, props])
 
     const breadcrumbs = useMemo(() => {
-        if (!currentPath || !workspaceRoot) return []
-        return buildBreadcrumbs(currentPath, workspaceRoot)
-    }, [currentPath, workspaceRoot])
+        if (!currentPath || !selectedRoot) return []
+        return buildBreadcrumbs(currentPath, selectedRoot)
+    }, [currentPath, selectedRoot])
 
     const directories = useMemo(() => entries.filter(e => e.type === 'directory'), [entries])
-    const atRoot = !!(currentPath && workspaceRoot && currentPath.replace(/\/+$/, '') === workspaceRoot.replace(/\/+$/, ''))
+    const atRoot = !!(currentPath && selectedRoot && normalizePathForComparison(currentPath) === normalizePathForComparison(selectedRoot))
 
     const machineSelector = (
         <div className="flex items-center gap-2">
@@ -213,7 +276,7 @@ export function WorkspaceBrowser(props: {
                 {machines.map(m => (
                     <option key={m.id} value={m.id}>
                         {getMachineTitle(m)}
-                        {m.metadata?.workspaceRoot ? ` — ${m.metadata.workspaceRoot}` : ''}
+                        {getMachineRootsSummary(m) ? ` — ${getMachineRootsSummary(m)}` : ''}
                     </option>
                 ))}
                 {machines.length === 0 && (
@@ -235,9 +298,9 @@ export function WorkspaceBrowser(props: {
         )
     }
 
-    // Selected machine hasn't reported a workspaceRoot — show an info state.
+    // Selected machine hasn't reported workspace roots — show an info state.
     // Browsing is opt-in, triggered by `--workspace-root`.
-    if (selectedMachine && !workspaceRoot) {
+    if (selectedMachine && workspaceRoots.length === 0) {
         return (
             <div className="flex flex-col h-full">
                 <div className="px-3 py-2 border-b border-[var(--app-divider)]">{machineSelector}</div>
@@ -245,7 +308,7 @@ export function WorkspaceBrowser(props: {
                     <div className="text-sm text-[var(--app-fg)] font-medium">{t('browse.noRootTitle')}</div>
                     <div className="max-w-md text-sm text-[var(--app-hint)]">{t('browse.noRootHint')}</div>
                     <code className="px-3 py-1.5 text-xs rounded bg-[var(--app-subtle-bg)] text-[var(--app-fg)]">
-                        hapi runner start --workspace-root /path/to/folder
+                        hapi runner start --workspace-root /path/a --workspace-root /path/b
                     </code>
                     <div className="text-xs text-[var(--app-hint)] mt-2">
                         {t('browse.noRootFooter')}
@@ -259,6 +322,22 @@ export function WorkspaceBrowser(props: {
         <div className="flex flex-col h-full">
             <div className="px-3 py-2 border-b border-[var(--app-divider)]">
                 {machineSelector}
+
+                {workspaceRoots.length > 1 && (
+                    <div className="mt-2">
+                        <select
+                            value={selectedRoot ?? ''}
+                            onChange={(e) => setSelectedRoot(e.target.value || null)}
+                            className="w-full bg-transparent text-xs text-[var(--app-hint)] outline-none"
+                        >
+                            {workspaceRoots.map((root) => (
+                                <option key={root} value={root}>
+                                    {root}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                )}
 
                 {currentPath && (
                     <div className="mt-2 flex items-center gap-1 text-xs overflow-x-auto">

--- a/web/src/hooks/queries/useConversationOutline.ts
+++ b/web/src/hooks/queries/useConversationOutline.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import type { ApiClient } from '@/api/client'
+import type { ConversationOutlineItem } from '@/chat/outline'
+import {
+    getConversationOutlineState,
+    hydrateConversationOutline,
+    resetConversationOutline,
+    seedConversationOutline,
+    setConversationOutlineLocating,
+    subscribeConversationOutline,
+    type ConversationOutlineState,
+} from '@/lib/outline-store'
+
+const EMPTY_STATE: ConversationOutlineState = {
+    sessionId: 'unknown',
+    items: [],
+    status: 'idle',
+    complete: false,
+    hasMore: true,
+    cursorBeforeAt: null,
+    cursorBeforeSeq: null,
+    error: null,
+    locateError: null,
+    isLocating: false,
+    locatingTargetMessageId: null,
+}
+
+export function useConversationOutline(
+    api: ApiClient | null,
+    sessionId: string | null,
+    seedItems: readonly ConversationOutlineItem[]
+): ConversationOutlineState & {
+    startHydrating: () => Promise<void>
+    retryHydrating: () => Promise<void>
+    setLocating: (targetMessageId: string | null, locateError?: string | null) => void
+} {
+    const state = useSyncExternalStore(
+        useCallback((listener) => {
+            if (!sessionId) {
+                return () => {}
+            }
+            return subscribeConversationOutline(sessionId, listener)
+        }, [sessionId]),
+        useCallback(() => {
+            if (!sessionId) {
+                return EMPTY_STATE
+            }
+            return getConversationOutlineState(sessionId)
+        }, [sessionId]),
+        () => EMPTY_STATE
+    )
+
+    useEffect(() => {
+        if (!sessionId || seedItems.length === 0) {
+            return
+        }
+        seedConversationOutline(sessionId, seedItems)
+    }, [sessionId, seedItems])
+
+    const startHydrating = useCallback(async () => {
+        if (!api || !sessionId) {
+            return
+        }
+        await hydrateConversationOutline(api, sessionId)
+    }, [api, sessionId])
+
+    const retryHydrating = useCallback(async () => {
+        if (!api || !sessionId) {
+            return
+        }
+        resetConversationOutline(sessionId)
+        if (seedItems.length > 0) {
+            seedConversationOutline(sessionId, seedItems)
+        }
+        await hydrateConversationOutline(api, sessionId)
+    }, [api, sessionId, seedItems])
+
+    const setLocating = useCallback((targetMessageId: string | null, locateError: string | null = null) => {
+        if (!sessionId) {
+            return
+        }
+        setConversationOutlineLocating(sessionId, targetMessageId, locateError)
+    }, [sessionId])
+
+    return {
+        ...state,
+        startHydrating,
+        retryHydrating,
+        setLocating,
+    }
+}

--- a/web/src/hooks/queries/useMessages.ts
+++ b/web/src/hooks/queries/useMessages.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useSyncExternalStore } from 'react'
 import type { ApiClient } from '@/api/client'
 import type { DecryptedMessage } from '@/types/api'
 import {
-    clearMessageWindow,
     fetchLatestMessages,
     fetchOlderMessages,
     flushPendingMessages,
@@ -62,15 +61,6 @@ export function useMessages(api: ApiClient | null, sessionId: string | null): {
         }
         void fetchLatestMessages(api, sessionId)
     }, [api, sessionId])
-
-    useEffect(() => {
-        if (!sessionId) {
-            return
-        }
-        return () => {
-            clearMessageWindow(sessionId)
-        }
-    }, [sessionId])
 
     const loadMore = useCallback(async () => {
         if (!api || !sessionId) return

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/types/api'
 import { queryKeys } from '@/lib/query-keys'
 import { clearMessageWindow, getMessageWindowState, ingestIncomingMessages, markMessagesConsumed, removeOptimisticMessage, updateMessageStatus } from '@/lib/message-window-store'
+import { ingestConversationOutlineMessage, resetConversationOutline } from '@/lib/outline-store'
 
 type SSESubscription = {
     all?: boolean
@@ -507,8 +508,13 @@ export function useSSE(options: {
                 removeOptimisticMessage(event.sessionId, event.messageId)
             }
 
+            if (event.type === 'messages-invalidated') {
+                resetConversationOutline(event.sessionId)
+            }
+
             if (event.type === 'message-received') {
                 ingestIncomingMessages(event.sessionId, [event.message])
+                ingestConversationOutlineMessage(event.sessionId, event.message)
             }
 
             if (event.type === 'session-added' || event.type === 'session-updated' || event.type === 'session-removed') {
@@ -516,6 +522,7 @@ export function useSSE(options: {
                     removeSessionSummary(event.sessionId)
                     void queryClient.removeQueries({ queryKey: queryKeys.session(event.sessionId) })
                     clearMessageWindow(event.sessionId)
+                    resetConversationOutline(event.sessionId)
                 } else if (isSessionRecord(event.data) && event.data.id === event.sessionId) {
                     queryClient.setQueryData<SessionResponse>(queryKeys.session(event.sessionId), { session: event.data })
                     upsertSessionSummary(event.data)

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -500,6 +500,13 @@ export function useSSE(options: {
 
             if (event.type === 'messages-consumed') {
                 markMessagesConsumed(event.sessionId, event.localIds, event.invokedAt)
+                const state = getMessageWindowState(event.sessionId)
+                for (const localId of event.localIds) {
+                    const consumed = state.messages.find((message) => message.localId === localId)
+                    if (consumed) {
+                        ingestConversationOutlineMessage(event.sessionId, consumed)
+                    }
+                }
             }
 
             if (event.type === 'message-cancelled') {

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -318,9 +318,9 @@ export default {
   'browse.startSession': 'Start Session',
   'browse.nav': 'Browse',
   'browse.noRootTitle': 'Workspace browsing is off',
-  'browse.noRootHint': 'Browsing is opt-in. Restart the runner with a workspace root to enable file-tree navigation and scoped session spawning.',
+  'browse.noRootHint': 'Browsing is opt-in. Restart the runner with one or more workspace roots to enable file-tree navigation and scoped session spawning.',
   'browse.noRootFooter': 'You can still create sessions from the “New Session” page.',
-  'browse.noMachinesConnected': 'No CLI connected. Run `hapi runner start --workspace-root /path` on a machine to get started.',
+  'browse.noMachinesConnected': 'No CLI connected. Run `hapi runner start --workspace-root /path/a --workspace-root /path/b` on a machine to get started.',
 
   // Misc
   'misc.noMachines': 'No machines available',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -73,6 +73,11 @@ export default {
   'session.outline.loadOlder': 'Load earlier',
   'session.outline.empty': 'No outline items in loaded messages',
   'session.outline.kind.user': 'User',
+  'session.outline.hydrating': 'Completing outline…',
+  'session.outline.complete': 'Outline complete',
+  'session.outline.retry': 'Retry hydration',
+  'session.outline.locating': 'Locating message…',
+  'session.outline.locateFailed': 'Could not locate that message',
 
   // Session actions
   'session.action.rename': 'Rename',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -73,6 +73,11 @@ export default {
   'session.outline.loadOlder': '加载更早',
   'session.outline.empty': '已加载消息中暂无大纲项',
   'session.outline.kind.user': '用户',
+  'session.outline.hydrating': '正在补全大纲…',
+  'session.outline.complete': '大纲已完整',
+  'session.outline.retry': '重试补全',
+  'session.outline.locating': '正在定位消息…',
+  'session.outline.locateFailed': '未能定位到该消息',
 
   // Session actions
   'session.action.rename': '重命名',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -320,9 +320,9 @@ export default {
   'browse.startSession': '启动会话',
   'browse.nav': '浏览',
   'browse.noRootTitle': '未启用 workspace 浏览',
-  'browse.noRootHint': '浏览功能是可选的。带 --workspace-root 参数重启 runner，即可启用文件树浏览和受限的会话启动。',
+  'browse.noRootHint': '浏览功能是可选的。带一个或多个 --workspace-root 参数重启 runner，即可启用文件树浏览和受限的会话启动。',
   'browse.noRootFooter': '你仍然可以在「新建会话」页面直接创建会话。',
-  'browse.noMachinesConnected': '没有已连接的 CLI。在某台机器上运行 `hapi runner start --workspace-root /path` 来开始。',
+  'browse.noMachinesConnected': '没有已连接的 CLI。在某台机器上运行 `hapi runner start --workspace-root /path/a --workspace-root /path/b` 来开始。',
 
   // Misc
   'misc.noMachines': '无可用机器',

--- a/web/src/lib/message-window-store.test.ts
+++ b/web/src/lib/message-window-store.test.ts
@@ -7,6 +7,7 @@ import {
     ingestIncomingMessages,
     markMessagesConsumed,
     removeOptimisticMessage,
+    subscribeMessageWindow,
     updateMessageStatus,
 } from '@/lib/message-window-store'
 
@@ -164,5 +165,26 @@ describe('message-window-store status updates', () => {
 
         const message = getMessageWindowState(SESSION_ID).messages.find((entry) => entry.id === 'server-queued')
         expect(message?.status).toBe('sent')
+    })
+})
+
+describe('message-window-store cache retention', () => {
+    const SESSION_ID = 'session-message-window-cache-test'
+
+    afterEach(() => {
+        clearMessageWindow(SESSION_ID)
+    })
+
+    it('keeps loaded messages after the last subscriber unsubscribes', () => {
+        const unsubscribe = subscribeMessageWindow(SESSION_ID, () => {})
+        appendOptimisticMessage(SESSION_ID, makeUserMessage({
+            id: 'cached-1',
+            localId: 'cached-1',
+            status: 'sent',
+        }))
+
+        unsubscribe()
+
+        expect(getMessageWindowState(SESSION_ID).messages.map((message) => message.id)).toEqual(['cached-1'])
     })
 })

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -20,6 +20,7 @@ export type MessageWindowState = {
 
 export const VISIBLE_WINDOW_SIZE = 400
 export const PENDING_WINDOW_SIZE = 200
+const INITIAL_PAGE_SIZE = VISIBLE_WINDOW_SIZE
 const PAGE_SIZE = 50
 const PENDING_OVERFLOW_WARNING = 'New messages arrived while you were away. Scroll to bottom to refresh.'
 
@@ -378,8 +379,6 @@ export function subscribeMessageWindow(sessionId: string, listener: () => void):
         current.delete(listener)
         if (current.size === 0) {
             listeners.delete(sessionId)
-            states.delete(sessionId)
-            clearPendingVisibilityCache(sessionId)
         }
     }
 }
@@ -422,10 +421,11 @@ export async function fetchLatestMessages(api: ApiClient, sessionId: string): Pr
     updateState(sessionId, (prev) => buildState(prev, { isLoading: true, warning: null }))
 
     try {
+        const limit = initial.messages.length > 0 ? PAGE_SIZE : INITIAL_PAGE_SIZE
         // Always request byPosition mode (V8). If the hub is V7 it ignores byPosition and
         // returns the standard seq-based response (no nextBeforeAt field) — we fall back
         // to seq-cursor mode seamlessly.
-        const response = await api.getMessages(sessionId, { byPosition: true, limit: PAGE_SIZE })
+        const response = await api.getMessages(sessionId, { byPosition: true, limit })
         // Derive composite cursor pair from server response. Both values come from
         // the same row on the server; we keep them paired so the next older fetch
         // doesn't mix `beforeAt` from the server with a recomputed minimum `seq`.

--- a/web/src/lib/outline-store.test.ts
+++ b/web/src/lib/outline-store.test.ts
@@ -151,6 +151,33 @@ describe('outline-store', () => {
         ])
     })
 
+    it('does not include queued user messages in outline state', async () => {
+        const api = makeApi([
+            {
+                messages: [{
+                    ...makeUserMessage('queued', 'Queued item', 100),
+                    invokedAt: null,
+                    status: 'queued',
+                }],
+                page: {
+                    nextBeforeAt: null,
+                    nextBeforeSeq: null,
+                    hasMore: false,
+                },
+            },
+        ])
+
+        await hydrateConversationOutline(api, SESSION_ID)
+        ingestConversationOutlineMessage(SESSION_ID, {
+            ...makeUserMessage('queued-live', 'Queued live item', 120),
+            invokedAt: null,
+            status: 'queued',
+        })
+
+        const state = getConversationOutlineState(SESSION_ID)
+        expect(state.items).toEqual([])
+    })
+
     it('tracks locating state and errors', () => {
         setConversationOutlineLocating(SESSION_ID, 'user:target')
         expect(getConversationOutlineState(SESSION_ID)).toMatchObject({

--- a/web/src/lib/outline-store.test.ts
+++ b/web/src/lib/outline-store.test.ts
@@ -178,6 +178,52 @@ describe('outline-store', () => {
         expect(state.items).toEqual([])
     })
 
+    it('ignores stale hydrate failures after reset and retry', async () => {
+        let rejectFirstPage: ((reason?: unknown) => void) | null = null
+
+        const api = {
+            getMessages: vi
+                .fn()
+                .mockImplementationOnce(async () => await new Promise<never>((_resolve, reject) => {
+                    rejectFirstPage = reject
+                }))
+                .mockResolvedValueOnce({
+                    messages: [makeUserMessage('fresh', 'Fresh item', 300)],
+                    page: {
+                        limit: 50,
+                        nextBeforeAt: null,
+                        nextBeforeSeq: null,
+                        hasMore: false,
+                    },
+                }),
+        } as unknown as ApiClient
+
+        const staleHydrate = hydrateConversationOutline(api, SESSION_ID)
+        resetConversationOutline(SESSION_ID)
+        await hydrateConversationOutline(api, SESSION_ID)
+
+        expect(getConversationOutlineState(SESSION_ID)).toMatchObject({
+            status: 'ready',
+            complete: true,
+            error: null,
+        })
+
+        const rejectStaleHydrate = rejectFirstPage
+        if (!rejectStaleHydrate) {
+            throw new Error('Expected stale hydrate request to be pending')
+        }
+        ;(rejectStaleHydrate as (reason?: unknown) => void)(new Error('stale failure'))
+        await staleHydrate
+
+        const state = getConversationOutlineState(SESSION_ID)
+        expect(state).toMatchObject({
+            status: 'ready',
+            complete: true,
+            error: null,
+        })
+        expect(state.items.map((item) => item.targetMessageId)).toEqual(['user:fresh'])
+    })
+
     it('tracks locating state and errors', () => {
         setConversationOutlineLocating(SESSION_ID, 'user:target')
         expect(getConversationOutlineState(SESSION_ID)).toMatchObject({

--- a/web/src/lib/outline-store.test.ts
+++ b/web/src/lib/outline-store.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '@/api/client'
+import type { DecryptedMessage } from '@/types/api'
+import {
+    getConversationOutlineState,
+    hydrateConversationOutline,
+    ingestConversationOutlineMessage,
+    resetConversationOutline,
+    seedConversationOutline,
+    setConversationOutlineLocating,
+} from '@/lib/outline-store'
+
+function makeUserMessage(id: string, text: string, createdAt: number): DecryptedMessage {
+    return {
+        id,
+        seq: createdAt,
+        localId: null,
+        createdAt,
+        invokedAt: createdAt,
+        content: {
+            role: 'user',
+            content: {
+                type: 'text',
+                text,
+            },
+        },
+    }
+}
+
+function makeApi(pages: Array<{
+    messages: DecryptedMessage[]
+    page: {
+        nextBeforeAt: number | null
+        nextBeforeSeq: number | null
+        hasMore: boolean
+        limit?: number
+    }
+}>): ApiClient {
+    return {
+        getMessages: vi.fn(async (_sessionId: string, options: { limit?: number }) => {
+            const next = pages.shift()
+            if (!next) {
+                throw new Error('No page configured')
+            }
+            return {
+                messages: next.messages,
+                page: {
+                    limit: options.limit ?? 50,
+                    nextBeforeAt: next.page.nextBeforeAt,
+                    nextBeforeSeq: next.page.nextBeforeSeq,
+                    hasMore: next.page.hasMore,
+                },
+            }
+        }),
+    } as unknown as ApiClient
+}
+
+describe('outline-store', () => {
+    const SESSION_ID = 'outline-store-session'
+
+    afterEach(() => {
+        resetConversationOutline(SESSION_ID)
+    })
+
+    it('hydrates across pages and keeps chronological order', async () => {
+        const api = makeApi([
+            {
+                messages: [
+                    makeUserMessage('newer', 'Newer item', 200),
+                ],
+                page: {
+                    nextBeforeAt: 200,
+                    nextBeforeSeq: 200,
+                    hasMore: true,
+                },
+            },
+            {
+                messages: [
+                    makeUserMessage('older', 'Older item', 100),
+                ],
+                page: {
+                    nextBeforeAt: null,
+                    nextBeforeSeq: null,
+                    hasMore: false,
+                },
+            },
+        ])
+
+        await hydrateConversationOutline(api, SESSION_ID)
+
+        const state = getConversationOutlineState(SESSION_ID)
+        expect(state.complete).toBe(true)
+        expect(state.items.map((item) => item.targetMessageId)).toEqual([
+            'user:older',
+            'user:newer',
+        ])
+    })
+
+    it('deduplicates seeded and hydrated items', async () => {
+        seedConversationOutline(SESSION_ID, [{
+            id: 'outline:user:newer',
+            targetMessageId: 'user:newer',
+            kind: 'user',
+            label: 'Newer item',
+            createdAt: 200,
+        }])
+
+        const api = makeApi([
+            {
+                messages: [
+                    makeUserMessage('newer', 'Newer item', 200),
+                    makeUserMessage('older', 'Older item', 100),
+                ],
+                page: {
+                    nextBeforeAt: null,
+                    nextBeforeSeq: null,
+                    hasMore: false,
+                },
+            },
+        ])
+
+        await hydrateConversationOutline(api, SESSION_ID)
+
+        const state = getConversationOutlineState(SESSION_ID)
+        expect(state.items.map((item) => item.targetMessageId)).toEqual([
+            'user:older',
+            'user:newer',
+        ])
+    })
+
+    it('ingests new user messages after completion', async () => {
+        const api = makeApi([
+            {
+                messages: [makeUserMessage('baseline', 'Baseline', 100)],
+                page: {
+                    nextBeforeAt: null,
+                    nextBeforeSeq: null,
+                    hasMore: false,
+                },
+            },
+        ])
+
+        await hydrateConversationOutline(api, SESSION_ID)
+        ingestConversationOutlineMessage(SESSION_ID, makeUserMessage('new', 'New item', 300))
+
+        const state = getConversationOutlineState(SESSION_ID)
+        expect(state.complete).toBe(true)
+        expect(state.items.map((item) => item.targetMessageId)).toEqual([
+            'user:baseline',
+            'user:new',
+        ])
+    })
+
+    it('tracks locating state and errors', () => {
+        setConversationOutlineLocating(SESSION_ID, 'user:target')
+        expect(getConversationOutlineState(SESSION_ID)).toMatchObject({
+            isLocating: true,
+            locatingTargetMessageId: 'user:target',
+            locateError: null,
+        })
+
+        setConversationOutlineLocating(SESSION_ID, null, 'Unable to locate')
+        expect(getConversationOutlineState(SESSION_ID)).toMatchObject({
+            isLocating: false,
+            locatingTargetMessageId: null,
+            locateError: 'Unable to locate',
+        })
+    })
+})

--- a/web/src/lib/outline-store.ts
+++ b/web/src/lib/outline-store.ts
@@ -291,12 +291,17 @@ export async function hydrateConversationOutline(
             }
         } catch (error) {
             const message = error instanceof Error ? error.message : 'Failed to hydrate outline'
-            updateState(sessionId, (prev) => ({
-                ...prev,
-                status: 'error',
-                error: message,
-                hydratePromise: null,
-            }))
+            updateState(sessionId, (prev) => {
+                if (prev.generation !== generation) {
+                    return prev
+                }
+                return {
+                    ...prev,
+                    status: 'error',
+                    error: message,
+                    hydratePromise: null,
+                }
+            })
         }
     })()
 

--- a/web/src/lib/outline-store.ts
+++ b/web/src/lib/outline-store.ts
@@ -5,6 +5,7 @@ import {
     decryptedMessageToOutlineItem,
     mergeConversationOutlineItems,
 } from '@/chat/outline'
+import { isQueuedForInvocation } from '@/lib/messages'
 
 export type ConversationOutlineStatus = 'idle' | 'loading' | 'ready' | 'error'
 
@@ -92,6 +93,9 @@ function updateState(
 function extractOutlineItems(messages: readonly DecryptedMessage[]): ConversationOutlineItem[] {
     const items: ConversationOutlineItem[] = []
     for (const message of messages) {
+        if (isQueuedForInvocation(message)) {
+            continue
+        }
         const item = decryptedMessageToOutlineItem(message)
         if (item) {
             items.push(item)
@@ -178,6 +182,9 @@ export function resetConversationOutline(sessionId: string): void {
 }
 
 export function ingestConversationOutlineMessage(sessionId: string, message: DecryptedMessage): void {
+    if (isQueuedForInvocation(message)) {
+        return
+    }
     const item = decryptedMessageToOutlineItem(message)
     if (!item) {
         return

--- a/web/src/lib/outline-store.ts
+++ b/web/src/lib/outline-store.ts
@@ -1,0 +1,302 @@
+import type { ApiClient } from '@/api/client'
+import type { DecryptedMessage } from '@/types/api'
+import type { ConversationOutlineItem } from '@/chat/outline'
+import {
+    decryptedMessageToOutlineItem,
+    mergeConversationOutlineItems,
+} from '@/chat/outline'
+
+export type ConversationOutlineStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+export type ConversationOutlineState = {
+    sessionId: string
+    items: ConversationOutlineItem[]
+    status: ConversationOutlineStatus
+    complete: boolean
+    hasMore: boolean
+    cursorBeforeAt: number | null
+    cursorBeforeSeq: number | null
+    error: string | null
+    locateError: string | null
+    isLocating: boolean
+    locatingTargetMessageId: string | null
+}
+
+type InternalConversationOutlineState = ConversationOutlineState & {
+    loadedTargetMessageIds: Set<string>
+    hydratePromise: Promise<void> | null
+    generation: number
+}
+
+const PAGE_SIZE = 50
+const states = new Map<string, InternalConversationOutlineState>()
+const listeners = new Map<string, Set<() => void>>()
+
+function createState(sessionId: string): InternalConversationOutlineState {
+    return {
+        sessionId,
+        items: [],
+        status: 'idle',
+        complete: false,
+        hasMore: true,
+        cursorBeforeAt: null,
+        cursorBeforeSeq: null,
+        error: null,
+        locateError: null,
+        isLocating: false,
+        locatingTargetMessageId: null,
+        loadedTargetMessageIds: new Set<string>(),
+        hydratePromise: null,
+        generation: 0,
+    }
+}
+
+function getState(sessionId: string): InternalConversationOutlineState {
+    const existing = states.get(sessionId)
+    if (existing) {
+        return existing
+    }
+    const created = createState(sessionId)
+    states.set(sessionId, created)
+    return created
+}
+
+function notify(sessionId: string): void {
+    const subs = listeners.get(sessionId)
+    if (!subs) {
+        return
+    }
+    for (const listener of subs) {
+        listener()
+    }
+}
+
+function setState(sessionId: string, next: InternalConversationOutlineState): void {
+    states.set(sessionId, next)
+    notify(sessionId)
+}
+
+function updateState(
+    sessionId: string,
+    updater: (prev: InternalConversationOutlineState) => InternalConversationOutlineState
+): InternalConversationOutlineState {
+    const prev = getState(sessionId)
+    const next = updater(prev)
+    if (next !== prev) {
+        setState(sessionId, next)
+        return next
+    }
+    return prev
+}
+
+function extractOutlineItems(messages: readonly DecryptedMessage[]): ConversationOutlineItem[] {
+    const items: ConversationOutlineItem[] = []
+    for (const message of messages) {
+        const item = decryptedMessageToOutlineItem(message)
+        if (item) {
+            items.push(item)
+        }
+    }
+    return items
+}
+
+function mergeItems(
+    prev: InternalConversationOutlineState,
+    incoming: readonly ConversationOutlineItem[]
+): { items: ConversationOutlineItem[]; loadedTargetMessageIds: Set<string> } {
+    if (incoming.length === 0) {
+        return {
+            items: prev.items,
+            loadedTargetMessageIds: prev.loadedTargetMessageIds,
+        }
+    }
+
+    const filtered = incoming.filter((item) => !prev.loadedTargetMessageIds.has(item.targetMessageId))
+    if (filtered.length === 0) {
+        return {
+            items: prev.items,
+            loadedTargetMessageIds: prev.loadedTargetMessageIds,
+        }
+    }
+
+    const nextIds = new Set(prev.loadedTargetMessageIds)
+    for (const item of filtered) {
+        nextIds.add(item.targetMessageId)
+    }
+
+    return {
+        items: mergeConversationOutlineItems(prev.items, filtered),
+        loadedTargetMessageIds: nextIds,
+    }
+}
+
+export function getConversationOutlineState(sessionId: string): ConversationOutlineState {
+    return getState(sessionId)
+}
+
+export function subscribeConversationOutline(sessionId: string, listener: () => void): () => void {
+    const subs = listeners.get(sessionId) ?? new Set()
+    subs.add(listener)
+    listeners.set(sessionId, subs)
+    return () => {
+        const current = listeners.get(sessionId)
+        if (!current) {
+            return
+        }
+        current.delete(listener)
+        if (current.size === 0) {
+            listeners.delete(sessionId)
+        }
+    }
+}
+
+export function seedConversationOutline(sessionId: string, items: readonly ConversationOutlineItem[]): void {
+    if (items.length === 0) {
+        return
+    }
+
+    updateState(sessionId, (prev) => {
+        const merged = mergeItems(prev, items)
+        if (merged.items === prev.items) {
+            return prev
+        }
+        return {
+            ...prev,
+            items: merged.items,
+            loadedTargetMessageIds: merged.loadedTargetMessageIds,
+            status: prev.status === 'idle' ? 'ready' : prev.status,
+        }
+    })
+}
+
+export function resetConversationOutline(sessionId: string): void {
+    const prev = getState(sessionId)
+    setState(sessionId, {
+        ...createState(sessionId),
+        generation: prev.generation + 1,
+    })
+}
+
+export function ingestConversationOutlineMessage(sessionId: string, message: DecryptedMessage): void {
+    const item = decryptedMessageToOutlineItem(message)
+    if (!item) {
+        return
+    }
+
+    updateState(sessionId, (prev) => {
+        const merged = mergeItems(prev, [item])
+        if (merged.items === prev.items) {
+            return prev
+        }
+        return {
+            ...prev,
+            items: merged.items,
+            loadedTargetMessageIds: merged.loadedTargetMessageIds,
+            status: prev.status === 'idle' ? 'ready' : prev.status,
+            error: prev.status === 'error' ? null : prev.error,
+        }
+    })
+}
+
+export function setConversationOutlineLocating(
+    sessionId: string,
+    locatingTargetMessageId: string | null,
+    locateError: string | null = null
+): void {
+    updateState(sessionId, (prev) => ({
+        ...prev,
+        isLocating: locatingTargetMessageId !== null,
+        locatingTargetMessageId,
+        locateError,
+    }))
+}
+
+export async function hydrateConversationOutline(
+    api: ApiClient,
+    sessionId: string
+): Promise<void> {
+    const initial = getState(sessionId)
+    if (initial.complete) {
+        return
+    }
+    if (initial.hydratePromise) {
+        return await initial.hydratePromise
+    }
+
+    const generation = initial.generation
+
+    const run = (async () => {
+        updateState(sessionId, (prev) => ({
+            ...prev,
+            status: 'loading',
+            error: null,
+        }))
+
+        try {
+            for (;;) {
+                const current = getState(sessionId)
+                if (current.generation !== generation) {
+                    return
+                }
+                if (current.complete || !current.hasMore) {
+                    updateState(sessionId, (prev) => ({
+                        ...prev,
+                        status: 'ready',
+                        complete: true,
+                        hasMore: false,
+                        hydratePromise: null,
+                    }))
+                    return
+                }
+
+                const response = await api.getMessages(sessionId, {
+                    byPosition: true,
+                    limit: PAGE_SIZE,
+                    beforeAt: current.cursorBeforeAt,
+                    beforeSeq: current.cursorBeforeSeq,
+                })
+
+                const pageItems = extractOutlineItems(response.messages)
+                const hasMore = response.page.hasMore
+                const nextBeforeAt = response.page.nextBeforeAt ?? null
+                const nextBeforeSeq = response.page.nextBeforeSeq ?? null
+
+                updateState(sessionId, (prev) => {
+                    if (prev.generation !== generation) {
+                        return prev
+                    }
+                    const merged = mergeItems(prev, pageItems)
+                    return {
+                        ...prev,
+                        items: merged.items,
+                        loadedTargetMessageIds: merged.loadedTargetMessageIds,
+                        status: 'ready',
+                        complete: !hasMore,
+                        hasMore,
+                        cursorBeforeAt: hasMore ? nextBeforeAt : prev.cursorBeforeAt,
+                        cursorBeforeSeq: hasMore ? nextBeforeSeq : prev.cursorBeforeSeq,
+                    }
+                })
+
+                if (!hasMore) {
+                    return
+                }
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to hydrate outline'
+            updateState(sessionId, (prev) => ({
+                ...prev,
+                status: 'error',
+                error: message,
+                hydratePromise: null,
+            }))
+        }
+    })()
+
+    updateState(sessionId, (prev) => ({
+        ...prev,
+        hydratePromise: run,
+    }))
+
+    await run
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -67,7 +67,7 @@ export type Machine = {
         platform: string
         happyCliVersion: string
         displayName?: string
-        workspaceRoot?: string
+        workspaceRoots?: string[]
     } | null
     runnerState?: RunnerState | null
 }


### PR DESCRIPTION
## Summary
我修复了 Web 会话历史加载体验回退的问题，并补上了独立的大纲全量补全链路。

- 我保留了会话消息窗口缓存，避免重复进入会话时每次重新拉取
- 我修复了打开会话后上滑历史消息时容易“卡顶”的问题
- 我新增了独立的 outline store，在不放大 thread 渲染负担的前提下后台补全全量大纲
- 我补上了点击旧大纲项时的自动补拉与定位逻辑
- 我补充了相关单测与设计/计划文档

## Details
这次改动只落在 `web/`：

- 新增 `useConversationOutline` 和 `outline-store`
- 将 outline 从“依赖当前 thread 已加载消息”改为“独立分页补全”
- 在 SSE 消息新增/失效时同步维护 outline cache
- 给 outline 面板增加了补全中、完整、重试、定位中、定位失败等状态
- 保持现有 thread window 策略，不改 hub API

## Test Plan
我本地执行并确认通过：

- `cd web && bun run test`
- `cd web && bun run typecheck`

## Notes
- 这次没有改 hub 协议
- outline 缓存目前是页面生命周期内存缓存，还没有做持久化