### PR TITLE
fix(web): suppress Mermaid render error SVGs

### DIFF
--- a/web/src/components/assistant-ui/mermaid-diagram.test.tsx
+++ b/web/src/components/assistant-ui/mermaid-diagram.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, waitFor } from '@testing-library/react'
 
 const mermaidMocks = vi.hoisted(() => ({
     initializeMock: vi.fn(),
+    parseMock: vi.fn(),
     renderMock: vi.fn(),
     setParseErrorHandlerMock: vi.fn(),
 }))
@@ -10,6 +11,7 @@ const mermaidMocks = vi.hoisted(() => ({
 vi.mock('mermaid', () => ({
     default: {
         initialize: mermaidMocks.initializeMock,
+        parse: mermaidMocks.parseMock,
         render: mermaidMocks.renderMock,
         setParseErrorHandler: mermaidMocks.setParseErrorHandlerMock,
     }
@@ -35,6 +37,8 @@ describe('MermaidDiagram', () => {
     beforeEach(() => {
         mermaidMocks.initializeMock.mockClear()
         mermaidMocks.setParseErrorHandlerMock.mockClear()
+        mermaidMocks.parseMock.mockReset()
+        mermaidMocks.parseMock.mockResolvedValue({ diagramType: 'flowchart-v2' })
         mermaidMocks.renderMock.mockReset()
         mermaidMocks.renderMock.mockResolvedValue({
             svg: '<svg data-testid="mock-mermaid"></svg>'
@@ -57,15 +61,17 @@ describe('MermaidDiagram', () => {
 
         expect(mermaidMocks.initializeMock).toHaveBeenCalled()
         expect(mermaidMocks.initializeMock).toHaveBeenCalledWith(expect.objectContaining({
-            securityLevel: 'strict'
+            securityLevel: 'strict',
+            suppressErrorRendering: true,
         }))
+        expect(mermaidMocks.parseMock).toHaveBeenCalledWith('graph TD\nA --> B', { suppressErrors: true })
         expect(mermaidMocks.renderMock).toHaveBeenCalledWith(expect.stringContaining('mermaid-'), 'graph TD\nA --> B')
         expect(MARKDOWN_COMPONENTS_BY_LANGUAGE.mermaid.SyntaxHighlighter).toBe(MermaidDiagram)
     })
 
-    it('falls back to source and suppresses Mermaid parse-error side effects when render fails', async () => {
+    it('falls back to source and suppresses Mermaid parse-error side effects for invalid syntax', async () => {
         document.documentElement.dataset.theme = 'dark'
-        mermaidMocks.renderMock.mockRejectedValueOnce(new Error('invalid Mermaid'))
+        mermaidMocks.parseMock.mockResolvedValueOnce(false)
 
         renderMermaid('graph TD\nA --')
 
@@ -75,9 +81,27 @@ describe('MermaidDiagram', () => {
             expect(fallback?.textContent).toBe('graph TD\nA --')
         })
 
-        expect(mermaidMocks.initializeMock).toHaveBeenCalledWith(expect.objectContaining({
-            suppressErrors: true,
-        }))
+        expect(mermaidMocks.parseMock).toHaveBeenCalledWith('graph TD\nA --', { suppressErrors: true })
+        expect(mermaidMocks.renderMock).not.toHaveBeenCalled()
         expect(mermaidMocks.setParseErrorHandlerMock).toHaveBeenCalled()
     })
+
+    it('falls back to source and asks Mermaid not to inject its own error SVG when render throws', async () => {
+        mermaidMocks.renderMock.mockRejectedValueOnce(new Error('render failed'))
+        const code = 'gantt\ndateFormat YYYY-MM-DD\nsection A\nTask :a, 2024-01-01'
+
+        renderMermaid(code)
+
+        await waitFor(() => {
+            const fallback = document.querySelector('.aui-mermaid-fallback')
+            expect(fallback).toBeTruthy()
+            expect(fallback?.textContent).toBe(code)
+        })
+
+        expect(mermaidMocks.renderMock).toHaveBeenCalled()
+        expect(mermaidMocks.initializeMock).toHaveBeenCalledWith(expect.objectContaining({
+            suppressErrorRendering: true,
+        }))
+    })
+
 })

--- a/web/src/components/assistant-ui/mermaid-diagram.test.tsx
+++ b/web/src/components/assistant-ui/mermaid-diagram.test.tsx
@@ -1,35 +1,53 @@
-import { describe, expect, it, vi } from 'vitest'
-import { render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
 
 const mermaidMocks = vi.hoisted(() => ({
     initializeMock: vi.fn(),
-    renderMock: vi.fn().mockResolvedValue({
-        svg: '<svg data-testid="mock-mermaid"></svg>'
-    })
+    renderMock: vi.fn(),
+    setParseErrorHandlerMock: vi.fn(),
 }))
 
 vi.mock('mermaid', () => ({
     default: {
         initialize: mermaidMocks.initializeMock,
         render: mermaidMocks.renderMock,
+        setParseErrorHandler: mermaidMocks.setParseErrorHandlerMock,
     }
 }))
 
 import { MermaidDiagram } from '@/components/assistant-ui/mermaid-diagram'
 import { MARKDOWN_COMPONENTS_BY_LANGUAGE } from '@/components/assistant-ui/markdown-text'
 
+function renderMermaid(code: string) {
+    return render(
+        <MermaidDiagram
+            code={code}
+            language="mermaid"
+            components={{
+                Pre: (props) => <pre {...props} />,
+                Code: (props) => <code {...props} />,
+            }}
+        />
+    )
+}
+
 describe('MermaidDiagram', () => {
+    beforeEach(() => {
+        mermaidMocks.initializeMock.mockClear()
+        mermaidMocks.setParseErrorHandlerMock.mockClear()
+        mermaidMocks.renderMock.mockReset()
+        mermaidMocks.renderMock.mockResolvedValue({
+            svg: '<svg data-testid="mock-mermaid"></svg>'
+        })
+    })
+
+    afterEach(() => {
+        cleanup()
+        document.documentElement.removeAttribute('data-theme')
+    })
+
     it('is wired into the shared markdown language overrides and renders svg output', async () => {
-        render(
-            <MermaidDiagram
-                code={'graph TD\nA --> B'}
-                language="mermaid"
-                components={{
-                    Pre: (props) => <pre {...props} />,
-                    Code: (props) => <code {...props} />,
-                }}
-            />
-        )
+        renderMermaid('graph TD\nA --> B')
 
         await waitFor(() => {
             const diagram = document.querySelector('[data-mermaid-diagram][data-rendered="true"]')
@@ -43,5 +61,23 @@ describe('MermaidDiagram', () => {
         }))
         expect(mermaidMocks.renderMock).toHaveBeenCalledWith(expect.stringContaining('mermaid-'), 'graph TD\nA --> B')
         expect(MARKDOWN_COMPONENTS_BY_LANGUAGE.mermaid.SyntaxHighlighter).toBe(MermaidDiagram)
+    })
+
+    it('falls back to source and suppresses Mermaid parse-error side effects when render fails', async () => {
+        document.documentElement.dataset.theme = 'dark'
+        mermaidMocks.renderMock.mockRejectedValueOnce(new Error('invalid Mermaid'))
+
+        renderMermaid('graph TD\nA --')
+
+        await waitFor(() => {
+            const fallback = document.querySelector('.aui-mermaid-fallback')
+            expect(fallback).toBeTruthy()
+            expect(fallback?.textContent).toBe('graph TD\nA --')
+        })
+
+        expect(mermaidMocks.initializeMock).toHaveBeenCalledWith(expect.objectContaining({
+            suppressErrors: true,
+        }))
+        expect(mermaidMocks.setParseErrorHandlerMock).toHaveBeenCalled()
     })
 })

--- a/web/src/components/assistant-ui/mermaid-diagram.tsx
+++ b/web/src/components/assistant-ui/mermaid-diagram.tsx
@@ -21,9 +21,12 @@ async function ensureMermaid(theme: 'light' | 'dark') {
     const mermaid = await getMermaid()
     if (initializedTheme === theme) return mermaid
 
+    mermaid.setParseErrorHandler(() => undefined)
+
     mermaid.initialize({
         startOnLoad: false,
         securityLevel: 'strict',
+        suppressErrorRendering: true,
         theme: theme === 'dark' ? 'dark' : 'default',
         themeVariables: theme === 'dark'
             ? {
@@ -101,6 +104,14 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
         const render = async () => {
             try {
                 const mermaid = await ensureMermaid(theme)
+                const isValid = await mermaid.parse(props.code, { suppressErrors: true })
+                if (cancelled) return
+                if (!isValid) {
+                    setSvg(null)
+                    setRenderError(true)
+                    return
+                }
+
                 const result = await mermaid.render(`mermaid-${id}`, props.code)
                 if (cancelled) return
                 setSvg(result.svg)


### PR DESCRIPTION
Closes #785

## Summary
- Suppress Mermaid's built-in error SVG rendering for invalid diagrams so failed Mermaid blocks do not inject the red "Syntax error in text" diagram into the page.
- Pre-validate Mermaid source with `mermaid.parse(..., { suppressErrors: true })`; invalid syntax falls back to the source block without calling `render`.
- Install a no-op Mermaid parse error handler to avoid global parse-error side effects.
- Add tests for valid rendering, invalid syntax fallback, and render-failure fallback without Mermaid error SVG injection.

## Notes
- Related to #741 because it also touches Mermaid rendering, but this fixes a separate render-error/fallback path.

## Test plan
- [x] `bun typecheck`
- [x] `bun run test:cli` — 93 files / 847 tests passed
- [x] `bun run test:hub` — 263 tests passed
- [x] `bun run test:web` — 89 files / 766 tests passed
- [x] `bun run test:shared` — 68 tests passed
- [x] `bun run --cwd web test src/components/assistant-ui/mermaid-diagram.test.tsx` — 3 tests passed
- [x] Manual verification: reproduced the original environment showing Mermaid error SVG while Markdown still rendered, then confirmed the fix prevents that error SVG path.
