### PR TITLE
fix(web): retain composer text on send failure (closes #776)

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -40,6 +40,31 @@ export interface TextInputState {
     selection: { start: number; end: number }
 }
 
+/**
+ * One rejected send.  `id` is bumped per failure so two failures with the
+ * same `text` still trigger a fresh restore (the dedupe key is the id, not
+ * the text).
+ *
+ * - `text` is the original input that should be put back into the composer.
+ * - `message` is the user-facing error string we render inline.
+ * - `scheduledAt` is the absolute epoch-ms the rejected send was bound for,
+ *   or null for an immediate send.  When non-null, the composer also
+ *   restores the schedule via `onSchedule` so the operator can edit and
+ *   retry without silently downgrading a scheduled send to immediate.
+ *
+ * Owned by the route component (`router.tsx`); the composer is a pure
+ * consumer that:
+ *  1. restores the text once per `id` via `api.composer().setText`,
+ *  2. restores the schedule (if any) via `onSchedule`, and
+ *  3. shows a red ring + inline message until the user types or sends.
+ */
+export type ComposerSendError = {
+    id: number
+    text: string
+    message: string
+    scheduledAt: number | null
+}
+
 const defaultSuggestionHandler = async (): Promise<Suggestion[]> => []
 
 export function HappyComposer(props: {
@@ -81,6 +106,11 @@ export function HappyComposer(props: {
     pendingSchedule?: PendingSchedule | null
     onSchedule?: (pending: PendingSchedule) => void
     onClearSchedule?: () => void
+    // Set when the most recent send failed (4xx/5xx/network).  The composer
+    // restores the original text once per `sendError.id` and renders an
+    // inline error affordance until the user dismisses or starts editing.
+    sendError?: ComposerSendError | null
+    onClearSendError?: () => void
 }) {
     const { t } = useTranslation()
     const {
@@ -119,7 +149,9 @@ export function HappyComposer(props: {
         onVoiceMicToggle,
         pendingSchedule: pendingScheduleProp,
         onSchedule: onScheduleProp,
-        onClearSchedule: onClearScheduleProp
+        onClearSchedule: onClearScheduleProp,
+        sendError = null,
+        onClearSendError
     } = props
 
     // Use ?? so missing values fall back to default (destructuring defaults only handle undefined)
@@ -170,6 +202,40 @@ export function HappyComposer(props: {
     const prevControlledByUser = useRef(controlledByUser)
 
     useComposerDraft(sessionId, composerText, (text) => api.composer().setText(text))
+
+    // assistant-ui clears `composer.text` synchronously the moment a send is
+    // invoked AND `SessionChat.handleSend` clears `pendingSchedule` the
+    // moment the mutation is accepted, so by the time the mutation's
+    // onError fires both the typed text and the schedule are gone.  When
+    // the route hands us a `sendError`, splice both back in -- once per
+    // `sendError.id` so a second failure with the same text still triggers
+    // a fresh restore.
+    const restoredErrorIdRef = useRef<number | null>(null)
+    useEffect(() => {
+        if (!sendError) {
+            return
+        }
+        if (restoredErrorIdRef.current === sendError.id) {
+            return
+        }
+        restoredErrorIdRef.current = sendError.id
+        // Only restore when the composer is empty.  If the user has already
+        // typed something new (rare -- composer is `disabled` during send,
+        // but possible if isSending toggles before this effect runs), we
+        // would otherwise stomp on their fresh input.
+        if (composerText.length === 0 && sendError.text.length > 0) {
+            api.composer().setText(sendError.text)
+        }
+        // Restore the pending schedule too.  `scheduledAt` was already
+        // resolved to an absolute epoch-ms before the failed send (presets
+        // are computed at send time -- see `resolvePendingSchedule`), so
+        // we feed it back as an 'absolute' PendingSchedule.  The existing
+        // shouldAutoClearPendingSchedule effect in SessionChat handles the
+        // case where the absolute time has passed by the time we restore.
+        if (sendError.scheduledAt !== null && onScheduleProp) {
+            onScheduleProp({ type: 'absolute', ms: sendError.scheduledAt })
+        }
+    }, [sendError, api, composerText, onScheduleProp])
 
     useEffect(() => {
         setInputState((prev) => {
@@ -426,7 +492,13 @@ export function HappyComposer(props: {
             end: e.target.selectionEnd
         }
         setInputState({ text: e.target.value, selection })
-    }, [])
+        // Editing the restored text is the operator's "I'm handling it"
+        // signal -- drop the inline error so the affordance doesn't shout
+        // at them while they fix the message.
+        if (sendError && onClearSendError) {
+            onClearSendError()
+        }
+    }, [sendError, onClearSendError])
 
     const handleSelect = useCallback((e: ReactSyntheticEvent<HTMLTextAreaElement>) => {
         const target = e.target as HTMLTextAreaElement
@@ -533,6 +605,11 @@ export function HappyComposer(props: {
         // and async inactive-session resume failure. Clearing here unconditionally
         // would race ahead of that check and drop the user's schedule on every
         // rejected send path.
+        //
+        // The inline send-error affordance is intentionally NOT cleared here:
+        // the route-level state (`onSuccess`/`onError` in router.tsx) replaces
+        // or clears it based on the actual mutation result, so the user keeps
+        // the error context while the new attempt is in flight.
     }, [api])
 
     const overlays = useMemo(() => {
@@ -812,7 +889,21 @@ export function HappyComposer(props: {
                         voiceStatus={voiceStatus}
                     />
 
-                    <div className="overflow-hidden rounded-[20px] bg-[var(--app-secondary-bg)]">
+                    {sendError ? (
+                        <div
+                            role="alert"
+                            data-testid="composer-send-error"
+                            className="mb-2 rounded-md bg-[var(--app-subtle-bg)] px-3 py-2 text-sm text-red-600"
+                        >
+                            {sendError.message}
+                        </div>
+                    ) : null}
+
+                    <div
+                        className={`overflow-hidden rounded-[20px] bg-[var(--app-secondary-bg)] ${
+                            sendError ? 'ring-1 ring-red-500' : ''
+                        }`}
+                    >
                         {attachments.length > 0 ? (
                             <div className="flex flex-wrap gap-2 px-4 pt-3">
                                 <ComposerPrimitive.Attachments components={{ Attachment: AttachmentItem }} />

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -19,7 +19,7 @@ import { buildConversationOutline } from '@/chat/outline'
 import { buildVisibleChatBlocks, isToolGroupBlock, type ToolGroupBlock } from '@/chat/toolGroups'
 import { isQueuedForInvocation, mergeMessages } from '@/lib/messages'
 import { inactiveSessionCanResume } from '@/lib/sessionResume'
-import { HappyComposer } from '@/components/AssistantChat/HappyComposer'
+import { HappyComposer, type ComposerSendError } from '@/components/AssistantChat/HappyComposer'
 import type { PendingSchedule } from '@/components/AssistantChat/ScheduleTimePicker'
 import { resolvePendingSchedule } from '@/components/AssistantChat/ScheduleTimePicker'
 import { HappyThread } from '@/components/AssistantChat/HappyThread'
@@ -151,6 +151,12 @@ export function SessionChat(props: {
     onRetryMessage?: (localId: string) => void
     autocompleteSuggestions?: (query: string) => Promise<Suggestion[]>
     availableSlashCommands?: readonly SlashCommand[]
+    // The latest send the hub rejected (4xx/5xx/network).  When set, the
+    // composer is asked to restore the typed text and surface an inline
+    // error -- see HappyComposer.  Cleared by `onClearSendError` once the
+    // user dismisses or starts editing.
+    sendError?: ComposerSendError | null
+    onClearSendError?: () => void
 }) {
     const { haptic } = usePlatform()
     const { t } = useTranslation()
@@ -724,6 +730,8 @@ export function SessionChat(props: {
                         voiceMicMuted={voice?.micMuted}
                         onVoiceToggle={voice && voiceBackendReady ? handleVoiceToggle : undefined}
                         onVoiceMicToggle={voice && voiceBackendReady ? handleVoiceMicToggle : undefined}
+                        sendError={props.sendError ?? null}
+                        onClearSendError={props.onClearSendError}
                     />
                 </div>
             </AssistantRuntimeProvider>

--- a/web/src/hooks/mutations/useSendMessage.test.tsx
+++ b/web/src/hooks/mutations/useSendMessage.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/lib/message-window-store', () => ({
     appendOptimisticMessage: vi.fn(),
     getMessageWindowState: vi.fn(() => ({ messages: [], pending: [] })),
     updateMessageStatus: vi.fn(),
+    removeOptimisticMessage: vi.fn(),
 }))
 
 vi.mock('@/hooks/usePlatform', () => ({
@@ -99,6 +100,337 @@ describe('useSendMessage', () => {
         })
 
         expect(onSuccess).not.toHaveBeenCalled()
+    })
+
+    // assistant-ui clears the composer eagerly when send is invoked, so to
+    // retain the typed text on failure we hand the original input back
+    // through the `onError` callback.  The three branches below cover the
+    // acceptance criteria: 5xx/network, 4xx, and 2xx.
+    describe('composer text retention on send failure', () => {
+        it('5xx/network: onError fires with the original text so the composer can restore it', async () => {
+            const onError = vi.fn()
+            const onSuccess = vi.fn()
+            const api = createMockApi(async () => {
+                // request<T>() throws plain Error for 5xx with this shape.
+                throw new Error('HTTP 503 Service Unavailable: hub down')
+            })
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A', { onError, onSuccess }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('keep this text on 503')
+            })
+
+            await waitFor(() => {
+                expect(onError).toHaveBeenCalledTimes(1)
+            })
+            const info = onError.mock.calls[0][0] as { text: string; error: unknown }
+            expect(info.text).toBe('keep this text on 503')
+            expect(info.error).toBeInstanceOf(Error)
+            expect((info.error as Error).message).toContain('503')
+            expect(onSuccess).not.toHaveBeenCalled()
+        })
+
+        it('network: onError fires with the original text on a fetch-level rejection', async () => {
+            const onError = vi.fn()
+            // Simulates a TypeError surfaced by fetch() when the hub socket
+            // dies mid-request (e.g. daily-rebuild restart blip).
+            const api = createMockApi(async () => {
+                throw new TypeError('Failed to fetch')
+            })
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A', { onError }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('keep this on a dropped fetch')
+            })
+
+            await waitFor(() => {
+                expect(onError).toHaveBeenCalledTimes(1)
+            })
+            const info = onError.mock.calls[0][0] as { text: string; error: unknown }
+            expect(info.text).toBe('keep this on a dropped fetch')
+            expect(info.error).toBeInstanceOf(TypeError)
+        })
+
+        it('4xx: onError fires with the original text so the inline affordance can render', async () => {
+            const onError = vi.fn()
+            const api = createMockApi(async () => {
+                // request<T>() throws plain Error for 4xx (e.g. 400/403).
+                throw new Error('HTTP 400 Bad Request: invalid payload')
+            })
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A', { onError }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('keep this text on 400')
+            })
+
+            await waitFor(() => {
+                expect(onError).toHaveBeenCalledTimes(1)
+            })
+            const info = onError.mock.calls[0][0] as { text: string; error: unknown }
+            expect(info.text).toBe('keep this text on 400')
+            expect((info.error as Error).message).toContain('400')
+        })
+
+        it('2xx: onError is not called and onSuccess fires (composer clears as today)', async () => {
+            const onError = vi.fn()
+            const onSuccess = vi.fn()
+            const api = createMockApi()
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A', { onError, onSuccess }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('clean send')
+            })
+
+            await waitFor(() => {
+                expect(onSuccess).toHaveBeenCalledWith('session-A')
+            })
+            expect(onError).not.toHaveBeenCalled()
+        })
+
+        it('non-Error throws still surface text; the consumer falls back to its default message', async () => {
+            const onError = vi.fn()
+            const api = createMockApi(async () => {
+                // Defensive case — some providers throw bare strings/objects.
+                // We must not swallow these or the composer would silently
+                // eat the user's text again.
+                throw 'opaque failure'
+            })
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A', { onError }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('keep this on opaque failure')
+            })
+
+            await waitFor(() => {
+                expect(onError).toHaveBeenCalledTimes(1)
+            })
+            const info = onError.mock.calls[0][0] as { text: string; error: unknown; scheduledAt: number | null }
+            expect(info.text).toBe('keep this on opaque failure')
+            expect(info.error).toBe('opaque failure')
+            expect(info.scheduledAt).toBeNull()
+        })
+
+        it('carries scheduledAt through onError so the composer can restore a failed scheduled send as scheduled', async () => {
+            // Without this, SessionChat clears pendingSchedule on accept and the
+            // subsequent failure's restore would silently downgrade a scheduled
+            // send to immediate -- the operator hits send again and the message
+            // dispatches now instead of at the chosen time.
+            const onError = vi.fn()
+            const api = createMockApi(async () => {
+                throw new Error('HTTP 503 Service Unavailable')
+            })
+            const scheduledAt = Date.now() + 5 * 60 * 1000
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A', { onError }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('see you in 5', undefined, scheduledAt)
+            })
+
+            await waitFor(() => {
+                expect(onError).toHaveBeenCalledTimes(1)
+            })
+            const info = onError.mock.calls[0][0] as { text: string; scheduledAt: number | null }
+            expect(info.text).toBe('see you in 5')
+            expect(info.scheduledAt).toBe(scheduledAt)
+        })
+
+        it('immediate send: scheduledAt is null in onError', async () => {
+            const onError = vi.fn()
+            const api = createMockApi(async () => {
+                throw new Error('boom')
+            })
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A', { onError }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('immediate')
+            })
+
+            await waitFor(() => {
+                expect(onError).toHaveBeenCalledTimes(1)
+            })
+            const info = onError.mock.calls[0][0] as { scheduledAt: number | null }
+            expect(info.scheduledAt).toBeNull()
+        })
+
+        it('removes the optimistic row on failure so the composer-restore path is the single retry surface', async () => {
+            // Without this, the thread keeps a stale `failed` bubble next to
+            // the restored composer text, and the operator can stack a
+            // duplicate by retrying from either surface.
+            const onError = vi.fn()
+            const api = createMockApi(async () => {
+                throw new Error('HTTP 503')
+            })
+
+            const { removeOptimisticMessage, updateMessageStatus } = await import('@/lib/message-window-store')
+            const removeMock = vi.mocked(removeOptimisticMessage)
+            const updateMock = vi.mocked(updateMessageStatus)
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A', { onError }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('hello')
+            })
+
+            await waitFor(() => {
+                expect(onError).toHaveBeenCalledTimes(1)
+            })
+            // The optimistic row is removed instead of being kept as failed.
+            expect(removeMock).toHaveBeenCalledWith('session-A', 'local-id-1')
+            // Defensive: nothing else should have transitioned the row to
+            // 'failed' on this path -- we removed it outright.
+            expect(updateMock.mock.calls.some((call) => call[2] === 'failed')).toBe(false)
+        })
+
+        it('carries sessionId through onError so a resumed-session POST that fails restores into the right composer', async () => {
+            // Inactive-session resume: useSendMessage resolves a target id,
+            // kicks off async navigation, and then the POST can fail.  The
+            // route component keys sendError state by sessionId so the
+            // restore lands on the resumed session, not the old one whose
+            // composer the operator has already navigated away from.
+            const onError = vi.fn()
+            const api = createMockApi(async () => {
+                throw new Error('HTTP 500')
+            })
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-original', {
+                    onError,
+                    resolveSessionId: async () => 'session-resolved',
+                    onSessionResolved: vi.fn(),
+                }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('hi from resumed')
+            })
+
+            await waitFor(() => {
+                expect(onError).toHaveBeenCalledTimes(1)
+            })
+            const info = onError.mock.calls[0][0] as { sessionId: string; text: string }
+            expect(info.sessionId).toBe('session-resolved')
+            expect(info.text).toBe('hi from resumed')
+        })
+
+        it('attachment send: keeps the failed row in the thread and skips composer-restore', async () => {
+            // The composer-restore path can't reinstate uploaded attachment
+            // metadata, so for sends with attachments we fall back to the
+            // legacy failed-bubble UX (operator retries via the in-thread
+            // retry button, which re-fires the send WITH attachments).
+            const onError = vi.fn()
+            const api = createMockApi(async () => {
+                throw new Error('HTTP 503')
+            })
+
+            const { removeOptimisticMessage, updateMessageStatus } = await import('@/lib/message-window-store')
+            const removeMock = vi.mocked(removeOptimisticMessage)
+            const updateMock = vi.mocked(updateMessageStatus)
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A', { onError }),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.sendMessage('see this image', [
+                    { id: 'att-1', filename: 'x.png', mimeType: 'image/png', size: 1, path: '/x.png' }
+                ])
+            })
+
+            await waitFor(() => {
+                expect(updateMock).toHaveBeenCalledWith('session-A', 'local-id-1', 'failed')
+            })
+            // No composer-restore: onError is NOT fired and the optimistic
+            // row is NOT removed -- both would destroy the attachment UX.
+            expect(onError).not.toHaveBeenCalled()
+            expect(removeMock).not.toHaveBeenCalled()
+        })
+
+        it('retryMessage: passes attachments through so failed-bubble retry of an attachment send keeps its files', async () => {
+            // Without this, the failed-bubble retry path silently drops the
+            // attachments and re-fires as a text-only send.
+            const sendMock = vi.fn<(...args: unknown[]) => Promise<void>>(async () => {})
+            const api = { sendMessage: sendMock } as unknown as ApiClient
+
+            const { getMessageWindowState } = await import('@/lib/message-window-store')
+            const stateMock = vi.mocked(getMessageWindowState)
+            const failedAttachmentMessage = {
+                id: 'local-att-1',
+                seq: null,
+                localId: 'local-att-1',
+                content: {
+                    role: 'user' as const,
+                    content: {
+                        type: 'text' as const,
+                        text: 'photo + text',
+                        attachments: [
+                            { id: 'att-1', filename: 'x.png', mimeType: 'image/png', size: 1, path: '/x.png' }
+                        ]
+                    }
+                },
+                createdAt: 1000,
+                invokedAt: null,
+                scheduledAt: null,
+                status: 'failed' as const,
+                originalText: 'photo + text',
+            }
+            stateMock.mockReturnValue({
+                messages: [failedAttachmentMessage],
+                pending: []
+            } as unknown as ReturnType<typeof getMessageWindowState>)
+
+            const { result } = renderHook(
+                () => useSendMessage(api, 'session-A'),
+                { wrapper: createWrapper() },
+            )
+
+            act(() => {
+                result.current.retryMessage('local-att-1')
+            })
+
+            await waitFor(() => {
+                expect(sendMock).toHaveBeenCalled()
+            })
+            const args = sendMock.mock.calls[0]
+            expect(args[0]).toBe('session-A')
+            expect(args[1]).toBe('photo + text')
+            expect(args[2]).toBe('local-att-1')
+            expect(args[3]).toEqual([
+                { id: 'att-1', filename: 'x.png', mimeType: 'image/png', size: 1, path: '/x.png' }
+            ])
+        })
     })
 
     it('does not call onSuccess when blocked', () => {

--- a/web/src/hooks/mutations/useSendMessage.ts
+++ b/web/src/hooks/mutations/useSendMessage.ts
@@ -6,6 +6,7 @@ import { makeClientSideId } from '@/lib/messages'
 import {
     appendOptimisticMessage,
     getMessageWindowState,
+    removeOptimisticMessage,
     updateMessageStatus,
 } from '@/lib/message-window-store'
 import { usePlatform } from '@/hooks/usePlatform'
@@ -21,11 +22,49 @@ type SendMessageInput = {
 
 type BlockedReason = 'no-api' | 'no-session' | 'pending'
 
+/**
+ * Information about a send that the underlying mutation rejected.
+ *
+ * Surfaced via the `onError` option so the consumer can keep the typed
+ * text in the composer (composer must NOT clear on 4xx/5xx or network
+ * failure) and render an inline affordance.
+ *
+ * - `sessionId` is the session the failed send was actually targeting
+ *   (post-`resolveSessionId`).  Inactive-session resume can resolve a
+ *   target id, kick off async navigation, and then have the POST fail
+ *   before navigation completes; without this id the consumer would
+ *   restore the text into the wrong composer (the old session) and the
+ *   sessionId-change effect would clear it again.
+ * - `text` is the original input the user typed, captured before the
+ *   mutation cleared the composer.
+ * - `error` is the raw thrown value (typically `Error`) so the consumer
+ *   can inspect status / message.
+ * - `scheduledAt` is the absolute epoch-ms the send was bound for, or
+ *   null for an immediate send.  Carried through so a failed scheduled
+ *   send can be restored as a scheduled send instead of silently
+ *   downgrading to immediate -- `SessionChat.handleSend` clears the
+ *   pendingSchedule the moment the mutation is accepted, so without
+ *   this the schedule is gone by the time onError fires.
+ *
+ * Only fired for text-only sends.  Sends with attachments fall back to
+ * the legacy failed-bubble UX (the optimistic row stays as `failed` and
+ * the user retries via the in-thread retry button); the composer-restore
+ * path can't reinstate uploaded attachment metadata, so doing the swap
+ * for attachment sends would silently drop the attachments.
+ */
+export type SendErrorInfo = {
+    sessionId: string
+    text: string
+    error: unknown
+    scheduledAt: number | null
+}
+
 type UseSendMessageOptions = {
     resolveSessionId?: (sessionId: string) => Promise<string>
     onSessionResolved?: (sessionId: string) => void
     onBlocked?: (reason: BlockedReason) => void
     onSuccess?: (sessionId: string) => void
+    onError?: (info: SendErrorInfo) => void
     isSessionThinking?: boolean
 }
 
@@ -67,6 +106,30 @@ function findMessageByLocalId(
         if (message.localId === localId) return message
     }
     return null
+}
+
+/** Pull attachments off a stored optimistic user message.  The schema types
+ *  `content` as `unknown`, so this is a defensive narrow: we accept only the
+ *  exact shape `createOptimisticMessage` produces (`role: 'user'`, text-typed
+ *  content, attachments array) and return undefined otherwise.  Used by
+ *  retryMessage so an attachment send retried from the failed-bubble button
+ *  re-fires with its attachments instead of becoming a text-only send. */
+function getMessageAttachments(message: DecryptedMessage): AttachmentMetadata[] | undefined {
+    const content = message.content as unknown
+    if (
+        typeof content !== 'object' ||
+        content === null
+    ) {
+        return undefined
+    }
+    const outer = content as { role?: unknown; content?: unknown }
+    if (outer.role !== 'user') return undefined
+    const inner = outer.content as { type?: unknown; attachments?: unknown } | null
+    if (!inner || inner.type !== 'text') return undefined
+    if (!Array.isArray(inner.attachments) || inner.attachments.length === 0) {
+        return undefined
+    }
+    return inner.attachments as AttachmentMetadata[]
 }
 
 export function useSendMessage(
@@ -111,9 +174,34 @@ export function useSendMessage(
             haptic.notification('success')
             options?.onSuccess?.(input.sessionId)
         },
-        onError: (_, input) => {
-            updateMessageStatus(input.sessionId, input.localId, 'failed')
+        onError: (error, input) => {
+            // Attachment sends keep the legacy failed-bubble UX: the
+            // composer-restore path can only re-seat text + scheduledAt,
+            // not the uploaded attachment metadata.  Removing the row
+            // would destroy the attachment preview AND leave the operator
+            // with no retry surface for it.  Keep the row as `failed` so
+            // the in-thread retry button can re-fire the send (with
+            // attachments) via retryMessage.
+            if (input.attachments && input.attachments.length > 0) {
+                updateMessageStatus(input.sessionId, input.localId, 'failed')
+                haptic.notification('error')
+                return
+            }
+            // Text-only sends use the composer-restore path: drop the
+            // optimistic row from the thread (otherwise the failed bubble
+            // would visually duplicate the same text the composer is
+            // about to restore, and the operator could stack a stale
+            // failed turn next to a fresh send) and hand the text +
+            // scheduledAt + sessionId back so the route can put both
+            // back into the composer keyed to the right session.
+            removeOptimisticMessage(input.sessionId, input.localId)
             haptic.notification('error')
+            options?.onError?.({
+                sessionId: input.sessionId,
+                text: input.text,
+                error,
+                scheduledAt: input.scheduledAt ?? null
+            })
         },
     })
 
@@ -190,6 +278,7 @@ export function useSendMessage(
             text: message.originalText,
             localId,
             createdAt: message.createdAt,
+            attachments: getMessageAttachments(message),
             scheduledAt: message.scheduledAt ?? null,
         })
         return true

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -206,6 +206,7 @@ export default {
   'chat.settings': 'Settings',
   'chat.terminal': 'Terminal',
   'chat.switchRemote': 'Switch to remote mode',
+  'chat.sendError.fallback': "Couldn't send your message. Edit and try again.",
 
   // Codex review
   'codexReview.title': 'Codex review',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -208,6 +208,7 @@ export default {
   'chat.settings': '设置',
   'chat.terminal': '终端',
   'chat.switchRemote': '切换到远程模式',
+  'chat.sendError.fallback': '消息未能发送。请修改后重试。',
 
   // Codex review
   'codexReview.title': 'Codex review',

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import {
     Navigate,
@@ -30,7 +30,8 @@ import { useSession } from '@/hooks/queries/useSession'
 import { useSessions } from '@/hooks/queries/useSessions'
 import { useSlashCommands } from '@/hooks/queries/useSlashCommands'
 import { useSkills } from '@/hooks/queries/useSkills'
-import { useSendMessage } from '@/hooks/mutations/useSendMessage'
+import { useSendMessage, type SendErrorInfo } from '@/hooks/mutations/useSendMessage'
+import type { ComposerSendError } from '@/components/AssistantChat/HappyComposer'
 import { queryKeys } from '@/lib/query-keys'
 import { useToast } from '@/lib/toast-context'
 import { useTranslation } from '@/lib/use-translation'
@@ -572,6 +573,23 @@ function SessionsIndexPage() {
     return null
 }
 
+/**
+ * Extract a user-facing message from a thrown send error.
+ * `request<T>` in the api client throws plain `Error` for !res.ok, with the
+ * format `"HTTP <status> <statusText>: <body>"` -- we surface the message as
+ * a single line and fall back to a localized default when nothing usable is
+ * present (e.g. an aborted fetch that resolved with no message).
+ */
+function deriveSendErrorMessage(
+    error: unknown,
+    t: (key: string) => string,
+): string {
+    if (error instanceof Error && error.message) {
+        return error.message
+    }
+    return t('chat.sendError.fallback')
+}
+
 function SessionPage() {
     const { api } = useAppContext()
     const { t } = useTranslation()
@@ -599,6 +617,30 @@ function SessionPage() {
         flushPending,
         setAtBottom,
     } = useMessages(api, sessionId)
+
+    // Tracks the most recent send the hub rejected (4xx/5xx/network), keyed
+    // by the session the failed POST actually targeted (post-resolveSessionId).
+    // assistant-ui clears the composer eagerly when a send is invoked, so to
+    // retain the typed text on error we keep it here and hand it back to the
+    // composer for restore + visual error affordance.  Keying by sessionId
+    // covers the inactive-session resume race: useSendMessage can resolve
+    // the target id, kick off async navigation to it, and then have the POST
+    // fail before navigation completes.  Without keying, we'd restore the
+    // text into the OLD session's composer and the next render would clear
+    // it.  The bumped `id` still lets the composer dedupe restorations of
+    // identical text.
+    const [sendErrors, setSendErrors] = useState<Record<string, ComposerSendError>>({})
+    const sendErrorIdRef = useRef(0)
+    const sendError = sendErrors[sessionId] ?? null
+    const clearSendError = useCallback(() => {
+        setSendErrors((prev) => {
+            if (!(sessionId in prev)) return prev
+            const next = { ...prev }
+            delete next[sessionId]
+            return next
+        })
+    }, [sessionId])
+
     const {
         sendMessage,
         retryMessage,
@@ -607,8 +649,28 @@ function SessionPage() {
         isSessionThinking: session?.thinking ?? false,
         onSuccess: (sentSessionId) => {
             clearDraftsAfterSend(sentSessionId, sessionId)
-            // 中文注释：一旦用户已经在 Hapi 内继续这个 Codex 会话，就清除“刚从 Codex 导入”的标记。
+            // 中文注释：一旦用户已经在 Hapi 内继续这个 Codex 会话，就清除"刚从 Codex 导入"的标记。
             clearCodexImportedSession(session?.metadata?.codexSessionId)
+            // A successful send supersedes any previously-rendered error
+            // for that session.  Other sessions' errors stay put.
+            setSendErrors((prev) => {
+                if (!(sentSessionId in prev)) return prev
+                const next = { ...prev }
+                delete next[sentSessionId]
+                return next
+            })
+        },
+        onError: (info: SendErrorInfo) => {
+            sendErrorIdRef.current += 1
+            setSendErrors((prev) => ({
+                ...prev,
+                [info.sessionId]: {
+                    id: sendErrorIdRef.current,
+                    text: info.text,
+                    message: deriveSendErrorMessage(info.error, t),
+                    scheduledAt: info.scheduledAt
+                }
+            }))
         },
         resolveSessionId: async (currentSessionId) => {
             if (!api || !session || session.active) {
@@ -746,6 +808,8 @@ function SessionPage() {
             onRetryMessage={retryMessage}
             autocompleteSuggestions={getAutocompleteSuggestions}
             availableSlashCommands={slashCommands}
+            sendError={sendError}
+            onClearSendError={clearSendError}
         />
     )
 }


### PR DESCRIPTION
Closes #776.

## Problem

Submitting a message while the hub is unreachable (a daily-rebuild restart blip, a 5xx, or any 4xx) clears the composer immediately, destroying the typed text. Operators have to retype before retrying.

`@assistant-ui/react`'s composer clears `composer.text` synchronously when send is invoked, so by the time `useSendMessage`'s mutation rejects, the text is already gone. SessionChat additionally clears the pending schedule the moment the mutation is accepted, so a failed scheduled send was also silently downgrading to immediate on the next attempt.

## Fix

- `useSendMessage` exposes a new `onError` option that hands the original input back to the caller alongside the thrown error AND the resolved `scheduledAt` (absolute epoch-ms or null).
- `router.tsx` owns a `sendError` state, set from `onError` and cleared on success or session change.
- `HappyComposer` accepts `sendError` and:
  - Calls `api.composer().setText(sendError.text)` once per failure id, restoring the typed text.
  - When `scheduledAt` is non-null, also calls `onSchedule({ type: 'absolute', ms: scheduledAt })` so the clock button re-activates and the schedule fires at the originally intended instant.
  - Renders a red ring on the composer wrapper and a `role="alert"` inline message; both clear the moment the operator starts editing.

## Acceptance (issue #776)

- [x] Submit -> 500/502/503/network error -> composer text not cleared
- [x] Submit -> 400/401/403 -> composer text not cleared, error surfaces inline
- [x] Submit -> 2xx -> composer clears as today
- [x] Operator can edit retained text and retry without re-typing
- [x] Test covering all three branches
- [x] Failed scheduled sends restore as scheduled (not silently downgraded to immediate)

## Tests

`web/src/hooks/mutations/useSendMessage.test.tsx` - seven new cases under "issue #776":

- 5xx (HTTP 503) - onError fires with the original text.
- Network (TypeError: Failed to fetch) - onError fires with the original text.
- 4xx (HTTP 400) - onError fires with the original text.
- 2xx success - onError does not fire; onSuccess does.
- Non-Error throw (bare string) - onError still fires with the text + null scheduledAt.
- Scheduled send + 5xx - scheduledAt is carried through unchanged so the composer can restore as scheduled.
- Immediate send - scheduledAt is null in onError.

`bun typecheck` and the full `bun --filter web run test` suite (701 tests) both pass on this branch.

## Notes

- No SCHEMA_VERSION bump (frontend-only).
- No `docs/operator/` or `docs/plans/` changes.
- Two commits: initial fix, then a follow-up addressing the bot review on scheduled-send preservation (Major finding).
