### PR TITLE
feat: add Fable model presets for Claude sessions

### DIFF
--- a/shared/src/models.ts
+++ b/shared/src/models.ts
@@ -2,7 +2,9 @@ export const CLAUDE_MODEL_LABELS = {
     sonnet: 'Sonnet',
     'sonnet[1m]': 'Sonnet 1M',
     opus: 'Opus',
-    'opus[1m]': 'Opus 1M'
+    'opus[1m]': 'Opus 1M',
+    fable: 'Fable',
+    'fable[1m]': 'Fable 1M'
 } as const
 
 export type ClaudeModelPreset = keyof typeof CLAUDE_MODEL_LABELS

--- a/web/src/components/AssistantChat/claudeModelOptions.test.ts
+++ b/web/src/components/AssistantChat/claudeModelOptions.test.ts
@@ -10,6 +10,8 @@ describe('getClaudeComposerModelOptions', () => {
             { value: 'sonnet[1m]', label: 'Sonnet 1M' },
             { value: 'opus', label: 'Opus' },
             { value: 'opus[1m]', label: 'Opus 1M' },
+            { value: 'fable', label: 'Fable' },
+            { value: 'fable[1m]', label: 'Fable 1M' },
         ])
     })
 
@@ -20,6 +22,8 @@ describe('getClaudeComposerModelOptions', () => {
             { value: 'sonnet[1m]', label: 'Sonnet 1M' },
             { value: 'opus', label: 'Opus' },
             { value: 'opus[1m]', label: 'Opus 1M' },
+            { value: 'fable', label: 'Fable' },
+            { value: 'fable[1m]', label: 'Fable 1M' },
         ])
     })
 })

--- a/web/src/components/AssistantChat/modelOptions.test.ts
+++ b/web/src/components/AssistantChat/modelOptions.test.ts
@@ -27,7 +27,9 @@ describe('getModelOptionsForFlavor', () => {
             { value: 'sonnet', label: 'Sonnet' },
             { value: 'sonnet[1m]', label: 'Sonnet 1M' },
             { value: 'opus', label: 'Opus' },
-            { value: 'opus[1m]', label: 'Opus 1M' }
+            { value: 'opus[1m]', label: 'Opus 1M' },
+            { value: 'fable', label: 'Fable' },
+            { value: 'fable[1m]', label: 'Fable 1M' }
         ])
     })
 
@@ -41,7 +43,9 @@ describe('getModelOptionsForFlavor', () => {
             { value: 'sonnet', label: 'Sonnet' },
             { value: 'sonnet[1m]', label: 'Sonnet 1M' },
             { value: 'opus', label: 'Opus' },
-            { value: 'opus[1m]', label: 'Opus 1M' }
+            { value: 'opus[1m]', label: 'Opus 1M' },
+            { value: 'fable', label: 'Fable' },
+            { value: 'fable[1m]', label: 'Fable 1M' }
         ])
     })
 

--- a/web/src/components/NewSession/types.test.ts
+++ b/web/src/components/NewSession/types.test.ts
@@ -14,9 +14,10 @@ describe('Claude model options', () => {
     })
 
     it('exposes friendly labels for Claude model presets', () => {
-        expect(CLAUDE_MODEL_PRESETS).toEqual(['sonnet', 'sonnet[1m]', 'opus', 'opus[1m]'])
+        expect(CLAUDE_MODEL_PRESETS).toEqual(['sonnet', 'sonnet[1m]', 'opus', 'opus[1m]', 'fable', 'fable[1m]'])
         expect(getClaudeModelLabel('sonnet[1m]')).toBe('Sonnet 1M')
         expect(getClaudeModelLabel('opus[1m]')).toBe('Opus 1M')
+        expect(getClaudeModelLabel('fable[1m]')).toBe('Fable 1M')
     })
 })
 


### PR DESCRIPTION
## Summary

Adds `fable` / `fable[1m]` to the Claude model presets so Fable 5 (Anthropic's latest frontier model) is selectable in the new-session and in-session composer model pickers.

Closes #859

## Approach

As the bot analysis in #859 noted, hapi passes the Claude model string through verbatim (`hapi claude --model <value>` → `claude --model <value>`) and only the preset list in `shared/src/models.ts` gates what the web UI offers. So this is a presets-only change:

- `CLAUDE_MODEL_LABELS` gains `fable: 'Fable'` and `'fable[1m]': 'Fable 1M'`
- Model pickers, session labels, and the 1M context-window heuristic (`[1m]` suffix in `web/src/chat/modelConfig.ts`) all derive from this table, so no other plumbing is needed

To answer the open question in #859 — the exact `--model` values: Claude Code accepts `fable` and `fable[1m]` aliases (same alias style as the existing `opus` / `opus[1m]` presets). Verified against Claude Code 2.1.170 with `--output-format json`; the `modelUsage` field reports the resolved model IDs:

| alias | resolved model ID | reported contextWindow |
|---|---|---|
| `fable` | `claude-fable-5` | 1,000,000 |
| `fable[1m]` | `claude-fable-5[1m]` | 1,000,000 |

Note: `modelUsage` reported a 1M context window even for the plain `fable` alias. The web UI's context-budget heuristic still treats non-`[1m]` presets as 200k, which is the conservative direction; happy to special-case Fable there if you'd prefer.

## Testing

- `shared`: `bun test models` passes (preset/label consistency tests cover the new entries)
- `web`: vitest for `claudeModelOptions`, `NewSession/types`, `modelOptions` passes; updated the hard-coded preset-list assertions
- `bun run typecheck` clean across cli/web/hub
- E2E: built `build:single-exe` from this branch, swapped it into a live hub+runner setup, and verified in-browser that the picker shows Fable / Fable 1M and a session created with `fable` launches and responds normally