### PR TITLE
fix(claude): flush OutgoingMessageQueue before consuming next user turn

### DIFF
--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -306,6 +306,14 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                             return permissionHandler.isAborted(toolCallId);
                         },
                         nextMessage: async () => {
+                            // Flush any pending outgoing messages before consuming the next user
+                            // turn. Without this, scheduleProcessing()'s setTimeout(fn,0) fires
+                            // after the microtask that sends messages-consumed, causing the hub
+                            // to stamp invokedAt on the next user message before it stores the
+                            // current turn's queued agent messages — making them sort permanently
+                            // below the next user message.
+                            await messageQueue.flush();
+
                             if (pending) {
                                 let p = pending;
                                 pending = null;


### PR DESCRIPTION
## Summary

- `OutgoingMessageQueue.scheduleProcessing()` defers `socket.emit()` via `setTimeout(fn, 0)` (macrotask)
- The Claude SDK's `nextMessage()` callback runs in a microtask chain — **before** that `setTimeout` fires
- This allows `messages-consumed` for turn N+1 to reach the hub before the queued agent messages from turn N, causing the hub to stamp `invokedAt_N+1` earlier than those agent messages' `created_at`
- Since `compareMessages` sorts ascending by `invokedAt ?? createdAt`, the late-stamped agent messages sort permanently below the N+1 user message

Fix: `await messageQueue.flush()` at the top of `nextMessage()` so all pending outgoing agent messages are sent through the socket **before** `messages-consumed` is dispatched.

## Test plan

- [x] Multi-turn Claude session with tool use: agent messages from turn N should appear above the turn N+1 user message
- [x] Single-turn Claude session: no regression in message ordering
- [x] Sessions with plan mode / abort: no messages dropped or duplicated

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)