### PR TITLE
fix: bind imported Codex sessions to matching machine

### DIFF
--- a/hub/src/web/routes/codexDesktop.test.ts
+++ b/hub/src/web/routes/codexDesktop.test.ts
@@ -1,17 +1,18 @@
 import { afterEach, describe, expect, it } from 'bun:test'
+import { randomUUID } from 'node:crypto'
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Hono } from 'hono'
 import { AGENT_MESSAGE_PAYLOAD_TYPE } from '@hapi/protocol'
 import { Store } from '../../store'
-import type { SyncEngine } from '../../sync/syncEngine'
+import type { Machine, SyncEngine } from '../../sync/syncEngine'
 import type { WebAppEnv } from '../middleware/auth'
 import { createCodexDesktopRoutes, importSelectedCodexSessions } from './codexDesktop'
 
 const originalCodexHome = process.env.CODEX_HOME
 
-function createTranscript(codexHome: string, sessionId: string): void {
+function createTranscript(codexHome: string, sessionId: string, cwd = 'C:\\work\\project'): void {
     const sessionDir = join(codexHome, 'sessions', '2026', '06', '04')
     mkdirSync(sessionDir, { recursive: true })
     const transcriptPath = join(sessionDir, `rollout-${sessionId}.jsonl`)
@@ -20,7 +21,7 @@ function createTranscript(codexHome: string, sessionId: string): void {
             type: 'session_meta',
             payload: {
                 id: sessionId,
-                cwd: 'C:\\work\\project',
+                cwd,
                 originator: 'codex_cli_rs',
                 cli_version: '0.0.0-test'
             }
@@ -43,6 +44,50 @@ function createTranscript(codexHome: string, sessionId: string): void {
         }
     ]
     writeFileSync(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`, 'utf-8')
+}
+
+function createMachine(id: string, workspaceRoots: string[], namespace = 'default'): Machine {
+    return {
+        id,
+        namespace,
+        seq: 0,
+        createdAt: 0,
+        updatedAt: 0,
+        active: true,
+        activeAt: 0,
+        metadata: {
+            host: id,
+            platform: 'linux',
+            happyCliVersion: '0.0.0-test',
+            workspaceRoots
+        },
+        metadataVersion: 1,
+        runnerState: null,
+        runnerStateVersion: 1
+    }
+}
+
+function createImportSyncEngine(store: Store, machines: Machine[]): SyncEngine {
+    return {
+        getOnlineMachinesByNamespace: (namespace: string) => machines.filter((machine) => (
+            machine.namespace === namespace && machine.active
+        )),
+        getSessionsByNamespace: (namespace: string) => (
+            store.sessions.getSessionsByNamespace(namespace) as unknown as ReturnType<SyncEngine['getSessionsByNamespace']>
+        ),
+        getOrCreateSession: (
+            tag: string,
+            metadata: unknown,
+            agentState: unknown,
+            namespace: string
+        ) => (
+            store.sessions.getOrCreateSession(tag, metadata, agentState, namespace) as unknown as ReturnType<SyncEngine['getOrCreateSession']>
+        ),
+        handleRealtimeEvent: () => {},
+        recordSessionActivity: (sessionId: string, updatedAt: number) => {
+            store.sessions.touchSessionUpdatedAt(sessionId, updatedAt, 'default')
+        }
+    } as unknown as SyncEngine
 }
 
 function createRoutesApp(namespace: string): Hono<WebAppEnv> {
@@ -111,6 +156,138 @@ describe('Codex Desktop import routes', () => {
                 meta: {
                     sentFrom: 'cli'
                 }
+            })
+        } finally {
+            store.close()
+            rmSync(codexHome, { recursive: true, force: true })
+        }
+    })
+
+    it('binds imported transcripts to the unique online machine that owns the cwd', async () => {
+        const codexHome = mkdtempSync(join(tmpdir(), 'hapi-codex-home-machine-test-'))
+        const store = new Store(':memory:')
+        const codexSessionId = '22222222-2222-4222-8222-222222222222'
+        process.env.CODEX_HOME = codexHome
+
+        try {
+            createTranscript(codexHome, codexSessionId, '/home/user/workspace/project')
+            const engine = createImportSyncEngine(store, [
+                createMachine('machine-1', ['/home/user/workspace']),
+                createMachine('machine-2', ['/other/workspace'])
+            ])
+
+            const result = await importSelectedCodexSessions({
+                codexSessionIds: [codexSessionId],
+                store,
+                namespace: 'default',
+                getSyncEngine: () => engine
+            })
+
+            expect(result.success).toBe(true)
+            const session = store.sessions.getSessionsByNamespace('default')[0]
+            expect(session.metadata).toMatchObject({
+                path: '/home/user/workspace/project',
+                machineId: 'machine-1'
+            })
+        } finally {
+            store.close()
+            rmSync(codexHome, { recursive: true, force: true })
+        }
+    })
+
+    it('does not bind imported transcripts when multiple online machines own the cwd', async () => {
+        const codexHome = mkdtempSync(join(tmpdir(), 'hapi-codex-home-machine-ambiguous-test-'))
+        const store = new Store(':memory:')
+        const codexSessionId = '33333333-3333-4333-8333-333333333333'
+        process.env.CODEX_HOME = codexHome
+
+        try {
+            createTranscript(codexHome, codexSessionId, '/home/user/workspace/project')
+            const engine = createImportSyncEngine(store, [
+                createMachine('machine-1', ['/home/user/workspace']),
+                createMachine('machine-2', ['/home/user/workspace/project'])
+            ])
+
+            const result = await importSelectedCodexSessions({
+                codexSessionIds: [codexSessionId],
+                store,
+                namespace: 'default',
+                getSyncEngine: () => engine
+            })
+
+            expect(result.success).toBe(true)
+            const session = store.sessions.getSessionsByNamespace('default')[0]
+            expect(session.metadata).toMatchObject({
+                path: '/home/user/workspace/project'
+            })
+            expect(session.metadata).not.toHaveProperty('machineId')
+        } finally {
+            store.close()
+            rmSync(codexHome, { recursive: true, force: true })
+        }
+    })
+
+    it('does not bind imported transcripts when no online machine owns the cwd', async () => {
+        const codexHome = mkdtempSync(join(tmpdir(), 'hapi-codex-home-machine-miss-test-'))
+        const store = new Store(':memory:')
+        const codexSessionId = '44444444-4444-4444-8444-444444444444'
+        process.env.CODEX_HOME = codexHome
+
+        try {
+            createTranscript(codexHome, codexSessionId, '/home/user/workspace/project')
+            const engine = createImportSyncEngine(store, [
+                createMachine('machine-1', ['/home/user/other'])
+            ])
+
+            const result = await importSelectedCodexSessions({
+                codexSessionIds: [codexSessionId],
+                store,
+                namespace: 'default',
+                getSyncEngine: () => engine
+            })
+
+            expect(result.success).toBe(true)
+            const session = store.sessions.getSessionsByNamespace('default')[0]
+            expect(session.metadata).toMatchObject({
+                path: '/home/user/workspace/project'
+            })
+            expect(session.metadata).not.toHaveProperty('machineId')
+        } finally {
+            store.close()
+            rmSync(codexHome, { recursive: true, force: true })
+        }
+    })
+
+    it('keeps an existing machineId when updating an imported transcript', async () => {
+        const codexHome = mkdtempSync(join(tmpdir(), 'hapi-codex-home-machine-existing-test-'))
+        const store = new Store(':memory:')
+        const codexSessionId = '55555555-5555-4555-8555-555555555555'
+        process.env.CODEX_HOME = codexHome
+
+        try {
+            createTranscript(codexHome, codexSessionId, '/home/user/workspace/project')
+            store.sessions.getOrCreateSession(randomUUID(), {
+                path: '/home/user/workspace/project',
+                flavor: 'codex',
+                codexSessionId,
+                machineId: 'machine-existing'
+            }, {}, 'default')
+            const engine = createImportSyncEngine(store, [
+                createMachine('machine-new', ['/home/user/workspace'])
+            ])
+
+            const result = await importSelectedCodexSessions({
+                codexSessionIds: [codexSessionId],
+                store,
+                namespace: 'default',
+                getSyncEngine: () => engine
+            })
+
+            expect(result.success).toBe(true)
+            const session = store.sessions.getSessionsByNamespace('default')[0]
+            expect(session.metadata).toMatchObject({
+                path: '/home/user/workspace/project',
+                machineId: 'machine-existing'
             })
         } finally {
             store.close()

--- a/hub/src/web/routes/codexDesktop.ts
+++ b/hub/src/web/routes/codexDesktop.ts
@@ -5,7 +5,7 @@ import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { homedir, hostname, platform } from 'node:os'
 import { AGENT_MESSAGE_PAYLOAD_TYPE } from '@hapi/protocol'
 import { Hono } from 'hono'
-import type { SyncEngine } from '../../sync/syncEngine'
+import type { Machine, SyncEngine } from '../../sync/syncEngine'
 import type { Store, StoredMessage } from '../../store'
 import type { WebAppEnv } from '../middleware/auth'
 
@@ -672,15 +672,71 @@ function parseCodexTranscriptImportData(summary: CodexLocalSessionSummary): Code
     }
 }
 
+function normalizeComparablePath(pathValue: string, options?: { caseInsensitive?: boolean }): string {
+    let normalized = pathValue.trim().replace(/\\/g, '/').replace(/\/+/g, '/')
+    if (normalized.length > 1) {
+        normalized = normalized.replace(/\/+$/, '')
+    }
+    return options?.caseInsensitive ? normalized.toLowerCase() : normalized
+}
+
+function shouldCompareCaseInsensitive(...pathValues: string[]): boolean {
+    return pathValues.some((pathValue) => /^[a-z]:[\\/]/i.test(pathValue) || pathValue.includes('\\'))
+}
+
+function isPathInsideWorkspaceRoot(pathValue: string, rootValue: string): boolean {
+    if (!pathValue.trim() || !rootValue.trim()) {
+        return false
+    }
+
+    const caseInsensitive = shouldCompareCaseInsensitive(pathValue, rootValue)
+    const path = normalizeComparablePath(pathValue, { caseInsensitive })
+    const root = normalizeComparablePath(rootValue, { caseInsensitive })
+    if (!path || !root) {
+        return false
+    }
+    if (path === root) {
+        return true
+    }
+    if (root === '/') {
+        return path.startsWith('/')
+    }
+    return path.startsWith(`${root}/`)
+}
+
+function machineOwnsCodexCwd(machine: Machine, cwd: string): boolean {
+    const workspaceRoots = machine.metadata?.workspaceRoots ?? []
+    return workspaceRoots.some((workspaceRoot) => isPathInsideWorkspaceRoot(cwd, workspaceRoot))
+}
+
+function resolveImportMachineId(
+    cwd: string | null | undefined,
+    namespace: string,
+    engine: SyncEngine | null
+): string | undefined {
+    if (!cwd || !engine) {
+        return undefined
+    }
+
+    const matches = engine.getOnlineMachinesByNamespace(namespace)
+        .filter((machine) => machineOwnsCodexCwd(machine, cwd))
+    const machineIds = Array.from(new Set(matches.map((machine) => machine.id)))
+    return machineIds.length === 1 ? machineIds[0] : undefined
+}
+
 function buildImportedSessionMetadata(
     data: CodexTranscriptImportData,
-    existingMetadata?: Record<string, unknown> | null
+    existingMetadata?: Record<string, unknown> | null,
+    resolvedMachineId?: string
 ): Record<string, unknown> {
     const now = Date.now()
     const path = data.cwd ?? (typeof existingMetadata?.path === 'string' ? existingMetadata.path : dirname(data.file))
     const host = typeof existingMetadata?.host === 'string' ? existingMetadata.host : (process.env.HAPI_HOSTNAME || hostname())
     const osValue = typeof existingMetadata?.os === 'string' ? existingMetadata.os : platform()
     const summaryText = data.lastUserMessage ?? data.title
+    const machineId = typeof existingMetadata?.machineId === 'string'
+        ? existingMetadata.machineId
+        : resolvedMachineId
 
     return {
         ...(existingMetadata ?? {}),
@@ -696,6 +752,7 @@ function buildImportedSessionMetadata(
             : existingMetadata?.summary,
         flavor: 'codex',
         codexSessionId: data.id,
+        ...(machineId ? { machineId } : {}),
         lifecycleState: typeof existingMetadata?.lifecycleState === 'string'
             ? existingMetadata.lifecycleState
             : 'imported',
@@ -1484,7 +1541,11 @@ function importSingleCodexSession(options: {
         )
         const engine = options.getSyncEngine?.() ?? null
         const existingStored = target.sessionId ? options.store.sessions.getSessionByNamespace(target.sessionId, options.namespace) : null
-        const metadata = buildImportedSessionMetadata(transcript, asRecord(existingStored?.metadata))
+        const metadata = buildImportedSessionMetadata(
+            transcript,
+            asRecord(existingStored?.metadata),
+            resolveImportMachineId(transcript.cwd, options.namespace, engine)
+        )
 
         let sessionId = existingStored?.id ?? null
         let created = false


### PR DESCRIPTION
## Summary
- bind imported Codex transcripts to a HAPI machine when their `cwd` is covered by exactly one online machine workspace root
- preserve existing imported session `machineId` values and leave ambiguous/no-match imports unbound
- add Codex direct-import regression tests for unique, ambiguous, missing, and existing machine bindings

## Why
Direct Codex transcript import currently records `host`, `os`, and `path`, but not `machineId`. The web sidebar groups sessions by `metadata.machineId`, so imports from a connected runner can appear under the unknown machine group even when their `cwd` belongs to a known workspace root.

This keeps the inference conservative: only one matching online machine gets bound; ambiguous matches still stay unbound.

## Tests
- `npx --yes bun@1.3.14 test hub/src/web/routes/codexDesktop.test.ts`
- `npx --yes bun@1.3.14 run --cwd hub typecheck`
- `npx --yes bun@1.3.14 run --cwd hub test`
