### PR TITLE
Add Codex steer for queued messages

### DIFF
--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -176,6 +176,17 @@ export interface TurnStartResponse {
     [key: string]: unknown;
 }
 
+export interface TurnSteerParams {
+    threadId: string;
+    input: UserInput[];
+    expectedTurnId: string;
+}
+
+export interface TurnSteerResponse {
+    turnId: string;
+    [key: string]: unknown;
+}
+
 export interface TurnInterruptParams {
     threadId: string;
     turnId: string;

--- a/cli/src/codex/codexAppServerClient.ts
+++ b/cli/src/codex/codexAppServerClient.ts
@@ -13,6 +13,8 @@ import type {
     ThreadResumeResponse,
     TurnStartParams,
     TurnStartResponse,
+    TurnSteerParams,
+    TurnSteerResponse,
     TurnInterruptParams,
     TurnInterruptResponse,
     ThreadCompactStartParams,
@@ -198,6 +200,13 @@ export class CodexAppServerClient {
             timeoutMs: CodexAppServerClient.DEFAULT_TIMEOUT_MS
         });
         return response as TurnStartResponse;
+    }
+
+    async steerTurn(params: TurnSteerParams): Promise<TurnSteerResponse> {
+        const response = await this.sendRequest('turn/steer', params, {
+            timeoutMs: 30_000
+        });
+        return response as TurnSteerResponse;
     }
 
     async interruptTurn(params: TurnInterruptParams): Promise<TurnInterruptResponse> {

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -2560,8 +2560,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 return { status: 'not-active' };
             }
 
-            const item = session.queue.takeByLocalId(localId);
-            if (!item) {
+            const taken = session.queue.takeByLocalIdWithIndex(localId);
+            if (!taken) {
                 return { status: 'not-found' };
             }
 
@@ -2569,11 +2569,12 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 await appServerClient.steerTurn({
                     threadId: this.currentThreadId,
                     expectedTurnId: this.currentTurnId,
-                    input: [{ type: 'text', text: item.message }]
+                    input: [{ type: 'text', text: taken.item.message }]
                 });
+                session.emitMessagesConsumed([localId]);
                 return { status: 'steered', localId };
             } catch (error) {
-                session.queue.unshift(item.message, item.mode, item.localId, item.isolate);
+                session.queue.restoreAt(taken.index, taken.item);
                 return {
                     status: 'failed',
                     error: error instanceof Error ? error.message : String(error)

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -2549,6 +2549,38 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             onSwitch: () => this.handleSwitchRequest()
         });
 
+        session.client.rpcHandlerManager.registerHandler('steer-queued-message', async (payload: unknown) => {
+            const record = asRecord(payload);
+            const localId = asString(record?.localId);
+            if (!localId) {
+                return { status: 'failed', error: 'Invalid localId' };
+            }
+
+            if (!turnInFlight || !this.currentThreadId || !this.currentTurnId) {
+                return { status: 'not-active' };
+            }
+
+            const item = session.queue.takeByLocalId(localId);
+            if (!item) {
+                return { status: 'not-found' };
+            }
+
+            try {
+                await appServerClient.steerTurn({
+                    threadId: this.currentThreadId,
+                    expectedTurnId: this.currentTurnId,
+                    input: [{ type: 'text', text: item.message }]
+                });
+                return { status: 'steered', localId };
+            } catch (error) {
+                session.queue.unshift(item.message, item.mode, item.localId);
+                return {
+                    status: 'failed',
+                    error: error instanceof Error ? error.message : String(error)
+                };
+            }
+        });
+
         function logActiveHandles(tag: string) {
             if (!process.env.DEBUG) return;
             const anyProc: any = process as any;

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -2571,7 +2571,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     expectedTurnId: this.currentTurnId,
                     input: [{ type: 'text', text: taken.item.message }]
                 });
-                session.emitMessagesConsumed([localId]);
+                session.client.emitMessagesConsumed([localId]);
                 return { status: 'steered', localId };
             } catch (error) {
                 session.queue.restoreAt(taken.index, taken.item);

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -2573,7 +2573,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 });
                 return { status: 'steered', localId };
             } catch (error) {
-                session.queue.unshift(item.message, item.mode, item.localId);
+                session.queue.unshift(item.message, item.mode, item.localId, item.isolate);
                 return {
                     status: 'failed',
                     error: error instanceof Error ? error.message : String(error)

--- a/cli/src/utils/MessageQueue2.test.ts
+++ b/cli/src/utils/MessageQueue2.test.ts
@@ -627,4 +627,18 @@ describe('MessageQueue2', () => {
         expect(batch3?.message).toBe('after-isolated');
         expect(batch3?.mode.type).toBe('B');
     });
+
+    it('should preserve isolation when unshifting a message with isolate=true', async () => {
+        const queue = new MessageQueue2<string>(mode => mode);
+
+        queue.unshift('isolated', 'local', 'id-isolated', true);
+        queue.push('after', 'local', 'id-after');
+
+        const batch1 = await queue.waitForMessagesAndGetAsString();
+        expect(batch1?.message).toBe('isolated');
+        expect(batch1?.isolate).toBe(true);
+
+        const batch2 = await queue.waitForMessagesAndGetAsString();
+        expect(batch2?.message).toBe('after');
+    });
 });

--- a/cli/src/utils/MessageQueue2.test.ts
+++ b/cli/src/utils/MessageQueue2.test.ts
@@ -595,6 +595,21 @@ describe('MessageQueue2', () => {
             expect(taken).toBeNull();
             expect(queue.size()).toBe(1);
         });
+
+        it('should restore a taken item at its original position', () => {
+            const queue = new MessageQueue2<string>(mode => mode);
+            queue.push('msg1', 'local', 'id-abc');
+            queue.push('msg2', 'local', 'id-def');
+            queue.push('msg3', 'local', 'id-ghi');
+
+            const taken = queue.takeByLocalIdWithIndex('id-def');
+            expect(taken?.item.message).toBe('msg2');
+            expect(taken?.index).toBe(1);
+
+            queue.restoreAt(taken!.index, taken!.item);
+
+            expect(queue.queue.map(item => item.localId)).toEqual(['id-abc', 'id-def', 'id-ghi']);
+        });
     });
 
     it('should differentiate between pushImmediate and pushIsolateAndClear behavior', async () => {

--- a/cli/src/utils/MessageQueue2.test.ts
+++ b/cli/src/utils/MessageQueue2.test.ts
@@ -573,6 +573,30 @@ describe('MessageQueue2', () => {
         });
     });
 
+    describe('takeByLocalId', () => {
+        it('should remove and return the message with matching localId', () => {
+            const queue = new MessageQueue2<string>(mode => mode);
+            queue.push('msg1', 'local', 'id-abc');
+            queue.push('msg2', 'remote', 'id-def');
+
+            const taken = queue.takeByLocalId('id-def');
+            expect(taken?.message).toBe('msg2');
+            expect(taken?.mode).toBe('remote');
+            expect(taken?.localId).toBe('id-def');
+            expect(queue.size()).toBe(1);
+            expect(queue.queue[0].localId).toBe('id-abc');
+        });
+
+        it('should return null when localId is not found', () => {
+            const queue = new MessageQueue2<string>(mode => mode);
+            queue.push('msg1', 'local', 'id-abc');
+
+            const taken = queue.takeByLocalId('missing');
+            expect(taken).toBeNull();
+            expect(queue.size()).toBe(1);
+        });
+    });
+
     it('should differentiate between pushImmediate and pushIsolateAndClear behavior', async () => {
         const queue = new MessageQueue2<{ type: string }>((mode) => mode.type);
         

--- a/cli/src/utils/MessageQueue2.ts
+++ b/cli/src/utils/MessageQueue2.ts
@@ -187,7 +187,7 @@ export class MessageQueue2<T> {
     /**
      * Push a message to the beginning of the queue with a mode.
      */
-    unshift(message: string, mode: T, localId?: string): void {
+    unshift(message: string, mode: T, localId?: string, isolate = false): void {
         if (this.closed) {
             throw new Error('Cannot unshift to closed queue');
         }
@@ -200,7 +200,7 @@ export class MessageQueue2<T> {
             mode,
             modeHash,
             localId,
-            isolate: false
+            isolate
         });
 
         // Trigger message handler if set

--- a/cli/src/utils/MessageQueue2.ts
+++ b/cli/src/utils/MessageQueue2.ts
@@ -239,11 +239,20 @@ export class MessageQueue2<T> {
      * than the normal batch drain, such as steering it into an active turn.
      */
     takeByLocalId(localId: string): QueueItem<T> | null {
+        return this.takeByLocalIdWithIndex(localId)?.item ?? null;
+    }
+
+    takeByLocalIdWithIndex(localId: string): { item: QueueItem<T>; index: number } | null {
         if (!localId) return null;
-        const idx = this.queue.findIndex(item => item.localId === localId);
-        if (idx === -1) return null;
-        const [item] = this.queue.splice(idx, 1);
-        return item ?? null;
+        const index = this.queue.findIndex(item => item.localId === localId);
+        if (index === -1) return null;
+        const [item] = this.queue.splice(index, 1);
+        return item ? { item, index } : null;
+    }
+
+    restoreAt(index: number, item: QueueItem<T>): void {
+        const boundedIndex = Math.max(0, Math.min(index, this.queue.length));
+        this.queue.splice(boundedIndex, 0, item);
     }
 
     /**

--- a/cli/src/utils/MessageQueue2.ts
+++ b/cli/src/utils/MessageQueue2.ts
@@ -234,6 +234,19 @@ export class MessageQueue2<T> {
     }
 
     /**
+     * Remove and return the first queued message that matches the given localId.
+     * Used when a caller needs to consume a queued item through a path other
+     * than the normal batch drain, such as steering it into an active turn.
+     */
+    takeByLocalId(localId: string): QueueItem<T> | null {
+        if (!localId) return null;
+        const idx = this.queue.findIndex(item => item.localId === localId);
+        if (idx === -1) return null;
+        const [item] = this.queue.splice(idx, 1);
+        return item ?? null;
+    }
+
+    /**
      * Reset the queue - clears all messages and resets to empty state
      */
     reset(): void {

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -79,6 +79,13 @@ export class RpcGateway {
         await this.sessionRpc(sessionId, RPC_METHODS.Abort, { reason: 'User aborted via Telegram Bot' })
     }
 
+    async steerQueuedMessage(
+        sessionId: string,
+        localId: string
+    ): Promise<unknown> {
+        return await this.sessionRpc(sessionId, 'steer-queued-message', { localId })
+    }
+
     async switchSession(sessionId: string, to: 'remote' | 'local'): Promise<void> {
         await this.sessionRpc(sessionId, RPC_METHODS.Switch, { to })
     }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -10,6 +10,7 @@
 import { isKnownFlavor, type LocalResumeTarget, type ResumableSession } from '@hapi/protocol'
 import type { SlashCommandsResponse } from '@hapi/protocol/apiTypes'
 import type { AgentFlavor, CodexCollaborationMode, DecryptedMessage, PermissionMode, Session, SyncEvent } from '@hapi/protocol/types'
+import type { SteerQueuedMessageResponse } from '@hapi/protocol/schemas'
 import { unwrapRoleWrappedRecordEnvelope } from '@hapi/protocol/messages'
 import type { Server } from 'socket.io'
 import type { Store, CancelQueuedMessageResult } from '../store'
@@ -393,6 +394,62 @@ export class SyncEngine {
 
     sweepImmediateQueuedOnSessionEnd(sessionId: string, invokedAt: number): void {
         this.messageService.sweepImmediateQueuedOnSessionEnd(sessionId, invokedAt)
+    }
+
+    async steerQueuedMessage(
+        sessionId: string,
+        messageId: string
+    ): Promise<SteerQueuedMessageResponse> {
+        const lookup = this.store.messages.lookupQueuedMessage(sessionId, messageId)
+        if (lookup.status === 'absent') {
+            return { status: 'absent' }
+        }
+        if (lookup.status === 'invoked') {
+            return lookup
+        }
+        if (!lookup.localId) {
+            return { status: 'failed', error: 'Queued message has no localId' }
+        }
+
+        let result: unknown
+        try {
+            result = await this.rpcGateway.steerQueuedMessage(sessionId, lookup.localId)
+        } catch (error) {
+            return {
+                status: 'failed',
+                error: error instanceof Error ? error.message : String(error)
+            }
+        }
+
+        if (!result || typeof result !== 'object') {
+            return { status: 'failed', error: 'Unexpected steer response' }
+        }
+
+        const status = (result as { status?: unknown }).status
+        if (status === 'steered') {
+            const invokedAt = Date.now()
+            this.store.messages.markMessagesInvoked(sessionId, [lookup.localId], invokedAt)
+            this.recordSessionActivity(sessionId, invokedAt)
+            this.eventPublisher.emit({
+                type: 'messages-consumed',
+                sessionId,
+                localIds: [lookup.localId],
+                invokedAt
+            })
+            return { status: 'steered', localId: lookup.localId, invokedAt }
+        }
+        if (status === 'not-active' || status === 'not-found') {
+            return { status }
+        }
+        if (status === 'failed') {
+            const error = (result as { error?: unknown }).error
+            return {
+                status: 'failed',
+                error: typeof error === 'string' ? error : 'Steer failed'
+            }
+        }
+
+        return { status: 'failed', error: 'Unexpected steer response' }
     }
 
     async approvePermission(

--- a/hub/src/web/routes/messages.ts
+++ b/hub/src/web/routes/messages.ts
@@ -48,6 +48,23 @@ export function createMessagesRoutes(getSyncEngine: () => SyncEngine | null): Ho
         return c.json(result)
     })
 
+    app.post('/sessions/:id/messages/:messageId/steer', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+        const sessionId = sessionResult.sessionId
+        const messageId = c.req.param('messageId')
+
+        const result = await engine.steerQueuedMessage(sessionId, messageId)
+        return c.json(result)
+    })
+
     app.post('/sessions/:id/messages', async (c) => {
         const engine = requireSyncEngine(c, getSyncEngine)
         if (engine instanceof Response) {

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -374,3 +374,14 @@ export const CancelMessageResponseSchema = z.discriminatedUnion('status', [
 ])
 
 export type CancelMessageResponse = z.infer<typeof CancelMessageResponseSchema>
+
+export const SteerQueuedMessageResponseSchema = z.discriminatedUnion('status', [
+    z.object({ status: z.literal('steered'), localId: z.string(), invokedAt: z.number() }),
+    z.object({ status: z.literal('invoked'), message: DecryptedMessageSchema }),
+    z.object({ status: z.literal('absent') }),
+    z.object({ status: z.literal('not-active') }),
+    z.object({ status: z.literal('not-found') }),
+    z.object({ status: z.literal('failed'), error: z.string() }),
+])
+
+export type SteerQueuedMessageResponse = z.infer<typeof SteerQueuedMessageResponseSchema>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -36,7 +36,7 @@ import type {
     UploadFileResponse
 } from '@hapi/protocol/apiTypes'
 import type { AgentFlavor } from '@hapi/protocol'
-import type { CancelMessageResponse } from '@hapi/protocol/schemas'
+import type { CancelMessageResponse, SteerQueuedMessageResponse } from '@hapi/protocol/schemas'
 
 type ApiClientOptions = {
     baseUrl?: string
@@ -392,6 +392,14 @@ export class ApiClient {
             { method: 'DELETE' }
         )
         return response as CancelMessageResponse
+    }
+
+    async steerQueuedMessage(sessionId: string, messageId: string): Promise<SteerQueuedMessageResponse> {
+        const response = await this.request(
+            `/api/sessions/${encodeURIComponent(sessionId)}/messages/${encodeURIComponent(messageId)}/steer`,
+            { method: 'POST', body: JSON.stringify({}) }
+        )
+        return response as SteerQueuedMessageResponse
     }
 
     async abortSession(sessionId: string): Promise<void> {

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -7,6 +7,7 @@ import { EMPTY_STATE } from '@/hooks/queries/useMessages'
 import { normalizeDecryptedMessage } from '@/chat/normalize'
 import type { DecryptedMessage } from '@/types/api'
 import { useCancelQueuedMessage } from '@/hooks/mutations/useCancelQueuedMessage'
+import { useSteerQueuedMessage } from '@/hooks/mutations/useSteerQueuedMessage'
 import { useTranslation } from '@/lib/use-translation'
 import { useToast } from '@/lib/toast-context'
 import type { PendingSchedule } from '@/components/AssistantChat/ScheduleTimePicker'
@@ -180,6 +181,7 @@ export function QueuedMessagesBar({
     const queued = useQueuedMessages(sessionId)
     const assistantApi = useAssistantApi()
     const cancelMutation = useCancelQueuedMessage(api)
+    const steerMutation = useSteerQueuedMessage(api)
     const { t } = useTranslation()
     const { addToast } = useToast()
 
@@ -209,7 +211,9 @@ export function QueuedMessagesBar({
                         const hasAttachments = attachmentNames.length > 0
                         const localId = msg.localId ?? msg.id
                         const isPending = cancelMutation.isPending && cancelMutation.variables?.localId === localId
+                        const isSteering = steerMutation.isPending && steerMutation.variables?.localId === localId
                         const canCancel = computeCanCancel({ id: msg.id, localId: msg.localId, isPending })
+                        const canSteer = computeCanCancel({ id: msg.id, localId: msg.localId, isPending: isPending || isSteering })
 
                         const handleCancel = () => {
                             if (!canCancel) return
@@ -258,6 +262,14 @@ export function QueuedMessagesBar({
                             )
                         }
 
+                        const handleSteer = () => {
+                            if (!canSteer) return
+                            steerMutation.mutate({
+                                sessionId,
+                                messageId: msg.id,
+                                localId,
+                            })
+                        }
                         const canEdit = canCancel
 
                         return (
@@ -295,6 +307,30 @@ export function QueuedMessagesBar({
                                     )}
                                 </div>
                                 <div className="flex shrink-0 items-center gap-1">
+                                    <button
+                                        type="button"
+                                        aria-label="Steer queued message"
+                                        disabled={!canSteer}
+                                        onClick={handleSteer}
+                                        onMouseDown={(e) => e.preventDefault()}
+                                        className="flex h-6 items-center gap-1 rounded px-1.5 text-[var(--app-hint)] transition-colors hover:bg-[var(--app-border)] hover:text-[var(--app-fg)] disabled:cursor-not-allowed disabled:opacity-40"
+                                    >
+                                        <svg
+                                            viewBox="0 0 16 16"
+                                            fill="none"
+                                            className="h-3.5 w-3.5"
+                                            aria-hidden="true"
+                                        >
+                                            <path
+                                                d="M3 5h5a4 4 0 0 1 4 4v3M12 12l-3-3M12 12l3-3"
+                                                stroke="currentColor"
+                                                strokeWidth="1.5"
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                            />
+                                        </svg>
+                                        <span className="text-xs">{isSteering ? '引导中' : '引导'}</span>
+                                    </button>
                                     <button
                                         type="button"
                                         aria-label="Edit queued message"

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -167,10 +167,12 @@ export function formatScheduledTime(scheduledAt: number): string {
 export function QueuedMessagesBar({
     sessionId,
     api,
+    enableSteer = false,
     onEdit,
 }: {
     sessionId: string
     api: ApiClient | null
+    enableSteer?: boolean
     /**
      * Called when the user clicks Edit on a queued message.
      * The parent should restore `text` into the composer and `pendingSchedule` into the schedule state.
@@ -213,7 +215,7 @@ export function QueuedMessagesBar({
                         const isPending = cancelMutation.isPending && cancelMutation.variables?.localId === localId
                         const isSteering = steerMutation.isPending && steerMutation.variables?.localId === localId
                         const canCancel = computeCanCancel({ id: msg.id, localId: msg.localId, isPending })
-                        const canSteer = computeCanCancel({ id: msg.id, localId: msg.localId, isPending: isPending || isSteering })
+                        const canSteer = enableSteer && computeCanCancel({ id: msg.id, localId: msg.localId, isPending: isPending || isSteering })
 
                         const handleCancel = () => {
                             if (!canCancel) return
@@ -307,30 +309,32 @@ export function QueuedMessagesBar({
                                     )}
                                 </div>
                                 <div className="flex shrink-0 items-center gap-1">
-                                    <button
-                                        type="button"
-                                        aria-label="Steer queued message"
-                                        disabled={!canSteer}
-                                        onClick={handleSteer}
-                                        onMouseDown={(e) => e.preventDefault()}
-                                        className="flex h-6 items-center gap-1 rounded px-1.5 text-[var(--app-hint)] transition-colors hover:bg-[var(--app-border)] hover:text-[var(--app-fg)] disabled:cursor-not-allowed disabled:opacity-40"
-                                    >
-                                        <svg
-                                            viewBox="0 0 16 16"
-                                            fill="none"
-                                            className="h-3.5 w-3.5"
-                                            aria-hidden="true"
+                                    {enableSteer ? (
+                                        <button
+                                            type="button"
+                                            aria-label="Steer queued message"
+                                            disabled={!canSteer}
+                                            onClick={handleSteer}
+                                            onMouseDown={(e) => e.preventDefault()}
+                                            className="flex h-6 items-center gap-1 rounded px-1.5 text-[var(--app-hint)] transition-colors hover:bg-[var(--app-border)] hover:text-[var(--app-fg)] disabled:cursor-not-allowed disabled:opacity-40"
                                         >
-                                            <path
-                                                d="M3 5h5a4 4 0 0 1 4 4v3M12 12l-3-3M12 12l3-3"
-                                                stroke="currentColor"
-                                                strokeWidth="1.5"
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                            />
-                                        </svg>
-                                        <span className="text-xs">{isSteering ? '引导中' : '引导'}</span>
-                                    </button>
+                                            <svg
+                                                viewBox="0 0 16 16"
+                                                fill="none"
+                                                className="h-3.5 w-3.5"
+                                                aria-hidden="true"
+                                            >
+                                                <path
+                                                    d="M3 5h5a4 4 0 0 1 4 4v3M12 12l-3-3M12 12l3-3"
+                                                    stroke="currentColor"
+                                                    strokeWidth="1.5"
+                                                    strokeLinecap="round"
+                                                    strokeLinejoin="round"
+                                                />
+                                            </svg>
+                                            <span className="text-xs">{isSteering ? '引导中' : '引导'}</span>
+                                        </button>
+                                    ) : null}
                                     <button
                                         type="button"
                                         aria-label="Edit queued message"

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -214,8 +214,11 @@ export function QueuedMessagesBar({
                         const localId = msg.localId ?? msg.id
                         const isPending = cancelMutation.isPending && cancelMutation.variables?.localId === localId
                         const isSteering = steerMutation.isPending && steerMutation.variables?.localId === localId
+                        const isFutureScheduled = msg.scheduledAt != null && msg.scheduledAt > Date.now()
                         const canCancel = computeCanCancel({ id: msg.id, localId: msg.localId, isPending })
-                        const canSteer = enableSteer && computeCanCancel({ id: msg.id, localId: msg.localId, isPending: isPending || isSteering })
+                        const canSteer = enableSteer
+                            && !isFutureScheduled
+                            && computeCanCancel({ id: msg.id, localId: msg.localId, isPending: isPending || isSteering })
 
                         const handleCancel = () => {
                             if (!canCancel) return
@@ -332,7 +335,9 @@ export function QueuedMessagesBar({
                                                     strokeLinejoin="round"
                                                 />
                                             </svg>
-                                            <span className="text-xs">{isSteering ? '引导中' : '引导'}</span>
+                                            <span className="text-xs">
+                                                {isSteering ? t('queuedMessages.steering') : t('queuedMessages.steer')}
+                                            </span>
                                         </button>
                                     ) : null}
                                     <button

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -783,7 +783,7 @@ export function SessionChat(props: {
                         <QueuedMessagesBar
                             sessionId={props.session.id}
                             api={props.api}
-                            enableSteer={agentFlavor === 'codex' && !controlledByUser}
+                            enableSteer={props.session.active && agentFlavor === 'codex' && !controlledByUser}
                             onEdit={({ pendingSchedule: restored }) => {
                                 // Restore the schedule so the clock button re-activates
                                 setPendingSchedule(restored)

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -783,6 +783,7 @@ export function SessionChat(props: {
                         <QueuedMessagesBar
                             sessionId={props.session.id}
                             api={props.api}
+                            enableSteer={agentFlavor === 'codex' && !controlledByUser}
                             onEdit={({ pendingSchedule: restored }) => {
                                 // Restore the schedule so the clock button re-activates
                                 setPendingSchedule(restored)

--- a/web/src/hooks/mutations/useSteerQueuedMessage.ts
+++ b/web/src/hooks/mutations/useSteerQueuedMessage.ts
@@ -1,0 +1,52 @@
+import { useMutation } from '@tanstack/react-query'
+import type { ApiClient } from '@/api/client'
+import {
+    appendOptimisticMessage,
+    markMessagesConsumed,
+    removeOptimisticMessage,
+} from '@/lib/message-window-store'
+import { usePlatform } from '@/hooks/usePlatform'
+
+type SteerQueuedMessageInput = {
+    sessionId: string
+    messageId: string
+    localId: string
+}
+
+export function useSteerQueuedMessage(api: ApiClient | null) {
+    const { haptic } = usePlatform()
+
+    return useMutation({
+        mutationFn: async (input: SteerQueuedMessageInput) => {
+            if (!api) {
+                throw new Error('API unavailable')
+            }
+            return api.steerQueuedMessage(input.sessionId, input.messageId)
+        },
+        onSuccess: (result, input) => {
+            if (result.status === 'steered') {
+                markMessagesConsumed(input.sessionId, [input.localId], result.invokedAt)
+                haptic.notification('success')
+                return
+            }
+            if (result.status === 'invoked') {
+                removeOptimisticMessage(input.sessionId, input.localId)
+                appendOptimisticMessage(input.sessionId, {
+                    id: result.message.id,
+                    seq: result.message.seq,
+                    localId: result.message.localId,
+                    content: result.message.content,
+                    createdAt: result.message.createdAt,
+                    invokedAt: result.message.invokedAt,
+                    status: 'sent',
+                })
+                haptic.notification('success')
+                return
+            }
+            haptic.notification('error')
+        },
+        onError: (_error, _input) => {
+            haptic.notification('error')
+        },
+    })
+}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -393,6 +393,8 @@ export default {
   'composer.scheduleErrorTooFar': 'Maximum schedule time is 7 days.',
   'queuedMessages.scheduledFor': 'Scheduled for {time}',
   'queuedMessages.editAlreadyInvoked': "Message already sent — it can't be edited",
+  'queuedMessages.steer': 'Steer',
+  'queuedMessages.steering': 'Steering',
 
   // Scratchlist (per-session workbench, issue #11)
   'scratchlist.title': 'Scratchlist',
@@ -412,6 +414,7 @@ export default {
   'scratchlist.action.promoteToComposer': 'Copy into composer',
   'scratchlist.action.promoteToQueue': 'Send to queue',
   'scratchlist.action.delete': 'Delete entry',
+
   'composer.codexSlashUnsupported.title': 'Codex command unavailable',
   'composer.codexSlashUnsupported.body': 'HAPI remote mode does not yet run built-in Codex slash commands like {command}. Use natural language instead, or run it in the local Codex TUI.',
 

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -395,6 +395,8 @@ export default {
   'composer.scheduleErrorTooFar': '最多只能定时 7 天。',
   'queuedMessages.scheduledFor': '定时发送: {time}',
   'queuedMessages.editAlreadyInvoked': '消息已发送，无法编辑',
+  'queuedMessages.steer': '引导',
+  'queuedMessages.steering': '引导中',
 
   // Scratchlist (per-session workbench, issue #11)
   'scratchlist.title': '草稿夹',
@@ -414,6 +416,7 @@ export default {
   'scratchlist.action.promoteToComposer': '复制到输入框',
   'scratchlist.action.promoteToQueue': '加入发送队列',
   'scratchlist.action.delete': '删除条目',
+
   'composer.codexSlashUnsupported.title': '无法执行 Codex 命令',
   'composer.codexSlashUnsupported.body': 'HAPI 远程模式暂不支持 {command} 这类 Codex 内建 slash command，请改用自然语言，或在本地 Codex TUI 中执行。',
 


### PR DESCRIPTION
## Summary
- add Codex app-server `turn/steer` support and a CLI RPC to steer queued messages into the active turn
- add a hub `/messages/:messageId/steer` endpoint that marks steered messages invoked and broadcasts `messages-consumed`
- add a queued-message “引导” button in the web UI

## Verification
- `bun run typecheck:cli`
- `bun run typecheck:hub`
- `bun run typecheck:web`
- `cd cli && bun test src/utils/MessageQueue2.test.ts`
- `cd web && bun test src/components/AssistantChat/QueuedMessagesBar.test.tsx`