### PR TITLE
fix(opencode): surface ACP context usage live to web status bar

### DIFF
--- a/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
@@ -644,4 +644,105 @@ describe('AcpSdkBackend', () => {
         expect(stragglerIdx).toBeGreaterThanOrEqual(0);
         expect(turnCompleteIdx).toBeGreaterThan(stragglerIdx);
     });
+
+    it('emits a context-only usage mid-turn so the status bar updates live', async () => {
+        backendStatics.UPDATE_QUIET_PERIOD_MS = 25;
+        backendStatics.UPDATE_DRAIN_TIMEOUT_MS = 200;
+        backendStatics.PRE_PROMPT_UPDATE_QUIET_PERIOD_MS = 1;
+        backendStatics.PRE_PROMPT_UPDATE_DRAIN_TIMEOUT_MS = 50;
+        backendStatics.LATE_FLUSH_INTERVAL_MS = 5;
+        backendStatics.LATE_FLUSH_QUIET_PERIOD_MS = 10;
+        backendStatics.LATE_FLUSH_WINDOW_MS = 50;
+
+        const backend = new AcpSdkBackend({ command: 'opencode' });
+        const backendInternal = backend as unknown as {
+            transport: {
+                sendRequest: (...args: unknown[]) => Promise<unknown>;
+                close: () => Promise<void>;
+            } | null;
+            handleSessionUpdate: (params: unknown) => void;
+        };
+
+        const messages: AgentMessage[] = [];
+        backendInternal.transport = {
+            sendRequest: async () => {
+                backendInternal.handleSessionUpdate({
+                    sessionId: 'session-1',
+                    update: { sessionUpdate: 'usage_update', used: 1_000, size: 200_000 }
+                });
+                backendInternal.handleSessionUpdate({
+                    sessionId: 'session-1',
+                    update: { sessionUpdate: 'usage_update', used: 1_000, size: 200_000 }
+                });
+                backendInternal.handleSessionUpdate({
+                    sessionId: 'session-1',
+                    update: { sessionUpdate: 'usage_update', used: 2_500, size: 200_000 }
+                });
+                await sleep(5);
+                return {
+                    stopReason: 'end_turn',
+                    usage: { inputTokens: 100, outputTokens: 50 }
+                };
+            },
+            close: async () => {}
+        };
+
+        await backend.prompt('session-1', [{ type: 'text', text: 'hello' }], (m) => messages.push(m));
+
+        const usageMessages = messages.filter((m): m is Extract<AgentMessage, { type: 'usage' }> => m.type === 'usage');
+        // Two mid-turn ticks (deduped second 1_000) + one final emit with the
+        // prompt-level input/output totals.
+        expect(usageMessages.length).toBe(3);
+        expect(usageMessages[0]).toMatchObject({ inputTokens: 0, outputTokens: 0, contextTokens: 1_000, contextWindow: 200_000 });
+        expect(usageMessages[1]).toMatchObject({ inputTokens: 0, outputTokens: 0, contextTokens: 2_500, contextWindow: 200_000 });
+        expect(usageMessages[2]).toMatchObject({ inputTokens: 100, outputTokens: 50, contextTokens: 2_500, contextWindow: 200_000 });
+    });
+
+    it('emits a context-only usage on finalize when the prompt response carries no usage', async () => {
+        backendStatics.UPDATE_QUIET_PERIOD_MS = 25;
+        backendStatics.UPDATE_DRAIN_TIMEOUT_MS = 200;
+        backendStatics.PRE_PROMPT_UPDATE_QUIET_PERIOD_MS = 1;
+        backendStatics.PRE_PROMPT_UPDATE_DRAIN_TIMEOUT_MS = 50;
+        backendStatics.LATE_FLUSH_INTERVAL_MS = 5;
+        backendStatics.LATE_FLUSH_QUIET_PERIOD_MS = 10;
+        backendStatics.LATE_FLUSH_WINDOW_MS = 50;
+
+        const backend = new AcpSdkBackend({ command: 'opencode' });
+        const backendInternal = backend as unknown as {
+            transport: {
+                sendRequest: (...args: unknown[]) => Promise<unknown>;
+                close: () => Promise<void>;
+            } | null;
+            handleSessionUpdate: (params: unknown) => void;
+        };
+
+        const messages: AgentMessage[] = [];
+        backendInternal.transport = {
+            sendRequest: async () => {
+                backendInternal.handleSessionUpdate({
+                    sessionId: 'session-1',
+                    update: { sessionUpdate: 'usage_update', used: 4_200, size: 200_000 }
+                });
+                await sleep(5);
+                // No `usage` field on the response: simulates slash-handled
+                // turns or errored turns that skip the model.
+                return { stopReason: 'end_turn' };
+            },
+            close: async () => {}
+        };
+
+        await backend.prompt('session-1', [{ type: 'text', text: 'hi' }], (m) => messages.push(m));
+
+        const usageMessages = messages.filter((m): m is Extract<AgentMessage, { type: 'usage' }> => m.type === 'usage');
+        // One mid-turn emit and one finalize fallback — both context-only.
+        expect(usageMessages.length).toBe(2);
+        for (const usage of usageMessages) {
+            expect(usage).toMatchObject({
+                inputTokens: 0,
+                outputTokens: 0,
+                contextTokens: 4_200,
+                contextWindow: 200_000
+            });
+        }
+    });
 });

--- a/cli/src/agent/backends/acp/AcpSdkBackend.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.ts
@@ -55,6 +55,7 @@ export class AcpSdkBackend implements AgentBackend {
     private responseCompleteResolvers: Array<() => void> = [];
     private lastSessionUpdateAt = 0;
     private latestUsageUpdate: AcpUsageUpdate | null = null;
+    private activeOnUpdate: ((msg: AgentMessage) => void) | null = null;
 
     /** Retry configuration for ACP initialization */
     private static readonly INIT_RETRY_OPTIONS = {
@@ -283,6 +284,7 @@ export class AcpSdkBackend implements AgentBackend {
         );
         this.messageHandler?.drainBuffers();
         this.messageHandler = new AcpMessageHandler(onUpdate);
+        this.activeOnUpdate = onUpdate;
         this.isProcessingMessage = true;
         this.lastSessionUpdateAt = Date.now();
         this.latestUsageUpdate = null;
@@ -323,11 +325,27 @@ export class AcpSdkBackend implements AgentBackend {
                         contextTokens: latestUsageUpdate ? latestUsageUpdate.contextTokens : undefined,
                         contextWindow: latestUsageUpdate ? latestUsageUpdate.contextWindow : undefined
                     });
+                } else if (
+                    latestUsageUpdate
+                    && (latestUsageUpdate.contextTokens !== undefined || latestUsageUpdate.contextWindow !== undefined)
+                ) {
+                    // Agent did not return prompt usage (slash-handled turns,
+                    // errored turns), but we did see ACP usage updates during
+                    // the turn. Emit a context-only usage so the status bar
+                    // reflects the current context size.
+                    onUpdate({
+                        type: 'usage',
+                        inputTokens: 0,
+                        outputTokens: 0,
+                        contextTokens: latestUsageUpdate.contextTokens,
+                        contextWindow: latestUsageUpdate.contextWindow
+                    });
                 }
                 if (stopReason) {
                     onUpdate({ type: 'turn_complete', stopReason });
                 }
             } finally {
+                this.activeOnUpdate = null;
                 this.isProcessingMessage = false;
                 this.notifyResponseComplete();
             }
@@ -407,6 +425,7 @@ export class AcpSdkBackend implements AgentBackend {
         if (!this.transport) return;
         this.messageHandler?.drainBuffers();
         this.messageHandler = null;
+        this.activeOnUpdate = null;
         this.activeSessionId = null;
         this.isProcessingMessage = false;
         this.sessionModelsMetadata.clear();
@@ -431,12 +450,32 @@ export class AcpSdkBackend implements AgentBackend {
         if (!isObject(update)) return;
         if (asString(update.sessionUpdate) !== ACP_SESSION_UPDATE_TYPES.usageUpdate) return;
 
-        const contextTokens = this.asFiniteNumber(update.used);
-        const contextWindow = this.asFiniteNumber(update.size);
-        this.latestUsageUpdate = {
-            contextTokens: contextTokens ?? undefined,
-            contextWindow: contextWindow ?? undefined
-        };
+        const contextTokens = this.asFiniteNumber(update.used) ?? undefined;
+        const contextWindow = this.asFiniteNumber(update.size) ?? undefined;
+        const prev = this.latestUsageUpdate;
+        const changed = !prev
+            || prev.contextTokens !== contextTokens
+            || prev.contextWindow !== contextWindow;
+        this.latestUsageUpdate = { contextTokens, contextWindow };
+
+        // Surface context updates mid-turn so the web status bar shows live
+        // ctx N/M (X%) instead of staying blank until the final prompt usage
+        // arrives. ACP usage_update only carries context tokens, so I/O is
+        // sent as 0; the final prompt-finalize emit overwrites with the real
+        // input/output totals.
+        if (
+            changed
+            && this.activeOnUpdate
+            && (contextTokens !== undefined || contextWindow !== undefined)
+        ) {
+            this.activeOnUpdate({
+                type: 'usage',
+                inputTokens: 0,
+                outputTokens: 0,
+                contextTokens,
+                contextWindow
+            });
+        }
     }
 
     private readLatestUsageUpdate(): AcpUsageUpdate | null {


### PR DESCRIPTION
## Summary
- Emit a context-only \`usage\` AgentMessage from \`AcpSdkBackend.captureUsageUpdate\` whenever cached ACP context values change, so the OpenCode web status bar's \`ctx N/M (X%)\` segment updates **during** a turn instead of staying blank until prompt finalization.
- In the prompt finalizer, fall back to a context-only usage emit when \`promptUsage\` is null but a cached \`latestUsageUpdate\` exists — so slash-handled turns and errored turns still refresh the bar.

## Why
ACP \`usage_update\` notifications carry only context tokens (\`used\` / \`size\`), so the existing code parked them in \`latestUsageUpdate\` and only forwarded them inside the \`finally\` block of \`prompt(...)\`, gated on a non-null prompt-level \`usage\`. That meant:

- Mid-turn streaming never updated the bar (Claude, by contrast, attaches usage to every assistant chunk).
- Turns with no final \`usage\` (slash commands, errors) left the bar frozen at the previous value.

\`inputTokens\` / \`outputTokens\` are sent as 0 on the mid-turn ticks; the final prompt-usage emit overwrites with the real totals. Web's \`reducerTimeline\` already skips \`token-count\` events so these mid-turn emits don't appear as visible event rows, and the reducer picks the most-recent token_count for \`latestUsage\`.

Fixes #750

## Test plan
- [x] \`vitest run src/agent/backends/acp/AcpSdkBackend.test.ts\` (16 passed, including 2 new tests for mid-turn emit and finalize fallback)
- [x] \`vitest run src/opencode src/agent\` (186 passed)
- [ ] Manually verify a fresh OpenCode session shows \`ctx …\` once the first chunk arrives, the percentage ticks up during streaming, and the bar refreshes after \`/help\` or other slash-handled turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)