### PR TITLE
Fix CLI tests on Windows paths

### DIFF
--- a/cli/src/agent/backends/acp/AcpMessageHandler.test.ts
+++ b/cli/src/agent/backends/acp/AcpMessageHandler.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { AgentMessage } from '@/agent/types';
 import { AcpMessageHandler } from './AcpMessageHandler';
 import { ACP_SESSION_UPDATE_TYPES } from './constants';
@@ -1367,7 +1369,7 @@ describe('AcpMessageHandler', () => {
         // include rawInput in tool_call events and emits prose (non-JSON)
         // thoughts. There is therefore no JSON-thought-hoisting trigger —
         // tool_call input is null and the thought text surfaces as reasoning.
-        const fixtureDir = new URL('./__fixtures__', import.meta.url).pathname;
+        const fixtureDir = fileURLToPath(new URL('./__fixtures__', import.meta.url));
 
         const fixtures = [
             {
@@ -1375,14 +1377,14 @@ describe('AcpMessageHandler', () => {
                 // model expresses reasoning as a `kind: think` tool_call rather
                 // than as a thought chunk, so the reasoning channel is empty.
                 name: 'gemini-3-flash-preview / read_file',
-                file: `${fixtureDir}/gemini-3-flash-preview-read-file.json`,
+                file: join(fixtureDir, 'gemini-3-flash-preview-read-file.json'),
                 expectedMinToolCalls: 2,
                 expectedMinReasoning: 0,
                 hasMessageChunks: true,
             },
             {
                 name: 'gemini-3-flash-preview / run_shell',
-                file: `${fixtureDir}/gemini-3-flash-preview-run-shell.json`,
+                file: join(fixtureDir, 'gemini-3-flash-preview-run-shell.json'),
                 expectedMinToolCalls: 1,
                 expectedMinReasoning: 1,
                 hasMessageChunks: true,
@@ -1391,7 +1393,7 @@ describe('AcpMessageHandler', () => {
                 // write_file: kind=edit, locations carries the file path.
                 // Same shape (and zero thought chunks) as read_file.
                 name: 'gemini-3-flash-preview / write_file',
-                file: `${fixtureDir}/gemini-3-flash-preview-write-file.json`,
+                file: join(fixtureDir, 'gemini-3-flash-preview-write-file.json'),
                 expectedMinToolCalls: 2,
                 expectedMinReasoning: 0,
                 hasMessageChunks: true,
@@ -1399,7 +1401,7 @@ describe('AcpMessageHandler', () => {
             {
                 // replace (in-place edit): same kind=edit + locations pattern.
                 name: 'gemini-3-flash-preview / edit_file',
-                file: `${fixtureDir}/gemini-3-flash-preview-edit-file.json`,
+                file: join(fixtureDir, 'gemini-3-flash-preview-edit-file.json'),
                 expectedMinToolCalls: 2,
                 expectedMinReasoning: 0,
                 hasMessageChunks: true,
@@ -1411,7 +1413,7 @@ describe('AcpMessageHandler', () => {
             // assertions below match the flash captures.
             {
                 name: 'gemini-3.1-pro-preview / read_file',
-                file: `${fixtureDir}/gemini-3.1-pro-preview-read-file.json`,
+                file: join(fixtureDir, 'gemini-3.1-pro-preview-read-file.json'),
                 expectedMinToolCalls: 2,
                 expectedMinReasoning: 0,
                 hasMessageChunks: true,
@@ -1420,7 +1422,7 @@ describe('AcpMessageHandler', () => {
                 // run_shell: pro emits a single agent_thought_chunk in addition
                 // to the execute tool_call.
                 name: 'gemini-3.1-pro-preview / run_shell',
-                file: `${fixtureDir}/gemini-3.1-pro-preview-run-shell.json`,
+                file: join(fixtureDir, 'gemini-3.1-pro-preview-run-shell.json'),
                 expectedMinToolCalls: 1,
                 expectedMinReasoning: 1,
                 hasMessageChunks: true,
@@ -1428,7 +1430,7 @@ describe('AcpMessageHandler', () => {
             {
                 // write_file: kind=edit, locations carries the file path.
                 name: 'gemini-3.1-pro-preview / write_file',
-                file: `${fixtureDir}/gemini-3.1-pro-preview-write-file.json`,
+                file: join(fixtureDir, 'gemini-3.1-pro-preview-write-file.json'),
                 expectedMinToolCalls: 1,
                 expectedMinReasoning: 0,
                 hasMessageChunks: true,
@@ -1437,7 +1439,7 @@ describe('AcpMessageHandler', () => {
                 // replace (in-place edit): pro version interleaves think + read
                 // + edit kinds before the final agent_message_chunk burst.
                 name: 'gemini-3.1-pro-preview / edit_file',
-                file: `${fixtureDir}/gemini-3.1-pro-preview-edit-file.json`,
+                file: join(fixtureDir, 'gemini-3.1-pro-preview-edit-file.json'),
                 expectedMinToolCalls: 2,
                 expectedMinReasoning: 0,
                 hasMessageChunks: true,
@@ -1786,9 +1788,9 @@ describe('AcpMessageHandler', () => {
 
         it('replays write_file fixture and produces Write-shaped tool_call input', () => {
             // Integration: full fixture replay must produce Write with {file_path, content}
-            const fixtureDir = new URL('./__fixtures__', import.meta.url).pathname;
+            const fixtureDir = fileURLToPath(new URL('./__fixtures__', import.meta.url));
             // eslint-disable-next-line @typescript-eslint/no-require-imports
-            const data = require(`${fixtureDir}/gemini-3-flash-preview-write-file.json`) as {
+            const data = require(join(fixtureDir, 'gemini-3-flash-preview-write-file.json')) as {
                 updates: unknown[];
             };
 
@@ -1814,9 +1816,9 @@ describe('AcpMessageHandler', () => {
 
         it('replays edit_file fixture and produces Edit-shaped tool_call input', () => {
             // Integration: full fixture replay must produce Edit with {file_path, old_string, new_string}
-            const fixtureDir = new URL('./__fixtures__', import.meta.url).pathname;
+            const fixtureDir = fileURLToPath(new URL('./__fixtures__', import.meta.url));
             // eslint-disable-next-line @typescript-eslint/no-require-imports
-            const data = require(`${fixtureDir}/gemini-3-flash-preview-edit-file.json`) as {
+            const data = require(join(fixtureDir, 'gemini-3-flash-preview-edit-file.json')) as {
                 updates: unknown[];
             };
 

--- a/cli/src/claude/utils/path.test.ts
+++ b/cli/src/claude/utils/path.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getProjectPath } from './path';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 vi.mock('node:os', () => ({
     homedir: vi.fn(() => '/home/user')
@@ -8,6 +8,14 @@ vi.mock('node:os', () => ({
 
 // Store original env
 const originalEnv = process.env;
+
+function expectedProjectPath(workingDir: string, claudeConfigDir = join('/home/user', '.claude')): string {
+    return join(
+        claudeConfigDir,
+        'projects',
+        resolve(workingDir).replace(/[^a-zA-Z0-9]/g, '-')
+    );
+}
 
 describe('getProjectPath', () => {
     beforeEach(() => {
@@ -23,25 +31,25 @@ describe('getProjectPath', () => {
     it('should replace slashes with hyphens in the project path', () => {
         const workingDir = '/Users/steve/projects/my-app';
         const result = getProjectPath(workingDir);
-        expect(result).toBe(join('/home/user', '.claude', 'projects', '-Users-steve-projects-my-app'));
+        expect(result).toBe(expectedProjectPath(workingDir));
     });
 
     it('should replace dots with hyphens in the project path', () => {
         const workingDir = '/Users/steve/projects/app.test.js';
         const result = getProjectPath(workingDir);
-        expect(result).toBe(join('/home/user', '.claude', 'projects', '-Users-steve-projects-app-test-js'));
+        expect(result).toBe(expectedProjectPath(workingDir));
     });
 
     it('should handle paths with both slashes and dots', () => {
         const workingDir = '/var/www/my.site.com/public';
         const result = getProjectPath(workingDir);
-        expect(result).toBe(join('/home/user', '.claude', 'projects', '-var-www-my-site-com-public'));
+        expect(result).toBe(expectedProjectPath(workingDir));
     });
 
     it('should replace underscores with hyphens in the project path', () => {
         const workingDir = '/data/github/hapi__worktrees/ime';
         const result = getProjectPath(workingDir);
-        expect(result).toBe(join('/home/user', '.claude', 'projects', '-data-github-hapi--worktrees-ime'));
+        expect(result).toBe(expectedProjectPath(workingDir));
     });
 
     it('should handle relative paths by resolving them first', () => {
@@ -61,35 +69,35 @@ describe('getProjectPath', () => {
         it('should use default .claude directory when CLAUDE_CONFIG_DIR is not set', () => {
             const workingDir = '/Users/steve/projects/my-app';
             const result = getProjectPath(workingDir);
-            expect(result).toBe(join('/home/user', '.claude', 'projects', '-Users-steve-projects-my-app'));
+            expect(result).toBe(expectedProjectPath(workingDir));
         });
 
         it('should use CLAUDE_CONFIG_DIR when set', () => {
             process.env.CLAUDE_CONFIG_DIR = '/custom/claude/config';
             const workingDir = '/Users/steve/projects/my-app';
             const result = getProjectPath(workingDir);
-            expect(result).toBe(join('/custom/claude/config', 'projects', '-Users-steve-projects-my-app'));
+            expect(result).toBe(expectedProjectPath(workingDir, '/custom/claude/config'));
         });
 
         it('should handle relative CLAUDE_CONFIG_DIR path', () => {
             process.env.CLAUDE_CONFIG_DIR = './config/claude';
             const workingDir = '/Users/steve/projects/my-app';
             const result = getProjectPath(workingDir);
-            expect(result).toBe(join('./config/claude', 'projects', '-Users-steve-projects-my-app'));
+            expect(result).toBe(expectedProjectPath(workingDir, './config/claude'));
         });
 
         it('should fallback to default when CLAUDE_CONFIG_DIR is empty string', () => {
             process.env.CLAUDE_CONFIG_DIR = '';
             const workingDir = '/Users/steve/projects/my-app';
             const result = getProjectPath(workingDir);
-            expect(result).toBe(join('/home/user', '.claude', 'projects', '-Users-steve-projects-my-app'));
+            expect(result).toBe(expectedProjectPath(workingDir));
         });
 
         it('should handle CLAUDE_CONFIG_DIR with trailing slash', () => {
             process.env.CLAUDE_CONFIG_DIR = '/custom/claude/config/';
             const workingDir = '/Users/steve/projects/my-app';
             const result = getProjectPath(workingDir);
-            expect(result).toBe(join('/custom/claude/config/', 'projects', '-Users-steve-projects-my-app'));
+            expect(result).toBe(expectedProjectPath(workingDir, '/custom/claude/config/'));
         });
     });
 });

--- a/cli/src/claude/utils/sessionScanner.test.ts
+++ b/cli/src/claude/utils/sessionScanner.test.ts
@@ -5,6 +5,7 @@ import { mkdir, writeFile, appendFile, rm, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
 import { existsSync } from 'node:fs'
+import { getProjectPath } from './path'
 
 describe('sessionScanner', () => {
   let testDir: string
@@ -16,8 +17,7 @@ describe('sessionScanner', () => {
     testDir = join(tmpdir(), `scanner-test-${Date.now()}`)
     await mkdir(testDir, { recursive: true })
     
-    const projectName = testDir.replace(/\//g, '-')
-    projectDir = join(homedir(), '.claude', 'projects', projectName)
+    projectDir = getProjectPath(testDir)
     await mkdir(projectDir, { recursive: true })
     
     collectedMessages = []


### PR DESCRIPTION
## Summary
- make Claude project path expectations follow the platform-specific `resolve()` result
- build session scanner fixture directories with `getProjectPath()` instead of POSIX-only string replacement
- load ACP JSON fixtures via `fileURLToPath()` and `join()` so Windows drive-letter paths work correctly

## Why
Several CLI tests assumed POSIX-style paths. On Windows, absolute paths include a drive letter and backslashes, and `new URL(...).pathname` produces `/D:/...` paths that cannot be required directly.

## Validation
- `bun run test -- src/claude/utils/path.test.ts src/claude/utils/sessionScanner.test.ts src/agent/backends/acp/AcpMessageHandler.test.ts` in `cli`
- `bun run typecheck:cli`