### PR TITLE
fix(cli): replace existing runner on start

### DIFF
--- a/cli/src/commands/runner.test.ts
+++ b/cli/src/commands/runner.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+    checkIfRunnerRunningAndCleanupStaleStateMock,
+    listRunnerSessionsMock,
+    stopRunnerMock,
+    stopRunnerSessionMock,
+    spawnHappyCLIMock,
+    startRunnerMock,
+    getLatestRunnerLogMock,
+    runDoctorCommandMock,
+    initializeTokenMock,
+    existsSyncMock,
+    statSyncMock
+} = vi.hoisted(() => ({
+    checkIfRunnerRunningAndCleanupStaleStateMock: vi.fn(),
+    listRunnerSessionsMock: vi.fn(async () => []),
+    stopRunnerMock: vi.fn(async () => {}),
+    stopRunnerSessionMock: vi.fn(async () => true),
+    spawnHappyCLIMock: vi.fn(() => ({ unref: vi.fn() })),
+    startRunnerMock: vi.fn(async () => {}),
+    getLatestRunnerLogMock: vi.fn(async () => null),
+    runDoctorCommandMock: vi.fn(async () => {}),
+    initializeTokenMock: vi.fn(async () => {}),
+    existsSyncMock: vi.fn(() => true),
+    statSyncMock: vi.fn(() => ({ isDirectory: () => true }))
+}))
+
+vi.mock('node:fs', async () => {
+    const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+    return {
+        ...actual,
+        existsSync: existsSyncMock,
+        statSync: statSyncMock
+    }
+})
+
+vi.mock('@/runner/controlClient', () => ({
+    checkIfRunnerRunningAndCleanupStaleState: checkIfRunnerRunningAndCleanupStaleStateMock,
+    listRunnerSessions: listRunnerSessionsMock,
+    stopRunner: stopRunnerMock,
+    stopRunnerSession: stopRunnerSessionMock
+}))
+
+vi.mock('@/utils/spawnHappyCLI', () => ({
+    spawnHappyCLI: spawnHappyCLIMock
+}))
+
+vi.mock('@/runner/run', () => ({
+    startRunner: startRunnerMock
+}))
+
+vi.mock('@/ui/logger', () => ({
+    getLatestRunnerLog: getLatestRunnerLogMock
+}))
+
+vi.mock('@/ui/doctor', () => ({
+    runDoctorCommand: runDoctorCommandMock
+}))
+
+vi.mock('@/ui/tokenInit', () => ({
+    initializeToken: initializeTokenMock
+}))
+
+import { runnerCommand } from './runner'
+
+function createContext(commandArgs: string[]) {
+    return {
+        args: ['runner', ...commandArgs],
+        commandArgs
+    }
+}
+
+describe('runnerCommand start', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        existsSyncMock.mockReturnValue(true)
+        statSyncMock.mockReturnValue({ isDirectory: () => true })
+    })
+
+    it('stops an existing runner before starting a new detached runner', async () => {
+        const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+            throw new Error(`process.exit:${code ?? 'undefined'}`)
+        }) as never)
+        checkIfRunnerRunningAndCleanupStaleStateMock
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(true)
+
+        try {
+            await expect(runnerCommand.run(createContext(['start', '--workspace-root', '/workspace']))).rejects.toThrow('process.exit:0')
+
+            expect(stopRunnerMock).toHaveBeenCalledOnce()
+            expect(spawnHappyCLIMock).toHaveBeenCalledWith(['runner', 'start-sync', '--workspace-root', '/workspace'], {
+                detached: true,
+                stdio: 'ignore',
+                env: process.env
+            })
+            expect(stopRunnerMock.mock.invocationCallOrder[0]).toBeLessThan(spawnHappyCLIMock.mock.invocationCallOrder[0])
+            expect(consoleLogSpy).toHaveBeenCalledWith('Existing runner detected, stopping it before starting a new one...')
+            expect(consoleLogSpy).toHaveBeenCalledWith('Runner started successfully')
+        } finally {
+            consoleLogSpy.mockRestore()
+            exitSpy.mockRestore()
+        }
+    })
+
+    it('starts directly when no runner is already running', async () => {
+        const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+            throw new Error(`process.exit:${code ?? 'undefined'}`)
+        }) as never)
+        checkIfRunnerRunningAndCleanupStaleStateMock
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(true)
+
+        try {
+            await expect(runnerCommand.run(createContext(['start']))).rejects.toThrow('process.exit:0')
+
+            expect(stopRunnerMock).not.toHaveBeenCalled()
+            expect(spawnHappyCLIMock).toHaveBeenCalledOnce()
+            expect(consoleLogSpy).toHaveBeenCalledWith('Runner started successfully')
+        } finally {
+            consoleLogSpy.mockRestore()
+            exitSpy.mockRestore()
+        }
+    })
+})

--- a/cli/src/commands/runner.ts
+++ b/cli/src/commands/runner.ts
@@ -70,6 +70,17 @@ function extractWorkspaceRootArgs(args: string[]): string[] | undefined {
     return uniqueWorkspaceRoots.length > 0 ? uniqueWorkspaceRoots : undefined
 }
 
+async function waitForRunnerToStop(maxAttempts = 50): Promise<boolean> {
+    for (let i = 0; i < maxAttempts; i++) {
+        if (!(await checkIfRunnerRunningAndCleanupStaleState())) {
+            return true
+        }
+        await new Promise(resolve => setTimeout(resolve, 100))
+    }
+
+    return false
+}
+
 export const runnerCommand: CommandDefinition = {
     name: 'runner',
     requiresRuntimeAssets: true,
@@ -111,6 +122,16 @@ export const runnerCommand: CommandDefinition = {
         }
 
         if (runnerSubcommand === 'start') {
+            if (await checkIfRunnerRunningAndCleanupStaleState()) {
+                console.log('Existing runner detected, stopping it before starting a new one...')
+                await stopRunner()
+
+                if (!(await waitForRunnerToStop())) {
+                    console.error('Failed to stop existing runner')
+                    process.exit(1)
+                }
+            }
+
             const childArgs = ['runner', 'start-sync']
             if (workspaceRoots?.length) {
                 for (const workspaceRoot of workspaceRoots) {
@@ -172,7 +193,7 @@ export const runnerCommand: CommandDefinition = {
 ${chalk.bold('hapi runner')} - Runner management
 
 ${chalk.bold('Usage:')}
-  hapi runner start              Start the runner (detached)
+  hapi runner start              Start the runner (replaces existing runner)
   hapi runner stop               Stop the runner (sessions stay alive)
   hapi runner status             Show runner status
   hapi runner list               List active sessions
@@ -188,6 +209,7 @@ ${chalk.bold('Options:')}
   ${chalk.cyan('hapi doctor clean')}
 
 ${chalk.bold('Note:')} The runner runs in the background and manages Claude sessions.
+Running ${chalk.cyan('hapi runner start')} stops any existing runner first so new flags and environment variables take effect.
 
 ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('hapi doctor clean')}
 `)


### PR DESCRIPTION
## 变更概述
- `hapi runner start` 发现已有 runner 时，先停止旧 runner，再启动新的 detached runner。
- 停旧 runner 后会等待状态确认；如果旧 runner 没有停掉，会报错退出，不再假装启动成功。
- 帮助文案同步说明 `start` 会替换已有 runner，让新参数和环境变量生效。
- 补充 runner start 回归测试，覆盖有旧 runner 和无旧 runner 两条路径。

## 原因
旧逻辑会直接 spawn `runner start-sync`，而 `start-sync` 发现已有同版本/同身份 runner 后会直接退出。外层 `start` 只检查“有 runner 在运行”，导致输出 `Runner started successfully`，但实际仍是旧 runner，新传入的 `--workspace-root`、环境变量或配置不会生效。

## 影响范围
- 影响 `hapi runner start` 行为：从“如果已有 runner 则沿用”改为“替换已有 runner”。
- `hapi runner stop/status/list/stop-session/logs` 不变。
- 已由 runner 管理的 session 仍沿用现有 runner stop 语义：runner 停止，子 session 保持运行。

## 验证结果
- `C:\Users\junes\.bun\bin\bun.exe run --cwd cli vitest run src/commands/runner.test.ts`
- `C:\Users\junes\.bun\bin\bun.exe run --cwd cli tsc --noEmit`
- `git diff --check`

## 风险/回滚
- 风险：用户重复执行 `hapi runner start` 会重启 runner，不再静默复用旧 runner。
- 这是本 PR 的目标行为，用于保证新启动参数/环境一定生效。
- 回滚方式：revert 本 PR。

## Reviewer notes
- 重点看 `start` 分支中 stop -> wait stopped -> spawn 的顺序。
- 测试验证了已有 runner 时先 `stopRunner()`，并保留 `--workspace-root` 参数传给新 runner。
