### PR TITLE
fix(web): disable single-dollar inline math in remark-math

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -139,10 +139,14 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
         "autoprefixer": "^10.4.23",
+        "hast-util-to-html": "^9.0.5",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.6",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
+        "unified": "^11.0.5",
         "vite": "^7.3.0",
         "vitest": "^4.0.16",
       },
@@ -1069,6 +1073,8 @@
     "@twsxtd/hapi-linux-arm64": ["@twsxtd/hapi-linux-arm64@0.20.0", "", { "os": "linux", "cpu": "arm64", "bin": { "hapi": "bin/hapi" } }, "sha512-p/m27u19GlLGVbYHXmNWEX6ohaRgi7fioSbIVzM34QJAHZevnK1NYmC8xodWKQTEpRizqEbZBGUHycugquvpbg=="],
 
     "@twsxtd/hapi-linux-x64": ["@twsxtd/hapi-linux-x64@0.20.0", "", { "os": "linux", "cpu": "x64", "bin": { "hapi": "bin/hapi" } }, "sha512-hmdAxSgsAxeLfRFn57u13xLc7jHGxKJR/HZUwKkFKe6vcTkGRWsSJToVhGZrUSCT+giYo8g0YQpyOWI/i8cBLA=="],
+
+    "@twsxtd/hapi-win32-x64": ["@twsxtd/hapi-win32-x64@0.20.0", "", { "os": "win32", "cpu": "x64", "bin": { "hapi": "bin/hapi.exe" } }, "sha512-1GWfncMeaZvBIfSB0RY4UI4ywiKUtOAi41nRHxqUI/VdWS9Rw3syCRa4bH2gFJzrdRtDdi0kfSib9YRHs1uQgg=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -58,10 +58,14 @@
         "@tailwindcss/postcss": "^4.1.18",
         "@vitejs/plugin-react": "^5.1.2",
         "autoprefixer": "^10.4.23",
+        "hast-util-to-html": "^9.0.5",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.6",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
+        "unified": "^11.0.5",
         "vite": "^7.3.0",
         "vitest": "^4.0.16"
     }

--- a/web/src/components/assistant-ui/markdown-text.test.ts
+++ b/web/src/components/assistant-ui/markdown-text.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import { toHtml } from 'hast-util-to-html'
 import remarkBreaks from 'remark-breaks'
 import remarkNonHttpsAutolink from '@/lib/remark-non-https-autolink'
 import remarkStripCjkAutolink from '@/lib/remark-strip-cjk-autolink'
-import { MARKDOWN_PLUGINS, MARKDOWN_PLUGINS_WITH_BREAKS } from '@/components/assistant-ui/markdown-text'
+import {
+    MARKDOWN_PLUGINS,
+    MARKDOWN_PLUGINS_WITH_BREAKS,
+    MARKDOWN_REHYPE_PLUGINS,
+} from '@/components/assistant-ui/markdown-text'
 
 describe('MARKDOWN_PLUGINS integration', () => {
     it('includes remarkNonHttpsAutolink', () => {
@@ -19,5 +27,49 @@ describe('MARKDOWN_PLUGINS integration', () => {
     it('keeps hard-break parsing scoped to opt-in user prompt rendering', () => {
         expect(MARKDOWN_PLUGINS).not.toContain(remarkBreaks)
         expect(MARKDOWN_PLUGINS_WITH_BREAKS).toContain(remarkBreaks)
+    })
+})
+
+function render(markdown: string): string {
+    const processor = unified()
+        .use(remarkParse)
+        .use(MARKDOWN_PLUGINS)
+        .use(remarkRehype)
+        .use(MARKDOWN_REHYPE_PLUGINS)
+    const tree = processor.runSync(processor.parse(markdown))
+    return toHtml(tree as never)
+}
+
+describe('MARKDOWN_PLUGINS — currency prose vs KaTeX', () => {
+    // Regression: prose with multiple "$N" amounts must NOT be eaten by KaTeX.
+    // remarkMath is configured with `singleDollarTextMath: false` so single
+    // dollar signs are treated as literal text, matching GitHub markdown.
+
+    it('does not render single-$ currency amounts as KaTeX math', () => {
+        const md = "The plan is $200/mo and the bill is $80 — total $400 saved."
+        const html = render(md)
+        expect(html).not.toContain('class="katex"')
+        expect(html).not.toContain('<math')
+        expect(html).toContain('$200')
+        expect(html).toContain('$80')
+        expect(html).toContain('$400')
+    })
+
+    it('does not render the reported real-world prose as KaTeX', () => {
+        // Lifted (paraphrased) from the bug report: paragraph with multiple
+        // "$N" amounts and apostrophes that previously collapsed into a single
+        // KaTeX block and stripped whitespace from the running text.
+        const md = "Cursor's UI quotes the ratio: at least $400 of API usage on a $200 plan. That's 2:1."
+        const html = render(md)
+        expect(html).not.toContain('class="katex"')
+        expect(html).not.toContain('<math')
+        expect(html).toContain('$400')
+        expect(html).toContain('$200')
+    })
+
+    it('still renders block math with $$...$$ on its own lines', () => {
+        const md = "Before\n\n$$\nE = mc^2\n$$\n\nAfter"
+        const html = render(md)
+        expect(html).toContain('class="katex"')
     })
 })

--- a/web/src/components/assistant-ui/markdown-text.tsx
+++ b/web/src/components/assistant-ui/markdown-text.tsx
@@ -34,10 +34,17 @@ import type { MarkdownTextPrimitiveProps } from '@assistant-ui/react-markdown'
 // from them. Both must come before remarkMath (to avoid treating TeX as URI).
 // remarkFilePathLinks runs last to convert file paths → links after all other
 // transforms have settled.
+//
+// remarkMath is configured with `singleDollarTextMath: false` so that prose
+// containing currency amounts (e.g. "$200/mo ... $80 bill") is not garbled
+// into KaTeX output. Block math `$$...$$` (on its own line) still works.
+// This matches GitHub-flavored markdown behavior. The option lives on the
+// shared TAIL so both MARKDOWN_PLUGINS (default) and MARKDOWN_PLUGINS_WITH_BREAKS
+// (user-prompt rendering with hard breaks) inherit the fix.
 const MARKDOWN_PLUGIN_TAIL = [
     remarkNonHttpsAutolink,
     remarkStripCjkAutolink,
-    remarkMath,
+    [remarkMath, { singleDollarTextMath: false }],
     remarkDisableIndentedCode,
     remarkFilePathLinks,        // upstream — file path → link conversion, runs last
 ] satisfies NonNullable<MarkdownTextPrimitiveProps['remarkPlugins']>


### PR DESCRIPTION
## Summary

Disables single-dollar inline math in `remark-math` so prose containing currency amounts no longer collapses into KaTeX output.

`$$...$$` block math (on its own line) is unchanged.

Fixes #800.

## Problem

`remark-math` is configured with defaults, which means `singleDollarTextMath: true`. Any pair of `$` characters in a paragraph becomes a math span, so messages like:

```
The plan is $200/mo and the bill is $80 — total $400 saved.
```

render with everything between the first and last `$` collapsed into a single `<span class="katex">` block — whitespace stripped, letters reflowed as italic math symbols, apostrophes turned into prime marks. The text is no longer readable as prose.

Currency mentions are common in chat (pricing discussions, plan comparisons, billing), so the false-positive rate is high enough that day-to-day prose has been hitting it.

## Approach

Pass `singleDollarTextMath: false` to `remarkMath` in `web/src/components/assistant-ui/markdown-text.tsx`. This is a single source of truth — `MarkdownText`, `Reasoning`, and `MarkdownRenderer` all import the same `MARKDOWN_PLUGINS` array, so the fix lands in every markdown surface at once.

Block math `$$...$$` continues to render. This matches GitHub-flavored markdown semantics, which only treat `$$...$$` (or fenced ` ```math `) as math.

### Trade-off vs #237

#237 added KaTeX support and explicitly mentioned single-dollar form `$ E= mc^2 $` as desired. This PR partially reverses that — single-dollar inline math goes away. Math-heavy users will need to switch to `$$E = mc^2$$` on its own line. The trade-off felt worth it because false positives from currency `$` are common in chat prose, while inline math is rare; happy to revisit if maintainers prefer a different policy.

## Testing

3 new regression tests in `web/src/components/assistant-ui/markdown-text.test.ts` drive the unified pipeline end-to-end and assert against the rendered HTML:

- prose with multiple `$N` amounts → no `class="katex"`, no `<math>` element, all amounts present as literal text
- the real-world reported paragraph → renders as plain text
- `$$E = mc^2$$` block math → still produces a KaTeX block

```
$ bun run test
Test Files  85 passed (85)
     Tests  739 passed (739)

$ bun run typecheck
$ tsc --noEmit
```

## Related

- Fixes #800
- Partially reverses behavior introduced for #237

## Questions

Open to a different policy if maintainers prefer (e.g. only disable single-dollar when followed by a digit, to keep `$ E= mc^2 $` working). Happy to iterate.
