### PR TITLE
fix(web): clean up React tests globally

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,4 +1,10 @@
 import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+    cleanup()
+})
 
 function installMemoryLocalStorage(): void {
     const store = new Map<string, string>()


### PR DESCRIPTION
## Summary

- Add explicit React Testing Library cleanup in the shared web Vitest setup.
- Prevent React work from leaking past jsdom teardown when tests use `render`/`renderHook` without local cleanup.

## Root cause

`web/vitest.config.ts` uses `globals: false`, so React Testing Library's auto-cleanup is not reliably registered through the usual global hook path. A few web tests render React components/hooks without local `cleanup()`, leaving scheduled React work alive after jsdom has already removed `window`. On upstream `main` (`b44885a`), this surfaced in CI as Vitest unhandled `ReferenceError: window is not defined` errors after all web tests had otherwise passed.

## Testing

- `bun run test:web -- src/hooks/useThemeColors.test.ts`
- `bun typecheck && bun run test`
