### PR TITLE
fix(claude): apply mid-turn permission mode changes to canCallTool

### DIFF
--- a/cli/src/claude/session.ts
+++ b/cli/src/claude/session.ts
@@ -78,6 +78,13 @@ export class Session extends AgentSessionBase<EnhancedMode> {
         this.permissionMode = mode;
     };
 
+    // Override base getPermissionMode to return the Claude-narrow type. Safe
+    // because the only writer (setPermissionMode above) accepts only Claude
+    // PermissionMode, so the field cannot hold a foreign flavor value.
+    getPermissionMode(): PermissionMode | undefined {
+        return this.permissionMode as PermissionMode | undefined;
+    }
+
     setModel = (model: SessionModel): void => {
         this.model = model;
     };

--- a/cli/src/claude/utils/permissionHandler.test.ts
+++ b/cli/src/claude/utils/permissionHandler.test.ts
@@ -5,6 +5,7 @@ import type { Session } from '../session';
 
 function createFakeSession() {
     const queueItems: { message: string; mode: unknown }[] = [];
+    let permissionMode: string | undefined;
 
     const session = {
         client: {
@@ -18,7 +19,10 @@ function createFakeSession() {
                 queueItems.push({ message, mode });
             }),
         },
-        setPermissionMode: vi.fn(),
+        setPermissionMode: vi.fn((mode: string) => {
+            permissionMode = mode;
+        }),
+        getPermissionMode: vi.fn(() => permissionMode),
     } as unknown as Session;
 
     return { session, queueItems };
@@ -104,5 +108,36 @@ describe('PermissionHandler — YOLO plan mode', () => {
 
         expect(result.behavior).toBe('allow');
         expect(queueItems).toHaveLength(0);
+    });
+
+    // Regression: turn-in-progress switch from default to bypassPermissions via
+    // SetSessionConfig RPC updates session.setPermissionMode but doesn't go
+    // through handler.handleModeChange. The next canCallTool must reflect the
+    // new mode. See issue #735.
+    it('reflects session permission mode changes between tool calls', async () => {
+        const { session } = createFakeSession();
+        const handler = new PermissionHandler(session);
+        handler.handleModeChange('default');
+
+        // Simulate RPC handler in runClaude updating the session directly,
+        // bypassing handler.handleModeChange (as happens on web dropdown change).
+        session.setPermissionMode('bypassPermissions');
+
+        handler.onMessage({
+            type: 'assistant',
+            message: {
+                role: 'assistant',
+                content: [{ type: 'tool_use', id: 'tc-4', name: 'Bash', input: { command: 'ls' } }],
+            },
+        } as any);
+
+        const result = await handler.handleToolCall(
+            'Bash',
+            { command: 'ls' },
+            { permissionMode: 'bypassPermissions' } as any,
+            { signal: new AbortController().signal }
+        );
+
+        expect(result.behavior).toBe('allow');
     });
 });

--- a/cli/src/claude/utils/permissionHandler.ts
+++ b/cli/src/claude/utils/permissionHandler.ts
@@ -164,14 +164,22 @@ export class PermissionHandler extends BasePermissionHandler<PermissionResponse,
     private allowedTools = new Set<string>();
     private allowedBashLiterals = new Set<string>();
     private allowedBashPrefixes = new Set<string>();
-    private permissionMode: PermissionMode = 'default';
     private onPermissionRequestCallback?: (toolCallId: string) => void;
 
     constructor(session: Session) {
         super(session.client);
         this.session = session;
     }
-    
+
+    // Read from the session so mid-turn updates via SetSessionConfig RPC
+    // (which writes through session.setPermissionMode) are picked up by the
+    // next canCallTool check. Previously this was a stored field updated
+    // only on batch boundaries, so web dropdown changes during a turn were
+    // silently ignored — see issue #735.
+    private get permissionMode(): PermissionMode {
+        return this.session.getPermissionMode() ?? 'default';
+    }
+
     /**
      * Set callback to trigger when permission request is made
      */
@@ -180,7 +188,6 @@ export class PermissionHandler extends BasePermissionHandler<PermissionResponse,
     }
 
     handleModeChange(mode: PermissionMode) {
-        this.permissionMode = mode;
         this.session.setPermissionMode(mode);
     }
 
@@ -215,7 +222,6 @@ export class PermissionHandler extends BasePermissionHandler<PermissionResponse,
 
         // Update permission mode
         if (response.mode) {
-            this.permissionMode = response.mode;
             this.session.setPermissionMode(response.mode);
         }
 


### PR DESCRIPTION
## Summary

`PermissionHandler` stored its own `permissionMode` field and only updated it inside `handleModeChange`, which fires when a new batch is pulled from the queue. The `SetSessionConfig` RPC (web dropdown changes) updates `runClaude.ts`'s `currentPermissionMode` and the session keepalive metadata, but never reaches the handler — so switching from default to Yolo *while a turn was in progress* left `canCallTool` checking the stale mode and still prompting for approval.

Drop the stored field and read live from `session.getPermissionMode()`, mirroring how the OpenCode permission handler already works. Override `Session.getPermissionMode()` in `claude/session.ts` to return the Claude-narrow `PermissionMode`, which is sound because the matching `setPermissionMode` setter only accepts that subset, so the field cannot hold a foreign flavor value.

Closes #735.

### Why #735 triggers this

In #735's repro:
1. Plan finishes → `exit_plan_mode` approval card
2. User clicks 確定 *without* picking a mode (web has no mode selector here — that's #444)
3. Handler unshifts `PLAN_FAKE_RESTART` with `permissionMode: 'default'` and Claude restarts a new turn under default
4. User now manually switches to Yolo via the dropdown — RPC updates session/metadata but not the handler
5. Every subsequent tool call in the fake-restart turn still pops an approval card

After this fix step 5 auto-approves as expected.

## Disclosure

Vibe-coded with Claude Opus 4.7 (via HAPI).

## Test plan

- [x] `bun typecheck` passes
- [x] `bun run test src/claude` — 95/95 pass including new regression test
- [x] Manual: isolated hub + runner, ran the #735 repro on `fix/claude-mid-turn-permission-mode-735` source — switching to Yolo mid-turn after exit_plan_mode now auto-approves subsequent tool calls; before the fix the same flow kept prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)