### PR TITLE
fix(codex): render /help and /status as markdown

### DIFF
--- a/cli/src/codex/utils/slashCommands.ts
+++ b/cli/src/codex/utils/slashCommands.ts
@@ -150,11 +150,12 @@ export function resolveCodexSlashCommand(
         return {
             kind: 'handled',
             message: [
-                `Codex status`,
-                `permission: ${state.permissionMode}`,
-                `collaboration: ${state.collaborationMode}`,
-                `model: ${state.model ?? 'auto'}`,
-                `reasoning: ${state.modelReasoningEffort ?? 'default'}`
+                '**Codex status**',
+                '',
+                `- permission: \`${state.permissionMode}\``,
+                `- collaboration: \`${state.collaborationMode}\``,
+                `- model: \`${state.model ?? 'auto'}\``,
+                `- reasoning: \`${state.modelReasoningEffort ?? 'default'}\``
             ].join('\n')
         };
     }
@@ -216,18 +217,20 @@ export function resolveCodexSlashCommand(
         return {
             kind: 'handled',
             message: [
-                'Supported Codex slash commands:',
-                '/plan [prompt] — enable plan mode, optionally send prompt',
-                '/plan off — return to default mode',
-                '/goal [objective] — set or view the persistent goal',
-                '/goal pause|resume|clear — update the current goal',
-                '/clear — reset current Codex thread context',
-                '/compact — compact current Codex thread context',
-                '/status — show current Codex session config',
-                '/model [name|auto] — show or set model',
-                '/reasoning [low|medium|high|xhigh|default] — show or set reasoning effort',
-                '/permissions [default|read-only|safe-yolo|yolo] — show or set permission mode',
-                'Custom /commands from .codex/prompts are expanded before sending.'
+                '**Supported Codex slash commands**',
+                '',
+                '- `/plan [prompt]` — enable plan mode, optionally send prompt',
+                '- `/plan off` — return to default mode',
+                '- `/goal [objective]` — set or view the persistent goal',
+                '- `/goal pause|resume|clear` — update the current goal',
+                '- `/clear` — reset current Codex thread context',
+                '- `/compact` — compact current Codex thread context',
+                '- `/status` — show current Codex session config',
+                '- `/model [name|auto]` — show or set model',
+                '- `/reasoning [low|medium|high|xhigh|default]` — show or set reasoning effort',
+                '- `/permissions [default|read-only|safe-yolo|yolo]` — show or set permission mode',
+                '',
+                'Custom `/commands` from `.codex/prompts` are expanded before sending.'
             ].join('\n')
         };
     }


### PR DESCRIPTION
## Summary
- Reformat Codex `/help` and `/status` replies to use markdown bullets and code spans so the web composer renders them as a proper list instead of one collapsed paragraph.
- Matches the formatting already used by the OpenCode resolver.

## Why
The web composer renders assistant text through `MarkdownText` with `remark-gfm`, where single newlines collapse into one paragraph. The Codex resolvers built their replies with `array.join('\n')`, so multi-line lists arrived in the browser as a wall of text.

Fixes #749

## Test plan
- [x] `vitest run src/codex/utils/slashCommands.test.ts` (10 passed)
- [x] `vitest run src/codex/runCodex.test.ts` (1 passed)
- [ ] Manually verify `/help` and `/status` render as a bulleted list in the web composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)