### PR TITLE
  feat: support Codex local goal sync and remote approvals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1067,6 +1067,8 @@
 
     "@twsxtd/hapi-win32-x64": ["@twsxtd/hapi-win32-x64@0.18.3", "", { "os": "win32", "cpu": "x64", "bin": { "hapi": "bin/hapi.exe" } }, "sha512-kEG8tH5OcY/dRBpqbLmb3q2CS0UiM9L3OQX0LWvCn1aI3JQKaaZvzXElCXuwiIml0AI4fBAfofzUB/E31lxffw=="],
 
+    "@twsxtd/hapi-win32-x64": ["@twsxtd/hapi-win32-x64@0.18.3", "", { "os": "win32", "cpu": "x64", "bin": { "hapi": "bin/hapi.exe" } }, "sha512-kEG8tH5OcY/dRBpqbLmb3q2CS0UiM9L3OQX0LWvCn1aI3JQKaaZvzXElCXuwiIml0AI4fBAfofzUB/E31lxffw=="],
+
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],

--- a/cli/src/claude/utils/sessionHookForwarder.ts
+++ b/cli/src/claude/utils/sessionHookForwarder.ts
@@ -19,9 +19,18 @@ function parsePort(value: string | undefined): number | null {
     return port;
 }
 
-function parseArgs(args: string[]): { port: number | null; token: string | null } {
+function parsePath(value: string | undefined): string | null {
+    if (!value || !value.startsWith('/')) {
+        return null;
+    }
+
+    return value;
+}
+
+function parseArgs(args: string[]): { port: number | null; token: string | null; path: string } {
     let port: number | null = null;
     let token: string | null = null;
+    let path = '/hook/session-start';
 
     for (let i = 0; i < args.length; i += 1) {
         const arg = args[i];
@@ -51,6 +60,17 @@ function parseArgs(args: string[]): { port: number | null; token: string | null 
             continue;
         }
 
+        if (arg === '--path') {
+            path = parsePath(args[i + 1]) ?? path;
+            i += 1;
+            continue;
+        }
+
+        if (arg.startsWith('--path=')) {
+            path = parsePath(arg.slice('--path='.length)) ?? path;
+            continue;
+        }
+
         if (!port) {
             port = parsePort(arg);
             continue;
@@ -61,11 +81,11 @@ function parseArgs(args: string[]): { port: number | null; token: string | null 
         }
     }
 
-    return { port, token };
+    return { port, token, path };
 }
 
 export async function runSessionHookForwarder(args: string[]): Promise<void> {
-    const { port, token } = parseArgs(args);
+    const { port, token, path } = parseArgs(args);
     if (!port) {
         logError('Invalid or missing port argument');
         process.exitCode = 1;
@@ -97,7 +117,7 @@ export async function runSessionHookForwarder(args: string[]): Promise<void> {
                 host: '127.0.0.1',
                 port,
                 method: 'POST',
-                path: '/hook/session-start',
+                path,
                 headers: {
                     'Content-Type': 'application/json',
                     'Content-Length': body.length,
@@ -108,13 +128,21 @@ export async function runSessionHookForwarder(args: string[]): Promise<void> {
                     hadError = true;
                     logError(`Hook server responded with status ${res.statusCode}`);
                 }
+                const responseChunks: Buffer[] = [];
+                res.on('data', (chunk) => {
+                    responseChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+                });
                 res.on('error', (error) => {
                     hadError = true;
                     logError('Error reading hook server response', error);
                     resolve();
                 });
-                res.on('end', () => resolve());
-                res.resume();
+                res.on('end', () => {
+                    if (path !== '/hook/session-start' && responseChunks.length > 0) {
+                        process.stdout.write(Buffer.concat(responseChunks));
+                    }
+                    resolve();
+                });
             });
 
             req.on('error', (error) => {

--- a/cli/src/claude/utils/startHookServer.test.ts
+++ b/cli/src/claude/utils/startHookServer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { request } from 'node:http'
 import { startHookServer, type SessionHookData } from './startHookServer'
 
-const sendHookRequest = async (port: number, body: string, token?: string): Promise<{ statusCode?: number; body: string }> => {
+const sendHookRequest = async (port: number, body: string, token?: string, path = '/hook/session-start'): Promise<{ statusCode?: number; body: string }> => {
     return await new Promise((resolve, reject) => {
         const headers: Record<string, string | number> = {
             'Content-Type': 'application/json',
@@ -15,7 +15,7 @@ const sendHookRequest = async (port: number, body: string, token?: string): Prom
         const req = request({
             host: '127.0.0.1',
             port,
-            path: '/hook/session-start',
+            path,
             method: 'POST',
             headers
         }, (res) => {
@@ -113,5 +113,45 @@ describe('startHookServer', () => {
         }
 
         expect(hookCalled).toBe(false)
+    })
+
+    it('returns PermissionRequest hook output from callback', async () => {
+        const received: SessionHookData[] = []
+        const server = await startHookServer({
+            onSessionHook: () => {},
+            onPermissionRequest: async (data) => {
+                received.push(data)
+                return {
+                    hookSpecificOutput: {
+                        hookEventName: 'PermissionRequest',
+                        decision: {
+                            behavior: 'allow'
+                        }
+                    }
+                }
+            }
+        })
+
+        try {
+            const body = JSON.stringify({
+                hook_event_name: 'PermissionRequest',
+                tool_name: 'Bash',
+                tool_input: { command: 'pwd' }
+            })
+            const response = await sendHookRequest(server.port, body, server.token, '/hook/permission-request')
+            expect(response.statusCode).toBe(200)
+            expect(JSON.parse(response.body)).toEqual({
+                hookSpecificOutput: {
+                    hookEventName: 'PermissionRequest',
+                    decision: {
+                        behavior: 'allow'
+                    }
+                }
+            })
+        } finally {
+            server.stop()
+        }
+
+        expect(received[0]?.tool_name).toBe('Bash')
     })
 })

--- a/cli/src/claude/utils/startHookServer.ts
+++ b/cli/src/claude/utils/startHookServer.ts
@@ -25,6 +25,8 @@ export interface SessionHookData {
 export interface HookServerOptions {
     /** Called when a session hook is received with a valid session ID. */
     onSessionHook: (sessionId: string, data: SessionHookData) => void;
+    /** Called when a Codex PermissionRequest hook asks for an approval decision. */
+    onPermissionRequest?: (data: SessionHookData) => Promise<Record<string, unknown>>;
     /** Optional token to require for hook requests. */
     token?: string;
 }
@@ -50,13 +52,68 @@ function readHookToken(req: IncomingMessage): string | null {
  * Start a dedicated HTTP server for receiving Claude session hooks.
  */
 export async function startHookServer(options: HookServerOptions): Promise<HookServer> {
-    const { onSessionHook } = options;
+    const { onSessionHook, onPermissionRequest } = options;
     const hookToken = options.token || randomBytes(16).toString('hex');
 
     return new Promise((resolve, reject) => {
+        async function readJsonBody(
+            req: IncomingMessage,
+            res: ServerResponse,
+            timeoutMs: number
+        ): Promise<SessionHookData | null> {
+            let timedOut = false;
+            const timeout = setTimeout(() => {
+                timedOut = true;
+                if (!res.headersSent) {
+                    logger.debug('[hookServer] Request timeout');
+                    res.writeHead(408).end('timeout');
+                }
+                req.destroy(new Error('Request timeout'));
+            }, timeoutMs);
+
+            try {
+                const chunks: Buffer[] = [];
+                for await (const chunk of req) {
+                    chunks.push(chunk as Buffer);
+                }
+                clearTimeout(timeout);
+
+                if (timedOut || res.headersSent || res.writableEnded) {
+                    return null;
+                }
+
+                const body = Buffer.concat(chunks).toString('utf-8');
+                logger.debug('[hookServer] Received hook:', body);
+
+                try {
+                    const parsed = JSON.parse(body);
+                    if (!parsed || typeof parsed !== 'object') {
+                        logger.debug('[hookServer] Parsed hook data is not an object');
+                        res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
+                        return null;
+                    }
+                    return parsed as SessionHookData;
+                } catch (parseError) {
+                    logger.debug('[hookServer] Failed to parse hook data as JSON:', parseError);
+                    res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
+                    return null;
+                }
+            } catch (error) {
+                clearTimeout(timeout);
+                if (timedOut) {
+                    return null;
+                }
+                logger.debug('[hookServer] Error reading hook request:', error);
+                if (!res.headersSent && !res.writableEnded) {
+                    res.writeHead(500).end('error');
+                }
+                return null;
+            }
+        }
+
         const server: Server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
             const requestPath = req.url?.split('?')[0];
-            if (req.method === 'POST' && requestPath === '/hook/session-start') {
+            if (req.method === 'POST' && (requestPath === '/hook/session-start' || requestPath === '/hook/permission-request')) {
                 const providedToken = readHookToken(req);
                 if (providedToken !== hookToken) {
                     logger.debug('[hookServer] Unauthorized hook request');
@@ -65,45 +122,13 @@ export async function startHookServer(options: HookServerOptions): Promise<HookS
                     return;
                 }
 
-                let timedOut = false;
-                const timeout = setTimeout(() => {
-                    timedOut = true;
-                    if (!res.headersSent) {
-                        logger.debug('[hookServer] Request timeout');
-                        res.writeHead(408).end('timeout');
-                    }
-                    req.destroy(new Error('Request timeout'));
-                }, 5000);
+                const timeoutMs = requestPath === '/hook/permission-request' ? 10 * 60 * 1000 : 5000;
+                const data = await readJsonBody(req, res, timeoutMs);
+                if (!data) {
+                    return;
+                }
 
-                try {
-                    const chunks: Buffer[] = [];
-                    for await (const chunk of req) {
-                        chunks.push(chunk as Buffer);
-                    }
-                    clearTimeout(timeout);
-
-                    if (timedOut || res.headersSent || res.writableEnded) {
-                        return;
-                    }
-
-                    const body = Buffer.concat(chunks).toString('utf-8');
-                    logger.debug('[hookServer] Received session hook:', body);
-
-                    let data: SessionHookData = {};
-                    try {
-                        const parsed = JSON.parse(body);
-                        if (!parsed || typeof parsed !== 'object') {
-                            logger.debug('[hookServer] Parsed hook data is not an object');
-                            res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
-                            return;
-                        }
-                        data = parsed as SessionHookData;
-                    } catch (parseError) {
-                        logger.debug('[hookServer] Failed to parse hook data as JSON:', parseError);
-                        res.writeHead(400, { 'Content-Type': 'text/plain' }).end('invalid json');
-                        return;
-                    }
-
+                if (requestPath === '/hook/session-start') {
                     const sessionId = data.session_id || data.sessionId;
                     if (sessionId) {
                         logger.debug(`[hookServer] Session hook received session ID: ${sessionId}`);
@@ -117,14 +142,33 @@ export async function startHookServer(options: HookServerOptions): Promise<HookS
                     if (!res.headersSent && !res.writableEnded) {
                         res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ok');
                     }
-                } catch (error) {
-                    clearTimeout(timeout);
-                    if (timedOut) {
-                        return;
-                    }
-                    logger.debug('[hookServer] Error handling session hook:', error);
+                    return;
+                }
+
+                if (!onPermissionRequest) {
+                    logger.debug('[hookServer] Permission hook received but no handler is registered');
+                    res.writeHead(503, { 'Content-Type': 'text/plain' }).end('permission handler unavailable');
+                    return;
+                }
+
+                try {
+                    const result = await onPermissionRequest(data);
                     if (!res.headersSent && !res.writableEnded) {
-                        res.writeHead(500).end('error');
+                        res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify(result));
+                    }
+                } catch (error) {
+                    logger.debug('[hookServer] Error handling permission hook:', error);
+                    if (!res.headersSent && !res.writableEnded) {
+                        const reason = error instanceof Error ? error.message : 'Permission request failed';
+                        res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify({
+                            hookSpecificOutput: {
+                                hookEventName: 'PermissionRequest',
+                                decision: {
+                                    behavior: 'deny',
+                                    message: reason
+                                }
+                            }
+                        }));
                     }
                 }
                 return;

--- a/cli/src/codex/codexLocal.test.ts
+++ b/cli/src/codex/codexLocal.test.ts
@@ -70,6 +70,10 @@ describe('codexLocal', () => {
             sessionHook: {
                 port: 63996,
                 token: 'secret-token'
+            },
+            permissionHook: {
+                port: 63996,
+                token: 'secret-token'
             }
         });
 
@@ -90,6 +94,9 @@ describe('codexLocal', () => {
         const hookArg = args.find((arg) => arg.startsWith('hooks.SessionStart='));
         expect(hookArg).toBeDefined();
         expect(hookArg).toContain('{ hooks = [{ type = "command", command = "');
+        const permissionHookArg = args.find((arg) => arg.startsWith('hooks.PermissionRequest='));
+        expect(permissionHookArg).toBeDefined();
+        expect(permissionHookArg).toContain('--path /hook/permission-request');
         expect(args).toContain("mcp_servers.hapi.args=['mcp','--url','http://127.0.0.1:63995/']");
     });
 

--- a/cli/src/codex/codexLocal.ts
+++ b/cli/src/codex/codexLocal.ts
@@ -4,6 +4,7 @@ import {
     buildMcpServerConfigArgs,
     buildDeveloperInstructionsArg,
     buildSessionStartHookConfigArgs,
+    buildPermissionRequestHookConfigArgs,
     buildModelReasoningEffortConfigArgs
 } from './utils/codexMcpConfig';
 import { codexSystemPrompt } from './utils/systemPrompt';
@@ -42,6 +43,10 @@ export async function codexLocal(opts: {
         port: number;
         token: string;
     };
+    permissionHook?: {
+        port: number;
+        token: string;
+    };
 }): Promise<void> {
     const args: string[] = [];
 
@@ -69,6 +74,10 @@ export async function codexLocal(opts: {
 
     if (opts.sessionHook) {
         args.push(...buildSessionStartHookConfigArgs(opts.sessionHook.port, opts.sessionHook.token));
+    }
+
+    if (opts.permissionHook) {
+        args.push(...buildPermissionRequestHookConfigArgs(opts.permissionHook.port, opts.permissionHook.token));
     }
 
     // Add developer instructions (system prompt)

--- a/cli/src/codex/codexLocalLauncher.test.ts
+++ b/cli/src/codex/codexLocalLauncher.test.ts
@@ -93,7 +93,8 @@ function createSessionStub(
             client: {
                 rpcHandlerManager: {
                     registerHandler: () => {}
-                }
+                },
+                updateAgentState: () => {}
             },
             getPermissionMode: () => permissionMode,
             getModelReasoningEffort: () => null,
@@ -345,6 +346,48 @@ describe('codexLocalLauncher', () => {
             type: 'message',
             message: 'hello from transcript',
             id: expect.any(String)
+        });
+    });
+
+    it('syncs app-server transcript events while running local Codex', async () => {
+        const transcriptPath = join(tempDir, 'codex-app-server-transcript.jsonl');
+        const { session, agentMessages } = createSessionStub('default');
+        let releaseRunBarrier: (() => void) | undefined;
+        harness.runBarrier = new Promise((resolve) => {
+            releaseRunBarrier = resolve;
+        });
+
+        await writeFile(
+            transcriptPath,
+            JSON.stringify({ type: 'session_meta', payload: { id: 'codex-thread-1' } }) + '\n'
+        );
+
+        const launcherPromise = codexLocalLauncher(session as never);
+        await wait(50);
+
+        harness.sessionHookHandlers[0]?.('codex-thread-1', {
+            transcript_path: transcriptPath
+        });
+        await wait(100);
+
+        await appendFile(
+            transcriptPath,
+            [
+                JSON.stringify({ type: 'item/agentMessage/delta', payload: { itemId: 'msg-1', delta: 'Goal is ' } }),
+                JSON.stringify({ type: 'item/agentMessage/delta', payload: { itemId: 'msg-1', delta: 'running' } }),
+                JSON.stringify({ type: 'item/completed', payload: { item: { id: 'msg-1', type: 'agentMessage' } } })
+            ].join('\n') + '\n'
+        );
+
+        await wait(700);
+        if (releaseRunBarrier) {
+            releaseRunBarrier();
+        }
+        await launcherPromise;
+
+        expect(agentMessages).toContainEqual({
+            type: 'agent_message',
+            message: 'Goal is running'
         });
     });
 

--- a/cli/src/codex/codexLocalLauncher.ts
+++ b/cli/src/codex/codexLocalLauncher.ts
@@ -4,11 +4,51 @@ import { codexLocal } from './codexLocal';
 import type { ReasoningEffort } from './appServerTypes';
 import { CodexSession } from './session';
 import { createCodexSessionScanner, type CodexSessionScanner } from './utils/codexSessionScanner';
-import { convertCodexEvent } from './utils/codexEventConverter';
+import { CodexTranscriptEventConverter } from './utils/codexEventConverter';
 import { buildHapiMcpBridge } from './utils/buildHapiMcpBridge';
 import { stripCodexCliOverrides } from './utils/codexCliOverrides';
 import { buildCodexPermissionModeCliArgs } from './utils/permissionModeConfig';
+import { CodexPermissionHandler } from './utils/permissionHandler';
 import { BaseLocalLauncher } from '@/modules/common/launcher/BaseLocalLauncher';
+import type { CodexPermissionMode } from '@hapi/protocol/types';
+
+function asRecord(value: unknown): Record<string, unknown> {
+    return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+}
+
+function codexPermissionHookResponse(decision: 'approved' | 'approved_for_session' | 'denied' | 'abort', reason?: string): Record<string, unknown> {
+    if (decision === 'approved' || decision === 'approved_for_session') {
+        return {
+            hookSpecificOutput: {
+                hookEventName: 'PermissionRequest',
+                decision: {
+                    behavior: 'allow'
+                }
+            }
+        };
+    }
+
+    return {
+        hookSpecificOutput: {
+            hookEventName: 'PermissionRequest',
+            decision: {
+                behavior: 'deny',
+                message: reason ?? (decision === 'abort' ? 'Permission request aborted' : 'Permission request denied')
+            }
+        }
+    };
+}
+
+function codexPermissionMode(sessionMode: ReturnType<CodexSession['getPermissionMode']>): CodexPermissionMode {
+    switch (sessionMode) {
+        case 'read-only':
+        case 'safe-yolo':
+        case 'yolo':
+            return sessionMode;
+        default:
+            return 'default';
+    }
+}
 
 export async function codexLocalLauncher(session: CodexSession): Promise<'switch' | 'exit'> {
     const resumeSessionId = session.sessionId;
@@ -18,7 +58,9 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
     let hookReady = false;
     let shuttingDown = false;
     let pendingScannerSetup: Promise<void> | null = null;
+    const transcriptEventConverter = new CodexTranscriptEventConverter();
     const permissionMode = session.getPermissionMode();
+    const permissionHandler = new CodexPermissionHandler(session.client, () => codexPermissionMode(session.getPermissionMode()));
     const managedPermissionMode = permissionMode === 'read-only' || permissionMode === 'safe-yolo' || permissionMode === 'yolo'
         ? permissionMode
         : null;
@@ -79,6 +121,7 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
         }
         if (scanner) {
             await scanner.setTranscriptPath(transcriptPath);
+            transcriptEventConverter.reset();
             return;
         }
         const createdScanner = await createCodexSessionScanner({
@@ -91,19 +134,21 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
                 session.onSessionFound(sessionId);
             },
             onEvent: (event) => {
-                const converted = convertCodexEvent(event);
-                if (converted?.sessionId) {
-                    if (!isPrimarySessionId(converted.sessionId)) {
-                        logger.debug(`[codex-local]: Ignoring converted session id ${converted.sessionId}; primary is ${primarySessionId}`);
-                        return;
+                const convertedEvents = transcriptEventConverter.convert(event);
+                for (const converted of convertedEvents) {
+                    if (converted.sessionId) {
+                        if (!isPrimarySessionId(converted.sessionId)) {
+                            logger.debug(`[codex-local]: Ignoring converted session id ${converted.sessionId}; primary is ${primarySessionId}`);
+                            continue;
+                        }
+                        session.onSessionFound(converted.sessionId);
                     }
-                    session.onSessionFound(converted.sessionId);
-                }
-                if (converted?.userMessage) {
-                    session.sendUserMessage(converted.userMessage);
-                }
-                if (converted?.message) {
-                    session.sendAgentMessage(converted.message);
+                    if (converted.userMessage) {
+                        session.sendUserMessage(converted.userMessage);
+                    }
+                    if (converted.message) {
+                        session.sendAgentMessage(converted.message);
+                    }
                 }
             }
         });
@@ -154,6 +199,36 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
                 return;
             }
             handleSessionHook(sessionId, data);
+        },
+        onPermissionRequest: async (data) => {
+            if (shuttingDown) {
+                return codexPermissionHookResponse('abort', 'Session is shutting down');
+            }
+
+            const toolName = typeof data.tool_name === 'string' && data.tool_name.length > 0
+                ? data.tool_name
+                : 'CodexTool';
+            const toolInput = asRecord(data.tool_input);
+            const toolCallId = [
+                typeof data.session_id === 'string' ? data.session_id : null,
+                typeof data.turn_id === 'string' ? data.turn_id : null,
+                toolName,
+                typeof toolInput.command === 'string' ? toolInput.command : null
+            ].filter(Boolean).join(':') || `${toolName}:${Date.now()}`;
+
+            const result = await permissionHandler.handleToolCall(
+                toolCallId,
+                toolName === 'Bash' ? 'CodexBash' : toolName === 'Edit' ? 'CodexPatch' : `Codex${toolName}`,
+                {
+                    message: typeof toolInput.description === 'string' ? toolInput.description : undefined,
+                    command: toolInput.command,
+                    cwd: typeof data.cwd === 'string' ? data.cwd : undefined,
+                    hookEventName: data.hook_event_name,
+                    permissionMode: data.permission_mode
+                }
+            );
+
+            return codexPermissionHookResponse(result.decision, result.reason);
         }
     });
     logger.debug(`[codex-local]: Started Codex SessionStart hook server on port ${hookServer.port}`);
@@ -175,6 +250,10 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
                 codexArgs,
                 mcpServers,
                 sessionHook: {
+                    port: hookServer.port,
+                    token: hookServer.token
+                },
+                permissionHook: {
                     port: hookServer.port,
                     token: hookServer.token
                 }
@@ -209,6 +288,7 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
         if (activeScanner) {
             await activeScanner.cleanup();
         }
+        permissionHandler.reset();
         happyServer.stop();
         if (!hookReady) {
             logger.debug('[codex-local]: SessionStart hook did not provide transcript path before shutdown');

--- a/cli/src/codex/utils/appServerEventConverter.ts
+++ b/cli/src/codex/utils/appServerEventConverter.ts
@@ -1,6 +1,6 @@
 import { logger } from '@/ui/logger';
 
-type ConvertedEvent = {
+export type ConvertedEvent = {
     type: string;
     [key: string]: unknown;
 };

--- a/cli/src/codex/utils/codexEventConverter.test.ts
+++ b/cli/src/codex/utils/codexEventConverter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { convertCodexEvent } from './codexEventConverter';
+import { CodexTranscriptEventConverter, convertCodexEvent } from './codexEventConverter';
 
 describe('convertCodexEvent', () => {
     it('extracts session_meta id', () => {
@@ -90,5 +90,128 @@ describe('convertCodexEvent', () => {
             callId: 'call-2',
             output: { ok: true }
         });
+    });
+
+    it('converts thread goal update events from local transcript sync', () => {
+        const goal = {
+            threadId: 'thread-1',
+            objective: 'ship goal support',
+            status: 'active',
+            tokenBudget: null,
+            tokensUsed: 42,
+            timeUsedSeconds: 7,
+            createdAt: 1,
+            updatedAt: 2
+        };
+
+        const result = convertCodexEvent({
+            type: 'event_msg',
+            payload: {
+                type: 'thread_goal_updated',
+                thread_id: 'thread-1',
+                turn_id: 'turn-1',
+                goal
+            }
+        });
+
+        expect(result?.message).toEqual({
+            type: 'thread_goal_updated',
+            thread_id: 'thread-1',
+            turn_id: 'turn-1',
+            goal
+        });
+    });
+
+    it('converts thread goal clear events from local transcript sync', () => {
+        const result = convertCodexEvent({
+            type: 'event_msg',
+            payload: {
+                type: 'thread_goal_cleared',
+                thread_id: 'thread-1'
+            }
+        });
+
+        expect(result?.message).toEqual({
+            type: 'thread_goal_cleared',
+            thread_id: 'thread-1'
+        });
+    });
+});
+
+describe('CodexTranscriptEventConverter', () => {
+    it('accumulates app-server agent message deltas from local transcript sync', () => {
+        const converter = new CodexTranscriptEventConverter();
+
+        expect(converter.convert({
+            type: 'item/agentMessage/delta',
+            payload: { itemId: 'msg-1', delta: 'Hello' }
+        })).toEqual([]);
+        expect(converter.convert({
+            type: 'item/agentMessage/delta',
+            payload: { itemId: 'msg-1', delta: ' world' }
+        })).toEqual([]);
+
+        expect(converter.convert({
+            type: 'item/completed',
+            payload: {
+                item: { id: 'msg-1', type: 'agentMessage' }
+            }
+        })).toEqual([{
+            message: {
+                type: 'agent_message',
+                message: 'Hello world'
+            }
+        }]);
+    });
+
+    it('converts app-server goal notifications from local transcript sync', () => {
+        const converter = new CodexTranscriptEventConverter();
+        const goal = {
+            threadId: 'thread-1',
+            objective: 'ship goal support',
+            status: 'active'
+        };
+
+        expect(converter.convert({
+            type: 'notification',
+            payload: {
+                method: 'thread/goal/updated',
+                params: {
+                    threadId: 'thread-1',
+                    goal
+                }
+            }
+        })).toEqual([{
+            message: {
+                type: 'thread_goal_updated',
+                thread_id: 'thread-1',
+                goal
+            }
+        }]);
+    });
+
+    it('converts wrapped codex event transcript entries', () => {
+        const converter = new CodexTranscriptEventConverter();
+
+        expect(converter.convert({
+            type: 'codex/event/agent_message_delta',
+            payload: {
+                item_id: 'msg-1',
+                delta: 'Hello'
+            }
+        })).toEqual([]);
+
+        expect(converter.convert({
+            type: 'codex/event/item_completed',
+            payload: {
+                item_id: 'msg-1',
+                item: { id: 'msg-1', type: 'agentMessage' }
+            }
+        })).toEqual([{
+            message: {
+                type: 'agent_message',
+                message: 'Hello'
+            }
+        }]);
     });
 });

--- a/cli/src/codex/utils/codexEventConverter.ts
+++ b/cli/src/codex/utils/codexEventConverter.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { logger } from '@/ui/logger';
+import { AppServerEventConverter, type ConvertedEvent } from './appServerEventConverter';
 
 const CodexSessionEventSchema = z.object({
     timestamp: z.string().optional(),
@@ -14,6 +15,14 @@ export type CodexMessage = {
     type: 'message';
     message: string;
     id: string;
+} | {
+    type: 'thread_goal_updated';
+    thread_id: string;
+    turn_id?: string;
+    goal: Record<string, unknown>;
+} | {
+    type: 'thread_goal_cleared';
+    thread_id: string;
 } | {
     type: 'reasoning';
     message: string;
@@ -40,9 +49,60 @@ export type CodexMessage = {
 
 export type CodexConversionResult = {
     sessionId?: string;
-    message?: CodexMessage;
+    message?: CodexMessage | ConvertedEvent;
     userMessage?: string;
 };
+
+export class CodexTranscriptEventConverter {
+    private readonly appServerEventConverter = new AppServerEventConverter();
+
+    convert(rawEvent: unknown): CodexConversionResult[] {
+        const direct = convertCodexEvent(rawEvent);
+        if (direct) {
+            return [direct];
+        }
+
+        const appServerEvents = this.convertAppServerEvent(rawEvent);
+        return appServerEvents.map((message) => ({ message }));
+    }
+
+    reset(): void {
+        this.appServerEventConverter.reset();
+    }
+
+    private convertAppServerEvent(rawEvent: unknown): ConvertedEvent[] {
+        const parsed = CodexSessionEventSchema.safeParse(rawEvent);
+        if (!parsed.success) {
+            return [];
+        }
+
+        const payloadRecord = asRecord(parsed.data.payload);
+
+        if (parsed.data.type === 'notification' || parsed.data.type === 'app_server_notification') {
+            const method = asString(payloadRecord?.method);
+            if (!method) {
+                return [];
+            }
+            return this.appServerEventConverter.handleNotification(method, payloadRecord?.params);
+        }
+
+        if (parsed.data.type.startsWith('codex/event/')) {
+            const msgType = parsed.data.type.slice('codex/event/'.length);
+            return this.appServerEventConverter.handleNotification(parsed.data.type, {
+                msg: payloadRecord?.type ? payloadRecord : {
+                    ...(payloadRecord ?? {}),
+                    type: msgType
+                }
+            });
+        }
+
+        if (parsed.data.type.includes('/')) {
+            return this.appServerEventConverter.handleNotification(parsed.data.type, payloadRecord ?? {});
+        }
+
+        return [];
+    }
+}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
     if (!value || typeof value !== 'object') {
@@ -181,6 +241,39 @@ export function convertCodexEvent(rawEvent: unknown): CodexConversionResult | nu
                     type: 'token_count',
                     info,
                     id: randomUUID()
+                }
+            };
+        }
+
+        if (eventType === 'thread_goal_updated') {
+            const goal = asRecord(payloadRecord.goal);
+            const threadId = asString(payloadRecord.thread_id)
+                ?? asString(payloadRecord.threadId)
+                ?? asString(goal?.thread_id)
+                ?? asString(goal?.threadId);
+            if (!goal || !threadId) {
+                return null;
+            }
+            const turnId = asString(payloadRecord.turn_id) ?? asString(payloadRecord.turnId);
+            return {
+                message: {
+                    type: 'thread_goal_updated',
+                    thread_id: threadId,
+                    ...(turnId ? { turn_id: turnId } : {}),
+                    goal
+                }
+            };
+        }
+
+        if (eventType === 'thread_goal_cleared') {
+            const threadId = asString(payloadRecord.thread_id) ?? asString(payloadRecord.threadId);
+            if (!threadId) {
+                return null;
+            }
+            return {
+                message: {
+                    type: 'thread_goal_cleared',
+                    thread_id: threadId
                 }
             };
         }

--- a/cli/src/codex/utils/codexMcpConfig.test.ts
+++ b/cli/src/codex/utils/codexMcpConfig.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
     buildMcpServerConfigArgs,
     buildDeveloperInstructionsArg,
-    buildSessionStartHookConfigArgs
+    buildSessionStartHookConfigArgs,
+    buildPermissionRequestHookConfigArgs
 } from './codexMcpConfig';
 
 describe('codexMcpConfig', () => {
@@ -103,9 +104,27 @@ describe('codexMcpConfig', () => {
             expect(args[1]).toContain('hooks.SessionStart=[');
             expect(args[1]).toContain('type = "command"');
             expect(args[1]).toContain('hook-forwarder --port 4312 --token secret-token');
+            if (process.platform === 'win32') {
+                expect(args[1]).toContain('command = "& ');
+            }
             expect(args[2]).toBe('-c');
-            expect(args[3]).toContain('hooks.state={');
+            expect(args[3]).toContain('hooks.state."');
             expect(args[3]).toContain(':session_start:0:0');
+            expect(args[3]).toContain('trusted_hash="sha256:');
+        });
+    });
+
+    describe('buildPermissionRequestHookConfigArgs', () => {
+        it('builds a PermissionRequest hook config override', () => {
+            const args = buildPermissionRequestHookConfigArgs(4312, 'secret-token');
+
+            expect(args[0]).toBe('-c');
+            expect(args[1]).toContain('hooks.PermissionRequest=[');
+            expect(args[1]).toContain('type = "command"');
+            expect(args[1]).toContain('hook-forwarder --port 4312 --token secret-token --path /hook/permission-request');
+            expect(args[2]).toBe('-c');
+            expect(args[3]).toContain('hooks.state."');
+            expect(args[3]).toContain(':permission_request:0:0');
             expect(args[3]).toContain('trusted_hash="sha256:');
         });
     });

--- a/cli/src/codex/utils/codexMcpConfig.ts
+++ b/cli/src/codex/utils/codexMcpConfig.ts
@@ -52,6 +52,17 @@ function shellJoin(parts: string[]): string {
     return parts.map(shellQuote).join(' ');
 }
 
+function buildHookCommand(command: string, args: string[]): string {
+    const joined = shellJoin([command, ...args]);
+    if (process.platform !== 'win32') {
+        return joined;
+    }
+
+    // Codex executes hooks through the user's Windows shell. In PowerShell, a
+    // quoted executable path is treated as a string unless invoked with `&`.
+    return `& ${joined}`;
+}
+
 function canonicalJson(value: unknown): unknown {
     if (Array.isArray(value)) {
         return value.map(canonicalJson);
@@ -86,11 +97,32 @@ function buildSessionStartHookTrustedHash(command: string): string {
     });
 }
 
+function buildPermissionRequestHookTrustedHash(command: string): string {
+    return versionForTomlLikeValue({
+        event_name: 'permission_request',
+        hooks: [
+            {
+                async: false,
+                command,
+                timeout: 600,
+                type: 'command'
+            }
+        ]
+    });
+}
+
 function sessionFlagsHookStateKey(): string {
     const sourcePath = process.platform === 'win32'
         ? 'C:\\<session-flags>\\config.toml'
         : '/<session-flags>/config.toml';
     return `${sourcePath}:session_start:0:0`;
+}
+
+function permissionRequestFlagsHookStateKey(): string {
+    const sourcePath = process.platform === 'win32'
+        ? 'C:\\<session-flags>\\config.toml'
+        : '/<session-flags>/config.toml';
+    return `${sourcePath}:permission_request:0:0`;
 }
 
 export function buildSessionStartHookConfigArgs(port: number, token: string): string[] {
@@ -101,12 +133,31 @@ export function buildSessionStartHookConfigArgs(port: number, token: string): st
         '--token',
         token
     ]);
-    const hookCommand = shellJoin([command, ...args]);
+    const hookCommand = buildHookCommand(command, args);
     const escapedHookCommand = escapeTomlString(hookCommand);
     const hookConfig = `hooks.SessionStart=[{ hooks = [{ type = "command", command = "${escapedHookCommand}" }] }]`;
     const trustedHash = buildSessionStartHookTrustedHash(hookCommand);
     const escapedStateKey = escapeTomlString(sessionFlagsHookStateKey());
-    const hookState = `hooks.state={"${escapedStateKey}"={trusted_hash="${trustedHash}"}}`;
+    const hookState = `hooks.state."${escapedStateKey}".trusted_hash="${trustedHash}"`;
+    return ['-c', hookConfig, '-c', hookState];
+}
+
+export function buildPermissionRequestHookConfigArgs(port: number, token: string): string[] {
+    const { command, args } = getHappyCliCommand([
+        'hook-forwarder',
+        '--port',
+        String(port),
+        '--token',
+        token,
+        '--path',
+        '/hook/permission-request'
+    ]);
+    const hookCommand = buildHookCommand(command, args);
+    const escapedHookCommand = escapeTomlString(hookCommand);
+    const hookConfig = `hooks.PermissionRequest=[{ hooks = [{ type = "command", command = "${escapedHookCommand}" }] }]`;
+    const trustedHash = buildPermissionRequestHookTrustedHash(hookCommand);
+    const escapedStateKey = escapeTomlString(permissionRequestFlagsHookStateKey());
+    const hookState = `hooks.state."${escapedStateKey}".trusted_hash="${trustedHash}"`;
     return ['-c', hookConfig, '-c', hookState];
 }
 

--- a/hub/src/tunnel/tlsGate.ts
+++ b/hub/src/tunnel/tlsGate.ts
@@ -58,7 +58,8 @@ function hostMatchesCertificate(host: string, cert: PeerCertificate): boolean {
         return altNames.some(name => name.type === 'DNS' && dnsNameMatchesHost(host, name.value))
     }
 
-    const commonName = cert.subject?.CN
+    const rawCommonName = cert.subject?.CN
+    const commonName = Array.isArray(rawCommonName) ? rawCommonName[0] : rawCommonName
     if (!commonName) {
         return false
     }

--- a/hub/src/web/routes/guards.ts
+++ b/hub/src/web/routes/guards.ts
@@ -39,6 +39,9 @@ export function requireSessionFromParam(
 ): { sessionId: string; session: Session } | Response {
     const paramName = options?.paramName ?? 'id'
     const sessionId = c.req.param(paramName)
+    if (!sessionId) {
+        return c.json({ error: 'Missing session id' }, 400)
+    }
     const result = requireSession(c, engine, sessionId, { requireActive: options?.requireActive })
     if (result instanceof Response) {
         return result


### PR DESCRIPTION
  ## Summary

  This PR improves Codex local mode integration:

  - Syncs Codex local transcript events for app-server style goal/conversation events
  - Fixes Windows `SessionStart` hook command invocation
  - Adds Codex `PermissionRequest` hook forwarding so local mode approvals can be handled from HAPI web/mobile

  ## Why

  In Codex local mode, `/goal` progress and conversation details were not fully visible in HAPI web/mobile. Also, when Codex needed user
  approval, the approval had to be handled in the local TUI.

  This change lets HAPI keep local Codex sessions visible remotely and forwards Codex permission requests through the existing HAPI
  approval flow.

  ## Test

  - `bun run typecheck:cli`
  - `bun run test:win -- src/codex/codexLocal.test.ts src/codex/codexLocalLauncher.test.ts src/codex/utils/codexMcpConfig.test.ts src/  claude/utils/startHookServer.test.ts`