### PR TITLE
fix(web): use button CSS variables for Retry button on error screen

### DIFF
--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -771,7 +771,7 @@ function SessionPage() {
                         <button
                             type="button"
                             onClick={() => { void refetchSession() }}
-                            className="rounded-md bg-[var(--app-link)] px-3 py-1.5 text-sm text-white"
+                            className="rounded-md bg-[var(--app-button)] px-3 py-1.5 text-sm text-[var(--app-button-text)]"
                         >
                             Retry
                         </button>


### PR DESCRIPTION
## Summary

The **Retry** button on the \"Session unavailable\" error screen is invisible in dark mode - white text on a white background.

Root cause: the button used `bg-[var(--app-link)]` for its background. In dark mode `--app-link` falls back to `#ffffff`. The text was hardcoded `text-white`, so white-on-white.

Fix: swap to `bg-[var(--app-button)]` + `text-[var(--app-button-text)]` - the CSS variables that already exist precisely for button contrast in both themes:

- Light: `--app-button: #111827` (dark bg) / `--app-button-text: #ffffff` (white text)
- Dark: `--app-button: #ffffff` (white bg) / `--app-button-text: #111827` (dark text)

One-line change in `web/src/router.tsx`.

## Test plan

- Trigger the \"Session unavailable\" error screen (e.g. HTTP 502 from the hub)
- Confirm Retry button is readable in both light and dark mode (including Telegram theme overrides)

Made with [Cursor](https://cursor.com)