### PR TITLE
fix(cursor): requeue user message on transient agent exit (auth, rate limit)

### DIFF
--- a/cli/src/cursor/cursorLegacyRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorLegacyRemoteLauncher.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { PassThrough } from 'node:stream';
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -26,24 +27,62 @@ import { MessageQueue2 } from '@/utils/MessageQueue2';
 import { CursorSession } from './session';
 import type { EnhancedMode } from './loop';
 
-function makeChild() {
-    const stdoutHandlers: Array<(chunk: string) => void> = [];
-    return {
-        stdout: { on: vi.fn((event: string, handler: (chunk: string) => void) => {
-            if (event === 'data') stdoutHandlers.push(handler);
-        }) },
-        stderr: { on: vi.fn() },
+type ChildOptions = {
+    exitCode?: number | null;
+    stderr?: string;
+};
+
+function makeChild(opts: ChildOptions = {}) {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = {
+        stdout,
+        stderr,
         on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
             if (event === 'exit') {
-                setImmediate(() => handler(0, null));
+                setImmediate(() => {
+                    if (opts.stderr) {
+                        // emit synchronously so runAgentProcess captures it before
+                        // the exit handler resolves.
+                        stderr.emit('data', Buffer.from(opts.stderr));
+                    }
+                    handler(opts.exitCode ?? 0, null);
+                });
             }
         }),
         emitStdout(line: string) {
-            for (const handler of stdoutHandlers) {
-                handler(`${line}\n`);
-            }
+            stdout.write(`${line}\n`);
         }
     };
+    return child;
+}
+
+function makeClient() {
+    return {
+        rpcHandlerManager: { registerHandler: vi.fn() },
+        updateMetadata: vi.fn((handler: (m: Record<string, unknown>) => Record<string, unknown>) => {
+            handler({ path: '/tmp', host: 'h', flavor: 'cursor' });
+        }),
+        sendSessionEvent: vi.fn(),
+        sendAgentMessage: vi.fn(),
+        keepAlive: vi.fn(),
+        emitMessagesConsumed: vi.fn()
+    };
+}
+
+function makeSession(queue: MessageQueue2<EnhancedMode>, client: ReturnType<typeof makeClient>): CursorSession {
+    return new CursorSession({
+        api: {} as never,
+        client: client as never,
+        path: '/tmp/project',
+        logPath: '/tmp/log',
+        sessionId: 'legacy-id',
+        messageQueue: queue,
+        onModeChange: vi.fn(),
+        mode: 'remote',
+        startedBy: 'runner',
+        startingMode: 'remote'
+    });
 }
 
 describe('cursorLegacyRemoteLauncher', () => {
@@ -51,6 +90,11 @@ describe('cursorLegacyRemoteLauncher', () => {
         spawnMock.mockReset();
         process.stdin.isTTY = false;
         process.stdout.isTTY = false;
+        process.env.CURSOR_LEGACY_TRANSIENT_BACKOFF_MS = '0';
+    });
+
+    afterEach(() => {
+        delete process.env.CURSOR_LEGACY_TRANSIENT_BACKOFF_MS;
     });
 
     it('spawns agent with stream-json and trust, not acp', async () => {
@@ -61,30 +105,8 @@ describe('cursorLegacyRemoteLauncher', () => {
         queue.push('hello', { permissionMode: 'default' });
         queue.close();
 
-        const metadataUpdates: unknown[] = [];
-        const client = {
-            rpcHandlerManager: { registerHandler: vi.fn() },
-            updateMetadata: vi.fn((handler: (m: Record<string, unknown>) => Record<string, unknown>) => {
-                metadataUpdates.push(handler({ path: '/tmp', host: 'h', flavor: 'cursor' }));
-            }),
-            sendSessionEvent: vi.fn(),
-            sendAgentMessage: vi.fn(),
-            keepAlive: vi.fn(),
-            emitMessagesConsumed: vi.fn()
-        };
-
-        const session = new CursorSession({
-            api: {} as never,
-            client: client as never,
-            path: '/tmp/project',
-            logPath: '/tmp/log',
-            sessionId: 'legacy-id',
-            messageQueue: queue,
-            onModeChange: vi.fn(),
-            mode: 'remote',
-            startedBy: 'runner',
-            startingMode: 'remote'
-        });
+        const client = makeClient();
+        const session = makeSession(queue, client);
 
         const { cursorLegacyRemoteLauncher } = await import('./cursorLegacyRemoteLauncher');
         await cursorLegacyRemoteLauncher(session);
@@ -97,10 +119,143 @@ describe('cursorLegacyRemoteLauncher', () => {
         expect(args).toContain('--resume');
         expect(args).toContain('legacy-id');
         expect(args).not.toContain('acp');
+    });
 
-        expect(metadataUpdates[0]).toEqual(expect.objectContaining({
-            cursorSessionId: 'legacy-id',
-            cursorSessionProtocol: 'stream-json'
+    it('requeues the user message and surfaces an auth banner when agent exits with auth-required stderr', async () => {
+        const queue = new MessageQueue2<EnhancedMode>(() => 'm');
+        queue.push('do thing', { permissionMode: 'default' });
+
+        let call = 0;
+        spawnMock.mockImplementation(() => {
+            call += 1;
+            if (call === 1) {
+                return makeChild({
+                    exitCode: 1,
+                    stderr: "Error: Authentication required. Please run 'agent login' first\n"
+                });
+            }
+            queue.close();
+            return makeChild({ exitCode: 0 });
+        });
+
+        const client = makeClient();
+        const session = makeSession(queue, client);
+
+        const { cursorLegacyRemoteLauncher } = await import('./cursorLegacyRemoteLauncher');
+        await cursorLegacyRemoteLauncher(session);
+
+        expect(spawnMock).toHaveBeenCalledTimes(2);
+        const messages = client.sendSessionEvent.mock.calls
+            .map((c) => c[0])
+            .filter((e: any) => e.type === 'message');
+        expect(messages).toHaveLength(1);
+        expect(messages[0].message).toContain('Cursor authentication expired');
+        expect(messages[0].message).toContain("'agent login'");
+        expect(messages[0].message).toContain('queued and will retry');
+
+        const firstPrompt = spawnMock.mock.calls[0]?.[1] as string[];
+        const secondPrompt = spawnMock.mock.calls[1]?.[1] as string[];
+        const pIndex1 = firstPrompt.indexOf('-p');
+        const pIndex2 = secondPrompt.indexOf('-p');
+        expect(firstPrompt[pIndex1 + 1]).toBe('do thing');
+        expect(secondPrompt[pIndex2 + 1]).toBe('do thing');
+    });
+
+    it('uses a rate-limit-specific banner for rate limit stderr', async () => {
+        const queue = new MessageQueue2<EnhancedMode>(() => 'm');
+        queue.push('do thing', { permissionMode: 'default' });
+
+        let call = 0;
+        spawnMock.mockImplementation(() => {
+            call += 1;
+            if (call === 1) {
+                return makeChild({
+                    exitCode: 1,
+                    stderr: 'Error: rate limit exceeded, please retry later\n'
+                });
+            }
+            queue.close();
+            return makeChild({ exitCode: 0 });
+        });
+
+        const client = makeClient();
+        const session = makeSession(queue, client);
+
+        const { cursorLegacyRemoteLauncher } = await import('./cursorLegacyRemoteLauncher');
+        await cursorLegacyRemoteLauncher(session);
+
+        const messages = client.sendSessionEvent.mock.calls
+            .map((c) => c[0])
+            .filter((e: any) => e.type === 'message');
+        expect(messages).toHaveLength(1);
+        expect(messages[0].message).toContain('rate limit');
+        expect(messages[0].message).toContain('queued and will retry');
+    });
+
+    it('does not requeue when stderr is non-transient (real crash); surfaces error and emits ready', async () => {
+        const queue = new MessageQueue2<EnhancedMode>(() => 'm');
+        queue.push('do thing', { permissionMode: 'default' });
+        queue.close();
+
+        spawnMock.mockReturnValue(makeChild({
+            exitCode: 134,
+            stderr: 'fatal: Segmentation fault\n'
         }));
+
+        const client = makeClient();
+        const session = makeSession(queue, client);
+
+        const { cursorLegacyRemoteLauncher } = await import('./cursorLegacyRemoteLauncher');
+        await cursorLegacyRemoteLauncher(session);
+
+        expect(spawnMock).toHaveBeenCalledTimes(1);
+        const messageEvents = client.sendSessionEvent.mock.calls
+            .map((c) => c[0])
+            .filter((e: any) => e.type === 'message');
+        expect(messageEvents).toHaveLength(1);
+        expect(messageEvents[0].message).toContain('Agent exited (134)');
+        expect(messageEvents[0].message).toContain('Segmentation fault');
+        expect(messageEvents[0].message).not.toContain('queued and will retry');
+
+        const readyEvents = client.sendSessionEvent.mock.calls
+            .map((c) => c[0])
+            .filter((e: any) => e.type === 'ready');
+        expect(readyEvents).toHaveLength(1);
+    });
+
+    it('drops the message after MAX_CONSECUTIVE_TRANSIENT_FAILURES consecutive transient failures', async () => {
+        const queue = new MessageQueue2<EnhancedMode>(() => 'm');
+        queue.push('do thing', { permissionMode: 'default' });
+
+        let call = 0;
+        spawnMock.mockImplementation(() => {
+            call += 1;
+            if (call >= 5) {
+                queue.close();
+            }
+            return makeChild({
+                exitCode: 1,
+                stderr: "Error: Authentication required. Please run 'agent login' first\n"
+            });
+        });
+
+        const client = makeClient();
+        const session = makeSession(queue, client);
+
+        const { cursorLegacyRemoteLauncher } = await import('./cursorLegacyRemoteLauncher');
+        await cursorLegacyRemoteLauncher(session);
+
+        expect(spawnMock).toHaveBeenCalledTimes(5);
+
+        const messageEvents = client.sendSessionEvent.mock.calls
+            .map((c) => c[0])
+            .filter((e: any) => e.type === 'message');
+        // 4 transient retry banners + 1 drop banner = 5
+        expect(messageEvents).toHaveLength(5);
+        const banners = messageEvents.map((e: any) => e.message);
+        expect(banners.filter((m: string) => m.includes('queued and will retry'))).toHaveLength(4);
+        const drop = banners.find((m: string) => m.includes('5 times in a row'));
+        expect(drop).toBeDefined();
+        expect(drop).toContain('Dropping the queued message');
     });
 });

--- a/cli/src/cursor/cursorLegacyRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorLegacyRemoteLauncher.test.ts
@@ -223,6 +223,33 @@ describe('cursorLegacyRemoteLauncher', () => {
         expect(readyEvents).toHaveLength(1);
     });
 
+    it('does not retry signal-killed processes even if stderr contains a transient keyword', async () => {
+        // SIGTERM → exit 143; stderr happens to mention rate limit. Should NOT be
+        // classified transient because the documented contract is exit-1-only.
+        const queue = new MessageQueue2<EnhancedMode>(() => 'm');
+        queue.push('do thing', { permissionMode: 'default' });
+        queue.close();
+
+        spawnMock.mockReturnValue(makeChild({
+            exitCode: 143,
+            stderr: 'rate limit hit; aborting due to SIGTERM\n'
+        }));
+
+        const client = makeClient();
+        const session = makeSession(queue, client);
+
+        const { cursorLegacyRemoteLauncher } = await import('./cursorLegacyRemoteLauncher');
+        await cursorLegacyRemoteLauncher(session);
+
+        expect(spawnMock).toHaveBeenCalledTimes(1);
+        const messageEvents = client.sendSessionEvent.mock.calls
+            .map((c) => c[0])
+            .filter((e: any) => e.type === 'message');
+        expect(messageEvents).toHaveLength(1);
+        expect(messageEvents[0].message).toContain('Agent exited (143)');
+        expect(messageEvents[0].message).not.toContain('queued and will retry');
+    });
+
     it('preserves isolation when requeueing a slash command after a transient failure', async () => {
         const queue = new MessageQueue2<EnhancedMode>(() => 'm');
         // /compress is a pass-through slash command; enqueueCursorUserMessage uses

--- a/cli/src/cursor/cursorLegacyRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorLegacyRemoteLauncher.test.ts
@@ -39,11 +39,11 @@ function makeChild(opts: ChildOptions = {}) {
         stdout,
         stderr,
         on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-            if (event === 'exit') {
+            if (event === 'close') {
                 setImmediate(() => {
                     if (opts.stderr) {
                         // emit synchronously so runAgentProcess captures it before
-                        // the exit handler resolves.
+                        // the close handler resolves.
                         stderr.emit('data', Buffer.from(opts.stderr));
                     }
                     handler(opts.exitCode ?? 0, null);
@@ -221,6 +221,39 @@ describe('cursorLegacyRemoteLauncher', () => {
             .map((c) => c[0])
             .filter((e: any) => e.type === 'ready');
         expect(readyEvents).toHaveLength(1);
+    });
+
+    it('preserves isolation when requeueing a slash command after a transient failure', async () => {
+        const queue = new MessageQueue2<EnhancedMode>(() => 'm');
+        // /compress is a pass-through slash command; enqueueCursorUserMessage uses
+        // pushIsolated for these so they never batch with sibling prompts.
+        queue.pushIsolated('/compress', { permissionMode: 'default' });
+
+        let call = 0;
+        spawnMock.mockImplementation(() => {
+            call += 1;
+            if (call === 1) {
+                return makeChild({
+                    exitCode: 1,
+                    stderr: "Error: Authentication required. Please run 'agent login' first\n"
+                });
+            }
+            queue.close();
+            return makeChild({ exitCode: 0 });
+        });
+
+        const client = makeClient();
+        const session = makeSession(queue, client);
+
+        const { cursorLegacyRemoteLauncher } = await import('./cursorLegacyRemoteLauncher');
+        await cursorLegacyRemoteLauncher(session);
+
+        expect(spawnMock).toHaveBeenCalledTimes(2);
+        // Confirm the queue still flagged the requeued item as isolated
+        // (the second collectBatch saw it alone with isolate=true).
+        const secondPrompt = spawnMock.mock.calls[1]?.[1] as string[];
+        const pIdx = secondPrompt.indexOf('-p');
+        expect(secondPrompt[pIdx + 1]).toBe('/compress');
     });
 
     it('drops the message after MAX_CONSECUTIVE_TRANSIENT_FAILURES consecutive transient failures', async () => {

--- a/cli/src/cursor/cursorLegacyRemoteLauncher.ts
+++ b/cli/src/cursor/cursorLegacyRemoteLauncher.ts
@@ -29,6 +29,9 @@ const RATE_LIMIT_STDERR_PATTERN = /rate limit/i;
 const DEFAULT_TRANSIENT_BACKOFF_MS = 2_000;
 const MAX_CONSECUTIVE_TRANSIENT_FAILURES = 5;
 const STDERR_DISPLAY_LIMIT = 400;
+// In-memory stderr cap. Display only uses STDERR_DISPLAY_LIMIT chars; this is a
+// safety bound so a chatty `agent` failure cannot balloon CLI process memory.
+const STDERR_CAPTURE_LIMIT = 8_192;
 
 function getTransientBackoffMs(): number {
     const raw = process.env.CURSOR_LEGACY_TRANSIENT_BACKOFF_MS;
@@ -286,7 +289,9 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
 
             child.stderr?.on('data', (chunk) => {
                 const text = chunk.toString();
-                stderrCapture += text;
+                if (stderrCapture.length < STDERR_CAPTURE_LIMIT) {
+                    stderrCapture += text.slice(0, STDERR_CAPTURE_LIMIT - stderrCapture.length);
+                }
                 if (text.trim()) {
                     logger.debug('[cursor-remote] agent stderr:', text.trim());
                 }

--- a/cli/src/cursor/cursorLegacyRemoteLauncher.ts
+++ b/cli/src/cursor/cursorLegacyRemoteLauncher.ts
@@ -348,12 +348,21 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
         const signal = this.abortController.signal;
         if (signal.aborted) return;
         await new Promise<void>((resolve) => {
-            const timer = setTimeout(resolve, ms);
-            const onAbort = () => {
-                clearTimeout(timer);
+            let timer: ReturnType<typeof setTimeout> | null = null;
+            // Single completion path so the abort listener is always removed,
+            // whether the timer or the abort wins. Without this, repeated
+            // transient retries on the same AbortController accumulate stale
+            // listeners until the next abort fires them in bulk.
+            const finish = () => {
+                if (timer !== null) {
+                    clearTimeout(timer);
+                    timer = null;
+                }
+                signal.removeEventListener('abort', finish);
                 resolve();
             };
-            signal.addEventListener('abort', onAbort, { once: true });
+            timer = setTimeout(finish, ms);
+            signal.addEventListener('abort', finish, { once: true });
         });
     }
 

--- a/cli/src/cursor/cursorLegacyRemoteLauncher.ts
+++ b/cli/src/cursor/cursorLegacyRemoteLauncher.ts
@@ -39,8 +39,12 @@ function getTransientBackoffMs(): number {
 }
 
 function isTransientAgentError(exitCode: number, stderr: string): boolean {
-    if (exitCode === 0) return false;
-    return TRANSIENT_STDERR_PATTERN.test(stderr);
+    // Known transient failures (auth expiry, rate limit, transient network)
+    // all come back as exit code 1. Keep the retry path narrow to that contract;
+    // signal-kills (137 SIGKILL, 143 SIGTERM) and crashes (134 SIGABRT, etc.)
+    // should never auto-retry even if their stderr happens to contain a matching
+    // keyword.
+    return exitCode === 1 && TRANSIENT_STDERR_PATTERN.test(stderr);
 }
 
 function truncateStderrForDisplay(stderr: string): string {

--- a/cli/src/cursor/cursorLegacyRemoteLauncher.ts
+++ b/cli/src/cursor/cursorLegacyRemoteLauncher.ts
@@ -145,7 +145,7 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
                 break;
             }
 
-            const { message, mode } = batch;
+            const { message, mode, isolate: batchIsolated } = batch;
             const specialCommand = parseCursorSpecialCommand(message);
 
             const { mode: agentMode, yolo } = permissionModeToAgentArgs(mode.permissionMode as string);
@@ -208,7 +208,7 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
                 if (exitCode === 0 || exitCode === null) {
                     this.consecutiveTransientFailures = 0;
                 } else if (isTransientAgentError(exitCode, stderr)) {
-                    await this.handleTransientAgentFailure(exitCode, stderr, message, mode);
+                    await this.handleTransientAgentFailure(exitCode, stderr, message, mode, batchIsolated);
                 } else {
                     this.consecutiveTransientFailures = 0;
                     const errMsg = `Agent exited (${exitCode}): ${truncateStderrForDisplay(stderr)}`;
@@ -262,7 +262,12 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
                 reject(err);
             });
 
-            child.on('exit', (code, signal) => {
+            // `close` (not `exit`) waits for the stdio streams to flush before
+            // firing. Otherwise stderr from an agent that prints + exits quickly
+            // (e.g. "Authentication required" → exit 1) can arrive after we
+            // already classified the failure, turning a transient error into a
+            // dropped message.
+            child.on('close', (code, signal) => {
                 cleanup();
                 resolve({ exitCode: code, stderr: stderrCapture });
             });
@@ -289,7 +294,8 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
         exitCode: number,
         stderr: string,
         message: string,
-        mode: EnhancedMode
+        mode: EnhancedMode,
+        batchIsolated: boolean
     ): Promise<void> {
         const session = this.session;
         const messageBuffer = this.messageBuffer;
@@ -316,7 +322,17 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
                 stderr: stderr.slice(0, STDERR_DISPLAY_LIMIT)
             }
         );
-        session.queue.unshift(message, mode);
+        // Preserve isolation when the original batch was isolated (e.g. a
+        // pass-through slash command queued via pushIsolated). Without this the
+        // requeued command could be batched with a sibling prompt on retry and
+        // change semantics. parseCursorSpecialCommand is the same gate
+        // enqueueCursorUserMessage uses to decide isolation in the first place.
+        const requeueIsolated = batchIsolated || parseCursorSpecialCommand(message).type !== null;
+        if (requeueIsolated) {
+            session.queue.unshiftIsolated(message, mode);
+        } else {
+            session.queue.unshift(message, mode);
+        }
         const friendly = friendlyTransientMessage(exitCode, stderr);
         session.sendSessionEvent({ type: 'message', message: friendly });
         messageBuffer.addMessage(friendly, 'status');

--- a/cli/src/cursor/cursorLegacyRemoteLauncher.ts
+++ b/cli/src/cursor/cursorLegacyRemoteLauncher.ts
@@ -11,6 +11,7 @@ import {
     type RemoteLauncherExitReason
 } from '@/modules/common/remote/RemoteLauncherBase';
 import type { CursorSession } from './session';
+import type { EnhancedMode } from './loop';
 // TODO(cursor-acp): remove legacy stream-json resume path after migration window.
 // New Cursor sessions use ACP only. This path exists because pre-ACP Cursor
 // session_id values are not loadable via ACP session/load.
@@ -18,6 +19,47 @@ import type { CursorSession } from './session';
 import type { CursorStreamEvent } from './utils/cursorLegacyEventConverter';
 import { parseCursorEvent, convertCursorEventToAgentMessage } from './utils/cursorLegacyEventConverter';
 import { cursorPassThroughStatusMessage, parseCursorSpecialCommand } from './cursorSpecialCommands';
+
+// Transient `agent` failures (auth expiry, rate limits, transient network) come back
+// as exit code 1 with a recognisable stderr signature. We requeue and retry instead
+// of silently swallowing the user message.
+const TRANSIENT_STDERR_PATTERN = /authentication required|please run ['"]?agent login['"]?|rate limit|ETIMEDOUT|ECONNRESET|EAI_AGAIN/i;
+const AUTH_STDERR_PATTERN = /authentication required|please run ['"]?agent login['"]?/i;
+const RATE_LIMIT_STDERR_PATTERN = /rate limit/i;
+const DEFAULT_TRANSIENT_BACKOFF_MS = 2_000;
+const MAX_CONSECUTIVE_TRANSIENT_FAILURES = 5;
+const STDERR_DISPLAY_LIMIT = 400;
+
+function getTransientBackoffMs(): number {
+    const raw = process.env.CURSOR_LEGACY_TRANSIENT_BACKOFF_MS;
+    if (raw === undefined) return DEFAULT_TRANSIENT_BACKOFF_MS;
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed) || parsed < 0) return DEFAULT_TRANSIENT_BACKOFF_MS;
+    return parsed;
+}
+
+function isTransientAgentError(exitCode: number, stderr: string): boolean {
+    if (exitCode === 0) return false;
+    return TRANSIENT_STDERR_PATTERN.test(stderr);
+}
+
+function truncateStderrForDisplay(stderr: string): string {
+    const trimmed = stderr.trim();
+    if (!trimmed) return '(no stderr)';
+    return trimmed.length > STDERR_DISPLAY_LIMIT
+        ? `${trimmed.slice(0, STDERR_DISPLAY_LIMIT)}...`
+        : trimmed;
+}
+
+function friendlyTransientMessage(exitCode: number, stderr: string): string {
+    if (AUTH_STDERR_PATTERN.test(stderr)) {
+        return "Cursor authentication expired. Re-run 'agent login' or set CURSOR_API_KEY. Your message is queued and will retry automatically.";
+    }
+    if (RATE_LIMIT_STDERR_PATTERN.test(stderr)) {
+        return 'Cursor rate limit hit. Your message is queued and will retry automatically.';
+    }
+    return `Cursor agent failed transiently (exit ${exitCode}). Your message is queued and will retry automatically.`;
+}
 
 function buildAgentArgs(opts: {
     message: string;
@@ -57,6 +99,7 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
     private readonly session: CursorSession;
     private abortController = new AbortController();
     private displayPermissionMode: string | null = null;
+    private consecutiveTransientFailures = 0;
 
     constructor(session: CursorSession) {
         super(process.env.DEBUG ? session.logPath : undefined);
@@ -128,7 +171,7 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
             session.onThinkingChange(true);
 
             try {
-                const exitCode = await this.runAgentProcess(args, session.path, (event) => {
+                const { exitCode, stderr } = await this.runAgentProcess(args, session.path, (event) => {
                     if (event.type === 'system' && event.subtype === 'init' && event.session_id) {
                         cursorSessionId = event.session_id;
                         session.onSessionFoundWithProtocol(event.session_id, 'stream-json');
@@ -162,11 +205,19 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
                     }
                 });
 
-                if (exitCode !== 0 && exitCode !== null) {
-                    logger.debug(`[cursor-remote] Agent exited with code ${exitCode}`);
-                    messageBuffer.addMessage(`Agent exited with code ${exitCode}`, 'status');
+                if (exitCode === 0 || exitCode === null) {
+                    this.consecutiveTransientFailures = 0;
+                } else if (isTransientAgentError(exitCode, stderr)) {
+                    await this.handleTransientAgentFailure(exitCode, stderr, message, mode);
+                } else {
+                    this.consecutiveTransientFailures = 0;
+                    const errMsg = `Agent exited (${exitCode}): ${truncateStderrForDisplay(stderr)}`;
+                    logger.warn(`[cursor-remote] ${errMsg}`);
+                    session.sendSessionEvent({ type: 'message', message: errMsg });
+                    messageBuffer.addMessage(errMsg, 'status');
                 }
             } catch (error) {
+                this.consecutiveTransientFailures = 0;
                 logger.warn('[cursor-remote] Agent run failed', error);
                 const errMsg = error instanceof Error ? error.message : String(error);
                 session.sendSessionEvent({ type: 'message', message: `Cursor Agent failed: ${errMsg}` });
@@ -184,7 +235,7 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
         args: string[],
         cwd: string,
         onEvent: (event: ReturnType<typeof parseCursorEvent> & object) => void
-    ): Promise<number | null> {
+    ): Promise<{ exitCode: number | null; stderr: string }> {
         return new Promise((resolve, reject) => {
             const child = spawn('agent', args, {
                 cwd,
@@ -194,9 +245,11 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
                 windowsHide: process.platform === 'win32'
             });
 
+            let stderrCapture = '';
+
             const abortHandler = () => {
                 killProcessByChildProcess(child, false).catch(() => {});
-                resolve(null);
+                resolve({ exitCode: null, stderr: stderrCapture });
             };
             this.abortController.signal.addEventListener('abort', abortHandler);
 
@@ -211,7 +264,7 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
 
             child.on('exit', (code, signal) => {
                 cleanup();
-                resolve(code);
+                resolve({ exitCode: code, stderr: stderrCapture });
             });
 
             const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
@@ -224,10 +277,63 @@ class CursorRemoteLauncher extends RemoteLauncherBase {
 
             child.stderr?.on('data', (chunk) => {
                 const text = chunk.toString();
+                stderrCapture += text;
                 if (text.trim()) {
                     logger.debug('[cursor-remote] agent stderr:', text.trim());
                 }
             });
+        });
+    }
+
+    private async handleTransientAgentFailure(
+        exitCode: number,
+        stderr: string,
+        message: string,
+        mode: EnhancedMode
+    ): Promise<void> {
+        const session = this.session;
+        const messageBuffer = this.messageBuffer;
+        this.consecutiveTransientFailures += 1;
+
+        if (this.consecutiveTransientFailures >= MAX_CONSECUTIVE_TRANSIENT_FAILURES) {
+            const summary = truncateStderrForDisplay(stderr);
+            const dropMsg = `Cursor agent failed ${MAX_CONSECUTIVE_TRANSIENT_FAILURES} times in a row (${summary}). Dropping the queued message; resolve the issue ('agent login', wait out rate limit, etc.) and resend.`;
+            logger.warn(
+                `[cursor-remote] transient agent failures hit cap (${MAX_CONSECUTIVE_TRANSIENT_FAILURES}); dropping message`,
+                { exitCode, stderr: stderr.slice(0, STDERR_DISPLAY_LIMIT) }
+            );
+            session.sendSessionEvent({ type: 'message', message: dropMsg });
+            messageBuffer.addMessage(dropMsg, 'status');
+            this.consecutiveTransientFailures = 0;
+            return;
+        }
+
+        logger.warn(
+            '[cursor-remote] transient agent failure, requeueing user message',
+            {
+                exitCode,
+                attempt: this.consecutiveTransientFailures,
+                stderr: stderr.slice(0, STDERR_DISPLAY_LIMIT)
+            }
+        );
+        session.queue.unshift(message, mode);
+        const friendly = friendlyTransientMessage(exitCode, stderr);
+        session.sendSessionEvent({ type: 'message', message: friendly });
+        messageBuffer.addMessage(friendly, 'status');
+        await this.transientBackoff(getTransientBackoffMs());
+    }
+
+    private async transientBackoff(ms: number): Promise<void> {
+        if (ms <= 0) return;
+        const signal = this.abortController.signal;
+        if (signal.aborted) return;
+        await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, ms);
+            const onAbort = () => {
+                clearTimeout(timer);
+                resolve();
+            };
+            signal.addEventListener('abort', onAbort, { once: true });
         });
     }
 

--- a/cli/src/utils/MessageQueue2.ts
+++ b/cli/src/utils/MessageQueue2.ts
@@ -220,6 +220,42 @@ export class MessageQueue2<T> {
     }
 
     /**
+     * Push a message to the beginning of the queue with isolation preserved.
+     * Mirrors `pushIsolated` but inserts at the head. Use this when requeueing a
+     * batch that was originally collected under isolation (e.g. a slash command
+     * that failed transiently and must retry without batching against sibling
+     * prompts).
+     */
+    unshiftIsolated(message: string, mode: T, localId?: string): void {
+        if (this.closed) {
+            throw new Error('Cannot unshift to closed queue');
+        }
+
+        const modeHash = this.modeHasher(mode);
+        logger.debug(`[MessageQueue2] unshiftIsolated() called with mode hash: ${modeHash}`);
+
+        this.queue.unshift({
+            message,
+            mode,
+            modeHash,
+            localId,
+            isolate: true
+        });
+
+        if (this.onMessageHandler) {
+            this.onMessageHandler(message, mode);
+        }
+
+        if (this.waiter) {
+            const waiter = this.waiter;
+            this.waiter = null;
+            waiter(true);
+        }
+
+        logger.debug(`[MessageQueue2] unshiftIsolated() completed. Queue size: ${this.queue.length}`);
+    }
+
+    /**
      * Remove the first queued message that matches the given localId.
      * Returns true if a message was removed, false if not found.
      * Best-effort: if the CLI is offline when cancel is issued, the message


### PR DESCRIPTION
## Summary

`cursorLegacyRemoteLauncher.runMainLoop` pops a user message off the queue before spawning `agent`, then silently discards it whenever `agent` exits non-zero. Auth expiry, rate limit, and transient network failure all produce exit code 1 and all currently cost the operator the messages they had queued. The wrapper logs the failure at `debug` level only, never surfaces it to the web UI, and emits `ready` as if a normal turn ended.

This change:

1. Captures stderr from `runAgentProcess` (previously only debug-logged) and returns it alongside the exit code. Resolves on `child.on('close', ...)` instead of `'exit'` so the stdio streams flush before the failure is classified - otherwise a fast "Authentication required → exit 1" can land with empty `stderr` and be misclassified.
2. Classifies exit-1 with a transient signature (`/authentication required|please run 'agent login'|rate limit|ETIMEDOUT|ECONNRESET|EAI_AGAIN/i`) as recoverable.
3. On transient: re-heads the message in the queue, surfaces a friendly banner via `sendSessionEvent({type: 'message', ...})` ("Cursor authentication expired. Re-run 'agent login' or set CURSOR_API_KEY. Your message is queued and will retry automatically."), and waits ~2 s before the loop picks it up again.
4. Preserves slash-command isolation on requeue. `enqueueCursorUserMessage` uses `pushIsolated` for pass-through commands like `/compress` and `/model`; the requeue path now uses a new `MessageQueue2.unshiftIsolated` (or re-detects via `parseCursorSpecialCommand`) so the retried command never batches with sibling prompts.
5. Caps consecutive transient failures at 5 - after the cap the message is dropped with an explicit "resolve and resend" event so we never spin forever on a genuinely broken auth.
6. On non-transient non-zero exit (e.g. SIGSEGV → 134), the stderr is surfaced to the UI now (was previously only in the local TUI ring buffer).
7. Backoff is overridable via `CURSOR_LEGACY_TRANSIENT_BACKOFF_MS` (defaults to 2000 ms) for tests and operator tuning.

## Reproduction (forensic capture)

From a real session against `cursorLegacyRemoteLauncher`:

```
[17:35:48] push msg X — spawn agent
[17:44:38] push msg A (queue size: 1)
[17:48:39] push msg B (queue size: 2)
[17:49:54] push msg C (queue size: 3)
[17:56:24] Collected batch of 3 messages — spawn agent (concat prompt)
[17:56:25] agent stderr: Error: Authentication required. Please run 'agent login' first
[17:56:25] Agent exited with code 1
[17:56:25] Waiting for messages...   ← three user messages silently destroyed
```

The web UI showed `Invoke: 17:56:24` for each of the three queued messages (the hub did invoke them). The 850 ms-later spawn failure was never communicated back.

## Testing

- `bun typecheck` (cli + web + hub): green
- `bun run test` in `cli/`: 942/942 passing (added 6 tests; existing test unchanged)

New tests in `cli/src/cursor/cursorLegacyRemoteLauncher.test.ts`:

- success path (existing)
- transient auth failure → message requeued + auth-specific banner
- transient rate-limit failure → rate-limit-specific banner
- non-transient crash (exit 134, segfault) → no requeue; error event + `ready` event fired
- slash-command isolation preserved on transient requeue (`/compress` retried alone, not batched)
- 5 consecutive transient failures → 4 retry banners + 1 drop banner; counter resets

## Related

Closes #818

## Notes

- The new `MessageQueue2.unshiftIsolated` mirrors the existing `pushIsolated` for the head of the queue. Used only by the transient-requeue path; `enqueueCursorUserMessage` continues to use `pushIsolated` at enqueue time.
- The ACP launcher (`cursorAcpRemoteLauncher`) uses a different error surface (ACP `prompt()` throws on failure) and is not touched by this PR. The transient classification helpers are kept private to this file; if a similar bug shows up in the ACP path they can be extracted.
- `CURSOR_LEGACY_TRANSIENT_BACKOFF_MS` is parsed defensively (NaN / negative → fallback to 2000 ms default).
