### PR TITLE
fix(web): add missing i18n keys for session.inactive banner

### DIFF
--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -119,6 +119,10 @@ export default {
   'session.time.importedFromCodex.hoursAgo': 'imported from Codex {n}h ago',
   'session.time.importedFromCodex.daysAgo': 'imported from Codex {n}d ago',
 
+  // Session inactive
+  'session.inactive.autoResume': 'This session is inactive. Send a message to resume.',
+  'session.inactive.cannotResume': 'This session is inactive and cannot be resumed.',
+
   // Session header
   'session.title': 'Files',
   'session.more': 'More actions',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -119,6 +119,10 @@ export default {
   'session.time.importedFromCodex.hoursAgo': '{n} 小时前从codex客户端导入',
   'session.time.importedFromCodex.daysAgo': '{n} 天前从codex客户端导入',
 
+  // Session inactive
+  'session.inactive.autoResume': '此会话已停止。发送消息即可恢复。',
+  'session.inactive.cannotResume': '此会话已停止，无法恢复。',
+
   // Session header
   'session.title': '文件',
   'session.more': '更多操作',


### PR DESCRIPTION
The inactive-session banner rendered by `SessionChat.tsx` referenced two translation keys — `session.inactive.autoResume` and `session.inactive.cannotResume` — that were never added to the locale dictionaries, so the UI showed the raw key string.

Added both keys to `en.ts` and `zh-CN.ts`.

- EN: *This session is inactive. Send a message to resume.* / *This session is inactive and cannot be resumed.*
- ZH: *此会话已停止。发送消息即可恢复。* / *此会话已停止，无法恢复。*

Verified with `bun typecheck` and `bun run test` (all packages green).