### PR TITLE
feat: support Claude Code 'auto' permission mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ Before commit/push/PR: use the **`pre-push-review`** skill (`~/.cursor/skills/pr
 - **RPC**: CLI registers handlers (`rpc-register`), hub routes requests via `rpcGateway.ts`
 - **Versioned updates**: CLI sends `update-metadata`/`update-state` with version; hub rejects stale
 - **Session modes**: `local` (terminal) vs `remote` (web-controlled); switchable mid-session
-- **Permission modes**: `default`, `acceptEdits`, `bypassPermissions`, `plan`
+- **Permission modes**: `default`, `acceptEdits`, `auto`, `bypassPermissions`, `plan`
 - **Namespaces**: Multi-user isolation via `CLI_API_TOKEN:<namespace>` suffix
 
 ## Adding new web features — consider an FUE

--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -153,8 +153,11 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
     setControlledByUser(session, startingMode);
 
     // Import MessageQueue2 and create message queue
+    // 'plan' and 'auto' are enforced inside Claude itself (not emulated via
+    // canCallTool like acceptEdits/bypassPermissions), so switching to/from
+    // them must start a new process with the matching --permission-mode flag.
     const messageQueue = new MessageQueue2<EnhancedMode>(mode => hashObject({
-        isPlan: mode.permissionMode === 'plan',
+        agentEnforcedMode: mode.permissionMode === 'plan' || mode.permissionMode === 'auto' ? mode.permissionMode : null,
         model: mode.model,
         effort: mode.effort,
         fallbackModel: mode.fallbackModel,

--- a/cli/src/claude/utils/permissionHandler.ts
+++ b/cli/src/claude/utils/permissionHandler.ts
@@ -32,7 +32,7 @@ interface PermissionResponse {
     receivedAt?: number;
 }
 
-const PLAN_EXIT_MODES: PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions'];
+const PLAN_EXIT_MODES: PermissionMode[] = ['default', 'acceptEdits', 'auto', 'bypassPermissions'];
 
 function isAskUserQuestionToolName(toolName: string): boolean {
     return toolName === 'AskUserQuestion' || toolName === 'ask_user_question';

--- a/cli/src/runner/buildCliArgs.test.ts
+++ b/cli/src/runner/buildCliArgs.test.ts
@@ -72,7 +72,7 @@ describe('buildCliArgs', () => {
     })
 
     it('validates all known permission modes', () => {
-        for (const mode of ['default', 'acceptEdits', 'bypassPermissions', 'plan', 'ask', 'read-only', 'safe-yolo', 'yolo']) {
+        for (const mode of ['default', 'acceptEdits', 'auto', 'bypassPermissions', 'plan', 'ask', 'read-only', 'safe-yolo', 'yolo']) {
             const args = buildCliArgs('claude', {
                 directory: '/tmp',
                 permissionMode: mode,

--- a/shared/src/modes.test.ts
+++ b/shared/src/modes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test'
+import {
+    getPermissionModeLabel,
+    getPermissionModeTone,
+    isPermissionModeAllowedForFlavor
+} from './modes'
+
+describe('claude auto permission mode', () => {
+    it('is allowed for claude only', () => {
+        expect(isPermissionModeAllowedForFlavor('auto', 'claude')).toBe(true)
+        expect(isPermissionModeAllowedForFlavor('auto', 'codex')).toBe(false)
+        expect(isPermissionModeAllowedForFlavor('auto', 'gemini')).toBe(false)
+        expect(isPermissionModeAllowedForFlavor('auto', 'cursor')).toBe(false)
+        expect(isPermissionModeAllowedForFlavor('auto', 'opencode')).toBe(false)
+        expect(isPermissionModeAllowedForFlavor('auto', 'kimi')).toBe(false)
+    })
+
+    it('has a label and tone', () => {
+        expect(getPermissionModeLabel('auto')).toBe('Auto')
+        expect(getPermissionModeTone('auto')).toBe('warning')
+    })
+})

--- a/shared/src/modes.ts
+++ b/shared/src/modes.ts
@@ -11,7 +11,7 @@ export const AGENT_FLAVORS = ['claude', 'codex', 'cursor', 'gemini', 'kimi', 'op
 export type AgentFlavor = typeof AGENT_FLAVORS[number]
 export const AgentFlavorSchema = z.enum(AGENT_FLAVORS)
 
-export const CLAUDE_PERMISSION_MODES = ['default', 'acceptEdits', 'bypassPermissions', 'plan'] as const
+export const CLAUDE_PERMISSION_MODES = ['default', 'acceptEdits', 'auto', 'bypassPermissions', 'plan'] as const
 export type ClaudePermissionMode = typeof CLAUDE_PERMISSION_MODES[number]
 
 export const CODEX_PERMISSION_MODES = ['default', 'read-only', 'safe-yolo', 'yolo'] as const
@@ -35,6 +35,7 @@ export type CursorPermissionMode = typeof CURSOR_PERMISSION_MODES[number]
 export const PERMISSION_MODES = [
     'default',
     'acceptEdits',
+    'auto',
     'bypassPermissions',
     'plan',
     'ask',
@@ -49,6 +50,7 @@ export type PermissionMode = typeof PERMISSION_MODES[number]
 export const PERMISSION_MODE_LABELS: Record<PermissionMode, string> = {
     default: 'Default',
     acceptEdits: 'Accept Edits',
+    auto: 'Auto',
     plan: 'Plan Mode',
     ask: 'Ask Mode',
     debug: 'Debug Mode',
@@ -63,6 +65,7 @@ export type PermissionModeTone = 'neutral' | 'info' | 'warning' | 'danger'
 export const PERMISSION_MODE_TONES: Record<PermissionMode, PermissionModeTone> = {
     default: 'neutral',
     acceptEdits: 'warning',
+    auto: 'warning',
     plan: 'info',
     ask: 'info',
     debug: 'info',

--- a/web/README.md
+++ b/web/README.md
@@ -47,7 +47,7 @@ See `src/router.tsx` for route definitions.
 
 - Message thread with infinite scroll.
 - Composer for sending messages.
-- Permission mode toggle (default/acceptEdits/bypassPermissions/plan).
+- Permission mode toggle (default/acceptEdits/auto/bypassPermissions/plan).
 - Model selection (default/sonnet/sonnet[1m]/opus/opus[1m]).
 - Session abort and mode switch controls.
 - Context size display.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -521,8 +521,8 @@ export class ApiClient {
     async approvePermission(
         sessionId: string,
         requestId: string,
-        modeOrOptions?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | {
-            mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan'
+        modeOrOptions?: 'default' | 'acceptEdits' | 'auto' | 'bypassPermissions' | 'plan' | {
+            mode?: 'default' | 'acceptEdits' | 'auto' | 'bypassPermissions' | 'plan'
             allowTools?: string[]
             decision?: 'approved' | 'approved_for_session' | 'denied' | 'abort'
             answers?: Record<string, string[]> | Record<string, { answers: string[] }>


### PR DESCRIPTION
Closes #858

## What

Adds Claude Code's [auto mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) (`--permission-mode auto`) as a first-class HAPI permission mode for claude-flavored sessions. Auto mode runs without routine permission prompts while a classifier blocks anything irreversible, destructive, or aimed outside the environment — a safer alternative to Yolo (`bypassPermissions`).

## How

`auto` differs from `acceptEdits`/`bypassPermissions` in one important way: those are emulated by HAPI inside its `canCallTool` handler, while `auto` (like `plan`) is enforced **inside Claude itself** by the classifier. That drives the two non-mechanical changes:

- **`shared/src/modes.ts`** — add `auto` to `CLAUDE_PERMISSION_MODES` and `PERMISSION_MODES` (label *Auto*, tone *warning*). CLI flag parsing, hub validation, runner spawn args, and the web mode dropdown all derive from these lists, so they pick it up automatically.
- **`cli/src/claude/runClaude.ts`** — the message-queue batch hash previously only tracked `isPlan`. It now treats `auto` the same way, so switching to/from `auto` mid-session starts a new Claude process with the matching `--permission-mode` flag (otherwise the switch would silently not take effect until the next respawn).
- **`cli/src/claude/utils/permissionHandler.ts`** — allow `auto` as a plan-exit target mode, matching Claude Code's own "Approve and start in auto mode" plan-approval option.
- **`web/src/api/client.ts`** — extend the `approvePermission` mode union.

Permission escalations in auto mode (classifier blocks, explicit ask rules) still arrive through the existing `--permission-prompt-tool stdio` → `canCallTool` path and surface in the web UI as normal — no local auto-approval is added for `auto`, since Claude's classifier is the decision-maker.

## Notes

- Requires Claude Code ≥ 2.1.83 and an auto-mode-eligible account; on older binaries `claude` rejects the flag at spawn and the error surfaces in the session, same as any unsupported flag.
- `auto` stays claude-only: codex/gemini/cursor/kimi/opencode keep their own mode lists and validation rejects it for them (covered by the new shared test).
- `dontAsk` mode is intentionally out of scope.

## Testing

- `bun typecheck` — clean (cli/web/hub)
- `bun run test` — cli, hub, web, shared all pass (one pre-existing `apiMachine.test.ts` failure on macOS, reproduces on clean `main`, unrelated)
- New test: `shared/src/modes.test.ts` (auto is claude-only + label/tone)