### PR TITLE
修复 workspace 浏览页初始化后不加载目录

### DIFF
--- a/web/src/components/WorkspaceBrowser.tsx
+++ b/web/src/components/WorkspaceBrowser.tsx
@@ -184,7 +184,10 @@ export function WorkspaceBrowser(props: {
         () => machineId ? machines.find(m => m.id === machineId) ?? null : null,
         [machineId, machines]
     )
-    const workspaceRoots = selectedMachine?.metadata?.workspaceRoots ?? []
+    const workspaceRoots = useMemo(
+        () => selectedMachine?.metadata?.workspaceRoots ?? [],
+        [selectedMachine?.metadata?.workspaceRoots]
+    )
 
     const loadDirectory = useCallback(async (path: string) => {
         if (!machineId) return

--- a/web/src/components/WorkspaceBrowser.tsx
+++ b/web/src/components/WorkspaceBrowser.tsx
@@ -226,13 +226,14 @@ export function WorkspaceBrowser(props: {
         void loadDirectory(selectedRoot)
     }, [machineId, selectedRoot, currentPath, loadDirectory])
 
-    // If switching machines, reset view
+    // 切换机器时重置浏览状态，并立即对齐到新机器的第一个 workspace root。
+    // 否则 selectedRoot 可能被清空后跳过自动加载，页面会停在空态。
     useEffect(() => {
-        setSelectedRoot(null)
+        setSelectedRoot(workspaceRoots[0] ?? null)
         setCurrentPath(null)
         setEntries([])
         setError(null)
-    }, [machineId])
+    }, [machineId, workspaceRoots])
 
     const handleEntryClick = useCallback((entry: MachineDirectoryEntry) => {
         if (entry.type !== 'directory' || !currentPath) return

--- a/web/src/components/WorkspaceBrowser.tsx
+++ b/web/src/components/WorkspaceBrowser.tsx
@@ -229,14 +229,14 @@ export function WorkspaceBrowser(props: {
         void loadDirectory(selectedRoot)
     }, [machineId, selectedRoot, currentPath, loadDirectory])
 
-    // 切换机器时重置浏览状态，并立即对齐到新机器的第一个 workspace root。
-    // 否则 selectedRoot 可能被清空后跳过自动加载，页面会停在空态。
+    // 切换机器时才重置浏览状态；workspaceRoots 的刷新由上面的 effect
+    // 只做 root 有效性校正，避免 metadata 更新时清空用户当前浏览位置。
     useEffect(() => {
         setSelectedRoot(workspaceRoots[0] ?? null)
         setCurrentPath(null)
         setEntries([])
         setError(null)
-    }, [machineId, workspaceRoots])
+    }, [machineId])
 
     const handleEntryClick = useCallback((entry: MachineDirectoryEntry) => {
         if (entry.type !== 'directory' || !currentPath) return


### PR DESCRIPTION
## 背景

`/browse` 页面在 runner 已经通过 `--workspace-root` 上报 workspace roots 的情况下，仍可能停留在「No subdirectories found / 未找到子目录」空态。

实际排查时，后端 `list-directory` RPC 能正常返回目录列表，机器 metadata 中也包含正确的 `workspaceRoots`，问题发生在前端 `WorkspaceBrowser` 的状态初始化流程。

## 问题原因

`WorkspaceBrowser` 中有两个 effect 会同时影响浏览根目录状态：

- 一个 effect 根据当前机器的 `workspaceRoots` 设置 `selectedRoot`。
- 另一个 effect 在 `machineId` 变化时重置视图，并把 `selectedRoot` 清空。

当机器数据加载或切换机器时，后一个重置逻辑可能把刚设置好的 `selectedRoot` 清掉，导致自动加载目录的 effect 因 `selectedRoot` 为空而直接返回。最终 UI 没有 `currentPath`，也没有触发 `list-directory`，只显示空态。

## 修复内容

切换机器时不再把 `selectedRoot` 置空，而是同步设置为当前机器的第一个 `workspaceRoot`，同时保留清空 `currentPath`、`entries` 和 `error` 的重置行为。

这样自动加载 effect 可以继续以新的 root 作为入口请求目录，避免页面卡在空态。

## 验证

- 本地执行 `bun run typecheck:web` 通过。
- 本地执行 `bun run build:web` 通过。
- 手动验证后端 `list-directory` 对同一 workspace root 能返回目录数据，修复点限定在前端状态同步逻辑。
