### PR TITLE
fix(cursor): persist resume id early and return 409 for resume_unavailable

### DIFF
--- a/cli/src/cursor/cursorRemoteLauncher.ts
+++ b/cli/src/cursor/cursorRemoteLauncher.ts
@@ -82,6 +82,9 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
         };
 
         let cursorSessionId: string | null = session.sessionId;
+        if (cursorSessionId) {
+            session.onSessionFound(cursorSessionId);
+        }
 
         while (!this.shouldExit) {
             const waitSignal = this.abortController.signal;

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -818,7 +818,7 @@ describe('session model', () => {
 
             expect(result).toEqual({
                 type: 'error',
-                message: 'Resume session ID unavailable',
+                message: 'Resume session ID unavailable. Start a new session in this directory, or retry after the agent has initialized.',
                 code: 'resume_unavailable'
             })
         } finally {
@@ -1011,7 +1011,39 @@ describe('session model', () => {
 
             expect(engine.resolveLocalResumeTarget(session.id, 'default')).toEqual({
                 type: 'error',
-                message: 'Resume session ID unavailable',
+                message: 'Resume session ID unavailable. Start a new session in this directory, or retry after the agent has initialized.',
+                code: 'resume_unavailable'
+            })
+        } finally {
+            engine.stop()
+        }
+    })
+
+    it('returns resume_unavailable when a cursor session lacks cursorSessionId', () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'local-resume-cursor-no-id',
+                {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    machineId: 'machine-1',
+                    flavor: 'cursor'
+                },
+                null,
+                'default'
+            )
+
+            expect(engine.resolveLocalResumeTarget(session.id, 'default')).toEqual({
+                type: 'error',
+                message: 'Resume session ID unavailable. Start a new session in this directory, or retry after the agent has initialized.',
                 code: 'resume_unavailable'
             })
         } finally {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -540,7 +540,11 @@ export class SyncEngine {
 
         const agentSessionId = this.resolveAgentResumeId(session, namespace)
         if (!agentSessionId) {
-            return { type: 'error', message: 'Resume session ID unavailable', code: 'resume_unavailable' }
+            return {
+                type: 'error',
+                message: 'Resume session ID unavailable. Start a new session in this directory, or retry after the agent has initialized.',
+                code: 'resume_unavailable'
+            }
         }
 
         return {

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -569,6 +569,32 @@ describe('sessions routes', () => {
         expect(capturedResumeOpts).toEqual({ permissionMode: 'bypassPermissions' })
     })
 
+    it('returns 409 when resume token is unavailable', async () => {
+        const session = createSession({
+            active: false,
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'cursor' }
+        })
+        const { app } = createApp(session, {
+            resumeSession: async () => ({
+                type: 'error',
+                message: 'Resume session ID unavailable. Start a new session in this directory, or retry after the agent has initialized.',
+                code: 'resume_unavailable'
+            })
+        })
+
+        const response = await app.request('/api/sessions/session-1/resume', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({})
+        })
+
+        expect(response.status).toBe(409)
+        expect(await response.json()).toEqual({
+            error: 'Resume session ID unavailable. Start a new session in this directory, or retry after the agent has initialized.',
+            code: 'resume_unavailable'
+        })
+    })
+
     it('falls back to metadata slash commands when RPC listing fails', async () => {
         const session = createSession({
             metadata: {

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -140,7 +140,8 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
             const status = result.code === 'no_machine_online' ? 503
                 : result.code === 'access_denied' ? 403
                     : result.code === 'session_not_found' ? 404
-                        : 500
+                        : result.code === 'resume_unavailable' ? 409
+                            : 500
             return c.json({ error: result.message, code: result.code }, status)
         }
 


### PR DESCRIPTION
## Summary

- Remote cursor launcher now persists `cursorSessionId` to hub metadata immediately when `--resume` is already known at spawn (matching existing local launcher behavior).
- `POST /api/sessions/:id/resume` returns **409** (not 500) for `resume_unavailable`, consistent with `GET /api/cli/sessions/:id/resume-target`.
- Error message now suggests starting fresh vs retrying after init.

Fixes #744

## Problem

If a cursor session archives before the agent stream emits `system init`, hub metadata never receives `cursorSessionId` even though the CLI was started with `--resume <uuid>`. Resume from the web UI then fails with HTTP 500.

## Approach

1. Call `session.onSessionFound(cursorSessionId)` at remote launcher startup when `session.sessionId` is set.
2. Map `resume_unavailable` → 409 on the web resume route.
3. Clarify the sync engine error message.

## Testing

```bash
bun typecheck
bun run test
```

- Added hub route test for 409 on `resume_unavailable`
- Added session model test for cursor sessions missing `cursorSessionId`

## Related

- #728 (different failure mode: resume/config RPC race)

## Questions

- Transcript-path recovery for missing `cursorSessionId` was left out of this PR — happy to follow up if that is worth doing on the CLI side.