### PR TITLE
feat(codex): support file mentions

### DIFF
--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -128,6 +128,11 @@ export type UserInput =
         type: 'skill';
         name: string;
         path: string;
+    }
+    | {
+        type: 'mention';
+        name: string;
+        path: string;
     };
 
 export type SandboxPolicy =

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -372,4 +372,12 @@ describe('appServerConfig', () => {
             { type: 'text', text: ' now' }
         ]);
     });
+
+    it('builds mention inputs from quoted @file tokens with spaces', () => {
+        expect(buildUserInputFromMessage('please inspect @"docs/My File.md" now')).toEqual([
+            { type: 'text', text: 'please inspect ' },
+            { type: 'mention', name: 'My File.md', path: 'docs/My File.md' },
+            { type: 'text', text: ' now' }
+        ]);
+    });
 });

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -380,4 +380,12 @@ describe('appServerConfig', () => {
             { type: 'text', text: ' now' }
         ]);
     });
+
+    it('keeps trailing sentence punctuation outside unquoted @file tokens', () => {
+        expect(buildUserInputFromMessage('please inspect @src/index.ts.')).toEqual([
+            { type: 'text', text: 'please inspect ' },
+            { type: 'mention', name: 'index.ts', path: 'src/index.ts' },
+            { type: 'text', text: '.' }
+        ]);
+    });
 });

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -365,8 +365,8 @@ describe('appServerConfig', () => {
         expect(params.model).toBe('o3');
     });
 
-    it('builds mention inputs from @file tokens', () => {
-        expect(buildUserInputFromMessage('please inspect @src/index.ts now')).toEqual([
+    it('builds mention inputs from quoted @file tokens', () => {
+        expect(buildUserInputFromMessage('please inspect @"src/index.ts" now')).toEqual([
             { type: 'text', text: 'please inspect ' },
             { type: 'mention', name: 'index.ts', path: 'src/index.ts' },
             { type: 'text', text: ' now' }
@@ -381,11 +381,17 @@ describe('appServerConfig', () => {
         ]);
     });
 
-    it('keeps trailing sentence punctuation outside unquoted @file tokens', () => {
-        expect(buildUserInputFromMessage('please inspect @src/index.ts.')).toEqual([
+    it('builds mention inputs from quoted root-level @file tokens', () => {
+        expect(buildUserInputFromMessage('please inspect @"package.json" now')).toEqual([
             { type: 'text', text: 'please inspect ' },
-            { type: 'mention', name: 'index.ts', path: 'src/index.ts' },
-            { type: 'text', text: '.' }
+            { type: 'mention', name: 'package.json', path: 'package.json' },
+            { type: 'text', text: ' now' }
+        ]);
+    });
+
+    it('keeps literal at-mentions as text', () => {
+        expect(buildUserInputFromMessage('please ask @alice to upgrade @types/node.')).toEqual([
+            { type: 'text', text: 'please ask @alice to upgrade @types/node.' }
         ]);
     });
 });

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -3,6 +3,7 @@ import type { EnhancedMode } from '../loop';
 import {
     buildThreadStartParams,
     buildTurnStartParams,
+    buildUserInputFromMessage,
     codexCollaborationSpawnAgentInstructions,
     supportsReasoningSummary
 } from './appServerConfig';
@@ -362,5 +363,13 @@ describe('appServerConfig', () => {
 
         expect(params.collaborationMode).toBeUndefined();
         expect(params.model).toBe('o3');
+    });
+
+    it('builds mention inputs from @file tokens', () => {
+        expect(buildUserInputFromMessage('please inspect @src/index.ts now')).toEqual([
+            { type: 'text', text: 'please inspect ' },
+            { type: 'mention', name: 'index.ts', path: 'src/index.ts' },
+            { type: 'text', text: ' now' }
+        ]);
     });
 });

--- a/cli/src/codex/utils/appServerConfig.ts
+++ b/cli/src/codex/utils/appServerConfig.ts
@@ -94,18 +94,14 @@ function mentionNameFromPath(path: string): string {
 
 export function buildUserInputFromMessage(message: string): UserInput[] {
     const inputs: UserInput[] = [];
-    const mentionPattern = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s]+))/g;
+    const mentionPattern = /(^|\s)@"((?:\\.|[^"\\])*)"/g;
     let lastIndex = 0;
     let match: RegExpExecArray | null;
 
     while ((match = mentionPattern.exec(message)) !== null) {
         const prefix = match[1] ?? '';
-        const quotedPath = match[2];
-        const unquotedPath = match[3];
-        const rawPath = quotedPath ?? unquotedPath ?? '';
-        const pathText = quotedPath === undefined
-            ? rawPath.replace(/[),.;!?]+$/, '')
-            : rawPath;
+        const rawPath = match[2] ?? '';
+        const pathText = rawPath;
         const path = pathText.replace(/\\(["\\])/g, '$1');
         if (!path) continue;
 

--- a/cli/src/codex/utils/appServerConfig.ts
+++ b/cli/src/codex/utils/appServerConfig.ts
@@ -100,8 +100,13 @@ export function buildUserInputFromMessage(message: string): UserInput[] {
 
     while ((match = mentionPattern.exec(message)) !== null) {
         const prefix = match[1] ?? '';
-        const rawPath = match[2] ?? match[3] ?? '';
-        const path = rawPath.replace(/\\(["\\])/g, '$1');
+        const quotedPath = match[2];
+        const unquotedPath = match[3];
+        const rawPath = quotedPath ?? unquotedPath ?? '';
+        const pathText = quotedPath === undefined
+            ? rawPath.replace(/[),.;!?]+$/, '')
+            : rawPath;
+        const path = pathText.replace(/\\(["\\])/g, '$1');
         if (!path) continue;
 
         const atIndex = match.index + prefix.length;
@@ -115,7 +120,7 @@ export function buildUserInputFromMessage(message: string): UserInput[] {
             name: mentionNameFromPath(path),
             path
         });
-        lastIndex = mentionPattern.lastIndex;
+        lastIndex = mentionPattern.lastIndex - (rawPath.length - pathText.length);
     }
 
     const remainder = message.slice(lastIndex);

--- a/cli/src/codex/utils/appServerConfig.ts
+++ b/cli/src/codex/utils/appServerConfig.ts
@@ -94,13 +94,14 @@ function mentionNameFromPath(path: string): string {
 
 export function buildUserInputFromMessage(message: string): UserInput[] {
     const inputs: UserInput[] = [];
-    const mentionPattern = /(^|\s)@([^\s]+)/g;
+    const mentionPattern = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s]+))/g;
     let lastIndex = 0;
     let match: RegExpExecArray | null;
 
     while ((match = mentionPattern.exec(message)) !== null) {
         const prefix = match[1] ?? '';
-        const path = match[2] ?? '';
+        const rawPath = match[2] ?? match[3] ?? '';
+        const path = rawPath.replace(/\\(["\\])/g, '$1');
         if (!path) continue;
 
         const atIndex = match.index + prefix.length;
@@ -114,7 +115,7 @@ export function buildUserInputFromMessage(message: string): UserInput[] {
             name: mentionNameFromPath(path),
             path
         });
-        lastIndex = atIndex + path.length + 1;
+        lastIndex = mentionPattern.lastIndex;
     }
 
     const remainder = message.slice(lastIndex);

--- a/cli/src/codex/utils/appServerConfig.ts
+++ b/cli/src/codex/utils/appServerConfig.ts
@@ -7,7 +7,8 @@ import type {
     SandboxMode,
     SandboxPolicy,
     ThreadStartParams,
-    TurnStartParams
+    TurnStartParams,
+    UserInput
 } from '../appServerTypes';
 import { resolveCodexPermissionModeConfig } from './permissionModeConfig';
 
@@ -86,6 +87,44 @@ function appendCollaborationInstructions(developerInstructions: string): string 
     return `${developerInstructions}\n\n${codexCollaborationSpawnAgentInstructions}`;
 }
 
+function mentionNameFromPath(path: string): string {
+    const parts = path.split(/[\\/]/).filter(Boolean);
+    return parts[parts.length - 1] ?? path;
+}
+
+export function buildUserInputFromMessage(message: string): UserInput[] {
+    const inputs: UserInput[] = [];
+    const mentionPattern = /(^|\s)@([^\s]+)/g;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = mentionPattern.exec(message)) !== null) {
+        const prefix = match[1] ?? '';
+        const path = match[2] ?? '';
+        if (!path) continue;
+
+        const atIndex = match.index + prefix.length;
+        const textBeforeMention = message.slice(lastIndex, atIndex);
+        if (textBeforeMention) {
+            inputs.push({ type: 'text', text: textBeforeMention });
+        }
+
+        inputs.push({
+            type: 'mention',
+            name: mentionNameFromPath(path),
+            path
+        });
+        lastIndex = atIndex + path.length + 1;
+    }
+
+    const remainder = message.slice(lastIndex);
+    if (remainder || inputs.length === 0) {
+        inputs.push({ type: 'text', text: remainder });
+    }
+
+    return inputs;
+}
+
 export function buildThreadStartParams(args: {
     cwd: string;
     mode: EnhancedMode;
@@ -146,7 +185,7 @@ export function buildTurnStartParams(args: {
     const params: TurnStartParams = {
         threadId: args.threadId,
         cwd: args.cwd,
-        input: [{ type: 'text', text: args.message }]
+        input: buildUserInputFromMessage(args.message)
     };
 
     const allowCliOverrides = args.mode?.permissionMode === 'default';

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -364,11 +364,23 @@ function SessionPage() {
     } = useSkills(api, sessionId)
 
     const getAutocompleteSuggestions = useCallback(async (query: string) => {
+        if (query.startsWith('@')) {
+            if (!api || !sessionId) return []
+            const search = query.slice(1)
+            const response = await api.searchSessionFiles(sessionId, search, 50)
+            if (!response.success || !response.files) return []
+            return response.files.map((file) => ({
+                key: `@${file.fullPath}`,
+                text: `@${file.fullPath}`,
+                label: `@${file.fileName}`,
+                description: file.filePath || file.fullPath
+            }))
+        }
         if (query.startsWith('$')) {
             return await getSkillSuggestions(query)
         }
         return await getSlashSuggestions(query)
-    }, [getSkillSuggestions, getSlashSuggestions])
+    }, [api, sessionId, getSkillSuggestions, getSlashSuggestions])
 
     const refreshSelectedSession = useCallback(() => {
         void refetchSession()

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -370,9 +370,7 @@ function SessionPage() {
             const response = await api.searchSessionFiles(sessionId, search, 50)
             if (!response.success || !response.files) return []
             return response.files.map((file) => {
-                const mentionText = /\s/.test(file.fullPath)
-                    ? `@"${file.fullPath.replace(/(["\\])/g, '\\$1')}"`
-                    : `@${file.fullPath}`
+                const mentionText = `@"${file.fullPath.replace(/(["\\])/g, '\\$1')}"`
                 return {
                     key: mentionText,
                     text: mentionText,

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -365,7 +365,7 @@ function SessionPage() {
 
     const getAutocompleteSuggestions = useCallback(async (query: string) => {
         if (query.startsWith('@')) {
-            if (!api || !sessionId) return []
+            if (agentType !== 'codex' || !api || !sessionId) return []
             const search = query.slice(1)
             const response = await api.searchSessionFiles(sessionId, search, 50)
             if (!response.success || !response.files) return []
@@ -383,7 +383,7 @@ function SessionPage() {
             return await getSkillSuggestions(query)
         }
         return await getSlashSuggestions(query)
-    }, [api, sessionId, getSkillSuggestions, getSlashSuggestions])
+    }, [agentType, api, sessionId, getSkillSuggestions, getSlashSuggestions])
 
     const refreshSelectedSession = useCallback(() => {
         void refetchSession()

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -369,12 +369,17 @@ function SessionPage() {
             const search = query.slice(1)
             const response = await api.searchSessionFiles(sessionId, search, 50)
             if (!response.success || !response.files) return []
-            return response.files.map((file) => ({
-                key: `@${file.fullPath}`,
-                text: `@${file.fullPath}`,
-                label: `@${file.fileName}`,
-                description: file.filePath || file.fullPath
-            }))
+            return response.files.map((file) => {
+                const mentionText = /\s/.test(file.fullPath)
+                    ? `@"${file.fullPath.replace(/(["\\])/g, '\\$1')}"`
+                    : `@${file.fullPath}`
+                return {
+                    key: mentionText,
+                    text: mentionText,
+                    label: `@${file.fileName}`,
+                    description: file.filePath || file.fullPath
+                }
+            })
         }
         if (query.startsWith('$')) {
             return await getSkillSuggestions(query)


### PR DESCRIPTION
## Summary
- add Codex app-server `mention` user input support
- parse `@path` tokens into mention inputs when starting Codex turns
- surface `@` autocomplete suggestions from session file search in the web composer

## Tests
- `bun typecheck`
- `cd cli && bun test src/codex/utils/appServerConfig.test.ts`
