### PR TITLE
feat(web): global word-wrap toggle for code and diff views

### DIFF
--- a/web/src/components/CliOutputBlock.test.tsx
+++ b/web/src/components/CliOutputBlock.test.tsx
@@ -14,4 +14,20 @@ describe('CliOutputBlock', () => {
         expect(screen.getByRole('button', { name: /npm test/i })).toBeInTheDocument()
         expect(screen.queryByTitle('Copy')).not.toBeInTheDocument()
     })
+
+    it('does not render a nested wrap toggle button inside the preview trigger', () => {
+        // The preview CodeBlock renders inside a DialogTrigger <button>, so
+        // its wrap toggle <button> must be suppressed to avoid nesting
+        // interactive elements (invalid HTML / hydration violation).
+        render(
+            <I18nProvider>
+                <CliOutputBlock text={'<command-name>npm test</command-name><local-command-stdout>ok</local-command-stdout>'} />
+            </I18nProvider>
+        )
+
+        // The wrap toggle is the only button carrying aria-pressed; asserting
+        // its absence by role avoids coupling to the localized title.
+        expect(screen.queryByRole('button', { pressed: false })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { pressed: true })).not.toBeInTheDocument()
+    })
 })

--- a/web/src/components/CliOutputBlock.tsx
+++ b/web/src/components/CliOutputBlock.tsx
@@ -140,6 +140,7 @@ export function CliOutputBlock(props: { text: string }) {
                                 language="shellscript"
                                 title="Terminal output"
                                 showCopyButton={false}
+                                showWrapToggle={false}
                                 collapseLongContent={isCollapsedPreview}
                                 collapsedHeight={PREVIEW_MAX_HEIGHT}
                             />

--- a/web/src/components/CodeBlock.test.tsx
+++ b/web/src/components/CodeBlock.test.tsx
@@ -1,12 +1,22 @@
-import { describe, expect, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { I18nProvider } from '@/lib/i18n-context'
 import { CodeBlock } from '@/components/CodeBlock'
 
+afterEach(() => cleanup())
+
+// In jsdom the async shiki highlighter never resolves, so these tests
+// exercise the plain-text fallback (code split on newlines), which is the
+// same per-line row structure the highlighted path produces.
+
 describe('CodeBlock', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
     it('renders a header label and truncation badge for long content', () => {
         const longCode = Array.from({ length: 40 }, (_, index) => `line ${index + 1}`).join('\n')
-        const { container } = render(
+        render(
             <I18nProvider>
                 <CodeBlock
                     code={longCode}
@@ -21,7 +31,116 @@ describe('CodeBlock', () => {
         expect(screen.getByText('TypeScript')).toBeInTheDocument()
         expect(screen.getByTitle('Copy')).toBeInTheDocument()
         expect(screen.getByText(/Preview truncated/)).toBeInTheDocument()
-        expect(container.querySelector('[style*="grid-template-columns: 3ch max-content"]')).not.toBeNull()
-        expect(container.querySelector('[aria-hidden="true"]')).toHaveTextContent(/^1 2 3/)
+    })
+
+    it('renders one line-number cell per source line, aligned with the code', () => {
+        const { container } = render(
+            <I18nProvider>
+                <CodeBlock code={'const a = 1\nconst b = 2\nconst c = 3'} language="typescript" />
+            </I18nProvider>
+        )
+
+        const lineNumbers = container.querySelectorAll('[data-line-number]')
+        expect(lineNumbers).toHaveLength(3)
+        expect(Array.from(lineNumbers).map((el) => el.textContent)).toEqual(['1', '2', '3'])
+    })
+
+    it('renders the code inside a <pre> element for preformatted semantics', () => {
+        const { container } = render(
+            <I18nProvider>
+                <CodeBlock code={'const a = 1\nconst b = 2'} language="typescript" />
+            </I18nProvider>
+        )
+
+        const pre = container.querySelector('pre.shiki')
+        expect(pre).not.toBeNull()
+        expect(pre?.querySelector('[data-line-number]')).not.toBeNull()
+        expect(pre?.querySelector('[data-code-cell]')).not.toBeNull()
+    })
+
+    it('defaults to wrap off: line-number column present, horizontal scroll container, no wrapping', () => {
+        const { container } = render(
+            <I18nProvider>
+                <CodeBlock code={'const a = 1\nconst b = 2'} language="typescript" />
+            </I18nProvider>
+        )
+
+        expect(container.querySelector('[data-line-number]')).not.toBeNull()
+        expect(container.querySelector('.overflow-x-auto')).not.toBeNull()
+        const codeCell = container.querySelector('[data-code-cell]') as HTMLElement | null
+        expect(codeCell?.style.whiteSpace).not.toBe('pre-wrap')
+    })
+
+    it('toggling wrap on keeps the line-number column and wraps the code cells (no horizontal scroll)', () => {
+        // Select the toggle by its aria-pressed state, not its localized title.
+        const { container } = render(
+            <I18nProvider>
+                <CodeBlock code={'const a = 1\nconst b = 2'} language="typescript" />
+            </I18nProvider>
+        )
+
+        fireEvent.click(screen.getByRole('button', { pressed: false }))
+
+        // Line numbers stay (this is the whole point of the per-line layout).
+        expect(container.querySelectorAll('[data-line-number]')).toHaveLength(2)
+        expect(container.querySelector('.overflow-x-auto')).toBeNull()
+        const codeCell = container.querySelector('[data-code-cell]') as HTMLElement | null
+        expect(codeCell?.style.whiteSpace).toBe('pre-wrap')
+        expect(screen.getByRole('button', { pressed: true })).toBeInTheDocument()
+    })
+
+    it('reads the persisted wrap preference on mount and still keeps line numbers', () => {
+        window.localStorage.setItem('hapi-code-wrap', '1')
+
+        const { container } = render(
+            <I18nProvider>
+                <CodeBlock code={'const a = 1\nconst b = 2'} language="typescript" />
+            </I18nProvider>
+        )
+
+        expect(container.querySelectorAll('[data-line-number]')).toHaveLength(2)
+        const codeCell = container.querySelector('[data-code-cell]') as HTMLElement | null
+        expect(codeCell?.style.whiteSpace).toBe('pre-wrap')
+        expect(screen.getByRole('button', { pressed: true })).toBeInTheDocument()
+    })
+
+    it('renders the plain-text fallback as per-line rows when highlighting is unavailable', () => {
+        const { container } = render(
+            <I18nProvider>
+                <CodeBlock code={'plain one\nplain two'} language="text" />
+            </I18nProvider>
+        )
+
+        const codeCells = container.querySelectorAll('[data-code-cell]')
+        expect(codeCells).toHaveLength(2)
+        expect(codeCells[0]).toHaveTextContent('plain one')
+        expect(codeCells[1]).toHaveTextContent('plain two')
+        expect(container.querySelectorAll('[data-line-number]')).toHaveLength(2)
+    })
+
+    it('renders the wrap toggle button by default', () => {
+        render(
+            <I18nProvider>
+                <CodeBlock code="const a = 1" language="typescript" />
+            </I18nProvider>
+        )
+
+        expect(screen.getByRole('button', { pressed: false })).toBeInTheDocument()
+    })
+
+    it('omits the wrap toggle button when showWrapToggle is false', () => {
+        // The wrap toggle is a <button>. When CodeBlock renders inside an
+        // interactive ancestor (DialogTrigger's button, a role="button"
+        // preview), that nested <button> is invalid HTML / a hydration
+        // violation. Such callsites pass showWrapToggle={false}.
+        render(
+            <I18nProvider>
+                <CodeBlock code="const a = 1" language="typescript" showWrapToggle={false} />
+            </I18nProvider>
+        )
+
+        // The toggle is the only button carrying aria-pressed.
+        expect(screen.queryByRole('button', { pressed: false })).toBeNull()
+        expect(screen.queryByRole('button', { pressed: true })).toBeNull()
     })
 })

--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -1,7 +1,8 @@
-import type { CSSProperties } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
-import { useShikiHighlighter } from '@/lib/shiki'
-import { CopyIcon, CheckIcon } from '@/components/icons'
+import { useCodeWrap } from '@/hooks/useCodeWrap'
+import { useShikiHighlightedLines, splitCodeLines } from '@/lib/shiki'
+import { CopyIcon, CheckIcon, WrapIcon } from '@/components/icons'
 import { useTranslation } from '@/lib/use-translation'
 
 const DEFAULT_COLLAPSE_LINE_THRESHOLD = 18
@@ -20,20 +21,12 @@ function formatCodeLabel(language?: string, title?: string): string {
     return language
 }
 
-function countCodeLines(code: string): number {
-    if (code.length === 0) return 1
-    const lines = code.split('\n')
-    if (lines.length > 1 && lines[lines.length - 1] === '') {
-        lines.pop()
-    }
-    return Math.max(lines.length, 1)
-}
-
 export function CodeBlock(props: {
     code: string
     language?: string
     title?: string
     showCopyButton?: boolean
+    showWrapToggle?: boolean
     collapseLongContent?: boolean
     collapsedHeight?: number
     maxHeight?: number
@@ -44,8 +37,14 @@ export function CodeBlock(props: {
 }) {
     const { t } = useTranslation()
     const showCopyButton = props.showCopyButton ?? true
+    // The wrap toggle is a <button>. Callsites that render CodeBlock inside
+    // an interactive ancestor (a DialogTrigger button, a role="button"
+    // inline preview) must pass false to avoid nesting interactive elements
+    // (invalid HTML / hydration violation). Default on for standalone use.
+    const showWrapToggle = props.showWrapToggle ?? true
     const { copied, copy } = useCopyToClipboard()
-    const highlighted = useShikiHighlighter(props.code, props.language)
+    const { codeWrap, setCodeWrap } = useCodeWrap()
+    const highlightedLines = useShikiHighlightedLines(props.code, props.language)
     const isCollapsed = Boolean(props.collapseLongContent) && shouldCollapseCode(
         props.code,
         props.collapseLineThreshold ?? DEFAULT_COLLAPSE_LINE_THRESHOLD,
@@ -56,13 +55,31 @@ export function CodeBlock(props: {
     const codeTextClass = props.size === 'comfortable'
         ? 'text-sm leading-5'
         : 'text-xs'
-    const lineCount = countCodeLines(props.code)
-    const lineNumberWidth = Math.max(String(lineCount).length, 3)
-    const lineNumbers = Array.from({ length: lineCount }, (_, index) => String(index + 1)).join('\n')
+    // Render one grid row per logical line: a line-number cell and a code
+    // cell that are siblings in the same row. Because they share a grid row,
+    // the line number stays aligned with its line even when the code cell
+    // wraps (the row grows taller and the number pins to the top) -- the
+    // GitHub / VS Code diff behavior. This replaces the earlier two-<pre>
+    // approach whose independent text flows drifted out of alignment while
+    // wrapped.
+    //
+    // `highlightedLines` (one ReactNode per line) is null while shiki is
+    // pending or for unsupported languages; fall back to the raw code split
+    // on newlines using the same normalization, so line numbers match.
+    const fallbackLines = splitCodeLines(props.code)
+    const codeLines: ReactNode[] = highlightedLines ?? fallbackLines
+    const lineNumberWidth = Math.max(String(codeLines.length).length, 3)
     const label = formatCodeLabel(props.language, props.title)
+    // First track sizes to the line-number column; the code column takes the
+    // rest. When wrapped the code column is capped to the container width
+    // (minmax(0,1fr)) so long lines wrap instead of overflowing; unwrapped it
+    // grows to its content (max-content) inside the horizontal-scroll body.
     const codeGridStyle = {
-        gridTemplateColumns: `${lineNumberWidth}ch max-content`
+        gridTemplateColumns: `${lineNumberWidth}ch ${codeWrap ? 'minmax(0, 1fr)' : 'max-content'}`
     } satisfies CSSProperties
+    const codeCellStyle = codeWrap
+        ? { whiteSpace: 'pre-wrap' as const, wordBreak: 'break-word' as const }
+        : { whiteSpace: 'pre' as const }
     const bodyStyle = isCollapsed
         ? { maxHeight: collapsedHeight, overflowY: 'hidden' as const }
         : props.scrollY
@@ -75,36 +92,61 @@ export function CodeBlock(props: {
                 <div className="min-w-0 flex-1 truncate font-mono text-[11px] uppercase tracking-[0.08em] text-[var(--app-code-header-fg)]">
                     {label}
                 </div>
-                {showCopyButton ? (
-                    <button
-                        type="button"
-                        onClick={(event) => {
-                            event.stopPropagation()
-                            copy(props.code)
-                        }}
-                        className="shrink-0 rounded-md p-1 text-[var(--app-code-header-fg)] transition-colors hover:bg-[var(--app-code-copy-hover-bg)] hover:text-[var(--app-fg)]"
-                        title={t('code.copy')}
-                    >
-                        {copied ? <CheckIcon className="h-3.5 w-3.5" /> : <CopyIcon className="h-3.5 w-3.5" />}
-                    </button>
-                ) : null}
+                <div className="flex shrink-0 items-center gap-1">
+                    {showWrapToggle ? (
+                        <button
+                            type="button"
+                            onClick={(event) => {
+                                event.stopPropagation()
+                                setCodeWrap(!codeWrap)
+                            }}
+                            className={`rounded-md p-1 transition-colors hover:bg-[var(--app-code-copy-hover-bg)] hover:text-[var(--app-fg)] ${codeWrap ? 'text-[var(--app-fg)]' : 'text-[var(--app-code-header-fg)]'}`}
+                            title={t(codeWrap ? 'code.wrap.disable' : 'code.wrap.enable')}
+                            aria-pressed={codeWrap}
+                        >
+                            <WrapIcon className="h-3.5 w-3.5" />
+                        </button>
+                    ) : null}
+                    {showCopyButton ? (
+                        <button
+                            type="button"
+                            onClick={(event) => {
+                                event.stopPropagation()
+                                copy(props.code)
+                            }}
+                            className="rounded-md p-1 text-[var(--app-code-header-fg)] transition-colors hover:bg-[var(--app-code-copy-hover-bg)] hover:text-[var(--app-fg)]"
+                            title={t('code.copy')}
+                        >
+                            {copied ? <CheckIcon className="h-3.5 w-3.5" /> : <CopyIcon className="h-3.5 w-3.5" />}
+                        </button>
+                    ) : null}
+                </div>
             </div>
 
             <div
-                className="min-w-0 w-full max-w-full overflow-x-auto"
+                className={`min-w-0 w-full max-w-full ${codeWrap ? '' : 'overflow-x-auto'}`}
                 style={bodyStyle}
             >
-                <div className={`grid w-max min-w-full font-mono ${codeTextClass}`} style={codeGridStyle}>
-                    <pre
-                        aria-hidden="true"
-                        className="m-0 select-none px-3 py-3 text-left text-[var(--app-hint)]/70"
-                    >
-                        {lineNumbers}
-                    </pre>
-                    <pre className="shiki m-0 px-4 py-3 pr-8">
-                        <code className="block">{highlighted ?? props.code}</code>
-                    </pre>
-                </div>
+                <pre
+                    className={`shiki m-0 grid ${codeWrap ? 'w-full' : 'w-max min-w-full'} font-mono ${codeTextClass} py-3`}
+                    style={codeGridStyle}
+                >
+                    {codeLines.map((line, index) => (
+                        <span key={index} className="contents">
+                            <span
+                                data-line-number
+                                aria-hidden="true"
+                                className="select-none px-3 text-left text-[var(--app-hint)]/70"
+                                style={{ alignSelf: 'start' }}
+                            >
+                                {index + 1}
+                            </span>
+                            <span data-code-cell className="pl-4 pr-8" style={codeCellStyle}>
+                                {line}
+                            </span>
+                        </span>
+                    ))}
+                </pre>
             </div>
             {isCollapsed ? (
                 <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center bg-gradient-to-t from-[var(--app-code-bg)] via-[var(--app-code-bg)]/94 to-transparent px-2 pb-2 pt-10">

--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -128,24 +128,28 @@ export function CodeBlock(props: {
                 style={bodyStyle}
             >
                 <pre
-                    className={`shiki m-0 grid ${codeWrap ? 'w-full' : 'w-max min-w-full'} font-mono ${codeTextClass} py-3`}
+                    className={`shiki m-0 grid ${codeWrap ? 'w-full' : 'w-max min-w-full'} font-mono ${codeTextClass}`}
                     style={codeGridStyle}
                 >
-                    {codeLines.map((line, index) => (
-                        <span key={index} className="contents">
-                            <span
-                                data-line-number
-                                aria-hidden="true"
-                                className="select-none px-3 text-left text-[var(--app-hint)]/70"
-                                style={{ alignSelf: 'start' }}
-                            >
-                                {index + 1}
+                    {codeLines.map((line, index) => {
+                        // py lives on the first/last row cells (not the container)
+                        // so the gutter background reaches the top and bottom edges.
+                        const rowPad = `${index === 0 ? 'pt-3' : ''} ${index === codeLines.length - 1 ? 'pb-3' : ''}`
+                        return (
+                            <span key={index} className="contents">
+                                <span
+                                    data-line-number
+                                    aria-hidden="true"
+                                    className={`select-none bg-[var(--app-code-header-bg)] px-3 text-right text-[var(--app-hint)]/70 ${rowPad}`}
+                                >
+                                    {index + 1}
+                                </span>
+                                <span data-code-cell className={`pl-4 pr-8 ${rowPad}`} style={codeCellStyle}>
+                                    {line}
+                                </span>
                             </span>
-                            <span data-code-cell className="pl-4 pr-8" style={codeCellStyle}>
-                                {line}
-                            </span>
-                        </span>
-                    ))}
+                        )
+                    })}
                 </pre>
             </div>
             {isCollapsed ? (

--- a/web/src/components/DiffView.test.tsx
+++ b/web/src/components/DiffView.test.tsx
@@ -1,9 +1,15 @@
-import { describe, expect, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
 import { I18nProvider } from '@/lib/i18n-context'
 import { DiffView } from '@/components/DiffView'
 
+afterEach(() => cleanup())
+
 describe('DiffView', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
     it('counts blank-line additions and removals in diff stats', () => {
         render(
             <I18nProvider>
@@ -65,5 +71,89 @@ describe('DiffView', () => {
         expect(row).not.toBeNull()
         expect(row?.children[0]).toHaveClass('text-left')
         expect(row?.children[1]).toHaveClass('text-left')
+    })
+
+    it('comfortable rows default to whitespace-pre (wrap off, no toggle button on DiffView)', () => {
+        const { container } = render(
+            <I18nProvider>
+                <DiffView
+                    oldString={'old line\n'}
+                    newString={'a very long new line that would need to wrap to avoid horizontal scroll on narrow screens\n'}
+                    variant="inline"
+                    size="comfortable"
+                />
+            </I18nProvider>
+        )
+
+        expect(container.querySelector('.whitespace-pre:not(.whitespace-pre-wrap)')).not.toBeNull()
+        // DiffView consumes the global wrap value but exposes no toggle
+        // button; assert by aria-pressed absence rather than a localized title.
+        expect(screen.queryByRole('button', { pressed: false })).toBeNull()
+        expect(screen.queryByRole('button', { pressed: true })).toBeNull()
+    })
+
+    it('comfortable rows consume the global wrap preference from localStorage', () => {
+        window.localStorage.setItem('hapi-code-wrap', '1')
+
+        const { container } = render(
+            <I18nProvider>
+                <DiffView
+                    oldString={'old line\n'}
+                    newString={'a very long new line that would need to wrap to avoid horizontal scroll on narrow screens\n'}
+                    variant="inline"
+                    size="comfortable"
+                />
+            </I18nProvider>
+        )
+
+        expect(container.querySelector('.whitespace-pre-wrap')).not.toBeNull()
+        expect(container.querySelector('.whitespace-pre:not(.whitespace-pre-wrap)')).toBeNull()
+    })
+
+    it('wrap on drops the horizontal-scroll container and max-content grid track (Phase 1 lesson applied here too)', () => {
+        // Same trap as CodeBlock's Phase 1 spike: `whitespace-pre-wrap` alone
+        // does nothing if the row's grid track is `max-content` and an
+        // ancestor is `w-max` inside `overflow-x-auto` — the row still
+        // claims full content width before wrapping is ever evaluated.
+        window.localStorage.setItem('hapi-code-wrap', '1')
+
+        const { container } = render(
+            <I18nProvider>
+                <DiffView
+                    oldString={'old line\n'}
+                    newString={'a very long new line that would need to wrap to avoid horizontal scroll on narrow screens\n'}
+                    variant="inline"
+                    size="comfortable"
+                />
+            </I18nProvider>
+        )
+
+        expect(container.querySelector('.overflow-x-auto')).toBeNull()
+        expect(container.querySelector('[style*="max-content"]')).toBeNull()
+    })
+
+    it('wrap on keeps line-number columns aligned across all rows (grid-per-line structure)', () => {
+        const oldString = Array.from({ length: 12 }, (_, index) => `old ${index + 1}`).join('\n')
+        const newString = `${oldString}\na very long new line that would need to wrap to avoid horizontal scroll on narrow screens`
+        window.localStorage.setItem('hapi-code-wrap', '1')
+
+        const { container } = render(
+            <I18nProvider>
+                <DiffView
+                    oldString={oldString}
+                    newString={newString}
+                    variant="inline"
+                    size="comfortable"
+                />
+            </I18nProvider>
+        )
+
+        const rows = Array.from(container.querySelectorAll('[style*="grid-template-columns"]'))
+        expect(rows.length).toBeGreaterThan(1)
+        const templates = new Set(rows.map((row) => (row as HTMLElement).style.gridTemplateColumns))
+        // Every row must share the exact same column template so line
+        // numbers stay pixel-aligned regardless of how many visual lines a
+        // wrapped row occupies.
+        expect(templates.size).toBe(1)
     })
 })

--- a/web/src/components/DiffView.test.tsx
+++ b/web/src/components/DiffView.test.tsx
@@ -92,6 +92,27 @@ describe('DiffView', () => {
         expect(screen.queryByRole('button', { pressed: true })).toBeNull()
     })
 
+    it('compact rows also follow the global wrap preference (previously hard-coded to wrap)', () => {
+        const props = {
+            oldString: 'old line\n',
+            newString: 'a very long new line that would need to wrap to avoid horizontal scroll on narrow screens\n',
+            variant: 'inline' as const,
+            size: 'compact' as const
+        }
+
+        // wrap off (default): compact rows now use whitespace-pre + horizontal scroll
+        const off = render(<I18nProvider><DiffView {...props} /></I18nProvider>)
+        expect(off.container.querySelector('.whitespace-pre:not(.whitespace-pre-wrap)')).not.toBeNull()
+        expect(off.container.querySelector('.overflow-x-auto')).not.toBeNull()
+        off.unmount()
+
+        // wrap on: compact rows wrap and drop the horizontal-scroll container
+        window.localStorage.setItem('hapi-code-wrap', '1')
+        const on = render(<I18nProvider><DiffView {...props} /></I18nProvider>)
+        expect(on.container.querySelector('.whitespace-pre-wrap')).not.toBeNull()
+        expect(on.container.querySelector('.overflow-x-auto')).toBeNull()
+    })
+
     it('comfortable rows consume the global wrap preference from localStorage', () => {
         window.localStorage.setItem('hapi-code-wrap', '1')
 

--- a/web/src/components/DiffView.tsx
+++ b/web/src/components/DiffView.tsx
@@ -166,8 +166,8 @@ function DiffInlineView(props: {
     // Same trap as CodeBlock's Phase 1 spike: a `max-content` third track
     // lets the row claim full content width before `whitespace-pre-wrap`
     // ever gets a chance to wrap, so wrap-on must also switch the track to
-    // `minmax(0, 1fr)` (matching the compact variant, which already wraps).
-    const codeColumnTrack = (isComfortable && !codeWrap) ? 'max-content' : 'minmax(0, 1fr)'
+    // `minmax(0, 1fr)`. Both size variants follow the global wrap setting.
+    const codeColumnTrack = codeWrap ? 'minmax(0, 1fr)' : 'max-content'
     const rowStyle = {
         gridTemplateColumns: `${lineNumberWidth}ch ${lineNumberWidth}ch ${codeColumnTrack}`
     } satisfies CSSProperties
@@ -191,16 +191,15 @@ function DiffInlineView(props: {
 
             <div
                 className={cn(
-                    (isComfortable && codeWrap) ? '' : 'overflow-x-auto',
+                    codeWrap ? '' : 'overflow-x-auto',
                     props.scrollY ? 'overflow-y-auto' : 'overflow-y-hidden'
                 )}
                 style={props.scrollY ? { maxHeight: props.maxHeight ?? 420 } : undefined}
             >
                 <div className={cn(
                     'font-mono',
-                    isComfortable
-                        ? cn('text-sm leading-6', codeWrap ? 'w-full' : 'w-max min-w-full')
-                        : 'text-xs'
+                    isComfortable ? 'text-sm leading-6' : 'text-xs',
+                    codeWrap ? 'w-full' : 'w-max min-w-full'
                 )}>
                     {diff.map((part, i) => {
                         const lines = splitDiffLines(part.value)
@@ -224,9 +223,7 @@ function DiffInlineView(props: {
                                             <div className={cn('text-left text-[var(--app-hint)]/80', isComfortable ? 'text-xs leading-6' : 'text-[10px]')}>{leftNumber}</div>
                                             <div className={cn('text-left text-[var(--app-hint)]/80', isComfortable ? 'text-xs leading-6' : 'text-[10px]')}>{rightNumber}</div>
                                             <div className={cn(
-                                                isComfortable
-                                                    ? (codeWrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre')
-                                                    : 'min-w-0 whitespace-pre-wrap break-words'
+                                                codeWrap ? 'min-w-0 whitespace-pre-wrap break-words' : 'whitespace-pre'
                                             )}>
                                                 <span className="mr-2 inline-block w-3 text-[var(--app-hint)]/90">{prefix}</span>
                                                 <span>{line}</span>

--- a/web/src/components/DiffView.tsx
+++ b/web/src/components/DiffView.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from 'react'
 import { useMemo } from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { usePointerFocusRing } from '@/hooks/usePointerFocusRing'
+import { useCodeWrap } from '@/hooks/useCodeWrap'
 import { cn } from '@/lib/utils'
 import { useTranslation } from '@/lib/use-translation'
 
@@ -155,14 +156,20 @@ function DiffInlineView(props: {
     maxHeight?: number
 }) {
     const diff = useMemo(() => diffLines(props.oldString, props.newString), [props.oldString, props.newString])
+    const { codeWrap } = useCodeWrap()
     const isComfortable = props.size === 'comfortable'
     const lineNumberWidth = Math.max(
         String(countLines(props.oldString)).length,
         String(countLines(props.newString)).length,
         2
     )
+    // Same trap as CodeBlock's Phase 1 spike: a `max-content` third track
+    // lets the row claim full content width before `whitespace-pre-wrap`
+    // ever gets a chance to wrap, so wrap-on must also switch the track to
+    // `minmax(0, 1fr)` (matching the compact variant, which already wraps).
+    const codeColumnTrack = (isComfortable && !codeWrap) ? 'max-content' : 'minmax(0, 1fr)'
     const rowStyle = {
-        gridTemplateColumns: `${lineNumberWidth}ch ${lineNumberWidth}ch ${isComfortable ? 'max-content' : 'minmax(0, 1fr)'}`
+        gridTemplateColumns: `${lineNumberWidth}ch ${lineNumberWidth}ch ${codeColumnTrack}`
     } satisfies CSSProperties
 
     let oldLineNumber = 1
@@ -184,12 +191,17 @@ function DiffInlineView(props: {
 
             <div
                 className={cn(
-                    'overflow-x-auto',
+                    (isComfortable && codeWrap) ? '' : 'overflow-x-auto',
                     props.scrollY ? 'overflow-y-auto' : 'overflow-y-hidden'
                 )}
                 style={props.scrollY ? { maxHeight: props.maxHeight ?? 420 } : undefined}
             >
-                <div className={cn('font-mono', isComfortable ? 'w-max min-w-full text-sm leading-6' : 'text-xs')}>
+                <div className={cn(
+                    'font-mono',
+                    isComfortable
+                        ? cn('text-sm leading-6', codeWrap ? 'w-full' : 'w-max min-w-full')
+                        : 'text-xs'
+                )}>
                     {diff.map((part, i) => {
                         const lines = splitDiffLines(part.value)
 
@@ -211,7 +223,11 @@ function DiffInlineView(props: {
                                         <div key={j} className={rowClass} style={rowStyle}>
                                             <div className={cn('text-left text-[var(--app-hint)]/80', isComfortable ? 'text-xs leading-6' : 'text-[10px]')}>{leftNumber}</div>
                                             <div className={cn('text-left text-[var(--app-hint)]/80', isComfortable ? 'text-xs leading-6' : 'text-[10px]')}>{rightNumber}</div>
-                                            <div className={cn(isComfortable ? 'whitespace-pre' : 'min-w-0 whitespace-pre-wrap break-words')}>
+                                            <div className={cn(
+                                                isComfortable
+                                                    ? (codeWrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre')
+                                                    : 'min-w-0 whitespace-pre-wrap break-words'
+                                            )}>
                                                 <span className="mr-2 inline-block w-3 text-[var(--app-hint)]/90">{prefix}</span>
                                                 <span>{line}</span>
                                             </div>

--- a/web/src/components/ToolCard/ToolCard.tsx
+++ b/web/src/components/ToolCard/ToolCard.tsx
@@ -116,9 +116,13 @@ function renderTaskSummary(
 
 function renderToolInput(block: ToolCallBlock, surface: 'inline' | 'dialog' = 'inline'): ReactNode {
     const collapseLongContent = surface === 'inline'
+    // The inline surface renders inside a role="button" preview, so the
+    // wrap toggle's <button> would nest inside an interactive ancestor
+    // (invalid HTML / hydration violation). Suppress it for inline; the
+    // dialog surface (button-free) keeps the toggle.
     const codeBlockSurfaceProps = surface === 'dialog'
         ? { size: 'comfortable' as const, scrollY: true }
-        : {}
+        : { showWrapToggle: false }
     const toolName = block.tool.name
     const input = block.tool.input
 

--- a/web/src/components/ToolCard/views/_results.test.tsx
+++ b/web/src/components/ToolCard/views/_results.test.tsx
@@ -11,8 +11,8 @@ vi.mock('@/components/MarkdownRenderer', () => ({
 }))
 
 vi.mock('@/components/CodeBlock', () => ({
-    CodeBlock: (props: { code: string; language?: string; title?: string; className?: string }) => (
-        <div className={props.className}>
+    CodeBlock: (props: { code: string; language?: string; title?: string; className?: string; showWrapToggle?: boolean }) => (
+        <div className={props.className} data-show-wrap-toggle={String(props.showWrapToggle ?? true)}>
             {props.title ? <div>{props.title}</div> : null}
             <pre data-language={props.language ?? 'text'}>
                 <code>{props.code}</code>
@@ -348,7 +348,12 @@ describe('Codex agent result formatting', () => {
 })
 
 describe('read file result formatting', () => {
-    function renderToolResult(toolName: string, result: unknown, input: unknown = {}) {
+    function renderToolResult(
+        toolName: string,
+        result: unknown,
+        input: unknown = {},
+        surface: 'inline' | 'dialog' = 'dialog'
+    ) {
         const ResultView = getToolResultViewComponent(toolName)
         const block: ToolCallBlock = {
             id: 'tool-read',
@@ -371,7 +376,7 @@ describe('read file result formatting', () => {
 
         return render(
             <I18nProvider>
-                <ResultView block={block} metadata={null} surface="dialog" />
+                <ResultView block={block} metadata={null} surface={surface} />
             </I18nProvider>
         )
     }
@@ -429,5 +434,29 @@ describe('read file result formatting', () => {
         expect(container.querySelector('pre')).not.toBeNull()
         expect(container).toHaveTextContent('File content')
         expect(container).toHaveTextContent('const value = 1')
+    })
+
+    it('suppresses the CodeBlock wrap toggle on the inline surface (avoids nesting a <button> in the role="button" preview)', () => {
+        const { container } = renderToolResult(
+            'Read',
+            { file: { filePath: '/tmp/example.ts', content: 'const value = 1\nexport { value }' } },
+            {},
+            'inline'
+        )
+
+        expect(container.querySelector('[data-show-wrap-toggle="false"]')).not.toBeNull()
+        expect(container.querySelector('[data-show-wrap-toggle="true"]')).toBeNull()
+    })
+
+    it('keeps the CodeBlock wrap toggle on the dialog surface (button-free container)', () => {
+        const { container } = renderToolResult(
+            'Read',
+            { file: { filePath: '/tmp/example.ts', content: 'const value = 1\nexport { value }' } },
+            {},
+            'dialog'
+        )
+
+        expect(container.querySelector('[data-show-wrap-toggle="true"]')).not.toBeNull()
+        expect(container.querySelector('[data-show-wrap-toggle="false"]')).toBeNull()
     })
 })

--- a/web/src/components/ToolCard/views/_results.tsx
+++ b/web/src/components/ToolCard/views/_results.tsx
@@ -241,9 +241,13 @@ function inferCodeLanguage(path: string | null, text: string): string | null {
 }
 
 function resultCodeBlockProps(surface: ToolViewProps['surface'], collapseLongContent?: boolean) {
+    // The inline surface renders inside ToolCard's role="button" preview,
+    // so the wrap toggle's <button> would nest inside an interactive
+    // ancestor (invalid HTML / hydration violation). Suppress it here; the
+    // dialog surface (button-free) keeps the toggle.
     return surface === 'dialog'
         ? { collapseLongContent: false, size: 'comfortable' as const, scrollY: true }
-        : { collapseLongContent }
+        : { collapseLongContent, showWrapToggle: false }
 }
 
 function renderResultBody(

--- a/web/src/components/assistant-ui/markdown-text-codeblock.test.tsx
+++ b/web/src/components/assistant-ui/markdown-text-codeblock.test.tsx
@@ -1,0 +1,73 @@
+import type { ComponentType } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { I18nProvider } from '@/lib/i18n-context'
+import { defaultComponents } from '@/components/assistant-ui/markdown-text'
+
+afterEach(() => cleanup())
+
+// Render the exact components the markdown pipeline wires up for a fenced
+// code block: `defaultComponents.CodeHeader` (the toggle header) and
+// `defaultComponents.pre` (the languageless-fallback body). Going through
+// `defaultComponents` keeps the test on the real production render path
+// without widening the module's public surface. `memoizeMarkdownComponents`
+// narrows the memoized components to `{ node? }` props, so cast to feed the
+// real runtime props the pipeline passes.
+const CodeHeader = defaultComponents.CodeHeader as ComponentType<{ language?: string; code: string }>
+const Pre = defaultComponents.pre as ComponentType<{ children: string }>
+
+describe('markdown-text CodeHeader + Pre wrap toggle', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('defaults to wrap off: Pre keeps the horizontal-scroll wrapper and w-max pre', () => {
+        const { container } = render(
+            <I18nProvider>
+                <CodeHeader language="typescript" code="const a = 1" />
+                <Pre>const a = 1</Pre>
+            </I18nProvider>
+        )
+
+        expect(container.querySelector('.overflow-x-auto')).not.toBeNull()
+        expect(container.querySelector('.aui-md-pre')).toHaveClass('w-max')
+        expect((container.querySelector('.aui-md-pre') as HTMLElement | null)?.style.whiteSpace).not.toBe('pre-wrap')
+    })
+
+    // The wrap CSS is applied via inline `style`, not a `whitespace-pre-wrap`
+    // Tailwind class: `.aui-md :where(pre) { white-space: pre }` in
+    // index.css is unlayered CSS, which the cascade always ranks above ANY
+    // `@layer` (including Tailwind's own `utilities` layer) regardless of
+    // selector specificity — a class-based approach silently loses inside
+    // `.aui-md` markdown code blocks (found live in Phase 4 isolated E2E).
+    it('toggling wrap on from CodeHeader flips Pre to inline whitespace-pre-wrap with no horizontal scroll', () => {
+        const { container } = render(
+            <I18nProvider>
+                <CodeHeader language="typescript" code="const a = 1" />
+                <Pre>const a = 1</Pre>
+            </I18nProvider>
+        )
+
+        // Select the toggle by aria-pressed state, not its localized title.
+        fireEvent.click(screen.getByRole('button', { pressed: false }))
+
+        expect(container.querySelector('.overflow-x-auto')).toBeNull()
+        expect((container.querySelector('.aui-md-pre') as HTMLElement | null)?.style.whiteSpace).toBe('pre-wrap')
+        expect(container.querySelector('.aui-md-pre')).not.toHaveClass('w-max')
+        expect(screen.getByRole('button', { pressed: true })).toBeInTheDocument()
+    })
+
+    it('reads the persisted wrap preference on mount', () => {
+        window.localStorage.setItem('hapi-code-wrap', '1')
+
+        const { container } = render(
+            <I18nProvider>
+                <CodeHeader language="typescript" code="const a = 1" />
+                <Pre>const a = 1</Pre>
+            </I18nProvider>
+        )
+
+        expect((container.querySelector('.aui-md-pre') as HTMLElement | null)?.style.whiteSpace).toBe('pre-wrap')
+        expect(screen.getByRole('button', { pressed: true })).toBeInTheDocument()
+    })
+})

--- a/web/src/components/assistant-ui/markdown-text.tsx
+++ b/web/src/components/assistant-ui/markdown-text.tsx
@@ -21,7 +21,9 @@ import { cn, encodeBase64 } from '@/lib/utils'
 import { SyntaxHighlighter } from '@/components/assistant-ui/shiki-highlighter'
 import { MermaidDiagram } from '@/components/assistant-ui/mermaid-diagram'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
-import { CopyIcon, CheckIcon } from '@/components/icons'
+import { useCodeWrap } from '@/hooks/useCodeWrap'
+import { CopyIcon, CheckIcon, WrapIcon } from '@/components/icons'
+import { useTranslation } from '@/lib/use-translation'
 import { useOptionalHappyChatContext } from '@/components/AssistantChat/context'
 import { decodeFilePathHref, remarkFilePathLinks } from '@/lib/remark-file-path-links'
 import { UriConfirmDialog } from '@/components/UriConfirmDialog'
@@ -362,7 +364,9 @@ export function UriConfirmProvider({ children }: { children: ReactNode }) {
 // ── Components ───────────────────────────────────────────────────────────────
 
 function CodeHeader(props: CodeHeaderProps) {
+    const { t } = useTranslation()
     const { copied, copy } = useCopyToClipboard()
+    const { codeWrap, setCodeWrap } = useCodeWrap()
     const language = props.language && props.language !== 'unknown' ? props.language : 'text'
 
     return (
@@ -370,29 +374,52 @@ function CodeHeader(props: CodeHeaderProps) {
             <div className="min-w-0 flex-1 truncate font-mono">
                 {language}
             </div>
-            <button
-                type="button"
-                onClick={() => copy(props.code)}
-                className="shrink-0 rounded-md p-1 text-[var(--app-code-header-fg)] transition-colors hover:bg-[var(--app-code-copy-hover-bg)] hover:text-[var(--app-fg)]"
-                title="Copy"
-            >
-                {copied ? <CheckIcon className="h-3.5 w-3.5" /> : <CopyIcon className="h-3.5 w-3.5" />}
-            </button>
+            <div className="flex shrink-0 items-center gap-1">
+                <button
+                    type="button"
+                    onClick={() => setCodeWrap(!codeWrap)}
+                    className={`rounded-md p-1 transition-colors hover:bg-[var(--app-code-copy-hover-bg)] hover:text-[var(--app-fg)] ${codeWrap ? 'text-[var(--app-fg)]' : 'text-[var(--app-code-header-fg)]'}`}
+                    title={t(codeWrap ? 'code.wrap.disable' : 'code.wrap.enable')}
+                    aria-pressed={codeWrap}
+                >
+                    <WrapIcon className="h-3.5 w-3.5" />
+                </button>
+                <button
+                    type="button"
+                    onClick={() => copy(props.code)}
+                    className="rounded-md p-1 text-[var(--app-code-header-fg)] transition-colors hover:bg-[var(--app-code-copy-hover-bg)] hover:text-[var(--app-fg)]"
+                    title="Copy"
+                >
+                    {copied ? <CheckIcon className="h-3.5 w-3.5" /> : <CopyIcon className="h-3.5 w-3.5" />}
+                </button>
+            </div>
         </div>
     )
 }
 
 function Pre(props: ComponentPropsWithoutRef<'pre'>) {
-    const { className, ...rest } = props
+    const { className, style, ...rest } = props
+    const { codeWrap } = useCodeWrap()
 
     return (
-        <div className="aui-md-pre-wrapper min-w-0 w-full max-w-full overflow-x-auto overflow-y-hidden">
+        <div className={cn(
+            'aui-md-pre-wrapper min-w-0 w-full max-w-full overflow-y-hidden',
+            codeWrap ? '' : 'overflow-x-auto'
+        )}>
             <pre
                 {...rest}
                 className={cn(
-                    'aui-md-pre m-0 w-max min-w-full rounded-b-xl bg-[var(--app-code-bg)] px-4 py-3 text-sm',
+                    'aui-md-pre m-0 rounded-b-xl bg-[var(--app-code-bg)] px-4 py-3 text-sm',
+                    codeWrap ? '' : 'w-max min-w-full',
                     className
                 )}
+                // Inline style, not a `whitespace-pre-wrap` class: index.css
+                // has an unlayered `.aui-md :where(pre) { white-space: pre }`
+                // rule that always beats Tailwind's `@layer utilities`
+                // regardless of specificity (unlayered CSS always outranks
+                // any `@layer` in the cascade). See shiki-highlighter.tsx
+                // for the same fix + fuller explanation.
+                style={codeWrap ? { ...style, whiteSpace: 'pre-wrap', wordBreak: 'break-word' } : style}
             />
         </div>
     )

--- a/web/src/components/assistant-ui/shiki-highlighter.test.tsx
+++ b/web/src/components/assistant-ui/shiki-highlighter.test.tsx
@@ -1,0 +1,91 @@
+import type { ComponentPropsWithoutRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { I18nProvider } from '@/lib/i18n-context'
+import { SyntaxHighlighter } from '@/components/assistant-ui/shiki-highlighter'
+
+// `SyntaxHighlighter` never actually uses `components.Pre`/`components.Code`
+// (it renders its own markup directly), but the prop is required by
+// `SyntaxHighlighterProps`, so pass through minimal stand-ins.
+function StubPre(props: ComponentPropsWithoutRef<'pre'>) {
+    return <pre {...props} />
+}
+function StubCode(props: ComponentPropsWithoutRef<'code'>) {
+    return <code {...props} />
+}
+
+afterEach(() => cleanup())
+
+// This is the component `@assistant-ui/react-markdown`'s DefaultCodeBlock
+// actually renders for fenced code blocks that declare a language (the
+// overwhelming majority of real assistant-message code blocks) — `Pre` is
+// only used for the languageless fallback path. It must consume the same
+// wrap preference and use the same per-line row layout as CodeBlock.
+// In jsdom shiki never resolves, so these tests exercise the plain-text
+// fallback, which shares the per-line structure with the highlighted path.
+describe('SyntaxHighlighter wrap toggle', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('renders the code inside a <pre> element for preformatted semantics', () => {
+        const { container } = render(
+            <I18nProvider>
+                <SyntaxHighlighter code={'const a = 1\nconst b = 2'} language="typescript" components={{ Pre: StubPre, Code: StubCode }} />
+            </I18nProvider>
+        )
+
+        const pre = container.querySelector('pre.shiki')
+        expect(pre).not.toBeNull()
+        expect(pre?.querySelector('[data-line-number]')).not.toBeNull()
+        expect(pre?.querySelector('[data-code-cell]')).not.toBeNull()
+    })
+
+    it('defaults to wrap off: per-line rows, horizontal scroll, no wrapping', () => {
+        const { container } = render(
+            <I18nProvider>
+                <SyntaxHighlighter code={'const a = 1\nconst b = 2'} language="typescript" components={{ Pre: StubPre, Code: StubCode }} />
+            </I18nProvider>
+        )
+
+        expect(container.querySelectorAll('[data-line-number]')).toHaveLength(2)
+        expect(container.querySelectorAll('[data-code-cell]')).toHaveLength(2)
+        expect(container.querySelector('.overflow-x-auto')).not.toBeNull()
+        const codeCell = container.querySelector('[data-code-cell]') as HTMLElement | null
+        expect(codeCell?.style.whiteSpace).not.toBe('pre-wrap')
+    })
+
+    // The wrap CSS is applied via inline `style`, not a `whitespace-pre-wrap`
+    // Tailwind class: `.aui-md :where(pre) { white-space: pre }` in index.css
+    // is unlayered CSS that outranks any `@layer` regardless of specificity;
+    // a class would silently lose inside `.aui-md` markdown code blocks
+    // (found live in Phase 4 isolated E2E).
+    it('reads the persisted wrap preference: keeps line numbers and wraps the code cells via inline style', () => {
+        window.localStorage.setItem('hapi-code-wrap', '1')
+
+        const { container } = render(
+            <I18nProvider>
+                <SyntaxHighlighter code={'const a = 1\nconst b = 2'} language="typescript" components={{ Pre: StubPre, Code: StubCode }} />
+            </I18nProvider>
+        )
+
+        // Line numbers stay (per-line layout), not hidden.
+        expect(container.querySelectorAll('[data-line-number]')).toHaveLength(2)
+        expect(container.querySelector('.overflow-x-auto')).toBeNull()
+        const codeCell = container.querySelector('[data-code-cell]') as HTMLElement | null
+        expect(codeCell?.style.whiteSpace).toBe('pre-wrap')
+    })
+
+    it('renders the plain-text fallback as per-line rows', () => {
+        const { container } = render(
+            <I18nProvider>
+                <SyntaxHighlighter code={'plain one\nplain two'} language="text" components={{ Pre: StubPre, Code: StubCode }} />
+            </I18nProvider>
+        )
+
+        const codeCells = container.querySelectorAll('[data-code-cell]')
+        expect(codeCells).toHaveLength(2)
+        expect(codeCells[0]).toHaveTextContent('plain one')
+        expect(codeCells[1]).toHaveTextContent('plain two')
+    })
+})

--- a/web/src/components/assistant-ui/shiki-highlighter.tsx
+++ b/web/src/components/assistant-ui/shiki-highlighter.tsx
@@ -30,24 +30,28 @@ export function SyntaxHighlighter(props: SyntaxHighlighterProps) {
     return (
         <div className={`aui-md-codeblock min-w-0 w-full max-w-full overflow-y-hidden rounded-b-xl bg-[var(--app-code-bg)] ${codeWrap ? '' : 'overflow-x-auto'}`}>
             <pre
-                className={`shiki m-0 grid ${codeWrap ? 'w-full' : 'w-max min-w-full'} text-sm font-mono py-3`}
+                className={`shiki m-0 grid ${codeWrap ? 'w-full' : 'w-max min-w-full'} text-sm font-mono`}
                 style={codeGridStyle}
             >
-                {codeLines.map((line, index) => (
-                    <span key={index} className="contents">
-                        <span
-                            data-line-number
-                            aria-hidden="true"
-                            className="select-none px-3 text-left text-[var(--app-hint)]/70"
-                            style={{ alignSelf: 'start' }}
-                        >
-                            {index + 1}
+                {codeLines.map((line, index) => {
+                    // py lives on the first/last row cells (not the container)
+                    // so the gutter background reaches the top and bottom edges.
+                    const rowPad = `${index === 0 ? 'pt-3' : ''} ${index === codeLines.length - 1 ? 'pb-3' : ''}`
+                    return (
+                        <span key={index} className="contents">
+                            <span
+                                data-line-number
+                                aria-hidden="true"
+                                className={`select-none bg-[var(--app-code-header-bg)] px-3 text-right text-[var(--app-hint)]/70 ${rowPad}`}
+                            >
+                                {index + 1}
+                            </span>
+                            <span data-code-cell className={`pl-4 pr-4 ${rowPad}`} style={codeCellStyle}>
+                                {line}
+                            </span>
                         </span>
-                        <span data-code-cell className="pl-4 pr-4" style={codeCellStyle}>
-                            {line}
-                        </span>
-                    </span>
-                ))}
+                    )
+                })}
             </pre>
         </div>
     )

--- a/web/src/components/assistant-ui/shiki-highlighter.tsx
+++ b/web/src/components/assistant-ui/shiki-highlighter.tsx
@@ -1,38 +1,54 @@
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-markdown'
-import type { CSSProperties } from 'react'
-import { useShikiHighlighter } from '@/lib/shiki'
+import type { CSSProperties, ReactNode } from 'react'
+import { useShikiHighlightedLines, splitCodeLines } from '@/lib/shiki'
+import { useCodeWrap } from '@/hooks/useCodeWrap'
 
-function countCodeLines(code: string): number {
-    if (code.length === 0) return 1
-    const lines = code.split('\n')
-    if (lines.length > 1 && lines[lines.length - 1] === '') {
-        lines.pop()
-    }
-    return Math.max(lines.length, 1)
-}
-
+// `@assistant-ui/react-markdown`'s DefaultCodeBlock renders this component
+// (not `Pre`) for every fenced code block that declares a language — i.e.
+// almost every real assistant-message code block. `Pre` only covers the
+// languageless fallback path. Uses the same per-line row layout as
+// CodeBlock: a line-number cell and a code cell share each grid row, so the
+// number stays aligned with its line even when the code cell wraps.
 export function SyntaxHighlighter(props: SyntaxHighlighterProps) {
-    const highlighted = useShikiHighlighter(props.code, props.language)
-    const lineCount = countCodeLines(props.code)
-    const lineNumberWidth = Math.max(String(lineCount).length, 3)
-    const lineNumbers = Array.from({ length: lineCount }, (_, index) => String(index + 1)).join('\n')
+    const highlightedLines = useShikiHighlightedLines(props.code, props.language)
+    const { codeWrap } = useCodeWrap()
+    const codeLines: ReactNode[] = highlightedLines ?? splitCodeLines(props.code)
+    const lineNumberWidth = Math.max(String(codeLines.length).length, 3)
     const codeGridStyle = {
-        gridTemplateColumns: `${lineNumberWidth}ch max-content`
+        gridTemplateColumns: `${lineNumberWidth}ch ${codeWrap ? 'minmax(0, 1fr)' : 'max-content'}`
     } satisfies CSSProperties
+    // Inline style, not a Tailwind class: `.aui-md :where(pre)
+    // { white-space: pre }` in index.css is unlayered CSS that outranks any
+    // `@layer` regardless of specificity. The grid container below is a <pre>
+    // (so it matches that rule), but an element's own inline style always wins
+    // over a stylesheet rule, so the code cells' inline whiteSpace controls
+    // wrapping regardless.
+    const codeCellStyle = codeWrap
+        ? { whiteSpace: 'pre-wrap' as const, wordBreak: 'break-word' as const }
+        : { whiteSpace: 'pre' as const }
 
     return (
-        <div className="aui-md-codeblock min-w-0 w-full max-w-full overflow-x-auto overflow-y-hidden rounded-b-xl bg-[var(--app-code-bg)]">
-            <div className="grid w-max min-w-full text-sm font-mono" style={codeGridStyle}>
-                <pre
-                    aria-hidden="true"
-                    className="m-0 select-none px-3 py-3 text-left text-[var(--app-hint)]/70"
-                >
-                    {lineNumbers}
-                </pre>
-                <pre className="shiki m-0 px-4 py-3">
-                    <code className="block">{highlighted ?? props.code}</code>
-                </pre>
-            </div>
+        <div className={`aui-md-codeblock min-w-0 w-full max-w-full overflow-y-hidden rounded-b-xl bg-[var(--app-code-bg)] ${codeWrap ? '' : 'overflow-x-auto'}`}>
+            <pre
+                className={`shiki m-0 grid ${codeWrap ? 'w-full' : 'w-max min-w-full'} text-sm font-mono py-3`}
+                style={codeGridStyle}
+            >
+                {codeLines.map((line, index) => (
+                    <span key={index} className="contents">
+                        <span
+                            data-line-number
+                            aria-hidden="true"
+                            className="select-none px-3 text-left text-[var(--app-hint)]/70"
+                            style={{ alignSelf: 'start' }}
+                        >
+                            {index + 1}
+                        </span>
+                        <span data-code-cell className="pl-4 pr-4" style={codeCellStyle}>
+                            {line}
+                        </span>
+                    </span>
+                ))}
+            </pre>
         </div>
     )
 }

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -72,3 +72,17 @@ export function ScheduleIcon(props: IconProps) {
         2
     )
 }
+
+/** Word-wrap toggle — lines with a wrap-around arrow on the last line. */
+export function WrapIcon(props: IconProps) {
+    return createIcon(
+        <>
+            <path d="M3 6h18" />
+            <path d="M3 12h13a3 3 0 0 1 0 6h-4" />
+            <polyline points="15 15 12 18 15 21" />
+            <path d="M3 18h4" />
+        </>,
+        props,
+        2
+    )
+}

--- a/web/src/hooks/useCodeWrap.test.ts
+++ b/web/src/hooks/useCodeWrap.test.ts
@@ -1,0 +1,114 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getInitialCodeWrap, useCodeWrap } from '@/hooks/useCodeWrap'
+
+const STORAGE_KEY = 'hapi-code-wrap'
+
+describe('useCodeWrap helpers', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('defaults to off when nothing is stored', () => {
+        expect(getInitialCodeWrap()).toBe(false)
+    })
+
+    it('reads a stored "1" as on', () => {
+        window.localStorage.setItem(STORAGE_KEY, '1')
+
+        expect(getInitialCodeWrap()).toBe(true)
+    })
+
+    it('treats any non-"1" stored value as off', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'garbage')
+
+        expect(getInitialCodeWrap()).toBe(false)
+    })
+})
+
+describe('useCodeWrap', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('starts off by default', () => {
+        const { result } = renderHook(() => useCodeWrap())
+
+        expect(result.current.codeWrap).toBe(false)
+    })
+
+    it('turning on writes "1" to localStorage and updates state', () => {
+        const { result } = renderHook(() => useCodeWrap())
+
+        act(() => {
+            result.current.setCodeWrap(true)
+        })
+
+        expect(result.current.codeWrap).toBe(true)
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('1')
+    })
+
+    it('turning off removes the localStorage key and updates state', () => {
+        window.localStorage.setItem(STORAGE_KEY, '1')
+        const { result } = renderHook(() => useCodeWrap())
+        expect(result.current.codeWrap).toBe(true)
+
+        act(() => {
+            result.current.setCodeWrap(false)
+        })
+
+        expect(result.current.codeWrap).toBe(false)
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('syncs across instances via the storage event', () => {
+        const { result } = renderHook(() => useCodeWrap())
+        expect(result.current.codeWrap).toBe(false)
+
+        act(() => {
+            window.localStorage.setItem(STORAGE_KEY, '1')
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: STORAGE_KEY,
+                newValue: '1',
+            }))
+        })
+
+        expect(result.current.codeWrap).toBe(true)
+    })
+
+    it('ignores storage events for unrelated keys', () => {
+        const { result } = renderHook(() => useCodeWrap())
+
+        act(() => {
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: 'hapi-some-other-key',
+                newValue: '1',
+            }))
+        })
+
+        expect(result.current.codeWrap).toBe(false)
+    })
+
+    it('syncs across multiple hook instances in the same tab (e.g. two CodeBlocks)', () => {
+        // Same-tab localStorage writes do NOT fire a `storage` event in the
+        // same document (the spec only fires it in *other* browsing
+        // contexts), so this instance must learn about the toggle through
+        // an in-memory channel, not just the storage listener.
+        const a = renderHook(() => useCodeWrap())
+        const b = renderHook(() => useCodeWrap())
+
+        act(() => {
+            a.result.current.setCodeWrap(true)
+        })
+
+        expect(a.result.current.codeWrap).toBe(true)
+        expect(b.result.current.codeWrap).toBe(true)
+
+        act(() => {
+            b.result.current.setCodeWrap(false)
+        })
+
+        expect(a.result.current.codeWrap).toBe(false)
+        expect(b.result.current.codeWrap).toBe(false)
+    })
+})

--- a/web/src/hooks/useCodeWrap.ts
+++ b/web/src/hooks/useCodeWrap.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useState } from 'react'
+
+function getCodeWrapStorageKey(): string {
+    return 'hapi-code-wrap'
+}
+
+// `storage` events only fire in *other* browsing contexts (tabs/windows),
+// never in the document that made the write. Code blocks render many
+// independent `useCodeWrap()` instances in the same tab (CodeBlock,
+// markdown Pre, DiffView all read the same preference), so a same-tab
+// in-memory broadcast is required to keep every instance in sync when one
+// of them toggles the value.
+const sameTabListeners = new Set<(wrap: boolean) => void>()
+
+function broadcastSameTab(wrap: boolean): void {
+    for (const listener of sameTabListeners) {
+        listener(wrap)
+    }
+}
+
+function isBrowser(): boolean {
+    return typeof window !== 'undefined' && typeof document !== 'undefined'
+}
+
+function safeGetItem(key: string): string | null {
+    if (!isBrowser()) {
+        return null
+    }
+    try {
+        return localStorage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
+function safeSetItem(key: string, value: string): void {
+    if (!isBrowser()) {
+        return
+    }
+    try {
+        localStorage.setItem(key, value)
+    } catch {
+        // Ignore storage errors
+    }
+}
+
+function safeRemoveItem(key: string): void {
+    if (!isBrowser()) {
+        return
+    }
+    try {
+        localStorage.removeItem(key)
+    } catch {
+        // Ignore storage errors
+    }
+}
+
+function parseCodeWrap(raw: string | null): boolean {
+    return raw === '1'
+}
+
+export function getInitialCodeWrap(): boolean {
+    return parseCodeWrap(safeGetItem(getCodeWrapStorageKey()))
+}
+
+export function useCodeWrap(): {
+    codeWrap: boolean
+    setCodeWrap: (wrap: boolean) => void
+} {
+    const [codeWrap, setCodeWrapState] = useState<boolean>(getInitialCodeWrap)
+
+    useEffect(() => {
+        if (!isBrowser()) {
+            return
+        }
+
+        const onStorage = (event: StorageEvent) => {
+            if (event.key !== getCodeWrapStorageKey()) {
+                return
+            }
+            setCodeWrapState(parseCodeWrap(event.newValue))
+        }
+
+        sameTabListeners.add(setCodeWrapState)
+        window.addEventListener('storage', onStorage)
+        return () => {
+            sameTabListeners.delete(setCodeWrapState)
+            window.removeEventListener('storage', onStorage)
+        }
+    }, [])
+
+    const setCodeWrap = useCallback((wrap: boolean) => {
+        // Broadcast only: every mounted instance (including this one, which
+        // registered its own `setCodeWrapState` as a listener on mount)
+        // updates through the same path, so the initiating instance is not
+        // double-set. Toggle buttons fire from onClick handlers, which React
+        // guarantees run after the mount effect, so this instance's listener
+        // is always registered by the time this runs.
+        broadcastSameTab(wrap)
+
+        if (wrap) {
+            safeSetItem(getCodeWrapStorageKey(), '1')
+        } else {
+            safeRemoveItem(getCodeWrapStorageKey())
+        }
+    }, [])
+
+    return { codeWrap, setCodeWrap }
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -488,18 +488,6 @@ body {
     color: inherit;
 }
 
-.aui-md-codeblock pre.shiki {
-    margin: 0;
-    padding: 0.75rem 1rem;
-    background-color: transparent !important;
-    font-size: 0.875rem;
-}
-
-.aui-md-codeblock pre.shiki code {
-    display: block;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-}
-
 .aui-md-codeblock .shiki,
 .aui-md-codeblock .shiki span {
     background-color: transparent !important;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -489,13 +489,13 @@ body {
 }
 
 .aui-md-codeblock .shiki,
-.aui-md-codeblock .shiki span {
+.aui-md-codeblock .shiki span:not([data-line-number]) {
     background-color: transparent !important;
 }
 
 /* Shiki dual theme colors */
 .shiki,
-.shiki span {
+.shiki span:not([data-line-number]) {
     color: var(--shiki-light) !important;
     font-style: var(--shiki-light-font-style) !important;
     font-weight: var(--shiki-light-font-weight) !important;
@@ -503,9 +503,9 @@ body {
 }
 
 html[data-theme="dark"] .shiki,
-html[data-theme="dark"] .shiki span,
+html[data-theme="dark"] .shiki span:not([data-line-number]),
 html[data-theme="oled"] .shiki,
-html[data-theme="oled"] .shiki span {
+html[data-theme="oled"] .shiki span:not([data-line-number]) {
     color: var(--shiki-dark) !important;
     font-style: var(--shiki-dark-font-style) !important;
     font-weight: var(--shiki-dark-font-weight) !important;

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -298,6 +298,8 @@ export default {
   // Code block
   'code.copy': 'Copy',
   'code.truncated': 'Preview truncated — open details for full output',
+  'code.wrap.enable': 'Enable word wrap',
+  'code.wrap.disable': 'Disable word wrap',
 
   // Diff view
   'diff.title': 'Diff',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -302,6 +302,8 @@ export default {
   // Code block
   'code.copy': '复制',
   'code.truncated': '预览已截断 — 打开详情查看完整输出',
+  'code.wrap.enable': '开启自动换行',
+  'code.wrap.disable': '关闭自动换行',
 
   // Diff view
   'diff.title': '差异',

--- a/web/src/lib/shiki.test.ts
+++ b/web/src/lib/shiki.test.ts
@@ -1,0 +1,102 @@
+import type { Root, RootContent } from 'hast'
+import { describe, expect, it } from 'vitest'
+import { splitCodeLines, splitHastLines } from '@/lib/shiki'
+
+function span(text: string): RootContent {
+    return {
+        type: 'element',
+        tagName: 'span',
+        properties: {},
+        children: [{ type: 'text', value: text }],
+    }
+}
+
+function br(): RootContent {
+    return { type: 'element', tagName: 'br', properties: {}, children: [] }
+}
+
+function root(children: RootContent[]): Root {
+    return { type: 'root', children }
+}
+
+function lineText(nodes: RootContent[]): string {
+    return nodes
+        .map((node) =>
+            node.type === 'element'
+                ? (node.children ?? []).map((c) => (c.type === 'text' ? c.value : '')).join('')
+                : node.type === 'text'
+                    ? node.value
+                    : ''
+        )
+        .join('')
+}
+
+describe('splitHastLines', () => {
+    it('splits a multi-line inline hast on <br> boundaries', () => {
+        // "const a" <br> "return x" <br> "}"
+        const tree = root([span('const a'), br(), span('return x'), br(), span('}')])
+
+        const lines = splitHastLines(tree)
+
+        expect(lines).toHaveLength(3)
+        expect(lines.map(lineText)).toEqual(['const a', 'return x', '}'])
+    })
+
+    it('returns a single group for code with no line breaks', () => {
+        const tree = root([span('const a = 1')])
+
+        const lines = splitHastLines(tree)
+
+        expect(lines).toHaveLength(1)
+        expect(lineText(lines[0])).toBe('const a = 1')
+    })
+
+    it('preserves a trailing empty line (br at the end)', () => {
+        // "a" <br>  -> two lines: "a" and ""
+        const tree = root([span('a'), br()])
+
+        const lines = splitHastLines(tree)
+
+        expect(lines).toHaveLength(2)
+        expect(lineText(lines[0])).toBe('a')
+        expect(lineText(lines[1])).toBe('')
+    })
+
+    it('preserves interior empty lines', () => {
+        // "a" <br> <br> "b" -> "a", "", "b"
+        const tree = root([span('a'), br(), br(), span('b')])
+
+        const lines = splitHastLines(tree)
+
+        expect(lines.map(lineText)).toEqual(['a', '', 'b'])
+    })
+
+    it('groups all token spans belonging to one line together', () => {
+        // one line made of several tokens, then a break, then another line
+        const tree = root([span('const'), span(' '), span('a'), br(), span('b')])
+
+        const lines = splitHastLines(tree)
+
+        expect(lines).toHaveLength(2)
+        expect(lines[0]).toHaveLength(3)
+        expect(lineText(lines[0])).toBe('const a')
+    })
+})
+
+describe('splitCodeLines', () => {
+    it('splits multi-line code into one entry per line', () => {
+        expect(splitCodeLines('a\nb\nc')).toEqual(['a', 'b', 'c'])
+    })
+
+    it('drops a single trailing newline so it is not counted as an extra line', () => {
+        expect(splitCodeLines('a\nb\n')).toEqual(['a', 'b'])
+    })
+
+    it('keeps interior empty lines', () => {
+        expect(splitCodeLines('a\n\nb')).toEqual(['a', '', 'b'])
+    })
+
+    it('returns a single entry for a one-line string', () => {
+        expect(splitCodeLines('const a = 1')).toEqual(['const a = 1'])
+    })
+})

--- a/web/src/lib/shiki.ts
+++ b/web/src/lib/shiki.ts
@@ -1,6 +1,7 @@
 import { createHighlighterCore } from 'shiki/core'
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 import type { HighlighterCore } from 'shiki/core'
+import type { Root, RootContent } from 'hast'
 import { useState, useEffect, useMemo, type ReactNode } from 'react'
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime'
@@ -111,7 +112,70 @@ function resolveLanguage(lang: string | undefined): string {
 }
 
 /**
- * Custom hook for syntax highlighting with our minimal Shiki bundle
+ * Normalize code the way the line renderer counts lines: a single trailing
+ * newline is dropped so `"a\n"` is one line, not one line plus an empty
+ * one. Shared by the highlighted and plain-text-fallback paths so both
+ * produce the same number of lines.
+ */
+function stripTrailingNewline(code: string): string {
+    return code.endsWith('\n') ? code.slice(0, -1) : code
+}
+
+/**
+ * Split raw code into logical lines for the plain-text fallback (when
+ * highlighting is unavailable). Mirrors the normalization applied before
+ * highlighting so line numbers line up on both paths.
+ */
+export function splitCodeLines(code: string): string[] {
+    return stripTrailingNewline(code).split('\n')
+}
+
+/**
+ * Split an inline shiki hast tree into per-logical-line child arrays.
+ *
+ * With `structure: 'inline'`, shiki emits a flat list of token `<span>`s
+ * with `<br>` elements marking line breaks (verified against the bundled
+ * shiki version). Grouping on those `<br>` boundaries yields one child
+ * array per source line, so each line can be rendered in its own grid row
+ * with an aligned line number — even when the line wraps.
+ *
+ * The number of returned groups always equals `splitCodeLines(code).length`:
+ * N lines have N-1 `<br>`s between them, so N-1 splits produce N groups
+ * (including interior empty lines).
+ */
+export function splitHastLines(hast: Root): RootContent[][] {
+    const lines: RootContent[][] = []
+    let current: RootContent[] = []
+    for (const child of hast.children) {
+        if (child.type === 'element' && child.tagName === 'br') {
+            lines.push(current)
+            current = []
+        } else {
+            current.push(child)
+        }
+    }
+    lines.push(current)
+    return lines
+}
+
+function highlightToLineNodes(highlighter: HighlighterCore, code: string, lang: string): ReactNode[] {
+    const hast = highlighter.codeToHast(stripTrailingNewline(code), {
+        lang,
+        themes: SHIKI_THEMES,
+        defaultColor: false,
+        structure: 'inline',
+    })
+
+    return splitHastLines(hast as Root).map((children) => {
+        const lineRoot: Root = { type: 'root', children }
+        return toJsxRuntime(lineRoot, { jsx, jsxs, Fragment }) as ReactNode
+    })
+}
+
+/**
+ * Custom hook for syntax highlighting with our minimal Shiki bundle.
+ * Returns a single ReactNode of the highlighted code (inline structure),
+ * or null while pending / for unsupported languages (plain-text fallback).
  */
 export function useShikiHighlighter(
     code: string,
@@ -162,4 +226,52 @@ export function useShikiHighlighter(
     }, [code, lang])
 
     return highlighted
+}
+
+/**
+ * Like {@link useShikiHighlighter} but returns the highlighted code split
+ * into one ReactNode per logical line, so callers can render each line in
+ * its own row with an aligned line number that survives wrapping. Returns
+ * null while pending / for unsupported languages (the caller falls back to
+ * splitting the raw `code` on newlines).
+ */
+export function useShikiHighlightedLines(
+    code: string,
+    language: string | undefined
+): ReactNode[] | null {
+    const [lines, setLines] = useState<ReactNode[] | null>(null)
+    const lang = useMemo(() => resolveLanguage(language), [language])
+
+    useEffect(() => {
+        let cancelled = false
+
+        async function highlight() {
+            const highlighter = await getHighlighter()
+            if (cancelled) return
+
+            const loadedLangs = highlighter.getLoadedLanguages()
+
+            // Skip highlighting for unsupported languages (graceful fallback to plain text)
+            if (lang === 'text' || !loadedLangs.includes(lang)) {
+                setLines(null)
+                return
+            }
+
+            const lineNodes = highlightToLineNodes(highlighter, code, lang)
+
+            if (cancelled) return
+
+            setLines(lineNodes)
+        }
+
+        // Debounce highlighting — 150ms reduces CPU pressure on Windows during
+        // streaming where code blocks update rapidly (see #310)
+        const timer = setTimeout(highlight, 150)
+        return () => {
+            cancelled = true
+            clearTimeout(timer)
+        }
+    }, [code, lang])
+
+    return lines
 }


### PR DESCRIPTION
Fixes #905.

## Problem

The web UI renders code blocks, unified diffs, and long tool output/input with horizontal scrolling only (`overflow-x-auto`). On narrow screens — Android PWA, phones — long lines run off the right edge and you have to scroll sideways to read them, which is awkward mid-conversation.

## Solution

Add a **word-wrap toggle** next to the copy button in the code block header. The preference is stored globally in `localStorage` (`hapi-code-wrap`, default **off**), so one toggle applies to every code block, diff, and tool input/output at once, and it survives reloads.

To keep line numbers aligned when a line wraps, code blocks now render **one grid row per logical line** — a line-number cell and a code cell as siblings in the same row. When the code cell wraps, the row grows taller and the number stays pinned to the first visual line, matching the GitHub / VS Code gutter behavior. This replaces the previous two independent `<pre>` columns, whose separate text flows drifted out of alignment when wrapped. Rendering falls back to plain-text line splitting (with the same normalization) while highlighting is pending or the language is unsupported, so line numbers always match.

This PR also adds a lightly shaded **gutter background** behind the line numbers, consistent in light and dark themes, so the line-number column reads as a distinct gutter.

Default is **off**, so existing horizontal-scroll rendering is unchanged unless the user turns wrap on.

## Usage

Click the wrap icon in any code block header. The setting is remembered across the session and all code/diff/tool views.

|  | Wrap off (default) | Wrap on |
|---|---|---|
| **Light** | ![](https://github.com/user-attachments/assets/56cb158c-394a-40ba-9cfb-b7cc1fa33837) | ![](https://github.com/user-attachments/assets/95a8b945-3712-48c0-a196-505cad5ad6cd) |
| **Dark** | ![](https://github.com/user-attachments/assets/7ca896ac-b069-4b8f-a70e-e3626ec5bd8d) | ![](https://github.com/user-attachments/assets/f202d34e-e902-4376-ad68-30e71dd45068) |

## Tests

- Unit tests (vitest + Testing Library): `useCodeWrap` persistence + same-tab sync; per-line rendering (line count, wrap on/off, plain-text fallback); wrap-toggle suppression when a code block is nested inside an interactive ancestor (avoids nested `<button>`); `<pre>` preformatted semantics.
- Manually verified end-to-end on desktop and mobile (390px) viewports, in light and dark themes.

## Reviewing

Commits are split for review:
1. `refactor(web): add per-line shiki line-splitting helper`
2. `feat(web): add global word-wrap toggle for code, markdown, and diff views`
3. `feat(web): add a shaded gutter background behind line numbers`

If the gutter background (commit 3) is out of scope for you, it drops cleanly on its own without touching the wrap feature.