### PR TITLE
fix(cli): resolve Windows Claude npm shim

### DIFF
--- a/cli/src/claude/sdk/utils.test.ts
+++ b/cli/src/claude/sdk/utils.test.ts
@@ -1,0 +1,159 @@
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { existsSyncMock, execFileSyncMock, execSyncMock, homedirMock } = vi.hoisted(() => ({
+    existsSyncMock: vi.fn(),
+    execFileSyncMock: vi.fn(),
+    execSyncMock: vi.fn(),
+    homedirMock: vi.fn(() => 'C:\\Users\\junes')
+}))
+
+vi.mock('node:fs', async () => {
+    const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+    return {
+        ...actual,
+        existsSync: existsSyncMock
+    }
+})
+
+vi.mock('node:child_process', async () => {
+    const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process')
+    return {
+        ...actual,
+        execFileSync: execFileSyncMock,
+        execSync: execSyncMock
+    }
+})
+
+vi.mock('node:os', async () => {
+    const actual = await vi.importActual<typeof import('node:os')>('node:os')
+    return {
+        ...actual,
+        homedir: homedirMock
+    }
+})
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+const originalEnv = process.env
+
+function setPlatform(value: string) {
+    Object.defineProperty(process, 'platform', {
+        value,
+        configurable: true
+    })
+}
+
+describe('getDefaultClaudeCodePath', () => {
+    beforeAll(() => {
+        if (!originalPlatformDescriptor?.configurable) {
+            throw new Error('process.platform is not configurable in this runtime')
+        }
+    })
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.resetModules()
+        process.env = { ...originalEnv }
+        delete process.env.HAPI_CLAUDE_PATH
+        homedirMock.mockReturnValue('C:\\Users\\junes')
+        execFileSyncMock.mockImplementation(() => {
+            throw new Error('not found')
+        })
+        execSyncMock.mockImplementation(() => {
+            throw new Error('not found')
+        })
+        existsSyncMock.mockReturnValue(false)
+    })
+
+    afterAll(() => {
+        process.env = originalEnv
+        if (originalPlatformDescriptor) {
+            Object.defineProperty(process, 'platform', originalPlatformDescriptor)
+        }
+    })
+
+    it('uses HAPI_CLAUDE_PATH when set', async () => {
+        process.env.HAPI_CLAUDE_PATH = 'C:\\tools\\claude.exe'
+        const { getDefaultClaudeCodePath } = await import('./utils')
+
+        expect(getDefaultClaudeCodePath()).toBe('C:\\tools\\claude.exe')
+        expect(execFileSyncMock).not.toHaveBeenCalled()
+    })
+
+    it('resolves HAPI_CLAUDE_PATH when it points to a Windows npm shim', async () => {
+        setPlatform('win32')
+        const shim = 'C:\\nvm4w\\nodejs\\claude.cmd'
+        const executable = 'C:\\nvm4w\\nodejs\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe'
+        process.env.HAPI_CLAUDE_PATH = shim
+        existsSyncMock.mockImplementation((candidate: string) => candidate === shim || candidate === executable)
+        const { getDefaultClaudeCodePath } = await import('./utils')
+
+        expect(getDefaultClaudeCodePath()).toBe(executable)
+        expect(execFileSyncMock).not.toHaveBeenCalled()
+    })
+
+    it('resolves Windows npm claude.cmd shim to the real Claude Code exe', async () => {
+        setPlatform('win32')
+        const shim = 'C:\\nvm4w\\nodejs\\claude.cmd'
+        const executable = 'C:\\nvm4w\\nodejs\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe'
+        execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'where.exe' && args[0] === 'claude.cmd') {
+                return `${shim}\r\n`
+            }
+            throw new Error('not found')
+        })
+        existsSyncMock.mockImplementation((candidate: string) => candidate === shim || candidate === executable)
+        const { getDefaultClaudeCodePath } = await import('./utils')
+
+        expect(getDefaultClaudeCodePath()).toBe(executable)
+    })
+
+    it('continues through multiple Windows where results until it finds a resolvable shim', async () => {
+        setPlatform('win32')
+        const staleShim = 'C:\\old-node\\claude.cmd'
+        const validShim = 'C:\\nvm4w\\nodejs\\claude.cmd'
+        const executable = 'C:\\nvm4w\\nodejs\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe'
+        execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'where.exe' && args[0] === 'claude.cmd') {
+                return `${staleShim}\r\n${validShim}\r\n`
+            }
+            throw new Error('not found')
+        })
+        existsSyncMock.mockImplementation((candidate: string) => (
+            candidate === staleShim || candidate === validShim || candidate === executable
+        ))
+        const { getDefaultClaudeCodePath } = await import('./utils')
+
+        expect(getDefaultClaudeCodePath()).toBe(executable)
+    })
+
+    it('resolves Windows npm extensionless claude shim to the real Claude Code exe', async () => {
+        setPlatform('win32')
+        const shim = 'C:\\nvm4w\\nodejs\\claude'
+        const executable = 'C:\\nvm4w\\nodejs\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe'
+        execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'where.exe' && args[0] === 'claude') {
+                return `${shim}\r\n`
+            }
+            throw new Error('not found')
+        })
+        existsSyncMock.mockImplementation((candidate: string) => candidate === shim || candidate === executable)
+        const { getDefaultClaudeCodePath } = await import('./utils')
+
+        expect(getDefaultClaudeCodePath()).toBe(executable)
+    })
+
+    it('keeps an actual Windows claude.exe result from PATH', async () => {
+        setPlatform('win32')
+        const executable = 'C:\\tools\\claude.exe'
+        execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'where.exe' && args[0] === 'claude.exe') {
+                return `${executable}\r\n`
+            }
+            throw new Error('not found')
+        })
+        existsSyncMock.mockImplementation((candidate: string) => candidate === executable)
+        const { getDefaultClaudeCodePath } = await import('./utils')
+
+        expect(getDefaultClaudeCodePath()).toBe(executable)
+    })
+})

--- a/cli/src/claude/sdk/utils.ts
+++ b/cli/src/claude/sdk/utils.ts
@@ -4,17 +4,61 @@
  */
 
 import { existsSync } from 'node:fs'
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 import { homedir } from 'node:os'
+import path from 'node:path'
 import { logger } from '@/ui/logger'
+
+const windowsPath = path.win32
 
 /**
  * Find Claude executable path on Windows.
  * Returns absolute path to claude.exe for use with shell: false
  */
+function resolveWindowsNpmShimExecutable(shimPath: string): string | null {
+    const shimDirectory = windowsPath.dirname(shimPath)
+    const executableName = windowsPath.basename(shimPath, windowsPath.extname(shimPath))
+    const packageExecutable = windowsPath.join(shimDirectory, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', `${executableName}.exe`)
+
+    if (existsSync(packageExecutable)) {
+        logger.debug(`[Claude SDK] Resolved Windows npm shim ${shimPath} to ${packageExecutable}`)
+        return packageExecutable
+    }
+
+    return null
+}
+
+function resolveWindowsClaudePathCandidate(candidate: string): string | null {
+    if (!existsSync(candidate)) {
+        return null
+    }
+
+    if (windowsPath.extname(candidate).toLowerCase() === '.exe') {
+        return candidate
+    }
+
+    return resolveWindowsNpmShimExecutable(candidate)
+}
+
+function findWhereResults(command: string): string[] {
+    try {
+        const result = execFileSync('where.exe', [command], {
+            encoding: 'utf8',
+            stdio: ['pipe', 'pipe', 'pipe'],
+            cwd: homedir()
+        })
+
+        return result
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean)
+    } catch {
+        return []
+    }
+}
+
 function findWindowsClaudePath(): string | null {
     const homeDir = homedir()
-    const path = require('node:path')
 
     // Known installation paths for Claude on Windows
     const candidates = [
@@ -24,25 +68,23 @@ function findWindowsClaudePath(): string | null {
     ]
 
     for (const candidate of candidates) {
-        if (existsSync(candidate)) {
-            logger.debug(`[Claude SDK] Found Windows claude.exe at: ${candidate}`)
-            return candidate
+        const resolved = resolveWindowsClaudePathCandidate(candidate)
+        if (resolved) {
+            logger.debug(`[Claude SDK] Found Windows claude.exe at: ${resolved}`)
+            return resolved
         }
     }
 
-    // Try 'where claude' to find in PATH
-    try {
-        const result = execSync('where claude.exe', {
-            encoding: 'utf8',
-            stdio: ['pipe', 'pipe', 'pipe'],
-            cwd: homeDir
-        }).trim().split('\n')[0].trim()
-        if (result && existsSync(result)) {
-            logger.debug(`[Claude SDK] Found Windows claude.exe via where: ${result}`)
-            return result
+    // Try PATH lookup. npm global installs usually expose claude.cmd/claude
+    // shims, while HAPI spawns Claude with shell:false and needs the real exe.
+    for (const command of ['claude.exe', 'claude.cmd', 'claude']) {
+        for (const result of findWhereResults(command)) {
+            const resolved = resolveWindowsClaudePathCandidate(result)
+            if (resolved) {
+                logger.debug(`[Claude SDK] Found Windows claude.exe via where ${command}: ${resolved}`)
+                return resolved
+            }
         }
-    } catch {
-        // where didn't find it
     }
 
     return null
@@ -100,10 +142,20 @@ function findGlobalClaudePath(): string | null {
  * - HAPI_CLAUDE_PATH: Force a specific path to claude executable
  */
 export function getDefaultClaudeCodePath(): string {
-    // Allow explicit override via env var
+    // Allow explicit override via env var. On Windows, tolerate npm
+    // shim paths (`claude.cmd` / extensionless `claude`) by resolving them
+    // to the real `claude.exe` because Claude is spawned with shell:false.
     if (process.env.HAPI_CLAUDE_PATH) {
-        logger.debug(`[Claude SDK] Using HAPI_CLAUDE_PATH: ${process.env.HAPI_CLAUDE_PATH}`)
-        return process.env.HAPI_CLAUDE_PATH
+        const configuredPath = process.env.HAPI_CLAUDE_PATH
+        if (process.platform === 'win32') {
+            const resolved = resolveWindowsClaudePathCandidate(configuredPath)
+            if (resolved) {
+                logger.debug(`[Claude SDK] Using resolved HAPI_CLAUDE_PATH: ${resolved}`)
+                return resolved
+            }
+        }
+        logger.debug(`[Claude SDK] Using HAPI_CLAUDE_PATH: ${configuredPath}`)
+        return configuredPath
     }
 
     // Find global claude


### PR DESCRIPTION
## 变更概述
- Windows 下如果 PATH 只暴露 npm 生成的 `claude.cmd` / extensionless `claude` shim，自动解析到真实的 `node_modules/@anthropic-ai/claude-code/bin/claude.exe`。
- `HAPI_CLAUDE_PATH` 显式配置为 npm shim 时也做同样解析，避免用户必须手动定位 `claude.exe`。
- 为 Windows PATH / env 覆盖场景补充单元测试。

## 原因
HAPI 启动 Claude Code 使用 `shell: false`，Windows 上 npm 全局安装通常只把 `claude.cmd` 或 extensionless `claude` 放进 PATH。旧逻辑只查 `claude.exe`，导致 Web/runner 发起 Claude 会话时报：

```text
Claude Code CLI not found on PATH. Install Claude Code or set HAPI_CLAUDE_PATH.
```

这不应要求用户额外设置 `HAPI_CLAUDE_PATH`。

## 影响范围
- 仅影响 CLI 的 Claude Code 路径解析逻辑。
- 非 Windows 平台保持原有 `claude --version` / `which claude` 路径。
- Windows 上真实 `claude.exe` 已在 PATH 或已安装到已知路径时保持兼容。

## 验证结果
- `C:\Users\junes\.bun\bin\bun.exe run --cwd cli vitest run src/claude/sdk/utils.test.ts`
- `C:\Users\junes\.bun\bin\bun.exe run --cwd cli tsc --noEmit`

## 风险/回滚
- 风险较低：只在候选路径存在时解析 npm shim，否则回到原有错误路径。
- 回滚方式：revert 本 PR。

## Reviewer notes
- 重点看 `resolveWindowsClaudePathCandidate()` 是否覆盖 npm shim 解析边界。
- 当前只解析标准 npm 全局布局：`<prefix>/node_modules/@anthropic-ai/claude-code/bin/claude.exe`。
