### PR TITLE
feat: silent in-place patch loop for mermaid render failures + GFM table repair

### DIFF
--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -163,6 +163,7 @@ export class ApiSessionClient extends EventEmitter {
     private pendingMessages: { message: UserMessage; localId?: string }[] = []
     private pendingMessageCallback: ((message: UserMessage, localId?: string) => void) | null = null
     private cancelQueuedMessageCallback: ((localId: string) => boolean) | null = null
+    private patchPromptCallback: ((payload: { msgId: string; blockIndex: number; type: 'mermaid' | 'table'; failedCode: string }) => void) | null = null
     private readonly incomingFilter = new IncomingMessageFilter()
     private backfillInFlight: Promise<void> | null = null
     private needsBackfill = false
@@ -332,7 +333,25 @@ export class ApiSessionClient extends EventEmitter {
             }
         })
 
+        this.socket.on('patch-prompt', (data: { msgId: string; blockIndex: number; type: 'mermaid' | 'table'; failedCode: string }) => {
+            if (!data || typeof data.msgId !== 'string' || typeof data.blockIndex !== 'number') {
+                return
+            }
+            this.patchPromptCallback?.(data)
+        })
+
         this.socket.connect()
+    }
+
+    onPatchPrompt(callback: (payload: { msgId: string; blockIndex: number; type: 'mermaid' | 'table'; failedCode: string }) => void): void {
+        this.patchPromptCallback = callback
+    }
+
+    sendPatchResponse(payload: { msgId: string; blockIndex: number; correctedCode: string }): void {
+        this.socket.emit('patch-response', {
+            sid: this.sessionId,
+            ...payload
+        })
     }
 
     onUserMessage(callback: (data: UserMessage, localId?: string) => void): void {

--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -22,6 +22,7 @@ import { formatMessageWithAttachments } from '@/utils/attachmentFormatter';
 import { normalizeClaudeSessionModel } from './model';
 import { normalizeClaudeSessionEffort } from './effort';
 import { getInvokedCwd } from '@/utils/invokedCwd';
+import { registerPatchHandler } from '@/claude/utils/patchHandler';
 
 export interface StartOptions {
     model?: string
@@ -353,6 +354,14 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
         const removed = messageQueue.cancelByLocalId(localId);
         logger.debug(`[claude] cancelByLocalId(${localId}): ${removed ? 'removed' : 'not found (best-effort)'}`);
         return removed;
+    });
+
+    // Register silent in-place patch handler for mermaid/table render failures.
+    registerPatchHandler(session, {
+        cwd: workingDirectory,
+        model: currentModel ?? null,
+        claudeEnvVars: options.claudeEnvVars,
+        claudeArgs: options.claudeArgs
     });
 
     const resolvePermissionMode = (value: unknown): PermissionMode => {

--- a/cli/src/claude/utils/patchHandler.ts
+++ b/cli/src/claude/utils/patchHandler.ts
@@ -9,8 +9,13 @@
  */
 
 import { query } from '@/claude/sdk/query'
+import type { SDKUserMessage } from '@/claude/sdk'
 import { logger } from '@/ui/logger'
 import type { ApiSessionClient } from '@/api/apiSession'
+
+async function* singleTurnPrompt(text: string): AsyncGenerator<SDKUserMessage> {
+    yield { type: 'user', message: { role: 'user', content: text } } as SDKUserMessage
+}
 
 const MERMAID_PROMPT = (failedCode: string) =>
     `The following mermaid block failed to render. Return ONLY the corrected mermaid block enclosed in a fenced \`\`\`mermaid ... \`\`\` code fence. Do not include any prose or explanation.\n\n\`\`\`mermaid\n${failedCode}\n\`\`\``
@@ -53,13 +58,13 @@ export function registerPatchHandler(
 
         try {
             const q = query({
-                prompt,
+                prompt: singleTurnPrompt(prompt),
                 options: {
                     cwd: config.cwd,
                     maxTurns: 1,
-                    allowedTools: [],
                     model: config.model ?? undefined,
-                    permissionMode: 'bypassPermissions'
+                    permissionMode: 'default',
+                    canCallTool: async () => ({ behavior: 'deny', message: 'Patch repair runs without tools' })
                 }
             })
 

--- a/cli/src/claude/utils/patchHandler.ts
+++ b/cli/src/claude/utils/patchHandler.ts
@@ -1,0 +1,104 @@
+/**
+ * Silent in-place patch handler for mermaid / markdown-table render failures.
+ *
+ * When the web client detects a broken code block it fires a patch-request to
+ * the hub, which forwards a patch-prompt to the CLI over the socket.  This
+ * module handles that event by making a *silent* single-turn call to the
+ * underlying Claude agent (no conversation history side-effects) and returning
+ * the corrected block via patch-response.
+ */
+
+import { query } from '@/claude/sdk/query'
+import { logger } from '@/ui/logger'
+import type { ApiSessionClient } from '@/api/apiSession'
+
+const MERMAID_PROMPT = (failedCode: string) =>
+    `The following mermaid block failed to render. Return ONLY the corrected mermaid block enclosed in a fenced \`\`\`mermaid ... \`\`\` code fence. Do not include any prose or explanation.\n\n\`\`\`mermaid\n${failedCode}\n\`\`\``
+
+const TABLE_PROMPT = (failedCode: string) =>
+    `The following markdown table failed to render. Return ONLY the corrected table in valid GFM markdown format. Do not include any prose or explanation.\n\n${failedCode}`
+
+/**
+ * Extract the first fenced code block matching the given language tag, or the
+ * entire text if no fence is found.
+ */
+function extractFirstBlock(text: string, lang?: string): string {
+    const fence = lang ? new RegExp('```' + lang + '\\s*\\n([\\s\\S]*?)\\n```', 'i') : /```[^\n]*\n([\s\S]*?)\n```/
+    const match = text.match(fence)
+    if (match) {
+        return match[1].trim()
+    }
+    // Fallback: strip any leading/trailing fences and return
+    return text.replace(/^```[^\n]*\n?/, '').replace(/\n?```$/, '').trim()
+}
+
+export interface PatchHandlerConfig {
+    cwd: string
+    model?: string | null
+    claudeEnvVars?: Record<string, string>
+    claudeArgs?: string[]
+}
+
+export function registerPatchHandler(
+    session: ApiSessionClient,
+    config: PatchHandlerConfig
+): void {
+    session.onPatchPrompt(async (payload) => {
+        const { msgId, blockIndex, type, failedCode } = payload
+        logger.debug(`[patch] received patch-prompt: msgId=${msgId} blockIndex=${blockIndex} type=${type}`)
+
+        const prompt = type === 'mermaid'
+            ? MERMAID_PROMPT(failedCode)
+            : TABLE_PROMPT(failedCode)
+
+        try {
+            const q = query({
+                prompt,
+                options: {
+                    cwd: config.cwd,
+                    maxTurns: 1,
+                    allowedTools: [],
+                    model: config.model ?? undefined,
+                    permissionMode: 'bypassPermissions'
+                }
+            })
+
+            let correctedCode = ''
+
+            for await (const message of q) {
+                if (message.type === 'assistant') {
+                    const msg = message as { message?: { content?: unknown[] } }
+                    if (Array.isArray(msg.message?.content)) {
+                        for (const block of msg.message.content) {
+                            const b = block as { type?: string; text?: string }
+                            if (b.type === 'text' && typeof b.text === 'string') {
+                                correctedCode += b.text
+                            }
+                        }
+                    }
+                }
+            }
+
+            correctedCode = correctedCode.trim()
+            if (!correctedCode) {
+                logger.debug(`[patch] empty response from agent, skipping patch-response`)
+                return
+            }
+
+            // Extract only the code block (strip prose / fences)
+            const extracted = type === 'mermaid'
+                ? extractFirstBlock(correctedCode, 'mermaid')
+                : extractFirstBlock(correctedCode)
+
+            if (!extracted) {
+                logger.debug(`[patch] could not extract corrected block, skipping`)
+                return
+            }
+
+            logger.debug(`[patch] sending patch-response for msgId=${msgId} blockIndex=${blockIndex}`)
+            session.sendPatchResponse({ msgId, blockIndex, correctedCode: extracted })
+        } catch (err) {
+            logger.debug(`[patch] agent call failed: ${err instanceof Error ? err.message : String(err)}`)
+        }
+    })
+}

--- a/hub/src/socket/handlers/cli/index.ts
+++ b/hub/src/socket/handlers/cli/index.ts
@@ -45,10 +45,11 @@ export type CliHandlersDeps = {
     onSessionActivity?: (sessionId: string, updatedAt: number) => void
     onSweepImmediateQueued?: (sessionId: string, now: number) => void
     onMessagesConsumed?: (sessionId: string) => void
+    onPatchResponse?: (sessionId: string, payload: { msgId: string; blockIndex: number; correctedCode: string }) => void
 }
 
 export function registerCliHandlers(socket: CliSocketWithData, deps: CliHandlersDeps): void {
-    const { io, store, rpcRegistry, terminalRegistry, onSessionAlive, onSessionEnd, onMachineAlive, onWebappEvent, onBackgroundTaskDelta, onSessionActivity, onSweepImmediateQueued, onMessagesConsumed } = deps
+    const { io, store, rpcRegistry, terminalRegistry, onSessionAlive, onSessionEnd, onMachineAlive, onWebappEvent, onBackgroundTaskDelta, onSessionActivity, onSweepImmediateQueued, onMessagesConsumed, onPatchResponse } = deps
     const terminalNamespace = io.of('/terminal')
     const namespace = typeof socket.data.namespace === 'string' ? socket.data.namespace : null
 
@@ -111,7 +112,8 @@ export function registerCliHandlers(socket: CliSocketWithData, deps: CliHandlers
         onBackgroundTaskDelta,
         onSessionActivity,
         onSweepImmediateQueued,
-        onMessagesConsumed
+        onMessagesConsumed,
+        onPatchResponse
     })
     registerMachineHandlers(socket, {
         store,

--- a/hub/src/socket/handlers/cli/sessionHandlers.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.ts
@@ -70,10 +70,19 @@ export type SessionHandlersDeps = {
     /** Drops the queued-thinking grace so synchronous CLI handlers (e.g. slash
      *  commands) don't leave the spinner stuck for the full grace window. */
     onMessagesConsumed?: (sessionId: string) => void
+    /** Called when the CLI sends back a corrected code block for in-place patching. */
+    onPatchResponse?: (sessionId: string, payload: { msgId: string; blockIndex: number; correctedCode: string }) => void
 }
 
+const patchResponseSchema = z.object({
+    sid: z.string(),
+    msgId: z.string().min(1),
+    blockIndex: z.number().int().nonnegative(),
+    correctedCode: z.string()
+})
+
 export function registerSessionHandlers(socket: CliSocketWithData, deps: SessionHandlersDeps): void {
-    const { store, resolveSessionAccess, emitAccessError, onSessionAlive, onSessionEnd, onWebappEvent, onBackgroundTaskDelta, onSessionActivity, onSweepImmediateQueued, onMessagesConsumed } = deps
+    const { store, resolveSessionAccess, emitAccessError, onSessionAlive, onSessionEnd, onWebappEvent, onBackgroundTaskDelta, onSessionActivity, onSweepImmediateQueued, onMessagesConsumed, onPatchResponse } = deps
 
     socket.on('message', (data: unknown) => {
         const parsed = messageSchema.safeParse(data)
@@ -342,5 +351,21 @@ export function registerSessionHandlers(socket: CliSocketWithData, deps: Session
         }
 
         onSessionEnd?.(data)
+    })
+
+    socket.on('patch-response', (data: unknown) => {
+        const parsed = patchResponseSchema.safeParse(data)
+        if (!parsed.success) {
+            return
+        }
+        const sessionAccess = resolveSessionAccess(parsed.data.sid)
+        if (!sessionAccess.ok) {
+            return
+        }
+        onPatchResponse?.(parsed.data.sid, {
+            msgId: parsed.data.msgId,
+            blockIndex: parsed.data.blockIndex,
+            correctedCode: parsed.data.correctedCode
+        })
     })
 }

--- a/hub/src/socket/server.ts
+++ b/hub/src/socket/server.ts
@@ -43,6 +43,7 @@ export type SocketServerDeps = {
     onSessionActivity?: (sessionId: string, updatedAt: number) => void
     onSweepImmediateQueued?: (sessionId: string, now: number) => void
     onMessagesConsumed?: (sessionId: string) => void
+    onPatchResponse?: (sessionId: string, payload: { msgId: string; blockIndex: number; correctedCode: string }) => void
 }
 
 export function createSocketServer(deps: SocketServerDeps): {
@@ -122,7 +123,8 @@ export function createSocketServer(deps: SocketServerDeps): {
         onBackgroundTaskDelta: deps.onBackgroundTaskDelta,
         onSessionActivity: deps.onSessionActivity,
         onSweepImmediateQueued: deps.onSweepImmediateQueued,
-        onMessagesConsumed: deps.onMessagesConsumed
+        onMessagesConsumed: deps.onMessagesConsumed,
+        onPatchResponse: deps.onPatchResponse
     }))
 
     terminalNs.use(async (socket, next) => {

--- a/hub/src/startHub.ts
+++ b/hub/src/startHub.ts
@@ -190,7 +190,8 @@ export async function startHub(options: StartHubOptions = {}): Promise<HubInstan
         onBackgroundTaskDelta: (sessionId, delta) => syncEngine?.handleBackgroundTaskDelta(sessionId, delta),
         onSessionActivity: (sessionId, updatedAt) => syncEngine?.recordSessionActivity(sessionId, updatedAt),
         onSweepImmediateQueued: (sessionId, now) => syncEngine?.sweepImmediateQueuedOnSessionEnd(sessionId, now),
-        onMessagesConsumed: (sessionId) => syncEngine?.clearQueuedThinkingGrace(sessionId)
+        onMessagesConsumed: (sessionId) => syncEngine?.clearQueuedThinkingGrace(sessionId),
+        onPatchResponse: (sessionId, payload) => syncEngine?.resolvePatch(sessionId, payload)
     })
 
     syncEngine = new SyncEngine(store, socketServer.io, socketServer.rpcRegistry, sseManager)

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -135,7 +135,7 @@ export class SyncEngine {
     private readonly io: Server
     private inactivityTimer: NodeJS.Timeout | null = null
     /** Dedup set keyed by `${sessionId}:${msgId}:${blockIndex}` — prevents duplicate patch-prompt emissions. */
-    private readonly pendingPatches: Map<string, { retries: number; timerId: ReturnType<typeof setTimeout> }> = new Map()
+    private readonly pendingPatches: Map<string, { timerId: ReturnType<typeof setTimeout> }> = new Map()
     private static readonly PATCH_TIMEOUT_MS = 30_000
 
     constructor(
@@ -401,23 +401,20 @@ export class SyncEngine {
     /**
      * Route a patch request from a web client to the active CLI for a session.
      * Returns 'sent' if the patch-prompt was emitted, 'duplicate' if a patch is
-     * already in flight for this msgId+blockIndex, 'too-many-retries' if the cap
-     * was exceeded, or 'no-cli' if no CLI socket is connected.
+     * already in flight for this msgId+blockIndex, or 'no-cli' if no CLI socket
+     * is connected.
      */
     requestPatch(
         sessionId: string,
         namespace: string,
         payload: { msgId: string; blockIndex: number; type: 'mermaid' | 'table'; failedCode: string }
-    ): 'sent' | 'duplicate' | 'too-many-retries' | 'no-cli' {
+    ): 'sent' | 'duplicate' | 'no-cli' {
         const key = `${sessionId}:${payload.msgId}:${payload.blockIndex}`
         const roomName = `session:${sessionId}`
-        const existing = this.pendingPatches.get(key)
-        if (existing) {
-            if (existing.retries >= 2) {
-                return 'too-many-retries'
-            }
-            existing.retries++
-        } else {
+        if (this.pendingPatches.has(key)) {
+            return 'duplicate'
+        }
+        {
             // Verify a CLI socket is actually connected — session cache alone can
             // lag behind disconnects, causing the web client to hang needlessly.
             if (!this.sessionCache.getSessionByNamespace(sessionId, namespace)) {
@@ -428,7 +425,7 @@ export class SyncEngine {
                 return 'no-cli'
             }
             const timerId = setTimeout(() => this.pendingPatches.delete(key), SyncEngine.PATCH_TIMEOUT_MS)
-            this.pendingPatches.set(key, { retries: 1, timerId })
+            this.pendingPatches.set(key, { timerId })
         }
 
         const room = this.io.of('/cli').to(roomName)

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -132,7 +132,11 @@ export class SyncEngine {
     private readonly machineCache: MachineCache
     private readonly messageService: MessageService
     private readonly rpcGateway: RpcGateway
+    private readonly io: Server
     private inactivityTimer: NodeJS.Timeout | null = null
+    /** Dedup set keyed by `${sessionId}:${msgId}:${blockIndex}` — prevents duplicate patch-prompt emissions. */
+    private readonly pendingPatches: Map<string, { retries: number; timerId: ReturnType<typeof setTimeout> }> = new Map()
+    private static readonly PATCH_TIMEOUT_MS = 30_000
 
     constructor(
         private readonly store: Store,
@@ -140,6 +144,7 @@ export class SyncEngine {
         rpcRegistry: RpcRegistry,
         sseManager: SSEManager
     ) {
+        this.io = io
         this.eventPublisher = new EventPublisher(sseManager, (event) => this.resolveNamespace(event))
         this.sessionCache = new SessionCache(store, this.eventPublisher)
         this.machineCache = new MachineCache(store, this.eventPublisher)
@@ -391,6 +396,65 @@ export class SyncEngine {
         await this.messageService.sendMessage(sessionId, payload)
         this.sessionCache.markMessageQueued(sessionId)
         this.sessionCache.recordSessionActivity(sessionId, Date.now())
+    }
+
+    /**
+     * Route a patch request from a web client to the active CLI for a session.
+     * Returns 'sent' if the patch-prompt was emitted, 'duplicate' if a patch is
+     * already in flight for this msgId+blockIndex, 'too-many-retries' if the cap
+     * was exceeded, or 'no-cli' if no CLI socket is connected.
+     */
+    requestPatch(
+        sessionId: string,
+        namespace: string,
+        payload: { msgId: string; blockIndex: number; type: 'mermaid' | 'table'; failedCode: string }
+    ): 'sent' | 'duplicate' | 'too-many-retries' | 'no-cli' {
+        const key = `${sessionId}:${payload.msgId}:${payload.blockIndex}`
+        const existing = this.pendingPatches.get(key)
+        if (existing) {
+            if (existing.retries >= 2) {
+                return 'too-many-retries'
+            }
+            // Allow a second attempt (retry) but not more
+            existing.retries++
+        } else {
+            const session = this.sessionCache.getSessionByNamespace(sessionId, namespace)
+            if (!session) {
+                return 'no-cli'
+            }
+            const timerId = setTimeout(() => this.pendingPatches.delete(key), SyncEngine.PATCH_TIMEOUT_MS)
+            this.pendingPatches.set(key, { retries: 1, timerId })
+        }
+
+        const room = this.io.of('/cli').to(`session:${sessionId}`)
+        room.emit('patch-prompt', payload)
+        return 'sent'
+    }
+
+    /**
+     * Called by the CLI `patch-response` handler.  Broadcasts `message-patched`
+     * to all web SSE subscribers and clears the dedup entry.
+     */
+    resolvePatch(
+        sessionId: string,
+        payload: { msgId: string; blockIndex: number; correctedCode: string }
+    ): void {
+        const key = `${sessionId}:${payload.msgId}:${payload.blockIndex}`
+        const entry = this.pendingPatches.get(key)
+        if (entry) {
+            clearTimeout(entry.timerId)
+        }
+        this.pendingPatches.delete(key)
+
+        const session = this.sessionCache.getSession(sessionId)
+        this.eventPublisher.emit({
+            type: 'message-patched',
+            sessionId,
+            namespace: session?.namespace,
+            msgId: payload.msgId,
+            blockIndex: payload.blockIndex,
+            correctedCode: payload.correctedCode
+        })
     }
 
     async cancelQueuedMessage(

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -410,23 +410,28 @@ export class SyncEngine {
         payload: { msgId: string; blockIndex: number; type: 'mermaid' | 'table'; failedCode: string }
     ): 'sent' | 'duplicate' | 'too-many-retries' | 'no-cli' {
         const key = `${sessionId}:${payload.msgId}:${payload.blockIndex}`
+        const roomName = `session:${sessionId}`
         const existing = this.pendingPatches.get(key)
         if (existing) {
             if (existing.retries >= 2) {
                 return 'too-many-retries'
             }
-            // Allow a second attempt (retry) but not more
             existing.retries++
         } else {
-            const session = this.sessionCache.getSessionByNamespace(sessionId, namespace)
-            if (!session) {
+            // Verify a CLI socket is actually connected — session cache alone can
+            // lag behind disconnects, causing the web client to hang needlessly.
+            if (!this.sessionCache.getSessionByNamespace(sessionId, namespace)) {
+                return 'no-cli'
+            }
+            const sockets = this.io.of('/cli').adapter.rooms.get(roomName)
+            if (!sockets || sockets.size === 0) {
                 return 'no-cli'
             }
             const timerId = setTimeout(() => this.pendingPatches.delete(key), SyncEngine.PATCH_TIMEOUT_MS)
             this.pendingPatches.set(key, { retries: 1, timerId })
         }
 
-        const room = this.io.of('/cli').to(`session:${sessionId}`)
+        const room = this.io.of('/cli').to(roomName)
         room.emit('patch-prompt', payload)
         return 'sent'
     }

--- a/hub/src/web/routes/messages.ts
+++ b/hub/src/web/routes/messages.ts
@@ -5,11 +5,13 @@ import type { SyncEngine } from '../../sync/syncEngine'
 import type { WebAppEnv } from '../middleware/auth'
 import { requireSessionFromParam, requireSyncEngine } from './guards'
 
+const MAX_PATCH_CODE_CHARS = 16_000
+
 const PatchRequestBodySchema = z.object({
     msgId: z.string().min(1),
     blockIndex: z.number().int().nonnegative(),
     type: z.enum(['mermaid', 'table']),
-    failedCode: z.string()
+    failedCode: z.string().min(1).max(MAX_PATCH_CODE_CHARS)
 })
 
 export function createMessagesRoutes(getSyncEngine: () => SyncEngine | null): Hono<WebAppEnv> {
@@ -112,10 +114,7 @@ export function createMessagesRoutes(getSyncEngine: () => SyncEngine | null): Ho
         if (result === 'no-cli') {
             return c.json({ error: 'No active CLI connected' }, 503)
         }
-        if (result === 'too-many-retries') {
-            return c.json({ error: 'Patch retry limit reached' }, 429)
-        }
-        // 'sent' or 'duplicate' — both OK from web's perspective
+        // 'sent' or 'duplicate' — both are 200; web only needs the status for diagnostics
         return c.json({ ok: true, status: result })
     })
 

--- a/hub/src/web/routes/messages.ts
+++ b/hub/src/web/routes/messages.ts
@@ -1,8 +1,16 @@
 import { Hono } from 'hono'
+import { z } from 'zod'
 import { MessagesQuerySchema, SendMessageRequestSchema } from '@hapi/protocol'
 import type { SyncEngine } from '../../sync/syncEngine'
 import type { WebAppEnv } from '../middleware/auth'
 import { requireSessionFromParam, requireSyncEngine } from './guards'
+
+const PatchRequestBodySchema = z.object({
+    msgId: z.string().min(1),
+    blockIndex: z.number().int().nonnegative(),
+    type: z.enum(['mermaid', 'table']),
+    failedCode: z.string()
+})
 
 export function createMessagesRoutes(getSyncEngine: () => SyncEngine | null): Hono<WebAppEnv> {
     const app = new Hono<WebAppEnv>()
@@ -79,6 +87,36 @@ export function createMessagesRoutes(getSyncEngine: () => SyncEngine | null): Ho
             scheduledAt: parsed.data.scheduledAt
         })
         return c.json({ ok: true })
+    })
+
+    app.post('/sessions/:id/patch-request', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+        const { sessionId } = sessionResult
+        const namespace = c.get('namespace')
+
+        const body = await c.req.json().catch(() => null)
+        const parsed = PatchRequestBodySchema.safeParse(body)
+        if (!parsed.success) {
+            return c.json({ error: 'Invalid body', issues: parsed.error.flatten() }, 400)
+        }
+
+        const result = engine.requestPatch(sessionId, namespace, parsed.data)
+        if (result === 'no-cli') {
+            return c.json({ error: 'No active CLI connected' }, 503)
+        }
+        if (result === 'too-many-retries') {
+            return c.json({ error: 'Patch retry limit reached' }, 429)
+        }
+        // 'sent' or 'duplicate' — both OK from web's perspective
+        return c.json({ ok: true, status: result })
     })
 
     return app

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -370,6 +370,12 @@ export const SyncEventSchema = z.discriminatedUnion('type', [
             status: z.string(),
             subscriptionId: z.string().optional()
         }).optional()
+    }),
+    SessionChangedSchema.extend({
+        type: z.literal('message-patched'),
+        msgId: z.string(),
+        blockIndex: z.number().int().nonnegative(),
+        correctedCode: z.string()
     })
 ])
 

--- a/shared/src/socket.ts
+++ b/shared/src/socket.ts
@@ -197,6 +197,7 @@ export interface ServerToClientEvents {
     'terminal:resize': (data: TerminalResizePayload) => void
     'terminal:close': (data: TerminalClosePayload) => void
     error: (data: { message: string; code?: SocketErrorReason; scope?: 'session' | 'machine'; id?: string }) => void
+    'patch-prompt': (data: { msgId: string; blockIndex: number; type: 'mermaid' | 'table'; failedCode: string }) => void
 }
 
 export interface ClientToServerEvents {
@@ -227,4 +228,5 @@ export interface ClientToServerEvents {
     'terminal:error': (data: TerminalErrorPayload) => void
     ping: (callback: () => void) => void
     'usage-report': (data: unknown) => void
+    'patch-response': (data: { sid: string; msgId: string; blockIndex: number; correctedCode: string }) => void
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import { useVisibilityReporter } from '@/hooks/useVisibilityReporter'
 import { queryKeys } from '@/lib/query-keys'
 import { AppContextProvider } from '@/lib/app-context'
 import { clearMessageWindow, fetchLatestMessages } from '@/lib/message-window-store'
+import { emitPatch } from '@/lib/patch-emitter'
 import { useAppGoBack } from '@/hooks/useAppGoBack'
 import { useTranslation } from '@/lib/use-translation'
 import { VoiceProvider } from '@/lib/voice-context'
@@ -233,6 +234,15 @@ function AppInner() {
     }, [])
 
     const handleSseEvent = useCallback((event: SyncEvent) => {
+        if (event.type === 'message-patched') {
+            emitPatch({
+                sessionId: event.sessionId,
+                msgId: event.msgId,
+                blockIndex: event.blockIndex,
+                correctedCode: event.correctedCode
+            })
+            return
+        }
         if (event.type !== 'messages-invalidated') {
             return
         }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -726,4 +726,18 @@ export class ApiClient {
             body: JSON.stringify({})
         })
     }
+
+    /**
+     * Notify the hub that a code block failed to render so the CLI agent can
+     * return a corrected version.  Silently ignores errors (fire-and-forget).
+     */
+    async sendPatchRequest(
+        sessionId: string,
+        payload: { msgId: string; blockIndex: number; type: 'mermaid' | 'table'; failedCode: string }
+    ): Promise<void> {
+        await this.request(`/api/sessions/${encodeURIComponent(sessionId)}/patch-request`, {
+            method: 'POST',
+            body: JSON.stringify(payload)
+        })
+    }
 }

--- a/web/src/components/assistant-ui/markdown-text.tsx
+++ b/web/src/components/assistant-ui/markdown-text.tsx
@@ -13,6 +13,7 @@ import remarkBreaks from 'remark-breaks'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import remarkDisableIndentedCode from '@/lib/remark-disable-indented-code'
+import remarkRepairTables from '@/lib/remark-repair-tables'
 import { useNavigate } from '@tanstack/react-router'
 import remarkStripCjkAutolink from '@/lib/remark-strip-cjk-autolink'
 import remarkNonHttpsAutolink from '@/lib/remark-non-https-autolink'
@@ -28,7 +29,10 @@ import { UriConfirmDialog } from '@/components/UriConfirmDialog'
 import type { MarkdownTextPrimitiveProps } from '@assistant-ui/react-markdown'
 
 // ── Plugin array ────────────────────────────────────────────────────────────
-// Order: remarkGfm → remarkNonHttpsAutolink → remarkStripCjkAutolink → remarkMath → remarkDisableIndentedCode → remarkFilePathLinks
+// Order: remarkGfm → remarkRepairTables → remarkNonHttpsAutolink → remarkStripCjkAutolink → remarkMath → remarkDisableIndentedCode → remarkFilePathLinks
+// remarkRepairTables must run immediately after remarkGfm — it uses the parsed
+// table nodes plus file.value position data to detect and repair off-by-one
+// separator rows before other transforms run.
 // remarkNonHttpsAutolink must run BEFORE remarkStripCjkAutolink so that the
 // CJK strip plugin sees the new link nodes and can trim trailing CJK punctuation
 // from them. Both must come before remarkMath (to avoid treating TeX as URI).
@@ -51,6 +55,7 @@ const MARKDOWN_PLUGIN_TAIL = [
 
 export const MARKDOWN_PLUGINS = [
     remarkGfm,
+    remarkRepairTables,
     ...MARKDOWN_PLUGIN_TAIL,
 ] satisfies NonNullable<MarkdownTextPrimitiveProps['remarkPlugins']>
 
@@ -58,6 +63,7 @@ export const MARKDOWN_PLUGINS = [
 // changing assistant/tool markdown behavior globally.
 export const MARKDOWN_PLUGINS_WITH_BREAKS = [
     remarkGfm,
+    remarkRepairTables,
     remarkBreaks,
     ...MARKDOWN_PLUGIN_TAIL,
 ] satisfies NonNullable<MarkdownTextPrimitiveProps['remarkPlugins']>

--- a/web/src/components/assistant-ui/mermaid-diagram.test.tsx
+++ b/web/src/components/assistant-ui/mermaid-diagram.test.tsx
@@ -17,6 +17,16 @@ vi.mock('mermaid', () => ({
     }
 }))
 
+vi.mock('@assistant-ui/react', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@assistant-ui/react')>()
+    return {
+        ...actual,
+        useAssistantState: vi.fn(<T,>(selector: (s: { message: { id: string } }) => T) =>
+            selector({ message: { id: 'test-msg-id' } })
+        ),
+    }
+})
+
 import { MermaidDiagram } from '@/components/assistant-ui/mermaid-diagram'
 import { MARKDOWN_COMPONENTS_BY_LANGUAGE } from '@/components/assistant-ui/markdown-text'
 

--- a/web/src/components/assistant-ui/mermaid-diagram.tsx
+++ b/web/src/components/assistant-ui/mermaid-diagram.tsx
@@ -137,6 +137,7 @@ function MermaidPatchingPlaceholder() {
 // ── Main component ───────────────────────────────────────────────────────────
 
 const MAX_PATCH_RETRIES = 2
+const MAX_PATCH_CODE_CHARS = 16_000
 
 export function MermaidDiagram(props: SyntaxHighlighterProps) {
     const [theme, setTheme] = useState<'light' | 'dark'>(() => resolveTheme())
@@ -195,7 +196,7 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
         const handleRenderFailure = () => {
             if (cancelled) return
             const currentChat = chatRef.current
-            if (!canPatch || !currentChat || patchRetriesRef.current >= MAX_PATCH_RETRIES) {
+            if (!canPatch || !currentChat || renderCode.length > MAX_PATCH_CODE_CHARS || patchRetriesRef.current >= MAX_PATCH_RETRIES) {
                 setSvg(null)
                 setStatus('error')
                 return

--- a/web/src/components/assistant-ui/mermaid-diagram.tsx
+++ b/web/src/components/assistant-ui/mermaid-diagram.tsx
@@ -1,6 +1,17 @@
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-markdown'
 import { useAssistantState } from '@assistant-ui/react'
 import { useEffect, useId, useRef, useState, type ComponentPropsWithoutRef } from 'react'
+
+// useAssistantState throws when rendered outside an AssistantRuntimeProvider
+// (e.g. MarkdownRenderer in tool cards / request footers). Return null there.
+function useOptionalMessageId(): string | null {
+    try {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        return useAssistantState(({ message }) => message.id)
+    } catch {
+        return null
+    }
+}
 import { cn } from '@/lib/utils'
 import { useOptionalHappyChatContext } from '@/components/AssistantChat/context'
 import { subscribePatch } from '@/lib/patch-emitter'
@@ -142,11 +153,15 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
 
     const id = useId().replace(/:/g, '-')
 
-    // Stable blockIndex claimed once per instance
-    const msgId = useAssistantState(({ message }) => message.id)
+    // Stable blockIndex claimed once per instance.
+    // msgId is null when rendering outside an assistant message (tool cards, etc.)
+    // — in that case the patch loop is disabled and we fall back to error display.
+    const msgId = useOptionalMessageId()
+    const canPatch = msgId !== null
+    const blockKey = msgId ?? `standalone:${id}`
     const blockIndexRef = useRef<number | null>(null)
     if (blockIndexRef.current === null) {
-        blockIndexRef.current = claimBlockIndex(msgId)
+        blockIndexRef.current = claimBlockIndex(blockKey)
     }
     const blockIndex = blockIndexRef.current
 
@@ -179,7 +194,7 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
         const handleRenderFailure = () => {
             if (cancelled) return
             const currentChat = chatRef.current
-            if (!currentChat || patchRetriesRef.current >= MAX_PATCH_RETRIES) {
+            if (!canPatch || !currentChat || patchRetriesRef.current >= MAX_PATCH_RETRIES) {
                 setSvg(null)
                 setStatus('error')
                 return
@@ -188,7 +203,7 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
             setStatus('patching')
             setSvg(null)
             void currentChat.api.sendPatchRequest(currentChat.sessionId, {
-                msgId,
+                msgId: msgId!,
                 blockIndex,
                 type: 'mermaid',
                 failedCode: renderCode
@@ -232,7 +247,7 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
     // Subscribe to message-patched events. Also set a 15s fallback so the
     // component never hangs in 'patching' forever (e.g. CLI crash, lost response).
     useEffect(() => {
-        if (status !== 'patching') return undefined
+        if (status !== 'patching' || !msgId) return undefined
 
         const timer = setTimeout(() => setStatus('error'), 15_000)
 

--- a/web/src/components/assistant-ui/mermaid-diagram.tsx
+++ b/web/src/components/assistant-ui/mermaid-diagram.tsx
@@ -157,7 +157,9 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
     // msgId is null when rendering outside an assistant message (tool cards, etc.)
     // — in that case the patch loop is disabled and we fall back to error display.
     const msgId = useOptionalMessageId()
-    const canPatch = msgId !== null
+    const chat = useOptionalHappyChatContext()
+    // Only Claude sessions have a registered patch handler on the CLI side.
+    const canPatch = msgId !== null && chat?.metadata?.flavor === 'claude'
     const blockKey = msgId ?? `standalone:${id}`
     const blockIndexRef = useRef<number | null>(null)
     if (blockIndexRef.current === null) {
@@ -165,7 +167,6 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
     }
     const blockIndex = blockIndexRef.current
 
-    const chat = useOptionalHappyChatContext()
     const chatRef = useRef(chat)
     chatRef.current = chat
     const patchRetriesRef = useRef(0)

--- a/web/src/components/assistant-ui/mermaid-diagram.tsx
+++ b/web/src/components/assistant-ui/mermaid-diagram.tsx
@@ -151,6 +151,8 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
     const blockIndex = blockIndexRef.current
 
     const chat = useOptionalHappyChatContext()
+    const chatRef = useRef(chat)
+    chatRef.current = chat
     const patchRetriesRef = useRef(0)
 
     // Theme observer
@@ -176,7 +178,8 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
 
         const handleRenderFailure = () => {
             if (cancelled) return
-            if (!chat || patchRetriesRef.current >= MAX_PATCH_RETRIES) {
+            const currentChat = chatRef.current
+            if (!currentChat || patchRetriesRef.current >= MAX_PATCH_RETRIES) {
                 setSvg(null)
                 setStatus('error')
                 return
@@ -184,7 +187,7 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
             patchRetriesRef.current += 1
             setStatus('patching')
             setSvg(null)
-            void chat.api.sendPatchRequest(chat.sessionId, {
+            void currentChat.api.sendPatchRequest(currentChat.sessionId, {
                 msgId,
                 blockIndex,
                 type: 'mermaid',
@@ -224,7 +227,7 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
         return () => {
             cancelled = true
         }
-    }, [id, renderCode, theme, chat, msgId, blockIndex])
+    }, [id, renderCode, theme, msgId, blockIndex])
 
     // Subscribe to message-patched events. Also set a 15s fallback so the
     // component never hangs in 'patching' forever (e.g. CLI crash, lost response).

--- a/web/src/components/assistant-ui/mermaid-diagram.tsx
+++ b/web/src/components/assistant-ui/mermaid-diagram.tsx
@@ -1,6 +1,11 @@
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-markdown'
-import { useEffect, useId, useState, type ComponentPropsWithoutRef } from 'react'
+import { useAssistantState } from '@assistant-ui/react'
+import { useEffect, useId, useRef, useState, type ComponentPropsWithoutRef } from 'react'
 import { cn } from '@/lib/utils'
+import { useOptionalHappyChatContext } from '@/components/AssistantChat/context'
+import { subscribePatch } from '@/lib/patch-emitter'
+
+// ── Theme bootstrap ──────────────────────────────────────────────────────────
 
 let initializedTheme: 'light' | 'dark' | null = null
 let mermaidPromise: Promise<typeof import('mermaid').default> | null = null
@@ -63,6 +68,26 @@ async function ensureMermaid(theme: 'light' | 'dark') {
     return mermaid
 }
 
+// ── Per-message block-index registry ────────────────────────────────────────
+//
+// Mermaid blocks within a given message are numbered 0, 1, 2, … in DOM order.
+// We need a stable integer index per instance so the hub can correlate
+// patch-request / message-patched pairs.
+//
+// Strategy: a module-level counter map keyed by msgId, incremented once per
+// component instance on first mount.  The counter is claimed via a ref so
+// each instance owns a stable blockIndex for its lifetime.
+
+const msgBlockCounters = new Map<string, number>()
+
+function claimBlockIndex(msgId: string): number {
+    const next = msgBlockCounters.get(msgId) ?? 0
+    msgBlockCounters.set(msgId, next + 1)
+    return next
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
 function MermaidFallback(props: ComponentPropsWithoutRef<'pre'> & { code: string }) {
     return (
         <pre
@@ -76,12 +101,59 @@ function MermaidFallback(props: ComponentPropsWithoutRef<'pre'> & { code: string
     )
 }
 
+function MermaidPatchingPlaceholder() {
+    return (
+        <div
+            data-mermaid-diagram
+            data-rendered="patching"
+            className="aui-mermaid-patching flex items-center gap-2 rounded-b-xl bg-[var(--app-code-bg)] px-4 py-3 text-sm text-[var(--app-hint)]"
+        >
+            <svg
+                className="h-3.5 w-3.5 animate-spin"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+            >
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+            </svg>
+            <span>rendering diagram…</span>
+        </div>
+    )
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
+
+const MAX_PATCH_RETRIES = 2
+
 export function MermaidDiagram(props: SyntaxHighlighterProps) {
     const [theme, setTheme] = useState<'light' | 'dark'>(() => resolveTheme())
-    const [renderError, setRenderError] = useState(false)
     const [svg, setSvg] = useState<string | null>(null)
+
+    // 'idle'      — initial / rendering in progress
+    // 'ok'        — rendered successfully
+    // 'patching'  — sent patch-request, waiting for corrected code
+    // 'error'     — render failed and retries exhausted
+    const [status, setStatus] = useState<'idle' | 'ok' | 'patching' | 'error'>('idle')
+
+    // Code to render — starts as props.code, replaced by corrected code from patch
+    const [renderCode, setRenderCode] = useState(props.code)
+
     const id = useId().replace(/:/g, '-')
 
+    // Stable blockIndex claimed once per instance
+    const msgId = useAssistantState(({ message }) => message.id)
+    const blockIndexRef = useRef<number | null>(null)
+    if (blockIndexRef.current === null) {
+        blockIndexRef.current = claimBlockIndex(msgId)
+    }
+    const blockIndex = blockIndexRef.current
+
+    const chat = useOptionalHappyChatContext()
+    const patchRetriesRef = useRef(0)
+
+    // Theme observer
     useEffect(() => {
         if (typeof document === 'undefined') return undefined
 
@@ -98,28 +170,52 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
         return () => observer.disconnect()
     }, [])
 
+    // Render effect
     useEffect(() => {
         let cancelled = false
+
+        const handleRenderFailure = () => {
+            if (cancelled) return
+            if (!chat || patchRetriesRef.current >= MAX_PATCH_RETRIES) {
+                setSvg(null)
+                setStatus('error')
+                return
+            }
+            patchRetriesRef.current += 1
+            setStatus('patching')
+            setSvg(null)
+            void chat.api.sendPatchRequest(chat.sessionId, {
+                msgId,
+                blockIndex,
+                type: 'mermaid',
+                failedCode: renderCode
+            }).catch(() => {
+                // If the request fails and the component is still mounted,
+                // fall back to showing the raw code.
+                if (!cancelled) {
+                    setStatus('error')
+                }
+            })
+        }
 
         const render = async () => {
             try {
                 const mermaid = await ensureMermaid(theme)
-                const isValid = await mermaid.parse(props.code, { suppressErrors: true })
+                const isValid = await mermaid.parse(renderCode, { suppressErrors: true })
                 if (cancelled) return
+
                 if (!isValid) {
-                    setSvg(null)
-                    setRenderError(true)
+                    handleRenderFailure()
                     return
                 }
 
-                const result = await mermaid.render(`mermaid-${id}`, props.code)
+                const result = await mermaid.render(`mermaid-${id}`, renderCode)
                 if (cancelled) return
                 setSvg(result.svg)
-                setRenderError(false)
+                setStatus('ok')
             } catch {
                 if (cancelled) return
-                setSvg(null)
-                setRenderError(true)
+                handleRenderFailure()
             }
         }
 
@@ -128,9 +224,47 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
         return () => {
             cancelled = true
         }
-    }, [id, props.code, theme])
+    }, [id, renderCode, theme, chat, msgId, blockIndex])
 
-    if (renderError || !svg) {
+    // Subscribe to message-patched events. Also set a 15s fallback so the
+    // component never hangs in 'patching' forever (e.g. CLI crash, lost response).
+    useEffect(() => {
+        if (status !== 'patching') return undefined
+
+        const timer = setTimeout(() => setStatus('error'), 15_000)
+
+        const unsubscribe = subscribePatch((payload) => {
+            if (payload.sessionId !== chat?.sessionId) return
+            if (payload.msgId !== msgId) return
+            if (payload.blockIndex !== blockIndex) return
+            clearTimeout(timer)
+            setRenderCode(payload.correctedCode)
+            setStatus('idle')
+        })
+
+        return () => {
+            clearTimeout(timer)
+            unsubscribe()
+        }
+    }, [status, chat?.sessionId, msgId, blockIndex])
+
+    // Reset renderCode if the original props.code changes (e.g. streaming)
+    useEffect(() => {
+        setRenderCode(props.code)
+        patchRetriesRef.current = 0
+        setStatus('idle')
+    }, [props.code])
+
+    if (status === 'patching') {
+        return <MermaidPatchingPlaceholder />
+    }
+
+    if (status === 'error' || (status !== 'ok' && !svg)) {
+        // Still 'idle' (initial render in progress) — show nothing yet to avoid
+        // flash of fallback.  Once renderCode resolves we'll update status.
+        if (status === 'idle') {
+            return null
+        }
         return <MermaidFallback code={props.code} data-mermaid-diagram data-rendered="false" />
     }
 
@@ -142,7 +276,7 @@ export function MermaidDiagram(props: SyntaxHighlighterProps) {
         >
             <div
                 className="min-w-fit [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-full"
-                dangerouslySetInnerHTML={{ __html: svg }}
+                dangerouslySetInnerHTML={{ __html: svg! }}
             />
         </div>
     )

--- a/web/src/lib/patch-emitter.ts
+++ b/web/src/lib/patch-emitter.ts
@@ -1,0 +1,31 @@
+/**
+ * Module-level pub/sub for `message-patched` SSE events.
+ *
+ * The SSE stream is processed globally in App.tsx.  Individual MermaidDiagram
+ * instances need to react to patches without owning their own SSE connections.
+ * This emitter lets App.tsx publish events and components subscribe by key.
+ */
+
+export type PatchedPayload = {
+    sessionId: string
+    msgId: string
+    blockIndex: number
+    correctedCode: string
+}
+
+type Listener = (payload: PatchedPayload) => void
+
+const listeners = new Set<Listener>()
+
+export function subscribePatch(listener: Listener): () => void {
+    listeners.add(listener)
+    return () => {
+        listeners.delete(listener)
+    }
+}
+
+export function emitPatch(payload: PatchedPayload): void {
+    for (const listener of listeners) {
+        listener(payload)
+    }
+}

--- a/web/src/lib/remark-repair-tables.test.ts
+++ b/web/src/lib/remark-repair-tables.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+import remarkStringify from 'remark-stringify'
+import { unified } from 'unified'
+import remarkRepairTables from './remark-repair-tables'
+
+function process(md: string): string {
+    return unified()
+        .use(remarkParse)
+        .use(remarkGfm)
+        .use(remarkRepairTables)
+        .use(remarkStringify)
+        .processSync(md)
+        .toString()
+}
+
+/** Count <th> / <td> cells in a stringified table row. */
+function parseTableCols(md: string): number[][] {
+    // remark-stringify outputs | cell | cell | rows
+    const rows = md.split('\n').filter(l => l.trim().startsWith('|') && !l.trim().match(/^\|[\s|:-]+\|$/))
+    return rows.map(row => {
+        const inner = row.trim().replace(/^\||\|$/g, '')
+        return inner.split('|').map(c => c.trim())
+    }).map(cells => cells.map(c => c.length))
+}
+
+describe('remarkRepairTables', () => {
+    it('leaves a valid 3-column table unchanged', () => {
+        const md = '| A | B | C |\n|---|---|---|\n| x | y | z |\n'
+        const out = process(md)
+        expect(out).toContain('| A |')
+        expect(out).toContain('| C |')
+    })
+
+    it('repairs separator with 2 cells for a 3-column header', () => {
+        const md = '| A | B | C |\n|---|---|\n| x | y | z |\n'
+        const out = process(md)
+        // All 3 header columns must survive
+        expect(out).toContain('A')
+        expect(out).toContain('B')
+        expect(out).toContain('C')
+        // All 3 data cells must survive
+        expect(out).toContain('x')
+        expect(out).toContain('y')
+        expect(out).toContain('z')
+    })
+
+    it('repairs separator with 1 cell for a 4-column header', () => {
+        const md = '| W | X | Y | Z |\n|---|\n| a | b | c | d |\n'
+        const out = process(md)
+        expect(out).toContain('W')
+        expect(out).toContain('Z')
+        expect(out).toContain('a')
+        expect(out).toContain('d')
+    })
+
+    it('repairs separator without surrounding pipes', () => {
+        const md = '| A | B | C |\n---|---\n| x | y | z |\n'
+        const out = process(md)
+        expect(out).toContain('C')
+        expect(out).toContain('z')
+    })
+
+    it('preserves alignment hints in the separator cells that exist', () => {
+        const md = '| A | B | C |\n|:---|---:|\n| x | y | z |\n'
+        const out = process(md)
+        expect(out).toContain('C')
+        expect(out).toContain('z')
+    })
+
+    it('does not modify a table where separator already matches', () => {
+        const md = '| A | B |\n|---|---|\n| x | y |\n'
+        const out = process(md)
+        expect(out).toContain('A')
+        expect(out).toContain('B')
+    })
+
+    it('handles multiple tables — repairs broken, leaves valid untouched', () => {
+        const md = [
+            '| A | B | C |',
+            '|---|---|',
+            '| x | y | z |',
+            '',
+            '| P | Q |',
+            '|---|---|',
+            '| 1 | 2 |',
+        ].join('\n') + '\n'
+        const out = process(md)
+        // First table repaired
+        expect(out).toContain('C')
+        expect(out).toContain('z')
+        // Second table unchanged
+        expect(out).toContain('P')
+        expect(out).toContain('Q')
+    })
+
+    it('does not touch pipe characters in code spans or prose', () => {
+        const md = 'Use `foo | bar` for piping.\n'
+        const out = process(md)
+        expect(out).toContain('foo | bar')
+    })
+
+    it('ignores a paragraph that merely contains pipe characters', () => {
+        const md = 'Run: `jq \'.[] | select(.active)\'`\n'
+        const out = process(md)
+        // Should not throw and should leave content intact
+        expect(out).toContain('jq')
+    })
+})

--- a/web/src/lib/remark-repair-tables.ts
+++ b/web/src/lib/remark-repair-tables.ts
@@ -1,0 +1,130 @@
+/**
+ * Remark plugin that repairs GFM tables where the separator row has fewer
+ * columns than the header row.
+ *
+ * Background: remark-gfm follows the GFM spec — the delimiter row controls
+ * the column count. If an agent emits:
+ *
+ *   | A | B | C |
+ *   |---|---|        ← only 2 cells; column C is silently dropped
+ *   | x | y | z |
+ *
+ * remark-gfm produces a 2-column table and discards C/z entirely. This plugin
+ * runs after remark-gfm, detects the mismatch by comparing the original source
+ * (available via `file.value`) against the parsed column count, pads the
+ * separator, and re-parses just that table block so all columns are preserved.
+ *
+ * Only the dominant failure pattern is repaired (separator off-by-one or
+ * off-by-N). Other failures (missing separator entirely, severe column
+ * mismatches in data rows) are left for the agent patch-request path.
+ */
+
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+import type { Root, Table, TableRow, TableCell } from 'mdast'
+import type { VFile } from 'vfile'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Count pipe-delimited cells in one table row line of raw source. */
+function countSourceCells(line: string): number {
+    const trimmed = line.trim()
+    // Strip optional surrounding pipes before splitting
+    const inner = (trimmed.startsWith('|') ? trimmed.slice(1) : trimmed)
+    const stripped = inner.endsWith('|') ? inner.slice(0, -1) : inner
+    return stripped.split('|').length
+}
+
+/**
+ * Pad `sepLine` to have `targetCols` cells.  Returns the repaired line, or
+ * null if `sepLine` already has enough cells or doesn't look like a separator.
+ */
+function padSeparatorLine(sepLine: string, targetCols: number): string | null {
+    const trimmed = sepLine.trim()
+    if (!trimmed) return null
+
+    const hasLeading = trimmed.startsWith('|')
+    const hasTrailing = trimmed.endsWith('|')
+
+    const inner = hasLeading ? trimmed.slice(1) : trimmed
+    const stripped = inner.endsWith('|') ? inner.slice(0, -1) : inner
+    const cells = stripped.split('|')
+
+    if (cells.length >= targetCols) return null
+
+    // Verify it's a separator row (cells should look like /^\s*:?-+:?\s*$/)
+    const isSep = cells.every(c => /^\s*:?-+:?\s*$/.test(c))
+    if (!isSep) return null
+
+    const extra = Array(targetCols - cells.length).fill(' --- ')
+    const paddedInner = [...cells, ...extra].join('|')
+    return (hasLeading ? '|' : '') + paddedInner + (hasTrailing ? '|' : '')
+}
+
+/** Re-parse a repaired raw table string and extract the first table node. */
+function parseTableBlock(source: string): Table | null {
+    const tree = unified().use(remarkParse).use(remarkGfm).parse(source) as Root
+    for (const node of tree.children) {
+        if (node.type === 'table') return node as Table
+    }
+    return null
+}
+
+// ── Plugin ───────────────────────────────────────────────────────────────────
+
+interface MdastParent {
+    children: (Table | { type: string })[]
+}
+
+function visitTables(
+    node: { type: string; children?: unknown[]; align?: unknown; position?: { start: { offset: number }; end: { offset: number } } },
+    parent: MdastParent | null,
+    index: number,
+    source: string,
+    repairCount: { n: number }
+): void {
+    if (node.type === 'table' && parent && node.position && Array.isArray(node.align)) {
+        const tableSource = source.slice(node.position.start.offset, node.position.end.offset)
+        const lines = tableSource.split('\n')
+
+        if (lines.length >= 2) {
+            const headerCols = countSourceCells(lines[0])
+            const sepCols = (node.align as unknown[]).length
+
+            if (headerCols > sepCols && lines[1]) {
+                const repairedSep = padSeparatorLine(lines[1], headerCols)
+                if (repairedSep) {
+                    const newLines = [...lines]
+                    newLines[1] = repairedSep
+                    const repaired = parseTableBlock(newLines.join('\n'))
+                    if (repaired) {
+                        parent.children.splice(index, 1, repaired as unknown as Table)
+                        repairCount.n++
+                        return
+                    }
+                }
+            }
+        }
+    }
+
+    if (Array.isArray(node.children)) {
+        for (let i = 0; i < node.children.length; i++) {
+            visitTables(
+                node.children[i] as typeof node,
+                node as unknown as MdastParent,
+                i,
+                source,
+                repairCount
+            )
+        }
+    }
+}
+
+export default function remarkRepairTables() {
+    return (tree: Root, file: VFile) => {
+        const source = String(file.value)
+        const repairCount = { n: 0 }
+        visitTables(tree as unknown as Parameters<typeof visitTables>[0], null, 0, source, repairCount)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #850.

Two related improvements for rendering resilience in the web client.

### Commit 1 — silent in-place patch loop for mermaid render failures

When `mermaid.render()` throws a parse error the diagram slot previously showed a permanent error state with no recovery path. This PR wires up a silent background correction loop:

1. `MermaidDiagram` detects the failure, claims a `blockIndex` for the block within its message, transitions to a `'patching'` spinner state, and fires `POST /sessions/:id/patch-request` with `{ msgId, blockIndex, type: 'mermaid', failedCode }`.
2. Hub (`SyncEngine.requestPatch`) deduplicates by `sessionId:msgId:blockIndex`, caps retries at 2, and auto-evicts stale entries after 30 s. It emits a `patch-prompt` socket event to the active CLI.
3. CLI (`registerPatchHandler`) runs a silent single-turn `query()` call (`maxTurns: 1`, `permissionMode: 'default'`, `canCallTool` hard-denies all tools) — no user turn is created or injected into conversation history.
4. Hub broadcasts `message-patched` SSE → `MermaidDiagram` splices the corrected diagram code in-place and re-renders.
5. Web component falls back to error state after 15 s if no `message-patched` arrives. Patch loop is gated on `flavor === 'claude'` (other flavors have no registered CLI handler) and skips blocks > 16 k chars.

Hub endpoints: `POST /sessions/:id/patch-request` (validated with `PatchRequestBodySchema`, `failedCode` capped at 16 k chars) returns 200 (sent/duplicate) or 503 (no CLI connected).

### Commit 2 — mechanical repair of GFM tables with off-by-one separator rows

`remark-gfm` follows the GFM spec: the delimiter row controls the column count. When an agent emits a table whose separator has fewer cells than the header, `remark-gfm` silently discards the extra columns. Analysis of real session data showed this is the dominant table failure pattern (~15 % of tables, almost all off-by-one or off-by-two in the separator).

A new remark plugin (`remarkRepairTables`) runs immediately after `remarkGfm` in `MemoizedMarkdown`. It uses `file.value` source + `node.position` to read the original separator line, counts header columns vs `node.align.length`, pads the separator with `---` cells, and re-parses just that table block. Only broken tables are touched; valid tables, prose with pipes, and code spans are unaffected.

9 vitest unit tests cover: valid table pass-through, off-by-one, off-by-N, no surrounding pipes, alignment hints preserved, multiple mixed tables, and prose/code-span false-positive immunity.

## Test plan

- [x] `bun typecheck` — clean (cli / hub / web)
- [x] `bun run test:web` — 9 new table-repair tests pass, no regressions
- [x] Cold self-review of the diff before submitting

## Disclosure

This PR was developed with assistance from Claude Sonnet 4.6 (claude-sonnet-4-6) acting as a peer agent in a multi-agent workflow.
