### PR TITLE
Fix Codex subagent final result preservation

### DIFF
--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -21,6 +21,11 @@ const harness = vi.hoisted(() => ({
     emitChildThreadEvents: false,
     emitChildUsageEvents: false,
     emitChildReasoningBurst: false,
+    emitChildDoneStatusWithoutMessage: false,
+    emitChildTaskCompleteBeforeMessage: false,
+    suppressChildTaskCompleteEvent: false,
+    emitSecondChildMessage: false,
+    emitLateChildCommandAfterParentTool: false,
     emitParentUsageEvents: false,
     emitChildNestedAgentTool: false,
     emitParentTitleChange: false,
@@ -228,6 +233,19 @@ vi.mock('./codexAppServerClient', () => {
                 const childThreadId = 'child-thread';
                 const childTurnId = 'child-turn';
                 const childMessage = 'child output should stay hidden';
+                const secondChildMessage = 'final child output should win';
+
+                const emitChildDone = () => {
+                    const childDone = {
+                        msg: {
+                            type: 'task_complete',
+                            thread_id: childThreadId,
+                            turn_id: childTurnId
+                        }
+                    };
+                    harness.notifications.push({ method: 'codex/event/task_complete', params: childDone });
+                    this.notificationHandler?.('codex/event/task_complete', childDone);
+                };
 
                 if (harness.emitChildReasoningBurst) {
                     for (let i = 0; i < 20; i += 1) {
@@ -245,6 +263,10 @@ vi.mock('./codexAppServerClient', () => {
                     }
                 }
 
+                if (harness.emitChildDoneStatusWithoutMessage && harness.emitChildTaskCompleteBeforeMessage) {
+                    emitChildDone();
+                }
+
                 const childMessageCompleted = {
                     item: {
                         id: 'child-msg-1',
@@ -256,6 +278,28 @@ vi.mock('./codexAppServerClient', () => {
                 };
                 harness.notifications.push({ method: 'item/completed', params: childMessageCompleted });
                 this.notificationHandler?.('item/completed', childMessageCompleted);
+
+                if (harness.emitSecondChildMessage) {
+                    const secondChildMessageCompleted = {
+                        item: {
+                            id: 'child-msg-2',
+                            type: 'agentMessage',
+                            content: [{ type: 'text', text: secondChildMessage }]
+                        },
+                        threadId: childThreadId,
+                        turnId: childTurnId
+                    };
+                    harness.notifications.push({ method: 'item/completed', params: secondChildMessageCompleted });
+                    this.notificationHandler?.('item/completed', secondChildMessageCompleted);
+                }
+
+                if (
+                    harness.emitChildDoneStatusWithoutMessage
+                    && !harness.emitChildTaskCompleteBeforeMessage
+                    && !harness.suppressChildTaskCompleteEvent
+                ) {
+                    emitChildDone();
+                }
 
                 if (harness.emitChildUsageEvents) {
                     const childUsage = {
@@ -413,8 +457,12 @@ vi.mock('./codexAppServerClient', () => {
                         receiverThreadIds: [childThreadId],
                         agentsStates: {
                             [childThreadId]: {
-                                status: 'completed',
-                                message: childMessage
+                                status: harness.emitChildDoneStatusWithoutMessage ? 'done' : 'completed',
+                                message: harness.emitChildDoneStatusWithoutMessage
+                                    ? null
+                                    : harness.emitSecondChildMessage
+                                        ? secondChildMessage
+                                        : childMessage
                             }
                         }
                     },
@@ -488,6 +536,20 @@ vi.mock('./codexAppServerClient', () => {
                     };
                     harness.notifications.push({ method: 'item/completed', params: resumeCompleted });
                     this.notificationHandler?.('item/completed', resumeCompleted);
+                }
+
+                if (harness.emitLateChildCommandAfterParentTool) {
+                    const lateChildCommandStart = {
+                        item: {
+                            id: 'late-child-cmd',
+                            type: 'commandExecution',
+                            command: 'echo late'
+                        },
+                        threadId: childThreadId,
+                        turnId: childTurnId
+                    };
+                    harness.notifications.push({ method: 'item/started', params: lateChildCommandStart });
+                    this.notificationHandler?.('item/started', lateChildCommandStart);
                 }
             }
 
@@ -658,6 +720,11 @@ describe('codexRemoteLauncher', () => {
         harness.emitChildThreadEvents = false;
         harness.emitChildUsageEvents = false;
         harness.emitChildReasoningBurst = false;
+        harness.emitChildDoneStatusWithoutMessage = false;
+        harness.emitChildTaskCompleteBeforeMessage = false;
+        harness.suppressChildTaskCompleteEvent = false;
+        harness.emitSecondChildMessage = false;
+        harness.emitLateChildCommandAfterParentTool = false;
         harness.emitParentUsageEvents = false;
         harness.emitChildNestedAgentTool = false;
         harness.emitParentTitleChange = false;
@@ -954,6 +1021,86 @@ describe('codexRemoteLauncher', () => {
         }));
     });
 
+    it('keeps the child final message as result when wait_agent only reports done', async () => {
+        harness.emitChildThreadEvents = true;
+        harness.emitChildDoneStatusWithoutMessage = true;
+        const { session, codexMessages } = createSessionStub();
+
+        await codexRemoteLauncher(session as never);
+
+        const completedUpdates = codexMessages.filter((message) => {
+            const record = message as Record<string, unknown>;
+            return record.type === 'agent-run-update'
+                && record.agentId === 'child-thread'
+                && record.status === 'completed';
+        }) as Array<Record<string, unknown>>;
+
+        expect(completedUpdates).toContainEqual(expect.objectContaining({
+            result: 'child output should stay hidden',
+            activity: 'Completed: child output should stay hidden'
+        }));
+        expect(completedUpdates).not.toContainEqual(expect.objectContaining({
+            result: expect.objectContaining({
+                status: 'done'
+            })
+        }));
+    });
+
+    it('fills wait_agent done without message from the latest child message', async () => {
+        harness.emitChildThreadEvents = true;
+        harness.emitChildDoneStatusWithoutMessage = true;
+        harness.suppressChildTaskCompleteEvent = true;
+        harness.emitSecondChildMessage = true;
+        const { session, codexMessages } = createSessionStub();
+
+        await codexRemoteLauncher(session as never);
+
+        const completedUpdates = codexMessages.filter((message) => {
+            const record = message as Record<string, unknown>;
+            return record.type === 'agent-run-update'
+                && record.agentId === 'child-thread'
+                && record.status === 'completed';
+        }) as Array<Record<string, unknown>>;
+        const lastCompleted = completedUpdates.at(-1);
+
+        expect(lastCompleted).toEqual(expect.objectContaining({
+            result: 'final child output should win',
+            activity: 'Completed: final child output should win'
+        }));
+    });
+
+    it('does not regress a completed child agent to running when message arrives late', async () => {
+        harness.emitChildThreadEvents = true;
+        harness.emitChildDoneStatusWithoutMessage = true;
+        harness.emitChildTaskCompleteBeforeMessage = true;
+        const { session, codexMessages } = createSessionStub();
+
+        await codexRemoteLauncher(session as never);
+
+        const terminalIndex = codexMessages.findIndex((message) => {
+            const record = message as Record<string, unknown>;
+            return record.type === 'agent-run-update'
+                && record.agentId === 'child-thread'
+                && record.status === 'completed';
+        });
+        expect(terminalIndex).toBeGreaterThanOrEqual(0);
+
+        const laterUpdates = codexMessages.slice(terminalIndex + 1).filter((message) => {
+            const record = message as Record<string, unknown>;
+            return record.type === 'agent-run-update'
+                && record.agentId === 'child-thread';
+        }) as Array<Record<string, unknown>>;
+
+        expect(laterUpdates).not.toContainEqual(expect.objectContaining({
+            status: 'running'
+        }));
+        expect(laterUpdates).toContainEqual(expect.objectContaining({
+            status: 'completed',
+            result: 'child output should stay hidden',
+            activity: 'Completed: child output should stay hidden'
+        }));
+    });
+
     it('surfaces send_input failures on the target child agent card', async () => {
         harness.emitChildThreadEvents = true;
         harness.emitParentSendInputFailure = true;
@@ -1008,6 +1155,31 @@ describe('codexRemoteLauncher', () => {
                 status: 'completed',
                 targets: ['child-thread']
             })
+        }));
+    });
+
+    it('does not regress a terminal child after resume_agent when a late command starts', async () => {
+        harness.emitChildThreadEvents = true;
+        harness.emitParentResumeSuccess = true;
+        harness.emitLateChildCommandAfterParentTool = true;
+        const { session, codexMessages } = createSessionStub();
+
+        await codexRemoteLauncher(session as never);
+
+        expect(codexMessages).toContainEqual(expect.objectContaining({
+            type: 'agent-run-trace',
+            agentId: 'child-thread',
+            message: expect.objectContaining({
+                type: 'tool-call',
+                callId: 'late-child-cmd'
+            })
+        }));
+        expect(codexMessages).not.toContainEqual(expect.objectContaining({
+            type: 'agent-run-update',
+            agentId: 'child-thread',
+            activity: 'Running command: echo late',
+            activityKind: 'running-command',
+            status: 'running'
         }));
     });
 

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -36,6 +36,8 @@ type ChildAgentRuntime = {
     }>;
     pendingTitleByCallId: Map<string, string>;
     reasoningPreview: string;
+    finalMessage: string | null;
+    terminal: boolean;
     blockedNestedAgent: boolean;
 };
 
@@ -696,7 +698,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             if (
                 isTerminalAgentRunStatus(currentStatus)
                 && !isTerminalAgentRunStatus(nextStatus)
-                && (activityKind === 'wait_agent' || activityKind === 'close_agent')
+                && activityKind !== 'send_input'
+                && activityKind !== 'resume_agent'
             ) {
                 return;
             }
@@ -822,14 +825,58 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 activeToolsByCallId: new Map(),
                 pendingTitleByCallId: new Map(),
                 reasoningPreview: '',
+                finalMessage: null,
+                terminal: false,
                 blockedNestedAgent: false
             };
             childAgentRuntimeById.set(agentId, runtime);
             return runtime;
         };
 
+        const extractAgentStatusMessage = (record: Record<string, unknown>): unknown => {
+            return record.message
+                ?? record.output
+                ?? record.result
+                ?? record.finalMessage
+                ?? record.final_message;
+        };
+
+        const normalizeAgentStateValue = (value: unknown): string | null => {
+            return asString(value)?.trim().toLowerCase().replace(/[\s_-]/g, '') ?? null;
+        };
+
+        const hasOwn = (record: Record<string, unknown>, key: string): boolean => {
+            return Object.prototype.hasOwnProperty.call(record, key);
+        };
+
+        const fillCompletedAgentUpdateFromRuntime = (
+            agentId: string,
+            update: Record<string, unknown>
+        ): Record<string, unknown> => {
+            if (asString(update.status) !== 'completed') return update;
+            if (hasOwn(update, 'result') || hasOwn(update, 'error')) return update;
+
+            const result = childAgentRuntimeById.get(agentId)?.finalMessage;
+            if (!result) return update;
+
+            return {
+                ...update,
+                activity: formatActivity('Completed', result),
+                result
+            };
+        };
+
         const normalizeAgentStatusUpdate = (value: unknown): Record<string, unknown> => {
             if (typeof value === 'string') {
+                const normalized = normalizeAgentStateValue(value);
+                if (normalized === 'completed' || normalized === 'complete' || normalized === 'done') {
+                    return {
+                        status: 'completed',
+                        statusText: 'Completed',
+                        activity: 'Completed',
+                        activityKind: 'completed'
+                    };
+                }
                 const activity = formatActivity('Completed', previewText(value));
                 return {
                     status: 'completed',
@@ -862,6 +909,16 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     result: completed
                 };
             }
+            const done = asString(record.done);
+            if (done) {
+                return {
+                    status: 'completed',
+                    statusText: 'Completed',
+                    activity: formatActivity('Completed', done),
+                    activityKind: 'completed',
+                    result: done
+                };
+            }
             const failed = asString(record.failed ?? record.error);
             if (failed) {
                 return {
@@ -884,7 +941,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             }
 
             const rawStatus = asString(record.status ?? record.state);
-            if (rawStatus === 'notFound' || rawStatus === 'not_found') {
+            const normalizedStatus = normalizeAgentStateValue(record.status ?? record.state);
+            if (normalizedStatus === 'notfound') {
                 const error = record.message ?? record.error ?? value;
                 return {
                     status: 'failed',
@@ -894,18 +952,24 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     error
                 };
             }
-            if (rawStatus === 'completed') {
-                const result = record.message ?? record.output ?? value;
+            if (
+                normalizedStatus === 'completed'
+                || normalizedStatus === 'complete'
+                || normalizedStatus === 'done'
+                || record.completed === true
+                || record.done === true
+            ) {
+                const result = extractAgentStatusMessage(record);
                 return {
                     status: 'completed',
                     statusText: 'Completed',
                     activity: formatActivity('Completed', previewText(result)),
                     activityKind: 'completed',
-                    result
+                    ...(result !== undefined && result !== null ? { result } : {})
                 };
             }
-            if (rawStatus === 'failed' || rawStatus === 'error') {
-                const error = record.message ?? record.error ?? value;
+            if (normalizedStatus === 'failed' || normalizedStatus === 'error') {
+                const error = extractAgentStatusMessage(record) ?? record.error ?? value;
                 return {
                     status: 'failed',
                     statusText: 'Failed',
@@ -914,8 +978,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     error
                 };
             }
-            if (rawStatus === 'canceled' || rawStatus === 'cancelled') {
-                const error = record.message ?? record.error ?? value;
+            if (normalizedStatus === 'canceled' || normalizedStatus === 'cancelled') {
+                const error = extractAgentStatusMessage(record) ?? record.error ?? value;
                 return {
                     status: 'canceled',
                     statusText: 'Canceled',
@@ -928,7 +992,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             return {
                 status: rawStatus ?? 'running',
                 statusText: rawStatus ?? 'Running',
-                activity: formatActivity(rawStatus ?? 'Running', previewText(record.message ?? record.output ?? value)),
+                activity: formatActivity(rawStatus ?? 'Running', previewText(extractAgentStatusMessage(record) ?? value)),
                 activityKind: rawStatus ?? 'running',
                 result: value
             };
@@ -981,9 +1045,18 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 const outputRecord = asRecord(output);
                 const statusMap = asRecord(outputRecord?.status) ?? {};
                 for (const [agentId, statusValue] of Object.entries(statusMap)) {
-                    const update = normalizeAgentStatusUpdate(statusValue);
+                    const update = fillCompletedAgentUpdateFromRuntime(
+                        agentId,
+                        normalizeAgentStatusUpdate(statusValue)
+                    );
                     if (!agentCardByAgentId.has(agentId) && isAgentNotFoundStatusUpdate(update)) {
                         continue;
+                    }
+                    if (asString(update.status) === 'completed') {
+                        const runtime = childAgentRuntimeById.get(agentId);
+                        if (runtime) {
+                            runtime.terminal = true;
+                        }
                     }
                     emitAgentRunUpdate(agentId, update);
                 }
@@ -1044,6 +1117,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 activityKind: string,
                 extra?: Record<string, unknown>
             ): void => {
+                if (runtime.terminal) {
+                    return;
+                }
                 emitAgentRunUpdate(agentId, {
                     status: 'running',
                     statusText: activity,
@@ -1068,6 +1144,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
 
             if (msgType === 'task_started') {
                 runtime.reasoningPreview = '';
+                runtime.finalMessage = null;
+                runtime.terminal = false;
+                agentStatusByAgentId.delete(agentId);
                 updateActivity('Starting task', 'starting');
                 return;
             }
@@ -1098,11 +1177,24 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             if (msgType === 'agent_message') {
                 const message = asString(msg.message);
                 if (message) {
+                    runtime.finalMessage = message;
                     emitAgentRunTraceMessage(agentId, {
                         type: 'message',
                         message,
                         id: randomUUID()
                     });
+                }
+                if (runtime.terminal) {
+                    if (message) {
+                        emitAgentRunUpdate(agentId, {
+                            status: 'completed',
+                            statusText: 'Completed',
+                            activity: formatActivity('Completed', message),
+                            activityKind: 'completed',
+                            result: message
+                        });
+                    }
+                    return;
                 }
                 updateActivity(formatActivity('Writing', message), 'writing');
                 return;
@@ -1122,18 +1214,20 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                         id: randomUUID()
                     });
                     const command = normalizeCommand(inputs.command) ?? 'command';
-                    runtime.activeToolsByCallId.set(callId, {
-                        name: 'CodexBash',
-                        label: command,
-                        activity: formatActivity('Running command', command),
-                        activityKind: 'running-command'
-                    });
-                    emitAgentRunUpdate(agentId, {
-                        status: 'running',
-                        statusText: formatActivity('Running command', command),
-                        activity: formatActivity('Running command', command),
-                        activityKind: 'running-command'
-                    });
+                    if (!runtime.terminal) {
+                        runtime.activeToolsByCallId.set(callId, {
+                            name: 'CodexBash',
+                            label: command,
+                            activity: formatActivity('Running command', command),
+                            activityKind: 'running-command'
+                        });
+                        emitAgentRunUpdate(agentId, {
+                            status: 'running',
+                            statusText: formatActivity('Running command', command),
+                            activity: formatActivity('Running command', command),
+                            activityKind: 'running-command'
+                        });
+                    }
                 }
                 return;
             }
@@ -1355,6 +1449,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 return;
             }
             if (isChildTerminalEvent) {
+                runtime.terminal = true;
                 runtime.reasoningProcessor.reset();
                 runtime.diffProcessor.reset();
                 runtime.activeToolsByCallId.clear();
@@ -1377,11 +1472,13 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                         activityKind: 'canceled'
                     });
                 } else {
+                    const result = runtime.finalMessage;
                     emitAgentRunUpdate(agentId, {
                         status: 'completed',
                         statusText: 'Completed',
-                        activity: 'Completed',
-                        activityKind: 'completed'
+                        activity: formatActivity('Completed', result),
+                        activityKind: 'completed',
+                        ...(result ? { result } : {})
                     });
                 }
             }

--- a/cli/src/codex/utils/appServerEventConverter.test.ts
+++ b/cli/src/codex/utils/appServerEventConverter.test.ts
@@ -279,7 +279,10 @@ describe('AppServerEventConverter', () => {
                 status: 'completed',
                 receiverThreadIds: ['agent-1'],
                 agentsStates: {
-                    'agent-1': { status: 'completed', message: '42' }
+                    'agent-1': { status: 'completed', message: '42' },
+                    'agent-2': { status: 'done', message: null },
+                    'agent-3': { status: 'done', result: { text: 'structured result' } },
+                    'agent-4': { status: 'completed', message: '', output: { value: 42 } }
                 }
             }
         });
@@ -289,7 +292,10 @@ describe('AppServerEventConverter', () => {
             name: 'wait_agent',
             output: {
                 status: {
-                    'agent-1': { completed: '42' }
+                    'agent-1': { completed: '42' },
+                    'agent-2': { status: 'completed', message: null },
+                    'agent-3': { status: 'completed', result: { text: 'structured result' } },
+                    'agent-4': { status: 'completed', message: '', output: { value: 42 } }
                 },
                 timed_out: false
             },

--- a/cli/src/codex/utils/appServerEventConverter.ts
+++ b/cli/src/codex/utils/appServerEventConverter.ts
@@ -295,11 +295,22 @@ function statusObjectFromAgentState(value: unknown): unknown {
     const record = asRecord(value);
     if (!record) return value;
 
-    const message = asString(record.message);
+    const message = asString(record.message)
+        ?? asString(record.output)
+        ?? asString(record.result)
+        ?? asString(record.finalMessage)
+        ?? asString(record.final_message);
     const status = asString(record.status ?? record.state);
-    if (status === 'completed' && message) return { completed: message };
-    if ((status === 'failed' || status === 'error') && message) return { failed: message };
-    if ((status === 'canceled' || status === 'cancelled') && message) return { canceled: message };
+    const normalizedStatus = status?.trim().toLowerCase().replace(/[\s_-]/g, '');
+    const completed = normalizedStatus === 'completed'
+        || normalizedStatus === 'complete'
+        || normalizedStatus === 'done'
+        || record.completed === true
+        || record.done === true;
+    if (completed && message) return { completed: message };
+    if (completed) return { ...record, status: 'completed' };
+    if ((normalizedStatus === 'failed' || normalizedStatus === 'error') && message) return { failed: message };
+    if ((normalizedStatus === 'canceled' || normalizedStatus === 'cancelled') && message) return { canceled: message };
     return value;
 }
 


### PR DESCRIPTION
## Summary
Fix Codex subagent result handling so completed subagent cards preserve the actual final assistant message instead of sometimes showing only a terminal status such as `done`.

## Problem
In some Codex multi-agent flows, a child agent could complete successfully but the parent-side result would only contain a completion marker (`done` / `completed`) rather than the child agent's final message.

This could happen when:
- `wait_agent` returned a completed/done status without a message
- child terminal events and child message events arrived in a non-ideal order
- later child trace/tool events arrived after the card had already reached a terminal state

## Changes
- Track each child Codex runtime's latest final `agent_message`
- Use that cached final message as fallback when `wait_agent` reports completed/done without a message
- Normalize `done`, `complete`, and `completed` agent states consistently
- Prevent terminal child agent cards from regressing back to running due to late child events
- Allow explicit parent operations like `send_input` / `resume_agent` to remain visible without letting late child tool events overwrite terminal state
- Reset cached final message and terminal state on child `task_started`
- Preserve late child messages as completed result updates instead of writing/running updates

## Tests
```bash
cd cli
bun run test -- src/codex/utils/appServerEventConverter.test.ts src/codex/codexRemoteLauncher.test.ts
bun run typecheck
```

Also smoke-tested against a deployed local HAPI build with real Codex subagents:
- spawned two subagents
- waited for both
- verified `wait_agent` result contained full final messages, not only `done`
