### PR TITLE
Refresh web console controls and Codex quota display

### DIFF
--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -66,6 +66,28 @@ export interface CollaborationModeListResponse {
     [key: string]: unknown;
 }
 
+export interface RateLimitWindow {
+    usedPercent?: number;
+    windowDurationMins?: number | null;
+    resetsAt?: number | null;
+    [key: string]: unknown;
+}
+
+export interface RateLimitSnapshot {
+    limitId?: string | null;
+    limitName?: string | null;
+    primary?: RateLimitWindow | null;
+    secondary?: RateLimitWindow | null;
+    planType?: string | null;
+    [key: string]: unknown;
+}
+
+export interface GetAccountRateLimitsResponse {
+    rateLimits?: RateLimitSnapshot;
+    rateLimitsByLimitId?: Record<string, RateLimitSnapshot | undefined> | null;
+    [key: string]: unknown;
+}
+
 export interface ThreadStartParams {
     model?: string;
     modelProvider?: string;

--- a/cli/src/codex/codexAppServerClient.ts
+++ b/cli/src/codex/codexAppServerClient.ts
@@ -4,6 +4,7 @@ import { JsonLineParser } from '@/utils/jsonLineParser';
 import { killProcessByChildProcess } from '@/utils/process';
 import type {
     CollaborationModeListResponse,
+    GetAccountRateLimitsResponse,
     InitializeParams,
     InitializeResponse,
     ModelListParams,
@@ -165,6 +166,13 @@ export class CodexAppServerClient extends JsonLineParser {
             timeoutMs: 30_000
         });
         return response as CollaborationModeListResponse;
+    }
+
+    async readAccountRateLimits(): Promise<GetAccountRateLimitsResponse> {
+        const response = await this.sendRequest('account/rateLimits/read', undefined, {
+            timeoutMs: 30_000
+        });
+        return response as GetAccountRateLimitsResponse;
     }
 
     async setExperimentalFeatureEnablement(

--- a/cli/src/modules/common/codexSubscriptionLimits.test.ts
+++ b/cli/src/modules/common/codexSubscriptionLimits.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { RateLimitSnapshot } from '@/codex/appServerTypes';
+import { selectCodexRateLimitSnapshotForTests } from './codexSubscriptionLimits';
+
+function snapshot(limitId: string, limitName: string, usedPercent: number): RateLimitSnapshot {
+    return {
+        limitId,
+        limitName,
+        primary: {
+            usedPercent,
+            windowDurationMins: 300,
+            resetsAt: 1
+        },
+        secondary: null,
+        planType: 'pro'
+    };
+}
+
+describe('Codex subscription limit snapshot selection', () => {
+    it('uses the model-specific limitName before the generic codex bucket', () => {
+        // Verifies Spark sessions read the Spark quota instead of the generic Codex quota.
+        const generic = snapshot('codex', 'Codex', 80);
+        const spark = snapshot('codex_bengalfox', 'GPT-5.3-Codex-Spark', 12);
+
+        const selected = selectCodexRateLimitSnapshotForTests(
+            generic,
+            {
+                codex: generic,
+                codex_bengalfox: spark
+            },
+            'gpt-5.3-codex-spark'
+        );
+
+        expect(selected).toBe(spark);
+    });
+
+    it('falls back to the generic codex bucket when no model-specific bucket matches', () => {
+        // Verifies regular Codex models keep using the existing generic quota bucket.
+        const generic = snapshot('codex', 'Codex', 80);
+        const spark = snapshot('codex_bengalfox', 'GPT-5.3-Codex-Spark', 12);
+
+        const selected = selectCodexRateLimitSnapshotForTests(
+            generic,
+            {
+                codex: generic,
+                codex_bengalfox: spark
+            },
+            'gpt-5.5'
+        );
+
+        expect(selected).toBe(generic);
+    });
+});

--- a/cli/src/modules/common/codexSubscriptionLimits.ts
+++ b/cli/src/modules/common/codexSubscriptionLimits.ts
@@ -1,0 +1,144 @@
+import type {
+    CodexSubscriptionLimits,
+    CodexSubscriptionLimitWindow,
+    CodexSubscriptionLimitsResponse,
+    GetCodexSubscriptionLimitsRequest as ProtocolGetCodexSubscriptionLimitsRequest
+} from '@hapi/protocol/apiTypes';
+import { CodexAppServerClient } from '@/codex/codexAppServerClient';
+import type { RateLimitSnapshot, RateLimitWindow } from '@/codex/appServerTypes';
+import { getErrorMessage } from './rpcResponses';
+
+export type GetCodexSubscriptionLimitsResponse = CodexSubscriptionLimitsResponse;
+export type GetCodexSubscriptionLimitsRequest = ProtocolGetCodexSubscriptionLimitsRequest;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' ? value as Record<string, unknown> : null;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function asStringOrNull(value: unknown): string | null {
+    return typeof value === 'string' ? value : null;
+}
+
+function normalizeLookup(value: string | null | undefined): string {
+    return (value ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function normalizeWindow(value: RateLimitWindow | null | undefined): CodexSubscriptionLimitWindow | null {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const usedPercent = asFiniteNumber(record.usedPercent);
+    if (usedPercent === null) {
+        return null;
+    }
+
+    return {
+        usedPercent,
+        windowDurationMins: asFiniteNumber(record.windowDurationMins),
+        resetsAt: asFiniteNumber(record.resetsAt)
+    };
+}
+
+function normalizeSnapshot(value: RateLimitSnapshot | null | undefined): CodexSubscriptionLimits | null {
+    const record = asRecord(value);
+    if (!record) {
+        return null;
+    }
+
+    const primary = normalizeWindow(record.primary as RateLimitWindow | null | undefined);
+    const secondary = normalizeWindow(record.secondary as RateLimitWindow | null | undefined);
+    if (!primary && !secondary) {
+        return null;
+    }
+
+    return {
+        limitId: asStringOrNull(record.limitId),
+        limitName: asStringOrNull(record.limitName),
+        planType: asStringOrNull(record.planType),
+        primary,
+        secondary,
+        updatedAt: Date.now()
+    };
+}
+
+function pickCodexSnapshot(
+    rateLimits: RateLimitSnapshot | undefined,
+    rateLimitsByLimitId: Record<string, RateLimitSnapshot | undefined> | null | undefined,
+    model?: string | null
+): RateLimitSnapshot | null {
+    if (rateLimitsByLimitId) {
+        const modelKey = normalizeLookup(model);
+        if (modelKey) {
+            const modelEntry = Object.entries(rateLimitsByLimitId).find(([key, entry]) => {
+                const record = asRecord(entry);
+                if (!record) {
+                    return false;
+                }
+
+                return normalizeLookup(key) === modelKey
+                    || normalizeLookup(asStringOrNull(record.limitId)) === modelKey
+                    || normalizeLookup(asStringOrNull(record.limitName)) === modelKey;
+            })?.[1];
+            if (modelEntry) {
+                return modelEntry;
+            }
+        }
+
+        const direct = rateLimitsByLimitId.codex;
+        if (direct) {
+            return direct;
+        }
+
+        const codexEntry = Object.values(rateLimitsByLimitId).find((entry) => {
+            const record = asRecord(entry);
+            if (!record) {
+                return false;
+            }
+            const limitId = asStringOrNull(record.limitId)?.toLowerCase();
+            const limitName = asStringOrNull(record.limitName)?.toLowerCase();
+            return limitId === 'codex' || limitName?.includes('codex') === true;
+        });
+        if (codexEntry) {
+            return codexEntry;
+        }
+    }
+
+    return rateLimits ?? null;
+}
+
+export const selectCodexRateLimitSnapshotForTests = pickCodexSnapshot;
+
+export async function getCodexSubscriptionLimits(model?: string | null): Promise<CodexSubscriptionLimits> {
+    const client = new CodexAppServerClient();
+
+    try {
+        await client.connect();
+        await client.initialize({
+            clientInfo: {
+                name: 'hapi-codex-limits',
+                version: '1.0.0'
+            },
+            capabilities: {
+                experimentalApi: true
+            }
+        });
+
+        const response = await client.readAccountRateLimits();
+        const snapshot = pickCodexSnapshot(response.rateLimits, response.rateLimitsByLimitId, model);
+        const limits = normalizeSnapshot(snapshot);
+        if (!limits) {
+            throw new Error('Codex subscription limits unavailable');
+        }
+        return limits;
+    } catch (error) {
+        throw new Error(getErrorMessage(error, 'Failed to read Codex subscription limits'));
+    } finally {
+        await client.disconnect().catch(() => undefined);
+    }
+}

--- a/cli/src/modules/common/handlers/codexModels.ts
+++ b/cli/src/modules/common/handlers/codexModels.ts
@@ -6,6 +6,11 @@ import {
     type ListCodexModelsRequest,
     type ListCodexModelsResponse
 } from '../codexModels';
+import {
+    getCodexSubscriptionLimits,
+    type GetCodexSubscriptionLimitsRequest,
+    type GetCodexSubscriptionLimitsResponse
+} from '../codexSubscriptionLimits';
 import { getErrorMessage, rpcError } from '../rpcResponses';
 
 export function registerCodexModelHandlers(rpcHandlerManager: RpcHandlerManager): void {
@@ -20,4 +25,19 @@ export function registerCodexModelHandlers(rpcHandlerManager: RpcHandlerManager)
             return rpcError(getErrorMessage(error, 'Failed to list Codex models'));
         }
     });
+
+    rpcHandlerManager.registerHandler<GetCodexSubscriptionLimitsRequest, GetCodexSubscriptionLimitsResponse>(
+        RPC_METHODS.GetCodexSubscriptionLimits,
+        async (data) => {
+            logger.debug('Get Codex subscription limits request');
+
+            try {
+                const limits = await getCodexSubscriptionLimits(data?.model);
+                return { success: true, limits };
+            } catch (error) {
+                logger.debug('Failed to read Codex subscription limits:', error);
+                return rpcError(getErrorMessage(error, 'Failed to read Codex subscription limits'));
+            }
+        }
+    );
 }

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -1,6 +1,8 @@
 import type { AgentFlavor, CodexCollaborationMode, PermissionMode } from '@hapi/protocol/types'
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods'
 import type {
+    CodexSubscriptionLimitsResponse,
+    GetCodexSubscriptionLimitsRequest,
     CodexModelSummary,
     CodexModelsResponse,
     CommandResponse,
@@ -55,6 +57,7 @@ export type RpcListDirectoryResponse = ListDirectoryResponse
 export type RpcPathExistsResponse = PathExistsResponse
 export type RpcCodexModel = CodexModelSummary
 export type RpcListCodexModelsResponse = CodexModelsResponse
+export type RpcGetCodexSubscriptionLimitsResponse = CodexSubscriptionLimitsResponse
 export type RpcCursorModel = CursorModelSummary
 export type RpcListCursorModelsResponse = CursorModelsResponse
 export type RpcOpencodeModel = OpencodeModelSummary
@@ -262,8 +265,28 @@ export class RpcGateway {
         return await this.sessionRpc(sessionId, RPC_METHODS.ListCodexModels, {}, MODEL_LIST_RPC_TIMEOUT_MS) as RpcListCodexModelsResponse
     }
 
+    async getCodexSubscriptionLimitsForSession(sessionId: string, model?: string | null): Promise<RpcGetCodexSubscriptionLimitsResponse> {
+        const request: GetCodexSubscriptionLimitsRequest = { model: model ?? null }
+        return await this.sessionRpc(
+            sessionId,
+            RPC_METHODS.GetCodexSubscriptionLimits,
+            request,
+            DEFAULT_RPC_TIMEOUT_MS
+        ) as RpcGetCodexSubscriptionLimitsResponse
+    }
+
     async listCodexModelsForMachine(machineId: string): Promise<RpcListCodexModelsResponse> {
         return await this.machineRpc(machineId, RPC_METHODS.ListCodexModels, {}, MODEL_LIST_RPC_TIMEOUT_MS) as RpcListCodexModelsResponse
+    }
+
+    async getCodexSubscriptionLimitsForMachine(machineId: string, model?: string | null): Promise<RpcGetCodexSubscriptionLimitsResponse> {
+        const request: GetCodexSubscriptionLimitsRequest = { model: model ?? null }
+        return await this.machineRpc(
+            machineId,
+            RPC_METHODS.GetCodexSubscriptionLimits,
+            request,
+            DEFAULT_RPC_TIMEOUT_MS
+        ) as RpcGetCodexSubscriptionLimitsResponse
     }
 
     async listCursorModelsForSession(sessionId: string): Promise<RpcListCursorModelsResponse> {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -28,6 +28,7 @@ import {
     type RpcCommandResponse,
     type RpcDeleteUploadResponse,
     type RpcGeneratedImageResponse,
+    type RpcGetCodexSubscriptionLimitsResponse,
     type RpcListDirectoryResponse,
     type RpcListCodexModelsResponse,
     type RpcListCursorModelsResponse,
@@ -49,6 +50,7 @@ export type {
     RpcCommandResponse,
     RpcDeleteUploadResponse,
     RpcGeneratedImageResponse,
+    RpcGetCodexSubscriptionLimitsResponse,
     RpcListDirectoryResponse,
     RpcListCodexModelsResponse,
     RpcListCursorModelsResponse,
@@ -1585,8 +1587,46 @@ export class SyncEngine {
         return await this.rpcGateway.listCodexModelsForSession(sessionId)
     }
 
+    async getCodexSubscriptionLimitsForSession(sessionId: string): Promise<RpcGetCodexSubscriptionLimitsResponse> {
+        const session = this.getSession(sessionId)
+        const model = session?.model ?? null
+        try {
+            return await this.rpcGateway.getCodexSubscriptionLimitsForSession(sessionId, model)
+        } catch (error) {
+            if (!(error instanceof RpcTargetMissingError)) {
+                throw error
+            }
+
+            const metadata = session?.metadata
+            const onlineMachines = session
+                ? this.machineCache.getOnlineMachinesByNamespace(session.namespace)
+                : []
+            const targetMachine = (() => {
+                if (metadata?.machineId) {
+                    const exact = onlineMachines.find((machine) => machine.id === metadata.machineId)
+                    if (exact) return exact
+                }
+                if (metadata?.host) {
+                    const hostMatch = onlineMachines.find((machine) => machine.metadata?.host === metadata.host)
+                    if (hostMatch) return hostMatch
+                }
+                return onlineMachines.length === 1 ? onlineMachines[0] : null
+            })()
+
+            if (!targetMachine) {
+                throw error
+            }
+
+            return await this.rpcGateway.getCodexSubscriptionLimitsForMachine(targetMachine.id, model)
+        }
+    }
+
     async listCodexModelsForMachine(machineId: string): Promise<RpcListCodexModelsResponse> {
         return await this.rpcGateway.listCodexModelsForMachine(machineId)
+    }
+
+    async getCodexSubscriptionLimitsForMachine(machineId: string): Promise<RpcGetCodexSubscriptionLimitsResponse> {
+        return await this.rpcGateway.getCodexSubscriptionLimitsForMachine(machineId)
     }
 
     async listCursorModelsForSession(sessionId: string): Promise<RpcListCursorModelsResponse> {

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -74,6 +74,17 @@ function createApp(session: Session, opts?: {
             { id: 'gpt-5.5', displayName: 'GPT-5.5', isDefault: true }
         ]
     })
+    const getCodexSubscriptionLimitsForSession = async () => ({
+        success: true,
+        limits: {
+            limitId: 'codex',
+            limitName: 'Codex',
+            planType: 'plus',
+            primary: { usedPercent: 12, windowDurationMins: 300, resetsAt: 1_762_000_000 },
+            secondary: { usedPercent: 34, windowDurationMins: 10_080, resetsAt: 1_762_500_000 },
+            updatedAt: 1_762_000_000_000
+        }
+    })
     const listOpencodeModelsForSession = async () => ({
         success: true,
         availableModels: [
@@ -112,6 +123,7 @@ function createApp(session: Session, opts?: {
             : { ok: false, reason: 'not-found' },
         applySessionConfig,
         listCodexModelsForSession,
+        getCodexSubscriptionLimitsForSession,
         listCursorModelsForSession,
         listOpencodeModelsForSession,
         listOpencodeReasoningEffortOptionsForSession,
@@ -618,6 +630,25 @@ describe('sessions routes', () => {
             models: [
                 { id: 'gpt-5.5', displayName: 'GPT-5.5', isDefault: true }
             ]
+        })
+    })
+
+    it('returns Codex subscription limits for active Codex sessions', async () => {
+        const { app } = createApp(createSession())
+
+        const response = await app.request('/api/sessions/session-1/codex-subscription-limits')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+            success: true,
+            limits: {
+                limitId: 'codex',
+                limitName: 'Codex',
+                planType: 'plus',
+                primary: { usedPercent: 12, windowDurationMins: 300, resetsAt: 1_762_000_000 },
+                secondary: { usedPercent: 34, windowDurationMins: 10_080, resetsAt: 1_762_500_000 },
+                updatedAt: 1_762_000_000_000
+            }
         })
     })
 

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -763,6 +763,36 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         }
     })
 
+    app.get('/sessions/:id/codex-subscription-limits', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+
+        const flavor = sessionResult.session.metadata?.flavor ?? 'claude'
+        if (flavor !== 'codex') {
+            return c.json({
+                success: false,
+                error: 'Codex subscription limits are only available for Codex sessions'
+            }, 400)
+        }
+
+        try {
+            const result = await engine.getCodexSubscriptionLimitsForSession(sessionResult.sessionId)
+            return c.json(result)
+        } catch (error) {
+            return c.json({
+                success: false,
+                error: error instanceof Error ? error.message : 'Failed to read Codex subscription limits'
+            }, 500)
+        }
+    })
+
     app.get('/sessions/:id/opencode-models', async (c) => {
         const engine = requireSyncEngine(c, getSyncEngine)
         if (engine instanceof Response) {

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -358,6 +358,33 @@ export type CodexModelsResponse = {
 
 export type ListCodexModelsResponse = CodexModelsResponse
 
+export type CodexSubscriptionLimitWindow = {
+    usedPercent: number
+    windowDurationMins: number | null
+    resetsAt: number | null
+}
+
+export type CodexSubscriptionLimits = {
+    limitId: string | null
+    limitName: string | null
+    planType: string | null
+    primary: CodexSubscriptionLimitWindow | null
+    secondary: CodexSubscriptionLimitWindow | null
+    updatedAt: number
+}
+
+export type CodexSubscriptionLimitsResponse = {
+    success: boolean
+    limits?: CodexSubscriptionLimits
+    error?: string
+}
+
+export type GetCodexSubscriptionLimitsRequest = {
+    model?: string | null
+}
+
+export type GetCodexSubscriptionLimitsResponse = CodexSubscriptionLimitsResponse
+
 export type OpencodeModelSummary = {
     modelId: string
     name?: string

--- a/shared/src/rpcMethods.ts
+++ b/shared/src/rpcMethods.ts
@@ -26,6 +26,7 @@ export const RPC_METHODS = {
     ListSlashCommands: 'listSlashCommands',
     ListSkills: 'listSkills',
     ListCodexModels: 'listCodexModels',
+    GetCodexSubscriptionLimits: 'getCodexSubscriptionLimits',
     ListCursorModels: 'listCursorModels',
     ListPiModels: 'listPiModels',
     ListOpencodeModels: 'listOpencodeModels',

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -24,6 +24,7 @@ import type {
     SessionsResponse
 } from '@/types/api'
 import type {
+    CodexSubscriptionLimitsResponse,
     CodexModelsResponse,
     CursorMigrateOutcome,
     CursorMigrateToAcpRequest,
@@ -613,6 +614,12 @@ export class ApiClient {
     async getSessionCodexModels(sessionId: string): Promise<CodexModelsResponse> {
         return await this.request<CodexModelsResponse>(
             `/api/sessions/${encodeURIComponent(sessionId)}/codex-models`
+        )
+    }
+
+    async getSessionCodexSubscriptionLimits(sessionId: string): Promise<CodexSubscriptionLimitsResponse> {
+        return await this.request<CodexSubscriptionLimitsResponse>(
+            `/api/sessions/${encodeURIComponent(sessionId)}/codex-subscription-limits`
         )
     }
 

--- a/web/src/components/AssistantChat/ComposerButtons.tsx
+++ b/web/src/components/AssistantChat/ComposerButtons.tsx
@@ -1,15 +1,32 @@
 import { ComposerPrimitive } from '@assistant-ui/react'
+import type { PermissionMode } from '@/types/api'
 import type { ConversationStatus } from '@/realtime/types'
 import { useTranslation } from '@/lib/use-translation'
 import { ScheduleIcon } from '@/components/icons'
 import { ScheduleTimePicker } from './ScheduleTimePicker'
 import type { PendingSchedule } from './ScheduleTimePicker'
-import { useFue } from '@/lib/use-fue'
-import { FueCallout, FueDot } from '@/components/Fue'
-import { useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from 'react'
 
 function ChevronIcon() {
     return <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"><path d="M2.5 3.75L5 6.25L7.5 3.75" /></svg>
+}
+
+function PlusIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        >
+            <path d="M12 5v14M5 12h14" />
+        </svg>
+    )
 }
 
 function VoiceAssistantIcon() {
@@ -77,25 +94,6 @@ function SpeakerIcon(props: { muted?: boolean }) {
     )
 }
 
-function SettingsIcon() {
-    return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-        >
-            <circle cx="12" cy="12" r="3" />
-            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-        </svg>
-    )
-}
-
 function SwitchToRemoteIcon() {
     return (
         <svg
@@ -149,6 +147,44 @@ function AttachmentIcon() {
             strokeLinejoin="round"
         >
             <path d="M21.44 11.05l-8.49 8.49a5.5 5.5 0 0 1-7.78-7.78l8.49-8.49a3.5 3.5 0 0 1 4.95 4.95l-8.49 8.49a1.5 1.5 0 0 1-2.12-2.12l7.78-7.78" />
+        </svg>
+    )
+}
+
+function PlanModeIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        >
+            <path d="M8 6h13M8 12h13M8 18h13" />
+            <path d="M3 6h.01M3 12h.01M3 18h.01" />
+        </svg>
+    )
+}
+
+function GoalModeIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        >
+            <circle cx="12" cy="12" r="8" />
+            <circle cx="12" cy="12" r="3" />
         </svg>
     )
 }
@@ -223,82 +259,6 @@ function ScratchlistToggleIcon() {
     )
 }
 
-/**
- * ScratchlistToggleButton — composer affordance for toggling scratchlist mode,
- * wrapped in the generic FUE (First-User Experience) primitive so a new
- * operator sees a pulsing dot + a one-time explainer popover the first time
- * they encounter the feature; once they engage with it, the dot disappears
- * for good and the entry counter takes over.
- *
- * The FUE wiring here is the canonical example for future features: the
- * pattern is "wrap the affordance in useFue + FueDot, conditionally render
- * FueCallout while engaging". See web/src/lib/use-fue.ts for the contract.
- */
-function ScratchlistToggleButton(props: {
-    scratchlistMode: boolean
-    scratchlistCount: number
-    onScratchlistToggle: () => void
-    controlsDisabled?: boolean
-}) {
-    const { t } = useTranslation()
-    const fue = useFue('scratchlist-toggle')
-    const buttonRef = useRef<HTMLButtonElement>(null)
-
-    const showFueDot = fue.status !== 'acknowledged'
-    // Counter and FUE dot are mutually exclusive (see FueDot doc comment).
-    // Onboarding signal beats inventory signal: the user can't read the
-    // counter as "you have N items" until they understand the feature.
-    const showCounter = !showFueDot && props.scratchlistCount > 0
-
-    return (
-        <>
-            <button
-                ref={buttonRef}
-                type="button"
-                aria-label={t('scratchlist.toggleAriaLabel')}
-                title={t('scratchlist.toggleTooltip')}
-                aria-pressed={props.scratchlistMode ? true : false}
-                disabled={props.controlsDisabled}
-                onClick={() => {
-                    fue.engage()
-                    props.onScratchlistToggle()
-                }}
-                className={`relative flex h-8 w-8 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                    props.scratchlistMode
-                        ? 'bg-amber-500 text-white hover:bg-amber-600'
-                        : 'text-[var(--app-fg)]/60 hover:bg-[var(--app-bg)] hover:text-[var(--app-fg)]'
-                }`}
-            >
-                <ScratchlistToggleIcon />
-                {showFueDot ? (
-                    <FueDot
-                        pulsing={fue.status === 'unseen'}
-                        ariaLabel={t('fue.newFeatureDot')}
-                    />
-                ) : null}
-                {showCounter ? (
-                    <span
-                        aria-hidden="true"
-                        className="absolute -top-0.5 -right-0.5 min-w-[12px] h-3 px-[3px] flex items-center justify-center rounded-full bg-amber-500 text-white text-[8px] font-semibold leading-none tabular-nums shadow-sm"
-                    >
-                        {props.scratchlistCount > 99 ? '99+' : props.scratchlistCount}
-                    </span>
-                ) : null}
-            </button>
-            {fue.status === 'engaging' ? (
-                <FueCallout
-                    title={t('scratchlist.fueTitle')}
-                    body={t('scratchlist.fueBody')}
-                    onDismiss={fue.dismiss}
-                    dismissLabel={t('fue.gotIt')}
-                    closeAriaLabel={t('fue.closeAriaLabel')}
-                    anchorRef={buttonRef}
-                />
-            ) : null}
-        </>
-    )
-}
-
 function StopIcon() {
     return (
         <svg
@@ -328,6 +288,124 @@ function LoadingIcon() {
             <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
             <path d="M12 2a10 10 0 0 1 10 10" strokeOpacity="0.75" />
         </svg>
+    )
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max)
+}
+
+function ToolbarMenu(props: {
+    anchorRef: RefObject<HTMLElement | null>
+    align?: 'left' | 'right'
+    width?: number
+    maxHeight?: number
+    onClose: () => void
+    children: ReactNode
+}) {
+    const panelRef = useRef<HTMLDivElement>(null)
+    const [position, setPosition] = useState<{ top: number; left: number; maxHeight: number } | null>(null)
+
+    useLayoutEffect(() => {
+        function measure() {
+            const anchor = props.anchorRef.current
+            if (!anchor) return
+            const panel = panelRef.current
+            const viewport = window.visualViewport
+            const viewportLeft = viewport?.offsetLeft ?? 0
+            const viewportTop = viewport?.offsetTop ?? 0
+            const viewportWidth = viewport?.width ?? window.innerWidth
+            const viewportHeight = viewport?.height ?? window.innerHeight
+            const margin = 8
+            const gap = 8
+            const panelWidth = props.width ?? panel?.offsetWidth ?? 220
+            const fullHeight = Math.min(panel?.scrollHeight ?? props.maxHeight ?? 260, props.maxHeight ?? 260)
+            const rect = anchor.getBoundingClientRect()
+            const minLeft = viewportLeft + margin
+            const maxLeft = viewportLeft + viewportWidth - panelWidth - margin
+            const preferredLeft = props.align === 'right' ? rect.right - panelWidth : rect.left
+            const left = clamp(preferredLeft, minLeft, Math.max(minLeft, maxLeft))
+            const aboveTop = rect.top - gap - fullHeight
+            const belowTop = rect.bottom + gap
+            const top = aboveTop >= viewportTop + margin
+                ? aboveTop
+                : clamp(belowTop, viewportTop + margin, viewportTop + viewportHeight - margin - fullHeight)
+            const maxHeight = Math.max(120, Math.min(fullHeight, viewportTop + viewportHeight - margin - top))
+            setPosition({ top, left, maxHeight })
+        }
+
+        measure()
+        window.addEventListener('resize', measure, { passive: true })
+        window.addEventListener('scroll', measure, { passive: true, capture: true })
+        window.visualViewport?.addEventListener('resize', measure, { passive: true })
+        window.visualViewport?.addEventListener('scroll', measure, { passive: true })
+        return () => {
+            window.removeEventListener('resize', measure)
+            window.removeEventListener('scroll', measure, true)
+            window.visualViewport?.removeEventListener('resize', measure)
+            window.visualViewport?.removeEventListener('scroll', measure)
+        }
+    }, [props.anchorRef, props.align, props.width, props.maxHeight])
+
+    useEffect(() => {
+        function handlePointerDown(event: PointerEvent) {
+            const target = event.target as Node
+            if (panelRef.current?.contains(target)) return
+            if (props.anchorRef.current?.contains(target)) return
+            props.onClose()
+        }
+        document.addEventListener('pointerdown', handlePointerDown)
+        return () => document.removeEventListener('pointerdown', handlePointerDown)
+    }, [props.anchorRef, props.onClose])
+
+    return (
+        <div
+            ref={panelRef}
+            style={position
+                ? { position: 'fixed', top: position.top, left: position.left, width: props.width ?? 220, maxHeight: position.maxHeight }
+                : { position: 'fixed', visibility: 'hidden', width: props.width ?? 220 }
+            }
+            className="z-50 overflow-hidden rounded-xl border border-[var(--app-divider)] bg-[var(--app-bg)] shadow-lg"
+            onPointerDown={(event) => event.stopPropagation()}
+        >
+            <div className="overflow-y-auto" style={{ maxHeight: position?.maxHeight ?? props.maxHeight ?? 260 }}>
+                {props.children}
+            </div>
+        </div>
+    )
+}
+
+function ContextUsageIndicator(props: { percentage: number | null | undefined; label?: string }) {
+    if (props.percentage == null) return null
+
+    const percentage = Math.min(100, Math.max(0, props.percentage))
+    const radius = 6
+    const circumference = 2 * Math.PI * radius
+    const shade = Math.round(185 - percentage * 1.25)
+    const progressColor = `rgb(${shade}, ${shade}, ${shade})`
+
+    return (
+        <span
+            className="flex h-8 w-5 shrink-0 items-center justify-center"
+            aria-label={props.label}
+            title={props.label}
+        >
+            <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+                <circle cx="8" cy="8" r={radius} fill="none" stroke="rgb(229, 231, 235)" strokeWidth="2" />
+                <circle
+                    cx="8"
+                    cy="8"
+                    r={radius}
+                    fill="none"
+                    stroke={progressColor}
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeDasharray={circumference}
+                    strokeDashoffset={circumference * (1 - percentage / 100)}
+                    transform="rotate(-90 8 8)"
+                />
+            </svg>
+        </span>
     )
 }
 
@@ -372,7 +450,7 @@ export function UnifiedButton(props: {
         }
     }
 
-    let icon: React.ReactNode
+    let icon: ReactNode
     let className: string
     let ariaLabel: string
 
@@ -435,6 +513,22 @@ export function ComposerButtons(props: {
     controlsDisabled: boolean
     showSettingsButton: boolean
     onSettingsToggle: () => void
+    settingsLabel?: string
+    settingsModelLabel?: string
+    settingsReasoningLabel?: string | null
+    settingsOpen?: boolean
+    contextUsagePercent?: number | null
+    contextUsageLabel?: string
+    permissionMode?: PermissionMode
+    permissionLabel?: string
+    permissionModeOptions?: Array<{ mode: PermissionMode; label: string }>
+    onPermissionModeChange?: (mode: PermissionMode) => void
+    showPlanModeButton?: boolean
+    planModeActive?: boolean
+    onPlanModeToggle?: () => void
+    showGoalModeButton?: boolean
+    goalModeActive?: boolean
+    onGoalModeOpen?: () => void
     showTerminalButton: boolean
     terminalDisabled: boolean
     terminalLabel: string
@@ -481,34 +575,240 @@ export function ComposerButtons(props: {
     const { t } = useTranslation()
     const isVoiceConnected = props.voiceStatus === 'connected'
     const [showSchedulePicker, setShowSchedulePicker] = useState(false)
-    const scheduleButtonRef = useRef<HTMLButtonElement>(null)
+    const [showToolsMenu, setShowToolsMenu] = useState(false)
+    const [showPermissionMenu, setShowPermissionMenu] = useState(false)
+    const toolsButtonRef = useRef<HTMLButtonElement>(null)
+    const permissionButtonRef = useRef<HTMLButtonElement>(null)
 
     const hasSchedule = props.pendingSchedule != null
     const hasAttachments = props.hasAttachments ?? false
+    const showPermissionButton = Boolean(props.onPermissionModeChange && props.permissionModeOptions?.length)
+    const permissionLabel = props.permissionLabel
+        ?? props.permissionModeOptions?.find((option) => option.mode === props.permissionMode)?.label
+        ?? props.permissionMode
+        ?? t('misc.permissionMode')
+    const isYoloPermission = (mode: PermissionMode | undefined) => (
+        mode === 'bypassPermissions'
+        || mode === 'safe-yolo'
+        || mode === 'yolo'
+    )
+    const toolMenuItemClass = 'flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[var(--app-fg)] transition-colors hover:bg-[var(--app-secondary-bg)] disabled:cursor-not-allowed disabled:opacity-45'
 
     return (
         <div className="flex items-center justify-between px-2 pb-2">
             <div className="flex items-center gap-1">
-                <ComposerPrimitive.AddAttachment
-                    aria-label={t('composer.attach')}
-                    title={t('composer.attach')}
-                    disabled={props.controlsDisabled || hasSchedule}
-                    className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--app-fg)]/60 transition-colors hover:bg-[var(--app-bg)] hover:text-[var(--app-fg)] disabled:cursor-not-allowed disabled:opacity-50"
+                <button
+                    ref={toolsButtonRef}
+                    type="button"
+                    aria-label={t('composer.moreTools')}
+                    title={t('composer.moreTools')}
+                    className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors ${
+                        showToolsMenu
+                            ? 'bg-[var(--app-bg)] text-[var(--app-fg)]'
+                            : 'text-[var(--app-fg)]/65 hover:bg-[var(--app-bg)] hover:text-[var(--app-fg)]'
+                    }`}
+                    onClick={() => {
+                        setShowToolsMenu((open) => !open)
+                        setShowPermissionMenu(false)
+                        setShowSchedulePicker(false)
+                    }}
                 >
-                    <AttachmentIcon />
-                </ComposerPrimitive.AddAttachment>
+                    <PlusIcon />
+                </button>
 
-                {props.showSettingsButton ? (
+                {showPermissionButton ? (
                     <button
+                        ref={permissionButtonRef}
                         type="button"
-                        aria-label={t('composer.settings')}
-                        title={t('composer.settings')}
-                        className="settings-button flex h-8 w-8 items-center justify-center rounded-full text-[var(--app-fg)]/60 transition-colors hover:bg-[var(--app-bg)] hover:text-[var(--app-fg)]"
-                        onClick={props.onSettingsToggle}
+                        aria-label={t('misc.permissionMode')}
+                        title={t('misc.permissionMode')}
                         disabled={props.controlsDisabled}
+                        className={`flex h-8 items-center gap-1 rounded-full px-2 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                            showPermissionMenu
+                                ? isYoloPermission(props.permissionMode) ? 'bg-[var(--app-bg)] text-orange-500' : 'bg-[var(--app-bg)] text-[var(--app-fg)]'
+                                : isYoloPermission(props.permissionMode) ? 'text-orange-500 hover:bg-[var(--app-bg)] hover:text-orange-600' : 'text-[var(--app-fg)]/65 hover:bg-[var(--app-bg)] hover:text-[var(--app-fg)]'
+                        }`}
+                        onClick={() => {
+                            setShowPermissionMenu((open) => !open)
+                            setShowToolsMenu(false)
+                            setShowSchedulePicker(false)
+                        }}
                     >
-                        <SettingsIcon />
+                        <span className="max-w-28 truncate">{permissionLabel}</span>
+                        <ChevronIcon />
                     </button>
+                ) : null}
+
+                {showToolsMenu ? (
+                    <ToolbarMenu
+                        anchorRef={toolsButtonRef}
+                        align="left"
+                        width={220}
+                        maxHeight={280}
+                        onClose={() => setShowToolsMenu(false)}
+                    >
+                        <div className="py-1">
+                            {props.showPlanModeButton && props.onPlanModeToggle ? (
+                                <button
+                                    type="button"
+                                    aria-label={t('composer.planMode')}
+                                    title={t('composer.planMode')}
+                                    disabled={props.controlsDisabled}
+                                    onClick={() => {
+                                        setShowToolsMenu(false)
+                                        props.onPlanModeToggle?.()
+                                    }}
+                                    className={toolMenuItemClass}
+                                >
+                                    <PlanModeIcon />
+                                    <span className="flex-1">{t('composer.planMode')}</span>
+                                    {props.planModeActive ? <span className="text-[var(--app-hint)]">✓</span> : null}
+                                </button>
+                            ) : null}
+
+                            {props.showGoalModeButton && props.onGoalModeOpen ? (
+                                <button
+                                    type="button"
+                                    aria-label={t('composer.goalMode')}
+                                    title={t('composer.goalMode')}
+                                    disabled={props.controlsDisabled}
+                                    onClick={() => {
+                                        setShowToolsMenu(false)
+                                        props.onGoalModeOpen?.()
+                                    }}
+                                    className={toolMenuItemClass}
+                                >
+                                    <GoalModeIcon />
+                                    <span className="flex-1">{t('composer.goalMode')}</span>
+                                    {props.goalModeActive ? <span className="text-[var(--app-hint)]">✓</span> : null}
+                                </button>
+                            ) : null}
+
+                            {(props.showPlanModeButton || props.showGoalModeButton) ? (
+                                <div className="my-1 h-px bg-[var(--app-divider)]" />
+                            ) : null}
+
+                            <ComposerPrimitive.AddAttachment
+                                aria-label={t('composer.attach')}
+                                title={t('composer.attach')}
+                                disabled={props.controlsDisabled || hasSchedule}
+                                onClick={() => setShowToolsMenu(false)}
+                                className={toolMenuItemClass}
+                            >
+                                <AttachmentIcon />
+                                <span className="flex-1">{t('composer.attach')}</span>
+                            </ComposerPrimitive.AddAttachment>
+
+                            {props.showTerminalButton ? (
+                                <button
+                                    type="button"
+                                    aria-label={props.terminalLabel}
+                                    title={props.terminalLabel}
+                                    className={toolMenuItemClass}
+                                    onClick={() => {
+                                        setShowToolsMenu(false)
+                                        props.onTerminal()
+                                    }}
+                                    disabled={props.terminalDisabled}
+                                >
+                                    <TerminalIcon />
+                                    <span className="flex-1">{props.terminalLabel}</span>
+                                </button>
+                            ) : null}
+
+                            {props.onSchedule ? (
+                                <button
+                                    type="button"
+                                    aria-label={t('composer.scheduleSend')}
+                                    title={t('composer.scheduleSend')}
+                                    disabled={props.controlsDisabled || hasAttachments}
+                                    onClick={() => {
+                                        setShowToolsMenu(false)
+                                        if (hasSchedule && props.onClearSchedule) {
+                                            props.onClearSchedule()
+                                            return
+                                        }
+                                        setShowSchedulePicker(true)
+                                    }}
+                                    className={toolMenuItemClass}
+                                >
+                                    <ScheduleIcon className="h-[18px] w-[18px]" />
+                                    <span className="flex-1">{t('composer.scheduleSend')}</span>
+                                    {hasSchedule ? <span className="text-[var(--app-hint)]">✓</span> : null}
+                                </button>
+                            ) : null}
+
+                            {props.onScratchlistToggle ? (
+                                <button
+                                    type="button"
+                                    aria-label={t('scratchlist.toggleAriaLabel')}
+                                    title={t('scratchlist.toggleTooltip')}
+                                    aria-pressed={props.scratchlistMode ? true : false}
+                                    disabled={props.controlsDisabled}
+                                    onClick={() => {
+                                        setShowToolsMenu(false)
+                                        props.onScratchlistToggle?.()
+                                    }}
+                                    className={toolMenuItemClass}
+                                >
+                                    <ScratchlistToggleIcon />
+                                    <span className="flex-1">{t('scratchlist.title')}</span>
+                                    {props.scratchlistMode ? <span className="text-amber-500">✓</span> : null}
+                                    {!props.scratchlistMode && (props.scratchlistCount ?? 0) > 0 ? (
+                                        <span className="rounded-full bg-amber-500 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white">
+                                            {(props.scratchlistCount ?? 0) > 99 ? '99+' : props.scratchlistCount}
+                                        </span>
+                                    ) : null}
+                                </button>
+                            ) : null}
+                        </div>
+                    </ToolbarMenu>
+                ) : null}
+
+                {showPermissionMenu && props.permissionModeOptions ? (
+                    <ToolbarMenu
+                        anchorRef={permissionButtonRef}
+                        align="left"
+                        width={190}
+                        maxHeight={280}
+                        onClose={() => setShowPermissionMenu(false)}
+                    >
+                        <div className="py-1">
+                            {props.permissionModeOptions.map((option) => {
+                                const selected = option.mode === props.permissionMode
+                                const yoloOption = isYoloPermission(option.mode)
+                                return (
+                                    <button
+                                        key={option.mode}
+                                        type="button"
+                                        disabled={props.controlsDisabled}
+                                        className={toolMenuItemClass}
+                                        onClick={() => {
+                                            props.onPermissionModeChange?.(option.mode)
+                                            setShowPermissionMenu(false)
+                                        }}
+                                    >
+                                        <span className={`flex-1 ${selected ? 'font-medium' : ''} ${yoloOption ? 'text-orange-500' : ''}`}>
+                                            {option.label}
+                                        </span>
+                                        {selected ? <span className="text-[var(--app-hint)]">✓</span> : null}
+                                    </button>
+                                )
+                            })}
+                        </div>
+                    </ToolbarMenu>
+                ) : null}
+
+                {showSchedulePicker && props.onSchedule ? (
+                    <ScheduleTimePicker
+                        anchorRef={toolsButtonRef}
+                        onSchedule={(pending) => {
+                            props.onSchedule!(pending)
+                            setShowSchedulePicker(false)
+                        }}
+                        onClose={() => setShowSchedulePicker(false)}
+                        pendingSchedule={props.pendingSchedule}
+                    />
                 ) : null}
 
                 {props.piModelLabel ? (
@@ -547,19 +847,6 @@ export function ComposerButtons(props: {
                     </button>
                 ) : null}
 
-                {props.showTerminalButton ? (
-                    <button
-                        type="button"
-                        aria-label={props.terminalLabel}
-                        title={props.terminalLabel}
-                        className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--app-fg)]/60 transition-colors hover:bg-[var(--app-bg)] hover:text-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
-                        onClick={props.onTerminal}
-                        disabled={props.terminalDisabled}
-                    >
-                        <TerminalIcon />
-                    </button>
-                ) : null}
-
                 {props.showAbortButton ? (
                     <button
                         type="button"
@@ -585,6 +872,45 @@ export function ComposerButtons(props: {
                         <SwitchToRemoteIcon />
                     </button>
                 ) : null}
+            </div>
+
+            <div className="flex items-center gap-1">
+                <ContextUsageIndicator
+                    percentage={props.contextUsagePercent}
+                    label={props.contextUsageLabel}
+                />
+
+                {props.showSettingsButton ? (
+                    <button
+                        type="button"
+                        aria-label={t('composer.settings')}
+                        title={t('composer.settings')}
+                        className={`settings-button flex h-8 items-center gap-1.5 rounded-full px-2 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                            props.settingsOpen
+                                ? 'bg-[var(--app-bg)] text-[var(--app-fg)]'
+                                : 'text-[var(--app-fg)]/65 hover:bg-[var(--app-bg)] hover:text-[var(--app-fg)]'
+                        }`}
+                        onClick={() => {
+                            setShowToolsMenu(false)
+                            setShowPermissionMenu(false)
+                            setShowSchedulePicker(false)
+                            props.onSettingsToggle()
+                        }}
+                        disabled={props.controlsDisabled}
+                    >
+                        {props.settingsModelLabel ? (
+                            <>
+                                <span className="whitespace-nowrap font-bold text-[var(--app-fg)]">{props.settingsModelLabel}</span>
+                                {props.settingsReasoningLabel ? (
+                                    <span className="whitespace-nowrap">{props.settingsReasoningLabel}</span>
+                                ) : null}
+                            </>
+                        ) : (
+                            <span className="whitespace-nowrap font-semibold">{props.settingsLabel ?? t('composer.settings')}</span>
+                        )}
+                        <ChevronIcon />
+                    </button>
+                ) : null}
 
                 {isVoiceConnected && props.onVoiceMicToggle ? (
                     <button
@@ -602,88 +928,30 @@ export function ComposerButtons(props: {
                     </button>
                 ) : null}
 
-                {/*
-                 * Scratchlist toggle - prototype of the composer-controlled
-                 * drawer (replaces the always-visible orange band). Counter
-                 * shown only when entries exist (>0); empty-state shows just
-                 * the icon to avoid the "you have 0 things" guilt UI.
-                 *
-                 * Clicking enters scratchlist mode: the send button repaints
-                 * amber and SessionChat's wrapped onSend routes the next
-                 * submission to addScratchlistEntry() instead of the chat.
-                 * Mode is sticky - operator clicks the icon again to exit.
-                 */}
-                {props.onScratchlistToggle ? (
-                    <ScratchlistToggleButton
-                        scratchlistMode={props.scratchlistMode ?? false}
-                        scratchlistCount={props.scratchlistCount ?? 0}
-                        onScratchlistToggle={props.onScratchlistToggle}
-                        controlsDisabled={props.controlsDisabled}
-                    />
-                ) : null}
-
-                {/* Schedule button — only shown when onSchedule handler is provided */}
-                {props.onSchedule ? (
-                    <>
-                        <button
-                            ref={scheduleButtonRef}
-                            type="button"
-                            aria-label={t('composer.scheduleSend')}
-                            title={t('composer.scheduleSend')}
-                            disabled={props.controlsDisabled || hasAttachments}
-                            onClick={() => {
-                                if (hasSchedule && props.onClearSchedule) {
-                                    props.onClearSchedule()
-                                } else {
-                                    setShowSchedulePicker((v) => !v)
-                                }
-                            }}
-                            className={`flex h-8 w-8 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
-                                hasSchedule
-                                    ? 'bg-blue-500 text-white hover:bg-blue-600'
-                                    : 'text-[var(--app-fg)]/60 hover:bg-[var(--app-bg)] hover:text-[var(--app-fg)]'
-                            }`}
-                        >
-                            <ScheduleIcon className="h-[18px] w-[18px]" />
-                        </button>
-                        {showSchedulePicker && (
-                            <ScheduleTimePicker
-                                anchorRef={scheduleButtonRef}
-                                onSchedule={(pending) => {
-                                    props.onSchedule!(pending)
-                                    setShowSchedulePicker(false)
-                                }}
-                                onClose={() => setShowSchedulePicker(false)}
-                                pendingSchedule={props.pendingSchedule}
-                            />
-                        )}
-                    </>
-                ) : null}
+                <UnifiedButton
+                    canSend={props.canSend}
+                    voiceStatus={props.voiceStatus}
+                    voiceEnabled={props.voiceEnabled}
+                    controlsDisabled={props.controlsDisabled}
+                    onSend={props.onSend}
+                    onVoiceToggle={props.onVoiceToggle}
+                    /*
+                     * Derived, NOT raw scratchlistMode. Mirror SessionChat's
+                     * shouldRouteToScratchlist so the visible send-button state
+                     * matches the actual routing decision: amber + "Send to
+                     * scratchlist" only when mode is on AND the payload would
+                     * be a pure-text scratchlist add. Attachments or a pending
+                     * schedule force a chat fallback in onSendForComposer; the
+                     * button must reflect that, otherwise the UI lies about
+                     * where the user's content is going.
+                     */
+                    routesToScratchlist={
+                        (props.scratchlistMode ?? false)
+                        && !hasAttachments
+                        && props.pendingSchedule == null
+                    }
+                />
             </div>
-
-            <UnifiedButton
-                canSend={props.canSend}
-                voiceStatus={props.voiceStatus}
-                voiceEnabled={props.voiceEnabled}
-                controlsDisabled={props.controlsDisabled}
-                onSend={props.onSend}
-                onVoiceToggle={props.onVoiceToggle}
-                /*
-                 * Derived, NOT raw scratchlistMode. Mirror SessionChat's
-                 * shouldRouteToScratchlist so the visible send-button state
-                 * matches the actual routing decision: amber + "Send to
-                 * scratchlist" only when mode is on AND the payload would
-                 * be a pure-text scratchlist add. Attachments or a pending
-                 * schedule force a chat fallback in onSendForComposer; the
-                 * button must reflect that, otherwise the UI lies about
-                 * where the user's content is going.
-                 */
-                routesToScratchlist={
-                    (props.scratchlistMode ?? false)
-                    && !hasAttachments
-                    && props.pendingSchedule == null
-                }
-            />
         </div>
     )
 }

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -31,6 +31,7 @@ import { shouldShowComposerStatusBar, StatusBar } from '@/components/AssistantCh
 import { ComposerButtons } from '@/components/AssistantChat/ComposerButtons'
 import type { PendingSchedule } from '@/components/AssistantChat/ScheduleTimePicker'
 import { AttachmentItem } from '@/components/AssistantChat/AttachmentItem'
+import { getContextBudgetTokens } from '@/chat/modelConfig'
 import { useTranslation } from '@/lib/use-translation'
 import { getModelOptionsForFlavor, getNextModelForFlavor } from './modelOptions'
 import { getClaudeComposerEffortOptions } from './claudeEffortOptions'
@@ -80,6 +81,30 @@ export type ComposerSendError = {
 }
 
 const defaultSuggestionHandler = async (): Promise<Suggestion[]> => []
+type SettingsPanel = 'main' | 'model' | 'speed'
+
+function formatReasoningLabel(value: string | null | undefined, label: string, locale: 'en' | 'zh-CN'): string {
+    const normalized = value?.trim().toLowerCase()
+    if (locale !== 'zh-CN') return label
+    if (!normalized || normalized === 'default') return '默认'
+    if (normalized === 'low') return '低'
+    if (normalized === 'medium') return '中'
+    if (normalized === 'high') return '高'
+    if (normalized === 'xhigh' || normalized === 'max') return '超高'
+    return label
+}
+
+function formatCompactModelLabel(label: string): string {
+    return label
+        .replace(/^GPT-/i, '')
+        .replace(/^gpt-/i, '')
+}
+
+function formatTokenCount(value: number): string {
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+    if (value >= 1_000) return `${Math.round(value / 1_000)}k`
+    return String(value)
+}
 
 export function ModelEffortSettingsSection(props: {
     agentFlavor?: string | null
@@ -200,8 +225,9 @@ export function HappyComposer(props: {
     // inline error affordance until the user dismisses or starts editing.
     sendError?: ComposerSendError | null
     onClearSendError?: () => void
+    showStatusBar?: boolean
 }) {
-    const { t } = useTranslation()
+    const { t, locale } = useTranslation()
     const {
         sessionId,
         disabled = false,
@@ -249,7 +275,8 @@ export function HappyComposer(props: {
         onSchedule: onScheduleProp,
         onClearSchedule: onClearScheduleProp,
         sendError = null,
-        onClearSendError
+        onClearSendError,
+        showStatusBar = true
     } = props
 
     // Use ?? so missing values fall back to default (destructuring defaults only handle undefined)
@@ -288,6 +315,7 @@ export function HappyComposer(props: {
         selection: { start: 0, end: 0 }
     })
     const [showSettings, setShowSettings] = useState(false)
+    const [settingsPanel, setSettingsPanel] = useState<SettingsPanel>('main')
     const [showPiModelPanel, setShowPiModelPanel] = useState(false)
     const [showPiThinkingPanel, setShowPiThinkingPanel] = useState(false)
     const [isAborting, setIsAborting] = useState(false)
@@ -678,7 +706,13 @@ export function HappyComposer(props: {
 
     const handleSettingsToggle = useCallback(() => {
         haptic('light')
-        setShowSettings(prev => !prev)
+        setShowSettings(prev => {
+            const next = !prev
+            if (next) {
+                setSettingsPanel('main')
+            }
+            return next
+        })
     }, [haptic])
 
     const handleSubmit = useCallback((event?: ReactFormEvent<HTMLFormElement>) => {
@@ -702,6 +736,33 @@ export function HappyComposer(props: {
         setShowSettings(false)
         haptic('light')
     }, [onCollaborationModeChange, controlsDisabled, haptic])
+
+    const handlePlanModeToggle = useCallback(() => {
+        handleCollaborationChange(collaborationMode === 'plan' ? 'default' : 'plan')
+    }, [collaborationMode, handleCollaborationChange])
+
+    const handleGoalModeOpen = useCallback(() => {
+        if (controlsDisabled) return
+        const trimmedStart = composerText.trimStart()
+        const nextText = trimmedStart.startsWith('/goal')
+            ? composerText
+            : composerText.trim().length > 0
+                ? `/goal ${composerText.trim()}`
+                : '/goal '
+        api.composer().setText(nextText)
+        setTimeout(() => {
+            const el = textareaRef.current
+            if (!el) return
+            const cursor = nextText.length
+            el.setSelectionRange(cursor, cursor)
+            try {
+                el.focus({ preventScroll: true })
+            } catch {
+                el.focus()
+            }
+        }, 0)
+        haptic('light')
+    }, [api, composerText, controlsDisabled, haptic])
 
     const handleModelChange = useCallback((nextModel: { provider: string; modelId: string } | string | null) => {
         if (!onModelChange || controlsDisabled) return
@@ -747,6 +808,12 @@ export function HappyComposer(props: {
     ], [t])
 
     const showCollaborationSettings = Boolean(onCollaborationModeChange && collaborationModeOptions.length > 0)
+    const showPlanModeTool = Boolean(
+        agentFlavor === 'codex'
+        && onCollaborationModeChange
+        && collaborationModeOptions.some((option) => option.mode === 'plan')
+    )
+    const showGoalModeTool = agentFlavor === 'codex'
     const showPermissionSettings = Boolean(onPermissionModeChange && permissionModeOptions.length > 0)
     const showModelSettings = Boolean(onModelChange && supportsModelChange(agentFlavor) && (piModels && piModels.length > 0 || modelOptions.length > 0))
     const showModelEffortSettings = Boolean(
@@ -761,7 +828,6 @@ export function HappyComposer(props: {
     const showFastModeSettings = Boolean(onServiceTierChange)
     const showSettingsButton = Boolean(
         showCollaborationSettings
-        || showPermissionSettings
         || showModelSettings
         || showModelEffortSettings
         || showModelReasoningEffortSettings
@@ -770,6 +836,48 @@ export function HappyComposer(props: {
     )
     const showAbortButton = true
     const voiceEnabled = Boolean(onVoiceToggle)
+    const currentModelLabel = useMemo(() => {
+        if (selectedModelBase !== undefined) {
+            const match = modelOptions.find((option) => option.value === selectedModelBase)
+            if (match) return match.label
+        }
+        const match = modelOptions.find((option) => option.value === model)
+        return match?.label ?? model ?? t('misc.model')
+    }, [model, modelOptions, selectedModelBase, t])
+    const currentReasoningOption = useMemo(
+        () => codexReasoningEffortOptions.find((option) => option.value === modelReasoningEffort)
+            ?? codexReasoningEffortOptions.find((option) => option.value === null)
+            ?? null,
+        [codexReasoningEffortOptions, modelReasoningEffort]
+    )
+    const currentReasoningLabel = currentReasoningOption
+        ? formatReasoningLabel(currentReasoningOption.value, currentReasoningOption.label, locale)
+        : null
+    const compactModelLabel = formatCompactModelLabel(currentModelLabel)
+    const settingsLabel = currentReasoningLabel
+        ? `${compactModelLabel} ${currentReasoningLabel}`
+        : compactModelLabel
+    const permissionLabel = useMemo(
+        () => permissionModeOptions.find((option) => option.mode === permissionMode)?.label ?? permissionMode,
+        [permissionModeOptions, permissionMode]
+    )
+    const contextUsage = useMemo(() => {
+        if (contextSize === undefined) return null
+        const maxContextSize = contextWindow ?? getContextBudgetTokens(model, agentFlavor)
+        if (!maxContextSize) {
+            return {
+                percentage: 0,
+                label: `ctx ${formatTokenCount(contextSize)}`
+            }
+        }
+
+        const percentage = Math.min(100, Math.max(0, (contextSize / maxContextSize) * 100))
+        const percentageLeft = Math.max(0, Math.round(100 - percentage))
+        return {
+            percentage,
+            label: `ctx ${formatTokenCount(contextSize)}/${formatTokenCount(maxContextSize)} (${percentageLeft}% left)`
+        }
+    }, [contextSize, contextWindow, model, agentFlavor])
 
     const handleSend = useCallback(() => {
         api.composer().send()
@@ -824,6 +932,20 @@ export function HappyComposer(props: {
         haptic('light')
     }, [controlsDisabled, haptic])
 
+    useEffect(() => {
+        if (!showSettings) return
+
+        function handlePointerDown(event: PointerEvent) {
+            const target = event.target
+            if (!(target instanceof Element)) return
+            if (target.closest('[data-composer-settings-menu], .settings-button')) return
+            setShowSettings(false)
+        }
+
+        document.addEventListener('pointerdown', handlePointerDown)
+        return () => document.removeEventListener('pointerdown', handlePointerDown)
+    }, [showSettings])
+
     const overlays = useMemo(() => {
         // Pi flavor: separate floating panels for model and thinking level.
         // (Pi RPC mode has no runtime permission switching → no permission panel.)
@@ -867,132 +989,76 @@ export function HappyComposer(props: {
             if (panels.length > 0) return <>{panels}</>
         }
 
-        // Non-Pi flavors: original unified gear menu
-        if (showSettings && (showCollaborationSettings || showPermissionSettings || showModelSettings || showModelEffortSettings || showModelReasoningEffortSettings || showEffortSettings || showFastModeSettings)) {
-            return (
-                <div className="absolute bottom-[100%] mb-2 w-full">
-                    <FloatingOverlay maxHeight={320}>
-                        {showCollaborationSettings ? (
-                            <div className="py-2">
-                                <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
-                                    {t('misc.collaborationMode')}
-                                </div>
-                                {collaborationModeOptions.map((option) => (
-                                    <button
-                                        key={option.mode}
-                                        type="button"
-                                        disabled={controlsDisabled}
-                                        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                                            controlsDisabled
-                                                ? 'cursor-not-allowed opacity-50'
-                                                : 'cursor-pointer hover:bg-[var(--app-secondary-bg)]'
-                                        }`}
-                                        onClick={() => handleCollaborationChange(option.mode)}
-                                        onMouseDown={(e) => e.preventDefault()}
-                                    >
-                                        <div
-                                            className={`flex h-4 w-4 items-center justify-center rounded-full border-2 ${
-                                                collaborationMode === option.mode
-                                                    ? 'border-[var(--app-link)]'
-                                                    : 'border-[var(--app-hint)]'
-                                            }`}
-                                        >
-                                            {collaborationMode === option.mode && (
-                                                <div className="h-2 w-2 rounded-full bg-[var(--app-link)]" />
-                                            )}
-                                        </div>
-                                        <span className={collaborationMode === option.mode ? 'text-[var(--app-link)]' : ''}>
-                                            {option.label}
-                                        </span>
-                                    </button>
-                                ))}
-                            </div>
-                        ) : null}
+        const renderMenuOption = (
+            key: string,
+            selected: boolean,
+            label: string,
+            onClick: () => void
+        ) => (
+            <button
+                key={key}
+                type="button"
+                disabled={controlsDisabled}
+                className={`flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors ${
+                    controlsDisabled
+                        ? 'cursor-not-allowed opacity-50'
+                        : 'cursor-pointer hover:bg-[var(--app-secondary-bg)]'
+                }`}
+                onClick={onClick}
+                onMouseDown={(e) => e.preventDefault()}
+            >
+                <span className={selected ? 'font-medium text-[var(--app-fg)]' : 'text-[var(--app-fg)]'}>
+                    {label}
+                </span>
+                {selected ? <span className="text-[var(--app-hint)]">✓</span> : <span className="h-4 w-4" />}
+            </button>
+        )
+        const renderMenuRow = (key: string, label: string, onClick: () => void) => (
+            <button
+                key={key}
+                type="button"
+                disabled={controlsDisabled}
+                className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-[var(--app-fg)] transition-colors hover:bg-[var(--app-secondary-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+                onClick={onClick}
+                onMouseDown={(e) => e.preventDefault()}
+            >
+                <span className="truncate">{label}</span>
+                <span className="text-base leading-none text-[var(--app-hint)]">›</span>
+            </button>
+        )
+        const renderBackRow = (label: string) => (
+            <button
+                type="button"
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-semibold text-[var(--app-hint)] transition-colors hover:bg-[var(--app-secondary-bg)]"
+                onClick={() => setSettingsPanel('main')}
+                onMouseDown={(e) => e.preventDefault()}
+            >
+                <span className="text-base leading-none">‹</span>
+                {label}
+            </button>
+        )
+        const sectionDivider = <div className="mx-3 h-px bg-[var(--app-divider)]" />
 
-                        {showCollaborationSettings && (showPermissionSettings || showModelSettings || showModelReasoningEffortSettings || showEffortSettings) ? (
-                            <div className="mx-3 h-px bg-[var(--app-divider)]" />
-                        ) : null}
-
-                        {showPermissionSettings ? (
-                            <div className="py-2">
-                                <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
-                                    {t('misc.permissionMode')}
-                                </div>
-                                {permissionModeOptions.map((option) => (
-                                    <button
-                                        key={option.mode}
-                                        type="button"
-                                        disabled={controlsDisabled}
-                                        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                                            controlsDisabled
-                                                ? 'cursor-not-allowed opacity-50'
-                                                : 'cursor-pointer hover:bg-[var(--app-secondary-bg)]'
-                                        }`}
-                                        onClick={() => handlePermissionChange(option.mode)}
-                                        onMouseDown={(e) => e.preventDefault()}
-                                    >
-                                        <div
-                                            className={`flex h-4 w-4 items-center justify-center rounded-full border-2 ${
-                                                permissionMode === option.mode
-                                                    ? 'border-[var(--app-link)]'
-                                                    : 'border-[var(--app-hint)]'
-                                            }`}
-                                        >
-                                            {permissionMode === option.mode && (
-                                                <div className="h-2 w-2 rounded-full bg-[var(--app-link)]" />
-                                            )}
-                                        </div>
-                                        <span className={permissionMode === option.mode ? 'text-[var(--app-link)]' : ''}>
-                                            {option.label}
-                                        </span>
-                                    </button>
-                                ))}
-                            </div>
-                        ) : null}
-
-                        {(showCollaborationSettings || showPermissionSettings) && (showModelSettings || showModelEffortSettings || showModelReasoningEffortSettings || showEffortSettings) ? (
-                            <div className="mx-3 h-px bg-[var(--app-divider)]" />
-                        ) : null}
-
-                        {showModelSettings ? (
-                            <div className="py-2">
-                                <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
-                                    {t('misc.model')}
-                                </div>
-                                {piModelGroups ? (
+        // Non-Pi flavors: compact lower-right menu, with model/speed as subpanels.
+        if (showSettings && (showCollaborationSettings || showModelSettings || showModelEffortSettings || showModelReasoningEffortSettings || showEffortSettings || showFastModeSettings)) {
+            if (settingsPanel === 'model') {
+                return (
+                    <div data-composer-settings-menu className="absolute bottom-[100%] right-0 mb-2 w-[210px]">
+                        <FloatingOverlay maxHeight={320}>
+                            {renderBackRow(t('misc.model'))}
+                            {sectionDivider}
+                            {showModelSettings ? (
+                                piModelGroups ? (
                                     piModelGroups.map((group) => (
                                         <div key={group.provider}>
                                             <div className="px-3 pt-2 pb-0.5 text-xs font-medium text-[var(--app-hint)]">
                                                 {group.label}
                                             </div>
-                                            {group.models.map((piModel) => (
-                                                <button
-                                                    key={piModel.modelId}
-                                                    type="button"
-                                                    disabled={controlsDisabled}
-                                                    className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                                                        controlsDisabled
-                                                            ? 'cursor-not-allowed opacity-50'
-                                                            : 'cursor-pointer hover:bg-[var(--app-secondary-bg)]'
-                                                    }`}
-                                                    onClick={() => handleModelChange({ provider: piModel.provider, modelId: piModel.modelId })}
-                                                    onMouseDown={(e) => e.preventDefault()}
-                                                >
-                                                    <div
-                                                        className={`flex h-4 w-4 items-center justify-center rounded-full border-2 ${
-                                                            model === piModel.modelId
-                                                                ? 'border-[var(--app-link)]'
-                                                                : 'border-[var(--app-hint)]'
-                                                    }`}
-                                                    >
-                                                        {model === piModel.modelId && (
-                                                            <div className="h-2 w-2 rounded-full bg-[var(--app-link)]" />
-                                                        )}
-                                                    </div>
-                                                    <span className={model === piModel.modelId ? 'text-[var(--app-link)]' : ''}>
-                                                        {piModel.name ?? piModel.modelId}
-                                                    </span>
-                                                </button>
+                                            {group.models.map((piModel) => renderMenuOption(
+                                                piModel.modelId,
+                                                model === piModel.modelId,
+                                                piModel.name ?? piModel.modelId,
+                                                () => handleModelChange({ provider: piModel.provider, modelId: piModel.modelId })
                                             ))}
                                         </div>
                                     ))
@@ -1001,179 +1067,102 @@ export function HappyComposer(props: {
                                         const isSelected = selectedModelBase !== undefined
                                             ? selectedModelBase === option.value
                                             : model === option.value
-                                        return (
-                                        <button
-                                            key={option.value ?? 'auto'}
-                                            type="button"
-                                            disabled={controlsDisabled}
-                                            className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                                                controlsDisabled
-                                                    ? 'cursor-not-allowed opacity-50'
-                                                    : 'cursor-pointer hover:bg-[var(--app-secondary-bg)]'
-                                            }`}
-                                            onClick={() => handleModelChange(option.value)}
-                                            onMouseDown={(e) => e.preventDefault()}
-                                        >
-                                            <div
-                                                className={`flex h-4 w-4 items-center justify-center rounded-full border-2 ${
-                                                    isSelected
-                                                        ? 'border-[var(--app-link)]'
-                                                        : 'border-[var(--app-hint)]'
-                                                }`}
-                                            >
-                                                {isSelected && (
-                                                    <div className="h-2 w-2 rounded-full bg-[var(--app-link)]" />
-                                                )}
-                                            </div>
-                                            <span className={isSelected ? 'text-[var(--app-link)]' : ''}>
-                                                {option.label}
-                                            </span>
-                                        </button>
+                                        return renderMenuOption(
+                                            option.value ?? 'auto',
+                                            isSelected,
+                                            option.label,
+                                            () => handleModelChange(option.value)
                                         )
                                     })
-                                )}
-                            </div>
-                        ) : null}
+                                )
+                            ) : null}
+                            {showModelSettings && showModelEffortSettings ? sectionDivider : null}
+                            {showModelEffortSettings ? (
+                                modelEffortOptions!.map((option) => renderMenuOption(
+                                    option.value ?? 'auto',
+                                    (selectedModelVariant ?? model) === option.value,
+                                    option.label,
+                                    () => handleModelEffortChange(option.value)
+                                ))
+                            ) : null}
+                        </FloatingOverlay>
+                    </div>
+                )
+            }
 
-                        {showModelSettings && showModelEffortSettings ? (
-                            <div className="mx-3 h-px bg-[var(--app-divider)]" />
-                        ) : null}
+            if (settingsPanel === 'speed') {
+                return (
+                    <div data-composer-settings-menu className="absolute bottom-[100%] right-0 mb-2 w-[210px]">
+                        <FloatingOverlay maxHeight={240}>
+                            {renderBackRow(t('misc.speed'))}
+                            {sectionDivider}
+                            {fastModeOptions.map((option) => renderMenuOption(
+                                option.value ?? 'standard',
+                                serviceTier === option.value,
+                                option.label,
+                                () => handleServiceTierChange(option.value)
+                            ))}
+                        </FloatingOverlay>
+                    </div>
+                )
+            }
 
-                        {showModelEffortSettings ? (
-                            <ModelEffortSettingsSection
-                                agentFlavor={agentFlavor}
-                                options={modelEffortOptions!}
-                                selectedValue={selectedModelVariant ?? model}
-                                controlsDisabled={controlsDisabled}
-                                onChange={handleModelEffortChange}
-                            />
-                        ) : null}
-
-                        {(showModelSettings || showModelEffortSettings) && showModelReasoningEffortSettings ? (
-                            <div className="mx-3 h-px bg-[var(--app-divider)]" />
-                        ) : null}
-
-                        {(showModelSettings || showModelEffortSettings || showModelReasoningEffortSettings) && showEffortSettings ? (
-                            <div className="mx-3 h-px bg-[var(--app-divider)]" />
-                        ) : null}
-
+            return (
+                <div data-composer-settings-menu className="absolute bottom-[100%] right-0 mb-2 w-[210px]">
+                    <FloatingOverlay maxHeight={320}>
                         {showModelReasoningEffortSettings ? (
                             <div className="py-2">
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
-                                    {t('misc.reasoningEffort')}
+                                    {t('misc.reasoning')}
                                 </div>
-                                {codexReasoningEffortOptions.map((option) => (
-                                    <button
-                                        key={option.value ?? 'default'}
-                                        type="button"
-                                        disabled={controlsDisabled}
-                                        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                                            controlsDisabled
-                                                ? 'cursor-not-allowed opacity-50'
-                                                : 'cursor-pointer hover:bg-[var(--app-secondary-bg)]'
-                                        }`}
-                                        onClick={() => handleModelReasoningEffortChange(option.value)}
-                                        onMouseDown={(e) => e.preventDefault()}
-                                    >
-                                        <div
-                                            className={`flex h-4 w-4 items-center justify-center rounded-full border-2 ${
-                                                modelReasoningEffort === option.value
-                                                    ? 'border-[var(--app-link)]'
-                                                    : 'border-[var(--app-hint)]'
-                                            }`}
-                                        >
-                                            {modelReasoningEffort === option.value && (
-                                                <div className="h-2 w-2 rounded-full bg-[var(--app-link)]" />
-                                            )}
-                                        </div>
-                                        <span className={modelReasoningEffort === option.value ? 'text-[var(--app-link)]' : ''}>
-                                            {option.label}
-                                        </span>
-                                    </button>
-                                ))}
+                                {codexReasoningEffortOptions
+                                    .filter((option) => option.value !== null)
+                                    .map((option) => renderMenuOption(
+                                        option.value ?? 'default',
+                                        modelReasoningEffort === option.value,
+                                        formatReasoningLabel(option.value, option.label, locale),
+                                        () => handleModelReasoningEffortChange(option.value)
+                                    ))}
                             </div>
                         ) : null}
 
-                        {showModelReasoningEffortSettings && showEffortSettings ? (
-                            <div className="mx-3 h-px bg-[var(--app-divider)]" />
-                        ) : null}
-
-                        {showEffortSettings ? (
+                        {!showModelReasoningEffortSettings && showEffortSettings ? (
                             <div className="py-2">
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
                                     {t('misc.effort')}
                                 </div>
-                                {claudeEffortOptions.map((option) => (
-                                    <button
-                                        key={option.value ?? 'auto'}
-                                        type="button"
-                                        disabled={controlsDisabled}
-                                        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                                            controlsDisabled
-                                                ? 'cursor-not-allowed opacity-50'
-                                                : 'cursor-pointer hover:bg-[var(--app-secondary-bg)]'
-                                        }`}
-                                        onClick={() => handleEffortChange(option.value)}
-                                        onMouseDown={(e) => e.preventDefault()}
-                                    >
-                                        <div
-                                            className={`flex h-4 w-4 items-center justify-center rounded-full border-2 ${
-                                                effort === option.value
-                                                    ? 'border-[var(--app-link)]'
-                                                    : 'border-[var(--app-hint)]'
-                                            }`}
-                                        >
-                                            {effort === option.value && (
-                                                <div className="h-2 w-2 rounded-full bg-[var(--app-link)]" />
-                                            )}
-                                        </div>
-                                        <span className={effort === option.value ? 'text-[var(--app-link)]' : ''}>
-                                            {option.label}
-                                        </span>
-                                    </button>
+                                {claudeEffortOptions.map((option) => renderMenuOption(
+                                    option.value ?? 'auto',
+                                    effort === option.value,
+                                    option.label,
+                                    () => handleEffortChange(option.value)
                                 ))}
                             </div>
                         ) : null}
 
-                        {(showModelReasoningEffortSettings || showEffortSettings) && showFastModeSettings ? (
-                            <div className="mx-3 h-px bg-[var(--app-divider)]" />
-                        ) : null}
+                        {(showModelReasoningEffortSettings || showEffortSettings) && (showModelSettings || showModelEffortSettings || showFastModeSettings) ? sectionDivider : null}
 
-                        {showFastModeSettings ? (
-                            <div className="py-2">
-                                <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
-                                    {t('misc.fastMode')}
+                        {showModelSettings || showModelEffortSettings
+                            ? renderMenuRow('model', currentModelLabel, () => setSettingsPanel('model'))
+                            : null}
+                        {showFastModeSettings
+                            ? renderMenuRow('speed', t('misc.speed'), () => setSettingsPanel('speed'))
+                            : null}
+
+                        {!showModelReasoningEffortSettings && !showEffortSettings && showCollaborationSettings ? (
+                            <>
+                                <div className="py-2">
+                                    <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
+                                        {t('misc.collaborationMode')}
+                                    </div>
+                                    {collaborationModeOptions.map((option) => renderMenuOption(
+                                        option.mode,
+                                        collaborationMode === option.mode,
+                                        option.label,
+                                        () => handleCollaborationChange(option.mode)
+                                    ))}
                                 </div>
-                                {fastModeOptions.map((option) => (
-                                    <button
-                                        key={option.value ?? 'standard'}
-                                        type="button"
-                                        disabled={controlsDisabled}
-                                        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
-                                            controlsDisabled
-                                                ? 'cursor-not-allowed opacity-50'
-                                                : 'cursor-pointer hover:bg-[var(--app-secondary-bg)]'
-                                        }`}
-                                        onClick={() => handleServiceTierChange(option.value)}
-                                        onMouseDown={(e) => e.preventDefault()}
-                                    >
-                                        <div
-                                            className={`flex h-4 w-4 items-center justify-center rounded-full border-2 ${
-                                                serviceTier === option.value
-                                                    ? 'border-[var(--app-link)]'
-                                                    : 'border-[var(--app-hint)]'
-                                            }`}
-                                        >
-                                            {serviceTier === option.value && (
-                                                <div className="h-2 w-2 rounded-full bg-[var(--app-link)]" />
-                                            )}
-                                        </div>
-                                        <span className={serviceTier === option.value ? 'text-[var(--app-link)]' : ''}>
-                                            {option.label}
-                                        </span>
-                                    </button>
-                                ))}
-                            </div>
+                            </>
                         ) : null}
                     </FloatingOverlay>
                 </div>
@@ -1197,6 +1186,7 @@ export function HappyComposer(props: {
         return null
     }, [
         showSettings,
+        settingsPanel,
         showPiModelPanel,
         showPiThinkingPanel,
         agentFlavor,
@@ -1214,6 +1204,8 @@ export function HappyComposer(props: {
         showEffortSettings,
         showFastModeSettings,
         modelOptions,
+        piModelGroups,
+        currentModelLabel,
         codexReasoningEffortOptions,
         claudeEffortOptions,
         fastModeOptions,
@@ -1231,10 +1223,12 @@ export function HappyComposer(props: {
         handleCollaborationChange,
         handlePermissionChange,
         handleModelChange,
+        handleModelEffortChange,
         handleModelReasoningEffortChange,
         handleEffortChange,
         handleServiceTierChange,
         handleSuggestionSelect,
+        locale,
         t
     ])
 
@@ -1244,7 +1238,7 @@ export function HappyComposer(props: {
                 <ComposerPrimitive.Root className="relative" onSubmit={handleSubmit}>
                     {overlays}
 
-                    {shouldShowComposerStatusBar(agentFlavor) ? (
+                    {showStatusBar && shouldShowComposerStatusBar(agentFlavor) ? (
                         <StatusBar
                             active={active}
                             thinking={thinking}
@@ -1318,6 +1312,22 @@ export function HappyComposer(props: {
                             controlsDisabled={controlsDisabled}
                             showSettingsButton={showSettingsButton}
                             onSettingsToggle={handleSettingsToggle}
+                            settingsLabel={settingsLabel}
+                            settingsModelLabel={compactModelLabel}
+                            settingsReasoningLabel={currentReasoningLabel}
+                            settingsOpen={showSettings}
+                            contextUsagePercent={contextUsage?.percentage ?? null}
+                            contextUsageLabel={contextUsage?.label}
+                            permissionMode={permissionMode}
+                            permissionLabel={permissionLabel}
+                            permissionModeOptions={permissionModeOptions}
+                            onPermissionModeChange={showPermissionSettings ? handlePermissionChange : undefined}
+                            showPlanModeButton={showPlanModeTool}
+                            planModeActive={collaborationMode === 'plan'}
+                            onPlanModeToggle={showPlanModeTool ? handlePlanModeToggle : undefined}
+                            showGoalModeButton={showGoalModeTool}
+                            goalModeActive={threadGoal?.status === 'active'}
+                            onGoalModeOpen={showGoalModeTool ? handleGoalModeOpen : undefined}
                             showTerminalButton={showTerminalButton}
                             terminalDisabled={terminalDisabled}
                             terminalLabel={terminalLabel}

--- a/web/src/components/AssistantChat/StatusBar.tsx
+++ b/web/src/components/AssistantChat/StatusBar.tsx
@@ -126,8 +126,8 @@ function formatTokenCount(value: number): string {
 
 function formatCodexReasoningLabel(effort?: string | null): string {
     const normalized = effort?.trim().toLowerCase()
-    if (!normalized || normalized === 'default') return 'reasoning default'
-    return `reasoning ${normalized}`
+    if (!normalized || normalized === 'default') return 'default'
+    return normalized
 }
 
 function isCodexFastMode(model?: string | null, effort?: string | null): boolean {
@@ -145,7 +145,7 @@ export function shouldShowComposerStatusBar(agentFlavor: string | null | undefin
     return agentFlavor !== 'cursor'
 }
 
-export function StatusBar(props: {
+export type StatusBarProps = {
     active: boolean
     thinking: boolean
     agentState: AgentState | null | undefined
@@ -161,7 +161,35 @@ export function StatusBar(props: {
     threadGoal?: ThreadGoal | null
     agentFlavor?: string | null
     voiceStatus?: ConversationStatus
-}) {
+}
+
+function getContextUsageInfo(props: Pick<StatusBarProps, 'contextSize' | 'contextWindow' | 'model' | 'agentFlavor'>): {
+    text: string
+    compactText: string
+    percentageUsed: number
+} | null {
+    if (props.contextSize === undefined) return null
+    const maxContextSize = props.contextWindow ?? getContextBudgetTokens(props.model, props.agentFlavor)
+    if (!maxContextSize) {
+        const count = formatTokenCount(props.contextSize)
+        return {
+            text: `ctx ${count}`,
+            compactText: `ctx ${count.toUpperCase()}`,
+            percentageUsed: 0
+        }
+    }
+
+    const percentageUsed = Math.min(100, Math.max(0, (props.contextSize / maxContextSize) * 100))
+    const roundedUsed = Math.round(percentageUsed)
+    const percentageLeft = Math.max(0, Math.round(100 - percentageUsed))
+    return {
+        text: `ctx ${formatTokenCount(props.contextSize)}/${formatTokenCount(maxContextSize)} (${roundedUsed}%)`,
+        compactText: `ctx ${formatTokenCount(maxContextSize).toUpperCase()}, ${percentageLeft}% left`,
+        percentageUsed
+    }
+}
+
+export function StatusBar(props: StatusBarProps) {
     const { t } = useTranslation()
     const connectionStatus = useMemo(
         () => getConnectionStatus(props.active, props.thinking, props.agentState, props.voiceStatus, props.backgroundTaskCount ?? 0, t),
@@ -177,20 +205,10 @@ export function StatusBar(props: {
         },
         [props.contextSize, props.contextWindow, props.model, props.agentFlavor, t]
     )
-    const contextUsageLabel = useMemo(() => {
-        if (props.contextSize === undefined) return null
-        const maxContextSize = props.contextWindow ?? getContextBudgetTokens(props.model, props.agentFlavor)
-        if (!maxContextSize) return `ctx ${formatTokenCount(props.contextSize)}`
-        const percentageUsed = Math.min(100, Math.round((props.contextSize / maxContextSize) * 100))
-        return `ctx ${formatTokenCount(props.contextSize)}/${formatTokenCount(maxContextSize)} (${percentageUsed}%)`
-    }, [props.contextSize, props.contextWindow, props.model, props.agentFlavor])
-    const compactContextUsageLabel = useMemo(() => {
-        if (props.contextSize === undefined) return null
-        const maxContextSize = props.contextWindow ?? getContextBudgetTokens(props.model, props.agentFlavor)
-        if (!maxContextSize) return `ctx ${formatTokenCount(props.contextSize)}`
-        const percentageLeft = Math.max(0, Math.round(100 - (props.contextSize / maxContextSize) * 100))
-        return `ctx ${formatTokenCount(maxContextSize).toUpperCase()}, ${percentageLeft}% left`
-    }, [props.contextSize, props.contextWindow, props.model, props.agentFlavor])
+    const contextUsage = useMemo(
+        () => getContextUsageInfo(props),
+        [props.contextSize, props.contextWindow, props.model, props.agentFlavor]
+    )
     const cacheHitLabel = useMemo(() => {
         if (!props.contextCacheRead || props.contextCacheRead <= 0) return null
         return `cache ${formatTokenCount(props.contextCacheRead)}`
@@ -227,6 +245,35 @@ export function StatusBar(props: {
             ? 'goal'
             : `goal ${props.threadGoal.status === 'budgetLimited' ? 'limited' : props.threadGoal.status}`
         : null
+    const modeItems = (
+        <>
+            {codexReasoningLabel ? (
+                <span className="whitespace-nowrap text-xs text-[var(--app-hint)]">
+                    {codexReasoningLabel}
+                </span>
+            ) : null}
+            {codexFastMode ? (
+                <span className="whitespace-nowrap text-xs text-[#34C759]">
+                    fast
+                </span>
+            ) : null}
+            {goalLabel ? (
+                <span className="whitespace-nowrap text-xs text-[var(--app-link)]">
+                    {goalLabel}
+                </span>
+            ) : null}
+            {collaborationModeLabel ? (
+                <span className="whitespace-nowrap text-xs text-blue-500">
+                    {collaborationModeLabel}
+                </span>
+            ) : null}
+            {displayPermissionMode ? (
+                <span className={`whitespace-nowrap text-xs ${permissionModeColor}`}>
+                    {permissionModeLabel}
+                </span>
+            ) : null}
+        </>
+    )
 
     return (
         <div className="flex min-w-0 items-center justify-between gap-2 px-2 pb-1">
@@ -239,13 +286,13 @@ export function StatusBar(props: {
                         {connectionStatus.text}
                     </span>
                 </div>
-                {contextUsageLabel ? (
+                {contextUsage ? (
                     <span className={`min-w-0 whitespace-nowrap text-[10px] ${contextWarning?.color ?? 'text-[var(--app-hint)]'}`}>
                         <span className="sm:hidden">
-                            {compactContextUsageLabel}
+                            {contextUsage.compactText}
                         </span>
                         <span className="hidden sm:inline">
-                            {contextUsageLabel}{contextWarning ? ` · ${contextWarning.text}` : ''}
+                            {contextUsage.text}{contextWarning ? ` · ${contextWarning.text}` : ''}
                         </span>
                     </span>
                 ) : null}
@@ -257,31 +304,7 @@ export function StatusBar(props: {
             </div>
 
             <div className="flex min-w-0 shrink-0 items-center gap-2">
-                {codexReasoningLabel ? (
-                    <span className="whitespace-nowrap text-xs text-[var(--app-hint)]">
-                        {codexReasoningLabel}
-                    </span>
-                ) : null}
-                {codexFastMode ? (
-                    <span className="whitespace-nowrap text-xs text-[#34C759]">
-                        fast
-                    </span>
-                ) : null}
-                {goalLabel ? (
-                    <span className="whitespace-nowrap text-xs text-[var(--app-link)]">
-                        {goalLabel}
-                    </span>
-                ) : null}
-                {collaborationModeLabel ? (
-                    <span className="whitespace-nowrap text-xs text-blue-500">
-                        {collaborationModeLabel}
-                    </span>
-                ) : null}
-                {displayPermissionMode ? (
-                    <span className={`whitespace-nowrap text-xs ${permissionModeColor}`}>
-                        {permissionModeLabel}
-                    </span>
-                ) : null}
+                {modeItems}
             </div>
         </div>
     )

--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -18,6 +18,10 @@ type SessionActionMenuProps = {
     onArchive: () => void
     onReopen?: () => void
     onDelete: () => void
+    onToggleFiles?: () => void
+    filesActive?: boolean
+    onToggleOutline?: () => void
+    outlineActive?: boolean
     anchorPoint: { x: number; y: number }
     menuId?: string
 }
@@ -84,6 +88,50 @@ function DownloadIcon(props: { className?: string }) {
     )
 }
 
+function FilesIcon(props: { className?: string }) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={props.className}
+        >
+            <path d="M14 2H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+            <path d="M14 2v6h6" />
+        </svg>
+    )
+}
+
+function OutlineIcon(props: { className?: string }) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={props.className}
+        >
+            <path d="M8 6h13" />
+            <path d="M8 12h13" />
+            <path d="M8 18h13" />
+            <path d="M3 6h.01" />
+            <path d="M3 12h.01" />
+            <path d="M3 18h.01" />
+        </svg>
+    )
+}
+
 function ReopenIcon(props: { className?: string }) {
     return (
         <svg
@@ -144,6 +192,10 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         onArchive,
         onReopen,
         onDelete,
+        onToggleFiles,
+        filesActive,
+        onToggleOutline,
+        outlineActive,
         anchorPoint,
         menuId
     } = props
@@ -176,6 +228,16 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
     const handleDelete = () => {
         onClose()
         onDelete()
+    }
+
+    const handleToggleFiles = () => {
+        onClose()
+        onToggleFiles?.()
+    }
+
+    const handleToggleOutline = () => {
+        onClose()
+        onToggleOutline?.()
     }
 
     const updatePosition = useCallback(() => {
@@ -284,6 +346,34 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
                 aria-labelledby={headingId}
                 className="flex flex-col gap-1"
             >
+                {onToggleFiles ? (
+                    <button
+                        type="button"
+                        role="menuitem"
+                        className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
+                        onClick={handleToggleFiles}
+                    >
+                        <FilesIcon className={filesActive ? 'text-[var(--app-link)]' : 'text-[var(--app-hint)]'} />
+                        {filesActive ? t('session.view.returnToChat') : t('session.title')}
+                    </button>
+                ) : null}
+
+                {onToggleOutline ? (
+                    <button
+                        type="button"
+                        role="menuitem"
+                        className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
+                        onClick={handleToggleOutline}
+                    >
+                        <OutlineIcon className={outlineActive ? 'text-[var(--app-link)]' : 'text-[var(--app-hint)]'} />
+                        {outlineActive ? t('session.outline.close') : t('session.outline.open')}
+                    </button>
+                ) : null}
+
+                {(onToggleFiles || onToggleOutline) ? (
+                    <div className="mx-2 h-px bg-[var(--app-divider)]" />
+                ) : null}
+
                 <button
                     type="button"
                     role="menuitem"

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1118,6 +1118,23 @@ function SessionChatInner(props: SessionChatProps) {
                         replace: true
                     })
                 }}
+                status={{
+                    active: props.session.active,
+                    thinking: props.session.thinking,
+                    agentState: props.session.agentState,
+                    backgroundTaskCount: props.session.backgroundTaskCount,
+                    contextSize: reduced.latestUsage?.contextSize,
+                    contextCacheRead: reduced.latestUsage?.cacheRead,
+                    contextWindow: reduced.latestUsage?.contextWindow,
+                    model: props.session.model,
+                    modelReasoningEffort: agentFlavor === 'codex' || agentFlavor === 'opencode' ? props.session.modelReasoningEffort : undefined,
+                    serviceTier: props.session.serviceTier,
+                    permissionMode: props.session.permissionMode,
+                    collaborationMode: codexCollaborationModeSupported ? props.session.collaborationMode : undefined,
+                    threadGoal: reduced.latestGoal,
+                    agentFlavor,
+                    voiceStatus: voice?.status
+                }}
             />
 
             <CursorMigrationBanner metadata={props.session.metadata} />
@@ -1212,6 +1229,7 @@ function SessionChatInner(props: SessionChatProps) {
                         pendingSchedule={pendingSchedule}
                         onSchedule={setPendingSchedule}
                         onClearSchedule={() => setPendingSchedule(null)}
+                        showStatusBar={false}
                         permissionMode={props.session.permissionMode}
                         collaborationMode={codexCollaborationModeSupported ? props.session.collaborationMode : undefined}
                         threadGoal={reduced.latestGoal}

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -1,16 +1,16 @@
 import { useId, useMemo, useRef, useState } from 'react'
-import type { Session } from '@/types/api'
+import type { CodexSubscriptionLimits, CodexSubscriptionLimitWindow, Session } from '@/types/api'
 import type { ApiClient } from '@/api/client'
 import { isTelegramApp } from '@/hooks/useTelegram'
 import { useSessionActions } from '@/hooks/mutations/useSessionActions'
+import { useCodexSubscriptionLimits } from '@/hooks/queries/useCodexSubscriptionLimits'
 import { SessionActionMenu } from '@/components/SessionActionMenu'
 import { SessionExportDialog } from '@/components/SessionExportDialog'
 import { RenameSessionDialog } from '@/components/RenameSessionDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { formatReopenError } from '@/lib/reopenError'
-import { getSessionModelLabel } from '@/lib/sessionModelLabel'
 import { useTranslation } from '@/lib/use-translation'
-import { AgentFlavorIcon } from '@/components/AgentFlavorIcon'
+import type { StatusBarProps } from '@/components/AssistantChat/StatusBar'
 
 function getSessionTitle(session: Session): string {
     if (session.metadata?.name) {
@@ -24,58 +24,6 @@ function getSessionTitle(session: Session): string {
         return parts.length > 0 ? parts[parts.length - 1] : session.id.slice(0, 8)
     }
     return session.id.slice(0, 8)
-}
-
-function FilesIcon(props: { className?: string }) {
-    return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className={props.className}
-        >
-            <path d="M14 2H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
-            <path d="M14 2v6h6" />
-        </svg>
-    )
-}
-
-function OutlineIcon(props: { className?: string }) {
-    return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className={props.className}
-        >
-            <path d="M8 6h13" />
-            <path d="M8 12h13" />
-            <path d="M8 18h13" />
-            <path d="M3 6h.01" />
-            <path d="M3 12h.01" />
-            <path d="M3 18h.01" />
-        </svg>
-    )
-}
-
-function headerToggleClass(active: boolean): string {
-    return `flex h-8 w-8 items-center justify-center rounded-full transition-colors ${
-        active
-            ? 'bg-[var(--app-button)] text-[var(--app-button-text)] hover:opacity-90'
-            : 'text-[var(--app-hint)] hover:bg-[var(--app-secondary-bg)] hover:text-[var(--app-fg)]'
-    }`
 }
 
 function MoreVerticalIcon(props: { className?: string }) {
@@ -95,6 +43,141 @@ function MoreVerticalIcon(props: { className?: string }) {
     )
 }
 
+function getStatusDotClass(status?: StatusBarProps): string {
+    if (!status) return 'hidden'
+    const hasPermissions = status.agentState?.requests && Object.keys(status.agentState.requests).length > 0
+    if (!status.active) return 'bg-[#999]'
+    if (status.voiceStatus === 'connecting' || status.thinking || (status.backgroundTaskCount ?? 0) > 0) return 'bg-[#007AFF] animate-pulse'
+    if (hasPermissions) return 'bg-[#FF9500] animate-pulse'
+    return 'bg-[#34C759]'
+}
+
+function clampPercent(value: number): number {
+    return Math.max(0, Math.min(100, value))
+}
+
+function formatLimitDuration(window: CodexSubscriptionLimitWindow | null): string {
+    const duration = window?.windowDurationMins
+    if (!duration || duration <= 0) {
+        return 'limit'
+    }
+    if (duration === 300) {
+        return '5h'
+    }
+    if (duration >= 7 * 24 * 60) {
+        const days = Math.round(duration / (24 * 60))
+        return `${days}d`
+    }
+    if (duration >= 60) {
+        const hours = duration / 60
+        return Number.isInteger(hours) ? `${hours}h` : `${hours.toFixed(1)}h`
+    }
+    return `${duration}m`
+}
+
+function formatLimitWindow(window: CodexSubscriptionLimitWindow | null): string | null {
+    if (!window) {
+        return null
+    }
+    return `${formatLimitDuration(window)} ${Math.round(100 - clampPercent(window.usedPercent))}%`
+}
+
+function getRemainingPercent(window: CodexSubscriptionLimitWindow): number {
+    return Math.round(100 - clampPercent(window.usedPercent))
+}
+
+function getLimitPercentClass(remainingPercent: number | null): string {
+    if (remainingPercent === null) {
+        return 'text-[var(--app-hint)]'
+    }
+    if (remainingPercent < 10) {
+        return 'text-red-500'
+    }
+    if (remainingPercent < 30) {
+        return 'text-orange-500'
+    }
+    return 'text-[var(--app-hint)]'
+}
+
+function getDisplayLimitWindows(limits: CodexSubscriptionLimits | null): CodexSubscriptionLimitWindow[] {
+    const windows = [limits?.primary, limits?.secondary]
+        .filter((window): window is CodexSubscriptionLimitWindow => Boolean(window))
+
+    const fiveHourWindow = windows.find((window) => window.windowDurationMins === 300)
+    const weeklyWindow = windows.find((window) => (window.windowDurationMins ?? 0) >= 7 * 24 * 60)
+    if (fiveHourWindow || weeklyWindow) {
+        return [fiveHourWindow, weeklyWindow]
+            .filter((window): window is CodexSubscriptionLimitWindow => Boolean(window))
+    }
+
+    return windows.sort((a, b) => (a.windowDurationMins ?? Number.MAX_SAFE_INTEGER) - (b.windowDurationMins ?? Number.MAX_SAFE_INTEGER))
+}
+
+function formatResetAt(resetsAt: number | null): string | null {
+    if (!resetsAt) {
+        return null
+    }
+    const timestamp = resetsAt > 1_000_000_000_000 ? resetsAt : resetsAt * 1000
+    const date = new Date(timestamp)
+    if (Number.isNaN(date.getTime())) {
+        return null
+    }
+    return date.toLocaleString()
+}
+
+function CodexSubscriptionLimitsBadge(props: {
+    limits: CodexSubscriptionLimits | null
+    isFetching: boolean
+    error: string | null
+}) {
+    const windows = getDisplayLimitWindows(props.limits)
+    const text = windows.length > 0
+        ? windows.map(formatLimitWindow).filter(Boolean).join(' · ')
+        : '5h -- · 7d --'
+    const rows = windows.length > 0
+        ? windows.map((window) => ({
+            label: formatLimitDuration(window),
+            remaining: getRemainingPercent(window)
+        }))
+        : [
+            { label: '5h', remaining: null },
+            { label: '7d', remaining: null }
+        ]
+    const resetDetails = windows
+        .map((window) => {
+            const resetAt = formatResetAt(window.resetsAt)
+            const used = Math.round(clampPercent(window.usedPercent))
+            const remaining = getRemainingPercent(window)
+            const prefix = `${formatLimitDuration(window)}: ${remaining}% remaining, ${used}% used`
+            return resetAt ? `${prefix}, resets ${resetAt}` : prefix
+        })
+        .filter(Boolean)
+        .join('\n')
+    const title = props.error
+        ? `Codex limits unavailable: ${props.error}`
+        : resetDetails || 'Codex subscription limits'
+
+    return (
+        <div
+            className={[
+                'flex shrink-0 flex-col items-end justify-center px-2 py-0.5 text-[11px] font-medium leading-3 tabular-nums',
+                props.isFetching ? 'opacity-60' : ''
+            ].filter(Boolean).join(' ')}
+            title={title}
+            aria-label={`Codex subscription limits: ${text}`}
+        >
+            {rows.map((row) => (
+                <div key={row.label} className="flex items-center gap-1 text-[var(--app-hint)]">
+                    <span>{row.label}</span>
+                    <span className={getLimitPercentClass(row.remaining)}>
+                        {row.remaining === null ? '--' : `${row.remaining}%`}
+                    </span>
+                </div>
+            ))}
+        </div>
+    )
+}
+
 export function SessionHeader(props: {
     session: Session
     onBack: () => void
@@ -105,12 +188,11 @@ export function SessionHeader(props: {
     api: ApiClient | null
     onSessionDeleted?: () => void
     onSessionReopened?: (newSessionId: string) => void
+    status?: StatusBarProps
 }) {
     const { t } = useTranslation()
     const { session, api, onSessionDeleted, onSessionReopened } = props
     const title = useMemo(() => getSessionTitle(session), [session])
-    const worktreeBranch = session.metadata?.worktree?.branch
-    const modelLabel = getSessionModelLabel(session)
 
     const [menuOpen, setMenuOpen] = useState(false)
     const [menuAnchorPoint, setMenuAnchorPoint] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
@@ -126,6 +208,13 @@ export function SessionHeader(props: {
         session.id,
         session.metadata?.flavor ?? null
     )
+    const codexLimitsState = useCodexSubscriptionLimits({
+        api,
+        sessionId: session.id,
+        model: session.model ?? null,
+        enabled: session.active && session.metadata?.flavor === 'codex',
+        thinking: props.status?.thinking ?? session.thinking
+    })
     const [reopenError, setReopenError] = useState<string | null>(null)
 
     const handleDelete = async () => {
@@ -183,51 +272,24 @@ export function SessionHeader(props: {
                         </svg>
                     </button>
 
-                    {/* Session info - two lines: title and path */}
-                    <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                        {props.status ? (
+                            <span
+                                className={`h-2 w-2 shrink-0 rounded-full ${getStatusDotClass(props.status)}`}
+                                aria-hidden="true"
+                            />
+                        ) : null}
                         <div className="truncate font-semibold">
                             {title}
                         </div>
-                        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-[var(--app-hint)]">
-                            <span className="inline-flex items-center gap-1">
-                                <AgentFlavorIcon flavor={session.metadata?.flavor} className="h-3.5 w-3.5 shrink-0" />
-                                {session.metadata?.flavor?.trim() || 'unknown'}
-                            </span>
-                            {modelLabel ? (
-                                <span>
-                                    {t(modelLabel.key)}: {modelLabel.value}
-                                </span>
-                            ) : null}
-                            {worktreeBranch ? (
-                                <span>{t('session.item.worktree')}: {worktreeBranch}</span>
-                            ) : null}
-                        </div>
                     </div>
 
-                    {props.onToggleFiles ? (
-                        <button
-                            type="button"
-                            onClick={props.onToggleFiles}
-                            className={headerToggleClass(props.filesActive ?? false)}
-                            title={props.filesActive ? t('session.view.returnToChat') : t('session.title')}
-                            aria-label={props.filesActive ? t('session.view.returnToChat') : t('session.title')}
-                            aria-pressed={props.filesActive ?? false}
-                        >
-                            <FilesIcon />
-                        </button>
-                    ) : null}
-
-                    {props.onToggleOutline ? (
-                        <button
-                            type="button"
-                            onClick={props.onToggleOutline}
-                            className={headerToggleClass(props.outlineActive ?? false)}
-                            title={props.outlineActive ? t('session.outline.close') : t('session.outline.open')}
-                            aria-label={props.outlineActive ? t('session.outline.close') : t('session.outline.open')}
-                            aria-pressed={props.outlineActive ?? false}
-                        >
-                            <OutlineIcon />
-                        </button>
+                    {session.metadata?.flavor === 'codex' ? (
+                        <CodexSubscriptionLimitsBadge
+                            limits={codexLimitsState.limits}
+                            isFetching={codexLimitsState.isFetching}
+                            error={codexLimitsState.error}
+                        />
                     ) : null}
 
                     <button
@@ -255,6 +317,10 @@ export function SessionHeader(props: {
                 onArchive={() => setArchiveOpen(true)}
                 onReopen={handleReopen}
                 onDelete={() => setDeleteOpen(true)}
+                onToggleFiles={props.onToggleFiles}
+                filesActive={props.filesActive}
+                onToggleOutline={props.onToggleOutline}
+                outlineActive={props.outlineActive}
                 anchorPoint={menuAnchorPoint}
                 menuId={menuId}
             />

--- a/web/src/hooks/queries/useCodexSubscriptionLimits.ts
+++ b/web/src/hooks/queries/useCodexSubscriptionLimits.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import type { ApiClient } from '@/api/client'
+import type { CodexSubscriptionLimits } from '@/types/api'
+import { queryKeys } from '@/lib/query-keys'
+
+export function useCodexSubscriptionLimits(args: {
+    api: ApiClient | null
+    sessionId?: string | null
+    model?: string | null
+    enabled?: boolean
+    thinking?: boolean
+}): {
+    limits: CodexSubscriptionLimits | null
+    isLoading: boolean
+    isFetching: boolean
+    error: string | null
+} {
+    const { api, sessionId } = args
+    const model = args.model ?? null
+    const thinking = args.thinking === true
+    const enabled = Boolean(args.enabled && api && sessionId)
+    const query = useQuery({
+        queryKey: queryKeys.sessionCodexSubscriptionLimits(sessionId ?? 'unknown', model),
+        queryFn: async () => {
+            if (!api || !sessionId) {
+                throw new Error('API unavailable')
+            }
+            return await api.getSessionCodexSubscriptionLimits(sessionId)
+        },
+        enabled,
+        staleTime: Number.POSITIVE_INFINITY,
+        refetchOnWindowFocus: false,
+        retry: false
+    })
+
+    const prevThinkingRef = useRef(thinking)
+    useEffect(() => {
+        prevThinkingRef.current = thinking
+    }, [sessionId, model])
+
+    useEffect(() => {
+        if (enabled && prevThinkingRef.current && !thinking) {
+            void query.refetch()
+        }
+        prevThinkingRef.current = thinking
+    }, [enabled, thinking, query, sessionId, model])
+
+    return {
+        limits: query.data?.limits ?? null,
+        isLoading: query.isLoading,
+        isFetching: query.isFetching,
+        error: query.data?.success === false
+            ? (query.data.error ?? 'Failed to read Codex subscription limits')
+            : query.error instanceof Error
+                ? query.error.message
+                : query.error
+                    ? 'Failed to read Codex subscription limits'
+                    : null
+    }
+}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -429,6 +429,9 @@ export default {
 
   // Composer buttons
   'composer.settings': 'Settings',
+  'composer.moreTools': 'More tools',
+  'composer.planMode': 'Plan mode',
+  'composer.goalMode': 'Goal mode',
   'composer.terminal': 'Terminal',
   'composer.abort': 'Abort',
   'composer.switchRemote': 'Switch to remote mode',
@@ -684,8 +687,10 @@ export default {
   'misc.collaborationMode': 'Collaboration Mode',
   'misc.permissionMode': 'Permission Mode',
   'misc.model': 'Model',
+  'misc.reasoning': 'Reasoning',
   'misc.reasoningEffort': 'Reasoning Effort',
   'misc.effort': 'Effort',
+  'misc.speed': 'Speed',
   'misc.fastMode': 'Fast Mode',
   'misc.fastModeStandard': 'Standard',
   'misc.fastModeFast': 'Fast',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -433,6 +433,9 @@ export default {
 
   // Composer buttons
   'composer.settings': '设置',
+  'composer.moreTools': '更多工具',
+  'composer.planMode': '计划模式',
+  'composer.goalMode': '目标模式',
   'composer.terminal': '终端',
   'composer.abort': '中止',
   'composer.switchRemote': '切换到远程模式',
@@ -688,8 +691,10 @@ export default {
   'misc.collaborationMode': '协作模式',
   'misc.permissionMode': '权限模式',
   'misc.model': '模型',
+  'misc.reasoning': '推理',
   'misc.reasoningEffort': '推理强度',
   'misc.effort': '思考强度',
+  'misc.speed': '速度',
   'misc.fastMode': '快速模式',
   'misc.fastModeStandard': '标准',
   'misc.fastModeFast': '快速',

--- a/web/src/lib/query-keys.ts
+++ b/web/src/lib/query-keys.ts
@@ -16,6 +16,7 @@ export const queryKeys = {
     ] as const,
     slashCommands: (sessionId: string) => ['slash-commands', sessionId] as const,
     sessionCodexModels: (sessionId: string) => ['session-codex-models', sessionId] as const,
+    sessionCodexSubscriptionLimits: (sessionId: string, model: string | null) => ['session-codex-subscription-limits', sessionId, model] as const,
     sessionCursorModels: (sessionId: string) => ['session-cursor-models', sessionId] as const,
     sessionPiModels: (sessionId: string) => ['session-pi-models', sessionId] as const,
     machineCursorModels: (machineId: string) => ['machine-cursor-models', machineId] as const,

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -11,6 +11,9 @@ import type {
 export type {
     CodexModelsResponse,
     CodexModelSummary,
+    CodexSubscriptionLimitsResponse,
+    CodexSubscriptionLimits,
+    CodexSubscriptionLimitWindow,
     CommandResponse,
     CursorModelsResponse,
     CursorModelSummary,


### PR DESCRIPTION
## Summary
- Refresh the web session header and composer controls with a layout inspired by Codex Desktop.
- Move status, model, reasoning, permission, and auxiliary composer actions into compact controls and popovers.
- Add Codex subscription quota retrieval through the CLI/hub RPC path and show 5h and weekly quota indicators in the header.
- Cache Codex quota queries per session and model so model changes do not reuse stale quota buckets.

## Testing
- bun typecheck
- bun run test
- bun run typecheck:web
- cd web && bun run test src/components/AssistantChat/ComposerButtons.test.tsx src/components/AssistantChat/HappyComposer.modelEffort.test.tsx src/components/AssistantChat/StatusBar.test.ts src/api/client.test.ts

## AI assistance
- Implemented with Codex.