### PR TITLE
Fix Codex Spark sub-agent reasoning summary compatibility

### DIFF
--- a/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
@@ -214,7 +214,7 @@ describe('AcpSdkBackend', () => {
     });
 
     it('emits turn_complete after trailing tool updates from the same turn', async () => {
-        backendStatics.UPDATE_QUIET_PERIOD_MS = 8;
+        backendStatics.UPDATE_QUIET_PERIOD_MS = 25;
         backendStatics.UPDATE_DRAIN_TIMEOUT_MS = 200;
         backendStatics.PRE_PROMPT_UPDATE_QUIET_PERIOD_MS = 1;
         backendStatics.PRE_PROMPT_UPDATE_DRAIN_TIMEOUT_MS = 50;
@@ -254,7 +254,7 @@ describe('AcpSdkBackend', () => {
                             status: 'in_progress'
                         }
                     });
-                }, 3);
+                }, 1);
 
                 setTimeout(() => {
                     backendInternal.handleSessionUpdate({
@@ -266,7 +266,7 @@ describe('AcpSdkBackend', () => {
                             rawOutput: { ok: true }
                         }
                     });
-                }, 6);
+                }, 2);
 
                 return { stopReason: 'end_turn' };
             },

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import type { EnhancedMode } from '../loop';
 import {
     buildThreadStartParams,
     buildTurnStartParams,
-    codexCollaborationSpawnAgentInstructions
+    codexCollaborationSpawnAgentInstructions,
+    supportsReasoningSummary
 } from './appServerConfig';
 import { codexSystemPrompt } from './systemPrompt';
 
@@ -123,16 +125,98 @@ describe('appServerConfig', () => {
         expect(params.approvalPolicy).toBe('never');
         expect(params.sandboxPolicy).toEqual({ type: 'readOnly' });
         expect(params.effort).toBe('high');
-        expect(params.summary).toBe('detailed');
+        expect(params.summary).toBeUndefined();
         expect(params.collaborationMode).toEqual({
             mode: 'default',
             settings: {
                 model: 'o3',
-                reasoning_effort: 'high',
                 developer_instructions: withCollaborationInstructions(codexSystemPrompt)
             }
         });
         expect(params.model).toBeUndefined();
+    });
+
+    it('omits reasoning summary for models that do not support it', () => {
+        const params = buildTurnStartParams({
+            threadId: 'thread-1',
+            message: 'hello',
+            cwd: '/workspace/project',
+            mode: {
+                permissionMode: 'default',
+                model: 'gpt-5.3-codex-spark',
+                modelReasoningEffort: 'high',
+                collaborationMode: 'default'
+            }
+        });
+
+        expect(params.effort).toBe('high');
+        expect(params.summary).toBeUndefined();
+        expect(params.collaborationMode).toEqual({
+            mode: 'default',
+            settings: {
+                model: 'gpt-5.3-codex-spark',
+                developer_instructions: withCollaborationInstructions(codexSystemPrompt)
+            }
+        });
+    });
+
+    it('detects namespaced models that do not support reasoning summary', () => {
+        const params = buildTurnStartParams({
+            threadId: 'thread-1',
+            message: 'hello',
+            cwd: '/workspace/project',
+            mode: {
+                permissionMode: 'default',
+                model: 'codex/gpt-5.3-codex-spark',
+                modelReasoningEffort: 'high',
+                collaborationMode: 'default'
+            }
+        });
+
+        expect(params.effort).toBe('high');
+        expect(params.summary).toBeUndefined();
+    });
+
+    it('normalizes reasoning summary model support checks', () => {
+        expect(supportsReasoningSummary(' Codex/GPT-5.3-CODEX-SPARK ')).toBe(false);
+        expect(supportsReasoningSummary('gpt-5.5')).toBe(true);
+        expect(supportsReasoningSummary(undefined)).toBe(true);
+    });
+
+    it('omits reasoning summary for non-collaboration turns on unsupported models', () => {
+        const params = buildTurnStartParams({
+            threadId: 'thread-1',
+            message: 'hello',
+            cwd: '/workspace/project',
+            mode: {
+                permissionMode: 'default',
+                model: 'gpt-5.3-codex-spark',
+                modelReasoningEffort: 'high'
+            } as EnhancedMode
+        });
+
+        expect(params.effort).toBe('high');
+        expect(params.summary).toBeUndefined();
+        expect(params.model).toBe('gpt-5.3-codex-spark');
+        expect(params.collaborationMode).toBeUndefined();
+    });
+
+    it('keeps reasoning summary for non-collaboration turns on supported models', () => {
+        const params = buildTurnStartParams({
+            threadId: 'thread-1',
+            message: 'hello',
+            cwd: '/workspace/project',
+            mode: {
+                permissionMode: 'default',
+                model: 'o3',
+                modelReasoningEffort: 'high'
+            } as EnhancedMode
+        });
+
+        expect(params.effort).toBe('high');
+        expect(params.summary).toBe('detailed');
+        expect(params.model).toBe('o3');
+        expect(params.collaborationMode).toBeUndefined();
     });
 
     it('puts collaboration mode in turn params with model settings', () => {
@@ -152,7 +236,6 @@ describe('appServerConfig', () => {
             mode: 'plan',
             settings: {
                 model: 'o3',
-                reasoning_effort: 'high',
                 developer_instructions: withCollaborationInstructions(codexSystemPrompt)
             }
         });
@@ -189,6 +272,7 @@ describe('appServerConfig', () => {
         expect(instructions).toContain('If you call spawn_agent with fork_context: true');
         expect(instructions).toContain('do not set agent_type, model, or reasoning_effort');
         expect(instructions).toContain('omit fork_context or set fork_context: false');
+        expect(instructions).toContain('Do not rely on parent turn reasoning settings for spawned agents');
     });
 
     it('rejects collaboration mode payloads without a resolved model', () => {

--- a/cli/src/codex/utils/appServerConfig.ts
+++ b/cli/src/codex/utils/appServerConfig.ts
@@ -14,8 +14,13 @@ import { resolveCodexPermissionModeConfig } from './permissionModeConfig';
 export const codexCollaborationSpawnAgentInstructions = [
     'Codex sub-agent spawning rules:',
     '- If you call spawn_agent with fork_context: true, do not set agent_type, model, or reasoning_effort; full-history forked agents inherit these values from the parent.',
-    '- If you need a specific agent_type, model, or reasoning_effort, omit fork_context or set fork_context: false, and include only the necessary context in the message.'
+    '- If you need a specific agent_type, model, or reasoning_effort, omit fork_context or set fork_context: false, and include only the necessary context in the message.',
+    '- Do not rely on parent turn reasoning settings for spawned agents; only set reasoning_effort on spawn_agent when the chosen child model supports it.'
 ].join('\n');
+
+const MODELS_WITHOUT_REASONING_SUMMARY = new Set([
+    'gpt-5.3-codex-spark'
+]);
 
 function resolveApprovalPolicy(mode: EnhancedMode): ApprovalPolicy {
     return resolveCodexPermissionModeConfig(mode.permissionMode).approvalPolicy;
@@ -40,6 +45,13 @@ function resolveSandboxPolicyOverride(value: CodexCliOverrides['sandbox'] | unde
         default:
             return undefined;
     }
+}
+
+export function supportsReasoningSummary(model: string | undefined): boolean {
+    const normalized = model?.trim().toLowerCase();
+    if (!normalized) return true;
+    const modelName = normalized.split('/').pop() ?? normalized;
+    return !MODELS_WITHOUT_REASONING_SUMMARY.has(modelName);
 }
 
 function buildMcpServerConfig(mcpServers: McpServersConfig): Record<string, unknown> {
@@ -151,13 +163,16 @@ export function buildTurnStartParams(args: {
         params.sandboxPolicy = sandboxPolicy;
     }
 
-    if (args.mode?.modelReasoningEffort) {
-        params.effort = args.mode.modelReasoningEffort;
-        params.summary = 'detailed';
-    }
-
     const collaborationMode = args.mode?.collaborationMode;
     const model = args.overrides?.model ?? args.mode?.model;
+
+    if (args.mode?.modelReasoningEffort) {
+        params.effort = args.mode.modelReasoningEffort;
+        if (!collaborationMode && supportsReasoningSummary(model)) {
+            params.summary = 'detailed';
+        }
+    }
+
     if (collaborationMode) {
         if (!model) {
             throw new Error(`Collaboration mode '${collaborationMode}' requires a resolved model`);
@@ -167,7 +182,6 @@ export function buildTurnStartParams(args: {
             mode: collaborationMode,
             settings: {
                 model,
-                ...(args.mode?.modelReasoningEffort ? { reasoning_effort: args.mode.modelReasoningEffort } : {}),
                 developer_instructions: appendCollaborationInstructions(developerInstructions)
             }
         };


### PR DESCRIPTION
### Summary

This PR fixes Codex sub-agent startup failures when using `gpt-5.3-codex-spark`.

`gpt-5.3-codex-spark` does not support the `reasoning.summary` parameter. Previously, HAPI could implicitly attach detailed reasoning summary settings when a Codex session had `modelReasoningEffort` configured. That could make Spark-based sub-agent launches fail with:

```text
Unsupported parameter: 'reasoning.summary' is not supported with the 'gpt-5.3-codex-spark' model.
```

This change prevents unsupported reasoning summary settings from being sent to Spark, and avoids implicitly forwarding the parent turn reasoning effort into collaboration-mode sub-agent settings.

### Why this matters

`gpt-5.3-codex-spark` is useful as a sub-agent model because it uses a separate quota pool for Pro subscribers. That makes it a good fit for workflows that rely on many sub-agents, especially review-oriented tasks such as:

- code review sub-agents
- architecture and risk review sub-agents
- lightweight verification sub-agents
- parallel repository inspection tasks

With this fix, users can keep the main agent on a higher-capability model while using Spark for review or inspection sub-agents without consuming the same quota pool.

### Changes

- Add explicit detection for models that do not support reasoning summaries.
- Recognize both plain and namespaced Spark model names:
  - `gpt-5.3-codex-spark`
  - `codex/gpt-5.3-codex-spark`
- Omit `summary: "detailed"` for unsupported models.
- Do not attach reasoning summaries in collaboration-mode turns.
- Do not pass inherited parent `reasoning_effort` into `collaborationMode.settings`.
- Add collaboration instructions clarifying that spawned agents should not rely on inherited parent reasoning settings.
- Stabilize the ACP trailing tool update timing test that previously failed intermittently in CI.

### Compatibility

This is intentionally narrow:

- Non-collaboration turns on supported models still receive `summary: "detailed"` when `modelReasoningEffort` is set.
- Spark no longer receives unsupported reasoning summary settings.
- Collaboration-mode sub-agent launches no longer inherit parent reasoning settings implicitly, avoiding cross-model parameter incompatibilities.

### Verification

Ran locally:

```bash
git diff --check
cd cli && bun run test -- appServerConfig.test.ts src/agent/backends/acp/AcpSdkBackend.test.ts
bun run typecheck:cli
env -u HAPI_CLI_EXECUTABLE bun run test:cli
```

Also reviewed locally with a `gpt-5.3-codex-spark` sub-agent before opening this PR.
