### PR TITLE
fix(cli): Fix Codex CLI execution issue in PowerShell with Hapi Codex

### DIFF
--- a/cli/src/codex/codexLocal.test.ts
+++ b/cli/src/codex/codexLocal.test.ts
@@ -1,7 +1,13 @@
+import { win32 } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { spawnWithTerminalGuardMock } = vi.hoisted(() => ({
+const { resolveCodexCommandMock, spawnWithTerminalGuardMock } = vi.hoisted(() => ({
+    resolveCodexCommandMock: vi.fn(() => ({ command: 'codex', args: [] as string[] })),
     spawnWithTerminalGuardMock: vi.fn(async (_options: unknown) => {})
+}));
+
+vi.mock('./utils/codexExecutable', () => ({
+    resolveCodexCommand: resolveCodexCommandMock
 }));
 
 vi.mock('@/utils/spawnWithTerminalGuard', () => ({
@@ -15,6 +21,10 @@ vi.mock('@/ui/logger', () => ({
 }));
 
 import { codexLocal, filterResumeSubcommand } from './codexLocal';
+
+const codexScriptPath = win32.join('toolchains', 'nodejs', 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
+const hapiCommandPath = win32.join('hapi-bin', 'hapi.exe');
+const workspacePath = win32.join('workspace', 'project');
 
 describe('filterResumeSubcommand', () => {
     it('returns empty array unchanged', () => {
@@ -50,20 +60,26 @@ describe('filterResumeSubcommand', () => {
 
 describe('codexLocal', () => {
     beforeEach(() => {
+        resolveCodexCommandMock.mockReset();
+        resolveCodexCommandMock.mockReturnValue({ command: 'codex', args: [] as string[] });
         spawnWithTerminalGuardMock.mockClear();
     });
 
-    it('launches codex without shell so Windows keeps -c config values as argv elements', async () => {
+    it('launches the resolved Codex command without shell so Windows keeps -c config values as argv elements', async () => {
         const controller = new AbortController();
+        resolveCodexCommandMock.mockReturnValue({
+            command: 'node',
+            args: [codexScriptPath]
+        });
 
         await codexLocal({
             abort: controller.signal,
             sessionId: null,
-            path: 'C:\\workspace\\project',
+            path: workspacePath,
             onSessionFound: vi.fn(),
             mcpServers: {
                 hapi: {
-                    command: 'C:\\Users\\test\\AppData\\Local\\hapi.exe',
+                    command: hapiCommandPath,
                     args: ['mcp', '--url', 'http://127.0.0.1:63995/']
                 }
             },
@@ -81,12 +97,13 @@ describe('codexLocal', () => {
             shell?: unknown;
         };
         expect(spawnOptions).toEqual(expect.objectContaining({
-            command: 'codex',
-            cwd: 'C:\\workspace\\project'
+            command: 'node',
+            cwd: workspacePath
         }));
         expect(spawnOptions).not.toHaveProperty('shell');
 
         const args = spawnOptions.args;
+        expect(args[0]).toBe(codexScriptPath);
         const hookArg = args.find((arg) => arg.startsWith('hooks.SessionStart='));
         expect(hookArg).toBeDefined();
         expect(hookArg).toContain('{ hooks = [{ type = "command", command = "');
@@ -99,7 +116,7 @@ describe('codexLocal', () => {
         await codexLocal({
             abort: controller.signal,
             sessionId: 'codex-session-1',
-            path: '/workspace/project',
+            path: workspacePath,
             modelReasoningEffort: 'high',
             onSessionFound: vi.fn()
         });

--- a/cli/src/codex/codexLocal.ts
+++ b/cli/src/codex/codexLocal.ts
@@ -8,6 +8,7 @@ import {
 } from './utils/codexMcpConfig';
 import { codexSystemPrompt } from './utils/systemPrompt';
 import type { ReasoningEffort } from './appServerTypes';
+import { resolveCodexCommand } from './utils/codexExecutable';
 
 /**
  * Filter out 'resume' subcommand which is managed internally by hapi.
@@ -86,9 +87,11 @@ export async function codexLocal(opts: {
         return;
     }
 
+    const codexCommand = resolveCodexCommand();
+
     await spawnWithTerminalGuard({
-        command: 'codex',
-        args,
+        command: codexCommand.command,
+        args: [...codexCommand.args, ...args],
         cwd: opts.path,
         env: process.env,
         signal: opts.abort,

--- a/cli/src/codex/utils/codexExecutable.test.ts
+++ b/cli/src/codex/utils/codexExecutable.test.ts
@@ -93,18 +93,40 @@ describe('resolveCodexCommand', () => {
         }
     });
 
-    it('resolves a Windows npm codex.cmd shim to the native Codex exe without changing PATH precedence', async () => {
+    it('resolves a Windows npm codex.cmd shim through the Codex launcher', async () => {
         setPlatform('win32');
         const shim = codexShimPath();
         const laterExe = userCodexExePath();
         const executable = nativeCodexPath();
+        const script = codexScriptPath();
         execFileSyncMock.mockImplementation((command: string, args: string[]) => {
             if (command === 'where.exe' && args[0] === 'codex') {
                 return `${shim}\r\n${laterExe}\r\n`;
             }
             throw new Error('not found');
         });
-        existsSyncMock.mockImplementation((candidate: string) => candidate === shim || candidate === laterExe || candidate === executable);
+        existsSyncMock.mockImplementation((candidate: string) =>
+            candidate === shim || candidate === laterExe || candidate === executable || candidate === script
+        );
+        const { resolveCodexCommand } = await import('./codexExecutable');
+
+        expect(resolveCodexCommand()).toEqual({
+            command: 'node',
+            args: [script]
+        });
+    });
+
+    it('continues to the next Windows PATH candidate when a shim has no launcher script', async () => {
+        setPlatform('win32');
+        const shim = codexShimPath();
+        const executable = userCodexExePath();
+        execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'where.exe' && args[0] === 'codex') {
+                return `${shim}\r\n${executable}\r\n`;
+            }
+            throw new Error('not found');
+        });
+        existsSyncMock.mockImplementation((candidate: string) => candidate === shim || candidate === executable);
         const { resolveCodexCommand } = await import('./codexExecutable');
 
         expect(resolveCodexCommand()).toEqual({

--- a/cli/src/codex/utils/codexExecutable.test.ts
+++ b/cli/src/codex/utils/codexExecutable.test.ts
@@ -1,0 +1,162 @@
+import { win32 } from 'node:path';
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execFileSyncMock, existsSyncMock, homedirMock } = vi.hoisted(() => ({
+    execFileSyncMock: vi.fn(),
+    existsSyncMock: vi.fn(),
+    homedirMock: vi.fn(() => 'home\junes')
+}));
+
+vi.mock('node:child_process', async () => {
+    const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    return {
+        ...actual,
+        execFileSync: execFileSyncMock
+    };
+});
+
+vi.mock('node:fs', async () => {
+    const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+    return {
+        ...actual,
+        existsSync: existsSyncMock
+    };
+});
+
+vi.mock('node:os', async () => {
+    const actual = await vi.importActual<typeof import('node:os')>('node:os');
+    return {
+        ...actual,
+        homedir: homedirMock
+    };
+});
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+const homeDir = win32.join('home', 'junes');
+const nodeRoot = win32.join('toolchains', 'nodejs');
+
+function codexShimPath(): string {
+    return win32.join(nodeRoot, 'codex.cmd');
+}
+
+function nativeCodexPath(): string {
+    return win32.join(
+        nodeRoot,
+        'node_modules',
+        '@openai',
+        'codex',
+        'node_modules',
+        '@openai',
+        'codex-win32-x64',
+        'vendor',
+        'x86_64-pc-windows-msvc',
+        'bin',
+        'codex.exe'
+    );
+}
+
+function codexScriptPath(): string {
+    return win32.join(nodeRoot, 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
+}
+
+function userCodexExePath(): string {
+    return win32.join(homeDir, '.local', 'bin', 'codex.exe');
+}
+
+function setPlatform(value: string) {
+    Object.defineProperty(process, 'platform', {
+        value,
+        configurable: true
+    });
+}
+
+describe('resolveCodexCommand', () => {
+    beforeAll(() => {
+        if (!originalPlatformDescriptor?.configurable) {
+            throw new Error('process.platform is not configurable in this runtime');
+        }
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.resetModules();
+        homedirMock.mockReturnValue(homeDir);
+        execFileSyncMock.mockImplementation(() => {
+            throw new Error('not found');
+        });
+        existsSyncMock.mockReturnValue(false);
+    });
+
+    afterAll(() => {
+        if (originalPlatformDescriptor) {
+            Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+        }
+    });
+
+    it('resolves a Windows npm codex.cmd shim to the native Codex exe without changing PATH precedence', async () => {
+        setPlatform('win32');
+        const shim = codexShimPath();
+        const laterExe = userCodexExePath();
+        const executable = nativeCodexPath();
+        execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'where.exe' && args[0] === 'codex') {
+                return `${shim}\r\n${laterExe}\r\n`;
+            }
+            throw new Error('not found');
+        });
+        existsSyncMock.mockImplementation((candidate: string) => candidate === shim || candidate === laterExe || candidate === executable);
+        const { resolveCodexCommand } = await import('./codexExecutable');
+
+        expect(resolveCodexCommand()).toEqual({
+            command: executable,
+            args: []
+        });
+    });
+
+    it('keeps a Windows codex.exe found first on PATH', async () => {
+        setPlatform('win32');
+        const executable = userCodexExePath();
+        execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'where.exe' && args[0] === 'codex') {
+                return `${executable}\r\n`;
+            }
+            throw new Error('not found');
+        });
+        existsSyncMock.mockImplementation((candidate: string) => candidate === executable);
+        const { resolveCodexCommand } = await import('./codexExecutable');
+
+        expect(resolveCodexCommand()).toEqual({
+            command: executable,
+            args: []
+        });
+    });
+
+    it('falls back to node plus codex.js when a Windows shim has no native exe', async () => {
+        setPlatform('win32');
+        const shim = codexShimPath();
+        const script = codexScriptPath();
+        execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'where.exe' && args[0] === 'codex') {
+                return `${shim}\r\n`;
+            }
+            throw new Error('not found');
+        });
+        existsSyncMock.mockImplementation((candidate: string) => candidate === shim || candidate === script);
+        const { resolveCodexCommand } = await import('./codexExecutable');
+
+        expect(resolveCodexCommand()).toEqual({
+            command: 'node',
+            args: [script]
+        });
+    });
+
+    it('uses the plain codex command outside Windows', async () => {
+        setPlatform('linux');
+        const { resolveCodexCommand } = await import('./codexExecutable');
+
+        expect(resolveCodexCommand()).toEqual({
+            command: 'codex',
+            args: []
+        });
+    });
+});

--- a/cli/src/codex/utils/codexExecutable.ts
+++ b/cli/src/codex/utils/codexExecutable.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+const windowsPath = path.win32;
+
+export interface CodexCommand {
+    command: string;
+    args: string[];
+}
+
+function findWhereResults(command: string): string[] {
+    try {
+        const result = execFileSync('where.exe', [command], {
+            encoding: 'utf8',
+            stdio: ['pipe', 'pipe', 'pipe'],
+            cwd: homedir()
+        });
+
+        return result
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+    } catch {
+        return [];
+    }
+}
+
+function resolveNativePackageExecutable(shimPath: string): string | null {
+    const shimDirectory = windowsPath.dirname(shimPath);
+    const packageRoot = windowsPath.join(shimDirectory, 'node_modules', '@openai', 'codex');
+    const executable = windowsPath.join(
+        packageRoot,
+        'node_modules',
+        '@openai',
+        'codex-win32-x64',
+        'vendor',
+        'x86_64-pc-windows-msvc',
+        'bin',
+        'codex.exe'
+    );
+
+    if (existsSync(executable)) {
+        return executable;
+    }
+
+    return null;
+}
+
+function resolveShimScript(shimPath: string): string | null {
+    const shimDirectory = windowsPath.dirname(shimPath);
+    const script = windowsPath.join(shimDirectory, 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
+
+    if (existsSync(script)) {
+        return script;
+    }
+
+    return null;
+}
+
+function resolveWindowsCandidate(candidate: string): CodexCommand | null {
+    if (!existsSync(candidate)) {
+        return null;
+    }
+
+    if (windowsPath.extname(candidate).toLowerCase() === '.exe') {
+        return { command: candidate, args: [] };
+    }
+
+    const nativeExecutable = resolveNativePackageExecutable(candidate);
+    if (nativeExecutable) {
+        return { command: nativeExecutable, args: [] };
+    }
+
+    const script = resolveShimScript(candidate);
+    if (script) {
+        return { command: 'node', args: [script] };
+    }
+
+    return null;
+}
+
+function resolveWindowsCodexCommand(): CodexCommand {
+    for (const candidate of findWhereResults('codex')) {
+        const resolved = resolveWindowsCandidate(candidate);
+        if (resolved) {
+            return resolved;
+        }
+    }
+
+    return { command: 'codex', args: [] };
+}
+
+export function resolveCodexCommand(): CodexCommand {
+    if (process.platform !== 'win32') {
+        return { command: 'codex', args: [] };
+    }
+
+    return resolveWindowsCodexCommand();
+}

--- a/cli/src/codex/utils/codexExecutable.ts
+++ b/cli/src/codex/utils/codexExecutable.ts
@@ -27,27 +27,6 @@ function findWhereResults(command: string): string[] {
     }
 }
 
-function resolveNativePackageExecutable(shimPath: string): string | null {
-    const shimDirectory = windowsPath.dirname(shimPath);
-    const packageRoot = windowsPath.join(shimDirectory, 'node_modules', '@openai', 'codex');
-    const executable = windowsPath.join(
-        packageRoot,
-        'node_modules',
-        '@openai',
-        'codex-win32-x64',
-        'vendor',
-        'x86_64-pc-windows-msvc',
-        'bin',
-        'codex.exe'
-    );
-
-    if (existsSync(executable)) {
-        return executable;
-    }
-
-    return null;
-}
-
 function resolveShimScript(shimPath: string): string | null {
     const shimDirectory = windowsPath.dirname(shimPath);
     const script = windowsPath.join(shimDirectory, 'node_modules', '@openai', 'codex', 'bin', 'codex.js');
@@ -66,11 +45,6 @@ function resolveWindowsCandidate(candidate: string): CodexCommand | null {
 
     if (windowsPath.extname(candidate).toLowerCase() === '.exe') {
         return { command: candidate, args: [] };
-    }
-
-    const nativeExecutable = resolveNativePackageExecutable(candidate);
-    if (nativeExecutable) {
-        return { command: nativeExecutable, args: [] };
     }
 
     const script = resolveShimScript(candidate);

--- a/cli/src/codex/utils/codexVersion.test.ts
+++ b/cli/src/codex/utils/codexVersion.test.ts
@@ -1,7 +1,13 @@
+import { win32 } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { spawnSyncMock } = vi.hoisted(() => ({
+const { resolveCodexCommandMock, spawnSyncMock } = vi.hoisted(() => ({
+    resolveCodexCommandMock: vi.fn(() => ({ command: 'codex', args: [] as string[] })),
     spawnSyncMock: vi.fn()
+}))
+
+vi.mock('./codexExecutable', () => ({
+    resolveCodexCommand: resolveCodexCommandMock
 }))
 
 vi.mock('cross-spawn', () => ({
@@ -17,8 +23,12 @@ import {
     parseCodexVersion
 } from './codexVersion'
 
+const codexScriptPath = win32.join('toolchains', 'nodejs', 'node_modules', '@openai', 'codex', 'bin', 'codex.js')
+
 describe('codexVersion', () => {
     beforeEach(() => {
+        resolveCodexCommandMock.mockReset()
+        resolveCodexCommandMock.mockReturnValue({ command: 'codex', args: [] as string[] })
         spawnSyncMock.mockReset()
     })
 
@@ -48,6 +58,27 @@ describe('codexVersion', () => {
     })
 
     describe('assertCodexLocalSupported', () => {
+        it('checks the resolved Codex command', () => {
+            resolveCodexCommandMock.mockReturnValue({
+                command: 'node',
+                args: [codexScriptPath]
+            })
+            spawnSyncMock.mockReturnValueOnce({
+                status: 0,
+                stdout: 'codex-cli 0.124.0\n',
+                stderr: ''
+            })
+
+            expect(() => assertCodexLocalSupported()).not.toThrow()
+            expect(spawnSyncMock).toHaveBeenCalledWith(
+                'node',
+                [codexScriptPath, '--version'],
+                expect.objectContaining({
+                    encoding: 'utf8'
+                })
+            )
+        })
+
         it('passes when codex is new enough', () => {
             spawnSyncMock.mockReturnValueOnce({
                 status: 0,
@@ -56,9 +87,6 @@ describe('codexVersion', () => {
             })
 
             expect(() => assertCodexLocalSupported()).not.toThrow()
-            expect(spawnSyncMock).toHaveBeenCalledWith('codex', ['--version'], expect.objectContaining({
-                encoding: 'utf8'
-            }))
         })
 
         it('fails when codex is too old', () => {

--- a/cli/src/codex/utils/codexVersion.ts
+++ b/cli/src/codex/utils/codexVersion.ts
@@ -1,5 +1,6 @@
 import spawn from 'cross-spawn'
 import { withBunRuntimeEnv } from '@/utils/bunRuntime'
+import { resolveCodexCommand } from './codexExecutable'
 
 export const MIN_CODEX_HOOKS_VERSION = '0.124.0'
 
@@ -53,8 +54,9 @@ export function isCodexVersionAtLeast(version: string, minimum: string): boolean
 
 export function assertCodexLocalSupported(): void {
     let output: string
+    const codexCommand = resolveCodexCommand()
 
-    const result = spawn.sync('codex', ['--version'], {
+    const result = spawn.sync(codexCommand.command, [...codexCommand.args, '--version'], {
         encoding: 'utf8',
         env: withBunRuntimeEnv()
     })


### PR DESCRIPTION
关联Issue: https://github.com/tiann/hapi/issues/762

本次提交代码使用 codex cli + gpt5.5 xhigh(plan)与high(implement)生成

改动摘要：
- 新增 Codex 可执行文件解析逻辑，Windows 下优先解析 PATH 中的 codex，并识别 npm shim 对应的原生 codex.exe
- 当 Windows shim 找不到原生 exe 时，回退为 node + codex.js，避免直接执行 shim 导致参数转义异常
- codexLocal 和 codexVersion 统一使用同一套 Codex 命令解析结果，保证版本检查与实际启动行为一致
- 更新 codexLocal、codexVersion、codexExecutable 相关测试，覆盖 Windows shim、原生 exe、node fallback 和非 Windows 场景

本地运行结果：
<img width="802" height="217" alt="image" src="https://github.com/user-attachments/assets/d90aadf4-4292-4ca5-af75-b58e24b7a03b" />

启动日志：
[11:38:28.890] Starting hapi CLI with args:  ["bun","B:/~BUN/root/hapi.exe","codex"]
[11:38:29.444] [AUTO-START] Starting hub automatically... 
[11:38:29.446] [SPAWN HAPI CLI] Spawning: hapi hub in D:\*****\hapi 
[11:38:29.455] [AUTO-START] Hub process spawned with PID 35696 
[11:38:30.296] [AUTO-START] Server ready after 840ms 
[11:38:30.304] [codex] Starting with options: startedBy=terminal 
[11:38:30.306] Using machineId: 2e446020-****-****-****-6fcfcb971c79 
[11:38:30.449] [WORKTREE] Git probe miss in 123ms 
[11:38:30.461] [START] Reporting session 08b621fa-****-****-****a8fcfd0561d1 to runner 
[11:38:30.465] [CONTROL CLIENT] Runner is not running, file is stale 
[11:38:30.466] [START] Failed to report to runner (may not be running): Runner is not running, file is stale
[11:38:30.467] [MessageQueue2] Initialized 
[11:38:30.470] [Codex] Synced session config for keepalive: permissionMode=default, model=auto, modelReasoningEffort=default, collaborationMode=default 
[11:38:30.471] [codex-loop] Iteration with mode: local 
[11:38:30.487] Socket connected successfully 
[11:38:30.508] [codex-local]: Started hapi MCP bridge server at http://127.0.0.1:59083/ 
[11:38:30.539] [hookServer] Started on port 59084 
[11:38:30.540] [codex-local]: Started Codex SessionStart hook server on port 59084 
[11:38:30.542] [codex-local]: launch 
[11:38:30.544] [CodexLocal] Spawning codex with args: ["-c","mcp_servers.hapi.command=\"D:\\\\work\\\\code\\\\nodeJs\\\\hapi\\\\cli\\\\dist-exe\\\\bun-windows-x64\\\\hapi.exe\"","-c","mcp_servers.hapi.args=['mcp','--url','http://127.0.0.1:59083/']","-c","hooks.SessionStart=[{ hooks = [{ type = \"command\", command = \"\\\"D:\\\\\\\\work\\\\\\\\code\\\\\\\\nodeJs\\\\\\\\hapi\\\\\\\\cli\\\\\\\\dist-exe\\\\\\\\bun-windows-x64\\\\\\\\hapi.exe\\\" hook-forwarder --port 59084 --token 08d957975f***********31a374\" }] }]","-c","hooks.state={\"C:\\\\<session-flags>\\\\config.toml:session_start:0:0\"={trusted_hash=\"sha256:f4255c0************2\"}}","-c","developer_instructions=\"ALWAYS when you start a new chat, call the title tool to set a concise task title.\\nPrefer calling functions.hapi__change_title.\\nIf that exact tool name is unavailable, call an equivalent alias such as hapi__change_title, mcp__hapi__change_title, or hapi_change_title.\\nIf the task focus changes significantly later, call the title tool again with a better title.\\nWhen you create or find a local image file that the user should see, call functions.hapi__display_image with the image path. If that exact tool name is unavailable, use an equivalent alias such as hapi__display_image, mcp__hapi__display_image, or hapi_display_image.\""] 

**可以成功运行codex cli**