### PR TITLE
feat(web): in-app PWA update prompt when new service worker is available

### DIFF
--- a/docs/guide/pwa.md
+++ b/docs/guide/pwa.md
@@ -56,11 +56,14 @@ An offline indicator appears when you lose connection.
 
 ### Auto-Update
 
-HAPI automatically checks for updates:
+HAPI checks for updates in the background and lets you choose when to reload:
 
-- Updates are checked hourly in the background
-- When a new version is available, you'll see a prompt
-- Click "Reload" to get the latest version
+- Updates are checked hourly and when you return to the tab
+- When a new version is available, a persistent in-app banner appears at the top
+- Tap **Reload** when you're ready to apply the update — the banner stays until you do
+- Expand **"Why can't I dismiss this?"** on the banner for the rationale
+
+HAPI uses a user-controlled reload instead of forcing an automatic refresh, so you choose when to reload. The banner cannot be dismissed without upgrading, so you won't forget you're on an old build.
 
 ### Background Sync
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,7 +23,7 @@ import { getAppGlobalSseSubscription, getAppSessionSseSubscription } from '@/lib
 import { LoginPrompt } from '@/components/LoginPrompt'
 import { InstallPrompt } from '@/components/InstallPrompt'
 import { OfflineBanner } from '@/components/OfflineBanner'
-import { PwaUpdateBanner } from '@/components/PwaUpdateBanner'
+import { PwaUpdateBanner, PwaUpdateBannerWithStatusOffset } from '@/components/PwaUpdateBanner'
 import { SyncingBanner } from '@/components/SyncingBanner'
 import { ReconnectingBanner } from '@/components/ReconnectingBanner'
 import { VoiceErrorBanner } from '@/components/VoiceErrorBanner'
@@ -427,14 +427,13 @@ function AppInner() {
         )
     }
 
-    const pwaBannerTopClassName = isSyncing || (sseDisconnected && !isSyncing)
-        ? 'top-12'
-        : undefined
-
     return (
         <AppContextProvider value={{ api, token, baseUrl }}>
             <VoiceProvider>
-                <PwaUpdateBanner topClassName={pwaBannerTopClassName} />
+                <PwaUpdateBannerWithStatusOffset
+                    isSyncing={isSyncing}
+                    isReconnecting={sseDisconnected && !isSyncing}
+                />
                 <SyncingBanner isSyncing={isSyncing} />
                 <ReconnectingBanner
                     isReconnecting={sseDisconnected && !isSyncing}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Outlet, useLocation, useMatchRoute, useRouter } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { getTelegramWebApp, isTelegramApp } from '@/hooks/useTelegram'
@@ -29,6 +29,7 @@ import { ReconnectingBanner } from '@/components/ReconnectingBanner'
 import { VoiceErrorBanner } from '@/components/VoiceErrorBanner'
 import { LoadingState } from '@/components/LoadingState'
 import { ToastContainer } from '@/components/ToastContainer'
+import { PwaUpdateProvider } from '@/lib/pwa-update-context'
 import { ToastProvider, useToast } from '@/lib/toast-context'
 import type { SyncEvent } from '@/types/api'
 
@@ -36,10 +37,21 @@ type ToastEvent = Extract<SyncEvent, { type: 'toast' }>
 
 const REQUIRE_SERVER_URL = requireHubUrlForLogin()
 
+function withPwaBanner(content: ReactNode) {
+    return (
+        <>
+            <PwaUpdateBanner />
+            {content}
+        </>
+    )
+}
+
 export function App() {
     return (
         <ToastProvider>
-            <AppInner />
+            <PwaUpdateProvider>
+                <AppInner />
+            </PwaUpdateProvider>
         </ToastProvider>
     )
 }
@@ -339,16 +351,16 @@ function AppInner() {
 
     // Loading auth source
     if (isAuthSourceLoading) {
-        return (
+        return withPwaBanner(
             <div className="h-full flex items-center justify-center p-4">
                 <LoadingState label={t('loading')} className="text-sm" />
-            </div>
+            </div>,
         )
     }
 
     // No auth source (browser environment, not logged in)
     if (!authSource) {
-        return (
+        return withPwaBanner(
             <LoginPrompt
                 onLogin={setAccessToken}
                 baseUrl={baseUrl}
@@ -356,12 +368,12 @@ function AppInner() {
                 setServerUrl={setServerUrl}
                 clearServerUrl={clearServerUrl}
                 requireServerUrl={REQUIRE_SERVER_URL}
-            />
+            />,
         )
     }
 
     if (needsBinding) {
-        return (
+        return withPwaBanner(
             <LoginPrompt
                 mode="bind"
                 onBind={bind}
@@ -371,16 +383,16 @@ function AppInner() {
                 clearServerUrl={clearServerUrl}
                 requireServerUrl={REQUIRE_SERVER_URL}
                 error={authError ?? undefined}
-            />
+            />,
         )
     }
 
     // Authenticating (also covers the gap before useAuth effect starts)
     if (isAuthLoading || (authSource && !token && !authError)) {
-        return (
+        return withPwaBanner(
             <div className="h-full flex items-center justify-center p-4">
                 <LoadingState label={t('authorizing')} className="text-sm" />
-            </div>
+            </div>,
         )
     }
 
@@ -388,7 +400,7 @@ function AppInner() {
     if (authError || !token || !api) {
         // If using access token and auth failed, show login again
         if (authSource.type === 'accessToken') {
-            return (
+            return withPwaBanner(
                 <LoginPrompt
                     onLogin={setAccessToken}
                     baseUrl={baseUrl}
@@ -397,12 +409,12 @@ function AppInner() {
                     clearServerUrl={clearServerUrl}
                     requireServerUrl={REQUIRE_SERVER_URL}
                     error={authError ?? t('login.error.authFailed')}
-                />
+                />,
             )
         }
 
         // Telegram auth failed
-        return (
+        return withPwaBanner(
             <div className="p-4 space-y-3">
                 <div className="text-base font-semibold">{t('login.title')}</div>
                 <div className="text-sm text-red-600">
@@ -411,13 +423,14 @@ function AppInner() {
                 <div className="text-xs text-[var(--app-hint)]">
                     Open this page from Telegram using the bot's "Open App" button (not "Open in browser").
                 </div>
-            </div>
+            </div>,
         )
     }
 
     return (
         <AppContextProvider value={{ api, token, baseUrl }}>
             <VoiceProvider>
+                <PwaUpdateBanner />
                 <SyncingBanner isSyncing={isSyncing} />
                 <ReconnectingBanner
                     isReconnecting={sseDisconnected && !isSyncing}
@@ -425,7 +438,6 @@ function AppInner() {
                 />
                 <VoiceErrorBanner />
                 <OfflineBanner />
-                <PwaUpdateBanner />
                 <div className="h-full min-h-0 flex flex-col">
                     <Outlet />
                 </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,7 @@ import { getAppGlobalSseSubscription, getAppSessionSseSubscription } from '@/lib
 import { LoginPrompt } from '@/components/LoginPrompt'
 import { InstallPrompt } from '@/components/InstallPrompt'
 import { OfflineBanner } from '@/components/OfflineBanner'
+import { PwaUpdateBanner } from '@/components/PwaUpdateBanner'
 import { SyncingBanner } from '@/components/SyncingBanner'
 import { ReconnectingBanner } from '@/components/ReconnectingBanner'
 import { VoiceErrorBanner } from '@/components/VoiceErrorBanner'
@@ -424,6 +425,7 @@ function AppInner() {
                 />
                 <VoiceErrorBanner />
                 <OfflineBanner />
+                <PwaUpdateBanner />
                 <div className="h-full min-h-0 flex flex-col">
                     <Outlet />
                 </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -427,10 +427,14 @@ function AppInner() {
         )
     }
 
+    const pwaBannerTopClassName = isSyncing || (sseDisconnected && !isSyncing)
+        ? 'top-12'
+        : undefined
+
     return (
         <AppContextProvider value={{ api, token, baseUrl }}>
             <VoiceProvider>
-                <PwaUpdateBanner />
+                <PwaUpdateBanner topClassName={pwaBannerTopClassName} />
                 <SyncingBanner isSyncing={isSyncing} />
                 <ReconnectingBanner
                     isReconnecting={sseDisconnected && !isSyncing}

--- a/web/src/components/PwaUpdateBanner.test.tsx
+++ b/web/src/components/PwaUpdateBanner.test.tsx
@@ -1,12 +1,17 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { I18nProvider } from '@/lib/i18n-context'
-import { PwaUpdateBanner } from '@/components/PwaUpdateBanner'
+import { PwaUpdateBanner, PwaUpdateBannerWithStatusOffset } from '@/components/PwaUpdateBanner'
 
 const usePwaUpdateMock = vi.fn()
+const useVoiceOptionalMock = vi.fn()
 
 vi.mock('@/lib/pwa-update-context', () => ({
     usePwaUpdateContext: () => usePwaUpdateMock(),
+}))
+
+vi.mock('@/lib/voice-context', () => ({
+    useVoiceOptional: () => useVoiceOptionalMock(),
 }))
 
 vi.mock('@/hooks/useOnlineStatus', () => ({
@@ -33,6 +38,7 @@ function renderBanner() {
 describe('PwaUpdateBanner', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        useVoiceOptionalMock.mockReturnValue(null)
         Object.defineProperty(window, 'localStorage', {
             value: {
                 getItem: vi.fn(() => 'en'),
@@ -89,6 +95,25 @@ describe('PwaUpdateBanner', () => {
         render(
             <I18nProvider>
                 <PwaUpdateBanner topClassName="top-12" />
+            </I18nProvider>,
+        )
+
+        expect(screen.getByTestId('pwa-update-banner')).toHaveClass('top-12')
+    })
+
+    it('offsets below voice error banners when shown inside the voice provider', () => {
+        usePwaUpdateMock.mockReturnValue({
+            needRefresh: true,
+            reload: vi.fn(),
+        })
+        useVoiceOptionalMock.mockReturnValue({
+            status: 'error',
+            errorMessage: 'Mic failed',
+        })
+
+        render(
+            <I18nProvider>
+                <PwaUpdateBannerWithStatusOffset isSyncing={false} isReconnecting={false} />
             </I18nProvider>,
         )
 

--- a/web/src/components/PwaUpdateBanner.test.tsx
+++ b/web/src/components/PwaUpdateBanner.test.tsx
@@ -5,8 +5,8 @@ import { PwaUpdateBanner } from '@/components/PwaUpdateBanner'
 
 const usePwaUpdateMock = vi.fn()
 
-vi.mock('@/hooks/usePwaUpdate', () => ({
-    usePwaUpdate: () => usePwaUpdateMock(),
+vi.mock('@/lib/pwa-update-context', () => ({
+    usePwaUpdateContext: () => usePwaUpdateMock(),
 }))
 
 vi.mock('@/hooks/useOnlineStatus', () => ({

--- a/web/src/components/PwaUpdateBanner.test.tsx
+++ b/web/src/components/PwaUpdateBanner.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { I18nProvider } from '@/lib/i18n-context'
+import { PwaUpdateBanner } from '@/components/PwaUpdateBanner'
+
+const usePwaUpdateMock = vi.fn()
+
+vi.mock('@/hooks/usePwaUpdate', () => ({
+    usePwaUpdate: () => usePwaUpdateMock(),
+}))
+
+vi.mock('@/hooks/useOnlineStatus', () => ({
+    useOnlineStatus: () => true,
+}))
+
+vi.mock('@/hooks/usePlatform', () => ({
+    usePlatform: () => ({
+        haptic: {
+            impact: vi.fn(),
+            notification: vi.fn(),
+        },
+    }),
+}))
+
+function renderBanner() {
+    return render(
+        <I18nProvider>
+            <PwaUpdateBanner />
+        </I18nProvider>,
+    )
+}
+
+describe('PwaUpdateBanner', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        Object.defineProperty(window, 'localStorage', {
+            value: {
+                getItem: vi.fn(() => 'en'),
+                setItem: vi.fn(),
+                removeItem: vi.fn(),
+                clear: vi.fn(),
+                key: vi.fn(() => null),
+                length: 0,
+            },
+            configurable: true,
+        })
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('does not render when no update is available', () => {
+        usePwaUpdateMock.mockReturnValue({
+            needRefresh: false,
+            reload: vi.fn(),
+        })
+
+        renderBanner()
+
+        expect(screen.queryByTestId('pwa-update-banner')).not.toBeInTheDocument()
+    })
+
+    it('renders a reload-only banner with no dismiss action', () => {
+        const reload = vi.fn()
+
+        usePwaUpdateMock.mockReturnValue({
+            needRefresh: true,
+            reload,
+        })
+
+        renderBanner()
+
+        expect(screen.getByTestId('pwa-update-banner')).toBeInTheDocument()
+        expect(screen.getByText('New version available')).toBeInTheDocument()
+        expect(screen.getByText('Reload to get the latest HAPI')).toBeInTheDocument()
+        expect(screen.getAllByRole('button')).toHaveLength(1)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
+        expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('expands the rationale section when the disclosure is opened', () => {
+        usePwaUpdateMock.mockReturnValue({
+            needRefresh: true,
+            reload: vi.fn(),
+        })
+
+        renderBanner()
+
+        const disclosure = screen.getByText("Why can't I dismiss this?")
+        expect(screen.queryByText(/agent running/i)).not.toBeVisible()
+
+        fireEvent.click(disclosure)
+
+        expect(screen.getByText(/agent running/i)).toBeVisible()
+        expect(screen.getByText(/finish what you are doing first/i)).toBeVisible()
+    })
+})

--- a/web/src/components/PwaUpdateBanner.test.tsx
+++ b/web/src/components/PwaUpdateBanner.test.tsx
@@ -80,6 +80,21 @@ describe('PwaUpdateBanner', () => {
         expect(reload).toHaveBeenCalledTimes(1)
     })
 
+    it('honors a custom top offset when provided', () => {
+        usePwaUpdateMock.mockReturnValue({
+            needRefresh: true,
+            reload: vi.fn(),
+        })
+
+        render(
+            <I18nProvider>
+                <PwaUpdateBanner topClassName="top-12" />
+            </I18nProvider>,
+        )
+
+        expect(screen.getByTestId('pwa-update-banner')).toHaveClass('top-12')
+    })
+
     it('expands the rationale section when the disclosure is opened', () => {
         usePwaUpdateMock.mockReturnValue({
             needRefresh: true,

--- a/web/src/components/PwaUpdateBanner.tsx
+++ b/web/src/components/PwaUpdateBanner.tsx
@@ -1,0 +1,54 @@
+import { useOnlineStatus } from '@/hooks/useOnlineStatus'
+import { usePwaUpdate } from '@/hooks/usePwaUpdate'
+import { usePlatform } from '@/hooks/usePlatform'
+import { useTranslation } from '@/lib/use-translation'
+
+export function PwaUpdateBanner() {
+    const { t } = useTranslation()
+    const { needRefresh, reload } = usePwaUpdate()
+    const isOnline = useOnlineStatus()
+    const { haptic } = usePlatform()
+
+    if (!needRefresh) {
+        return null
+    }
+
+    return (
+        <div
+            data-testid="pwa-update-banner"
+            className={`fixed left-4 right-4 bg-[var(--app-secondary-bg)] border border-[var(--app-border)] rounded-lg p-4 shadow-lg z-50 ${
+                isOnline ? 'top-2' : 'top-10'
+            }`}
+        >
+            <div className="flex items-center justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-[var(--app-fg)]">
+                        {t('pwa.update.title')}
+                    </p>
+                    <p className="text-xs text-[var(--app-hint)] mt-0.5">
+                        {t('pwa.update.body')}
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={() => {
+                        haptic.impact('light')
+                        reload()
+                    }}
+                    className="shrink-0 px-4 py-2 bg-[var(--app-fg)] text-[var(--app-bg)] rounded-lg text-sm font-medium active:opacity-80"
+                >
+                    {t('pwa.update.reload')}
+                </button>
+            </div>
+
+            <details className="mt-3 border-t border-[var(--app-border)] pt-2">
+                <summary className="cursor-pointer text-xs text-[var(--app-link)] active:opacity-60 list-none [&::-webkit-details-marker]:hidden">
+                    {t('pwa.update.whyToggle')}
+                </summary>
+                <p className="mt-2 text-xs text-[var(--app-hint)] leading-relaxed">
+                    {t('pwa.update.whyBody')}
+                </p>
+            </details>
+        </div>
+    )
+}

--- a/web/src/components/PwaUpdateBanner.tsx
+++ b/web/src/components/PwaUpdateBanner.tsx
@@ -3,7 +3,7 @@ import { usePlatform } from '@/hooks/usePlatform'
 import { usePwaUpdateContext } from '@/lib/pwa-update-context'
 import { useTranslation } from '@/lib/use-translation'
 
-export function PwaUpdateBanner() {
+export function PwaUpdateBanner({ topClassName }: { topClassName?: string } = {}) {
     const { t } = useTranslation()
     const { needRefresh, reload } = usePwaUpdateContext()
     const isOnline = useOnlineStatus()
@@ -13,12 +13,12 @@ export function PwaUpdateBanner() {
         return null
     }
 
+    const topClass = topClassName ?? (isOnline ? 'top-2' : 'top-10')
+
     return (
         <div
             data-testid="pwa-update-banner"
-            className={`fixed left-4 right-4 bg-[var(--app-secondary-bg)] border border-[var(--app-border)] rounded-lg p-4 shadow-lg z-50 ${
-                isOnline ? 'top-2' : 'top-10'
-            }`}
+            className={`fixed left-4 right-4 bg-[var(--app-secondary-bg)] border border-[var(--app-border)] rounded-lg p-4 shadow-lg z-50 ${topClass}`}
         >
             <div className="flex items-center justify-between gap-3">
                 <div className="flex-1 min-w-0">

--- a/web/src/components/PwaUpdateBanner.tsx
+++ b/web/src/components/PwaUpdateBanner.tsx
@@ -2,6 +2,7 @@ import { useOnlineStatus } from '@/hooks/useOnlineStatus'
 import { usePlatform } from '@/hooks/usePlatform'
 import { usePwaUpdateContext } from '@/lib/pwa-update-context'
 import { useTranslation } from '@/lib/use-translation'
+import { useVoiceOptional } from '@/lib/voice-context'
 
 export function PwaUpdateBanner({ topClassName }: { topClassName?: string } = {}) {
     const { t } = useTranslation()
@@ -50,5 +51,23 @@ export function PwaUpdateBanner({ topClassName }: { topClassName?: string } = {}
                 </p>
             </details>
         </div>
+    )
+}
+
+export function PwaUpdateBannerWithStatusOffset({
+    isSyncing,
+    isReconnecting,
+}: {
+    isSyncing: boolean
+    isReconnecting: boolean
+}) {
+    const voice = useVoiceOptional()
+    const hasTopStatusBanner =
+        isSyncing ||
+        isReconnecting ||
+        Boolean(voice && voice.status === 'error' && voice.errorMessage)
+
+    return (
+        <PwaUpdateBanner topClassName={hasTopStatusBanner ? 'top-12' : undefined} />
     )
 }

--- a/web/src/components/PwaUpdateBanner.tsx
+++ b/web/src/components/PwaUpdateBanner.tsx
@@ -1,11 +1,11 @@
 import { useOnlineStatus } from '@/hooks/useOnlineStatus'
-import { usePwaUpdate } from '@/hooks/usePwaUpdate'
 import { usePlatform } from '@/hooks/usePlatform'
+import { usePwaUpdateContext } from '@/lib/pwa-update-context'
 import { useTranslation } from '@/lib/use-translation'
 
 export function PwaUpdateBanner() {
     const { t } = useTranslation()
-    const { needRefresh, reload } = usePwaUpdate()
+    const { needRefresh, reload } = usePwaUpdateContext()
     const isOnline = useOnlineStatus()
     const { haptic } = usePlatform()
 

--- a/web/src/hooks/usePwaUpdate.test.ts
+++ b/web/src/hooks/usePwaUpdate.test.ts
@@ -2,15 +2,35 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
     PWA_UPDATE_CHECK_INTERVAL_MS,
+    PWA_UPDATE_RELOAD_FALLBACK_MS,
+    requestPwaUpdateReload,
     setupRegistrationUpdateChecks,
     usePwaUpdate,
 } from '@/hooks/usePwaUpdate'
 
 const registerSWMock = vi.fn()
+const serviceWorkerListeners = new Map<string, Set<EventListener>>()
 
 vi.mock('virtual:pwa-register', () => ({
     registerSW: (options: Parameters<typeof registerSWMock>[0]) => registerSWMock(options),
 }))
+
+beforeEach(() => {
+    serviceWorkerListeners.clear()
+    Object.defineProperty(navigator, 'serviceWorker', {
+        configurable: true,
+        value: {
+            addEventListener: (type: string, listener: EventListener) => {
+                const bucket = serviceWorkerListeners.get(type) ?? new Set<EventListener>()
+                bucket.add(listener)
+                serviceWorkerListeners.set(type, bucket)
+            },
+            removeEventListener: (type: string, listener: EventListener) => {
+                serviceWorkerListeners.get(type)?.delete(listener)
+            },
+        },
+    })
+})
 
 describe('setupRegistrationUpdateChecks', () => {
     beforeEach(() => {
@@ -76,6 +96,53 @@ describe('setupRegistrationUpdateChecks', () => {
     })
 })
 
+describe('requestPwaUpdateReload', () => {
+    it('reloads immediately when updateSW is unavailable', async () => {
+        const reloadPage = vi.fn()
+
+        await requestPwaUpdateReload(null, { reloadPage })
+
+        expect(reloadPage).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls updateSW and reloads on controllerchange', async () => {
+        const updateSW = vi.fn().mockImplementation(async () => {
+            for (const listener of serviceWorkerListeners.get('controllerchange') ?? []) {
+                listener(new Event('controllerchange'))
+            }
+        })
+        const reloadPage = vi.fn()
+
+        await requestPwaUpdateReload(updateSW, { reloadPage })
+
+        expect(updateSW).toHaveBeenCalledWith(true)
+        expect(reloadPage).toHaveBeenCalledTimes(1)
+    })
+
+    it('falls back to reload when controllerchange never fires', async () => {
+        vi.useFakeTimers()
+
+        const updateSW = vi.fn().mockResolvedValue(undefined)
+        const reloadPage = vi.fn()
+
+        const pending = requestPwaUpdateReload(updateSW, {
+            reloadPage,
+            setTimeoutFn: vi.fn((callback: () => void, delay?: number) => {
+                expect(delay).toBe(PWA_UPDATE_RELOAD_FALLBACK_MS)
+                return setTimeout(callback, delay)
+            }),
+        })
+
+        await pending
+        vi.runAllTimers()
+
+        expect(updateSW).toHaveBeenCalledWith(true)
+        expect(reloadPage).toHaveBeenCalledTimes(1)
+
+        vi.useRealTimers()
+    })
+})
+
 describe('usePwaUpdate', () => {
     let capturedOptions: {
         onNeedRefresh?: () => void
@@ -105,10 +172,20 @@ describe('usePwaUpdate', () => {
         expect(result.current.needRefresh).toBe(true)
     })
 
-    it('reloads through updateSW when reload is called', () => {
+    it('reloads through updateSW when reload is called', async () => {
+        const updateSW = vi.fn().mockImplementation(async () => {
+            for (const listener of serviceWorkerListeners.get('controllerchange') ?? []) {
+                listener(new Event('controllerchange'))
+            }
+        })
+        registerSWMock.mockImplementation((options) => {
+            capturedOptions = options
+            return updateSW
+        })
+
         const { result } = renderHook(() => usePwaUpdate())
 
-        act(() => {
+        await act(async () => {
             result.current.reload()
         })
 

--- a/web/src/hooks/usePwaUpdate.test.ts
+++ b/web/src/hooks/usePwaUpdate.test.ts
@@ -1,0 +1,153 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    PWA_UPDATE_CHECK_INTERVAL_MS,
+    setupRegistrationUpdateChecks,
+    usePwaUpdate,
+} from '@/hooks/usePwaUpdate'
+
+const registerSWMock = vi.fn()
+
+vi.mock('virtual:pwa-register', () => ({
+    registerSW: (options: Parameters<typeof registerSWMock>[0]) => registerSWMock(options),
+}))
+
+describe('setupRegistrationUpdateChecks', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('checks for updates on an hourly interval', () => {
+        const registration = {
+            update: vi.fn().mockResolvedValue(undefined),
+        } as unknown as ServiceWorkerRegistration
+
+        const cleanup = setupRegistrationUpdateChecks(registration)
+
+        vi.advanceTimersByTime(PWA_UPDATE_CHECK_INTERVAL_MS)
+        expect(registration.update).toHaveBeenCalledTimes(1)
+
+        vi.advanceTimersByTime(PWA_UPDATE_CHECK_INTERVAL_MS)
+        expect(registration.update).toHaveBeenCalledTimes(2)
+
+        cleanup()
+    })
+
+    it('checks for updates when the tab becomes visible', () => {
+        const registration = {
+            update: vi.fn().mockResolvedValue(undefined),
+        } as unknown as ServiceWorkerRegistration
+
+        const cleanup = setupRegistrationUpdateChecks(registration)
+
+        Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            value: 'hidden',
+        })
+        document.dispatchEvent(new Event('visibilitychange'))
+        expect(registration.update).not.toHaveBeenCalled()
+
+        Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            value: 'visible',
+        })
+        document.dispatchEvent(new Event('visibilitychange'))
+        expect(registration.update).toHaveBeenCalledTimes(1)
+
+        cleanup()
+    })
+
+    it('removes listeners and clears the interval on cleanup', () => {
+        const registration = {
+            update: vi.fn().mockResolvedValue(undefined),
+        } as unknown as ServiceWorkerRegistration
+        const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener')
+        const clearIntervalSpy = vi.spyOn(window, 'clearInterval')
+
+        const cleanup = setupRegistrationUpdateChecks(registration)
+        cleanup()
+
+        expect(removeEventListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+        expect(clearIntervalSpy).toHaveBeenCalled()
+    })
+})
+
+describe('usePwaUpdate', () => {
+    let capturedOptions: {
+        onNeedRefresh?: () => void
+        onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void
+    } = {}
+    const updateSW = vi.fn().mockResolvedValue(undefined)
+
+    beforeEach(() => {
+        capturedOptions = {}
+        updateSW.mockClear()
+        registerSWMock.mockImplementation((options) => {
+            capturedOptions = options
+            return updateSW
+        })
+    })
+
+    it('registers the service worker and exposes refresh state', () => {
+        const { result } = renderHook(() => usePwaUpdate())
+
+        expect(registerSWMock).toHaveBeenCalledTimes(1)
+        expect(result.current.needRefresh).toBe(false)
+
+        act(() => {
+            capturedOptions.onNeedRefresh?.()
+        })
+
+        expect(result.current.needRefresh).toBe(true)
+    })
+
+    it('reloads through updateSW when reload is called', () => {
+        const { result } = renderHook(() => usePwaUpdate())
+
+        act(() => {
+            result.current.reload()
+        })
+
+        expect(updateSW).toHaveBeenCalledWith(true)
+    })
+
+    it('keeps needRefresh true until a successful reload clears the page', () => {
+        const { result } = renderHook(() => usePwaUpdate())
+
+        act(() => {
+            capturedOptions.onNeedRefresh?.()
+        })
+
+        expect(result.current.needRefresh).toBe(true)
+
+        act(() => {
+            result.current.reload()
+        })
+
+        expect(updateSW).toHaveBeenCalledWith(true)
+        expect(result.current.needRefresh).toBe(true)
+    })
+
+    it('wires registration update checks from onRegistered', () => {
+        vi.useFakeTimers()
+
+        const registration = {
+            update: vi.fn().mockResolvedValue(undefined),
+        } as unknown as ServiceWorkerRegistration
+
+        renderHook(() => usePwaUpdate())
+
+        act(() => {
+            capturedOptions.onRegistered?.(registration)
+        })
+
+        vi.advanceTimersByTime(PWA_UPDATE_CHECK_INTERVAL_MS)
+        expect(registration.update).toHaveBeenCalledTimes(1)
+
+        vi.useRealTimers()
+    })
+})

--- a/web/src/hooks/usePwaUpdate.test.ts
+++ b/web/src/hooks/usePwaUpdate.test.ts
@@ -127,10 +127,10 @@ describe('requestPwaUpdateReload', () => {
 
         const pending = requestPwaUpdateReload(updateSW, {
             reloadPage,
-            setTimeoutFn: vi.fn((callback: () => void, delay?: number) => {
+            setTimeoutFn: vi.fn((callback, delay) => {
                 expect(delay).toBe(PWA_UPDATE_RELOAD_FALLBACK_MS)
                 return setTimeout(callback, delay)
-            }),
+            }) as typeof setTimeout,
         })
 
         await pending

--- a/web/src/hooks/usePwaUpdate.ts
+++ b/web/src/hooks/usePwaUpdate.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { registerSW } from 'virtual:pwa-register'
+
+export const PWA_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000
+
+export function setupRegistrationUpdateChecks(
+    registration: ServiceWorkerRegistration,
+): () => void {
+    const intervalId = window.setInterval(() => {
+        void registration.update()
+    }, PWA_UPDATE_CHECK_INTERVAL_MS)
+
+    const handleVisibilityChange = () => {
+        if (document.visibilityState === 'visible') {
+            void registration.update()
+        }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+        window.clearInterval(intervalId)
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+}
+
+export function usePwaUpdate() {
+    const [needRefresh, setNeedRefresh] = useState(false)
+    const updateSWRef = useRef<((reloadPage?: boolean) => Promise<void>) | null>(null)
+    const cleanupRef = useRef<(() => void) | null>(null)
+
+    useEffect(() => {
+        const updateSW = registerSW({
+            onNeedRefresh() {
+                setNeedRefresh(true)
+            },
+            onOfflineReady() {
+                console.log('App ready for offline use')
+            },
+            onRegistered(registration) {
+                cleanupRef.current?.()
+                cleanupRef.current = null
+
+                if (!registration) {
+                    return
+                }
+
+                cleanupRef.current = setupRegistrationUpdateChecks(registration)
+            },
+            onRegisterError(error) {
+                console.error('SW registration error:', error)
+            },
+        })
+
+        updateSWRef.current = updateSW
+
+        return () => {
+            cleanupRef.current?.()
+            cleanupRef.current = null
+            updateSWRef.current = null
+        }
+    }, [])
+
+    const reload = useCallback(() => {
+        void updateSWRef.current?.(true)
+    }, [])
+
+    return { needRefresh, reload }
+}

--- a/web/src/hooks/usePwaUpdate.ts
+++ b/web/src/hooks/usePwaUpdate.ts
@@ -2,6 +2,60 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { registerSW } from 'virtual:pwa-register'
 
 export const PWA_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000
+export const PWA_UPDATE_RELOAD_FALLBACK_MS = 2000
+
+export async function requestPwaUpdateReload(
+    updateSW: ((reloadPage?: boolean) => Promise<void>) | null | undefined,
+    options: {
+        reloadPage?: () => void
+        setTimeoutFn?: typeof setTimeout
+        clearTimeoutFn?: typeof clearTimeout
+    } = {},
+): Promise<void> {
+    const reloadPage = options.reloadPage ?? (() => window.location.reload())
+    const setTimeoutFn = options.setTimeoutFn ?? setTimeout
+    const clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout
+
+    if (!updateSW) {
+        reloadPage()
+        return
+    }
+
+    let reloaded = false
+    const doReload = () => {
+        if (reloaded) {
+            return
+        }
+        reloaded = true
+        reloadPage()
+    }
+
+    const onControllerChange = () => {
+        navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange)
+        doReload()
+    }
+
+    navigator.serviceWorker.addEventListener('controllerchange', onControllerChange)
+
+    let fallbackTimer: ReturnType<typeof setTimeout> | undefined
+
+    try {
+        await updateSW(true)
+    } catch (error) {
+        console.error('PWA update failed', error)
+        navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange)
+        if (fallbackTimer !== undefined) {
+            clearTimeoutFn(fallbackTimer)
+        }
+        doReload()
+        return
+    }
+
+    fallbackTimer = setTimeoutFn(() => {
+        navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange)
+        doReload()
+    }, PWA_UPDATE_RELOAD_FALLBACK_MS)
+}
 
 export function setupRegistrationUpdateChecks(
     registration: ServiceWorkerRegistration,
@@ -62,7 +116,7 @@ export function usePwaUpdate() {
     }, [])
 
     const reload = useCallback(() => {
-        void updateSWRef.current?.(true)
+        void requestPwaUpdateReload(updateSWRef.current)
     }, [])
 
     return { needRefresh, reload }

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -464,6 +464,11 @@ export default {
   'reconnecting.reason.closed': 'stream closed',
   'reconnecting.reason.heartbeatTimeout': 'heartbeat timeout',
   'reconnecting.reason.visibilityRecovery': 'resuming after background',
+  'pwa.update.title': 'New version available',
+  'pwa.update.body': 'Reload to get the latest HAPI',
+  'pwa.update.reload': 'Reload',
+  'pwa.update.whyToggle': "Why can't I dismiss this?",
+  'pwa.update.whyBody': 'HAPI will not reload your tab automatically while you may have an agent running, a permission waiting, or a message in progress. Running an old web build against the current server can cause sync bugs and failed actions. This banner stays visible until you reload so you are not stuck on a stale version by accident — but you choose when to tap Reload and finish what you are doing first.',
 
   // Send blocked
   'send.blocked.title': 'Cannot send message',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -468,6 +468,11 @@ export default {
   'reconnecting.reason.closed': '流连接已关闭',
   'reconnecting.reason.heartbeatTimeout': '心跳超时',
   'reconnecting.reason.visibilityRecovery': '后台恢复中',
+  'pwa.update.title': '新版本可用',
+  'pwa.update.body': '重新加载以获取最新版 HAPI',
+  'pwa.update.reload': '重新加载',
+  'pwa.update.whyToggle': '为什么不能关闭此提示？',
+  'pwa.update.whyBody': '当你可能有正在运行的智能体、待处理的权限请求或未发送的消息时，HAPI 不会自动重新加载标签页。旧版网页与当前服务器一起运行可能导致同步错误和操作失败。此横幅会一直保持显示，直到你重新加载，以免你在不知情的情况下停留在旧版本 — 但何时点击「重新加载」由你决定，可以先完成手头的工作。',
 
   // Send blocked
   'send.blocked.title': '无法发送消息',

--- a/web/src/lib/pwa-update-context.tsx
+++ b/web/src/lib/pwa-update-context.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import { usePwaUpdate } from '@/hooks/usePwaUpdate'
+
+type PwaUpdateContextValue = ReturnType<typeof usePwaUpdate>
+
+const PwaUpdateContext = createContext<PwaUpdateContextValue | null>(null)
+
+export function PwaUpdateProvider({ children }: { children: ReactNode }) {
+    const value = usePwaUpdate()
+
+    return (
+        <PwaUpdateContext.Provider value={value}>
+            {children}
+        </PwaUpdateContext.Provider>
+    )
+}
+
+export function usePwaUpdateContext() {
+    const value = useContext(PwaUpdateContext)
+    if (!value) {
+        throw new Error('usePwaUpdateContext must be used within PwaUpdateProvider')
+    }
+    return value
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,7 +4,6 @@ import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { RouterProvider, createMemoryHistory } from '@tanstack/react-router'
 import './index.css'
-import { registerSW } from 'virtual:pwa-register'
 import { initializeFontScale } from '@/hooks/useFontScale'
 import { getTelegramWebApp, isTelegramEnvironment, loadTelegramSdk } from './hooks/useTelegram'
 import { queryClient } from './lib/query-client'
@@ -51,27 +50,6 @@ async function bootstrap() {
     if (!isTelegram) {
         restoreSpaRedirect()
     }
-
-    const updateSW = registerSW({
-        onNeedRefresh() {
-            if (confirm('New version available! Reload to update?')) {
-                updateSW(true)
-            }
-        },
-        onOfflineReady() {
-            console.log('App ready for offline use')
-        },
-        onRegistered(registration) {
-            if (registration) {
-                setInterval(() => {
-                    registration.update()
-                }, 60 * 60 * 1000)
-            }
-        },
-        onRegisterError(error) {
-            console.error('SW registration error:', error)
-        }
-    })
 
     const history = isTelegram
         ? createMemoryHistory({ initialEntries: [getInitialPath()] })

--- a/web/src/sw.ts
+++ b/web/src/sw.ts
@@ -91,6 +91,16 @@ registerRoute(
     })
 )
 
+self.addEventListener('message', (event) => {
+    if (event.data?.type === 'SKIP_WAITING') {
+        self.skipWaiting()
+    }
+})
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(self.clients.claim())
+})
+
 self.addEventListener('push', (event) => {
     const payload = event.data?.json() as PushPayload | undefined
     if (!payload) {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -41,89 +41,131 @@ function getVendorChunkName(id: string): string | undefined {
         return 'vendor-voice'
     }
 
+    if (
+        id.includes('/node_modules/three/')
+        || id.includes('/node_modules/@react-three/')
+    ) {
+        return 'vendor-three'
+    }
+
     return undefined
 }
 
-export default defineConfig({
-    define: {
-        __APP_VERSION__: JSON.stringify(appVersion),
-    },
-    server: {
-        host: true,
-        allowedHosts: ['hapidev.weishu.me'],
-        proxy: {
-            '/api': {
-                target: hubTarget,
-                changeOrigin: true
-            },
-            '/socket.io': {
-                target: hubTarget,
-                ws: true
+export default defineConfig(({ mode }) => {
+    // In production we stub out the IWER WebXR emulator packages so they
+    // don't bloat the bundle or introduce the @bufbuild/protobuf 2.x conflict.
+    // In dev/test the real packages are live so IWER-based Playwright tests work.
+    const stubIwer = mode === 'production'
+    const iwerStub = resolve(__dirname, 'src/vendor-stubs/iwer-stub.ts')
+    const iwerAliases = stubIwer
+        ? { '@iwer/sem': iwerStub, '@iwer/devui': iwerStub, 'iwer': iwerStub }
+        : {}
+
+    return {
+        define: {
+            __APP_VERSION__: JSON.stringify(appVersion),
+        },
+        server: {
+            host: true,
+            allowedHosts: ['hapidev.weishu.me'],
+            proxy: {
+                '/api': {
+                    target: hubTarget,
+                    changeOrigin: true
+                },
+                '/socket.io': {
+                    target: hubTarget,
+                    ws: true
+                }
             }
-        }
-    },
-    plugins: [
-        react(),
-        VitePWA({
-            // User-controlled reload avoids mid-session surprise reloads (autoUpdate reloads all tabs).
-            registerType: 'prompt',
-            includeAssets: ['favicon.ico', 'apple-touch-icon-180x180.png', 'mask-icon.svg'],
-            strategies: 'injectManifest',
-            srcDir: 'src',
-            filename: 'sw.ts',
-            manifest: {
-                name: 'HAPI',
-                short_name: 'HAPI',
-                description: 'AI-powered development assistant',
-                theme_color: '#ffffff',
-                background_color: '#ffffff',
-                display: 'standalone',
-                orientation: 'portrait',
-                scope: base,
-                start_url: base,
-                icons: [
-                    {
-                        src: 'pwa-64x64.png',
-                        sizes: '64x64',
-                        type: 'image/png',
-                        purpose: 'any'
-                    },
-                    {
-                        src: 'pwa-192x192.png',
-                        sizes: '192x192',
-                        type: 'image/png',
-                        purpose: 'any'
-                    },
-                    {
-                        src: 'pwa-512x512.png',
-                        sizes: '512x512',
-                        type: 'image/png',
-                        purpose: 'any'
+        },
+        plugins: [
+            react(),
+            VitePWA({
+                // User-controlled reload avoids mid-session surprise reloads (autoUpdate reloads all tabs).
+                registerType: 'prompt',
+                includeAssets: ['favicon.ico', 'apple-touch-icon-180x180.png', 'mask-icon.svg'],
+                strategies: 'injectManifest',
+                srcDir: 'src',
+                filename: 'sw.ts',
+                manifest: {
+                    name: 'HAPI',
+                    short_name: 'HAPI',
+                    description: 'AI-powered development assistant',
+                    theme_color: '#ffffff',
+                    background_color: '#ffffff',
+                    display: 'standalone',
+                    orientation: 'portrait',
+                    scope: base,
+                    start_url: base,
+                    icons: [
+                        {
+                            src: 'pwa-64x64.png',
+                            sizes: '64x64',
+                            type: 'image/png',
+                            purpose: 'any'
+                        },
+                        {
+                            src: 'pwa-192x192.png',
+                            sizes: '192x192',
+                            type: 'image/png',
+                            purpose: 'any'
+                        },
+                        {
+                            src: 'pwa-512x512.png',
+                            sizes: '512x512',
+                            type: 'image/png',
+                            purpose: 'any'
+                        }
+                    ],
+                    share_target: {
+                        action: '/share',
+                        method: 'POST',
+                        enctype: 'multipart/form-data',
+                        params: {
+                            title: 'title',
+                            text: 'text',
+                            url: 'url',
+                            files: [
+                                {
+                                    name: 'files',
+                                    accept: [
+                                        'image/*',
+                                        'application/pdf',
+                                        'text/*',
+                                        'application/json',
+                                        'application/zip',
+                                        '*/*'
+                                    ]
+                                }
+                            ]
+                        }
                     }
-                ]
-            },
-            injectManifest: {
-                globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}']
-            },
-            devOptions: {
-                enabled: true,
-                type: 'module'
+                },
+                injectManifest: {
+                    globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}']
+                },
+                devOptions: {
+                    enabled: true,
+                    type: 'module'
+                }
+            })
+        ],
+        base,
+        resolve: {
+            alias: {
+                '@': resolve(__dirname, 'src'),
+                ...iwerAliases,
             }
-        })
-    ],
-    base,
-    resolve: {
-        alias: {
-            '@': resolve(__dirname, 'src')
-        }
-    },
-    build: {
-        outDir: 'dist',
-        emptyOutDir: true,
-        rollupOptions: {
-            output: {
-                manualChunks(id) {
-                    return getVendorChunkName(id)
+        },
+        build: {
+            outDir: 'dist',
+            emptyOutDir: true,
+            rollupOptions: {
+                output: {
+                    manualChunks(id) {
+                        return getVendorChunkName(id)
+                    }
                 }
             }
         }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -41,131 +41,89 @@ function getVendorChunkName(id: string): string | undefined {
         return 'vendor-voice'
     }
 
-    if (
-        id.includes('/node_modules/three/')
-        || id.includes('/node_modules/@react-three/')
-    ) {
-        return 'vendor-three'
-    }
-
     return undefined
 }
 
-export default defineConfig(({ mode }) => {
-    // In production we stub out the IWER WebXR emulator packages so they
-    // don't bloat the bundle or introduce the @bufbuild/protobuf 2.x conflict.
-    // In dev/test the real packages are live so IWER-based Playwright tests work.
-    const stubIwer = mode === 'production'
-    const iwerStub = resolve(__dirname, 'src/vendor-stubs/iwer-stub.ts')
-    const iwerAliases = stubIwer
-        ? { '@iwer/sem': iwerStub, '@iwer/devui': iwerStub, 'iwer': iwerStub }
-        : {}
-
-    return {
-        define: {
-            __APP_VERSION__: JSON.stringify(appVersion),
-        },
-        server: {
-            host: true,
-            allowedHosts: ['hapidev.weishu.me'],
-            proxy: {
-                '/api': {
-                    target: hubTarget,
-                    changeOrigin: true
-                },
-                '/socket.io': {
-                    target: hubTarget,
-                    ws: true
-                }
+export default defineConfig({
+    define: {
+        __APP_VERSION__: JSON.stringify(appVersion),
+    },
+    server: {
+        host: true,
+        allowedHosts: ['hapidev.weishu.me'],
+        proxy: {
+            '/api': {
+                target: hubTarget,
+                changeOrigin: true
+            },
+            '/socket.io': {
+                target: hubTarget,
+                ws: true
             }
-        },
-        plugins: [
-            react(),
-            VitePWA({
-                // User-controlled reload avoids mid-session surprise reloads (autoUpdate reloads all tabs).
-                registerType: 'prompt',
-                includeAssets: ['favicon.ico', 'apple-touch-icon-180x180.png', 'mask-icon.svg'],
-                strategies: 'injectManifest',
-                srcDir: 'src',
-                filename: 'sw.ts',
-                manifest: {
-                    name: 'HAPI',
-                    short_name: 'HAPI',
-                    description: 'AI-powered development assistant',
-                    theme_color: '#ffffff',
-                    background_color: '#ffffff',
-                    display: 'standalone',
-                    orientation: 'portrait',
-                    scope: base,
-                    start_url: base,
-                    icons: [
-                        {
-                            src: 'pwa-64x64.png',
-                            sizes: '64x64',
-                            type: 'image/png',
-                            purpose: 'any'
-                        },
-                        {
-                            src: 'pwa-192x192.png',
-                            sizes: '192x192',
-                            type: 'image/png',
-                            purpose: 'any'
-                        },
-                        {
-                            src: 'pwa-512x512.png',
-                            sizes: '512x512',
-                            type: 'image/png',
-                            purpose: 'any'
-                        }
-                    ],
-                    share_target: {
-                        action: '/share',
-                        method: 'POST',
-                        enctype: 'multipart/form-data',
-                        params: {
-                            title: 'title',
-                            text: 'text',
-                            url: 'url',
-                            files: [
-                                {
-                                    name: 'files',
-                                    accept: [
-                                        'image/*',
-                                        'application/pdf',
-                                        'text/*',
-                                        'application/json',
-                                        'application/zip',
-                                        '*/*'
-                                    ]
-                                }
-                            ]
-                        }
+        }
+    },
+    plugins: [
+        react(),
+        VitePWA({
+            // User-controlled reload avoids mid-session surprise reloads (autoUpdate reloads all tabs).
+            registerType: 'prompt',
+            includeAssets: ['favicon.ico', 'apple-touch-icon-180x180.png', 'mask-icon.svg'],
+            strategies: 'injectManifest',
+            srcDir: 'src',
+            filename: 'sw.ts',
+            manifest: {
+                name: 'HAPI',
+                short_name: 'HAPI',
+                description: 'AI-powered development assistant',
+                theme_color: '#ffffff',
+                background_color: '#ffffff',
+                display: 'standalone',
+                orientation: 'portrait',
+                scope: base,
+                start_url: base,
+                icons: [
+                    {
+                        src: 'pwa-64x64.png',
+                        sizes: '64x64',
+                        type: 'image/png',
+                        purpose: 'any'
+                    },
+                    {
+                        src: 'pwa-192x192.png',
+                        sizes: '192x192',
+                        type: 'image/png',
+                        purpose: 'any'
+                    },
+                    {
+                        src: 'pwa-512x512.png',
+                        sizes: '512x512',
+                        type: 'image/png',
+                        purpose: 'any'
                     }
-                },
-                injectManifest: {
-                    globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}']
-                },
-                devOptions: {
-                    enabled: true,
-                    type: 'module'
-                }
-            })
-        ],
-        base,
-        resolve: {
-            alias: {
-                '@': resolve(__dirname, 'src'),
-                ...iwerAliases,
+                ]
+            },
+            injectManifest: {
+                globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}']
+            },
+            devOptions: {
+                enabled: true,
+                type: 'module'
             }
-        },
-        build: {
-            outDir: 'dist',
-            emptyOutDir: true,
-            rollupOptions: {
-                output: {
-                    manualChunks(id) {
-                        return getVendorChunkName(id)
-                    }
+        })
+    ],
+    base,
+    resolve: {
+        alias: {
+            '@': resolve(__dirname, 'src')
+        }
+    },
+    build: {
+        outDir: 'dist',
+        emptyOutDir: true,
+        rollupOptions: {
+            output: {
+                manualChunks(id) {
+                    return getVendorChunkName(id)
                 }
             }
         }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -65,7 +65,8 @@ export default defineConfig({
     plugins: [
         react(),
         VitePWA({
-            registerType: 'autoUpdate',
+            // User-controlled reload avoids mid-session surprise reloads (autoUpdate reloads all tabs).
+            registerType: 'prompt',
             includeAssets: ['favicon.ico', 'apple-touch-icon-180x180.png', 'mask-icon.svg'],
             strategies: 'injectManifest',
             srcDir: 'src',


### PR DESCRIPTION
## Summary

Replaces the native `confirm()` PWA update flow with an in-app sticky banner when a new service worker is waiting, aligned with `registerType: 'prompt'`.

- **`usePwaUpdate` hook** - registers the service worker, shows `needRefresh` state, checks for updates hourly and on tab visibility resume
- **`PwaUpdateBanner`** - top fixed banner (same pattern as `OfflineBanner`) with Reload action and expandable rationale for why it cannot be dismissed until reload
- **`requestPwaUpdateReload`** - applies the waiting worker via `updateSW(true)`, reloads on `controllerchange`, with a timed fallback for Windows PWA edge cases
- **`sw.ts`** - handles `SKIP_WAITING` and calls `clients.claim()` on activate so prompt-mode reload actually works with `injectManifest`
- **i18n** - en + zh-CN strings; **docs** - `docs/guide/pwa.md` updated to match behavior

Design note vs original issue draft: v1 intentionally omits a "Later" dismiss - the banner stays until Reload succeeds, avoiding silent stale-bundle use after deploy.

## Test plan

- [x] `bun typecheck`
- [x] `cd web && bun run test` (984 tests, including `usePwaUpdate.test.ts` and `PwaUpdateBanner.test.tsx`)
- [x] Manual dogfood on Windows PWA (`:3006`): banner appears after deploy; Reload refreshes the app and clears the banner

## Issues

Fixes tiann/hapi#938