### PR TITLE
Fix Codex MCP startup under Bun stdin

### DIFF
--- a/cli/src/codex/happyMcpStdioBridge.test.ts
+++ b/cli/src/codex/happyMcpStdioBridge.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+
+const mocks = vi.hoisted(() => ({
+    createReadStream: vi.fn(() => new PassThrough())
+}));
+
+vi.mock('node:fs', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('node:fs')>()),
+    createReadStream: mocks.createReadStream
+}));
+
+import { createHapiMcpStdin } from './happyMcpStdioBridge';
+
+describe('createHapiMcpStdin', () => {
+    const originalBunVersion = process.versions.bun;
+
+    afterEach(() => {
+        if (originalBunVersion === undefined) {
+            Reflect.deleteProperty(process.versions, 'bun');
+        } else {
+            Object.defineProperty(process.versions, 'bun', {
+                value: originalBunVersion,
+                configurable: true
+            });
+        }
+        vi.clearAllMocks();
+    });
+
+    it('uses an explicit fd 0 fs stream under Bun to avoid process.stdin EPERM', () => {
+        Object.defineProperty(process.versions, 'bun', {
+            value: '1.3.13',
+            configurable: true
+        });
+
+        const stdin = createHapiMcpStdin();
+
+        expect(mocks.createReadStream).toHaveBeenCalledWith('/dev/stdin', { fd: 0, autoClose: false });
+        expect(stdin).not.toBe(process.stdin);
+    });
+
+    it('keeps process.stdin outside Bun', () => {
+        Reflect.deleteProperty(process.versions, 'bun');
+
+        const stdin = createHapiMcpStdin();
+
+        expect(stdin).toBe(process.stdin);
+        expect(mocks.createReadStream).not.toHaveBeenCalled();
+    });
+});

--- a/cli/src/codex/happyMcpStdioBridge.ts
+++ b/cli/src/codex/happyMcpStdioBridge.ts
@@ -13,9 +13,17 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createReadStream } from 'node:fs';
+import type { Readable } from 'node:stream';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { z } from 'zod';
+
+export function createHapiMcpStdin(): Readable {
+  return process.versions.bun
+    ? createReadStream('/dev/stdin', { fd: 0, autoClose: false }) as Readable
+    : process.stdin;
+}
 
 function parseArgs(argv: string[]): { url: string | null } {
   let url: string | null = null;
@@ -93,8 +101,11 @@ export async function runHappyMcpStdioBridge(argv: string[]): Promise<void> {
       }
     );
 
-    // Start STDIO transport
-    const stdio = new StdioServerTransport();
+    // Start STDIO transport. Bun's global process.stdin stream can fail
+    // with EPERM when Codex app-server owns the stdio pipe. Reading fd 0 via
+    // an explicit fs stream avoids that Bun stdin edge case while keeping HAPI
+    // on the Bun runtime.
+    const stdio = new StdioServerTransport(createHapiMcpStdin(), process.stdout);
     await server.connect(stdio);
   } catch (err) {
     try {


### PR DESCRIPTION
Split out from the closed combined PR #618: https://github.com/tiann/hapi/pull/618

This PR fixes the Codex/HAPI MCP startup issue without introducing a Node stdio proxy. HAPI still runs the MCP bridge with Bun.

## Problem

This affects runner-managed Codex remote sessions, especially when the hub and the runner are running on different machines. In that setup, users start or control a Codex session from the web/mobile UI, while the actual Codex process runs on the runner machine.

HAPI expects Codex to load the built-in title update tool so new sessions can get useful names in the session list. On current `main`, Codex app-server can fail to start the HAPI MCP bridge, so the title update tool is unavailable. The user-visible result is that remote Codex sessions may keep generic, empty, or stale titles, making them hard to identify later from the browser or phone.

## Reproduction on current `main`

Tested on:

- HAPI `main`: `5512890`
- Bun: `1.3.13`
- Codex CLI: `0.130.0`
- OS: Ubuntu 20.04 x86_64

Steps:

1. Start a local HAPI HTTP MCP server and build the normal HAPI MCP stdio config:

   ```ts
   const happyServer = await startHappyServer(client);
   const bridgeCommand = getHappyCliCommand(['mcp', '--url', happyServer.url]);
   ```

   On `main`, this produces a Bun-backed stdio MCP server similar to:

   ```bash
   /root/.bun/bin/bun --cwd /path/to/hapi/cli /path/to/hapi/cli/src/index.ts mcp --url http://127.0.0.1:<port>/
   ```

2. Start Codex app-server and create a thread with that MCP server config:

   ```ts
   const app = new CodexAppServerClient();

   await app.connect();
   await app.initialize({
     clientInfo: { name: 'hapi-mcp-smoke', version: '0' },
     capabilities: { experimentalApi: true }
   });

   await app.startThread({
     cwd: '/tmp',
     approvalPolicy: 'on-request',
     sandbox: 'workspace-write',
     baseInstructions: 'smoke',
     developerInstructions: 'smoke',
     config: {
       'mcp_servers.hapi': {
         command: bridgeCommand.command,
         args: bridgeCommand.args
       },
       developer_instructions: 'smoke'
     }
   });
   ```

3. Observe Codex app-server MCP startup events:

   ```text
   mcpServer/startupStatus/updated {"name":"hapi","status":"starting","error":null}
   mcpServer/startupStatus/updated {"name":"hapi","status":"failed","error":"MCP client for `hapi` failed to start: MCP startup failed: handshaking with MCP server failed: connection closed: initialize response"}
   ```

Expected:

```text
hapi: ready
```

Actual on current `main`:

```text
hapi: failed
MCP startup failed: handshaking with MCP server failed: connection closed: initialize response
```

Control checks on the same `main` checkout:

- directly starting `hapi mcp` stays alive after 2 seconds
- stdout/stderr are empty
- MCP SDK stdio client can connect to the same Bun-backed bridge
- `listTools` returns `change_title`
- `callTool(change_title)` succeeds

So the bridge is valid for a normal MCP stdio client; the failure is specific to Codex app-server talking directly to the Bun-backed stdio MCP child.

## Root cause

The failing boundary is Codex app-server 0.130 talking directly to a Bun-backed stdio MCP child.

A minimal Bun MCP stdio server using the MCP SDK's default `StdioServerTransport()` reproduces the same failure under Codex app-server:

```text
MCP startup failed: handshaking with MCP server failed: connection closed: initialize response
```

The Bun child logs show:

```text
stdin error Error: EPERM: operation not permitted, read
stdin close
```

This happens because the SDK default transport reads from Bun's global `process.stdin` stream. In this Codex app-server child-process setup, that Bun stdin stream can fail with `EPERM` even though fd 0 itself is readable.

Two controls confirm that fd 0 and the MCP messages are fine:

- a Bun minimal server that reads fd 0 with `fs.readSync(0, ...)` works with Codex app-server
- a Bun minimal server using `fs.createReadStream(..., { fd: 0 })` also works with Codex app-server

## Fix

Use an explicit fd 0 read stream for the HAPI MCP stdio bridge when running under Bun:

```ts
export function createHapiMcpStdin(): Readable {
  return process.versions.bun
    ? createReadStream('/dev/stdin', { fd: 0, autoClose: false }) as Readable
    : process.stdin;
}
```

Then pass that stream to the MCP SDK transport:

```ts
const stdio = new StdioServerTransport(createHapiMcpStdin(), process.stdout);
```

This avoids the Bun `process.stdin` edge case while keeping the bridge running on Bun. No Node proxy or extra runtime process is introduced.

## Validation

- `bun run --cwd cli typecheck`
- `cd cli && bun x vitest run src/codex/happyMcpStdioBridge.test.ts src/codex/utils/codexMcpConfig.test.ts src/codex/utils/appServerConfig.test.ts`

Smoke checks after this fix:

- direct `hapi mcp`: alive after 2s, stdout/stderr empty
- MCP SDK stdio client -> Bun-backed `hapi mcp`: `listTools` and `callTool(change_title)` succeed
- Codex app-server -> Bun-backed `hapi mcp`: `hapi` startup reaches `ready`
