### PR TITLE
Preview Codex generated images in chat

### DIFF
--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -13,6 +13,7 @@ import type { CodexSession } from './session';
 import type { EnhancedMode } from './loop';
 import { hasCodexCliOverrides } from './utils/codexCliOverrides';
 import { AppServerEventConverter } from './utils/appServerEventConverter';
+import { registerGeneratedImage } from '@/modules/common/generatedImages';
 import { registerAppServerPermissionHandlers } from './utils/appServerPermissionAdapter';
 import { buildThreadStartParams, buildTurnStartParams } from './utils/appServerConfig';
 import type { ThreadGoal, ThreadGoalStatus } from './appServerTypes';
@@ -1964,6 +1965,28 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     session.sendAgentMessage({
                         type: 'message',
                         message,
+                        id: randomUUID()
+                    });
+                }
+            }
+            if (msgType === 'generated_image') {
+                const sourceImageId = asString(msg.image_id ?? msg.imageId ?? msg.id);
+                const imageId = randomUUID();
+                const savedPath = asString(msg.saved_path ?? msg.savedPath);
+                if (savedPath) {
+                    const image = registerGeneratedImage({
+                        id: imageId,
+                        path: savedPath,
+                        fileName: asString(msg.file_name ?? msg.fileName),
+                        mimeType: asString(msg.mime_type ?? msg.mimeType)
+                    });
+                    messageBuffer.addMessage(`Generated image: ${image.fileName}`, 'assistant');
+                    session.sendAgentMessage({
+                        type: 'generated-image',
+                        imageId: image.id,
+                        sourceImageId,
+                        fileName: image.fileName,
+                        mimeType: image.mimeType,
                         id: randomUUID()
                     });
                 }

--- a/cli/src/codex/utils/appServerEventConverter.test.ts
+++ b/cli/src/codex/utils/appServerEventConverter.test.ts
@@ -743,9 +743,8 @@ describe('AppServerEventConverter', () => {
         ]);
     });
 
-    it('truncates large unhandled notification payloads before logging', () => {
+    it('converts completed image generation items without including large result payloads', () => {
         const converter = new AppServerEventConverter();
-        const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
         const largeImageResult = 'a'.repeat(4096);
 
         const events = converter.handleNotification('item/completed', {
@@ -753,6 +752,31 @@ describe('AppServerEventConverter', () => {
                 id: 'image-1',
                 type: 'imageGeneration',
                 result: largeImageResult,
+                savedPath: '/tmp/image.png',
+                mimeType: 'image/png'
+            }
+        });
+
+        expect(events).toEqual([{
+            type: 'generated_image',
+            image_id: 'image-1',
+            saved_path: '/tmp/image.png',
+            file_name: 'image.png',
+            mime_type: 'image/png'
+        }]);
+        expect(JSON.stringify(events)).not.toContain(largeImageResult);
+    });
+
+    it('truncates large unhandled notification payloads before logging', () => {
+        const converter = new AppServerEventConverter();
+        const debug = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+        const largeResult = 'a'.repeat(4096);
+
+        const events = converter.handleNotification('item/completed', {
+            item: {
+                id: 'unknown-1',
+                type: 'unknownLargePayload',
+                result: largeResult,
                 savedPath: '/tmp/image.png'
             }
         });
@@ -760,7 +784,7 @@ describe('AppServerEventConverter', () => {
         expect(events).toEqual([]);
         expect(debug).toHaveBeenCalledTimes(1);
         const logged = debug.mock.calls[0]?.[1] as { params?: { item?: { result?: string; savedPath?: string } } };
-        expect(logged.params?.item?.result).not.toBe(largeImageResult);
+        expect(logged.params?.item?.result).not.toBe(largeResult);
         expect(logged.params?.item?.result).toContain('[truncated 3584 chars for logs]');
         expect(logged.params?.item?.savedPath).toBe('/tmp/image.png');
 

--- a/cli/src/codex/utils/appServerEventConverter.ts
+++ b/cli/src/codex/utils/appServerEventConverter.ts
@@ -56,6 +56,28 @@ function extractCommand(value: unknown): string | null {
     return null;
 }
 
+function extractGeneratedImagePath(item: Record<string, unknown>): string | null {
+    return asString(
+        item.savedPath
+        ?? item.saved_path
+        ?? item.path
+        ?? item.filePath
+        ?? item.file_path
+        ?? item.outputPath
+        ?? item.output_path
+    );
+}
+
+function extractGeneratedImageMimeType(item: Record<string, unknown>): string | null {
+    return asString(item.mimeType ?? item.mime_type ?? item.mediaType ?? item.media_type);
+}
+
+function extractGeneratedImageFileName(item: Record<string, unknown>, savedPath: string): string {
+    const direct = asString(item.fileName ?? item.file_name ?? item.filename ?? item.name);
+    if (direct) return direct;
+    return savedPath.split(/[\\/]/).filter(Boolean).pop() ?? 'generated-image.png';
+}
+
 function extractChanges(value: unknown): Record<string, unknown> | null {
     const record = asRecord(value);
     if (record) return record;
@@ -868,6 +890,24 @@ export class AppServerEventConverter {
                     }));
                 }
 
+                return events;
+            }
+
+            if (itemType === 'imagegeneration') {
+                if (method === 'item/completed') {
+                    const savedPath = extractGeneratedImagePath(item);
+                    if (!savedPath) {
+                        logger.debug('[AppServerEventConverter] imageGeneration missing savedPath', sanitizeUnhandledNotificationLogValue({ item }));
+                        return events;
+                    }
+                    events.push(scoped({
+                        type: 'generated_image',
+                        image_id: itemId,
+                        saved_path: savedPath,
+                        file_name: extractGeneratedImageFileName(item, savedPath),
+                        ...(extractGeneratedImageMimeType(item) ? { mime_type: extractGeneratedImageMimeType(item) } : {})
+                    }));
+                }
                 return events;
             }
 

--- a/cli/src/modules/common/generatedImages.ts
+++ b/cli/src/modules/common/generatedImages.ts
@@ -1,0 +1,50 @@
+import { basename, extname } from 'path'
+
+export type GeneratedImageMetadata = {
+    id: string
+    path: string
+    fileName: string
+    mimeType: string
+    createdAt: number
+}
+
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+    '.apng': 'image/apng',
+    '.avif': 'image/avif',
+    '.bmp': 'image/bmp',
+    '.gif': 'image/gif',
+    '.ico': 'image/x-icon',
+    '.jpeg': 'image/jpeg',
+    '.jpg': 'image/jpeg',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.tif': 'image/tiff',
+    '.tiff': 'image/tiff',
+    '.webp': 'image/webp'
+}
+
+const generatedImages = new Map<string, GeneratedImageMetadata>()
+
+export function resolveGeneratedImageMimeType(path: string): string {
+    return IMAGE_MIME_BY_EXTENSION[extname(path).toLowerCase()] ?? 'application/octet-stream'
+}
+
+export function registerGeneratedImage(args: { id: string; path: string; mimeType?: string | null; fileName?: string | null }): GeneratedImageMetadata {
+    const metadata: GeneratedImageMetadata = {
+        id: args.id,
+        path: args.path,
+        fileName: args.fileName || basename(args.path) || `${args.id}.png`,
+        mimeType: args.mimeType || resolveGeneratedImageMimeType(args.path),
+        createdAt: Date.now()
+    }
+    generatedImages.set(args.id, metadata)
+    return metadata
+}
+
+export function getGeneratedImage(id: string): GeneratedImageMetadata | null {
+    return generatedImages.get(id) ?? null
+}
+
+export function clearGeneratedImages(): void {
+    generatedImages.clear()
+}

--- a/cli/src/modules/common/handlers/files.ts
+++ b/cli/src/modules/common/handlers/files.ts
@@ -4,6 +4,7 @@ import { createHash } from 'crypto'
 import { resolve } from 'path'
 import type { RpcHandlerManager } from '@/api/rpc/RpcHandlerManager'
 import { validatePath } from '../pathSecurity'
+import { getGeneratedImage } from '../generatedImages'
 import { getErrorMessage, rpcError } from '../rpcResponses'
 
 interface ReadFileRequest {
@@ -13,6 +14,18 @@ interface ReadFileRequest {
 interface ReadFileResponse {
     success: boolean
     content?: string
+    error?: string
+}
+
+interface ReadGeneratedImageRequest {
+    id: string
+}
+
+interface ReadGeneratedImageResponse {
+    success: boolean
+    content?: string
+    mimeType?: string
+    fileName?: string
     error?: string
 }
 
@@ -45,6 +58,28 @@ export function registerFileHandlers(rpcHandlerManager: RpcHandlerManager, worki
         } catch (error) {
             logger.debug('Failed to read file:', error)
             return rpcError(getErrorMessage(error, 'Failed to read file'))
+        }
+    })
+
+    rpcHandlerManager.registerHandler<ReadGeneratedImageRequest, ReadGeneratedImageResponse>('readGeneratedImage', async (data) => {
+        logger.debug('Read generated image request:', data.id)
+
+        const image = getGeneratedImage(data.id)
+        if (!image) {
+            return rpcError('Generated image not found')
+        }
+
+        try {
+            const buffer = await readFile(image.path)
+            return {
+                success: true,
+                content: buffer.toString('base64'),
+                mimeType: image.mimeType,
+                fileName: image.fileName
+            }
+        } catch (error) {
+            logger.debug('Failed to read generated image:', error)
+            return rpcError(getErrorMessage(error, 'Failed to read generated image'))
         }
     })
 

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -19,6 +19,14 @@ export type RpcReadFileResponse = {
     error?: string
 }
 
+export type RpcGeneratedImageResponse = {
+    success: boolean
+    content?: string
+    mimeType?: string
+    fileName?: string
+    error?: string
+}
+
 export type RpcUploadFileResponse = {
     success: boolean
     path?: string
@@ -227,6 +235,10 @@ export class RpcGateway {
 
     async readSessionFile(sessionId: string, path: string): Promise<RpcReadFileResponse> {
         return await this.sessionRpc(sessionId, 'readFile', { path }) as RpcReadFileResponse
+    }
+
+    async readGeneratedImage(sessionId: string, imageId: string): Promise<RpcGeneratedImageResponse> {
+        return await this.sessionRpc(sessionId, 'readGeneratedImage', { id: imageId }) as RpcGeneratedImageResponse
     }
 
     async listDirectory(sessionId: string, path: string): Promise<RpcListDirectoryResponse> {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -20,6 +20,7 @@ import {
     type RpcCodexModel,
     type RpcCommandResponse,
     type RpcDeleteUploadResponse,
+    type RpcGeneratedImageResponse,
     type RpcListDirectoryResponse,
     type RpcListCodexModelsResponse,
     type RpcListOpencodeModelsResponse,
@@ -37,6 +38,7 @@ export type {
     RpcCodexModel,
     RpcCommandResponse,
     RpcDeleteUploadResponse,
+    RpcGeneratedImageResponse,
     RpcListDirectoryResponse,
     RpcListCodexModelsResponse,
     RpcListOpencodeModelsResponse,
@@ -653,6 +655,10 @@ export class SyncEngine {
 
     async readSessionFile(sessionId: string, path: string): Promise<RpcReadFileResponse> {
         return await this.rpcGateway.readSessionFile(sessionId, path)
+    }
+
+    async readGeneratedImage(sessionId: string, imageId: string): Promise<RpcGeneratedImageResponse> {
+        return await this.rpcGateway.readGeneratedImage(sessionId, imageId)
     }
 
     async listDirectory(sessionId: string, path: string): Promise<RpcListDirectoryResponse> {

--- a/hub/src/web/routes/git.ts
+++ b/hub/src/web/routes/git.ts
@@ -17,6 +17,10 @@ const filePathSchema = z.object({
     path: z.string().min(1)
 })
 
+const generatedImageSchema = z.object({
+    imageId: z.string().min(1)
+})
+
 function parseBooleanParam(value: string | undefined): boolean | undefined {
     if (value === 'true') return true
     if (value === 'false') return false
@@ -128,6 +132,35 @@ export function createGitRoutes(getSyncEngine: () => SyncEngine | null): Hono<We
 
         const result = await runRpc(() => engine.readSessionFile(sessionResult.sessionId, parsed.data.path))
         return c.json(result)
+    })
+
+    app.get('/sessions/:id/generated-images/:imageId', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine)
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+
+        const parsed = generatedImageSchema.safeParse(c.req.param())
+        if (!parsed.success) {
+            return c.json({ error: 'Invalid generated image id' }, 400)
+        }
+
+        const result = await runRpc(() => engine.readGeneratedImage(sessionResult.sessionId, parsed.data.imageId))
+        if (!result.success || !result.content) {
+            return c.json({ success: false, error: result.error ?? 'Generated image not found' }, 404)
+        }
+
+        const bytes = Uint8Array.from(Buffer.from(result.content, 'base64'))
+        return c.body(bytes, 200, {
+            'Content-Type': result.mimeType ?? 'application/octet-stream',
+            'Content-Disposition': `inline; filename="${encodeURIComponent(result.fileName ?? 'generated-image')}"`,
+            'Cache-Control': 'no-store'
+        })
     })
 
     app.get('/sessions/:id/files', async (c) => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -252,6 +252,31 @@ export class ApiClient {
         return await this.request<FileSearchResponse>(`/api/sessions/${encodeURIComponent(sessionId)}/files${qs ? `?${qs}` : ''}`)
     }
 
+    async getGeneratedImageBlob(sessionId: string, imageId: string, attempt: number = 0, overrideToken?: string | null): Promise<Blob> {
+        const headers = new Headers()
+        const liveToken = this.getToken ? this.getToken() : null
+        const authToken = overrideToken !== undefined
+            ? (overrideToken ?? (liveToken ?? this.token))
+            : (liveToken ?? this.token)
+        if (authToken) {
+            headers.set('authorization', `Bearer ${authToken}`)
+        }
+        const res = await fetch(this.buildUrl(`/api/sessions/${encodeURIComponent(sessionId)}/generated-images/${encodeURIComponent(imageId)}`), {
+            headers
+        })
+        if (res.status === 401 && attempt === 0 && this.onUnauthorized) {
+            const refreshed = await this.onUnauthorized()
+            if (refreshed) {
+                this.token = refreshed
+                return await this.getGeneratedImageBlob(sessionId, imageId, attempt + 1, refreshed)
+            }
+        }
+        if (!res.ok) {
+            throw new ApiError(`HTTP ${res.status}`, res.status, undefined, await res.text().catch(() => undefined))
+        }
+        return await res.blob()
+    }
+
     async readSessionFile(sessionId: string, path: string): Promise<FileReadResponse> {
         const params = new URLSearchParams()
         params.set('path', path)

--- a/web/src/chat/normalizeAgent.ts
+++ b/web/src/chat/normalizeAgent.ts
@@ -480,6 +480,28 @@ export function normalizeAgentRecord(
             }
         }
 
+        if (data.type === 'generated-image') {
+            const imageId = asString(data.imageId ?? data.image_id)
+            if (!imageId) return null
+            const uuid = asString(data.id) ?? messageId
+            return {
+                id: messageId,
+                localId,
+                createdAt,
+                role: 'agent',
+                isSidechain: false,
+                content: [{
+                    type: 'generated-image',
+                    imageId,
+                    fileName: asString(data.fileName ?? data.file_name) ?? 'generated-image',
+                    mimeType: asString(data.mimeType ?? data.mime_type),
+                    uuid,
+                    parentUUID: null
+                }],
+                meta
+            }
+        }
+
         if (data.type === 'message' && typeof data.message === 'string') {
             return {
                 id: messageId,

--- a/web/src/chat/reconcile.ts
+++ b/web/src/chat/reconcile.ts
@@ -4,6 +4,7 @@ import type {
     AgentReasoningBlock,
     AgentTextBlock,
     ChatBlock,
+    GeneratedImageBlock,
     CliOutputBlock,
     ToolCallBlock,
     ToolPermission,
@@ -135,6 +136,15 @@ function areCliOutputBlocksEqual(left: CliOutputBlock, right: CliOutputBlock): b
         && left.meta === right.meta
 }
 
+function areGeneratedImageBlocksEqual(left: GeneratedImageBlock, right: GeneratedImageBlock): boolean {
+    return left.localId === right.localId
+        && left.createdAt === right.createdAt
+        && left.imageId === right.imageId
+        && left.fileName === right.fileName
+        && left.mimeType === right.mimeType
+        && left.meta === right.meta
+}
+
 function areAgentEventBlocksEqual(left: AgentEventBlock, right: AgentEventBlock): boolean {
     return left.createdAt === right.createdAt
         && left.meta === right.meta
@@ -211,6 +221,11 @@ function reconcileBlock(block: ChatBlock, prevById: ChatBlocksById): ChatBlock {
     if (block.kind === 'agent-reasoning') {
         const prevBlock = prev as AgentReasoningBlock
         return areAgentReasoningBlocksEqual(prevBlock, block) ? prevBlock : block
+    }
+
+    if (block.kind === 'generated-image') {
+        const prevBlock = prev as GeneratedImageBlock
+        return areGeneratedImageBlocksEqual(prevBlock, block) ? prevBlock : block
     }
 
     const prevBlock = prev as AgentEventBlock

--- a/web/src/chat/reducerTimeline.ts
+++ b/web/src/chat/reducerTimeline.ts
@@ -730,6 +730,21 @@ export function reduceTimeline(
                     continue
                 }
 
+                if (c.type === 'generated-image') {
+                    blocks.push({
+                        kind: 'generated-image',
+                        id: `${msg.id}:${idx}`,
+                        localId: msg.localId,
+                        createdAt: msg.createdAt,
+                        invokedAt: msg.invokedAt,
+                        imageId: c.imageId,
+                        fileName: c.fileName,
+                        mimeType: c.mimeType,
+                        meta: msg.meta
+                    })
+                    continue
+                }
+
                 if (c.type === 'reasoning') {
                     blocks.push({
                         kind: 'agent-reasoning',

--- a/web/src/chat/types.ts
+++ b/web/src/chat/types.ts
@@ -56,6 +56,15 @@ export type ToolResult = {
     permissions?: ToolResultPermission
 }
 
+export type GeneratedImageContent = {
+    type: 'generated-image'
+    imageId: string
+    fileName: string
+    mimeType: string | null
+    uuid: string
+    parentUUID: string | null
+}
+
 export type NormalizedAgentContent =
     | {
         type: 'text'
@@ -71,6 +80,7 @@ export type NormalizedAgentContent =
     }
     | ToolUse
     | ToolResult
+    | GeneratedImageContent
     | { type: 'summary'; summary: string }
     | { type: 'sidechain'; uuid: string; parentUUID: string | null; prompt: string }
 
@@ -175,6 +185,18 @@ export type CliOutputBlock = {
     meta?: unknown
 }
 
+export type GeneratedImageBlock = {
+    kind: 'generated-image'
+    id: string
+    localId: string | null
+    createdAt: number
+    invokedAt?: number | null
+    imageId: string
+    fileName: string
+    mimeType: string | null
+    meta?: unknown
+}
+
 export type AgentEventBlock = {
     kind: 'agent-event'
     id: string
@@ -199,4 +221,4 @@ export type ToolCallBlock = {
     meta?: unknown
 }
 
-export type ChatBlock = UserTextBlock | AgentTextBlock | AgentReasoningBlock | CliOutputBlock | ToolCallBlock | AgentEventBlock
+export type ChatBlock = UserTextBlock | AgentTextBlock | AgentReasoningBlock | CliOutputBlock | ToolCallBlock | GeneratedImageBlock | AgentEventBlock

--- a/web/src/components/AssistantChat/messages/ToolMessage.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.tsx
@@ -1,6 +1,7 @@
+import { useEffect, useState } from 'react'
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
 import type { ChatBlock } from '@/chat/types'
-import type { ToolCallBlock } from '@/chat/types'
+import type { GeneratedImageBlock, ToolCallBlock } from '@/chat/types'
 import type { ToolGroupBlock } from '@/chat/toolGroups'
 import { isObject, safeStringify } from '@hapi/protocol'
 import { isSubagentToolName } from '@/chat/subagentTool'
@@ -35,6 +36,69 @@ function isToolGroupBlock(value: unknown): value is ToolGroupBlock {
     if (typeof value.id !== 'string') return false
     if (!Array.isArray(value.tools)) return false
     return true
+}
+
+function isGeneratedImageBlock(value: unknown): value is GeneratedImageBlock {
+    if (!isObject(value)) return false
+    if (value.kind !== 'generated-image') return false
+    if (typeof value.id !== 'string') return false
+    if (typeof value.imageId !== 'string') return false
+    if (typeof value.fileName !== 'string') return false
+    if (value.mimeType !== null && typeof value.mimeType !== 'string') return false
+    return true
+}
+
+function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
+    const ctx = useHappyChatContext()
+    const [objectUrl, setObjectUrl] = useState<string | null>(null)
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        let disposed = false
+        let nextObjectUrl: string | null = null
+
+        setObjectUrl(null)
+        setError(null)
+        void ctx.api.getGeneratedImageBlob(ctx.sessionId, props.block.imageId)
+            .then((blob) => {
+                if (disposed) return
+                nextObjectUrl = URL.createObjectURL(blob)
+                setObjectUrl(nextObjectUrl)
+            })
+            .catch((err: unknown) => {
+                if (disposed) return
+                setError(err instanceof Error ? err.message : 'Failed to load generated image')
+            })
+
+        return () => {
+            disposed = true
+            if (nextObjectUrl) {
+                URL.revokeObjectURL(nextObjectUrl)
+            }
+        }
+    }, [ctx.api, ctx.sessionId, props.block.imageId])
+
+    return (
+        <div className="max-w-[92%] rounded-2xl border border-[var(--app-border)] bg-[var(--app-tool-card-bg)] p-3">
+            <div className="mb-2 min-w-0 truncate text-xs font-medium text-[var(--app-hint)]">
+                Generated image · {props.block.fileName}
+            </div>
+            {objectUrl ? (
+                <img
+                    src={objectUrl}
+                    alt={props.block.fileName}
+                    className="max-h-[min(28rem,60vh)] max-w-full rounded-xl object-contain"
+                    draggable={false}
+                />
+            ) : error ? (
+                <div className="text-sm text-[var(--app-hint)]">
+                    Generated image is unavailable. {error}
+                </div>
+            ) : (
+                <div className="h-48 w-72 max-w-full animate-pulse rounded-xl bg-[var(--app-subtle-bg)]" />
+            )}
+        </div>
+    )
 }
 
 function isPendingPermissionBlock(block: ChatBlock): boolean {
@@ -101,6 +165,14 @@ function HappyNestedBlockList(props: {
                             <div className={alignClass}>
                                 <CliOutputBlock text={block.text} />
                             </div>
+                        </div>
+                    )
+                }
+
+                if (block.kind === 'generated-image') {
+                    return (
+                        <div key={`generated-image:${block.id}`} className="px-1">
+                            <GeneratedImageCard block={block} />
                         </div>
                     )
                 }
@@ -181,6 +253,14 @@ export function HappyToolMessage(props: ToolCallMessagePartProps) {
                     block={artifact}
                     metadata={ctx.metadata}
                 />
+            </div>
+        )
+    }
+
+    if (isGeneratedImageBlock(artifact)) {
+        return (
+            <div className="py-1 min-w-0 max-w-full overflow-x-hidden">
+                <GeneratedImageCard block={artifact} />
             </div>
         )
     }

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -63,6 +63,28 @@ function toThreadMessageLike(block: VisibleChatBlock): ThreadMessageLike {
         }
     }
 
+    if (block.kind === 'generated-image') {
+        return {
+            role: 'assistant',
+            id: `generated-image:${block.id}`,
+            createdAt: new Date(block.createdAt),
+            content: [{
+                type: 'tool-call',
+                toolCallId: block.id,
+                toolName: 'GeneratedImage',
+                argsText: '',
+                artifact: block
+            }],
+            metadata: {
+                custom: {
+                    kind: 'tool',
+                    toolCallId: block.id,
+                    invokedAt: block.invokedAt ?? null
+                } satisfies HappyChatMessageMetadata
+            }
+        }
+    }
+
     if (block.kind === 'agent-reasoning') {
         const messageId = `assistant:${block.id}`
         return {


### PR DESCRIPTION
## Summary

- Convert Codex `imageGeneration` items into lightweight generated-image chat messages using `savedPath` only.
- Add an authenticated generated-image endpoint that reads the original image file from the active CLI via RPC.
- Render generated images inline in the HAPI Web chat without storing base64 payloads in session messages or copying files into the workspace.

## Notes

Generated images are backed by Codex's original saved file path. If the CLI restarts or the temporary image file is removed, older previews may become unavailable.

## Validation

- `bun typecheck`
- `cd cli && bun run test -- src/codex/utils/appServerEventConverter.test.ts`
- `cd web && bun run test -- src/components/AssistantChat/HappyThread.test.tsx src/components/AssistantChat/messages/user-bubble.test.tsx`
- `cd web && bun run build`