### PR TITLE
fix: detect stale PID in runner state after abnormal shutdown

### DIFF
--- a/cli/src/runner/controlClient.ts
+++ b/cli/src/runner/controlClient.ts
@@ -10,7 +10,7 @@ import packageJson from '../../package.json';
 import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { isBunCompiled, projectPath } from '@/projectPath';
-import { isProcessAlive, killProcess } from '@/utils/process';
+import { isProcessAlive, isHapiRunnerProcess, killProcess } from '@/utils/process';
 import { configuration } from '@/configuration';
 import { hashRunnerCliApiToken, isRunnerStateCompatibleWithIdentity } from './runnerIdentity';
 
@@ -143,12 +143,12 @@ export async function checkIfRunnerRunningAndCleanupStaleState(): Promise<boolea
     return false;
   }
 
-  // Check if the runner is running
-  if (isProcessAlive(state.pid)) {
+  // Verify PID is alive AND belongs to hapi (not a reused PID from another process)
+  if (isHapiRunnerProcess(state.pid)) {
     return true;
   }
 
-  logger.debug('[RUNNER RUN] Runner PID not running, cleaning up state');
+  logger.debug('[RUNNER RUN] Runner PID not running or not a hapi process, cleaning up state');
   await cleanupRunnerState();
   return false;
 }

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -35,12 +35,11 @@ export function isHapiRunnerProcess(pid: number): boolean {
     }
     return isRunnerCommand(result.stdout?.toString() ?? '');
   }
-  try {
-    const result = spawn.sync('ps', ['-p', String(pid), '-o', 'command='], { stdio: 'pipe' });
-    return isRunnerCommand(result.stdout?.toString() ?? '');
-  } catch {
-    return true;
+  const result = spawn.sync('ps', ['-p', String(pid), '-o', 'command='], { stdio: 'pipe' });
+  if (result.error || result.status !== 0) {
+    return isProcessAlive(pid);
   }
+  return isRunnerCommand(result.stdout?.toString() ?? '');
 }
 
 function killProcessWindows(pid: number, force: boolean): boolean {

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -17,23 +17,29 @@ export function isProcessAlive(pid: number): boolean {
 }
 
 // ponytail: ps -p is cheap and avoids PID-reuse false positives after OS upgrades/reboots
+function isRunnerCommand(commandLine: string): boolean {
+  return /(?:^|\s)runner(?:\s|$)/.test(commandLine) && /(?:^|\s)start-sync(?:\s|$)/.test(commandLine);
+}
+
 export function isHapiRunnerProcess(pid: number): boolean {
   if (!isProcessAlive(pid)) {
     return false;
   }
   if (isWindows()) {
-    try {
-      const result = spawn.sync('wmic', ['process', 'where', `ProcessId=${pid}`, 'get', 'CommandLine'], { stdio: 'pipe' });
-      return result.stdout?.toString().includes('hapi') ?? false;
-    } catch {
-      return true; // fall back to alive-only check
+    const result = spawn.sync('wmic', ['process', 'where', `ProcessId=${pid}`, 'get', 'CommandLine'], { stdio: 'pipe' });
+    if (result.error) {
+      return true;
     }
+    if (result.status !== 0) {
+      return isProcessAlive(pid);
+    }
+    return isRunnerCommand(result.stdout?.toString() ?? '');
   }
   try {
     const result = spawn.sync('ps', ['-p', String(pid), '-o', 'command='], { stdio: 'pipe' });
-    return result.stdout?.toString().includes('hapi') ?? false;
+    return isRunnerCommand(result.stdout?.toString() ?? '');
   } catch {
-    return true; // fall back to alive-only check
+    return true;
   }
 }
 

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -16,6 +16,27 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
+// ponytail: ps -p is cheap and avoids PID-reuse false positives after OS upgrades/reboots
+export function isHapiRunnerProcess(pid: number): boolean {
+  if (!isProcessAlive(pid)) {
+    return false;
+  }
+  if (isWindows()) {
+    try {
+      const result = spawn.sync('wmic', ['process', 'where', `ProcessId=${pid}`, 'get', 'CommandLine'], { stdio: 'pipe' });
+      return result.stdout?.toString().includes('hapi') ?? false;
+    } catch {
+      return true; // fall back to alive-only check
+    }
+  }
+  try {
+    const result = spawn.sync('ps', ['-p', String(pid), '-o', 'command='], { stdio: 'pipe' });
+    return result.stdout?.toString().includes('hapi') ?? false;
+  } catch {
+    return true; // fall back to alive-only check
+  }
+}
+
 function killProcessWindows(pid: number, force: boolean): boolean {
   if (!isProcessAlive(pid)) {
     return true;


### PR DESCRIPTION
## Problem

After an abnormal shutdown (crash, force kill, power loss), `runner.state.json` retains the old PID. When the LaunchAgent restarts `hapi runner start-sync`, the existing `isProcessAlive()` check uses `kill(pid, 0)` which only verifies *a* process exists at that PID — not that it's actually hapi.

Since the OS reassigns PIDs after reboot, the stale PID often belongs to an unrelated process. The check passes, `start-sync` prints "Runner already running with matching version" and exits. With `KeepAlive: true`, launchd restarts it immediately, creating an infinite loop of failed starts.

## Fix

Added `isHapiRunnerProcess(pid)` which, after confirming the PID is alive, verifies the process command line contains "hapi" via:
- macOS/Linux: `ps -p <pid> -o command=`
- Windows: `wmic process where ProcessId=<pid> get CommandLine`

If `ps`/`wmic` itself fails (e.g. sandboxed environment), falls back to the old alive-only behavior to avoid false negatives.

`checkIfRunnerRunningAndCleanupStaleState()` now uses this stronger check. If the PID is alive but not a hapi process, the stale state is cleaned up and the runner starts normally.