### PR TITLE
feat(codex): add message rewind and fork controls

### DIFF
--- a/cli/src/api/apiMachine.ts
+++ b/cli/src/api/apiMachine.ts
@@ -249,7 +249,7 @@ export class ApiMachineClient {
 
     setRPCHandlers({ spawnSession, stopSession, requestShutdown }: MachineRpcHandlers): void {
         this.rpcHandlerManager.registerHandler(RPC_METHODS.SpawnHappySession, async (params: any) => {
-            const { directory, sessionId, resumeSessionId, machineId, approvedNewDirectoryCreation, agent, model, effort, modelReasoningEffort, yolo, permissionMode, token, sessionType, worktreeName } = params || {}
+            const { directory, sessionId, resumeSessionId, machineId, approvedNewDirectoryCreation, agent, model, effort, modelReasoningEffort, collaborationMode, yolo, permissionMode, token, sessionType, worktreeName } = params || {}
 
             if (!directory) {
                 throw new Error('Directory is required')
@@ -270,6 +270,7 @@ export class ApiMachineClient {
                 model,
                 effort,
                 modelReasoningEffort,
+                collaborationMode,
                 yolo,
                 permissionMode,
                 token,

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -498,7 +498,7 @@ export class ApiSessionClient extends EventEmitter {
         }
     }
 
-    sendUserMessage(text: string, meta?: MessageMeta): void {
+    sendUserMessage(text: string, meta?: MessageMeta, localId?: string): void {
         if (!text) {
             return
         }
@@ -517,7 +517,8 @@ export class ApiSessionClient extends EventEmitter {
 
         this.socket.emit('message', {
             sid: this.sessionId,
-            message: content
+            message: content,
+            ...(localId ? { localId } : {})
         })
     }
 

--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -77,12 +77,44 @@ export interface ThreadStartParams {
 export interface ThreadStartResponse {
     thread: {
         id: string;
+        turns?: ThreadTurn[];
     };
     model: string;
     [key: string]: unknown;
 }
 
 export type ResponseItem = Record<string, unknown>;
+
+export type ThreadItem = {
+    type?: string;
+    id?: string;
+    clientId?: string | null;
+    client_id?: string | null;
+    content?: unknown;
+    [key: string]: unknown;
+};
+
+export type ThreadTurn = {
+    id: string;
+    items?: ThreadItem[];
+    status?: string;
+    startedAt?: number | null;
+    started_at?: number | null;
+    completedAt?: number | null;
+    completed_at?: number | null;
+    [key: string]: unknown;
+};
+
+export type Thread = {
+    id: string;
+    sessionId?: string;
+    session_id?: string;
+    forkedFromId?: string | null;
+    forked_from_id?: string | null;
+    preview?: string;
+    turns?: ThreadTurn[];
+    [key: string]: unknown;
+};
 
 export interface ThreadResumeParams {
     threadId: string;
@@ -100,9 +132,7 @@ export interface ThreadResumeParams {
 }
 
 export interface ThreadResumeResponse {
-    thread: {
-        id: string;
-    };
+    thread: Thread;
     model: string;
     [key: string]: unknown;
 }
@@ -156,6 +186,7 @@ export type CollaborationMode = {
 
 export interface TurnStartParams {
     threadId: string;
+    clientUserMessageId?: string | null;
     input: UserInput[];
     cwd?: string;
     approvalPolicy?: ApprovalPolicy;
@@ -166,6 +197,72 @@ export interface TurnStartParams {
     personality?: string;
     outputSchema?: unknown;
     collaborationMode?: CollaborationMode;
+}
+
+export interface ThreadReadParams {
+    threadId: string;
+    includeTurns?: boolean;
+}
+
+export interface ThreadReadResponse {
+    thread: Thread;
+    [key: string]: unknown;
+}
+
+export interface ThreadForkParams {
+    threadId: string;
+    model?: string | null;
+    modelProvider?: string | null;
+    serviceTier?: string | null;
+    cwd?: string | null;
+    approvalPolicy?: ApprovalPolicy | null;
+    sandbox?: SandboxMode | null;
+    config?: Record<string, unknown> | null;
+    baseInstructions?: string | null;
+    developerInstructions?: string | null;
+    ephemeral?: boolean;
+}
+
+export interface ThreadForkResponse {
+    thread: Thread;
+    model?: string;
+    modelProvider?: string;
+    cwd?: string;
+    [key: string]: unknown;
+}
+
+export interface ThreadRollbackParams {
+    threadId: string;
+    /**
+     * Drops turns from Codex thread history only. This does not revert local files.
+     */
+    numTurns: number;
+}
+
+export interface ThreadRollbackResponse {
+    thread: Thread;
+    [key: string]: unknown;
+}
+
+export interface TurnSteerParams {
+    threadId: string;
+    clientUserMessageId?: string | null;
+    input: UserInput[];
+    expectedTurnId: string;
+}
+
+export interface TurnSteerResponse {
+    turnId: string;
+    [key: string]: unknown;
+}
+
+export interface ThreadInjectItemsParams {
+    threadId: string;
+    items: unknown[];
+}
+
+export interface ThreadInjectItemsResponse {
+    [key: string]: unknown;
 }
 
 export interface TurnStartResponse {

--- a/cli/src/codex/codexAppServerClient.ts
+++ b/cli/src/codex/codexAppServerClient.ts
@@ -11,12 +11,22 @@ import type {
     ThreadStartResponse,
     ThreadResumeParams,
     ThreadResumeResponse,
+    ThreadReadParams,
+    ThreadReadResponse,
+    ThreadForkParams,
+    ThreadForkResponse,
+    ThreadRollbackParams,
+    ThreadRollbackResponse,
     TurnStartParams,
     TurnStartResponse,
+    TurnSteerParams,
+    TurnSteerResponse,
     TurnInterruptParams,
     TurnInterruptResponse,
     ThreadCompactStartParams,
     ThreadCompactStartResponse,
+    ThreadInjectItemsParams,
+    ThreadInjectItemsResponse,
     ThreadGoalSetParams,
     ThreadGoalSetResponse,
     ThreadGoalGetParams,
@@ -192,12 +202,44 @@ export class CodexAppServerClient {
         return response as ThreadResumeResponse;
     }
 
+    async readThread(params: ThreadReadParams, options?: { signal?: AbortSignal }): Promise<ThreadReadResponse> {
+        const response = await this.sendRequest('thread/read', params, {
+            signal: options?.signal,
+            timeoutMs: 30_000
+        });
+        return response as ThreadReadResponse;
+    }
+
+    async forkThread(params: ThreadForkParams, options?: { signal?: AbortSignal }): Promise<ThreadForkResponse> {
+        const response = await this.sendRequest('thread/fork', params, {
+            signal: options?.signal,
+            timeoutMs: CodexAppServerClient.DEFAULT_TIMEOUT_MS
+        });
+        return response as ThreadForkResponse;
+    }
+
+    async rollbackThread(params: ThreadRollbackParams, options?: { signal?: AbortSignal }): Promise<ThreadRollbackResponse> {
+        const response = await this.sendRequest('thread/rollback', params, {
+            signal: options?.signal,
+            timeoutMs: CodexAppServerClient.DEFAULT_TIMEOUT_MS
+        });
+        return response as ThreadRollbackResponse;
+    }
+
     async startTurn(params: TurnStartParams, options?: { signal?: AbortSignal }): Promise<TurnStartResponse> {
         const response = await this.sendRequest('turn/start', params, {
             signal: options?.signal,
             timeoutMs: CodexAppServerClient.DEFAULT_TIMEOUT_MS
         });
         return response as TurnStartResponse;
+    }
+
+    async steerTurn(params: TurnSteerParams, options?: { signal?: AbortSignal }): Promise<TurnSteerResponse> {
+        const response = await this.sendRequest('turn/steer', params, {
+            signal: options?.signal,
+            timeoutMs: CodexAppServerClient.DEFAULT_TIMEOUT_MS
+        });
+        return response as TurnSteerResponse;
     }
 
     async interruptTurn(params: TurnInterruptParams): Promise<TurnInterruptResponse> {
@@ -216,6 +258,17 @@ export class CodexAppServerClient {
             timeoutMs: CodexAppServerClient.DEFAULT_TIMEOUT_MS
         });
         return response as ThreadCompactStartResponse;
+    }
+
+    async injectThreadItems(
+        params: ThreadInjectItemsParams,
+        options?: { signal?: AbortSignal }
+    ): Promise<ThreadInjectItemsResponse> {
+        const response = await this.sendRequest('thread/inject_items', params, {
+            signal: options?.signal,
+            timeoutMs: 30_000
+        });
+        return response as ThreadInjectItemsResponse;
     }
 
     async setThreadGoal(

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -863,6 +863,7 @@ function createSessionStub(messages = ['hello from launcher test'], mode = creat
     const sessionEvents: Array<{ type: string; [key: string]: unknown }> = [];
     const codexMessages: unknown[] = [];
     const userMessages: Array<{ text: string; meta?: unknown; localId?: string }> = [];
+    const consumedLocalIds: string[][] = [];
     const summaryMessages: unknown[] = [];
     const thinkingChanges: boolean[] = [];
     const foundSessionIds: string[] = [];
@@ -892,6 +893,9 @@ function createSessionStub(messages = ['hello from launcher test'], mode = creat
         },
         sendUserMessage(text: string, meta?: unknown, localId?: string) {
             userMessages.push({ text, meta, localId });
+        },
+        emitMessagesConsumed(localIds: string[]) {
+            consumedLocalIds.push(localIds);
         },
         sendClaudeSessionMessage(message: unknown) {
             summaryMessages.push(message);
@@ -957,6 +961,7 @@ function createSessionStub(messages = ['hello from launcher test'], mode = creat
         sessionEvents,
         codexMessages,
         userMessages,
+        consumedLocalIds,
         summaryMessages,
         thinkingChanges,
         foundSessionIds,
@@ -1186,7 +1191,7 @@ describe('codexRemoteLauncher', () => {
     it('steers the active Codex turn via RPC', async () => {
         harness.suppressTurnCompletion = true;
         harness.emitTurnAbortedOnInterrupt = true;
-        const { session, rpcHandlers, userMessages } = createSessionStub(['first message']);
+        const { session, rpcHandlers, userMessages, consumedLocalIds } = createSessionStub(['first message']);
 
         const running = codexRemoteLauncher(session as never);
         await vi.waitFor(() => {
@@ -1210,6 +1215,7 @@ describe('codexRemoteLauncher', () => {
             input: [{ type: 'text', text: 'please adjust' }]
         }]);
         expect(userMessages).toEqual([{ text: 'please adjust', meta: undefined, localId: 'steer-local' }]);
+        expect(consumedLocalIds).toEqual([['steer-local']]);
         expect(result).toEqual({
             success: true,
             turnId: 'turn-1',

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -18,6 +18,12 @@ const harness = vi.hoisted(() => ({
     startTurnParams: [] as Array<Record<string, unknown>>,
     startTurnErrors: [] as Error[],
     interruptedTurns: [] as Array<{ threadId: string; turnId: string }>,
+    readThreadCalls: [] as Array<Record<string, unknown>>,
+    forkThreadCalls: [] as Array<Record<string, unknown>>,
+    rollbackThreadCalls: [] as Array<Record<string, unknown>>,
+    steerTurnCalls: [] as Array<Record<string, unknown>>,
+    threadTurns: [] as Array<Record<string, unknown>>,
+    forkThreadId: 'thread-forked',
     compactThreadIds: [] as string[],
     goalSetCalls: [] as unknown[],
     goalGetCalls: [] as unknown[],
@@ -768,6 +774,31 @@ vi.mock('./codexAppServerClient', () => {
             return { turn: { id: turnId } };
         }
 
+        async readThread(params?: { threadId?: string; includeTurns?: boolean }): Promise<{ thread: { id: string; turns: Array<Record<string, unknown>> } }> {
+            harness.readThreadCalls.push((params ?? {}) as Record<string, unknown>);
+            return {
+                thread: {
+                    id: params?.threadId ?? 'thread-unknown',
+                    turns: harness.threadTurns
+                }
+            };
+        }
+
+        async forkThread(params?: { threadId?: string }): Promise<{ thread: { id: string }; model: string }> {
+            harness.forkThreadCalls.push((params ?? {}) as Record<string, unknown>);
+            return { thread: { id: harness.forkThreadId }, model: 'gpt-5.4' };
+        }
+
+        async rollbackThread(params?: { threadId?: string; numTurns?: number }): Promise<{ thread: { id: string } }> {
+            harness.rollbackThreadCalls.push((params ?? {}) as Record<string, unknown>);
+            return { thread: { id: params?.threadId ?? 'thread-unknown' } };
+        }
+
+        async steerTurn(params?: { threadId?: string; expectedTurnId?: string }): Promise<{ turnId: string }> {
+            harness.steerTurnCalls.push((params ?? {}) as Record<string, unknown>);
+            return { turnId: params?.expectedTurnId ?? 'turn-steered' };
+        }
+
         async interruptTurn(params?: { threadId?: string; turnId?: string }): Promise<Record<string, never>> {
             const threadId = params?.threadId ?? 'thread-unknown';
             const turnId = params?.turnId ?? 'turn-unknown';
@@ -818,13 +849,13 @@ function createMode(): EnhancedMode {
     };
 }
 
-function createSessionStub(messages = ['hello from launcher test'], mode = createMode()) {
+function createSessionStub(messages = ['hello from launcher test'], mode = createMode(), localIds: string[] = []) {
     const queue = new MessageQueue2<EnhancedMode>((mode) => JSON.stringify(mode));
     messages.forEach((message, index) => {
         if (index === 0 && messages.length > 1) {
-            queue.pushIsolateAndClear(message, mode);
+            queue.pushIsolateAndClear(message, mode, localIds[index]);
         } else {
-            queue.push(message, mode);
+            queue.push(message, mode, localIds[index]);
         }
     });
     queue.close();
@@ -838,6 +869,7 @@ function createSessionStub(messages = ['hello from launcher test'], mode = creat
     const collaborationModes: Array<EnhancedMode['collaborationMode'] | undefined> = [];
     let currentPermissionMode: EnhancedMode['permissionMode'] = mode.permissionMode;
     let currentModel: string | null | undefined = mode.model;
+    let currentModelReasoningEffort: EnhancedMode['modelReasoningEffort'] | undefined = mode.modelReasoningEffort;
     let currentCollaborationMode: EnhancedMode['collaborationMode'] | undefined = mode.collaborationMode;
     let agentState: FakeAgentState = {
         requests: {},
@@ -883,6 +915,9 @@ function createSessionStub(messages = ['hello from launcher test'], mode = creat
         },
         getModel() {
             return currentModel;
+        },
+        getModelReasoningEffort() {
+            return currentModelReasoningEffort;
         },
         getCollaborationMode() {
             return currentCollaborationMode;
@@ -950,6 +985,12 @@ describe('codexRemoteLauncher', () => {
         harness.startTurnParams = [];
         harness.startTurnErrors = [];
         harness.interruptedTurns = [];
+        harness.readThreadCalls = [];
+        harness.forkThreadCalls = [];
+        harness.rollbackThreadCalls = [];
+        harness.steerTurnCalls = [];
+        harness.threadTurns = [];
+        harness.forkThreadId = 'thread-forked';
         harness.compactThreadIds = [];
         harness.goalSetCalls = [];
         harness.goalGetCalls = [];
@@ -1023,6 +1064,123 @@ describe('codexRemoteLauncher', () => {
         expect(sessionEvents.filter((event) => event.type === 'ready').length).toBeGreaterThanOrEqual(1);
         expect(thinkingChanges).toContain(true);
         expect(session.thinking).toBe(false);
+    });
+
+    it('passes queued localId as the Codex client user message id', async () => {
+        const { session } = createSessionStub(['hello with local id'], createMode(), ['local-1']);
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.startTurnParams[0]?.clientUserMessageId).toBe('local-1');
+    });
+
+    it('rolls back the Codex thread to a mapped user message via RPC', async () => {
+        harness.suppressTurnCompletion = true;
+        harness.emitTurnAbortedOnInterrupt = true;
+        harness.threadTurns = [
+            {
+                id: 'turn-1',
+                items: [{ type: 'userMessage', clientId: 'local-1' }]
+            },
+            {
+                id: 'turn-2',
+                items: [{ type: 'agentMessage' }]
+            }
+        ];
+        const { session, rpcHandlers } = createSessionStub(['first message'], createMode(), ['local-1']);
+
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => {
+            expect(harness.startTurnThreadIds).toEqual(['thread-1']);
+            expect(rpcHandlers.has('codexRollbackToMessage')).toBe(true);
+        });
+
+        const result = await rpcHandlers.get('codexRollbackToMessage')?.({ localId: 'local-1' });
+        const exitReason = await running;
+
+        expect(exitReason).toBe('exit');
+        expect(harness.interruptedTurns).toEqual([{ threadId: 'thread-1', turnId: 'turn-1' }]);
+        expect(harness.readThreadCalls).toEqual([{ threadId: 'thread-1', includeTurns: true }]);
+        expect(harness.rollbackThreadCalls).toEqual([{ threadId: 'thread-1', numTurns: 2 }]);
+        expect(result).toMatchObject({
+            success: true,
+            threadId: 'thread-1',
+            targetTurnId: 'turn-1',
+            rolledBackTurns: 2
+        });
+    });
+
+    it('forks the Codex thread and rolls back the fork to the mapped user message via RPC', async () => {
+        harness.suppressTurnCompletion = true;
+        harness.emitTurnAbortedOnInterrupt = true;
+        harness.threadTurns = [
+            {
+                id: 'turn-1',
+                items: [{ type: 'userMessage', clientId: 'local-1' }]
+            },
+            {
+                id: 'turn-2',
+                items: [{ type: 'agentMessage' }]
+            }
+        ];
+        const { session, rpcHandlers } = createSessionStub(['first message'], createMode(), ['local-1']);
+
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => {
+            expect(harness.startTurnThreadIds).toEqual(['thread-1']);
+            expect(rpcHandlers.has('codexForkFromMessage')).toBe(true);
+            expect(rpcHandlers.has('abort')).toBe(true);
+        });
+
+        const result = await rpcHandlers.get('codexForkFromMessage')?.({ localId: 'local-1' });
+        await rpcHandlers.get('abort')?.({});
+        const exitReason = await running;
+
+        expect(exitReason).toBe('exit');
+        expect(harness.readThreadCalls).toEqual([{ threadId: 'thread-1', includeTurns: true }]);
+        expect(harness.forkThreadCalls[0]).toMatchObject({ threadId: 'thread-1' });
+        expect(harness.rollbackThreadCalls).toEqual([{ threadId: 'thread-forked', numTurns: 2 }]);
+        expect(result).toMatchObject({
+            success: true,
+            sourceThreadId: 'thread-1',
+            threadId: 'thread-forked',
+            targetTurnId: 'turn-1',
+            rolledBackTurns: 2
+        });
+    });
+
+    it('steers the active Codex turn via RPC', async () => {
+        harness.suppressTurnCompletion = true;
+        harness.emitTurnAbortedOnInterrupt = true;
+        const { session, rpcHandlers } = createSessionStub(['first message']);
+
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => {
+            expect(harness.startTurnThreadIds).toEqual(['thread-1']);
+            expect(rpcHandlers.has('codexSteerCurrentTurn')).toBe(true);
+            expect(rpcHandlers.has('abort')).toBe(true);
+        });
+
+        const result = await rpcHandlers.get('codexSteerCurrentTurn')?.({
+            text: 'please adjust',
+            localId: 'steer-local'
+        });
+        await rpcHandlers.get('abort')?.({});
+        const exitReason = await running;
+
+        expect(exitReason).toBe('exit');
+        expect(harness.steerTurnCalls).toEqual([{
+            threadId: 'thread-1',
+            expectedTurnId: 'turn-1',
+            clientUserMessageId: 'steer-local',
+            input: [{ type: 'text', text: 'please adjust' }]
+        }]);
+        expect(result).toEqual({
+            success: true,
+            turnId: 'turn-1',
+            localId: 'steer-local'
+        });
     });
 
     it('uses live permission mode for app-server MCP elicitation handlers', async () => {

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -1115,6 +1115,35 @@ describe('codexRemoteLauncher', () => {
         });
     });
 
+    it('does not interrupt an active turn when rollback target lookup fails', async () => {
+        harness.suppressTurnCompletion = true;
+        harness.emitTurnAbortedOnInterrupt = true;
+        harness.threadTurns = [
+            {
+                id: 'turn-1',
+                items: [{ type: 'userMessage', clientId: 'different-local' }]
+            }
+        ];
+        const { session, rpcHandlers } = createSessionStub(['first message'], createMode(), ['local-1']);
+
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => {
+            expect(harness.startTurnThreadIds).toEqual(['thread-1']);
+            expect(rpcHandlers.has('codexRollbackToMessage')).toBe(true);
+            expect(rpcHandlers.has('abort')).toBe(true);
+        });
+
+        await expect(rpcHandlers.get('codexRollbackToMessage')?.({ localId: 'missing-local' }))
+            .rejects.toThrow('Message is not present in the current Codex thread history');
+        expect(harness.interruptedTurns).toEqual([]);
+
+        await rpcHandlers.get('abort')?.({});
+        const exitReason = await running;
+
+        expect(exitReason).toBe('exit');
+        expect(harness.interruptedTurns).toEqual([{ threadId: 'thread-1', turnId: 'turn-1' }]);
+    });
+
     it('forks the Codex thread and rolls back the fork to the mapped user message via RPC', async () => {
         harness.suppressTurnCompletion = true;
         harness.emitTurnAbortedOnInterrupt = true;

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -862,6 +862,7 @@ function createSessionStub(messages = ['hello from launcher test'], mode = creat
 
     const sessionEvents: Array<{ type: string; [key: string]: unknown }> = [];
     const codexMessages: unknown[] = [];
+    const userMessages: Array<{ text: string; meta?: unknown; localId?: string }> = [];
     const summaryMessages: unknown[] = [];
     const thinkingChanges: boolean[] = [];
     const foundSessionIds: string[] = [];
@@ -889,7 +890,9 @@ function createSessionStub(messages = ['hello from launcher test'], mode = creat
         sendAgentMessage(message: unknown) {
             codexMessages.push(message);
         },
-        sendUserMessage(_text: string) {},
+        sendUserMessage(text: string, meta?: unknown, localId?: string) {
+            userMessages.push({ text, meta, localId });
+        },
         sendClaudeSessionMessage(message: unknown) {
             summaryMessages.push(message);
         },
@@ -944,8 +947,8 @@ function createSessionStub(messages = ['hello from launcher test'], mode = creat
         sendSessionEvent(event: { type: string; [key: string]: unknown }) {
             client.sendSessionEvent(event);
         },
-        sendUserMessage(text: string) {
-            client.sendUserMessage(text);
+        sendUserMessage(text: string, meta?: unknown, localId?: string) {
+            client.sendUserMessage(text, meta, localId);
         }
     };
 
@@ -953,6 +956,7 @@ function createSessionStub(messages = ['hello from launcher test'], mode = creat
         session,
         sessionEvents,
         codexMessages,
+        userMessages,
         summaryMessages,
         thinkingChanges,
         foundSessionIds,
@@ -1153,7 +1157,7 @@ describe('codexRemoteLauncher', () => {
     it('steers the active Codex turn via RPC', async () => {
         harness.suppressTurnCompletion = true;
         harness.emitTurnAbortedOnInterrupt = true;
-        const { session, rpcHandlers } = createSessionStub(['first message']);
+        const { session, rpcHandlers, userMessages } = createSessionStub(['first message']);
 
         const running = codexRemoteLauncher(session as never);
         await vi.waitFor(() => {
@@ -1176,6 +1180,7 @@ describe('codexRemoteLauncher', () => {
             clientUserMessageId: 'steer-local',
             input: [{ type: 'text', text: 'please adjust' }]
         }]);
+        expect(userMessages).toEqual([{ text: 'please adjust', meta: undefined, localId: 'steer-local' }]);
         expect(result).toEqual({
             success: true,
             turnId: 'turn-1',

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -2829,10 +2829,10 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             const localId = readLocalIdParam(payload);
             return await runCodexOperation(async () => {
                 const threadId = await ensureThreadForRpc();
+                const plan = await resolveRollbackPlan(threadId, localId);
                 await interruptActiveTurn();
                 resetCurrentTurnState();
 
-                const plan = await resolveRollbackPlan(threadId, localId);
                 await appServerClient.rollbackThread({
                     threadId,
                     numTurns: plan.numTurns

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -2919,6 +2919,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     signal: this.abortController.signal
                 });
                 session.sendUserMessage(text, undefined, clientUserMessageId);
+                session.client.emitMessagesConsumed([clientUserMessageId]);
                 return {
                     success: true,
                     turnId: response.turnId,

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -2918,7 +2918,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 }, {
                     signal: this.abortController.signal
                 });
-                session.sendUserMessage(text);
+                session.sendUserMessage(text, undefined, clientUserMessageId);
                 return {
                     success: true,
                     turnId: response.turnId,

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -25,6 +25,7 @@ import {
     type RemoteLauncherDisplayContext,
     type RemoteLauncherExitReason
 } from '@/modules/common/remote/RemoteLauncherBase';
+import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 
 
 async function registerGeneratedImageFromPath(args: { id: string; path: string; fileName?: string | null }): Promise<ReturnType<typeof registerGeneratedImage> | null> {
@@ -56,7 +57,8 @@ async function registerGeneratedImageFromPath(args: { id: string; path: string; 
 }
 
 type HappyServer = Awaited<ReturnType<typeof buildHapiMcpBridge>>['server'];
-type QueuedMessage = { message: string; mode: EnhancedMode; isolate: boolean; hash: string };
+type QueuedMessage = { message: string; mode: EnhancedMode; isolate: boolean; hash: string; localIds: string[] };
+type CodexTurnMapping = { threadId: string; turnId: string };
 type ChildAgentRuntime = {
     reasoningProcessor: ReasoningProcessor;
     diffProcessor: DiffProcessor;
@@ -185,6 +187,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
     private currentThreadId: string | null = null;
     private currentTurnId: string | null = null;
     private readonly activeChildTurns = new Map<string, string>();
+    private readonly turnByLocalId = new Map<string, CodexTurnMapping>();
+    private readonly localIdsByTurnId = new Map<string, string[]>();
 
     constructor(session: CodexSession) {
         super(process.env.DEBUG ? session.logPath : undefined);
@@ -2039,6 +2043,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 const turnId = eventTurnId;
                 if (turnId) {
                     this.currentTurnId = turnId;
+                    if (activeMessage && (eventThreadId ?? this.currentThreadId)) {
+                        rememberTurnMapping(activeMessage.localIds, eventThreadId ?? this.currentThreadId!, turnId);
+                    }
                     allowAnonymousTerminalEvent = false;
                 } else if (!this.currentTurnId) {
                     allowAnonymousTerminalEvent = true;
@@ -2646,6 +2653,137 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             });
         };
 
+        const rememberTurnMapping = (localIds: string[], threadId: string, turnId: string): void => {
+            const firstLocalId = localIds.find((id) => id.length > 0);
+            if (!firstLocalId) {
+                return;
+            }
+            const uniqueLocalIds = [firstLocalId];
+            this.localIdsByTurnId.set(turnId, uniqueLocalIds);
+            for (const localId of uniqueLocalIds) {
+                this.turnByLocalId.set(localId, { threadId, turnId });
+            }
+        };
+
+        const forgetTurnMappings = (turnIds: string[]): void => {
+            for (const turnId of turnIds) {
+                const localIds = this.localIdsByTurnId.get(turnId) ?? [];
+                for (const localId of localIds) {
+                    this.turnByLocalId.delete(localId);
+                }
+                this.localIdsByTurnId.delete(turnId);
+            }
+        };
+
+        const getCurrentModeForRpc = (): EnhancedMode => ({
+            permissionMode: (session.getPermissionMode() as EnhancedMode['permissionMode'] | undefined) ?? 'default',
+            model: session.getModel() ?? undefined,
+            modelReasoningEffort: (session.getModelReasoningEffort() as EnhancedMode['modelReasoningEffort'] | undefined) ?? undefined,
+            collaborationMode: (session.getCollaborationMode() as EnhancedMode['collaborationMode'] | undefined) ?? 'default'
+        });
+
+        const ensureThreadForRpc = async (): Promise<string> => {
+            if (this.currentThreadId && this.currentThreadId !== invalidThreadId) {
+                hasThread = true;
+                return this.currentThreadId;
+            }
+
+            const resumeCandidate = session.sessionId && session.sessionId !== invalidThreadId
+                ? session.sessionId
+                : null;
+            if (!resumeCandidate) {
+                throw new Error('No Codex thread is available yet');
+            }
+
+            const threadParams = buildThreadStartParams({
+                cwd: session.path,
+                mode: getCurrentModeForRpc(),
+                mcpServers,
+                cliOverrides: session.codexCliOverrides
+            });
+            const resumeResponse = await appServerClient.resumeThread({
+                threadId: resumeCandidate,
+                ...threadParams
+            }, {
+                signal: this.abortController.signal
+            });
+            const resumeRecord = asRecord(resumeResponse);
+            const resumeThread = resumeRecord ? asRecord(resumeRecord.thread) : null;
+            const threadId = asString(resumeThread?.id) ?? resumeCandidate;
+            applyResolvedModel(resumeRecord?.model);
+            this.currentThreadId = threadId;
+            session.onSessionFound(threadId);
+            hasThread = true;
+            return threadId;
+        };
+
+        const getThreadTurns = (thread: unknown): Array<Record<string, unknown>> => {
+            const record = asRecord(thread);
+            const turns = record && Array.isArray(record.turns) ? record.turns : [];
+            return turns
+                .map((turn) => asRecord(turn))
+                .filter((turn): turn is Record<string, unknown> => turn !== null);
+        };
+
+        const turnHasClientLocalId = (turn: Record<string, unknown>, localId: string): boolean => {
+            const items = Array.isArray(turn.items) ? turn.items : [];
+            return items.some((item) => {
+                const record = asRecord(item);
+                if (!record || record.type !== 'userMessage') {
+                    return false;
+                }
+                return asString(record.clientId ?? record.client_id) === localId;
+            });
+        };
+
+        const resolveRollbackPlan = async (
+            threadId: string,
+            localId: string
+        ): Promise<{
+            turns: Array<Record<string, unknown>>;
+            targetIndex: number;
+            targetTurnId: string;
+            numTurns: number;
+        }> => {
+            if (!localId) {
+                throw new Error('Missing message localId');
+            }
+
+            const readResponse = await appServerClient.readThread({
+                threadId,
+                includeTurns: true
+            }, {
+                signal: this.abortController.signal
+            });
+            const turns = getThreadTurns(readResponse.thread);
+            if (turns.length === 0) {
+                throw new Error('Codex thread has no readable turns');
+            }
+
+            const mapped = this.turnByLocalId.get(localId);
+            let targetIndex = mapped?.threadId === threadId
+                ? turns.findIndex((turn) => asString(turn.id) === mapped.turnId)
+                : -1;
+            if (targetIndex < 0) {
+                targetIndex = turns.findIndex((turn) => turnHasClientLocalId(turn, localId));
+            }
+            if (targetIndex < 0) {
+                throw new Error('Message is not present in the current Codex thread history');
+            }
+
+            const targetTurnId = asString(turns[targetIndex]?.id);
+            if (!targetTurnId) {
+                throw new Error('Matched Codex turn is missing an id');
+            }
+
+            const numTurns = turns.length - targetIndex;
+            if (numTurns < 1) {
+                throw new Error('Nothing to rewind');
+            }
+
+            return { turns, targetIndex, targetTurnId, numTurns };
+        };
+
         const resetCurrentTurnState = () => {
             turnInFlight = false;
             allowAnonymousTerminalEvent = false;
@@ -2661,6 +2799,133 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             suppressReadyForInterruptedTurn(this.currentTurnId);
             await this.interruptActiveTurns('slash command');
         };
+
+        let codexOperationChain: Promise<void> = Promise.resolve();
+        const runCodexOperation = async <T,>(operation: () => Promise<T>): Promise<T> => {
+            const run = codexOperationChain.then(operation, operation);
+            codexOperationChain = run.then(() => undefined, () => undefined);
+            return await run;
+        };
+
+        const readLocalIdParam = (payload: unknown): string => {
+            const record = asRecord(payload);
+            const localId = asString(record?.localId ?? record?.local_id);
+            if (!localId) {
+                throw new Error('localId is required');
+            }
+            return localId;
+        };
+
+        const readTextParam = (payload: unknown): string => {
+            const record = asRecord(payload);
+            const text = typeof record?.text === 'string' ? record.text.trim() : '';
+            if (!text) {
+                throw new Error('text is required');
+            }
+            return text;
+        };
+
+        session.client.rpcHandlerManager.registerHandler(RPC_METHODS.CodexRollbackToMessage, async (payload: unknown) => {
+            const localId = readLocalIdParam(payload);
+            return await runCodexOperation(async () => {
+                const threadId = await ensureThreadForRpc();
+                await interruptActiveTurn();
+                resetCurrentTurnState();
+
+                const plan = await resolveRollbackPlan(threadId, localId);
+                await appServerClient.rollbackThread({
+                    threadId,
+                    numTurns: plan.numTurns
+                }, {
+                    signal: this.abortController.signal
+                });
+                forgetTurnMappings(
+                    plan.turns
+                        .slice(plan.targetIndex)
+                        .map((turn) => asString(turn.id))
+                        .filter((turnId): turnId is string => turnId !== null)
+                );
+                activeMessage = null;
+                pending = null;
+                hasThread = true;
+                invalidThreadId = null;
+                sendVisibleStatus('Codex context rewound. Local file changes were not reverted.');
+                wakeLoop();
+                return {
+                    success: true,
+                    threadId,
+                    targetTurnId: plan.targetTurnId,
+                    rolledBackTurns: plan.numTurns,
+                    warning: 'Codex context was rewound, but local file changes were not reverted.'
+                };
+            });
+        });
+
+        session.client.rpcHandlerManager.registerHandler(RPC_METHODS.CodexForkFromMessage, async (payload: unknown) => {
+            const localId = readLocalIdParam(payload);
+            return await runCodexOperation(async () => {
+                const sourceThreadId = await ensureThreadForRpc();
+                const plan = await resolveRollbackPlan(sourceThreadId, localId);
+                const forkParams = buildThreadStartParams({
+                    cwd: session.path,
+                    mode: getCurrentModeForRpc(),
+                    mcpServers,
+                    cliOverrides: session.codexCliOverrides
+                });
+                const forkResponse = await appServerClient.forkThread({
+                    threadId: sourceThreadId,
+                    ...forkParams
+                }, {
+                    signal: this.abortController.signal
+                });
+                const forkThread = asRecord(forkResponse.thread);
+                const forkThreadId = asString(forkThread?.id);
+                if (!forkThreadId) {
+                    throw new Error('thread/fork did not return thread.id');
+                }
+
+                await appServerClient.rollbackThread({
+                    threadId: forkThreadId,
+                    numTurns: plan.numTurns
+                }, {
+                    signal: this.abortController.signal
+                });
+
+                return {
+                    success: true,
+                    sourceThreadId,
+                    threadId: forkThreadId,
+                    targetTurnId: plan.targetTurnId,
+                    rolledBackTurns: plan.numTurns,
+                    warning: 'Forked Codex context does not revert local file changes.'
+                };
+            });
+        });
+
+        session.client.rpcHandlerManager.registerHandler(RPC_METHODS.CodexSteerCurrentTurn, async (payload: unknown) => {
+            const text = readTextParam(payload);
+            const record = asRecord(payload);
+            const clientUserMessageId = asString(record?.localId ?? record?.local_id) ?? randomUUID();
+            return await runCodexOperation(async () => {
+                if (!this.currentThreadId || !this.currentTurnId || !turnInFlight) {
+                    throw new Error('No active Codex turn to steer');
+                }
+                const response = await appServerClient.steerTurn({
+                    threadId: this.currentThreadId,
+                    expectedTurnId: this.currentTurnId,
+                    clientUserMessageId,
+                    input: [{ type: 'text', text }]
+                }, {
+                    signal: this.abortController.signal
+                });
+                session.sendUserMessage(text);
+                return {
+                    success: true,
+                    turnId: response.turnId,
+                    localId: clientUserMessageId
+                };
+            });
+        });
 
         const resumeExistingThreadForCompact = async (mode: EnhancedMode): Promise<string | null> => {
             if (this.currentThreadId && this.currentThreadId !== invalidThreadId) {
@@ -3062,6 +3327,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 const buildParams = (suppressCollaborationMode: boolean) => buildTurnStartParams({
                     threadId: this.currentThreadId!,
                     message: message.message,
+                    clientUserMessageId: message.localIds[0] ?? null,
                     cwd: session.path,
                     mode,
                     cliOverrides: session.codexCliOverrides,
@@ -3105,6 +3371,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 if (turnInFlight) {
                     if (turnId) {
                         this.currentTurnId = turnId;
+                        rememberTurnMapping(message.localIds, this.currentThreadId!, turnId);
                     } else if (!this.currentTurnId) {
                         allowAnonymousTerminalEvent = true;
                     }
@@ -3169,6 +3436,18 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         }
 
         this.clearAbortHandlers(this.session.client.rpcHandlerManager);
+        this.session.client.rpcHandlerManager.registerHandler(RPC_METHODS.CodexRollbackToMessage, async () => ({
+            success: false,
+            error: 'Codex remote launcher is not active'
+        }));
+        this.session.client.rpcHandlerManager.registerHandler(RPC_METHODS.CodexForkFromMessage, async () => ({
+            success: false,
+            error: 'Codex remote launcher is not active'
+        }));
+        this.session.client.rpcHandlerManager.registerHandler(RPC_METHODS.CodexSteerCurrentTurn, async () => ({
+            success: false,
+            error: 'Codex remote launcher is not active'
+        }));
 
         if (this.happyServer) {
             this.happyServer.stop();

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -227,7 +227,12 @@ export async function runCodex(opts: {
                     messageQueue.pushIsolateAndClear(isolatedCommandText, enhancedMode, localId);
                     return;
                 }
-                messageQueue.push(text, enhancedMode, localId);
+                if (localId) {
+                    // Keep HAPI localIds one-to-one with Codex turns so rewind/fork can target a single user bubble.
+                    messageQueue.pushIsolated(text, enhancedMode, localId);
+                    return;
+                }
+                messageQueue.push(text, enhancedMode);
             } catch (error) {
                 logger.debug('[Codex] Failed to handle user message', error);
                 const enhancedMode: EnhancedMode = {
@@ -236,7 +241,13 @@ export async function runCodex(opts: {
                     modelReasoningEffort: currentModelReasoningEffort,
                     collaborationMode: currentCollaborationMode
                 };
-                messageQueue.push(formatMessageWithAttachments(message.content.text, message.content.attachments), enhancedMode, localId);
+                const formattedText = formatMessageWithAttachments(message.content.text, message.content.attachments);
+                if (localId) {
+                    // Keep HAPI localIds one-to-one with Codex turns so rewind/fork can target a single user bubble.
+                    messageQueue.pushIsolated(formattedText, enhancedMode, localId);
+                    return;
+                }
+                messageQueue.push(formattedText, enhancedMode);
             }
         }).catch((error) => {
             logger.debug('[Codex] User message handler chain failed', error);

--- a/cli/src/codex/session.ts
+++ b/cli/src/codex/session.ts
@@ -4,7 +4,7 @@ import { AgentSessionBase } from '@/agent/sessionBase';
 import type { EnhancedMode, PermissionMode } from './loop';
 import type { CodexCliOverrides } from './utils/codexCliOverrides';
 import type { LocalLaunchExitReason } from '@/agent/localLaunchPolicy';
-import type { Metadata, SessionModel, SessionModelReasoningEffort } from '@/api/types';
+import type { MessageMeta, Metadata, SessionModel, SessionModelReasoningEffort } from '@/api/types';
 
 type LocalLaunchFailure = {
     message: string;
@@ -133,8 +133,8 @@ export class CodexSession extends AgentSessionBase<EnhancedMode> {
         this.client.sendAgentMessage(message);
     };
 
-    sendUserMessage = (text: string): void => {
-        this.client.sendUserMessage(text);
+    sendUserMessage = (text: string, meta?: MessageMeta): void => {
+        this.client.sendUserMessage(text, meta);
     };
 
     sendSessionEvent = (event: Parameters<ApiSessionClient['sendSessionEvent']>[0]): void => {

--- a/cli/src/codex/session.ts
+++ b/cli/src/codex/session.ts
@@ -133,8 +133,8 @@ export class CodexSession extends AgentSessionBase<EnhancedMode> {
         this.client.sendAgentMessage(message);
     };
 
-    sendUserMessage = (text: string, meta?: MessageMeta): void => {
-        this.client.sendUserMessage(text, meta);
+    sendUserMessage = (text: string, meta?: MessageMeta, localId?: string): void => {
+        this.client.sendUserMessage(text, meta, localId);
     };
 
     sendSessionEvent = (event: Parameters<ApiSessionClient['sendSessionEvent']>[0]): void => {

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -110,6 +110,7 @@ describe('appServerConfig', () => {
         const params = buildTurnStartParams({
             threadId: 'thread-1',
             message: 'hello',
+            clientUserMessageId: 'local-1',
             cwd: '/workspace/project',
             mode: {
                 permissionMode: 'read-only',
@@ -120,6 +121,7 @@ describe('appServerConfig', () => {
         });
 
         expect(params.threadId).toBe('thread-1');
+        expect(params.clientUserMessageId).toBe('local-1');
         expect(params.cwd).toBe('/workspace/project');
         expect(params.input).toEqual([{ type: 'text', text: 'hello' }]);
         expect(params.approvalPolicy).toBe('never');
@@ -363,4 +365,5 @@ describe('appServerConfig', () => {
         expect(params.collaborationMode).toBeUndefined();
         expect(params.model).toBe('o3');
     });
+
 });

--- a/cli/src/codex/utils/appServerConfig.ts
+++ b/cli/src/codex/utils/appServerConfig.ts
@@ -131,6 +131,7 @@ export function buildThreadStartParams(args: {
 export function buildTurnStartParams(args: {
     threadId: string;
     message: string;
+    clientUserMessageId?: string | null;
     cwd: string;
     mode?: EnhancedMode;
     cliOverrides?: CodexCliOverrides;
@@ -148,6 +149,10 @@ export function buildTurnStartParams(args: {
         cwd: args.cwd,
         input: [{ type: 'text', text: args.message }]
     };
+
+    if (args.clientUserMessageId) {
+        params.clientUserMessageId = args.clientUserMessageId;
+    }
 
     const allowCliOverrides = args.mode?.permissionMode === 'default';
     const cliOverrides = allowCliOverrides ? args.cliOverrides : undefined;

--- a/cli/src/commands/codex.ts
+++ b/cli/src/commands/codex.ts
@@ -4,7 +4,7 @@ import { initializeToken } from '@/ui/tokenInit'
 import { maybeAutoStartServer } from '@/utils/autoStartServer'
 import type { CommandDefinition } from './types'
 import { CODEX_PERMISSION_MODES } from '@hapi/protocol/modes'
-import type { CodexPermissionMode } from '@hapi/protocol/types'
+import type { CodexCollaborationMode, CodexPermissionMode } from '@hapi/protocol/types'
 import type { ReasoningEffort } from '@/codex/appServerTypes'
 import { assertCodexLocalSupported } from '@/codex/utils/codexVersion'
 
@@ -36,6 +36,7 @@ export const codexCommand: CommandDefinition = {
                 resumeSessionId?: string
                 model?: string
                 modelReasoningEffort?: ReasoningEffort
+                collaborationMode?: CodexCollaborationMode
             } = {}
             const unknownArgs: string[] = []
             let hasExplicitPermissionMode = false
@@ -76,6 +77,12 @@ export const codexCommand: CommandDefinition = {
                         throw new Error('Missing --model-reasoning-effort value')
                     }
                     options.modelReasoningEffort = parseReasoningEffort(effort)
+                } else if (arg === '--collaboration-mode') {
+                    const mode = commandArgs[++i]
+                    if (mode !== 'default' && mode !== 'plan') {
+                        throw new Error(`Invalid --collaboration-mode value: ${mode ?? '(missing)'}`)
+                    }
+                    options.collaborationMode = mode
                 } else {
                     unknownArgs.push(arg)
                 }

--- a/cli/src/modules/common/rpcTypes.ts
+++ b/cli/src/modules/common/rpcTypes.ts
@@ -1,4 +1,4 @@
-import type { AgentFlavor } from '@hapi/protocol'
+import type { AgentFlavor, CodexCollaborationMode } from '@hapi/protocol'
 
 export interface SpawnSessionOptions {
     machineId?: string
@@ -10,6 +10,7 @@ export interface SpawnSessionOptions {
     model?: string
     effort?: string
     modelReasoningEffort?: string
+    collaborationMode?: CodexCollaborationMode
     yolo?: boolean
     permissionMode?: string
     token?: string

--- a/cli/src/runner/buildCliArgs.test.ts
+++ b/cli/src/runner/buildCliArgs.test.ts
@@ -71,6 +71,15 @@ describe('buildCliArgs', () => {
         expect(args).toContain('high')
     })
 
+    it('passes --collaboration-mode through for codex', () => {
+        const args = buildCliArgs('codex', {
+            directory: '/tmp',
+            collaborationMode: 'plan',
+        })
+        expect(args).toContain('--collaboration-mode')
+        expect(args).toContain('plan')
+    })
+
     it('validates all known permission modes', () => {
         for (const mode of ['default', 'acceptEdits', 'bypassPermissions', 'plan', 'ask', 'read-only', 'safe-yolo', 'yolo']) {
             const args = buildCliArgs('claude', {

--- a/cli/src/runner/run.ts
+++ b/cli/src/runner/run.ts
@@ -936,6 +936,9 @@ export function buildCliArgs(
   if (options.modelReasoningEffort && (agent === 'codex' || agent === 'opencode')) {
     args.push('--model-reasoning-effort', options.modelReasoningEffort);
   }
+  if (options.collaborationMode && agent === 'codex') {
+    args.push('--collaboration-mode', options.collaborationMode);
+  }
   if (options.permissionMode && (PERMISSION_MODES as readonly string[]).includes(options.permissionMode)) {
     args.push('--permission-mode', options.permissionMode);
   } else if (yolo) {

--- a/cli/src/utils/MessageQueue2.test.ts
+++ b/cli/src/utils/MessageQueue2.test.ts
@@ -12,14 +12,15 @@ describe('MessageQueue2', () => {
     it('should push and retrieve messages with same mode', async () => {
         const queue = new MessageQueue2<string>(mode => mode);
         
-        queue.push('message1', 'local');
-        queue.push('message2', 'local');
-        queue.push('message3', 'local');
+        queue.push('message1', 'local', 'local-1');
+        queue.push('message2', 'local', 'local-2');
+        queue.push('message3', 'local', 'local-3');
         
         const result = await queue.waitForMessagesAndGetAsString();
         expect(result).not.toBeNull();
         expect(result?.message).toBe('message1\nmessage2\nmessage3');
         expect(result?.mode).toBe('local');
+        expect(result?.localIds).toEqual(['local-1', 'local-2', 'local-3']);
         expect(queue.size()).toBe(0);
     });
 

--- a/cli/src/utils/MessageQueue2.ts
+++ b/cli/src/utils/MessageQueue2.ts
@@ -278,7 +278,7 @@ export class MessageQueue2<T> {
      * Wait for messages and return all messages with the same mode as a single string
      * Returns { message: string, mode: T } or null if aborted/closed
      */
-    async waitForMessagesAndGetAsString(abortSignal?: AbortSignal): Promise<{ message: string, mode: T, isolate: boolean, hash: string } | null> {
+    async waitForMessagesAndGetAsString(abortSignal?: AbortSignal): Promise<{ message: string, mode: T, isolate: boolean, hash: string, localIds: string[] } | null> {
         // If we have messages, return them immediately
         if (this.queue.length > 0) {
             return this.collectBatch();
@@ -302,7 +302,7 @@ export class MessageQueue2<T> {
     /**
      * Collect a batch of messages with the same mode, respecting isolation requirements
      */
-    private collectBatch(): { message: string, mode: T, hash: string, isolate: boolean } | null {
+    private collectBatch(): { message: string, mode: T, hash: string, isolate: boolean, localIds: string[] } | null {
         if (this.queue.length === 0) {
             return null;
         }
@@ -343,7 +343,8 @@ export class MessageQueue2<T> {
             message: combinedMessage,
             mode,
             hash: targetModeHash,
-            isolate
+            isolate,
+            localIds: consumedLocalIds
         };
     }
 

--- a/hub/src/store/messageStore.ts
+++ b/hub/src/store/messageStore.ts
@@ -4,8 +4,13 @@ import type { StoredMessage } from './types'
 import {
     addMessage,
     cancelQueuedMessage,
+    copyMessageToSession as copyStoredMessageToSession,
+    copyMessagesBeforeSeq,
+    deleteMessagesFromSeq,
     deleteQueuedMessageById,
     lookupQueuedMessage,
+    getAllMessages,
+    getMessageByLocalId,
     getMessages,
     getFirstMessages,
     getDeliverableMessagesAfter,
@@ -17,8 +22,6 @@ import {
     countFutureScheduledLocalMessages,
     markMessagesInvoked,
     mergeSessionMessages,
-    copyMessageToSession as copyStoredMessageToSession,
-    getAllMessages,
     type CancelQueuedMessageResult,
     type LookupQueuedMessageResult,
 } from './messages'
@@ -52,6 +55,18 @@ export class MessageStore {
 
     getFirstMessages(sessionId: string, limit: number = 50): StoredMessage[] {
         return getFirstMessages(this.db, sessionId, limit)
+    }
+
+    getMessageByLocalId(sessionId: string, localId: string): StoredMessage | null {
+        return getMessageByLocalId(this.db, sessionId, localId)
+    }
+
+    deleteMessagesFromSeq(sessionId: string, seq: number): number {
+        return deleteMessagesFromSeq(this.db, sessionId, seq)
+    }
+
+    copyMessagesBeforeSeq(fromSessionId: string, toSessionId: string, beforeSeq: number): number {
+        return copyMessagesBeforeSeq(this.db, fromSessionId, toSessionId, beforeSeq)
     }
 
     getDeliverableMessagesAfter(sessionId: string, afterSeq: number, now: number, limit: number = 200): StoredMessage[] {

--- a/hub/src/store/messages.test.ts
+++ b/hub/src/store/messages.test.ts
@@ -206,6 +206,58 @@ describe('addMessage: scheduledAt invariants', () => {
     })
 })
 
+describe('Codex rewind helpers', () => {
+    it('finds a message by localId within the session', () => {
+        const store = makeStore()
+        const sessionA = makeSession(store, 'lookup-local-a')
+        const sessionB = makeSession(store, 'lookup-local-b')
+        store.messages.addMessage(sessionA.id, { role: 'user', content: { type: 'text', text: 'a' } }, 'same-local')
+        store.messages.addMessage(sessionB.id, { role: 'user', content: { type: 'text', text: 'b' } }, 'same-local')
+
+        const found = store.messages.getMessageByLocalId(sessionA.id, 'same-local')
+
+        expect(found?.sessionId).toBe(sessionA.id)
+        expect(found?.localId).toBe('same-local')
+        expect(found?.content).toEqual({ role: 'user', content: { type: 'text', text: 'a' } })
+    })
+
+    it('deletes messages from a sequence onward in one session only', () => {
+        const store = makeStore()
+        const sessionA = makeSession(store, 'delete-from-seq-a')
+        const sessionB = makeSession(store, 'delete-from-seq-b')
+        const keep = store.messages.addMessage(sessionA.id, { role: 'user', content: { type: 'text', text: 'keep' } }, 'keep')
+        const target = store.messages.addMessage(sessionA.id, { role: 'user', content: { type: 'text', text: 'target' } }, 'target')
+        store.messages.addMessage(sessionA.id, { role: 'assistant', content: { type: 'text', text: 'later' } })
+        const other = store.messages.addMessage(sessionB.id, { role: 'user', content: { type: 'text', text: 'other' } }, 'other')
+
+        const deleted = store.messages.deleteMessagesFromSeq(sessionA.id, target.seq)
+
+        expect(deleted).toBe(2)
+        expect(store.messages.getMessages(sessionA.id).map((m) => m.id)).toEqual([keep.id])
+        expect(store.messages.getMessages(sessionB.id).map((m) => m.id)).toEqual([other.id])
+    })
+
+    it('copies invoked messages before a sequence into a fork session', () => {
+        const store = makeStore()
+        const source = makeSession(store, 'copy-before-source')
+        const fork = makeSession(store, 'copy-before-fork')
+        const first = store.messages.addMessage(source.id, { role: 'user', content: { type: 'text', text: 'first' } }, 'first')
+        const second = store.messages.addMessage(source.id, { role: 'assistant', content: { type: 'text', text: 'second' } })
+        const target = store.messages.addMessage(source.id, { role: 'user', content: { type: 'text', text: 'target' } }, 'target')
+        store.messages.addMessage(source.id, { role: 'assistant', content: { type: 'text', text: 'later' } })
+        store.messages.markMessagesInvoked(source.id, ['first', 'target'], Date.now())
+
+        const copied = store.messages.copyMessagesBeforeSeq(source.id, fork.id, target.seq)
+
+        expect(copied).toBe(2)
+        const forkMessages = store.messages.getMessages(fork.id)
+        expect(forkMessages.map((m) => m.content)).toEqual([first.content, second.content])
+        expect(forkMessages.map((m) => m.localId)).toEqual(['first', null])
+        expect(forkMessages.every((m) => m.invokedAt !== null)).toBe(true)
+        expect(forkMessages.map((m) => m.scheduledAt)).toEqual([null, null])
+    })
+})
+
 describe('getDeliverableMessagesAfter: CLI backfill excludes future-scheduled rows', () => {
     it('omits rows whose scheduled_at > now (would otherwise be replayed early on reconnect)', () => {
         const store = makeStore()

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -186,6 +186,74 @@ export function getFirstMessages(
     return rows.map(toStoredMessage)
 }
 
+export function getMessageByLocalId(
+    db: Database,
+    sessionId: string,
+    localId: string
+): StoredMessage | null {
+    const row = db.prepare(
+        'SELECT * FROM messages WHERE session_id = ? AND local_id = ? LIMIT 1'
+    ).get(sessionId, localId) as DbMessageRow | undefined
+    return row ? toStoredMessage(row) : null
+}
+
+export function deleteMessagesFromSeq(
+    db: Database,
+    sessionId: string,
+    seq: number
+): number {
+    const result = db.prepare(
+        'DELETE FROM messages WHERE session_id = ? AND seq >= ?'
+    ).run(sessionId, seq)
+    return result.changes
+}
+
+export function copyMessagesBeforeSeq(
+    db: Database,
+    fromSessionId: string,
+    toSessionId: string,
+    beforeSeq: number
+): number {
+    if (fromSessionId === toSessionId) {
+        return 0
+    }
+
+    const rows = db.prepare(`
+        SELECT * FROM messages
+        WHERE session_id = ?
+          AND seq < ?
+          AND invoked_at IS NOT NULL
+        ORDER BY seq ASC
+    `).all(fromSessionId, beforeSeq) as DbMessageRow[]
+    if (rows.length === 0) {
+        return 0
+    }
+
+    return db.transaction(() => {
+        let nextSeq = getMaxSeq(db, toSessionId)
+        const insert = db.prepare(`
+            INSERT INTO messages (
+                id, session_id, content, created_at, seq, local_id, invoked_at, scheduled_at
+            ) VALUES (
+                @id, @session_id, @content, @created_at, @seq, @local_id, @invoked_at, NULL
+            )
+        `)
+        for (const row of rows) {
+            nextSeq += 1
+            insert.run({
+                id: randomUUID(),
+                session_id: toSessionId,
+                content: row.content,
+                created_at: row.created_at,
+                seq: nextSeq,
+                local_id: row.local_id,
+                invoked_at: row.invoked_at ?? row.created_at
+            })
+        }
+        return rows.length
+    })()
+}
+
 /** CLI reconnect backfill: returns messages above the seq cursor that are
  *  deliverable now, i.e. excludes future-scheduled rows (scheduled_at > now).
  *  Without this filter, a CLI reconnect between schedule time and release time

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -37,6 +37,21 @@ export type RpcCursorModel = CursorModelSummary
 export type RpcListCursorModelsResponse = CursorModelsResponse
 export type RpcOpencodeModel = OpencodeModelSummary
 export type RpcListOpencodeModelsResponse = OpencodeModelsResponse
+export type RpcCodexMessageOperationResponse = {
+    success?: boolean
+    threadId?: string
+    sourceThreadId?: string
+    targetTurnId?: string
+    rolledBackTurns?: number
+    warning?: string
+    error?: string
+}
+export type RpcCodexSteerResponse = {
+    success?: boolean
+    turnId?: string
+    localId?: string
+    error?: string
+}
 
 export class RpcGateway {
     constructor(
@@ -236,6 +251,33 @@ export class RpcGateway {
 
     async listCodexModelsForSession(sessionId: string): Promise<RpcListCodexModelsResponse> {
         return await this.sessionRpc(sessionId, RPC_METHODS.ListCodexModels, {}, MODEL_LIST_RPC_TIMEOUT_MS) as RpcListCodexModelsResponse
+    }
+
+    async rollbackCodexToMessage(sessionId: string, localId: string): Promise<RpcCodexMessageOperationResponse> {
+        return await this.sessionRpc(
+            sessionId,
+            RPC_METHODS.CodexRollbackToMessage,
+            { localId },
+            DEFAULT_RPC_TIMEOUT_MS
+        ) as RpcCodexMessageOperationResponse
+    }
+
+    async forkCodexFromMessage(sessionId: string, localId: string): Promise<RpcCodexMessageOperationResponse> {
+        return await this.sessionRpc(
+            sessionId,
+            RPC_METHODS.CodexForkFromMessage,
+            { localId },
+            DEFAULT_RPC_TIMEOUT_MS
+        ) as RpcCodexMessageOperationResponse
+    }
+
+    async steerCodexCurrentTurn(sessionId: string, text: string, localId?: string): Promise<RpcCodexSteerResponse> {
+        return await this.sessionRpc(
+            sessionId,
+            RPC_METHODS.CodexSteerCurrentTurn,
+            { text, localId },
+            DEFAULT_RPC_TIMEOUT_MS
+        ) as RpcCodexSteerResponse
     }
 
     async listCodexModelsForMachine(machineId: string): Promise<RpcListCodexModelsResponse> {

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -130,13 +130,14 @@ export class RpcGateway {
         worktreeName?: string,
         resumeSessionId?: string,
         effort?: string,
-        permissionMode?: PermissionMode
+        permissionMode?: PermissionMode,
+        collaborationMode?: CodexCollaborationMode
     ): Promise<{ type: 'success'; sessionId: string } | { type: 'error'; message: string }> {
         try {
             const result = await this.machineRpc(
                 machineId,
                 RPC_METHODS.SpawnHappySession,
-                { type: 'spawn-in-directory', directory, agent, model, modelReasoningEffort, yolo, sessionType, worktreeName, resumeSessionId, effort, permissionMode }
+                { type: 'spawn-in-directory', directory, agent, model, modelReasoningEffort, collaborationMode, yolo, sessionType, worktreeName, resumeSessionId, effort, permissionMode }
             )
             if (result && typeof result === 'object') {
                 const obj = result as Record<string, unknown>

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -501,7 +501,8 @@ export class SyncEngine {
         worktreeName?: string,
         resumeSessionId?: string,
         effort?: string,
-        permissionMode?: PermissionMode
+        permissionMode?: PermissionMode,
+        collaborationMode?: CodexCollaborationMode
     ): Promise<{ type: 'success'; sessionId: string } | { type: 'error'; message: string }> {
         return await this.rpcGateway.spawnSession(
             machineId,
@@ -514,7 +515,8 @@ export class SyncEngine {
             worktreeName,
             resumeSessionId,
             effort,
-            permissionMode
+            permissionMode,
+            collaborationMode
         )
     }
 

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -29,6 +29,8 @@ import {
     type RpcListCodexModelsResponse,
     type RpcListCursorModelsResponse,
     type RpcListOpencodeModelsResponse,
+    type RpcCodexMessageOperationResponse,
+    type RpcCodexSteerResponse,
     type RpcCursorModel,
     type RpcOpencodeModel,
     type RpcPathExistsResponse,
@@ -49,6 +51,8 @@ export type {
     RpcListCodexModelsResponse,
     RpcListCursorModelsResponse,
     RpcListOpencodeModelsResponse,
+    RpcCodexMessageOperationResponse,
+    RpcCodexSteerResponse,
     RpcCursorModel,
     RpcOpencodeModel,
     RpcPathExistsResponse,
@@ -962,6 +966,53 @@ export class SyncEngine {
 
     async listCodexModelsForSession(sessionId: string): Promise<RpcListCodexModelsResponse> {
         return await this.rpcGateway.listCodexModelsForSession(sessionId)
+    }
+
+    async rollbackCodexAndTruncateMessages(sessionId: string, localId: string): Promise<RpcCodexMessageOperationResponse> {
+        const target = this.store.messages.getMessageByLocalId(sessionId, localId)
+        if (!target) {
+            return { success: false, error: 'Message not found' }
+        }
+        const result = await this.rpcGateway.rollbackCodexToMessage(sessionId, localId)
+        if (result?.success !== true) {
+            return {
+                success: false,
+                error: result?.error ?? 'Codex rollback failed'
+            }
+        }
+        this.store.messages.deleteMessagesFromSeq(sessionId, target.seq)
+        this.eventPublisher.emit({
+            type: 'messages-invalidated',
+            sessionId,
+            namespace: this.getSession(sessionId)?.namespace
+        })
+        this.sessionCache.recordSessionActivity(sessionId, Date.now())
+        return result
+    }
+
+    async forkCodexFromMessage(sessionId: string, localId: string): Promise<RpcCodexMessageOperationResponse> {
+        return await this.rpcGateway.forkCodexFromMessage(sessionId, localId)
+    }
+
+    copyMessagesBeforeLocalId(fromSessionId: string, toSessionId: string, localId: string): number {
+        const target = this.store.messages.getMessageByLocalId(fromSessionId, localId)
+        if (!target) {
+            return 0
+        }
+        const copied = this.store.messages.copyMessagesBeforeSeq(fromSessionId, toSessionId, target.seq)
+        if (copied > 0) {
+            this.eventPublisher.emit({
+                type: 'messages-invalidated',
+                sessionId: toSessionId,
+                namespace: this.getSession(toSessionId)?.namespace ?? this.getSession(fromSessionId)?.namespace
+            })
+            this.sessionCache.recordSessionActivity(toSessionId, Date.now())
+        }
+        return copied
+    }
+
+    async steerCodexCurrentTurn(sessionId: string, text: string, localId?: string): Promise<RpcCodexSteerResponse> {
+        return await this.rpcGateway.steerCodexCurrentTurn(sessionId, text, localId)
     }
 
     async listCodexModelsForMachine(machineId: string): Promise<RpcListCodexModelsResponse> {

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -680,6 +680,7 @@ describe('sessions routes', () => {
             undefined,
             'thread-forked',
             undefined,
+            'default',
             'default'
         ]])
         expect(copyCalls).toEqual([['session-1', 'session-forked', 'local-2']])

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -8,6 +8,7 @@ function createSession(overrides?: Partial<Session>): Session {
     const baseMetadata = {
         path: '/tmp/project',
         host: 'localhost',
+        machineId: 'machine-1',
         flavor: 'codex' as const
     }
     const base: Session = {
@@ -54,10 +55,22 @@ function createApp(session: Session, opts?: {
     resumeSession?: (sessionId: string, namespace: string, resumeOpts?: { permissionMode?: string }) => Promise<{ type: string; sessionId?: string; message?: string; code?: string }>
     listSlashCommands?: SyncEngine['listSlashCommands']
     getSessionExport?: (sessionId: string, session: Session) => unknown
+    rollbackCodexAndTruncateMessages?: SyncEngine['rollbackCodexAndTruncateMessages']
+    forkCodexFromMessage?: SyncEngine['forkCodexFromMessage']
+    steerCodexCurrentTurn?: SyncEngine['steerCodexCurrentTurn']
+    spawnSession?: SyncEngine['spawnSession']
+    copyMessagesBeforeLocalId?: SyncEngine['copyMessagesBeforeLocalId']
 }) {
     const applySessionConfigCalls: Array<[string, Record<string, unknown>]> = []
+    const sentMessages: Array<{ sessionId: string; payload: { text: string; localId?: string | null; sentFrom?: string } }> = []
     const applySessionConfig = async (sessionId: string, config: Record<string, unknown>) => {
         applySessionConfigCalls.push([sessionId, config])
+    }
+    const sendMessage = async (
+        sessionId: string,
+        payload: { text: string; localId?: string | null; sentFrom?: string }
+    ) => {
+        sentMessages.push({ sessionId, payload })
     }
     const listCodexModelsForSession = async () => ({
         success: true,
@@ -98,6 +111,23 @@ function createApp(session: Session, opts?: {
                 messages: []
             }
         })),
+        sendMessage,
+        rollbackCodexAndTruncateMessages: opts?.rollbackCodexAndTruncateMessages ?? (async () => ({
+            success: true,
+            warning: 'rewound'
+        })),
+        forkCodexFromMessage: opts?.forkCodexFromMessage ?? (async () => ({
+            success: true,
+            threadId: 'fork-thread',
+            warning: 'forked'
+        })),
+        steerCodexCurrentTurn: opts?.steerCodexCurrentTurn ?? (async () => ({
+            success: true,
+            turnId: 'turn-1',
+            localId: 'steer-local'
+        })),
+        spawnSession: opts?.spawnSession ?? (async () => ({ type: 'success', sessionId: 'fork-session' })),
+        copyMessagesBeforeLocalId: opts?.copyMessagesBeforeLocalId ?? (() => 0),
         listSlashCommands: opts?.listSlashCommands ?? (async () => ({
             success: true,
             commands: []
@@ -111,7 +141,7 @@ function createApp(session: Session, opts?: {
     })
     app.route('/api', createSessionsRoutes(() => engine as SyncEngine))
 
-    return { app, applySessionConfigCalls }
+    return { app, applySessionConfigCalls, sentMessages }
 }
 
 describe('sessions routes', () => {
@@ -579,6 +609,144 @@ describe('sessions routes', () => {
         const response = await app.request('/api/sessions/session-1/opencode-models')
 
         expect(response.status).toBe(400)
+    })
+
+    it('rewinds Codex context and sends the replacement message', async () => {
+        const rollbackCalls: Array<[string, string]> = []
+        const { app, sentMessages } = createApp(createSession(), {
+            rollbackCodexAndTruncateMessages: async (sessionId, localId) => {
+                rollbackCalls.push([sessionId, localId])
+                return { success: true, warning: 'local files unchanged' }
+            }
+        })
+
+        const response = await app.request('/api/sessions/session-1/codex/rewind-resend', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ localId: 'local-1', text: 'replacement prompt' })
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ success: true, warning: 'local files unchanged' })
+        expect(rollbackCalls).toEqual([['session-1', 'local-1']])
+        expect(sentMessages).toHaveLength(1)
+        expect(sentMessages[0]?.sessionId).toBe('session-1')
+        expect(sentMessages[0]?.payload.text).toBe('replacement prompt')
+        expect(sentMessages[0]?.payload.sentFrom).toBe('webapp')
+        expect(typeof sentMessages[0]?.payload.localId).toBe('string')
+    })
+
+    it('forks Codex context, resumes the forked thread, and sends the replacement message', async () => {
+        const forkCalls: Array<[string, string]> = []
+        const spawnCalls: unknown[][] = []
+        const copyCalls: Array<[string, string, string]> = []
+        const { app, sentMessages } = createApp(createSession(), {
+            forkCodexFromMessage: async (sessionId, localId) => {
+                forkCalls.push([sessionId, localId])
+                return { success: true, threadId: 'thread-forked', warning: 'fork warning' }
+            },
+            spawnSession: async (...args) => {
+                spawnCalls.push(args)
+                return { type: 'success', sessionId: 'session-forked' }
+            },
+            copyMessagesBeforeLocalId: (fromSessionId, toSessionId, localId) => {
+                copyCalls.push([fromSessionId, toSessionId, localId])
+                return 2
+            },
+        })
+
+        const response = await app.request('/api/sessions/session-1/codex/fork', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ localId: 'local-2', text: 'fork prompt' })
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+            success: true,
+            sessionId: 'session-forked',
+            threadId: 'thread-forked',
+            warning: 'fork warning'
+        })
+        expect(forkCalls).toEqual([['session-1', 'local-2']])
+        expect(spawnCalls).toEqual([[
+            'machine-1',
+            '/tmp/project',
+            'codex',
+            'gpt-5.4',
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            'thread-forked',
+            undefined,
+            'default'
+        ]])
+        expect(copyCalls).toEqual([['session-1', 'session-forked', 'local-2']])
+        expect(sentMessages).toHaveLength(1)
+        expect(sentMessages[0]?.sessionId).toBe('session-forked')
+        expect(sentMessages[0]?.payload.text).toBe('fork prompt')
+        expect(typeof sentMessages[0]?.payload.localId).toBe('string')
+    })
+
+    it('steers the active Codex turn', async () => {
+        const steerCalls: Array<[string, string, string | undefined]> = []
+        const { app } = createApp(createSession(), {
+            steerCodexCurrentTurn: async (sessionId, text, localId) => {
+                steerCalls.push([sessionId, text, localId])
+                return { success: true, turnId: 'turn-steered', localId: localId ?? 'generated-local' }
+            }
+        })
+
+        const response = await app.request('/api/sessions/session-1/codex/steer', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ text: 'adjust course', localId: 'steer-local' })
+        })
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+            success: true,
+            turnId: 'turn-steered',
+            localId: 'steer-local'
+        })
+        expect(steerCalls).toEqual([['session-1', 'adjust course', 'steer-local']])
+    })
+
+    it('rejects Codex message operations for non-Codex sessions', async () => {
+        const session = createSession({
+            metadata: { path: '/tmp/project', host: 'localhost', machineId: 'machine-1', flavor: 'claude' }
+        })
+        const { app, sentMessages } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/codex/rewind-resend', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ localId: 'local-1', text: 'replacement prompt' })
+        })
+
+        expect(response.status).toBe(400)
+        expect(sentMessages).toEqual([])
+    })
+
+    it('rejects Codex message operations for local Codex sessions', async () => {
+        const session = createSession({
+            agentState: {
+                controlledByUser: true,
+                requests: {},
+                completedRequests: {}
+            }
+        })
+        const { app, sentMessages } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/codex/fork', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ localId: 'local-1', text: 'replacement prompt' })
+        })
+
+        expect(response.status).toBe(409)
+        expect(sentMessages).toEqual([])
     })
 
     it('rejects OpenCode plan mode changes for local sessions', async () => {

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -1,4 +1,6 @@
 import {
+    CodexMessageOperationRequestSchema,
+    CodexSteerRequestSchema,
     DeleteUploadRequestSchema,
     getPermissionModesForFlavor,
     isPermissionModeAllowedForFlavor,
@@ -14,12 +16,14 @@ import {
     UploadFileRequestSchema
 } from '@hapi/protocol'
 import type { SlashCommand } from '@hapi/protocol/apiTypes'
+import { randomUUID } from 'node:crypto'
 import { Hono } from 'hono'
 import type { SyncEngine, Session } from '../../sync/syncEngine'
 import type { WebAppEnv } from '../middleware/auth'
 import { requireSessionFromParam, requireSyncEngine } from './guards'
 
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+const CODEX_FILE_WARNING = 'Codex context was changed, but local file changes were not reverted.'
 
 function commandsFromMetadataSlashCommands(names: readonly string[] | undefined): SlashCommand[] {
     if (!names?.length) {
@@ -589,6 +593,179 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
                 success: false,
                 error: error instanceof Error ? error.message : 'Failed to list skills'
             })
+        }
+    })
+
+    app.post('/sessions/:id/codex/rewind-resend', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+
+        const session = sessionResult.session
+        if ((session.metadata?.flavor ?? 'claude') !== 'codex') {
+            return c.json({ success: false, error: 'Rewind is only supported for Codex sessions' }, 400)
+        }
+        if (session.agentState?.controlledByUser === true) {
+            return c.json({ success: false, error: 'Rewind is only supported for remote Codex app-server sessions' }, 409)
+        }
+
+        const body = await c.req.json().catch(() => null)
+        const parsed = CodexMessageOperationRequestSchema.safeParse(body)
+        if (!parsed.success || !parsed.data.text?.trim()) {
+            return c.json({ success: false, error: 'Invalid body' }, 400)
+        }
+
+        try {
+            const rollback = await engine.rollbackCodexAndTruncateMessages(sessionResult.sessionId, parsed.data.localId)
+            if (rollback.success !== true) {
+                return c.json({ success: false, error: rollback.error ?? 'Codex rollback failed' }, 409)
+            }
+
+            await engine.sendMessage(sessionResult.sessionId, {
+                text: parsed.data.text,
+                localId: randomUUID(),
+                sentFrom: 'webapp'
+            })
+            return c.json({
+                success: true,
+                warning: rollback.warning ?? CODEX_FILE_WARNING
+            })
+        } catch (error) {
+            return c.json({
+                success: false,
+                error: error instanceof Error ? error.message : 'Codex rewind failed'
+            }, 500)
+        }
+    })
+
+    app.post('/sessions/:id/codex/fork', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+
+        const session = sessionResult.session
+        if ((session.metadata?.flavor ?? 'claude') !== 'codex') {
+            return c.json({ success: false, error: 'Fork is only supported for Codex sessions' }, 400)
+        }
+        if (session.agentState?.controlledByUser === true) {
+            return c.json({ success: false, error: 'Fork is only supported for remote Codex app-server sessions' }, 409)
+        }
+
+        const body = await c.req.json().catch(() => null)
+        const parsed = CodexMessageOperationRequestSchema.safeParse(body)
+        if (!parsed.success || !parsed.data.text?.trim()) {
+            return c.json({ success: false, error: 'Invalid body' }, 400)
+        }
+
+        const machineId = session.metadata?.machineId
+        const directory = session.metadata?.path
+        if (!machineId || !directory) {
+            return c.json({ success: false, error: 'Session machine/path metadata is missing' }, 409)
+        }
+
+        try {
+            const fork = await engine.forkCodexFromMessage(sessionResult.sessionId, parsed.data.localId)
+            if (fork.success !== true || !fork.threadId) {
+                return c.json({ success: false, error: fork.error ?? 'Codex fork failed' }, 409)
+            }
+
+            const spawn = await engine.spawnSession(
+                machineId,
+                directory,
+                'codex',
+                session.model ?? undefined,
+                session.modelReasoningEffort ?? undefined,
+                undefined,
+                undefined,
+                undefined,
+                fork.threadId,
+                undefined,
+                session.permissionMode
+            )
+            if (spawn.type === 'error') {
+                return c.json({
+                    success: false,
+                    threadId: fork.threadId,
+                    error: spawn.message
+                }, 503)
+            }
+
+            engine.copyMessagesBeforeLocalId(sessionResult.sessionId, spawn.sessionId, parsed.data.localId)
+            await engine.sendMessage(spawn.sessionId, {
+                text: parsed.data.text,
+                localId: randomUUID(),
+                sentFrom: 'webapp'
+            })
+            return c.json({
+                success: true,
+                sessionId: spawn.sessionId,
+                threadId: fork.threadId,
+                warning: fork.warning ?? CODEX_FILE_WARNING
+            })
+        } catch (error) {
+            return c.json({
+                success: false,
+                error: error instanceof Error ? error.message : 'Codex fork failed'
+            }, 500)
+        }
+    })
+
+    app.post('/sessions/:id/codex/steer', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+
+        const session = sessionResult.session
+        if ((session.metadata?.flavor ?? 'claude') !== 'codex') {
+            return c.json({ success: false, error: 'Steer is only supported for Codex sessions' }, 400)
+        }
+        if (session.agentState?.controlledByUser === true) {
+            return c.json({ success: false, error: 'Steer is only supported for remote Codex app-server sessions' }, 409)
+        }
+
+        const body = await c.req.json().catch(() => null)
+        const parsed = CodexSteerRequestSchema.safeParse(body)
+        if (!parsed.success) {
+            return c.json({ success: false, error: 'Invalid body' }, 400)
+        }
+
+        try {
+            const result = await engine.steerCodexCurrentTurn(
+                sessionResult.sessionId,
+                parsed.data.text,
+                parsed.data.localId
+            )
+            if (result.success !== true) {
+                return c.json({ success: false, error: result.error ?? 'Codex steer failed' }, 409)
+            }
+            return c.json({
+                success: true,
+                turnId: result.turnId,
+                localId: result.localId
+            })
+        } catch (error) {
+            return c.json({
+                success: false,
+                error: error instanceof Error ? error.message : 'Codex steer failed'
+            }, 500)
         }
     })
 

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -692,7 +692,8 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
                 undefined,
                 fork.threadId,
                 undefined,
-                session.permissionMode
+                session.permissionMode,
+                session.collaborationMode ?? undefined
             )
             if (spawn.type === 'error') {
                 return c.json({

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -174,6 +174,41 @@ export const SendMessageRequestSchema = z.object({
 
 export type SendMessageRequest = z.infer<typeof SendMessageRequestSchema>
 
+export const CodexMessageOperationRequestSchema = z.object({
+    localId: z.string().min(1),
+    text: z.string().min(1).optional()
+})
+
+export type CodexMessageOperationRequest = z.infer<typeof CodexMessageOperationRequestSchema>
+
+export const CodexSteerRequestSchema = z.object({
+    text: z.string().min(1),
+    localId: z.string().min(1).optional()
+})
+
+export type CodexSteerRequest = z.infer<typeof CodexSteerRequestSchema>
+
+export type CodexRewindResponse = {
+    success: boolean
+    warning?: string
+    error?: string
+}
+
+export type CodexForkResponse = {
+    success: boolean
+    sessionId?: string
+    threadId?: string
+    warning?: string
+    error?: string
+}
+
+export type CodexSteerResponse = {
+    success: boolean
+    turnId?: string
+    localId?: string
+    error?: string
+}
+
 export const SpawnSessionRequestSchema = z.object({
     directory: z.string().min(1),
     agent: AgentFlavorSchema.optional(),

--- a/shared/src/rpcMethods.ts
+++ b/shared/src/rpcMethods.ts
@@ -26,6 +26,9 @@ export const RPC_METHODS = {
     ListSlashCommands: 'listSlashCommands',
     ListSkills: 'listSkills',
     ListCodexModels: 'listCodexModels',
+    CodexRollbackToMessage: 'codexRollbackToMessage',
+    CodexForkFromMessage: 'codexForkFromMessage',
+    CodexSteerCurrentTurn: 'codexSteerCurrentTurn',
     ListCursorModels: 'listCursorModels',
     ListOpencodeModels: 'listOpencodeModels',
     ListOpencodeModelsForCwd: 'listOpencodeModelsForCwd'

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
     CodexDesktopSyncRequest,
     CodexDesktopStatusResponse,
     CodexCollaborationMode,
+    CodexForkResponse,
     FileSearchResponse,
     MachinesResponse,
     MessagesResponse,
@@ -17,6 +18,8 @@ import type {
     PushVapidPublicKeyResponse,
     SlashCommandsResponse,
     SkillsResponse,
+    CodexRewindResponse,
+    CodexSteerResponse,
     SpawnResponse,
     VisibilityPayload,
     HapiSessionExport,
@@ -392,6 +395,36 @@ export class ApiClient {
             { method: 'DELETE' }
         )
         return response as CancelMessageResponse
+    }
+
+    async codexRewindAndResend(sessionId: string, localId: string, text: string): Promise<CodexRewindResponse> {
+        return await this.request<CodexRewindResponse>(
+            `/api/sessions/${encodeURIComponent(sessionId)}/codex/rewind-resend`,
+            {
+                method: 'POST',
+                body: JSON.stringify({ localId, text })
+            }
+        )
+    }
+
+    async codexForkFromMessage(sessionId: string, localId: string, text: string): Promise<CodexForkResponse> {
+        return await this.request<CodexForkResponse>(
+            `/api/sessions/${encodeURIComponent(sessionId)}/codex/fork`,
+            {
+                method: 'POST',
+                body: JSON.stringify({ localId, text })
+            }
+        )
+    }
+
+    async codexSteerCurrentTurn(sessionId: string, text: string): Promise<CodexSteerResponse> {
+        return await this.request<CodexSteerResponse>(
+            `/api/sessions/${encodeURIComponent(sessionId)}/codex/steer`,
+            {
+                method: 'POST',
+                body: JSON.stringify({ text })
+            }
+        )
     }
 
     async abortSession(sessionId: string): Promise<void> {

--- a/web/src/components/AssistantChat/ComposerButtons.tsx
+++ b/web/src/components/AssistantChat/ComposerButtons.tsx
@@ -235,6 +235,8 @@ function UnifiedButton(props: {
     voiceStatus: ConversationStatus
     voiceEnabled: boolean
     controlsDisabled: boolean
+    title?: string
+    disabled?: boolean
     onSend: () => void
     onVoiceToggle: () => void
 }) {
@@ -284,7 +286,10 @@ function UnifiedButton(props: {
         ariaLabel = t('composer.send')
     }
 
-    const isDisabled = props.controlsDisabled || (!hasText && !props.voiceEnabled && !isVoiceActive)
+    const isDisabled = props.disabled || props.controlsDisabled || (!hasText && !props.voiceEnabled && !isVoiceActive)
+    if (props.title && hasText && !isVoiceActive) {
+        ariaLabel = props.title
+    }
 
     return (
         <button
@@ -323,6 +328,8 @@ export function ComposerButtons(props: {
     onVoiceToggle: () => void
     onVoiceMicToggle?: () => void
     onSend: () => void
+    sendTitle?: string
+    sendDisabled?: boolean
     pendingSchedule?: PendingSchedule | null
     onSchedule?: (pending: PendingSchedule) => void
     onClearSchedule?: () => void
@@ -464,6 +471,8 @@ export function ComposerButtons(props: {
                 voiceStatus={props.voiceStatus}
                 voiceEnabled={props.voiceEnabled}
                 controlsDisabled={props.controlsDisabled}
+                title={props.sendTitle}
+                disabled={props.sendDisabled}
                 onSend={props.onSend}
                 onVoiceToggle={props.onVoiceToggle}
             />

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -77,6 +77,7 @@ export function HappyComposer(props: {
     onEffortChange?: (effort: string | null) => void
     onSwitchToRemote?: () => void
     onTerminal?: () => void
+    onSteerCurrentTurn?: (text: string) => Promise<void>
     terminalUnsupported?: boolean
     autocompletePrefixes?: string[]
     autocompleteSuggestions?: (query: string) => Promise<Suggestion[]>
@@ -122,6 +123,7 @@ export function HappyComposer(props: {
         onEffortChange,
         onSwitchToRemote,
         onTerminal,
+        onSteerCurrentTurn,
         terminalUnsupported = false,
         autocompletePrefixes = ['@', '/', '$'],
         autocompleteSuggestions = defaultSuggestionHandler,
@@ -171,6 +173,7 @@ export function HappyComposer(props: {
     const [showSettings, setShowSettings] = useState(false)
     const [isAborting, setIsAborting] = useState(false)
     const [isSwitching, setIsSwitching] = useState(false)
+    const [isSteering, setIsSteering] = useState(false)
     const [showContinueHint, setShowContinueHint] = useState(false)
     // pendingSchedule is controlled externally when onSchedule prop is provided; otherwise local state
     const [pendingScheduleLocal, setPendingScheduleLocal] = useState<PendingSchedule | null>(null)
@@ -553,13 +556,26 @@ export function HappyComposer(props: {
     const voiceEnabled = Boolean(onVoiceToggle)
 
     const handleSend = useCallback(() => {
+        if (onSteerCurrentTurn && thinking && hasText && !hasAttachments && pendingSchedule == null) {
+            const text = composerText.trim()
+            setIsSteering(true)
+            void onSteerCurrentTurn(text)
+                .then(() => {
+                    api.composer().setText('')
+                })
+                .catch((error) => {
+                    console.error('Failed to steer Codex turn:', error)
+                })
+                .finally(() => setIsSteering(false))
+            return
+        }
         api.composer().send()
         // SessionChat owns clearing the schedule — it clears only after awaiting
         // the send hook's accepted result, which covers both pre-mutation guards
         // and async inactive-session resume failure. Clearing here unconditionally
         // would race ahead of that check and drop the user's schedule on every
         // rejected send path.
-    }, [api])
+    }, [api, onSteerCurrentTurn, thinking, hasText, hasAttachments, pendingSchedule, composerText])
 
     const overlays = useMemo(() => {
         if (showSettings && (showCollaborationSettings || showPermissionSettings || showModelSettings || showModelEffortSettings || showModelReasoningEffortSettings || showEffortSettings)) {
@@ -937,6 +953,8 @@ export function HappyComposer(props: {
                             onVoiceToggle={onVoiceToggle ?? (() => {})}
                             onVoiceMicToggle={onVoiceMicToggle}
                             onSend={handleSend}
+                            sendTitle={onSteerCurrentTurn && thinking && hasText && !hasAttachments && pendingSchedule == null ? 'Steer current turn' : undefined}
+                            sendDisabled={isSteering}
                             pendingSchedule={pendingSchedule}
                             onSchedule={setPendingSchedule}
                             onClearSchedule={isControlled ? onClearScheduleProp : () => setPendingScheduleLocal(null)}

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -244,8 +244,12 @@ export function HappyThread(props: {
     sessionId: string
     metadata: SessionMetadataSummary | null
     disabled: boolean
+    agentFlavor?: string | null
+    codexMessageOpsEnabled?: boolean
     onRefresh: () => void
     onRetryMessage?: (localId: string) => void
+    onCodexRewindAndResend?: (localId: string, text: string) => Promise<void>
+    onCodexForkFromMessage?: (localId: string, text: string) => Promise<void>
     onFlushPending: () => void
     onAtBottomChange: (atBottom: boolean) => void
     isLoadingMessages: boolean
@@ -680,8 +684,12 @@ export function HappyThread(props: {
             metadata: props.metadata,
             terminalToolDisplayMode,
             disabled: props.disabled,
+            agentFlavor: props.agentFlavor,
+            codexMessageOpsEnabled: props.codexMessageOpsEnabled,
             onRefresh: props.onRefresh,
             onRetryMessage: props.onRetryMessage,
+            onCodexRewindAndResend: props.onCodexRewindAndResend,
+            onCodexForkFromMessage: props.onCodexForkFromMessage,
             hasMoreMessages: props.hasMoreMessages,
             isLoadingMoreMessages: props.isLoadingMoreMessages,
             loadOlderMessagesPreservingScroll: loadOlderPreservingScroll

--- a/web/src/components/AssistantChat/context.tsx
+++ b/web/src/components/AssistantChat/context.tsx
@@ -10,8 +10,12 @@ export type HappyChatContextValue = {
     metadata: SessionMetadataSummary | null
     terminalToolDisplayMode: TerminalToolDisplayMode
     disabled: boolean
+    agentFlavor?: string | null
+    codexMessageOpsEnabled?: boolean
     onRefresh: () => void
     onRetryMessage?: (localId: string) => void
+    onCodexRewindAndResend?: (localId: string, text: string) => Promise<void>
+    onCodexForkFromMessage?: (localId: string, text: string) => Promise<void>
     hasMoreMessages: boolean
     isLoadingMoreMessages: boolean
     loadOlderMessagesPreservingScroll: () => Promise<boolean>

--- a/web/src/components/AssistantChat/messages/UserMessage.tsx
+++ b/web/src/components/AssistantChat/messages/UserMessage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { MessagePrimitive, useAssistantState } from '@assistant-ui/react'
+import { MessagePrimitive, useAssistantApi, useAssistantState } from '@assistant-ui/react'
 import { useHappyChatContext } from '@/components/AssistantChat/context'
 import type { HappyChatMessageMetadata } from '@/lib/assistant-runtime'
 import { MessageStatusIndicator } from '@/components/AssistantChat/messages/MessageStatusIndicator'
@@ -14,8 +14,10 @@ import { MessageTimestamp } from '@/components/AssistantChat/messages/MessageTim
 
 export function HappyUserMessage() {
     const ctx = useHappyChatContext()
+    const api = useAssistantApi()
     const { copied, copy } = useCopyToClipboard()
     const [showMetadata, setShowMetadata] = useState(false)
+    const [operationPending, setOperationPending] = useState(false)
     const role = useAssistantState(({ message }) => message.role)
     const messageId = useAssistantState(({ message }) => message.id)
     const text = useAssistantState(({ message }) => {
@@ -54,6 +56,48 @@ export function HappyUserMessage() {
     const canRetry = status === 'failed' && typeof localId === 'string' && Boolean(ctx.onRetryMessage)
     const onRetry = canRetry ? () => ctx.onRetryMessage!(localId) : undefined
     const showStatus = shouldShowMessageStatus(status)
+    const hasText = text.length > 0
+    const canCodexMessageOps = Boolean(
+        ctx.codexMessageOpsEnabled
+        && typeof localId === 'string'
+        && localId.length > 0
+        && hasText
+    )
+
+    const editInComposer = () => {
+        api.composer().setText(text)
+    }
+
+    const promptReplacement = (title: string): string | null => {
+        const next = window.prompt(title, text)
+        if (next === null) return null
+        const trimmed = next.trim()
+        return trimmed.length > 0 ? trimmed : null
+    }
+
+    const runMessageOperation = async (operation: 'rewind' | 'fork') => {
+        if (!canCodexMessageOps || typeof localId !== 'string') return
+        const next = promptReplacement(operation === 'rewind' ? 'Edit and resend from here' : 'Fork from here with message')
+        if (!next) return
+        const ok = window.confirm(
+            operation === 'rewind'
+                ? 'This rewinds Codex conversation context and removes later HAPI messages. It does not revert local file changes. Continue?'
+                : 'This forks Codex conversation context. It does not copy/revert local file changes. Continue?'
+        )
+        if (!ok) return
+        setOperationPending(true)
+        try {
+            if (operation === 'rewind') {
+                await ctx.onCodexRewindAndResend?.(localId, next)
+            } else {
+                await ctx.onCodexForkFromMessage?.(localId, next)
+            }
+        } catch (error) {
+            window.alert(error instanceof Error ? error.message : String(error))
+        } finally {
+            setOperationPending(false)
+        }
+    }
 
     if (isCliOutput) {
         return (
@@ -84,7 +128,6 @@ export function HappyUserMessage() {
         )
     }
 
-    const hasText = text.length > 0
     const hasAttachments = attachments && attachments.length > 0
 
     return (
@@ -112,6 +155,38 @@ export function HappyUserMessage() {
                                         : <CopyIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />}
                                 </button>
                             )}
+                            {hasText && (
+                                <button
+                                    type="button"
+                                    title="Edit in composer"
+                                    className="rounded-md px-1 py-0.5 text-[10px] text-[var(--app-hint)] opacity-60 transition-[opacity,background-color] hover:bg-[var(--app-chat-user-chip-bg)] hover:text-[var(--app-fg)] sm:opacity-0 sm:group-hover/msg:opacity-100"
+                                    onClick={editInComposer}
+                                >
+                                    Edit
+                                </button>
+                            )}
+                            {canCodexMessageOps ? (
+                                <>
+                                    <button
+                                        type="button"
+                                        title="Rewind Codex context and resend"
+                                        disabled={operationPending}
+                                        className="rounded-md px-1 py-0.5 text-[10px] text-[var(--app-hint)] opacity-60 transition-[opacity,background-color] hover:bg-[var(--app-chat-user-chip-bg)] hover:text-[var(--app-fg)] disabled:opacity-40 sm:opacity-0 sm:group-hover/msg:opacity-100"
+                                        onClick={() => { void runMessageOperation('rewind') }}
+                                    >
+                                        Rewind
+                                    </button>
+                                    <button
+                                        type="button"
+                                        title="Fork Codex context from here"
+                                        disabled={operationPending}
+                                        className="rounded-md px-1 py-0.5 text-[10px] text-[var(--app-hint)] opacity-60 transition-[opacity,background-color] hover:bg-[var(--app-chat-user-chip-bg)] hover:text-[var(--app-fg)] disabled:opacity-40 sm:opacity-0 sm:group-hover/msg:opacity-100"
+                                        onClick={() => { void runMessageOperation('fork') }}
+                                    >
+                                        Fork
+                                    </button>
+                                </>
+                            ) : null}
                             {showStatus ? <MessageStatusIndicator status={status} onRetry={onRetry} /> : null}
                         </div>
                     )}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -628,6 +628,37 @@ export function SessionChat(props: {
         props.onRefresh()
     }, [switchSession, props.onRefresh])
 
+    const handleCodexRewindAndResend = useCallback(async (localId: string, text: string) => {
+        const result = await props.api.codexRewindAndResend(props.session.id, localId, text)
+        if (!result.success) {
+            throw new Error(result.error ?? 'Codex rewind failed')
+        }
+        haptic.notification('success')
+        props.onRefresh()
+        setForceScrollToken((token) => token + 1)
+    }, [props.api, props.session.id, props.onRefresh, haptic])
+
+    const handleCodexForkFromMessage = useCallback(async (localId: string, text: string) => {
+        const result = await props.api.codexForkFromMessage(props.session.id, localId, text)
+        if (!result.success || !result.sessionId) {
+            throw new Error(result.error ?? 'Codex fork failed')
+        }
+        haptic.notification('success')
+        navigate({
+            to: '/sessions/$sessionId',
+            params: { sessionId: result.sessionId }
+        })
+    }, [props.api, props.session.id, navigate, haptic])
+
+    const handleCodexSteerCurrentTurn = useCallback(async (text: string) => {
+        const result = await props.api.codexSteerCurrentTurn(props.session.id, text)
+        if (!result.success) {
+            throw new Error(result.error ?? 'Codex steer failed')
+        }
+        haptic.notification('success')
+        props.onRefresh()
+    }, [props.api, props.session.id, props.onRefresh, haptic])
+
     const handleViewFiles = useCallback(() => {
         navigate({
             to: '/sessions/$sessionId/files',
@@ -733,8 +764,12 @@ export function SessionChat(props: {
                         sessionId={props.session.id}
                         metadata={props.session.metadata}
                         disabled={sessionInactive}
+                        agentFlavor={agentFlavor}
+                        codexMessageOpsEnabled={agentFlavor === 'codex' && props.session.active && !controlledByUser}
                         onRefresh={props.onRefresh}
                         onRetryMessage={props.onRetryMessage}
+                        onCodexRewindAndResend={handleCodexRewindAndResend}
+                        onCodexForkFromMessage={handleCodexForkFromMessage}
                         onFlushPending={props.onFlushPending}
                         onAtBottomChange={props.onAtBottomChange}
                         isLoadingMessages={props.isLoadingMessages}
@@ -882,6 +917,11 @@ export function SessionChat(props: {
                         onTerminal={props.session.active && terminalSupported ? handleViewTerminal : undefined}
                         terminalUnsupported={props.session.active && !terminalSupported}
                         autocompleteSuggestions={props.autocompleteSuggestions}
+                        onSteerCurrentTurn={
+                            agentFlavor === 'codex' && props.session.active && props.session.thinking && !controlledByUser
+                                ? handleCodexSteerCurrentTurn
+                                : undefined
+                        }
                         voiceStatus={voice?.status}
                         voiceMicMuted={voice?.micMuted}
                         onVoiceToggle={voice && voiceBackendReady ? handleVoiceToggle : undefined}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -11,6 +11,9 @@ import type {
 export type {
     CodexModelsResponse,
     CodexModelSummary,
+    CodexForkResponse,
+    CodexRewindResponse,
+    CodexSteerResponse,
     CommandResponse,
     CursorModelsResponse,
     CursorModelSummary,


### PR DESCRIPTION
## Summary
- add Codex app-server thread read/fork/rollback and turn steer RPC plumbing
- wire web actions for user-message edit, rewind/resend, fork/resend, and active-turn steer
- keep HAPI local message IDs mapped to Codex client user message IDs so rewinds/forks target the correct turn
- copy visible history before the fork point into the forked HAPI session

## Notes
- Codex thread rollback/fork updates conversation context only; it does not revert local file changes. The UI/API warning reflects that.
- This PR intentionally does not include `@file` mention support; that is split into #774.

## Tests
- `bun typecheck`
- `cd cli && bun test src/codex/utils/appServerConfig.test.ts src/utils/MessageQueue2.test.ts`
- `cd cli && bun run test src/codex/codexRemoteLauncher.test.ts src/codex/runCodex.test.ts`
- `cd hub && bun test src/web/routes/sessions.test.ts src/store/messages.test.ts`
