### PR TITLE
feat(cli): add /model slash command to show or set Claude model

### DIFF
--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -317,6 +317,28 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             return;
         }
 
+        if (specialCommand.type === 'model') {
+            logger.debug('[start] Detected /model command');
+            if (specialCommand.model == null) {
+                // /model with no arg: show current model
+                const modelName = currentModel ?? 'auto';
+                session.sendSessionEvent({ type: 'message', message: `Claude model: ${modelName}` });
+            } else {
+                // /model <name> or /model auto: set model
+                const newModel = specialCommand.model === 'auto' ? null : specialCommand.model;
+                currentModel = normalizeClaudeSessionModel(newModel);
+                currentSessionRef.current?.setModel(currentModel);
+                currentSessionRef.current?.pushKeepAlive();
+                const modelName = currentModel ?? 'auto';
+                session.sendSessionEvent({ type: 'message', message: `Claude model set to ${modelName}` });
+                logger.debug(`[start] /model command: model changed to ${modelName}`);
+            }
+            if (localId) {
+                session.emitMessagesConsumed([localId]);
+            }
+            return;
+        }
+
         // Push with resolved permission mode, model, system prompts, and tools
         const enhancedMode: EnhancedMode = {
             permissionMode: messagePermissionMode ?? 'default',

--- a/cli/src/modules/common/slashCommands.ts
+++ b/cli/src/modules/common/slashCommands.ts
@@ -30,6 +30,7 @@ const BUILTIN_COMMANDS: Record<string, SlashCommand[]> = {
         { name: 'compact', description: 'Compact conversation context', source: 'builtin' },
         { name: 'context', description: 'Show context information', source: 'builtin' },
         { name: 'cost', description: 'Show session cost', source: 'builtin' },
+        { name: 'model', description: 'Show or set Claude model, e.g. /model claude-opus-4-7', source: 'builtin' },
         { name: 'plan', description: 'Toggle plan mode', source: 'builtin' },
     ],
     codex: [

--- a/cli/src/parsers/specialCommands.test.ts
+++ b/cli/src/parsers/specialCommands.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseCompact, parseClear, parsePlan, parseSpecialCommand } from './specialCommands';
+import { parseCompact, parseClear, parsePlan, parseModel, parseSpecialCommand } from './specialCommands';
 
 describe('parseCompact', () => {
     it('should parse /compact command with argument', () => {
@@ -92,6 +92,33 @@ describe('parsePlan', () => {
     });
 });
 
+describe('parseModel', () => {
+    it('should parse /model without argument', () => {
+        const result = parseModel('/model');
+        expect(result).toEqual({ isModel: true, model: null });
+    });
+
+    it('should parse /model with a model name', () => {
+        const result = parseModel('/model claude-opus-4-7');
+        expect(result).toEqual({ isModel: true, model: 'claude-opus-4-7' });
+    });
+
+    it('should parse /model auto', () => {
+        const result = parseModel('/model auto');
+        expect(result).toEqual({ isModel: true, model: 'auto' });
+    });
+
+    it('should not parse /model with multiple arguments', () => {
+        const result = parseModel('/model foo bar');
+        expect(result.isModel).toBe(false);
+    });
+
+    it('should not parse partial matches', () => {
+        expect(parseModel('/modeler test').isModel).toBe(false);
+        expect(parseModel('please /model this').isModel).toBe(false);
+    });
+});
+
 describe('parseSpecialCommand', () => {
     it('should detect compact command', () => {
         const result = parseSpecialCommand('/compact optimize');
@@ -112,6 +139,18 @@ describe('parseSpecialCommand', () => {
         expect(result.prompt).toBe('帮我规划五一行程');
     });
 
+    it('should detect model command without argument', () => {
+        const result = parseSpecialCommand('/model');
+        expect(result.type).toBe('model');
+        expect(result.model).toBeNull();
+    });
+
+    it('should detect model command with a model name', () => {
+        const result = parseSpecialCommand('/model claude-sonnet-4-6');
+        expect(result.type).toBe('model');
+        expect(result.model).toBe('claude-sonnet-4-6');
+    });
+
     it('should return null for regular messages', () => {
         const result = parseSpecialCommand('hello world');
         expect(result.type).toBeNull();
@@ -123,11 +162,13 @@ describe('parseSpecialCommand', () => {
         expect(parseSpecialCommand('  /compact test  ').type).toBe('compact');
         expect(parseSpecialCommand('  /clear  ').type).toBe('clear');
         expect(parseSpecialCommand('  /plan test  ').type).toBe('plan');
-        
+        expect(parseSpecialCommand('  /model claude-opus-4-7  ').type).toBe('model');
+
         // Test partial matches should not trigger
         expect(parseSpecialCommand('some /compact text').type).toBeNull();
         expect(parseSpecialCommand('/compactor').type).toBeNull();
         expect(parseSpecialCommand('/clearing').type).toBeNull();
         expect(parseSpecialCommand('/planner').type).toBeNull();
+        expect(parseSpecialCommand('/modeler').type).toBeNull();
     });
 });

--- a/cli/src/parsers/specialCommands.ts
+++ b/cli/src/parsers/specialCommands.ts
@@ -17,11 +17,17 @@ export interface PlanCommandResult {
     prompt?: string;
 }
 
+export interface ModelCommandResult {
+    isModel: boolean;
+    model: string | null;
+}
+
 export interface SpecialCommandResult {
-    type: 'compact' | 'clear' | 'plan' | null;
+    type: 'compact' | 'clear' | 'plan' | 'model' | null;
     originalMessage?: string;
     mode?: 'plan' | 'default';
     prompt?: string;
+    model?: string | null;
 }
 
 /**
@@ -110,6 +116,22 @@ export function parsePlan(message: string): PlanCommandResult {
 }
 
 /**
+ * Parse /model command
+ * - /model: show current model
+ * - /model <name>: set model to <name>
+ * - /model auto: reset to default model
+ */
+export function parseModel(message: string): ModelCommandResult {
+    const trimmed = message.trim();
+    const match = /^\/model(?:\s+(\S+))?$/i.exec(trimmed);
+    if (!match) {
+        return { isModel: false, model: null };
+    }
+    const arg = match[1]?.trim() ?? null;
+    return { isModel: true, model: arg };
+}
+
+/**
  * Unified parser for special commands
  * Returns the type of command and original message if applicable
  */
@@ -121,7 +143,7 @@ export function parseSpecialCommand(message: string): SpecialCommandResult {
             originalMessage: compactResult.originalMessage
         };
     }
-    
+
     const clearResult = parseClear(message);
     if (clearResult.isClear) {
         return {
@@ -138,7 +160,15 @@ export function parseSpecialCommand(message: string): SpecialCommandResult {
             originalMessage: message.trim()
         };
     }
-    
+
+    const modelResult = parseModel(message);
+    if (modelResult.isModel) {
+        return {
+            type: 'model',
+            model: modelResult.model
+        };
+    }
+
     return {
         type: null
     };


### PR DESCRIPTION
## Summary

- Add a new `/model` slash command that allows users to view or switch the Claude model during a session.
- `/model` (no argument) — prints the currently active model (e.g. `Claude model: claude-sonnet-4-6`).
- `/model <name>` — switches the session to the given model (e.g. `/model claude-opus-4-7`).
- `/model auto` — resets the session to the default/auto model selection.

## Changes

- **`cli/src/parsers/specialCommands.ts`** — Added `parseModel()` function and `ModelCommandResult` interface; wired into `parseSpecialCommand()` which now returns `type: 'model'` and the optional model string.
- **`cli/src/parsers/specialCommands.test.ts`** — Full unit-test coverage for `parseModel` and the `/model` cases in `parseSpecialCommand`.
- **`cli/src/claude/runClaude.ts`** — Handle `specialCommand.type === 'model'`: show current model when no argument is supplied, or call `setModel` / `pushKeepAlive` when a model name is given.
- **`cli/src/modules/common/slashCommands.ts`** — Register `/model` in the built-in command list with a description so it appears in autocomplete / help.

## Test plan

- [x] Run `vitest` — all existing and new tests pass.
- [x] Send `/model` in a session — response shows `Claude model: <current>`.
- [x] Send `/model claude-opus-4-7` — response shows `Claude model set to claude-opus-4-7` and subsequent messages use that model.
- [x] Send `/model auto` — resets to default model selection.
- [x] Confirm that `/modeler` and other partial matches do **not** trigger the command.