### PR TITLE
feat(web): align Claude effort options with Claude Code --effort levels

### DIFF
--- a/cli/src/claude/effort.test.ts
+++ b/cli/src/claude/effort.test.ts
@@ -14,8 +14,10 @@ describe('normalizeClaudeSessionEffort', () => {
     })
 
     it('normalizes supported effort values', () => {
+        expect(normalizeClaudeSessionEffort('low')).toBe('low')
         expect(normalizeClaudeSessionEffort('medium')).toBe('medium')
         expect(normalizeClaudeSessionEffort('high')).toBe('high')
+        expect(normalizeClaudeSessionEffort('xhigh')).toBe('xhigh')
         expect(normalizeClaudeSessionEffort('max')).toBe('max')
         expect(normalizeClaudeSessionEffort('  High ')).toBe('high')
     })

--- a/shared/src/effort.test.ts
+++ b/shared/src/effort.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+import { CLAUDE_EFFORT_LABELS, CLAUDE_EFFORT_LEVELS } from './effort'
+
+describe('Claude effort constants', () => {
+    test('exposes the Claude Code --effort levels in ascending order', () => {
+        expect(CLAUDE_EFFORT_LEVELS).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
+    })
+
+    test('every CLAUDE_EFFORT_LEVEL has a label', () => {
+        for (const level of CLAUDE_EFFORT_LEVELS) {
+            expect(CLAUDE_EFFORT_LABELS[level]).toBeDefined()
+        }
+    })
+})

--- a/shared/src/effort.ts
+++ b/shared/src/effort.ts
@@ -1,0 +1,12 @@
+// Effort levels Claude Code's `--effort` flag accepts, in ascending order.
+// "auto"/null is hapi's sentinel for omitting --effort (model default), not a level here.
+export const CLAUDE_EFFORT_LABELS = {
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    xhigh: 'XHigh',
+    max: 'Max'
+} as const
+
+export type ClaudeEffortLevel = keyof typeof CLAUDE_EFFORT_LABELS
+export const CLAUDE_EFFORT_LEVELS = Object.keys(CLAUDE_EFFORT_LABELS) as ClaudeEffortLevel[]

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './apiTypes'
 export * from './messages'
 export * from './buildInfo'
+export * from './effort'
 export * from './flavors'
 export * from './models'
 export * from './modes'

--- a/web/src/components/AssistantChat/claudeEffortOptions.test.ts
+++ b/web/src/components/AssistantChat/claudeEffortOptions.test.ts
@@ -6,8 +6,10 @@ describe('getClaudeComposerEffortOptions', () => {
         expect(getClaudeComposerEffortOptions('ultra')).toEqual([
             { value: null, label: 'Auto' },
             { value: 'ultra', label: 'Ultra' },
+            { value: 'low', label: 'Low' },
             { value: 'medium', label: 'Medium' },
             { value: 'high', label: 'High' },
+            { value: 'xhigh', label: 'XHigh' },
             { value: 'max', label: 'Max' },
         ])
     })
@@ -15,8 +17,10 @@ describe('getClaudeComposerEffortOptions', () => {
     it('does not duplicate preset Claude effort values', () => {
         expect(getClaudeComposerEffortOptions('high')).toEqual([
             { value: null, label: 'Auto' },
+            { value: 'low', label: 'Low' },
             { value: 'medium', label: 'Medium' },
             { value: 'high', label: 'High' },
+            { value: 'xhigh', label: 'XHigh' },
             { value: 'max', label: 'Max' },
         ])
     })

--- a/web/src/components/AssistantChat/claudeEffortOptions.ts
+++ b/web/src/components/AssistantChat/claudeEffortOptions.ts
@@ -1,13 +1,8 @@
+import { CLAUDE_EFFORT_LABELS, CLAUDE_EFFORT_LEVELS, type ClaudeEffortLevel } from '@hapi/protocol'
+
 export type ClaudeComposerEffortOption = {
     value: string | null
     label: string
-}
-
-const CLAUDE_EFFORT_PRESETS = ['medium', 'high', 'max'] as const
-const CLAUDE_EFFORT_LABELS: Record<(typeof CLAUDE_EFFORT_PRESETS)[number], string> = {
-    medium: 'Medium',
-    high: 'High',
-    max: 'Max'
 }
 
 function normalizeClaudeComposerEffort(effort?: string | null): string | null {
@@ -32,7 +27,7 @@ export function getClaudeComposerEffortOptions(currentEffort?: string | null): C
 
     if (
         normalizedCurrentEffort
-        && !CLAUDE_EFFORT_PRESETS.includes(normalizedCurrentEffort as typeof CLAUDE_EFFORT_PRESETS[number])
+        && !CLAUDE_EFFORT_LEVELS.includes(normalizedCurrentEffort as ClaudeEffortLevel)
     ) {
         options.push({
             value: normalizedCurrentEffort,
@@ -40,7 +35,7 @@ export function getClaudeComposerEffortOptions(currentEffort?: string | null): C
         })
     }
 
-    options.push(...CLAUDE_EFFORT_PRESETS.map((effort) => ({
+    options.push(...CLAUDE_EFFORT_LEVELS.map((effort) => ({
         value: effort,
         label: CLAUDE_EFFORT_LABELS[effort]
     })))

--- a/web/src/components/NewSession/types.test.ts
+++ b/web/src/components/NewSession/types.test.ts
@@ -24,8 +24,10 @@ describe('Claude effort options', () => {
     it('matches supported effort presets in expected order', () => {
         expect(CLAUDE_EFFORT_OPTIONS).toEqual([
             { value: 'auto', label: 'Auto' },
+            { value: 'low', label: 'Low' },
             { value: 'medium', label: 'Medium' },
             { value: 'high', label: 'High' },
+            { value: 'xhigh', label: 'XHigh' },
             { value: 'max', label: 'Max' },
         ])
     })

--- a/web/src/components/NewSession/types.ts
+++ b/web/src/components/NewSession/types.ts
@@ -1,15 +1,17 @@
 import {
+    CLAUDE_EFFORT_LABELS,
+    CLAUDE_EFFORT_LEVELS,
     CLAUDE_MODEL_LABELS,
     CLAUDE_MODEL_PRESETS,
     GEMINI_MODEL_LABELS,
     GEMINI_MODEL_PRESETS
 } from '@hapi/protocol'
-import type { AgentFlavor } from '@hapi/protocol'
+import type { AgentFlavor, ClaudeEffortLevel } from '@hapi/protocol'
 
 export type AgentType = AgentFlavor
 export type SessionType = 'simple' | 'worktree'
 export type CodexReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
-export type ClaudeEffort = 'auto' | 'medium' | 'high' | 'max'
+export type ClaudeEffort = 'auto' | ClaudeEffortLevel
 
 function modelPresetOptions<TModel extends string>(
     presets: readonly TModel[],
@@ -48,7 +50,5 @@ export const CODEX_REASONING_EFFORT_OPTIONS: { value: CodexReasoningEffort; labe
 
 export const CLAUDE_EFFORT_OPTIONS: { value: ClaudeEffort; label: string }[] = [
     { value: 'auto', label: 'Auto' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'high', label: 'High' },
-    { value: 'max', label: 'Max' },
+    ...CLAUDE_EFFORT_LEVELS.map((value) => ({ value, label: CLAUDE_EFFORT_LABELS[value] })),
 ]


### PR DESCRIPTION
## What & why

hapi's Claude **Effort** selector only offered `Auto / Medium / High / Max`, missing `low` and `xhigh` — but Claude Code's `--effort` flag actually accepts `low/medium/high/xhigh/max` (`claude --help`). This aligns the selector with the CLI in both places it appears:

- New Session config (`CLAUDE_EFFORT_OPTIONS`)
- in-session composer (`getClaudeComposerEffortOptions`)

Final set in both: **Auto · Low · Medium · High · XHigh · Max**.

## How

- New single source of truth `shared/src/effort.ts` (`@hapi/protocol`), mirroring the existing `CLAUDE_MODEL_PRESETS` pattern, so the two UIs derive from one list and can't drift.
- **No backend change**: the effort string is free-form end-to-end (zod schemas, RPC, store, `normalizeClaudeSessionEffort`, and the final `--effort` passthrough), so `low`/`xhigh` already flow through untouched.

`ultracode` is intentionally **excluded** — it's a TUI-only `/effort` session setting, not an `--effort` value (`claude --effort ultracode` is rejected by the CLI).

## Tests

Updated `NewSession/types.test.ts` and `claudeEffortOptions.test.ts`; added `shared/src/effort.test.ts`; extended `cli/src/claude/effort.test.ts`. `bun run typecheck` + affected unit tests pass.

## Verification

Browser E2E against a live hub: both dropdowns render `Auto/Low/Medium/High/XHigh/Max`; selecting **XHigh** in New Session spawns `hapi claude … --effort xhigh` (confirmed in the spawned process args).