### PR TITLE
fix(web): preserve session preview folding

### DIFF
--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -102,10 +102,10 @@ describe('session list search helpers', () => {
 })
 
 describe('getVisibleSessionPreview', () => {
-    it('keeps selected and active sessions inside the collapsed preview without promoting them', () => {
+    it('keeps selected and pending sessions inside the collapsed preview without promoting them', () => {
         const sessions = Array.from({ length: 6 }, (_, index) => makeSession({
             id: `s-${index + 1}`,
-            active: index === 4,
+            pendingRequestsCount: index === 4 ? 1 : 0,
             metadata: { path: '/work/hapi' },
             updatedAt: 100 - index
         }))
@@ -116,6 +116,19 @@ describe('getVisibleSessionPreview', () => {
         })
 
         expect(preview.map(session => session.id)).toEqual(['s-1', 's-5', 's-6'])
+    })
+
+    it('does not exceed the limit just because many sessions are active', () => {
+        const sessions = Array.from({ length: 6 }, (_, index) => makeSession({
+            id: `s-${index + 1}`,
+            active: true,
+            metadata: { path: '/work/hapi' },
+            updatedAt: 100 - index
+        }))
+
+        const preview = getVisibleSessionPreview(sessions, { limit: 4 })
+
+        expect(preview.map(session => session.id)).toEqual(['s-1', 's-2', 's-3', 's-4'])
     })
 
     it('does not move an already-visible selected session to the top', () => {
@@ -145,7 +158,7 @@ describe('getVisibleSessionPreview', () => {
 
 
 describe('expandSelectedSessionCollapseOverrides', () => {
-    it('expands collapsed project, machine, and session preview overrides for selected sessions', () => {
+    it('expands collapsed project and machine, but preserves session preview folding', () => {
         const overrides = new Map<string, boolean>([
             ['machine-1::/work/hapi', true],
             ['sessions::machine-1::/work/hapi', true],
@@ -158,11 +171,11 @@ describe('expandSelectedSessionCollapseOverrides', () => {
         })
 
         expect(result.has('machine-1::/work/hapi')).toBe(false)
-        expect(result.get('sessions::machine-1::/work/hapi')).toBe(false)
+        expect(result.get('sessions::machine-1::/work/hapi')).toBe(true)
         expect(result.has('machine::machine-1')).toBe(false)
     })
 
-    it('sets missing session preview override to expanded', () => {
+    it('leaves missing session preview override unset', () => {
         const overrides = new Map<string, boolean>()
 
         const result = expandSelectedSessionCollapseOverrides(overrides, {
@@ -170,6 +183,6 @@ describe('expandSelectedSessionCollapseOverrides', () => {
             machineId: 'machine-1'
         })
 
-        expect(result.get('sessions::machine-1::/work/hapi')).toBe(false)
+        expect(result.has('sessions::machine-1::/work/hapi')).toBe(false)
     })
 })

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -191,13 +191,6 @@ export function expandSelectedSessionCollapseOverrides(
         changed = true
     }
 
-    // Session preview keys use inverted semantics: false = expanded, true/missing = collapsed.
-    const sessionPreviewKey = `sessions::${group.key}`
-    if (overrides.get(sessionPreviewKey) !== false) {
-        next.set(sessionPreviewKey, false)
-        changed = true
-    }
-
     const machineKey = `machine::${group.machineId ?? UNKNOWN_MACHINE_ID}`
     if (overrides.has(machineKey) && overrides.get(machineKey)) {
         next.delete(machineKey)
@@ -438,7 +431,7 @@ export function getVisibleSessionPreview(
 
     const requiredIds = new Set<string>()
     for (const session of sessions) {
-        if (session.active) requiredIds.add(session.id)
+        if (session.pendingRequestsCount > 0) requiredIds.add(session.id)
     }
     if (options.selectedSessionId && sessions.some(session => session.id === options.selectedSessionId)) {
         requiredIds.add(options.selectedSessionId)


### PR DESCRIPTION
## Summary
- keep the session preview limit in effect when auto-expanding the selected session
- do not let every active session bypass the preview limit
- still keep selected sessions and pending-request sessions visible inside the folded preview

## Why #629 was not enough
This follows up on #629, which added the configurable “Sessions Before Folding” / session preview limit. That setting was applied in the basic folded-preview path, but two later/default visibility rules could effectively bypass it:

1. Selecting a session auto-expanded its machine/project path and also forced the per-directory session preview override to expanded, so the directory showed all sessions instead of the configured preview count.
2. The preview helper treated every active session as required-visible. In directories with many active sessions, the preview could grow far beyond the configured limit.

This PR keeps the useful auto-expansion of the containing machine/project, but preserves session preview folding. It also narrows the required-visible exception to pending-request sessions and the selected session.

## Test plan
- `bun test web/src/components/SessionList.test.ts`
- `bun run typecheck:web`