### PR TITLE
fix: add scratchlist visibility setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ Before commit/push/PR: use the **`pre-push-review`** skill (`~/.cursor/skills/pr
 
 ## Testing
 
+- Before manual/integration testing: inspect local-only notes under `.git/info/` (e.g. `hapi-local-notes.md`, issue env files). They may define ports, tokens, restart scripts, and worktree caveats.
+- If a `.git/info` test script hardcodes `/home/ubuntu/hapi`, adjust it for the active worktree before starting hub/runner; otherwise you may test the wrong checkout.
 - Test framework: Vitest (via `bun run test`)
 - Test files: `*.test.ts` next to source
 - Run: `bun run test` (from root) or `bun run test` (from package)

--- a/web/src/components/AssistantChat/ScratchlistPanel.test.tsx
+++ b/web/src/components/AssistantChat/ScratchlistPanel.test.tsx
@@ -61,6 +61,13 @@ describe('ScratchlistPanel', () => {
         expect(toggle.textContent).toContain('held')
     })
 
+    it('uses the chat user surface instead of warning colors so the panel is subtle', () => {
+        renderPanel()
+        const panel = screen.getByTestId('scratchlist-panel')
+        expect(panel.className).toContain('bg-[var(--app-chat-user-surface-bg)]')
+        expect(panel.className).not.toContain('app-badge-warning')
+    })
+
     it('starts collapsed by default; clicking the header expands it', () => {
         renderPanel()
         const toggle = screen.getByRole('button', { name: /Scratchlist/ })

--- a/web/src/components/AssistantChat/ScratchlistPanel.tsx
+++ b/web/src/components/AssistantChat/ScratchlistPanel.tsx
@@ -142,8 +142,9 @@ function TrashIcon() {
  * - Scratchlist = workbench: notes / drafts / parking-lot ideas held until the
  *   operator explicitly promotes them (to the composer or into the queue).
  *
- * The "held -- not sent" pill plus the amber accent is the visual signal
- * that nothing here is being sent without an explicit action.
+ * The "held -- not sent" pill remains the visual signal that nothing here is
+ * being sent without an explicit action. Colors intentionally follow the user
+ * message surface instead of warning/amber chrome so the panel stays subtle.
  */
 export function ScratchlistPanel({
     sessionId,
@@ -278,7 +279,7 @@ export function ScratchlistPanel({
     return (
         <div className="mx-auto w-full max-w-content mb-1">
             <div
-                className="rounded-lg border border-[var(--app-badge-warning-border)] bg-[var(--app-badge-warning-bg)]"
+                className="rounded-lg border border-[var(--app-border)] bg-[var(--app-chat-user-surface-bg)]"
                 data-testid="scratchlist-panel"
             >
                 <button
@@ -286,7 +287,7 @@ export function ScratchlistPanel({
                     onClick={toggleCollapsed}
                     aria-expanded={!collapsed}
                     aria-controls={`scratchlist-body-${sessionId}`}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-[var(--app-badge-warning-text)] hover:opacity-90"
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-[var(--app-fg)] hover:opacity-90"
                 >
                     <ChevronIcon open={!collapsed} />
                     <NoteIcon />
@@ -294,7 +295,7 @@ export function ScratchlistPanel({
                         {t('scratchlist.title')}
                     </span>
                     <span
-                        className="rounded-full border border-[var(--app-badge-warning-border)] px-1.5 py-0.5 text-[10px] uppercase tracking-wide"
+                        className="rounded-full border border-[var(--app-border)] bg-[var(--app-bg)]/60 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-[var(--app-hint)]"
                         aria-hidden="true"
                     >
                         {t('scratchlist.heldLabel')}
@@ -333,12 +334,12 @@ export function ScratchlistPanel({
                                     placeholder={t('scratchlist.addPlaceholder')}
                                     aria-label={t('scratchlist.addAriaLabel')}
                                     disabled={hasReachedCap}
-                                    className="flex-1 min-w-0 resize-none rounded-md bg-[var(--app-bg)] px-2 py-1.5 text-sm text-[var(--app-fg)] placeholder-[var(--app-hint)] focus:outline-none focus:ring-1 focus:ring-[var(--app-badge-warning-text)] disabled:cursor-not-allowed disabled:opacity-50"
+                                    className="flex-1 min-w-0 resize-none rounded-md bg-[var(--app-bg)] px-2 py-1.5 text-sm text-[var(--app-fg)] placeholder-[var(--app-hint)] focus:outline-none focus:ring-1 focus:ring-[var(--app-link)] disabled:cursor-not-allowed disabled:opacity-50"
                                 />
                                 <button
                                     type="submit"
                                     disabled={hasReachedCap || draft.trim().length === 0}
-                                    className="shrink-0 rounded-md border border-[var(--app-badge-warning-border)] bg-[var(--app-bg)] px-3 py-1.5 text-xs font-medium text-[var(--app-badge-warning-text)] hover:bg-[var(--app-subtle-bg)] disabled:cursor-not-allowed disabled:opacity-40"
+                                    className="shrink-0 rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-1.5 text-xs font-medium text-[var(--app-fg)] hover:bg-[var(--app-subtle-bg)] disabled:cursor-not-allowed disabled:opacity-40"
                                 >
                                     {t('scratchlist.add')}
                                 </button>

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -31,6 +31,7 @@ import { useTranslation } from '@/lib/use-translation'
 import { SessionHeader } from '@/components/SessionHeader'
 import { TeamPanel } from '@/components/TeamPanel'
 import { usePlatform } from '@/hooks/usePlatform'
+import { useScratchlistEnabled } from '@/hooks/useScratchlistEnabled'
 import { useSessionActions } from '@/hooks/mutations/useSessionActions'
 import { useCodexModels } from '@/hooks/queries/useCodexModels'
 import { useCursorModels } from '@/hooks/queries/useCursorModels'
@@ -165,6 +166,7 @@ export function SessionChat(props: {
     availableSlashCommands?: readonly SlashCommand[]
 }) {
     const { haptic } = usePlatform()
+    const [scratchlistEnabled] = useScratchlistEnabled()
     const { t } = useTranslation()
     const navigate = useNavigate()
     const sessionInactive = !props.session.active
@@ -775,11 +777,13 @@ export function SessionChat(props: {
                          * read B's storage directly. Cleaner than chasing
                          * the race inside the panel.
                          */}
-                        <ScratchlistHost
-                            key={props.session.id}
-                            sessionId={props.session.id}
-                            onSend={props.onSend}
-                        />
+                        {scratchlistEnabled ? (
+                            <ScratchlistHost
+                                key={props.session.id}
+                                sessionId={props.session.id}
+                                onSend={props.onSend}
+                            />
+                        ) : null}
                         <QueuedMessagesBar
                             sessionId={props.session.id}
                             api={props.api}

--- a/web/src/hooks/useScratchlistEnabled.test.ts
+++ b/web/src/hooks/useScratchlistEnabled.test.ts
@@ -1,0 +1,31 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+    SCRATCHLIST_ENABLED_STORAGE_KEY,
+    readScratchlistEnabledPreference,
+    useScratchlistEnabled,
+} from './useScratchlistEnabled'
+
+describe('useScratchlistEnabled', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('defaults the scratchlist off so it does not take chat space unless enabled', () => {
+        expect(readScratchlistEnabledPreference()).toBe(false)
+        const { result } = renderHook(() => useScratchlistEnabled())
+        expect(result.current[0]).toBe(false)
+    })
+
+    it('persists true and removes storage when reset to the default false value', () => {
+        const { result } = renderHook(() => useScratchlistEnabled())
+
+        act(() => result.current[1](true))
+        expect(result.current[0]).toBe(true)
+        expect(localStorage.getItem(SCRATCHLIST_ENABLED_STORAGE_KEY)).toBe('true')
+
+        act(() => result.current[1](false))
+        expect(result.current[0]).toBe(false)
+        expect(localStorage.getItem(SCRATCHLIST_ENABLED_STORAGE_KEY)).toBeNull()
+    })
+})

--- a/web/src/hooks/useScratchlistEnabled.ts
+++ b/web/src/hooks/useScratchlistEnabled.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export const SCRATCHLIST_ENABLED_STORAGE_KEY = 'hapi-scratchlist-enabled'
+export const DEFAULT_SCRATCHLIST_ENABLED = false
+
+function isBrowser(): boolean {
+    return typeof window !== 'undefined'
+}
+
+export function readScratchlistEnabledPreference(): boolean {
+    if (!isBrowser()) return DEFAULT_SCRATCHLIST_ENABLED
+    try {
+        return window.localStorage.getItem(SCRATCHLIST_ENABLED_STORAGE_KEY) === 'true'
+    } catch {
+        return DEFAULT_SCRATCHLIST_ENABLED
+    }
+}
+
+export function writeScratchlistEnabledPreference(enabled: boolean): void {
+    if (!isBrowser()) return
+    try {
+        if (enabled === DEFAULT_SCRATCHLIST_ENABLED) {
+            window.localStorage.removeItem(SCRATCHLIST_ENABLED_STORAGE_KEY)
+        } else {
+            window.localStorage.setItem(SCRATCHLIST_ENABLED_STORAGE_KEY, 'true')
+        }
+    } catch {
+        // Ignore storage errors.
+    }
+}
+
+export function useScratchlistEnabled(): [boolean, (enabled: boolean) => void] {
+    const [enabled, setEnabledState] = useState<boolean>(readScratchlistEnabledPreference)
+
+    useEffect(() => {
+        const onStorage = (event: StorageEvent) => {
+            if (event.key !== SCRATCHLIST_ENABLED_STORAGE_KEY) return
+            setEnabledState(readScratchlistEnabledPreference())
+        }
+        window.addEventListener('storage', onStorage)
+        return () => window.removeEventListener('storage', onStorage)
+    }, [])
+
+    const setEnabled = useCallback((next: boolean) => {
+        setEnabledState(next)
+        writeScratchlistEnabledPreference(next)
+    }, [])
+
+    return [enabled, setEnabled]
+}

--- a/web/src/hooks/useScratchlistEnabled.ts
+++ b/web/src/hooks/useScratchlistEnabled.ts
@@ -33,6 +33,8 @@ export function useScratchlistEnabled(): [boolean, (enabled: boolean) => void] {
     const [enabled, setEnabledState] = useState<boolean>(readScratchlistEnabledPreference)
 
     useEffect(() => {
+        if (!isBrowser()) return
+
         const onStorage = (event: StorageEvent) => {
             if (event.key !== SCRATCHLIST_ENABLED_STORAGE_KEY) return
             setEnabledState(readScratchlistEnabledPreference())

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -489,6 +489,8 @@ export default {
   'settings.chat.terminalToolDisplay.detailed': 'Detailed (show output preview)',
   'settings.chat.groupedToolBackground': 'Grouped Tool Use Background',
   'settings.chat.userMessageBackground': 'User Message Background',
+  'settings.chat.scratchlist': 'Scratchlist',
+  'settings.chat.scratchlist.description': 'Hide scratchlist by default. Enable it here when you want a parking lot for drafts.',
   'settings.chat.surfaceColor.default': 'Default color',
   'settings.chat.surfaceColor.softBlue': 'Soft blue',
   'settings.chat.surfaceColor.softGreen': 'Soft green',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -491,6 +491,8 @@ export default {
   'settings.chat.terminalToolDisplay.detailed': '详细（显示输出预览）',
   'settings.chat.groupedToolBackground': '聚合 Tool Use 背景',
   'settings.chat.userMessageBackground': '用户消息背景',
+  'settings.chat.scratchlist': '草稿夹',
+  'settings.chat.scratchlist.description': '默认隐藏草稿夹。需要暂存草稿或想法时可在此开启。',
   'settings.chat.surfaceColor.default': '默认颜色',
   'settings.chat.surfaceColor.softBlue': '柔和蓝',
   'settings.chat.surfaceColor.softGreen': '柔和绿',

--- a/web/src/routes/settings/index.test.tsx
+++ b/web/src/routes/settings/index.test.tsx
@@ -270,6 +270,8 @@ describe('SettingsPage', () => {
         renderWithProviders(<SettingsPage />)
         expect(screen.getAllByText('Grouped Tool Use Background').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('User Message Background').length).toBeGreaterThanOrEqual(1)
+        expect(screen.getAllByText('Scratchlist').length).toBeGreaterThanOrEqual(1)
+        expect(screen.getAllByText('Hide scratchlist by default').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('Default color').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('Soft blue').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('Soft green').length).toBeGreaterThanOrEqual(1)
@@ -287,6 +289,8 @@ describe('SettingsPage', () => {
         expect(calledKeys).toContain('settings.chat.terminalToolDisplay.compact')
         expect(calledKeys).toContain('settings.chat.groupedToolBackground')
         expect(calledKeys).toContain('settings.chat.userMessageBackground')
+        expect(calledKeys).toContain('settings.chat.scratchlist')
+        expect(calledKeys).toContain('settings.chat.scratchlist.description')
         expect(calledKeys).toContain('settings.chat.surfaceColor.default')
     })
 

--- a/web/src/routes/settings/index.test.tsx
+++ b/web/src/routes/settings/index.test.tsx
@@ -271,7 +271,7 @@ describe('SettingsPage', () => {
         expect(screen.getAllByText('Grouped Tool Use Background').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('User Message Background').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('Scratchlist').length).toBeGreaterThanOrEqual(1)
-        expect(screen.getAllByText('Hide scratchlist by default').length).toBeGreaterThanOrEqual(1)
+        expect(screen.getAllByText(/Hide scratchlist by default/).length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('Default color').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('Soft blue').length).toBeGreaterThanOrEqual(1)
         expect(screen.getAllByText('Soft green').length).toBeGreaterThanOrEqual(1)

--- a/web/src/routes/settings/index.tsx
+++ b/web/src/routes/settings/index.tsx
@@ -18,6 +18,7 @@ import { getFontScaleOptions, useFontScale, type FontScale } from '@/hooks/useFo
 import { getTerminalFontSizeOptions, useTerminalFontSize, type TerminalFontSize } from '@/hooks/useTerminalFontSize'
 import { getComposerEnterBehaviorOptions, useComposerEnterBehavior, type ComposerEnterBehavior } from '@/hooks/useComposerEnterBehavior'
 import { getTerminalToolDisplayModeOptions, useTerminalToolDisplayMode, type TerminalToolDisplayMode } from '@/hooks/useTerminalToolDisplayMode'
+import { useScratchlistEnabled } from '@/hooks/useScratchlistEnabled'
 import { getSessionListStatusModeOptions, useSessionListStatusMode, type SessionListStatusMode } from '@/hooks/useSessionListStatusMode'
 import {
     MAX_SESSION_PREVIEW_LIMIT,
@@ -337,6 +338,7 @@ export default function SettingsPage() {
     const { sessionPreviewLimit, setSessionPreviewLimit } = useSessionPreviewLimit()
     const { composerEnterBehavior, setComposerEnterBehavior } = useComposerEnterBehavior()
     const { terminalToolDisplayMode, setTerminalToolDisplayMode } = useTerminalToolDisplayMode()
+    const [scratchlistEnabled, setScratchlistEnabled] = useScratchlistEnabled()
     const { sessionListStatusMode, setSessionListStatusMode } = useSessionListStatusMode()
     const {
         toolGroupBackground,
@@ -1006,6 +1008,19 @@ export default function SettingsPage() {
                             onCustomChange={(value) => setUserMessageBackground(toCustomChatSurfaceColorPreference(value))}
                             t={t}
                         />
+                        <label className="flex w-full items-start justify-between gap-3 px-3 py-3 transition-colors hover:bg-[var(--app-subtle-bg)]">
+                            <span className="min-w-0">
+                                <span className="block text-[var(--app-fg)]">{t('settings.chat.scratchlist')}</span>
+                                <span className="mt-1 block text-xs text-[var(--app-hint)]">{t('settings.chat.scratchlist.description')}</span>
+                            </span>
+                            <input
+                                type="checkbox"
+                                checked={scratchlistEnabled}
+                                onChange={(event) => setScratchlistEnabled(event.target.checked)}
+                                aria-label={t('settings.chat.scratchlist')}
+                                className="mt-1 h-5 w-5 shrink-0 accent-[var(--app-link)]"
+                            />
+                        </label>
                     </div>
 
                     {/* Voice Assistant section */}

--- a/web/src/routes/settings/index.tsx
+++ b/web/src/routes/settings/index.tsx
@@ -994,6 +994,19 @@ export default function SettingsPage() {
                                 </div>
                             )}
                         </div>
+                        <label className="flex w-full items-start justify-between gap-3 px-3 py-3 transition-colors hover:bg-[var(--app-subtle-bg)]">
+                            <span className="min-w-0">
+                                <span className="block text-[var(--app-fg)]">{t('settings.chat.scratchlist')}</span>
+                                <span className="mt-1 block text-xs text-[var(--app-hint)]">{t('settings.chat.scratchlist.description')}</span>
+                            </span>
+                            <input
+                                type="checkbox"
+                                checked={scratchlistEnabled}
+                                onChange={(event) => setScratchlistEnabled(event.target.checked)}
+                                aria-label={t('settings.chat.scratchlist')}
+                                className="mt-1 h-5 w-5 shrink-0 accent-[var(--app-link)]"
+                            />
+                        </label>
                         <ChatSurfaceColorControl
                             label={t('settings.chat.groupedToolBackground')}
                             preference={toolGroupBackground}
@@ -1008,19 +1021,6 @@ export default function SettingsPage() {
                             onCustomChange={(value) => setUserMessageBackground(toCustomChatSurfaceColorPreference(value))}
                             t={t}
                         />
-                        <label className="flex w-full items-start justify-between gap-3 px-3 py-3 transition-colors hover:bg-[var(--app-subtle-bg)]">
-                            <span className="min-w-0">
-                                <span className="block text-[var(--app-fg)]">{t('settings.chat.scratchlist')}</span>
-                                <span className="mt-1 block text-xs text-[var(--app-hint)]">{t('settings.chat.scratchlist.description')}</span>
-                            </span>
-                            <input
-                                type="checkbox"
-                                checked={scratchlistEnabled}
-                                onChange={(event) => setScratchlistEnabled(event.target.checked)}
-                                aria-label={t('settings.chat.scratchlist')}
-                                className="mt-1 h-5 w-5 shrink-0 accent-[var(--app-link)]"
-                            />
-                        </label>
                     </div>
 
                     {/* Voice Assistant section */}


### PR DESCRIPTION
Closes #812

## Summary
- Add a Chat settings toggle for Scratchlist, placed below Terminal Tool Cards.
- Default Scratchlist to off so it does not take chat space unless enabled.
- Restyle Scratchlist to use the user-message chat surface and normal borders instead of warning/amber colors.
- Document local `.git/info` testing notes in `AGENTS.md` to avoid testing the wrong worktree.

## Test plan
- [x] `cd web && bun run test -- src/hooks/useScratchlistEnabled.test.ts src/components/AssistantChat/ScratchlistPanel.test.tsx src/routes/settings/index.test.tsx`
- [x] `bun typecheck && bun run test`
- [x] Manual smoke on isolated hub/runner from `/tmp/hapi-issue-812`
