### PR TITLE
fix(web): recover silently-dead SSE connections quickly, stop banner noise

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { initializeThemeColors } from '@/hooks/useThemeColors'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthSource } from '@/hooks/useAuthSource'
 import { useServerUrl } from '@/hooks/useServerUrl'
+import { useDelayedTrue } from '@/hooks/useDelayedTrue'
 import { useSSE } from '@/hooks/useSSE'
 import { useSyncingState } from '@/hooks/useSyncingState'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
@@ -37,6 +38,10 @@ import type { SyncEvent } from '@/types/api'
 type ToastEvent = Extract<SyncEvent, { type: 'toast' }>
 
 const REQUIRE_SERVER_URL = requireHubUrlForLogin()
+
+// SSE reconnects on a healthy network complete in ~1-2s; only surface the
+// reconnecting banner when the disconnected state actually persists.
+const RECONNECT_BANNER_GRACE_MS = 3_000
 
 function withPwaBanner(content: ReactNode) {
     return (
@@ -140,6 +145,7 @@ function AppInner() {
     const { isSyncing, startSync, endSync } = useSyncingState()
     const [sseDisconnected, setSseDisconnected] = useState(false)
     const [sseDisconnectReason, setSseDisconnectReason] = useState<string | null>(null)
+    const showSseReconnecting = useDelayedTrue(sseDisconnected && !isSyncing, RECONNECT_BANNER_GRACE_MS)
     const syncTokenRef = useRef(0)
     const isFirstConnectRef = useRef(true)
     const baseUrlRef = useRef(baseUrl)
@@ -437,11 +443,11 @@ function AppInner() {
             <VoiceProvider>
                 <PwaUpdateBannerWithStatusOffset
                     isSyncing={isSyncing}
-                    isReconnecting={sseDisconnected && !isSyncing}
+                    isReconnecting={showSseReconnecting}
                 />
                 <SyncingBanner isSyncing={isSyncing} />
                 <ReconnectingBanner
-                    isReconnecting={sseDisconnected && !isSyncing}
+                    isReconnecting={showSseReconnecting}
                     reason={sseDisconnectReason}
                 />
                 <VoiceErrorBanner />

--- a/web/src/components/ReconnectingBanner.tsx
+++ b/web/src/components/ReconnectingBanner.tsx
@@ -8,6 +8,9 @@ function getReasonLabel(reason: string, t: (key: string) => string): string {
     if (reason === 'visibility-recovery') {
         return t('reconnecting.reason.visibilityRecovery')
     }
+    if (reason === 'connect-timeout') {
+        return t('reconnecting.reason.connectTimeout')
+    }
     if (reason === 'closed') {
         return t('reconnecting.reason.closed')
     }

--- a/web/src/hooks/useDelayedTrue.test.ts
+++ b/web/src/hooks/useDelayedTrue.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDelayedTrue } from './useDelayedTrue'
+
+describe('useDelayedTrue', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('stays false until the value has been true for the full delay', () => {
+        const { result, rerender } = renderHook(
+            ({ value }: { value: boolean }) => useDelayedTrue(value, 3000),
+            { initialProps: { value: false } }
+        )
+
+        expect(result.current).toBe(false)
+
+        rerender({ value: true })
+        expect(result.current).toBe(false)
+
+        act(() => { vi.advanceTimersByTime(2900) })
+        expect(result.current).toBe(false)
+
+        act(() => { vi.advanceTimersByTime(200) })
+        expect(result.current).toBe(true)
+    })
+
+    it('resets immediately when the value turns false', () => {
+        const { result, rerender } = renderHook(
+            ({ value }: { value: boolean }) => useDelayedTrue(value, 3000),
+            { initialProps: { value: true } }
+        )
+
+        act(() => { vi.advanceTimersByTime(3100) })
+        expect(result.current).toBe(true)
+
+        rerender({ value: false })
+        expect(result.current).toBe(false)
+    })
+
+    it('cancels a pending delay when the value flaps', () => {
+        const { result, rerender } = renderHook(
+            ({ value }: { value: boolean }) => useDelayedTrue(value, 3000),
+            { initialProps: { value: true } }
+        )
+
+        act(() => { vi.advanceTimersByTime(1000) })
+        rerender({ value: false })
+        act(() => { vi.advanceTimersByTime(5000) })
+
+        expect(result.current).toBe(false)
+    })
+})

--- a/web/src/hooks/useDelayedTrue.ts
+++ b/web/src/hooks/useDelayedTrue.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+// Returns true only after `value` has been continuously true for `delayMs`;
+// returns false again immediately when `value` turns false. Used to keep
+// short-lived transient states (e.g. a 1-2s SSE reconnect) from flashing
+// alarming UI.
+export function useDelayedTrue(value: boolean, delayMs: number): boolean {
+    const [delayed, setDelayed] = useState(false)
+
+    useEffect(() => {
+        if (!value) {
+            setDelayed(false)
+            return
+        }
+        const timer = setTimeout(() => setDelayed(true), delayMs)
+        return () => clearTimeout(timer)
+    }, [value, delayMs])
+
+    return delayed
+}

--- a/web/src/hooks/useSSE.test.ts
+++ b/web/src/hooks/useSSE.test.ts
@@ -1,5 +1,135 @@
-import { describe, expect, it } from 'vitest'
-import { isGlobalScopedMessageStreamEvent } from './useSSE'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isGlobalScopedMessageStreamEvent, useSSE } from './useSSE'
+
+class FakeEventSource {
+    static instances: FakeEventSource[] = []
+    static readonly CONNECTING = 0
+    static readonly OPEN = 1
+    static readonly CLOSED = 2
+    readonly url: string
+    readyState = FakeEventSource.CONNECTING
+    onopen: (() => void) | null = null
+    onmessage: ((event: MessageEvent<string>) => void) | null = null
+    onerror: ((error: unknown) => void) | null = null
+
+    constructor(url: string) {
+        this.url = url
+        FakeEventSource.instances.push(this)
+    }
+
+    close(): void {
+        this.readyState = FakeEventSource.CLOSED
+    }
+
+    simulateOpen(): void {
+        this.readyState = FakeEventSource.OPEN
+        this.onopen?.()
+    }
+
+    simulateMessage(data: unknown): void {
+        this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent<string>)
+    }
+}
+
+function renderUseSSE(options?: { onDisconnect?: (reason: string) => void }) {
+    const queryClient = new QueryClient()
+    const wrapper = ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children)
+    return renderHook(() => useSSE({
+        enabled: true,
+        token: 'test-token',
+        baseUrl: 'http://hub.test',
+        subscription: { all: true },
+        onEvent: () => {},
+        onDisconnect: options?.onDisconnect
+    }), { wrapper })
+}
+
+describe('useSSE connection liveness', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        FakeEventSource.instances = []
+        vi.stubGlobal('EventSource', FakeEventSource)
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        vi.useRealTimers()
+    })
+
+    it('reconnects on visibility resume when a heartbeat interval was missed', () => {
+        const onDisconnect = vi.fn()
+        const { unmount } = renderUseSSE({ onDisconnect })
+
+        expect(FakeEventSource.instances).toHaveLength(1)
+        act(() => { FakeEventSource.instances[0]?.simulateOpen() })
+
+        // Silence for 70s: more than one 30s heartbeat missed, but below the
+        // 90s watchdog threshold. A resume from background must not trust
+        // this connection.
+        act(() => { vi.advanceTimersByTime(70_000) })
+        act(() => { document.dispatchEvent(new Event('visibilitychange')) })
+
+        expect(onDisconnect).toHaveBeenCalledWith('visibility-recovery')
+        expect(FakeEventSource.instances[0]?.readyState).toBe(FakeEventSource.CLOSED)
+
+        // First reconnect attempt is immediate (jitter only)
+        act(() => { vi.advanceTimersByTime(600) })
+        expect(FakeEventSource.instances).toHaveLength(2)
+
+        unmount()
+    })
+
+    it('keeps a fresh connection on visibility resume', () => {
+        const onDisconnect = vi.fn()
+        const { unmount } = renderUseSSE({ onDisconnect })
+
+        act(() => { FakeEventSource.instances[0]?.simulateOpen() })
+        act(() => { vi.advanceTimersByTime(20_000) })
+        act(() => { document.dispatchEvent(new Event('visibilitychange')) })
+
+        expect(onDisconnect).not.toHaveBeenCalled()
+        expect(FakeEventSource.instances).toHaveLength(1)
+
+        unmount()
+    })
+
+    it('abandons a connection attempt that does not open in time', () => {
+        const onDisconnect = vi.fn()
+        const { unmount } = renderUseSSE({ onDisconnect })
+
+        expect(FakeEventSource.instances).toHaveLength(1)
+        // never opens (e.g. request hung on a dead pooled socket)
+        act(() => { vi.advanceTimersByTime(10_100) })
+
+        expect(onDisconnect).toHaveBeenCalledWith('connect-timeout')
+        expect(FakeEventSource.instances[0]?.readyState).toBe(FakeEventSource.CLOSED)
+
+        act(() => { vi.advanceTimersByTime(600) })
+        expect(FakeEventSource.instances).toHaveLength(2)
+
+        unmount()
+    })
+
+    it('does not time out a connection that opens promptly', () => {
+        const onDisconnect = vi.fn()
+        const { unmount } = renderUseSSE({ onDisconnect })
+
+        act(() => { FakeEventSource.instances[0]?.simulateOpen() })
+        act(() => {
+            FakeEventSource.instances[0]?.simulateMessage({ type: 'heartbeat', namespace: 'default', data: {} })
+        })
+        act(() => { vi.advanceTimersByTime(30_000) })
+
+        expect(onDisconnect).not.toHaveBeenCalled()
+        expect(FakeEventSource.instances).toHaveLength(1)
+
+        unmount()
+    })
+})
 
 describe('useSSE scope handling', () => {
     it('treats message stream events as global-scoped skips', () => {

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -39,6 +39,17 @@ type VisibilityState = 'visible' | 'hidden'
 type ToastEvent = Extract<SyncEvent, { type: 'toast' }>
 
 const HEARTBEAT_STALE_MS = 90_000
+// The hub sends a heartbeat every 30s. When the tab returns to the foreground
+// after the device was suspended, the connection may have been silently killed
+// (no FIN/RST ever reaches the browser), so a single missed heartbeat interval
+// is already enough to distrust it. Waiting for the full 90s watchdog threshold
+// instead would leave the UI stale and pop a "heartbeat timeout" banner up to
+// 90s into active use.
+const VISIBILITY_RESUME_STALE_MS = 45_000
+// A new EventSource that hasn't opened within this window is likely hung on a
+// dead pooled socket (common right after resume) — abandon it and retry on a
+// fresh connection instead of waiting for the 90s watchdog.
+const CONNECT_TIMEOUT_MS = 10_000
 const HEARTBEAT_WATCHDOG_INTERVAL_MS = 10_000
 const RECONNECT_BASE_DELAY_MS = 1_000
 const RECONNECT_MAX_DELAY_MS = 30_000
@@ -204,7 +215,11 @@ export function useSSE(options: {
 
         const scheduleReconnect = () => {
             const attempt = reconnectAttemptRef.current
-            const exponentialDelay = Math.min(RECONNECT_MAX_DELAY_MS, RECONNECT_BASE_DELAY_MS * (2 ** attempt))
+            // First attempt reconnects immediately (jitter only) — backoff is
+            // for repeated failures, not for the initial recovery.
+            const exponentialDelay = attempt === 0
+                ? 0
+                : Math.min(RECONNECT_MAX_DELAY_MS, RECONNECT_BASE_DELAY_MS * (2 ** (attempt - 1)))
             const jitter = Math.floor(Math.random() * (RECONNECT_JITTER_MS + 1))
             reconnectAttemptRef.current = attempt + 1
             if (reconnectTimerRef.current) {
@@ -557,8 +572,18 @@ export function useSSE(options: {
             handleSyncEvent(parsed as SyncEvent)
         }
 
+        const connectDeadlineTimer = setTimeout(() => {
+            if (eventSourceRef.current !== eventSource) {
+                return
+            }
+            if (eventSource.readyState !== EventSource.OPEN) {
+                requestReconnect('connect-timeout')
+            }
+        }, CONNECT_TIMEOUT_MS)
+
         eventSource.onmessage = handleMessage
         eventSource.onopen = () => {
+            clearTimeout(connectDeadlineTimer)
             if (reconnectTimerRef.current) {
                 clearTimeout(reconnectTimerRef.current)
                 reconnectTimerRef.current = null
@@ -592,12 +617,14 @@ export function useSSE(options: {
 
         // When the tab becomes visible again, check immediately whether the
         // SSE connection went stale while hidden (the watchdog skips checks
-        // for hidden tabs).  This avoids the user having to wait up to
-        // HEARTBEAT_WATCHDOG_INTERVAL_MS after switching back.
+        // for hidden tabs). Uses the tighter VISIBILITY_RESUME_STALE_MS
+        // threshold: a device suspend can kill the connection without the
+        // browser ever noticing, so a missed heartbeat interval at resume
+        // already warrants a proactive reconnect.
         const onVisibilityChange = () => {
             if (getVisibilityState() !== 'visible') return
             if (eventSourceRef.current !== eventSource) return
-            if (Date.now() - lastActivityAtRef.current >= HEARTBEAT_STALE_MS) {
+            if (Date.now() - lastActivityAtRef.current >= VISIBILITY_RESUME_STALE_MS) {
                 requestReconnect('visibility-recovery')
             }
         }
@@ -605,6 +632,7 @@ export function useSSE(options: {
 
         return () => {
             clearInterval(watchdogTimer)
+            clearTimeout(connectDeadlineTimer)
             document.removeEventListener('visibilitychange', onVisibilityChange)
             if (invalidationTimerRef.current) {
                 clearTimeout(invalidationTimerRef.current)

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -504,6 +504,7 @@ export default {
   'reconnecting.reason.closed': 'stream closed',
   'reconnecting.reason.heartbeatTimeout': 'heartbeat timeout',
   'reconnecting.reason.visibilityRecovery': 'resuming after background',
+  'reconnecting.reason.connectTimeout': 'connect timeout',
   'pwa.update.title': 'New version available',
   'pwa.update.body': 'Reload to get the latest HAPI',
   'pwa.update.reload': 'Reload',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -508,6 +508,7 @@ export default {
   'reconnecting.reason.closed': '流连接已关闭',
   'reconnecting.reason.heartbeatTimeout': '心跳超时',
   'reconnecting.reason.visibilityRecovery': '后台恢复中',
+  'reconnecting.reason.connectTimeout': '连接超时',
   'pwa.update.title': '新版本可用',
   'pwa.update.body': '重新加载以获取最新版 HAPI',
   'pwa.update.reload': '重新加载',


### PR DESCRIPTION
SSE connections can die without the browser ever noticing (device suspend, tab freeze, network path loss — no FIN/RST arrives). The webui only detected this via the 90s heartbeat watchdog, so every silent death meant up to 90s of stale UI followed by an alarming "Reconnecting... (heartbeat timeout)" banner popping mid-use. Verified against a live hub: heartbeats are sent every 30.0s without fail, so these banners were purely a client-side detection problem.

- useSSE: on visibility resume, distrust the connection after one missed heartbeat interval (45s) instead of 90s — a connection killed while the device was suspended is now replaced the moment the user returns
- useSSE: abandon connection attempts that don't open within 10s (hung on a dead pooled socket after resume) instead of waiting for the watchdog
- useSSE: first reconnect attempt is immediate; exponential backoff now starts from the second attempt
- App: only show the reconnecting banner when the disconnect persists beyond 3s (useDelayedTrue), so sub-second recoveries stay invisible while real outages still surface

via [HAPI](https://hapi.run)