### PR TITLE
fix(cli): bypass proxy env for loopback HTTP (hooks, runner control, local MCP)

### DIFF
--- a/cli/src/commands/runCli.ts
+++ b/cli/src/commands/runCli.ts
@@ -3,9 +3,12 @@ import { ensureRuntimeAssets } from '@/runtime/assets'
 import { isBunCompiled } from '@/projectPath'
 import { logger } from '@/ui/logger'
 import { getCliArgs } from '@/utils/cliArgs'
+import { ensureLoopbackProxyBypass } from '@/utils/proxyEnv'
 import { resolveCommand } from './registry'
 
 export async function runCli(): Promise<void> {
+    ensureLoopbackProxyBypass()
+
     const args = getCliArgs()
 
     if (args.includes('-v') || args.includes('--version')) {

--- a/cli/src/utils/proxyEnv.test.ts
+++ b/cli/src/utils/proxyEnv.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { ensureLoopbackProxyBypass } from './proxyEnv';
+
+describe('ensureLoopbackProxyBypass', () => {
+    it('adds loopback hosts when NO_PROXY is unset', () => {
+        const env: NodeJS.ProcessEnv = {};
+        ensureLoopbackProxyBypass(env);
+        expect(env.NO_PROXY).toBe('localhost,127.0.0.1,::1');
+        expect(env.no_proxy).toBe('localhost,127.0.0.1,::1');
+    });
+
+    it('preserves existing entries and appends missing loopback hosts', () => {
+        const env: NodeJS.ProcessEnv = { NO_PROXY: 'npmjs.org' };
+        ensureLoopbackProxyBypass(env);
+        expect(env.NO_PROXY).toBe('npmjs.org,localhost,127.0.0.1,::1');
+    });
+
+    it('does not duplicate already-present hosts', () => {
+        const env: NodeJS.ProcessEnv = { NO_PROXY: 'LOCALHOST, 127.0.0.1' };
+        ensureLoopbackProxyBypass(env);
+        expect(env.NO_PROXY).toBe('LOCALHOST,127.0.0.1,::1');
+    });
+
+    it('reads lowercase no_proxy when NO_PROXY is unset', () => {
+        const env: NodeJS.ProcessEnv = { no_proxy: 'example.com,localhost,127.0.0.1,::1' };
+        ensureLoopbackProxyBypass(env);
+        expect(env.NO_PROXY).toBe('example.com,localhost,127.0.0.1,::1');
+    });
+
+    it('leaves a wildcard NO_PROXY untouched', () => {
+        const env: NodeJS.ProcessEnv = { NO_PROXY: '*' };
+        ensureLoopbackProxyBypass(env);
+        expect(env.NO_PROXY).toBe('*');
+        expect(env.no_proxy).toBeUndefined();
+    });
+});

--- a/cli/src/utils/proxyEnv.ts
+++ b/cli/src/utils/proxyEnv.ts
@@ -1,0 +1,42 @@
+/**
+ * Loopback proxy bypass.
+ *
+ * The CLI talks to itself and to local agents over loopback HTTP (hook
+ * forwarder -> hook server, control client -> runner, claude -> local MCP
+ * server). Bun's fetch AND its node:http implementation honor the
+ * HTTP_PROXY/HTTPS_PROXY env vars, so when the user's shell exports a proxy
+ * (e.g. Surge/Clash with `HTTP_PROXY=http://127.0.0.1:1080`) without
+ * excluding localhost in NO_PROXY, every loopback request is routed through
+ * the proxy — which may forward "127.0.0.1" to a remote node where nothing
+ * is listening. Symptom: SessionStart hooks never arrive, transcripts never
+ * sync, web UI stays empty.
+ *
+ * Fix: make sure NO_PROXY always covers loopback. Children (claude, runner,
+ * hook-forwarder) inherit the patched env, so their loopback traffic is
+ * covered too. Non-loopback traffic keeps using the configured proxy.
+ */
+
+const LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '::1'];
+
+export function ensureLoopbackProxyBypass(env: NodeJS.ProcessEnv = process.env): void {
+    const existing = env.NO_PROXY ?? env.no_proxy ?? '';
+    const entries = existing
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+
+    const present = new Set(entries.map((entry) => entry.toLowerCase()));
+    if (present.has('*')) {
+        return;
+    }
+
+    for (const host of LOOPBACK_HOSTS) {
+        if (!present.has(host)) {
+            entries.push(host);
+        }
+    }
+
+    const merged = entries.join(',');
+    env.NO_PROXY = merged;
+    env.no_proxy = merged;
+}


### PR DESCRIPTION
## Problem

With a proxy exported in the shell (e.g. Surge/Clash: `HTTP_PROXY=http://127.0.0.1:1080`) and a `NO_PROXY` that doesn't literally cover loopback (`NO_PROXY=npmjs.org`, or the glibc-style `127.*` wildcard Bun doesn't match), **every loopback HTTP request in the CLI is routed through the proxy**. Depending on the proxy's active policy, "127.0.0.1" gets forwarded to a remote node where nothing listens, and the request dies.

This breaks, flakily (depends on proxy policy at that moment):

- **Claude SessionStart hook-forwarder → hook server**: the CLI never learns the Claude session id, the transcript scanner never starts, and the **web UI stays empty** (how this was found)
- **Runner control client** (`/session-started` webhook → "Session webhook timeout", the bug in #563)
- **claude → local HAPI MCP server** connection
- `autoStartServer` health checks

## Root cause

Bun honors `HTTP_PROXY`/`HTTPS_PROXY` for both `fetch` **and** its `node:http` implementation. Evidence: posting to a dead loopback port returns the proxy's HTTP 503 error page instead of `ECONNREFUSED`.

Contrary to the analysis in #563, runtime mutation of `process.env.NO_PROXY` **does** take effect on Bun 1.3.14 (the version our CI builds with) — verified for both `fetch` and `node:http`, including after a prior `fetch` (no startup caching):

```
=== control (no mutation):     fetch → HTTP 503 (proxied), node:http → HTTP 503 (proxied)
=== with runtime mutation:     fetch → ConnectionRefused (direct), node:http → ECONNREFUSED (direct)
```

## Fix

`ensureLoopbackProxyBypass()` appends `localhost,127.0.0.1,::1` to `NO_PROXY`/`no_proxy` (preserving existing entries, no-op on `*`), called first thing in `runCli()`. One fix covers all in-process loopback calls **and** all child processes (claude, runner daemon, hook-forwarder), which inherit the patched env. Non-loopback traffic keeps using the configured proxy.

This also fixes the #563 reproducer: `NO_PROXY="127.*,localhost"` becomes `127.*,localhost,127.0.0.1,::1`, and Bun matches the literal entry.

## Testing

- 5 new unit tests (`proxyEnv.test.ts`); cli suite: 972 passed, 1 pre-existing env-dependent failure (`apiMachine.test.ts` `/var` vs `/private/var`, fails on clean main too)
- E2E under a live Surge proxy with `HTTP_PROXY` set: hook-forwarder went from proxy-503 to direct `ECONNREFUSED` on a dead port; against a live session, hook delivery + transcript sync resumed immediately

Supersedes #563 (thanks @XWang20 for the report and reproducer — same disease, this treats all infected call sites instead of one).
