### PR TITLE
fix(cli,web): hide Windows spawn windows and show queued attachments

### DIFF
--- a/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import type { AgentMessage } from '@/agent/types';
 import { AcpSdkBackend } from './AcpSdkBackend';
+import { buildAcpStdioSpawnOptions } from './AcpStdioTransport';
 import { ACP_SESSION_UPDATE_TYPES } from './constants';
 
 function sleep(ms: number): Promise<void> {
@@ -27,6 +28,14 @@ const originalStatics = {
     lateFlushQuietPeriodMs: backendStatics.LATE_FLUSH_QUIET_PERIOD_MS,
     lateFlushWindowMs: backendStatics.LATE_FLUSH_WINDOW_MS
 };
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+function setPlatform(value: string) {
+    Object.defineProperty(process, 'platform', {
+        value,
+        configurable: true
+    });
+}
 
 afterEach(() => {
     backendStatics.UPDATE_QUIET_PERIOD_MS = originalStatics.updateQuietPeriodMs;
@@ -36,9 +45,23 @@ afterEach(() => {
     backendStatics.LATE_FLUSH_INTERVAL_MS = originalStatics.lateFlushIntervalMs;
     backendStatics.LATE_FLUSH_QUIET_PERIOD_MS = originalStatics.lateFlushQuietPeriodMs;
     backendStatics.LATE_FLUSH_WINDOW_MS = originalStatics.lateFlushWindowMs;
+    if (originalPlatformDescriptor) {
+        Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+    }
 });
 
 describe('AcpSdkBackend', () => {
+    it('hides the ACP stdio shell on Windows', () => {
+        setPlatform('win32');
+
+        expect(buildAcpStdioSpawnOptions({ TEST_ENV: '1' })).toMatchObject({
+            env: { TEST_ENV: '1' },
+            stdio: ['pipe', 'pipe', 'pipe'],
+            shell: true,
+            windowsHide: true
+        });
+    });
+
     it('allows the permission handler to resolve requests immediately', async () => {
         const backend = new AcpSdkBackend({ command: 'opencode' });
         let capturedRequestId: string | null = null;

--- a/cli/src/agent/backends/acp/AcpStdioTransport.ts
+++ b/cli/src/agent/backends/acp/AcpStdioTransport.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptions } from 'node:child_process';
 import { logger } from '@/ui/logger';
 import { killProcessByChildProcess } from '@/utils/process';
 import { GEMINI_MODEL_PRESETS } from '@hapi/protocol';
@@ -37,6 +37,16 @@ export type AcpStderrError = {
     raw: string;
 };
 
+/** @internal Exported for regression tests. */
+export function buildAcpStdioSpawnOptions(env?: Record<string, string>): SpawnOptions {
+    return {
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: process.platform === 'win32',
+        windowsHide: process.platform === 'win32'
+    };
+}
+
 export class AcpStdioTransport {
     private readonly process: ChildProcessWithoutNullStreams;
     private readonly pending = new Map<string | number, {
@@ -55,11 +65,11 @@ export class AcpStdioTransport {
         args?: string[];
         env?: Record<string, string>;
     }) {
-        this.process = spawn(options.command, options.args ?? [], {
-            env: options.env,
-            stdio: ['pipe', 'pipe', 'pipe'],
-            shell: process.platform === 'win32'
-        });
+        this.process = spawn(
+            options.command,
+            options.args ?? [],
+            buildAcpStdioSpawnOptions(options.env)
+        ) as ChildProcessWithoutNullStreams;
 
         this.process.stdout.setEncoding('utf8');
         this.process.stdout.on('data', (chunk) => this.handleStdout(chunk));

--- a/cli/src/claude/sdk/utils.ts
+++ b/cli/src/claude/sdk/utils.ts
@@ -45,7 +45,8 @@ function findWhereResults(command: string): string[] {
         const result = execFileSync('where.exe', [command], {
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'pipe'],
-            cwd: homedir()
+            cwd: homedir(),
+            windowsHide: process.platform === 'win32'
         })
 
         return result

--- a/cli/src/codex/utils/codexExecutable.ts
+++ b/cli/src/codex/utils/codexExecutable.ts
@@ -15,7 +15,8 @@ function findWhereResults(command: string): string[] {
         const result = execFileSync('where.exe', [command], {
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'pipe'],
-            cwd: homedir()
+            cwd: homedir(),
+            windowsHide: process.platform === 'win32'
         });
 
         return result

--- a/cli/src/codex/utils/codexVersion.ts
+++ b/cli/src/codex/utils/codexVersion.ts
@@ -58,7 +58,8 @@ export function assertCodexLocalSupported(): void {
 
     const result = spawn.sync(codexCommand.command, [...codexCommand.args, '--version'], {
         encoding: 'utf8',
-        env: withBunRuntimeEnv()
+        env: withBunRuntimeEnv(),
+        windowsHide: process.platform === 'win32'
     })
 
     if (result.error) {

--- a/cli/src/commands/claude.ts
+++ b/cli/src/commands/claude.ts
@@ -122,7 +122,12 @@ ${chalk.bold.cyan('Claude Code Options (from `claude --help`):')}
                 const claudeHelp = execFileSync(
                     'claude',
                     ['--help'],
-                    { encoding: 'utf8', env: withBunRuntimeEnv(), shell: process.platform === 'win32' }
+                    {
+                        encoding: 'utf8',
+                        env: withBunRuntimeEnv(),
+                        shell: process.platform === 'win32',
+                        windowsHide: process.platform === 'win32'
+                    }
                 )
                 console.log(claudeHelp)
             } catch {

--- a/cli/src/cursor/cursorRemoteLauncher.ts
+++ b/cli/src/cursor/cursorRemoteLauncher.ts
@@ -197,7 +197,8 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
                 cwd,
                 env: process.env,
                 stdio: ['ignore', 'pipe', 'pipe'],
-                shell: process.platform === 'win32'
+                shell: process.platform === 'win32',
+                windowsHide: process.platform === 'win32'
             });
 
             const abortHandler = () => {

--- a/cli/src/modules/common/cursorModels.ts
+++ b/cli/src/modules/common/cursorModels.ts
@@ -61,7 +61,8 @@ async function runCursorModelProbe(): Promise<ListCursorModelsResponse> {
         const child = spawn('agent', ['--list-models'], {
             env: process.env,
             stdio: ['ignore', 'pipe', 'pipe'],
-            shell: process.platform === 'win32'
+            shell: process.platform === 'win32',
+            windowsHide: process.platform === 'win32'
         });
         let stdout = '';
         let stderr = '';

--- a/cli/src/modules/difftastic/index.ts
+++ b/cli/src/modules/difftastic/index.ts
@@ -43,7 +43,8 @@ export function run(args: string[], options?: DifftasticOptions): Promise<Diffta
                 ...process.env,
                 // Force color output when needed
                 FORCE_COLOR: '1'
-            }
+            },
+            windowsHide: process.platform === 'win32'
         });
 
         let stdout = '';

--- a/cli/src/modules/ripgrep/index.ts
+++ b/cli/src/modules/ripgrep/index.ts
@@ -30,7 +30,8 @@ export function run(args: string[], options?: RipgrepOptions): Promise<RipgrepRe
         const child = spawn(binaryPath, args, {
             stdio: ['pipe', 'pipe', 'pipe'],
             cwd: options?.cwd,
-            env: withBunRuntimeEnv()
+            env: withBunRuntimeEnv(),
+            windowsHide: process.platform === 'win32'
         });
 
         let stdout = '';

--- a/cli/src/utils/spawnWithAbort.test.ts
+++ b/cli/src/utils/spawnWithAbort.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 
 // Create a fake child process emitter for each test
@@ -26,6 +26,24 @@ vi.mock('@/utils/process', () => ({
 }));
 
 import { spawnWithAbort } from './spawnWithAbort';
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+function setPlatform(value: string) {
+    Object.defineProperty(process, 'platform', {
+        value,
+        configurable: true
+    });
+}
+
+function getSpawnOptions() {
+    const firstCall = spawnMock.mock.calls[0] as unknown[] | undefined;
+    const options = firstCall?.[2] as { windowsHide?: boolean; shell?: unknown } | undefined;
+    if (!options) {
+        throw new Error('Expected spawn options');
+    }
+    return options;
+}
 
 function makeOptions(overrides: Partial<Parameters<typeof spawnWithAbort>[0]> = {}) {
     const controller = new AbortController();
@@ -55,7 +73,37 @@ describe('spawnWithAbort', () => {
         vi.clearAllMocks();
     });
 
+    afterEach(() => {
+        if (originalPlatformDescriptor) {
+            Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+        }
+    });
+
     describe('normal exit (no abort)', () => {
+        it('hides spawned console windows on Windows by default', async () => {
+            setPlatform('win32');
+            const { opts } = makeOptions();
+            const p = spawnWithAbort(opts);
+            await waitForExitListener();
+
+            expect(getSpawnOptions().windowsHide).toBe(true);
+
+            childEmitter.emit('exit', 0, null);
+            await expect(p).resolves.toBeUndefined();
+        });
+
+        it('allows callers to explicitly keep Windows child windows visible', async () => {
+            setPlatform('win32');
+            const { opts } = makeOptions({ windowsHide: false });
+            const p = spawnWithAbort(opts);
+            await waitForExitListener();
+
+            expect(getSpawnOptions().windowsHide).toBe(false);
+
+            childEmitter.emit('exit', 0, null);
+            await expect(p).resolves.toBeUndefined();
+        });
+
         it('resolves when process exits with code 0', async () => {
             const { opts } = makeOptions();
             const p = spawnWithAbort(opts);

--- a/cli/src/utils/spawnWithAbort.ts
+++ b/cli/src/utils/spawnWithAbort.ts
@@ -30,6 +30,7 @@ export type SpawnWithAbortOptions = {
     logExit?: boolean;
     shell?: SpawnOptions['shell'];
     stdio?: StdioOptions;
+    windowsHide?: SpawnOptions['windowsHide'];
 };
 
 export async function spawnWithAbort(options: SpawnWithAbortOptions): Promise<void> {
@@ -52,7 +53,8 @@ export async function spawnWithAbort(options: SpawnWithAbortOptions): Promise<vo
             stdio,
             cwd: options.cwd,
             env: options.env,
-            shell: options.shell
+            shell: options.shell,
+            windowsHide: options.windowsHide ?? process.platform === 'win32'
         });
 
         let abortKillTimeout: NodeJS.Timeout | null = null;

--- a/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { DecryptedMessage } from '@/types/api'
-import { computeCanCancel, computeEditPendingSchedule, formatScheduledTime, sortQueuedMessages } from './QueuedMessagesBar'
+import { computeCanCancel, computeEditPendingSchedule, formatScheduledTime, getQueuedMessagePreview, sortQueuedMessages } from './QueuedMessagesBar'
 
 /**
  * Unit tests for computeCanCancel — the race guard that prevents sending
@@ -126,6 +126,68 @@ describe('sortQueuedMessages', () => {
         const sched2 = make('sched-far', 600, 10_000)
         const result = sortQueuedMessages([sched2, im2, sched1, im1])
         expect(result.map((m) => m.id)).toEqual(['im1', 'im2', 'sched-near', 'sched-far'])
+    })
+})
+
+describe('getQueuedMessagePreview', () => {
+    it('keeps attachment names with a text prompt', () => {
+        const message = {
+            id: 'queued-with-image',
+            localId: 'queued-with-image',
+            createdAt: 1000,
+            seq: null,
+            invokedAt: null,
+            status: 'queued',
+            content: {
+                role: 'user',
+                content: {
+                    type: 'text',
+                    text: 'Analyze this screenshot',
+                    attachments: [{
+                        id: 'att-1',
+                        filename: 'image.png',
+                        mimeType: 'image/png',
+                        size: 1234,
+                        path: '/tmp/image.png',
+                    }],
+                },
+            },
+        } as unknown as DecryptedMessage
+
+        expect(getQueuedMessagePreview(message)).toEqual({
+            text: 'Analyze this screenshot',
+            attachmentNames: ['image.png'],
+        })
+    })
+
+    it('uses attachment names for attachment-only queued messages', () => {
+        const message = {
+            id: 'queued-image-only',
+            localId: 'queued-image-only',
+            createdAt: 1000,
+            seq: null,
+            invokedAt: null,
+            status: 'queued',
+            content: {
+                role: 'user',
+                content: {
+                    type: 'text',
+                    text: '',
+                    attachments: [{
+                        id: 'att-1',
+                        filename: 'image.png',
+                        mimeType: 'image/png',
+                        size: 1234,
+                        path: '/tmp/image.png',
+                    }],
+                },
+            },
+        } as unknown as DecryptedMessage
+
+        expect(getQueuedMessagePreview(message)).toEqual({
+            text: '',
+            attachmentNames: ['image.png'],
+        })
     })
 })
 

--- a/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { DecryptedMessage } from '@/types/api'
-import { computeCanCancel, computeEditPendingSchedule, formatScheduledTime, getQueuedMessagePreview, sortQueuedMessages } from './QueuedMessagesBar'
+import { computeCanCancel, computeEditPendingSchedule, formatScheduledTime, getQueuedMessageEditText, getQueuedMessagePreview, sortQueuedMessages } from './QueuedMessagesBar'
 
 /**
  * Unit tests for computeCanCancel — the race guard that prevents sending
@@ -188,6 +188,22 @@ describe('getQueuedMessagePreview', () => {
             text: '',
             attachmentNames: ['image.png'],
         })
+    })
+})
+
+describe('getQueuedMessageEditText', () => {
+    it('keeps the prompt text when queued message has both text and attachments', () => {
+        expect(getQueuedMessageEditText({
+            text: 'Analyze this screenshot',
+            attachmentNames: ['image.png'],
+        })).toBe('Analyze this screenshot')
+    })
+
+    it('falls back to attachment names for attachment-only queued messages', () => {
+        expect(getQueuedMessageEditText({
+            text: '',
+            attachmentNames: ['image.png', 'trace.log'],
+        })).toBe('image.png, trace.log')
     })
 })
 

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -75,23 +75,18 @@ function useQueuedMessages(sessionId: string): DecryptedMessage[] {
     }, [state])
 }
 
-function getTextFromMessage(msg: DecryptedMessage): string {
+/** @internal Exported for unit testing. */
+export function getQueuedMessagePreview(msg: DecryptedMessage): { text: string; attachmentNames: string[] } {
     const normalized = normalizeDecryptedMessage(msg)
     if (!normalized || normalized.role !== 'user') {
-        return ''
+        return { text: '', attachmentNames: [] }
     }
     const text = (normalized.content.text ?? '').trim()
-    if (text) {
-        return text
-    }
-    // Attachment-only sends: the composer / POST /messages allow empty text
-    // when attachments are present. Fall back to the filenames so the chip
-    // is not blank.
     const attachments = normalized.content.attachments ?? []
-    if (attachments.length === 0) {
-        return ''
+    return {
+        text,
+        attachmentNames: attachments.map((a) => a.filename ?? 'attachment'),
     }
-    return attachments.map((a) => a.filename ?? 'attachment').join(', ')
 }
 
 /**
@@ -203,7 +198,8 @@ export function QueuedMessagesBar({
                     aria-label="Queued messages"
                 >
                     {queued.map((msg) => {
-                        const text = getTextFromMessage(msg)
+                        const { text, attachmentNames } = getQueuedMessagePreview(msg)
+                        const hasAttachments = attachmentNames.length > 0
                         const localId = msg.localId ?? msg.id
                         const isPending = cancelMutation.isPending && cancelMutation.variables?.localId === localId
                         const canCancel = computeCanCancel({ id: msg.id, localId: msg.localId, isPending })
@@ -263,9 +259,25 @@ export function QueuedMessagesBar({
                                 className="flex items-start gap-2 min-w-0 rounded-lg bg-[var(--app-secondary-bg)] px-3 py-2 shadow-sm"
                             >
                                 <div className="flex-1 min-w-0">
-                                    <span className="line-clamp-3 whitespace-pre-wrap break-words text-[var(--app-fg)]">
-                                        {text}
-                                    </span>
+                                    {text ? (
+                                        <span className="line-clamp-3 whitespace-pre-wrap break-words text-[var(--app-fg)]">
+                                            {text}
+                                        </span>
+                                    ) : null}
+                                    {hasAttachments ? (
+                                        <div className={text ? 'mt-1 flex flex-wrap gap-1' : 'flex flex-wrap gap-1'}>
+                                            {attachmentNames.map((name, index) => (
+                                                <span
+                                                    key={`${name}-${index}`}
+                                                    className="inline-flex max-w-full items-center gap-1 rounded-md bg-[var(--app-bg)] px-2 py-0.5 text-xs text-[var(--app-hint)]"
+                                                    title={name}
+                                                >
+                                                    <span aria-hidden="true">📎</span>
+                                                    <span className="truncate">{name}</span>
+                                                </span>
+                                            ))}
+                                        </div>
+                                    ) : null}
                                     {msg.scheduledAt != null && msg.scheduledAt > Date.now() && (
                                         <div className="mt-1 flex items-center gap-1 text-xs text-[var(--app-hint)]">
                                             <ClockIcon />

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -89,6 +89,11 @@ export function getQueuedMessagePreview(msg: DecryptedMessage): { text: string; 
     }
 }
 
+/** @internal Exported for unit testing. */
+export function getQueuedMessageEditText(preview: { text: string; attachmentNames: string[] }): string {
+    return preview.text || preview.attachmentNames.join(', ')
+}
+
 /**
  * Computes the PendingSchedule to restore when editing a queued message.
  *
@@ -198,7 +203,9 @@ export function QueuedMessagesBar({
                     aria-label="Queued messages"
                 >
                     {queued.map((msg) => {
-                        const { text, attachmentNames } = getQueuedMessagePreview(msg)
+                        const preview = getQueuedMessagePreview(msg)
+                        const { text, attachmentNames } = preview
+                        const editText = getQueuedMessageEditText(preview)
                         const hasAttachments = attachmentNames.length > 0
                         const localId = msg.localId ?? msg.id
                         const isPending = cancelMutation.isPending && cancelMutation.variables?.localId === localId
@@ -241,11 +248,11 @@ export function QueuedMessagesBar({
                                             return
                                         }
                                         // Restore text into composer
-                                        if (text) {
-                                            assistantApi.composer().setText(text)
+                                        if (editText) {
+                                            assistantApi.composer().setText(editText)
                                         }
                                         // Restore schedule via parent callback (if provided)
-                                        onEdit?.({ text, pendingSchedule: restoredPendingSchedule })
+                                        onEdit?.({ text: editText, pendingSchedule: restoredPendingSchedule })
                                     },
                                 }
                             )


### PR DESCRIPTION
## Summary
- Show queued message attachments as inline filename chips so image/file context follows the queued prompt.
- Hide transient Windows child process windows for runner-spawned sessions and related CLI probes.
- Add regression coverage for queued attachment previews and Windows hidden-spawn options.

## Why
- Queued prompts with images looked like the attachment was still attached to the composer, which could make users think the next prompt would reuse it.
- On Windows, web-triggered new sessions could briefly open multiple pwsh/cmd windows before closing.

## Scope / impact
- Web: queued messages now keep text and attachment filenames together in the queued bar.
- CLI: child processes launched through common spawn paths set `windowsHide` on Windows.
- No protocol or storage migration changes.

## Validation
- `bun vitest run src/utils/spawnWithAbort.test.ts src/agent/backends/acp/AcpSdkBackend.test.ts src/utils/spawnHappyCLI.test.ts src/codex/utils/codexExecutable.test.ts src/claude/sdk/utils.test.ts src/codex/utils/codexVersion.test.ts` - 6 files, 63 tests passed.
- `bun run --cwd web test QueuedMessagesBar.test.tsx` - 1 file, 17 tests passed.
- `bun run --cwd cli tsc --noEmit` - passed.
- `bun run --cwd web typecheck` - passed.
- `git diff --check` - passed.

## Risk / rollback
- Low risk. Changes are limited to UI rendering for queued attachments and Windows spawn options.
- Roll back this commit if hidden process spawning causes agent launch issues on Windows.

## Reviewer notes
- Please focus on whether every web-triggered Windows spawn path that can create a transient shell now uses `windowsHide`.
- The queued attachment UI intentionally shows filename chips, not full previews, to keep the floating bar compact.
