### PR TITLE
fix(web): add close button to dialog so modals are dismissable on mobile

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { cn } from '@/lib/utils'
+import { CloseIcon } from '@/components/icons'
 
 export const Dialog = DialogPrimitive.Root
 export const DialogTrigger = DialogPrimitive.Trigger
@@ -8,7 +9,7 @@ export const DialogTrigger = DialogPrimitive.Trigger
 export const DialogContent = React.forwardRef<
     HTMLDivElement,
     React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
     <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50" />
         <DialogPrimitive.Content
@@ -18,7 +19,15 @@ export const DialogContent = React.forwardRef<
                 className
             )}
             {...props}
-        />
+        >
+            {children}
+            <DialogPrimitive.Close
+                className="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-full text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
+                aria-label="Close"
+            >
+                <CloseIcon className="h-4 w-4" />
+            </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
     </DialogPrimitive.Portal>
 ))
 DialogContent.displayName = 'DialogContent'

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { cn } from '@/lib/utils'
 import { CloseIcon } from '@/components/icons'
+import { useTranslation } from '@/lib/use-translation'
 
 export const Dialog = DialogPrimitive.Root
 export const DialogTrigger = DialogPrimitive.Trigger
@@ -9,27 +10,30 @@ export const DialogTrigger = DialogPrimitive.Trigger
 export const DialogContent = React.forwardRef<
     HTMLDivElement,
     React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-    <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50" />
-        <DialogPrimitive.Content
-            ref={ref}
-            className={cn(
-                'fixed left-1/2 top-1/2 z-50 w-[calc(100vw-24px)] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-xl bg-[var(--app-dialog-bg)] p-4 shadow-2xl',
-                className
-            )}
-            {...props}
-        >
-            {children}
-            <DialogPrimitive.Close
-                className="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-full text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
-                aria-label="Close"
+>(({ className, children, ...props }, ref) => {
+    const { t } = useTranslation()
+    return (
+        <DialogPrimitive.Portal>
+            <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50" />
+            <DialogPrimitive.Content
+                ref={ref}
+                className={cn(
+                    'fixed left-1/2 top-1/2 z-50 w-[calc(100vw-24px)] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-xl bg-[var(--app-dialog-bg)] p-4 shadow-2xl',
+                    className
+                )}
+                {...props}
             >
-                <CloseIcon className="h-4 w-4" />
-            </DialogPrimitive.Close>
-        </DialogPrimitive.Content>
-    </DialogPrimitive.Portal>
-))
+                {children}
+                <DialogPrimitive.Close
+                    className="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-full text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
+                    aria-label={t('button.close')}
+                >
+                    <CloseIcon className="h-4 w-4" />
+                </DialogPrimitive.Close>
+            </DialogPrimitive.Content>
+        </DialogPrimitive.Portal>
+    )
+})
 DialogContent.displayName = 'DialogContent'
 
 export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -33,7 +33,9 @@ export const DialogContent = React.forwardRef<
 DialogContent.displayName = 'DialogContent'
 
 export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-    <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+    // pr-12 reserves space for the absolutely-positioned close button (top-right)
+    // so long/breaking titles don't wrap underneath the tap target.
+    <div className={cn('flex flex-col space-y-1.5 pr-12 text-center sm:text-left', className)} {...props} />
 )
 
 export const DialogTitle = React.forwardRef<


### PR DESCRIPTION
## Problem

On mobile there's no way to dismiss a dialog (e.g. the tool-detail modal). A user reported opening the tool-call detail box on their phone with "no place to close it".

The shared `DialogContent` (`web/src/components/ui/dialog.tsx`) renders no close affordance. On desktop you can press <kbd>Escape</kbd> or click the overlay, but on mobile there's no Escape key, and the dialog spans `calc(100vw-24px)` — leaving almost no tappable overlay area — so the modal is effectively un-closable.

## Fix

Add a `DialogPrimitive.Close` "×" button in the top-right corner of `DialogContent` (reusing the existing `CloseIcon`). Since every dialog in the app shares this component, this fixes all of them at once — the standard shadcn/ui pattern.

## Verification

- `tsc --noEmit` passes
- `ToolGroupCard.test.tsx` (6 tests) pass
- Manual E2E with Playwright at iPhone-14 viewport (390×844): opened the tool-detail dialog, confirmed the close button renders in the top-right (`x=334` of 390-wide viewport), and clicking it dismisses the dialog (`role=dialog` count → 0)
- Confirmed `InstallPrompt`/`ImagePreview` use their own custom modals (not this component), so no duplicate close button appears