### PR TITLE
feat(web): auto-focus terminal on open

### DIFF
--- a/web/src/routes/sessions/terminal.tsx
+++ b/web/src/routes/sessions/terminal.tsx
@@ -264,6 +264,7 @@ export default function TerminalPage() {
                 const modifierState = modifierStateRef.current
                 dispatchSequence(data, modifierState)
             })
+            terminal.focus()
         },
         [dispatchSequence]
     )


### PR DESCRIPTION
## Summary

Closes #875.

When the terminal page loaded, keyboard focus stayed on the page body — the user had to click or tap inside the xterm area before they could type. This adds a single `terminal.focus()` call at the end of `handleTerminalMount` so focus lands inside the terminal as soon as the xterm instance is attached to the DOM.

The quick-input key buttons already call `terminalRef.current?.focus()` after each press (lines 348, 391, 408 in `terminal.tsx`) — this extends the same call to the initial mount.

## Changes

`web/src/routes/sessions/terminal.tsx` — one line added in `handleTerminalMount`:

```diff
+            terminal.focus()
```

## Test plan

- [x] `bun typecheck` clean (cli + web + hub)
- [x] `bun run test` — 3/3 terminal page tests pass; 972/973 total (1 pre-existing flaky runner integration test unrelated to this change)
- [x] Cold diff review: 0 Blocker, 0 Major. `terminal.focus()` is safe before `fitAddon.fit()` (xterm focuses its hidden textarea, not the canvas); does not trigger iOS/Android soft keyboard on mount (requires explicit tap on mobile).

Made with [Cursor](https://cursor.com)