### PR TITLE
fix(web): handle legacy session summaries

### DIFF
--- a/web/src/lib/sessionAttention.test.ts
+++ b/web/src/lib/sessionAttention.test.ts
@@ -42,6 +42,18 @@ describe('classifySessionAttention', () => {
         expect(attention).toEqual({ kind: 'permission' })
     })
 
+    it('handles summaries from older APIs without pendingRequestKinds', () => {
+        const legacySummary = makeSummary({ id: 'legacy', updatedAt: 5000 }) as unknown as SessionSummary
+        delete (legacySummary as Partial<SessionSummary>).pendingRequestKinds
+
+        const attention = classifySessionAttention(
+            legacySummary,
+            { selected: false, lastSeenAt: 1000 }
+        )
+
+        expect(attention).toEqual({ kind: 'unread' })
+    })
+
     it('shows unread activity when the session has updated since last seen', () => {
         const attention = classifySessionAttention(
             makeSummary({ id: 'a', updatedAt: 5000 }),

--- a/web/src/lib/sessionAttention.ts
+++ b/web/src/lib/sessionAttention.ts
@@ -14,15 +14,19 @@ export function classifySessionAttention(
         return null
     }
 
-    if (summary.pendingRequestKinds.includes('permission')) {
+    const pendingRequestKinds = Array.isArray(summary.pendingRequestKinds)
+        ? summary.pendingRequestKinds
+        : []
+
+    if (pendingRequestKinds.includes('permission')) {
         return { kind: 'permission' }
     }
 
-    if (summary.pendingRequestKinds.includes('input')) {
+    if (pendingRequestKinds.includes('input')) {
         return { kind: 'input' }
     }
 
-    if (summary.active && summary.backgroundTaskCount > 0) {
+    if (summary.active && (summary.backgroundTaskCount ?? 0) > 0) {
         return { kind: 'background' }
     }
 


### PR DESCRIPTION
## 变更概述
- 修复会话列表状态切到详细/消息状态后，旧格式 session summary 触发 `Cannot read properties of undefined (reading 'includes')` 的崩溃。
- `classifySessionAttention()` 对缺失的 `pendingRequestKinds` 做兼容兜底，并对 `backgroundTaskCount` 使用默认值。
- 补充旧 API/session summary 缺失 `pendingRequestKinds` 的回归测试。

## 原因
会话列表的详细状态会调用 `classifySessionAttention()`。该函数默认 `summary.pendingRequestKinds` 一定存在并直接调用 `.includes()`；但 Web 端可能遇到旧 Hub、缓存数据或旧格式 session summary，字段缺失时就会进入 ErrorBoundary 并显示：

```text
Something went wrong!
Cannot read properties of undefined (reading 'includes')
```

## 影响范围
- 仅影响 Web 会话列表状态分类逻辑。
- 新格式数据行为不变。
- 旧格式/缺字段数据不再导致页面崩溃，会按无 pending request 继续分类。

## 验证结果
- `C:\Users\junes\.bun\bin\bun.exe run --cwd web vitest run src/lib/sessionAttention.test.ts`
- `C:\Users\junes\.bun\bin\bun.exe run --cwd web tsc --noEmit`
- `git diff --check`

## 风险/回滚
- 风险低：只增加缺字段兜底，不改变正常数据路径。
- 回滚方式：revert 本 PR。

## Reviewer notes
- 重点看 `pendingRequestKinds` 缺失时是否应保持 Web 端兼容；当前处理与已有 count 字段的 `?? 0` 思路一致。
