### PR TITLE
fix(cursor): register cursorSessionId before ACP session/load

### DIFF
--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -12,7 +12,9 @@ const harness = vi.hoisted(() => ({
     backendArgs: null as { command: string; args?: string[] } | null,
     setConfigOptionCalls: [] as Array<{ sessionId: string; configId: string; value: string }>,
     deferSetConfigOption: null as Promise<void> | null,
-    releaseSetConfigOption: null as (() => void) | null
+    releaseSetConfigOption: null as (() => void) | null,
+    deferLoadSession: null as Promise<void> | null,
+    releaseLoadSession: null as (() => void) | null
 }));
 
 const legacyLauncher = vi.hoisted(() => vi.fn());
@@ -38,6 +40,9 @@ vi.mock('./utils/cursorAcpBackend', () => ({
             supportsLoadSession: vi.fn(() => harness.supportsLoadSession),
             loadSession: vi.fn(async () => {
                 harness.loadSessionCalled = true;
+                if (harness.deferLoadSession) {
+                    await harness.deferLoadSession;
+                }
                 if (harness.loadSessionError) throw harness.loadSessionError;
                 return 'loaded-acp-session';
             }),
@@ -174,6 +179,8 @@ describe('cursorAcpRemoteLauncher', () => {
         harness.setConfigOptionCalls = [];
         harness.deferSetConfigOption = null;
         harness.releaseSetConfigOption = null;
+        harness.deferLoadSession = null;
+        harness.releaseLoadSession = null;
         legacyLauncher.mockClear();
         process.stdin.isTTY = false;
         process.stdout.isTTY = false;
@@ -202,6 +209,27 @@ describe('cursorAcpRemoteLauncher', () => {
 
         expect(legacyLauncher).not.toHaveBeenCalled();
         expect(harness.newSessionCalled).toBe(false);
+    });
+
+    it('registers cursorSessionId before session/load completes', async () => {
+        let releaseLoadSession!: () => void;
+        harness.deferLoadSession = new Promise<void>((resolve) => {
+            harness.releaseLoadSession = resolve;
+            releaseLoadSession = resolve;
+        });
+
+        const session = makeSession('resume-thread-1');
+        const launchPromise = cursorAcpRemoteLauncher(session);
+
+        await vi.waitFor(() => {
+            expect(session.onSessionFoundWithProtocol).toHaveBeenCalledWith('resume-thread-1', 'acp');
+        });
+        expect(harness.loadSessionCalled).toBe(true);
+
+        releaseLoadSession();
+        await launchPromise;
+
+        expect(session.onSessionFoundWithProtocol).toHaveBeenCalledWith('loaded-acp-session', 'acp');
     });
 
     it('throws when session/load fails instead of falling back to stream-json', async () => {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -95,6 +95,8 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
         let acpSessionId: string;
 
         if (resumeSessionId && backend.supportsLoadSession()) {
+            // Register pending cursorSessionId before awaiting session/load (Zed PR #54431).
+            session.onSessionFoundWithProtocol(resumeSessionId, 'acp');
             try {
                 acpSessionId = await backend.loadSession({
                     sessionId: resumeSessionId,
@@ -118,7 +120,9 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             });
         }
 
-        session.onSessionFoundWithProtocol(acpSessionId, 'acp');
+        if (acpSessionId !== resumeSessionId) {
+            session.onSessionFoundWithProtocol(acpSessionId, 'acp');
+        }
 
         syncCursorModelsFromAcp(backend, acpSessionId);
 


### PR DESCRIPTION
## Summary

Pre-write `cursorSessionId` + `cursorSessionProtocol: acp` into session metadata before awaiting ACP `session/load` on resume, so hub/web dedup and resume checks work immediately (Zed PR #54431 pattern).

Fixes #834

## Test plan

- [x] `cursorAcpRemoteLauncher.test.ts` — metadata registered before deferred `session/load` resolves
- [ ] Live: archive → resume → first `GET /api/sessions/:id` has `metadata.cursorSessionId`


Made with [Cursor](https://cursor.com)