### PR TITLE
fix(web): embed agent text in voice ready event for readback

### DIFF
--- a/web/src/realtime/hooks/contextFormatters.test.ts
+++ b/web/src/realtime/hooks/contextFormatters.test.ts
@@ -29,10 +29,10 @@ describe('extractLastAssistantSpeakable', () => {
 
     it('skips trailing user messages and reads earlier assistant text', () => {
         const messages = [
-            msg({ id: '1', seq: 1, content: { role: 'assistant', content: 'done with subtitle search' } }),
+            msg({ id: '1', seq: 1, content: { role: 'assistant', content: 'done with the refactor' } }),
             msg({ id: '2', seq: 2, content: { role: 'user', content: 'thanks' } })
         ]
-        expect(extractLastAssistantSpeakable(messages)).toBe('done with subtitle search')
+        expect(extractLastAssistantSpeakable(messages)).toBe('done with the refactor')
     })
 
     it('extracts text blocks from assistant content arrays', () => {
@@ -63,7 +63,7 @@ describe('extractLastAssistantSpeakable', () => {
                         type: 'codex',
                         data: {
                             type: 'message',
-                            message: '**Subtitle coverage** — 5,018 indexed items.'
+                            message: 'Indexed 5,018 items in the search database.'
                         }
                     }
                 }
@@ -80,7 +80,7 @@ describe('extractLastAssistantSpeakable', () => {
                 }
             })
         ]
-        expect(extractLastAssistantSpeakable(messages)).toBe('**Subtitle coverage** — 5,018 indexed items.')
+        expect(extractLastAssistantSpeakable(messages)).toBe('Indexed 5,018 items in the search database.')
     })
 
     it('unwraps codex-style output envelopes', () => {
@@ -105,7 +105,7 @@ describe('formatReadyEvent', () => {
     const sessionId = '9d04335d-2b90-4941-98a7-eb414823f0e0'
 
     it('embeds assistant text when provided', () => {
-        const text = 'Added subtitle index search to jellybot.'
+        const text = 'Added full-text search to the API module.'
         const event = formatReadyEvent(sessionId, text)
         expect(event).toContain('coding agent finished working')
         expect(event).toContain(`<text>${text}</text>`)
@@ -135,14 +135,14 @@ describe('formatMessage', () => {
                     type: 'codex',
                     data: {
                         type: 'message',
-                        message: '**Subtitle coverage** — 5,018 indexed items.'
+                        message: 'Indexed 5,018 items in the search database.'
                     }
                 }
             }
         }))
 
         expect(formatted).toContain('Claude Code:')
-        expect(formatted).toContain('<text>**Subtitle coverage** — 5,018 indexed items.</text>')
+        expect(formatted).toContain('<text>Indexed 5,018 items in the search database.</text>')
     })
 
     it('ignores codex ready and tool-call payloads', () => {
@@ -172,7 +172,7 @@ describe('formatNewMessages', () => {
                         type: 'codex',
                         data: {
                             type: 'message',
-                            message: 'Database size is 2.43 GiB.'
+                            message: 'Local database file size is 2.43 GiB.'
                         }
                     }
                 }
@@ -180,6 +180,6 @@ describe('formatNewMessages', () => {
         ])
 
         expect(update).toContain('New messages in session: session-1')
-        expect(update).toContain('Database size is 2.43 GiB.')
+        expect(update).toContain('Local database file size is 2.43 GiB.')
     })
 })

--- a/web/src/realtime/hooks/contextFormatters.test.ts
+++ b/web/src/realtime/hooks/contextFormatters.test.ts
@@ -159,6 +159,21 @@ describe('formatMessage', () => {
         }))).toBeNull()
     })
 
+    it('does not treat session status events as speakable assistant text', () => {
+        expect(formatMessage(msg({
+            id: '1',
+            seq: 1,
+            content: {
+                role: 'agent',
+                content: {
+                    id: 'some-uuid',
+                    type: 'event',
+                    data: { type: 'message', message: 'Aborting task.' }
+                }
+            }
+        }))).toBeNull()
+    })
+
     it('preserves tool-call context for mixed text+tool_use content array', () => {
         const formatted = formatMessage(msg({
             id: '1',

--- a/web/src/realtime/hooks/contextFormatters.test.ts
+++ b/web/src/realtime/hooks/contextFormatters.test.ts
@@ -158,6 +158,23 @@ describe('formatMessage', () => {
             }
         }))).toBeNull()
     })
+
+    it('preserves tool-call context for mixed text+tool_use content array', () => {
+        const formatted = formatMessage(msg({
+            id: '1',
+            seq: 1,
+            content: {
+                role: 'assistant',
+                content: [
+                    { type: 'text', text: 'Here is the result.' },
+                    { type: 'tool_use', name: 'Bash', input: { command: 'ls' } }
+                ]
+            }
+        }))
+
+        expect(formatted).toContain('Here is the result.')
+        expect(formatted).toContain('Claude Code is using Bash')
+    })
 })
 
 describe('formatNewMessages', () => {

--- a/web/src/realtime/hooks/contextFormatters.test.ts
+++ b/web/src/realtime/hooks/contextFormatters.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+import type { DecryptedMessage } from '@/types/api'
+import { extractLastAssistantSpeakable, formatMessage, formatNewMessages, formatReadyEvent } from './contextFormatters'
+
+function msg(partial: Pick<DecryptedMessage, 'id' | 'seq' | 'content'>): DecryptedMessage {
+    return {
+        id: partial.id,
+        seq: partial.seq,
+        localId: null,
+        content: partial.content,
+        createdAt: 0,
+        sessionId: 'session-1'
+    } as DecryptedMessage
+}
+
+describe('extractLastAssistantSpeakable', () => {
+    it('returns null for empty history', () => {
+        expect(extractLastAssistantSpeakable([])).toBeNull()
+    })
+
+    it('returns the latest assistant plain string', () => {
+        const messages = [
+            msg({ id: '1', seq: 1, content: { role: 'user', content: 'hello' } }),
+            msg({ id: '2', seq: 2, content: { role: 'assistant', content: 'first reply' } }),
+            msg({ id: '3', seq: 3, content: { role: 'assistant', content: '  latest reply  ' } })
+        ]
+        expect(extractLastAssistantSpeakable(messages)).toBe('latest reply')
+    })
+
+    it('skips trailing user messages and reads earlier assistant text', () => {
+        const messages = [
+            msg({ id: '1', seq: 1, content: { role: 'assistant', content: 'done with subtitle search' } }),
+            msg({ id: '2', seq: 2, content: { role: 'user', content: 'thanks' } })
+        ]
+        expect(extractLastAssistantSpeakable(messages)).toBe('done with subtitle search')
+    })
+
+    it('extracts text blocks from assistant content arrays', () => {
+        const messages = [
+            msg({
+                id: '1',
+                seq: 1,
+                content: {
+                    role: 'assistant',
+                    content: [
+                        { type: 'text', text: 'Part one.' },
+                        { type: 'text', text: 'Part two.' }
+                    ]
+                }
+            })
+        ]
+        expect(extractLastAssistantSpeakable(messages)).toBe('Part one.\n\nPart two.')
+    })
+
+    it('extracts codex stream-json assistant messages', () => {
+        const messages = [
+            msg({
+                id: '1',
+                seq: 1,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'codex',
+                        data: {
+                            type: 'message',
+                            message: '**Subtitle coverage** — 5,018 indexed items.'
+                        }
+                    }
+                }
+            }),
+            msg({
+                id: '2',
+                seq: 2,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'codex',
+                        data: { type: 'ready' }
+                    }
+                }
+            })
+        ]
+        expect(extractLastAssistantSpeakable(messages)).toBe('**Subtitle coverage** — 5,018 indexed items.')
+    })
+
+    it('unwraps codex-style output envelopes', () => {
+        const messages = [
+            msg({
+                id: '1',
+                seq: 1,
+                content: {
+                    type: 'output',
+                    data: {
+                        type: 'assistant',
+                        message: { content: 'Codex finished the refactor.' }
+                    }
+                }
+            })
+        ]
+        expect(extractLastAssistantSpeakable(messages)).toBe('Codex finished the refactor.')
+    })
+})
+
+describe('formatReadyEvent', () => {
+    const sessionId = '9d04335d-2b90-4941-98a7-eb414823f0e0'
+
+    it('embeds assistant text when provided', () => {
+        const text = 'Added subtitle index search to jellybot.'
+        const event = formatReadyEvent(sessionId, text)
+        expect(event).toContain('coding agent finished working')
+        expect(event).toContain(`<text>${text}</text>`)
+        expect(event).not.toContain('Claude Code')
+    })
+
+    it('falls back when assistant text is missing', () => {
+        const event = formatReadyEvent(sessionId, null)
+        expect(event).toContain('Use the latest agent message already present in context')
+        expect(event).not.toContain('Claude Code')
+    })
+
+    it('treats blank assistant text as missing', () => {
+        const event = formatReadyEvent(sessionId, '   ')
+        expect(event).toContain('Use the latest agent message already present in context')
+    })
+})
+
+describe('formatMessage', () => {
+    it('formats codex stream-json assistant messages for voice context', () => {
+        const formatted = formatMessage(msg({
+            id: '1',
+            seq: 1,
+            content: {
+                role: 'agent',
+                content: {
+                    type: 'codex',
+                    data: {
+                        type: 'message',
+                        message: '**Subtitle coverage** — 5,018 indexed items.'
+                    }
+                }
+            }
+        }))
+
+        expect(formatted).toContain('Claude Code:')
+        expect(formatted).toContain('<text>**Subtitle coverage** — 5,018 indexed items.</text>')
+    })
+
+    it('ignores codex ready and tool-call payloads', () => {
+        expect(formatMessage(msg({
+            id: '1',
+            seq: 1,
+            content: {
+                role: 'agent',
+                content: {
+                    type: 'codex',
+                    data: { type: 'ready' }
+                }
+            }
+        }))).toBeNull()
+    })
+})
+
+describe('formatNewMessages', () => {
+    it('includes codex assistant replies in contextual updates', () => {
+        const update = formatNewMessages('session-1', [
+            msg({
+                id: '1',
+                seq: 1,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'codex',
+                        data: {
+                            type: 'message',
+                            message: 'Database size is 2.43 GiB.'
+                        }
+                    }
+                }
+            })
+        ])
+
+        expect(update).toContain('New messages in session: session-1')
+        expect(update).toContain('Database size is 2.43 GiB.')
+    })
+})

--- a/web/src/realtime/hooks/contextFormatters.ts
+++ b/web/src/realtime/hooks/contextFormatters.ts
@@ -149,7 +149,7 @@ function extractSpeakableFromContent(content: unknown): string | null {
     }
 
     // Codex / stream-json agent messages: { type: 'codex', data: { type: 'message', message: '...' } }
-    if (isObject(content) && typeof content.type === 'string' && isObject(content.data)) {
+    if (isObject(content) && content.type === 'codex' && isObject(content.data)) {
         const data = content.data
         if (data.type === 'message' && typeof data.message === 'string' && data.message.trim()) {
             return data.message.trim()

--- a/web/src/realtime/hooks/contextFormatters.ts
+++ b/web/src/realtime/hooks/contextFormatters.ts
@@ -100,7 +100,7 @@ export function formatMessage(message: DecryptedMessage): string | null {
         return null
     }
 
-    const speakable = extractSpeakableFromContent(content)
+    const speakable = !isContentArray(content) ? extractSpeakableFromContent(content) : null
     if (speakable) {
         const roleForFormat = normalizedRole === 'user' ? 'user' : 'assistant'
         return formatPlainText(roleForFormat, speakable)

--- a/web/src/realtime/hooks/contextFormatters.ts
+++ b/web/src/realtime/hooks/contextFormatters.ts
@@ -92,20 +92,25 @@ export function formatPermissionRequest(
  * Format a single message for voice context
  */
 export function formatMessage(message: DecryptedMessage): string | null {
-    const lines: string[] = []
     const { role, content: wrappedContent } = unwrapRoleWrappedContent(message)
     const { roleOverride, content } = unwrapOutputContent(wrappedContent)
     const normalizedRole = roleOverride ?? role
 
-    if (!isContentArray(content)) {
-        if (typeof content === 'string') {
-            return formatPlainText(normalizedRole, content)
-        }
-        if (isObject(content) && content.type === 'text' && typeof content.text === 'string') {
-            return formatPlainText(normalizedRole, content.text)
-        }
+    if (isNonSpeakableAgentPayload(wrappedContent) || isNonSpeakableAgentPayload(content)) {
         return null
     }
+
+    const speakable = extractSpeakableFromContent(content)
+    if (speakable) {
+        const roleForFormat = normalizedRole === 'user' ? 'user' : 'assistant'
+        return formatPlainText(roleForFormat, speakable)
+    }
+
+    if (!isContentArray(content)) {
+        return null
+    }
+
+    const lines: string[] = []
 
     // Determine message type by checking for tool_use (assistant) vs user content
     const hasToolUse = content.some(item => item.type === 'tool_use')
@@ -132,6 +137,81 @@ export function formatMessage(message: DecryptedMessage): string | null {
         return null
     }
     return lines.join('\n\n')
+}
+
+function extractSpeakableFromContent(content: unknown): string | null {
+    if (typeof content === 'string' && content.trim()) {
+        return content.trim()
+    }
+
+    if (isObject(content) && content.type === 'text' && typeof content.text === 'string' && content.text.trim()) {
+        return content.text.trim()
+    }
+
+    // Codex / stream-json agent messages: { type: 'codex', data: { type: 'message', message: '...' } }
+    if (isObject(content) && typeof content.type === 'string' && isObject(content.data)) {
+        const data = content.data
+        if (data.type === 'message' && typeof data.message === 'string' && data.message.trim()) {
+            return data.message.trim()
+        }
+    }
+
+    if (!isContentArray(content)) {
+        return null
+    }
+
+    const textParts = content
+        .filter((item) => item.type === 'text' && item.text)
+        .map((item) => item.text!.trim())
+        .filter(Boolean)
+
+    if (textParts.length > 0) {
+        return textParts.join('\n\n')
+    }
+
+    return null
+}
+
+function isNonSpeakableAgentPayload(content: unknown): boolean {
+    if (!isObject(content) || typeof content.type !== 'string') {
+        return false
+    }
+
+    if (content.type === 'codex' && isObject(content.data)) {
+        const eventType = content.data.type
+        return eventType === 'ready'
+            || eventType === 'tool-call'
+            || eventType === 'tool-call-result'
+            || eventType === 'event'
+    }
+
+    return false
+}
+
+export function extractLastAssistantSpeakable(messages: DecryptedMessage[]): string | null {
+    const sorted = [...messages].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0))
+
+    for (let i = sorted.length - 1; i >= 0; i -= 1) {
+        const message = sorted[i]
+        const { role, content: wrappedContent } = unwrapRoleWrappedContent(message)
+        const { roleOverride, content } = unwrapOutputContent(wrappedContent)
+        const normalizedRole = roleOverride ?? role
+
+        if (normalizedRole === 'user') {
+            continue
+        }
+
+        if (isNonSpeakableAgentPayload(wrappedContent) || isNonSpeakableAgentPayload(content)) {
+            continue
+        }
+
+        const speakable = extractSpeakableFromContent(content)
+        if (speakable) {
+            return speakable
+        }
+    }
+
+    return null
 }
 
 export function formatNewSingleMessage(sessionId: string, message: DecryptedMessage): string | null {
@@ -199,6 +279,10 @@ export function formatSessionFocus(sessionId: string, _metadata?: SessionMetadat
     return `Session became focused: ${sessionId}`
 }
 
-export function formatReadyEvent(sessionId: string): string {
-    return `Claude Code done working in session: ${sessionId}. The previous message(s) are the summary of the work done. Report this to the human immediately.`
+export function formatReadyEvent(sessionId: string, lastAssistantText?: string | null): string {
+    const trimmed = lastAssistantText?.trim()
+    if (trimmed) {
+        return `The coding agent finished working in session: ${sessionId}. Summarize this for the human immediately:\n<text>${trimmed}</text>`
+    }
+    return `The coding agent finished working in session: ${sessionId}. Use the latest agent message already present in context and summarize it for the human immediately.`
 }

--- a/web/src/realtime/hooks/voiceHooks.ts
+++ b/web/src/realtime/hooks/voiceHooks.ts
@@ -6,7 +6,8 @@ import {
     formatSessionFocus,
     formatSessionFull,
     formatSessionOffline,
-    formatSessionOnline
+    formatSessionOnline,
+    extractLastAssistantSpeakable
 } from './contextFormatters'
 import { VOICE_CONFIG } from '../voiceConfig'
 import type { DecryptedMessage, Session } from '@/types/api'
@@ -67,6 +68,7 @@ function reportSession(sessionId: string) {
     const contextUpdate = formatSessionFull(session, messages)
     reportContextualUpdate(contextUpdate)
 }
+
 
 export const voiceHooks = {
     /**
@@ -147,7 +149,9 @@ export const voiceHooks = {
         if (VOICE_CONFIG.DISABLE_READY_EVENTS) return
 
         reportSession(sessionId)
-        reportTextUpdate(formatReadyEvent(sessionId))
+        const messages = messagesGetter?.(sessionId) ?? []
+        const lastAssistantText = extractLastAssistantSpeakable(messages)
+        reportTextUpdate(formatReadyEvent(sessionId, lastAssistantText))
     },
 
     /**

--- a/web/src/realtime/index.ts
+++ b/web/src/realtime/index.ts
@@ -32,7 +32,8 @@ export {
     formatSessionOffline,
     formatSessionFocus,
     formatPermissionRequest,
-    formatReadyEvent
+    formatReadyEvent,
+    extractLastAssistantSpeakable
 } from './hooks/contextFormatters'
 
 // Config


### PR DESCRIPTION
## Summary

Sorry if this is the wrong seam - I might be missing context from #640.

When a coding agent finishes (`ready` event), the ElevenLabs voice assistant often did not read back the agent's answer. The user had to ask repeatedly; ConvAI sometimes hallucinated partial summaries.

Root cause (I think):

1. `formatReadyEvent` used to tell ConvAI the summary was in "previous messages" without embedding assistant text inline.
2. `formatMessage` did not format Codex/Cursor stream-json payloads, so `onMessages` and session history context were empty for those sessions.

This PR embeds the last speakable assistant message in the ready inject (`<text>…</text>`) and teaches `formatMessage` / `extractLastAssistantSpeakable` the same codex stream-json path.

## Test plan

- [x] `bun test web/src/realtime/hooks/contextFormatters.test.ts` (12 tests)
- [x] Manual dogfood: ElevenLabs `conv_4501ksdt0athfhfr189tq3jehkcq` (399s, Cursor session). At ~329s, ready inject included embedded `<text>…</text>` with the agent's last message; at ~330s voice summarized it accurately (e.g. DB 2.43 GiB → 842 MiB) without the user re-prompting.
- [ ] Regression: Claude session voice still works

## Issues

Fixes #681

## Notes

- Does not address #680 (hardcoded "Claude Code" label in `formatPlainText`) - happy to follow up separately if preferred.
- Related to #640 (Codex voice context) but targets ready readback specifically.
