### PR TITLE
Fix runner remote terminal disconnecting from web/mobile UI

### DIFF
--- a/cli/src/terminal/TerminalManager.test.ts
+++ b/cli/src/terminal/TerminalManager.test.ts
@@ -1,0 +1,136 @@
+import { PassThrough } from 'node:stream';
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    spawn: vi.fn(),
+    spawnSync: vi.fn()
+}));
+
+vi.mock('node:child_process', () => ({
+    spawn: mocks.spawn,
+    spawnSync: mocks.spawnSync
+}));
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn()
+    }
+}));
+
+import { TerminalManager } from './TerminalManager';
+
+type MockChild = EventEmitter & {
+    stdin: PassThrough;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    killed: boolean;
+    exitCode: number | null;
+    kill: ReturnType<typeof vi.fn>;
+};
+
+function createMockChild(): { child: MockChild; stdinLines: string[] } {
+    const stdin = new PassThrough();
+    const stdinLines: string[] = [];
+    stdin.on('data', (chunk) => {
+        stdinLines.push(chunk.toString());
+    });
+
+    const child = Object.assign(new EventEmitter(), {
+        stdin,
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+        killed: false,
+        exitCode: null,
+        kill: vi.fn(function (this: MockChild) {
+            this.killed = true;
+            this.exitCode = 0;
+        })
+    }) as MockChild;
+
+    return { child, stdinLines };
+}
+
+describe('TerminalManager', () => {
+    const originalShell = process.env.SHELL;
+    const originalDisableScriptPty = process.env.HAPI_TERMINAL_DISABLE_SCRIPT_PTY;
+    const originalUseBunPty = process.env.HAPI_TERMINAL_USE_BUN_PTY;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env.SHELL = '/bin/bash';
+        delete process.env.HAPI_TERMINAL_DISABLE_SCRIPT_PTY;
+        delete process.env.HAPI_TERMINAL_USE_BUN_PTY;
+        mocks.spawnSync.mockImplementation((command: string) => ({
+            status: command === 'python3' ? 0 : 1
+        }));
+    });
+
+    afterEach(() => {
+        if (originalShell === undefined) delete process.env.SHELL;
+        else process.env.SHELL = originalShell;
+
+        if (originalDisableScriptPty === undefined) delete process.env.HAPI_TERMINAL_DISABLE_SCRIPT_PTY;
+        else process.env.HAPI_TERMINAL_DISABLE_SCRIPT_PTY = originalDisableScriptPty;
+
+        if (originalUseBunPty === undefined) delete process.env.HAPI_TERMINAL_USE_BUN_PTY;
+        else process.env.HAPI_TERMINAL_USE_BUN_PTY = originalUseBunPty;
+    });
+
+    it('uses the Python PTY bridge for runner remote terminals and forwards writes/resizes', () => {
+        const { child, stdinLines } = createMockChild();
+        mocks.spawn.mockReturnValue(child);
+        const onReady = vi.fn();
+        const onOutput = vi.fn();
+        const onExit = vi.fn();
+        const onError = vi.fn();
+
+        const manager = new TerminalManager({
+            sessionId: 'session-1',
+            getSessionPath: () => '/workspace/project',
+            onReady,
+            onOutput,
+            onExit,
+            onError,
+            idleTimeoutMs: 0
+        });
+
+        manager.create('terminal-1', 80, 24);
+        manager.write('terminal-1', 'echo ok\n');
+        manager.resize('terminal-1', 100, 30);
+        child.stdout.emit('data', Buffer.from('ok\r\n'));
+        child.emit('exit', 0, null);
+
+        expect(mocks.spawnSync).toHaveBeenCalledWith('python3', ['--version'], { stdio: 'ignore' });
+        expect(mocks.spawn).toHaveBeenCalledWith(
+            'python3',
+            [
+                '-c',
+                expect.stringContaining('TIOCSWINSZ'),
+                '/bin/bash',
+                '80',
+                '24'
+            ],
+            expect.objectContaining({
+                cwd: '/workspace/project',
+                stdio: ['pipe', 'pipe', 'pipe']
+            })
+        );
+        expect(onReady).toHaveBeenCalledWith({ sessionId: 'session-1', terminalId: 'terminal-1' });
+        expect(JSON.parse(stdinLines[0] ?? '{}')).toEqual({
+            type: 'write',
+            data: Buffer.from('echo ok\n').toString('base64')
+        });
+        expect(JSON.parse(stdinLines[1] ?? '{}')).toEqual({
+            type: 'resize',
+            cols: 100,
+            rows: 30
+        });
+        expect(onOutput).toHaveBeenCalledWith({ sessionId: 'session-1', terminalId: 'terminal-1', data: 'ok\r\n' });
+        expect(onExit).toHaveBeenCalledWith({ sessionId: 'session-1', terminalId: 'terminal-1', code: 0, signal: null });
+        expect(onError).not.toHaveBeenCalled();
+    });
+});

--- a/cli/src/terminal/TerminalManager.test.ts
+++ b/cli/src/terminal/TerminalManager.test.ts
@@ -119,6 +119,10 @@ describe('TerminalManager', () => {
                 stdio: ['pipe', 'pipe', 'pipe']
             })
         );
+        const pythonScript = mocks.spawn.mock.calls[0]?.[1]?.[1] as string;
+        expect(pythonScript).toContain('TIOCSCTTY');
+        expect(pythonScript).toContain('terminate_child_group');
+        expect(pythonScript).toContain('os.killpg(proc.pid, sig)');
         expect(onReady).toHaveBeenCalledWith({ sessionId: 'session-1', terminalId: 'terminal-1' });
         expect(JSON.parse(stdinLines[0] ?? '{}')).toEqual({
             type: 'write',

--- a/cli/src/terminal/TerminalManager.test.ts
+++ b/cli/src/terminal/TerminalManager.test.ts
@@ -58,6 +58,7 @@ describe('TerminalManager', () => {
     const originalShell = process.env.SHELL;
     const originalDisableScriptPty = process.env.HAPI_TERMINAL_DISABLE_SCRIPT_PTY;
     const originalUseBunPty = process.env.HAPI_TERMINAL_USE_BUN_PTY;
+    const originalBun = (globalThis as unknown as { Bun?: unknown }).Bun;
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -78,6 +79,8 @@ describe('TerminalManager', () => {
 
         if (originalUseBunPty === undefined) delete process.env.HAPI_TERMINAL_USE_BUN_PTY;
         else process.env.HAPI_TERMINAL_USE_BUN_PTY = originalUseBunPty;
+
+        (globalThis as unknown as { Bun?: unknown }).Bun = originalBun;
     });
 
     it('uses the Python PTY bridge for runner remote terminals and forwards writes/resizes', () => {
@@ -122,6 +125,7 @@ describe('TerminalManager', () => {
         const pythonScript = mocks.spawn.mock.calls[0]?.[1]?.[1] as string;
         expect(pythonScript).toContain('TIOCSCTTY');
         expect(pythonScript).toContain('terminate_child_group');
+        expect(pythonScript).toContain('shutdown_child_group');
         expect(pythonScript).toContain('os.killpg(proc.pid, sig)');
         expect(onReady).toHaveBeenCalledWith({ sessionId: 'session-1', terminalId: 'terminal-1' });
         expect(JSON.parse(stdinLines[0] ?? '{}')).toEqual({
@@ -137,4 +141,68 @@ describe('TerminalManager', () => {
         expect(onExit).toHaveBeenCalledWith({ sessionId: 'session-1', terminalId: 'terminal-1', code: 0, signal: null });
         expect(onError).not.toHaveBeenCalled();
     });
+
+    it('lets the Python PTY bridge run its own child-group cleanup on close', () => {
+        const { child, stdinLines } = createMockChild();
+        mocks.spawn.mockReturnValue(child);
+        const manager = new TerminalManager({
+            sessionId: 'session-1',
+            getSessionPath: () => '/workspace/project',
+            onReady: vi.fn(),
+            onOutput: vi.fn(),
+            onExit: vi.fn(),
+            onError: vi.fn(),
+            idleTimeoutMs: 0
+        });
+
+        manager.create('terminal-1', 80, 24);
+        manager.close('terminal-1');
+
+        expect(JSON.parse(stdinLines[0] ?? '{}')).toEqual({ type: 'close' });
+        expect(child.stdin.writableEnded).toBe(true);
+        expect(child.kill).not.toHaveBeenCalled();
+    });
+
+    it('ignores stale Bun PTY exits after falling back to a pipe terminal', () => {
+        process.env.HAPI_TERMINAL_USE_BUN_PTY = '1';
+        const bunProc = {
+            terminal: undefined,
+            killed: false,
+            exitCode: null,
+            signalCode: null,
+            kill: vi.fn(function (this: { killed: boolean; exitCode: number | null }) {
+                this.killed = true;
+                this.exitCode = 0;
+            })
+        };
+        const bunSpawn = vi.fn(() => bunProc);
+        (globalThis as unknown as { Bun?: unknown }).Bun = { spawn: bunSpawn };
+        const { child: pipeChild } = createMockChild();
+        mocks.spawn.mockReturnValue(pipeChild);
+        const onReady = vi.fn();
+        const onExit = vi.fn();
+
+        const manager = new TerminalManager({
+            sessionId: 'session-1',
+            getSessionPath: () => '/workspace/project',
+            onReady,
+            onOutput: vi.fn(),
+            onExit,
+            onError: vi.fn(),
+            idleTimeoutMs: 0
+        });
+
+        manager.create('terminal-1', 80, 24);
+        const bunSpawnOptions = (bunSpawn.mock.calls[0] as unknown[])[1] as { onExit: (proc: unknown, code: number | null) => void };
+        const bunOnExit = bunSpawnOptions.onExit;
+        bunOnExit(bunProc, 0);
+        manager.write('terminal-1', 'echo still alive\n');
+
+        expect(bunProc.kill).toHaveBeenCalledTimes(1);
+        expect(onReady).toHaveBeenCalledTimes(1);
+        expect(onExit).not.toHaveBeenCalled();
+        expect(pipeChild.kill).not.toHaveBeenCalled();
+        expect(mocks.spawn).toHaveBeenCalled();
+    });
+
 });

--- a/cli/src/terminal/TerminalManager.ts
+++ b/cli/src/terminal/TerminalManager.ts
@@ -57,6 +57,19 @@ rows = int(sys.argv[3])
 name = os.path.basename(shell)
 argv = [shell, '-i'] if name in ('bash', 'zsh', 'fish') else [shell]
 master_fd, slave_fd = pty.openpty()
+master_fd_closed = False
+master_fd_lock = threading.Lock()
+
+def close_master_fd():
+    global master_fd_closed
+    with master_fd_lock:
+        if master_fd_closed:
+            return
+        try:
+            os.close(master_fd)
+        except OSError:
+            pass
+        master_fd_closed = True
 
 def set_size(next_cols, next_rows):
     winsize = struct.pack('HHHH', int(next_rows), int(next_cols), 0, 0)
@@ -67,8 +80,27 @@ def set_size(next_cols, next_rows):
         pass
 
 set_size(cols, rows)
-proc = subprocess.Popen(argv, stdin=slave_fd, stdout=slave_fd, stderr=slave_fd, preexec_fn=os.setsid)
+
+def setup_child():
+    os.setsid()
+    fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+
+proc = subprocess.Popen(argv, stdin=slave_fd, stdout=slave_fd, stderr=slave_fd, preexec_fn=setup_child)
 os.close(slave_fd)
+
+def terminate_child_group(sig=signal.SIGTERM):
+    try:
+        os.killpg(proc.pid, sig)
+    except OSError:
+        pass
+
+def handle_bridge_signal(signum, _frame):
+    terminate_child_group(signal.SIGTERM)
+    close_master_fd()
+    os._exit(128 + signum)
+
+for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    signal.signal(signum, handle_bridge_signal)
 
 def input_loop():
     for raw in sys.stdin.buffer:
@@ -88,14 +120,14 @@ def input_loop():
         except Exception as exc:
             print('[hapi-terminal-pty] input error: %s' % exc, file=sys.stderr)
             break
-    try:
-        proc.terminate()
-    except OSError:
-        pass
+    terminate_child_group()
+    close_master_fd()
 
 threading.Thread(target=input_loop, daemon=True).start()
 
 while True:
+    if master_fd_closed:
+        break
     if proc.poll() is not None:
         timeout = 0
     else:
@@ -118,11 +150,17 @@ while True:
     elif proc.poll() is not None:
         break
 
-try:
-    os.close(master_fd)
-except OSError:
-    pass
-os._exit(proc.wait() if proc.poll() is None else proc.returncode)
+close_master_fd()
+
+if proc.poll() is None:
+    terminate_child_group()
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        terminate_child_group(signal.SIGKILL)
+        proc.wait()
+
+os._exit(proc.returncode if proc.returncode is not None else 0)
 `;
 
 const SENSITIVE_ENV_KEYS = new Set([

--- a/cli/src/terminal/TerminalManager.ts
+++ b/cli/src/terminal/TerminalManager.ts
@@ -1,3 +1,5 @@
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { logger } from '@/ui/logger'
 import { getInvokedCwd } from '@/utils/invokedCwd'
 import type {
@@ -8,9 +10,15 @@ import type {
 } from '@hapi/protocol'
 import type { TerminalSession } from './types'
 
+type TerminalHandle = {
+    write: (data: string) => void
+    resize: (cols: number, rows: number) => void
+    close: () => void
+}
+
 type TerminalRuntime = TerminalSession & {
-    proc: Bun.Subprocess
-    terminal: Bun.Terminal
+    proc: { killed?: boolean; exitCode?: number | null; kill: () => unknown }
+    terminal: TerminalHandle
     idleTimer: ReturnType<typeof setTimeout> | null
 }
 
@@ -27,6 +35,96 @@ type TerminalManagerOptions = {
 
 const DEFAULT_IDLE_TIMEOUT_MS = 15 * 60_000
 const DEFAULT_MAX_TERMINALS = 4
+
+const PYTHON_PTY_BRIDGE_SCRIPT = String.raw`
+import base64
+import errno
+import fcntl
+import json
+import os
+import pty
+import select
+import signal
+import struct
+import subprocess
+import sys
+import threading
+import termios
+
+shell = sys.argv[1]
+cols = int(sys.argv[2])
+rows = int(sys.argv[3])
+name = os.path.basename(shell)
+argv = [shell, '-i'] if name in ('bash', 'zsh', 'fish') else [shell]
+master_fd, slave_fd = pty.openpty()
+
+def set_size(next_cols, next_rows):
+    winsize = struct.pack('HHHH', int(next_rows), int(next_cols), 0, 0)
+    fcntl.ioctl(master_fd, termios.TIOCSWINSZ, winsize)
+    try:
+        fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, winsize)
+    except OSError:
+        pass
+
+set_size(cols, rows)
+proc = subprocess.Popen(argv, stdin=slave_fd, stdout=slave_fd, stderr=slave_fd, preexec_fn=os.setsid)
+os.close(slave_fd)
+
+def input_loop():
+    for raw in sys.stdin.buffer:
+        try:
+            msg = json.loads(raw.decode('utf-8'))
+            msg_type = msg.get('type')
+            if msg_type == 'write':
+                os.write(master_fd, base64.b64decode(msg.get('data', '')))
+            elif msg_type == 'resize':
+                set_size(msg.get('cols', cols), msg.get('rows', rows))
+                try:
+                    os.killpg(proc.pid, signal.SIGWINCH)
+                except OSError:
+                    pass
+            elif msg_type == 'close':
+                break
+        except Exception as exc:
+            print('[hapi-terminal-pty] input error: %s' % exc, file=sys.stderr)
+            break
+    try:
+        proc.terminate()
+    except OSError:
+        pass
+
+threading.Thread(target=input_loop, daemon=True).start()
+
+while True:
+    if proc.poll() is not None:
+        timeout = 0
+    else:
+        timeout = 0.1
+    try:
+        readable, _, _ = select.select([master_fd], [], [], timeout)
+    except OSError:
+        break
+    if master_fd in readable:
+        try:
+            data = os.read(master_fd, 65536)
+        except OSError as exc:
+            if exc.errno == errno.EIO:
+                break
+            raise
+        if not data:
+            break
+        sys.stdout.buffer.write(data)
+        sys.stdout.buffer.flush()
+    elif proc.poll() is not None:
+        break
+
+try:
+    os.close(master_fd)
+except OSError:
+    pass
+os._exit(proc.wait() if proc.poll() is None else proc.returncode)
+`;
+
 const SENSITIVE_ENV_KEYS = new Set([
     'CLI_API_TOKEN',
     'HAPI_API_URL',
@@ -55,6 +153,35 @@ function resolveShell(): string {
         return '/bin/zsh'
     }
     return '/bin/bash'
+}
+
+function shellArgs(shell: string): string[] {
+    const name = shell.split(/[\\/]/).pop() ?? shell
+    if (name === 'bash' || name === 'zsh' || name === 'fish') {
+        return [shell, '-i']
+    }
+    return [shell]
+}
+
+function quotePosixShellArg(value: string): string {
+    return "'" + value.replace(/'/g, "'\\''") + "'"
+}
+
+function resolvePythonExecutable(): string | null {
+    for (const candidate of ['python3', 'python']) {
+        const result = spawnSync(candidate, ['--version'], { stdio: 'ignore' })
+        if (result.status === 0) {
+            return candidate
+        }
+    }
+    return null
+}
+
+function resolveTerminalCommand(shell: string): string[] {
+    if (process.platform !== 'darwin' && process.env.HAPI_TERMINAL_DISABLE_SCRIPT_PTY !== '1' && existsSync('/usr/bin/script')) {
+        return ['/usr/bin/script', '-q', '/dev/null', '-c', `${quotePosixShellArg(shell)} -i`]
+    }
+    return shellArgs(shell)
 }
 
 function buildFilteredEnv(): NodeJS.ProcessEnv {
@@ -125,77 +252,253 @@ export class TerminalManager {
             return
         }
 
-        if (typeof Bun === 'undefined' || typeof Bun.spawn !== 'function') {
-            this.emitError(terminalId, 'Terminal is unavailable in this runtime.')
-            return
-        }
-
         const sessionPath = this.getSessionPath() ?? getInvokedCwd()
         const shell = resolveShell()
-        const decoder = new TextDecoder()
 
         try {
-            const proc = Bun.spawn([shell], {
-                cwd: sessionPath,
-                env: this.filteredEnv,
-                terminal: {
-                    cols,
-                    rows,
-                    data: (terminal, data) => {
-                        const text = decoder.decode(data, { stream: true })
-                        if (text) {
-                            this.onOutput({ sessionId: this.sessionId, terminalId, data: text })
-                        }
-                        const active = this.terminals.get(terminalId)
-                        if (active) {
-                            this.markActivity(active)
-                        }
-                    },
-                    exit: (terminal, exitCode) => {
-                        if (exitCode === 1) {
-                            this.emitError(terminalId, 'Terminal stream closed unexpectedly.')
-                        }
-                    }
-                },
-                onExit: (subprocess, exitCode) => {
-                    const signal = subprocess.signalCode ?? null
-                    this.onExit({
-                        sessionId: this.sessionId,
-                        terminalId,
-                        code: exitCode ?? null,
-                        signal
-                    })
-                    this.cleanup(terminalId)
-                }
-            })
-
-            const terminal = proc.terminal
-            if (!terminal) {
-                try {
-                    proc.kill()
-                } catch (error) {
-                    logger.debug('[TERMINAL] Failed to kill process after missing terminal', { error })
-                }
-                this.emitError(terminalId, 'Failed to attach terminal.')
+            if (process.platform === 'darwin' || process.env.HAPI_TERMINAL_USE_BUN_PTY === '1') {
+                this.createBunTerminal(terminalId, cols, rows, sessionPath, shell)
                 return
             }
-
-            const runtime: TerminalRuntime = {
-                terminalId,
-                cols,
-                rows,
-                proc,
-                terminal,
-                idleTimer: null
+            const python = resolvePythonExecutable()
+            if (python) {
+                this.createPythonPtyTerminal(terminalId, cols, rows, sessionPath, shell, python)
+                return
             }
-
-            this.terminals.set(terminalId, runtime)
-            this.markActivity(runtime)
-            this.onReady({ sessionId: this.sessionId, terminalId })
+            this.createPipeTerminal(terminalId, cols, rows, sessionPath, shell)
         } catch (error) {
             logger.debug('[TERMINAL] Failed to spawn terminal', { error })
             this.emitError(terminalId, 'Failed to spawn terminal.')
         }
+    }
+
+    private createBunTerminal(terminalId: string, cols: number, rows: number, cwd: string, shell: string): void {
+        if (typeof Bun === 'undefined' || typeof Bun.spawn !== 'function') {
+            this.createPipeTerminal(terminalId, cols, rows, cwd, shell)
+            return
+        }
+
+        const decoder = new TextDecoder()
+        const proc = Bun.spawn(shellArgs(shell), {
+            cwd,
+            env: this.filteredEnv,
+            terminal: {
+                cols,
+                rows,
+                data: (_terminal, data) => {
+                    const text = decoder.decode(data, { stream: true })
+                    if (text) {
+                        this.onOutput({ sessionId: this.sessionId, terminalId, data: text })
+                    }
+                    const active = this.terminals.get(terminalId)
+                    if (active) {
+                        this.markActivity(active)
+                    }
+                }
+            },
+            onExit: (subprocess, exitCode) => {
+                const signal = subprocess.signalCode ?? null
+                this.onExit({
+                    sessionId: this.sessionId,
+                    terminalId,
+                    code: exitCode ?? null,
+                    signal
+                })
+                this.cleanup(terminalId)
+            }
+        })
+
+        const bunTerminal = proc.terminal
+        if (!bunTerminal) {
+            try {
+                proc.kill()
+            } catch (error) {
+                logger.debug('[TERMINAL] Failed to kill process after missing Bun terminal', { error })
+            }
+            this.createPipeTerminal(terminalId, cols, rows, cwd, shell)
+            return
+        }
+
+        const terminal: TerminalHandle = {
+            write: (data: string) => bunTerminal.write(data),
+            resize: (nextCols: number, nextRows: number) => bunTerminal.resize(nextCols, nextRows),
+            close: () => bunTerminal.close()
+        }
+
+        const runtime: TerminalRuntime = {
+            terminalId,
+            cols,
+            rows,
+            proc,
+            terminal,
+            idleTimer: null
+        }
+
+        this.terminals.set(terminalId, runtime)
+        this.markActivity(runtime)
+        this.onReady({ sessionId: this.sessionId, terminalId })
+    }
+
+    private createPythonPtyTerminal(
+        terminalId: string,
+        cols: number,
+        rows: number,
+        cwd: string,
+        shell: string,
+        python: string
+    ): void {
+        const proc = spawn(python, ['-c', PYTHON_PTY_BRIDGE_SCRIPT, shell, String(cols), String(rows)], {
+            cwd,
+            env: {
+                ...this.filteredEnv,
+                COLUMNS: String(cols),
+                LINES: String(rows)
+            },
+            stdio: ['pipe', 'pipe', 'pipe'],
+            windowsHide: process.platform === 'win32'
+        })
+
+        const emitOutput = (data: Buffer | string) => {
+            const text = data.toString()
+            if (text) {
+                this.onOutput({ sessionId: this.sessionId, terminalId, data: text })
+            }
+            const active = this.terminals.get(terminalId)
+            if (active) {
+                this.markActivity(active)
+            }
+        }
+
+        proc.stdout.on('data', emitOutput)
+        proc.stderr.on('data', emitOutput)
+        proc.on('error', (error) => {
+            logger.debug('[TERMINAL] Python PTY bridge process error', { error })
+            this.emitError(terminalId, 'Terminal process failed.')
+            this.cleanup(terminalId)
+        })
+        proc.on('exit', (exitCode, signal) => {
+            this.onExit({
+                sessionId: this.sessionId,
+                terminalId,
+                code: exitCode ?? null,
+                signal: signal ?? null
+            })
+            this.cleanup(terminalId)
+        })
+
+        const writeControl = (payload: Record<string, unknown>) => {
+            if (!proc.stdin.destroyed) {
+                proc.stdin.write(`${JSON.stringify(payload)}\n`)
+            }
+        }
+
+        const terminal: TerminalHandle = {
+            write: (data: string) => writeControl({ type: 'write', data: Buffer.from(data).toString('base64') }),
+            resize: (nextCols: number, nextRows: number) => writeControl({ type: 'resize', cols: nextCols, rows: nextRows }),
+            close: () => {
+                writeControl({ type: 'close' })
+                try {
+                    if (!proc.stdin.destroyed) {
+                        proc.stdin.end()
+                    }
+                } catch (error) {
+                    logger.debug('[TERMINAL] Failed to close Python PTY stdin', { error })
+                }
+            }
+        }
+
+        const runtime: TerminalRuntime = {
+            terminalId,
+            cols,
+            rows,
+            proc: proc as ChildProcessWithoutNullStreams,
+            terminal,
+            idleTimer: null
+        }
+
+        this.terminals.set(terminalId, runtime)
+        this.markActivity(runtime)
+        this.onReady({ sessionId: this.sessionId, terminalId })
+    }
+
+    private createPipeTerminal(terminalId: string, cols: number, rows: number, cwd: string, shell: string): void {
+        const [command, ...args] = resolveTerminalCommand(shell)
+        const env = {
+            ...this.filteredEnv,
+            COLUMNS: String(cols),
+            LINES: String(rows)
+        }
+        const proc = spawn(command, args, {
+            cwd,
+            env,
+            stdio: ['pipe', 'pipe', 'pipe'],
+            windowsHide: process.platform === 'win32'
+        })
+
+        const emitOutput = (data: Buffer | string) => {
+            const text = data.toString()
+            if (text) {
+                this.onOutput({ sessionId: this.sessionId, terminalId, data: text })
+            }
+            const active = this.terminals.get(terminalId)
+            if (active) {
+                this.markActivity(active)
+            }
+        }
+
+        proc.stdout.on('data', emitOutput)
+        proc.stderr.on('data', emitOutput)
+        proc.on('error', (error) => {
+            logger.debug('[TERMINAL] Pipe terminal process error', { error })
+            this.emitError(terminalId, 'Terminal process failed.')
+            this.cleanup(terminalId)
+        })
+        proc.on('exit', (exitCode, signal) => {
+            this.onExit({
+                sessionId: this.sessionId,
+                terminalId,
+                code: exitCode ?? null,
+                signal: signal ?? null
+            })
+            this.cleanup(terminalId)
+        })
+
+        const terminal: TerminalHandle = {
+            write: (data: string) => {
+                if (!proc.stdin.destroyed) {
+                    proc.stdin.write(data)
+                }
+            },
+            resize: (nextCols: number, nextRows: number) => {
+                // Pipes cannot resize a pseudo terminal. Preserve dimensions for
+                // reconnect/idleness bookkeeping and expose them to child shells
+                // that consult COLUMNS/LINES before prompt redraws.
+                env.COLUMNS = String(nextCols)
+                env.LINES = String(nextRows)
+            },
+            close: () => {
+                try {
+                    if (!proc.stdin.destroyed) {
+                        proc.stdin.end()
+                    }
+                } catch (error) {
+                    logger.debug('[TERMINAL] Failed to close pipe stdin', { error })
+                }
+            }
+        }
+
+        const runtime: TerminalRuntime = {
+            terminalId,
+            cols,
+            rows,
+            proc: proc as ChildProcessWithoutNullStreams,
+            terminal,
+            idleTimer: null
+        }
+
+        this.terminals.set(terminalId, runtime)
+        this.markActivity(runtime)
+        this.onReady({ sessionId: this.sessionId, terminalId })
     }
 
     write(terminalId: string, data: string): void {
@@ -259,18 +562,18 @@ export class TerminalManager {
             clearTimeout(runtime.idleTimer)
         }
 
+        try {
+            runtime.terminal.close()
+        } catch (error) {
+            logger.debug('[TERMINAL] Failed to close terminal stream', { error })
+        }
+
         if (!runtime.proc.killed && runtime.proc.exitCode === null) {
             try {
                 runtime.proc.kill()
             } catch (error) {
                 logger.debug('[TERMINAL] Failed to kill process', { error })
             }
-        }
-
-        try {
-            runtime.terminal.close()
-        } catch (error) {
-            logger.debug('[TERMINAL] Failed to close terminal', { error })
         }
     }
 

--- a/cli/src/terminal/TerminalManager.ts
+++ b/cli/src/terminal/TerminalManager.ts
@@ -20,6 +20,7 @@ type TerminalRuntime = TerminalSession & {
     proc: { killed?: boolean; exitCode?: number | null; kill: () => unknown }
     terminal: TerminalHandle
     idleTimer: ReturnType<typeof setTimeout> | null
+    killOnCleanup: boolean
 }
 
 type TerminalManagerOptions = {
@@ -94,9 +95,18 @@ def terminate_child_group(sig=signal.SIGTERM):
     except OSError:
         pass
 
-def handle_bridge_signal(signum, _frame):
-    terminate_child_group(signal.SIGTERM)
+def shutdown_child_group(sig=signal.SIGTERM):
+    terminate_child_group(sig)
     close_master_fd()
+    if proc.poll() is None:
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            terminate_child_group(signal.SIGKILL)
+            proc.wait()
+
+def handle_bridge_signal(signum, _frame):
+    shutdown_child_group(signal.SIGTERM)
     os._exit(128 + signum)
 
 for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
@@ -153,12 +163,7 @@ while True:
 close_master_fd()
 
 if proc.poll() is None:
-    terminate_child_group()
-    try:
-        proc.wait(timeout=2)
-    except subprocess.TimeoutExpired:
-        terminate_child_group(signal.SIGKILL)
-        proc.wait()
+    shutdown_child_group()
 
 os._exit(proc.returncode if proc.returncode is not None else 0)
 `;
@@ -324,6 +329,9 @@ export class TerminalManager {
                 cols,
                 rows,
                 data: (_terminal, data) => {
+                    if (!this.isRuntimeProc(terminalId, proc)) {
+                        return
+                    }
                     const text = decoder.decode(data, { stream: true })
                     if (text) {
                         this.onOutput({ sessionId: this.sessionId, terminalId, data: text })
@@ -335,6 +343,9 @@ export class TerminalManager {
                 }
             },
             onExit: (subprocess, exitCode) => {
+                if (!this.isRuntimeProc(terminalId, proc)) {
+                    return
+                }
                 const signal = subprocess.signalCode ?? null
                 this.onExit({
                     sessionId: this.sessionId,
@@ -369,7 +380,8 @@ export class TerminalManager {
             rows,
             proc,
             terminal,
-            idleTimer: null
+            idleTimer: null,
+            killOnCleanup: true
         }
 
         this.terminals.set(terminalId, runtime)
@@ -397,6 +409,9 @@ export class TerminalManager {
         })
 
         const emitOutput = (data: Buffer | string) => {
+            if (!this.isRuntimeProc(terminalId, proc)) {
+                return
+            }
             const text = data.toString()
             if (text) {
                 this.onOutput({ sessionId: this.sessionId, terminalId, data: text })
@@ -410,11 +425,17 @@ export class TerminalManager {
         proc.stdout.on('data', emitOutput)
         proc.stderr.on('data', emitOutput)
         proc.on('error', (error) => {
+            if (!this.isRuntimeProc(terminalId, proc)) {
+                return
+            }
             logger.debug('[TERMINAL] Python PTY bridge process error', { error })
             this.emitError(terminalId, 'Terminal process failed.')
             this.cleanup(terminalId)
         })
         proc.on('exit', (exitCode, signal) => {
+            if (!this.isRuntimeProc(terminalId, proc)) {
+                return
+            }
             this.onExit({
                 sessionId: this.sessionId,
                 terminalId,
@@ -451,7 +472,8 @@ export class TerminalManager {
             rows,
             proc: proc as ChildProcessWithoutNullStreams,
             terminal,
-            idleTimer: null
+            idleTimer: null,
+            killOnCleanup: false
         }
 
         this.terminals.set(terminalId, runtime)
@@ -474,6 +496,9 @@ export class TerminalManager {
         })
 
         const emitOutput = (data: Buffer | string) => {
+            if (!this.isRuntimeProc(terminalId, proc)) {
+                return
+            }
             const text = data.toString()
             if (text) {
                 this.onOutput({ sessionId: this.sessionId, terminalId, data: text })
@@ -487,11 +512,17 @@ export class TerminalManager {
         proc.stdout.on('data', emitOutput)
         proc.stderr.on('data', emitOutput)
         proc.on('error', (error) => {
+            if (!this.isRuntimeProc(terminalId, proc)) {
+                return
+            }
             logger.debug('[TERMINAL] Pipe terminal process error', { error })
             this.emitError(terminalId, 'Terminal process failed.')
             this.cleanup(terminalId)
         })
         proc.on('exit', (exitCode, signal) => {
+            if (!this.isRuntimeProc(terminalId, proc)) {
+                return
+            }
             this.onExit({
                 sessionId: this.sessionId,
                 terminalId,
@@ -531,7 +562,8 @@ export class TerminalManager {
             rows,
             proc: proc as ChildProcessWithoutNullStreams,
             terminal,
-            idleTimer: null
+            idleTimer: null,
+            killOnCleanup: true
         }
 
         this.terminals.set(terminalId, runtime)
@@ -589,6 +621,10 @@ export class TerminalManager {
         }, this.idleTimeoutMs)
     }
 
+    private isRuntimeProc(terminalId: string, proc: unknown): boolean {
+        return this.terminals.get(terminalId)?.proc === proc
+    }
+
     private cleanup(terminalId: string): void {
         const runtime = this.terminals.get(terminalId)
         if (!runtime) {
@@ -606,7 +642,7 @@ export class TerminalManager {
             logger.debug('[TERMINAL] Failed to close terminal stream', { error })
         }
 
-        if (!runtime.proc.killed && runtime.proc.exitCode === null) {
+        if (runtime.killOnCleanup && !runtime.proc.killed && runtime.proc.exitCode === null) {
             try {
                 runtime.proc.kill()
             } catch (error) {


### PR DESCRIPTION
# Fix runner remote terminal disconnecting from web/mobile UI

Split out from the closed combined PR #618: https://github.com/tiann/hapi/pull/618

This PR contains only the runner remote-terminal PTY fix. The Codex/HAPI MCP startup fix is intentionally kept in a separate PR so each user-visible issue has its own root-cause discussion and review scope.

## Problem

This affects runner-managed remote terminals, especially when the hub and the runner are running on different machines. In that setup, users open a terminal from the web/mobile UI expecting to run commands on the runner machine.

On current `main`, the terminal can report ready and then immediately disconnect in daemon/headless runner environments. The user-visible result is that the web/mobile terminal cannot be used to run commands on the runner machine, which breaks the remote terminal workflow.

## Root cause

The current remote terminal implementation relies on Bun's `Bun.spawn(..., { terminal })` PTY path. In the runner daemon/headless path this can be unstable: the shell may receive `SIGHUP` shortly after the terminal is created, before user input is processed.

A pipe-only fallback is not enough because interactive shells and full-screen terminal apps need a real PTY, and resize events must reach the active PTY instead of only updating parent-side bookkeeping.

## Fix

Use platform-specific terminal creation:

- macOS keeps the existing Bun PTY path to preserve native PTY behavior.
- Linux/non-Darwin defaults to a small Python stdlib PTY bridge when `python3` or `python` is available.
- The Python bridge owns the PTY, forwards terminal input/output, applies resize with `TIOCSWINSZ`, and sends `SIGWINCH` to the child process group.
- `/usr/bin/script` / pipe spawning remains a last-resort fallback when Python is unavailable.

This gives runner-managed web/mobile terminals a real PTY that stays alive and handles resize correctly.

## Validation

- `bun run --cwd cli typecheck`
- `cd cli && bun x vitest run src/terminal/TerminalManager.test.ts`
