### PR TITLE
feat(codex): support gpt-5.6 ultra reasoning effort

### DIFF
--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -153,7 +153,24 @@ export type SandboxPolicy =
         excludeSlashTmp?: boolean;
     };
 
-export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+export const REASONING_EFFORTS = [
+    'none',
+    'minimal',
+    'low',
+    'medium',
+    'high',
+    'xhigh',
+    'max',
+    'ultra'
+] as const;
+
+export type ReasoningEffort = typeof REASONING_EFFORTS[number];
+
+const REASONING_EFFORT_SET = new Set<string>(REASONING_EFFORTS);
+
+export function isReasoningEffort(value: unknown): value is ReasoningEffort {
+    return typeof value === 'string' && REASONING_EFFORT_SET.has(value);
+}
 export type ReasoningSummary = 'auto' | 'none' | 'brief' | 'detailed';
 
 export type CollaborationMode = {

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -15,14 +15,12 @@ import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 import { CodexCollaborationModeSchema, PermissionModeSchema } from '@hapi/protocol/schemas';
 import { formatMessageWithAttachments } from '@/utils/attachmentFormatter';
 import { getInvokedCwd } from '@/utils/invokedCwd';
-import type { ReasoningEffort } from './appServerTypes';
+import { isReasoningEffort, type ReasoningEffort } from './appServerTypes';
 import { parseCodexSpecialCommand } from './codexSpecialCommands';
 import { listSlashCommands } from '@/modules/common/slashCommands';
 import { resolveCodexSlashCommand } from './utils/slashCommands';
 
 export { emitReadyIfIdle } from './utils/emitReadyIfIdle';
-
-const REASONING_EFFORTS = new Set<ReasoningEffort>(['none', 'minimal', 'low', 'medium', 'high', 'xhigh'])
 
 export async function runCodex(opts: {
     startedBy?: 'runner' | 'terminal';
@@ -307,10 +305,10 @@ export async function runCodex(opts: {
         if (value === null) {
             return undefined;
         }
-        if (typeof value !== 'string' || !REASONING_EFFORTS.has(value as ReasoningEffort)) {
+        if (!isReasoningEffort(value)) {
             throw new Error('Invalid model reasoning effort');
         }
-        return value as ReasoningEffort;
+        return value;
     };
 
     const resolveModel = (value: unknown): string => {

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -269,6 +269,31 @@ describe('appServerConfig', () => {
         });
     });
 
+    it('passes gpt-5.6 ultra reasoning effort to turn/start', () => {
+        const params = buildTurnStartParams({
+            threadId: 'thread-1',
+            message: 'hello',
+            cwd: '/workspace/project',
+            mode: {
+                permissionMode: 'default',
+                model: 'gpt-5.6-sol',
+                modelReasoningEffort: 'ultra',
+                collaborationMode: 'default'
+            }
+        });
+
+        expect(params.effort).toBe('ultra');
+        expect(params.collaborationMode).toEqual({
+            mode: 'default',
+            settings: {
+                model: 'gpt-5.6-sol',
+                reasoning_effort: 'ultra',
+                developer_instructions: withCollaborationInstructions(codexSystemPrompt)
+            }
+        });
+        expect(params.model).toBeUndefined();
+    });
+
     it('detects namespaced models that do not support reasoning summary', () => {
         const params = buildTurnStartParams({
             threadId: 'thread-1',

--- a/cli/src/codex/utils/slashCommands.test.ts
+++ b/cli/src/codex/utils/slashCommands.test.ts
@@ -41,6 +41,9 @@ describe('resolveCodexSlashCommand', () => {
         expect(resolveCodexSlashCommand('/reasoning low', state)).toMatchObject({
             updates: { modelReasoningEffort: 'low' }
         });
+        expect(resolveCodexSlashCommand('/reasoning ultra', state)).toMatchObject({
+            updates: { modelReasoningEffort: 'ultra' }
+        });
         expect(resolveCodexSlashCommand('/permissions yolo', state)).toMatchObject({
             updates: { permissionMode: 'yolo' }
         });

--- a/cli/src/codex/utils/slashCommands.ts
+++ b/cli/src/codex/utils/slashCommands.ts
@@ -1,10 +1,9 @@
 import { CODEX_PERMISSION_MODES } from '@hapi/protocol/modes';
 import type { CodexPermissionMode } from '@hapi/protocol/types';
-import type { ReasoningEffort } from '../appServerTypes';
+import { isReasoningEffort, type ReasoningEffort } from '../appServerTypes';
 import type { EnhancedMode } from '../loop';
 import type { SlashCommand } from '@/modules/common/slashCommands';
 
-const REASONING_EFFORTS = new Set<ReasoningEffort>(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']);
 export const MAX_CODEX_GOAL_OBJECTIVE_CHARS = 4_000;
 
 const UNSUPPORTED_CODEX_BUILTIN_COMMANDS = new Set([
@@ -186,7 +185,7 @@ export function resolveCodexSlashCommand(
                 updates: { modelReasoningEffort: null }
             };
         }
-        if (!REASONING_EFFORTS.has(rest as ReasoningEffort)) {
+        if (!isReasoningEffort(rest)) {
             return {
                 kind: 'handled',
                 message: `Unknown Codex reasoning effort: ${rest}`
@@ -195,7 +194,7 @@ export function resolveCodexSlashCommand(
         return {
             kind: 'handled',
             message: `Codex reasoning effort set to ${rest}`,
-            updates: { modelReasoningEffort: rest as ReasoningEffort }
+            updates: { modelReasoningEffort: rest }
         };
     }
 
@@ -259,7 +258,7 @@ export function resolveCodexSlashCommand(
                 '- `/compact` — compact current Codex thread context',
                 '- `/status` — show current Codex session config',
                 '- `/model [name|auto]` — show or set model',
-                '- `/reasoning [low|medium|high|xhigh|default]` — show or set reasoning effort',
+                '- `/reasoning [low|medium|high|xhigh|max|ultra|default]` — show or set reasoning effort',
                 '- `/fast [on|off|status]` — toggle Fast mode (GPT-5.5 / GPT-5.4, ChatGPT login)',
                 '- `/permissions [default|read-only|safe-yolo|yolo]` — show or set permission mode',
                 '',

--- a/cli/src/commands/codex.test.ts
+++ b/cli/src/commands/codex.test.ts
@@ -89,6 +89,21 @@ describe('codexCommand', () => {
         })
     })
 
+    it('forwards the gpt-5.6 ultra reasoning effort to runCodex', async () => {
+        await codexCommand.run(createCommandContext([
+            '--started-by', 'runner',
+            '--model', 'gpt-5.6-sol',
+            '--model-reasoning-effort', 'ultra'
+        ]))
+
+        expect(runCodexMock).toHaveBeenCalledWith({
+            startedBy: 'runner',
+            model: 'gpt-5.6-sol',
+            modelReasoningEffort: 'ultra',
+            codexArgs: ['--model', 'gpt-5.6-sol']
+        })
+    })
+
     it('rejects an unsupported --service-tier value', async () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
         const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {

--- a/cli/src/commands/codex.ts
+++ b/cli/src/commands/codex.ts
@@ -5,21 +5,14 @@ import { maybeAutoStartServer } from '@/utils/autoStartServer'
 import type { CommandDefinition } from './types'
 import { CODEX_PERMISSION_MODES } from '@hapi/protocol/modes'
 import type { CodexPermissionMode } from '@hapi/protocol/types'
-import type { ReasoningEffort } from '@/codex/appServerTypes'
+import { isReasoningEffort, type ReasoningEffort } from '@/codex/appServerTypes'
 import { assertCodexLocalSupported } from '@/codex/utils/codexVersion'
 
 function parseReasoningEffort(value: string): ReasoningEffort {
-    switch (value) {
-        case 'none':
-        case 'minimal':
-        case 'low':
-        case 'medium':
-        case 'high':
-        case 'xhigh':
-            return value
-        default:
-            throw new Error('Invalid --model-reasoning-effort value')
+    if (isReasoningEffort(value)) {
+        return value
     }
+    throw new Error('Invalid --model-reasoning-effort value')
 }
 
 // Mirror the web /service-tier endpoint's enum so the internal resume spawn

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -469,7 +469,7 @@ export function HappyComposer(props: {
             ? getCodexComposerReasoningEffortOptions(
                 modelReasoningEffort,
                 agentFlavor,
-                agentFlavor === 'opencode' ? availableModelReasoningEffortOptions : undefined
+                availableModelReasoningEffortOptions
             )
             : [],
         [agentFlavor, modelReasoningEffort, availableModelReasoningEffortOptions]

--- a/web/src/components/AssistantChat/codexReasoningEffortOptions.test.ts
+++ b/web/src/components/AssistantChat/codexReasoningEffortOptions.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { getCodexComposerReasoningEffortOptions } from './codexReasoningEffortOptions'
+import {
+    getCodexComposerReasoningEffortOptions,
+    getCodexModelReasoningEffortOptions
+} from './codexReasoningEffortOptions'
 
 describe('getCodexComposerReasoningEffortOptions', () => {
     it('includes the default option and preset values for Codex', () => {
@@ -20,6 +23,60 @@ describe('getCodexComposerReasoningEffortOptions', () => {
             { value: 'medium', label: 'Medium' },
             { value: 'high', label: 'High' },
             { value: 'xhigh', label: 'XHigh' }
+        ])
+    })
+
+    it('uses the default Codex model catalog efforts for auto model selection', () => {
+        expect(getCodexModelReasoningEffortOptions('auto', [
+            {
+                id: 'gpt-5.6-sol',
+                isDefault: true,
+                supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']
+            },
+            {
+                id: 'gpt-5.6-luna',
+                isDefault: false,
+                supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max']
+            }
+        ])).toEqual([
+            { value: 'low', name: 'Low' },
+            { value: 'medium', name: 'Medium' },
+            { value: 'high', name: 'High' },
+            { value: 'xhigh', name: 'XHigh' },
+            { value: 'max', name: 'Max' },
+            { value: 'ultra', name: 'Ultra' }
+        ])
+    })
+
+    it('uses the explicitly selected Codex model effort subset', () => {
+        expect(getCodexModelReasoningEffortOptions('GPT-5.6-LUNA', [
+            {
+                id: 'gpt-5.6-sol',
+                isDefault: true,
+                supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']
+            },
+            {
+                id: 'gpt-5.6-luna',
+                isDefault: false,
+                supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max']
+            }
+        ])).toEqual([
+            { value: 'low', name: 'Low' },
+            { value: 'medium', name: 'Medium' },
+            { value: 'high', name: 'High' },
+            { value: 'xhigh', name: 'XHigh' },
+            { value: 'max', name: 'Max' }
+        ])
+    })
+
+    it('builds Codex composer options from the active model catalog', () => {
+        expect(getCodexComposerReasoningEffortOptions(null, 'codex', [
+            { value: 'max', name: 'Max' },
+            { value: 'ultra', name: 'Ultra' }
+        ])).toEqual([
+            { value: null, label: 'Default' },
+            { value: 'max', label: 'Max' },
+            { value: 'ultra', label: 'Ultra' }
         ])
     })
 

--- a/web/src/components/AssistantChat/codexReasoningEffortOptions.ts
+++ b/web/src/components/AssistantChat/codexReasoningEffortOptions.ts
@@ -8,13 +8,20 @@ export type ComposerReasoningEffortSourceOption = {
     name?: string
 }
 
+type CodexReasoningEffortModel = {
+    id: string
+    isDefault: boolean
+    supportedReasoningEfforts?: string[]
+}
+
 const CODEX_REASONING_EFFORT_PRESETS = ['low', 'medium', 'high', 'xhigh'] as const
 const CODEX_REASONING_EFFORT_LABELS: Record<string, string> = {
     low: 'Low',
     medium: 'Medium',
     high: 'High',
     xhigh: 'XHigh',
-    max: 'Max'
+    max: 'Max',
+    ultra: 'Ultra'
 }
 
 function normalizeCodexComposerReasoningEffort(effort?: string | null): string | null {
@@ -31,7 +38,29 @@ function formatCodexReasoningEffortLabel(effort: string): string {
         ?? `${effort.charAt(0).toUpperCase()}${effort.slice(1)}`
 }
 
-function buildOpencodeComposerReasoningEffortOptions(
+export function getCodexModelReasoningEffortOptions(
+    model: string | null | undefined,
+    models: ReadonlyArray<CodexReasoningEffortModel>
+): ComposerReasoningEffortSourceOption[] | undefined {
+    const normalizedModel = model?.trim().toLowerCase()
+    const activeModel = normalizedModel && normalizedModel !== 'auto'
+        ? models.find((candidate) => candidate.id.trim().toLowerCase() === normalizedModel)
+        : models.find((candidate) => candidate.isDefault)
+    const efforts = activeModel?.supportedReasoningEfforts
+        ?.map((effort) => effort.trim().toLowerCase())
+        .filter(Boolean)
+
+    if (!efforts || efforts.length === 0) {
+        return undefined
+    }
+
+    return Array.from(new Set(efforts)).map((effort) => ({
+        value: effort,
+        name: formatCodexReasoningEffortLabel(effort)
+    }))
+}
+
+function buildDynamicComposerReasoningEffortOptions(
     currentEffort: string | null,
     dynamicOptions: ComposerReasoningEffortSourceOption[]
 ): CodexComposerReasoningEffortOption[] {
@@ -66,7 +95,11 @@ export function getCodexComposerReasoningEffortOptions(
         if (!dynamicOptions || dynamicOptions.length === 0) {
             return []
         }
-        return buildOpencodeComposerReasoningEffortOptions(normalizedCurrentEffort, dynamicOptions)
+        return buildDynamicComposerReasoningEffortOptions(normalizedCurrentEffort, dynamicOptions)
+    }
+
+    if (flavor === 'codex' && dynamicOptions && dynamicOptions.length > 0) {
+        return buildDynamicComposerReasoningEffortOptions(normalizedCurrentEffort, dynamicOptions)
     }
 
     const options: CodexComposerReasoningEffortOption[] = [

--- a/web/src/components/NewSession/ReasoningEffortSelector.tsx
+++ b/web/src/components/NewSession/ReasoningEffortSelector.tsx
@@ -6,6 +6,7 @@ export function ReasoningEffortSelector(props: {
     agent: AgentType
     value: CodexReasoningEffort
     isDisabled: boolean
+    options?: Array<{ value: CodexReasoningEffort; label: string }>
     onChange: (value: CodexReasoningEffort) => void
 }) {
     const { t } = useTranslation()
@@ -26,7 +27,11 @@ export function ReasoningEffortSelector(props: {
                 disabled={props.isDisabled}
                 className="w-full px-3 py-2 text-sm rounded-lg border border-[var(--app-divider)] bg-[var(--app-bg)] text-[var(--app-text)] focus:outline-none focus:ring-2 focus:ring-[var(--app-link)] disabled:opacity-50"
             >
-                {CODEX_REASONING_EFFORT_OPTIONS.filter((option) => props.agent === 'opencode' ? option.value !== 'xhigh' : option.value !== 'max').map((option) => (
+                {(props.options ?? CODEX_REASONING_EFFORT_OPTIONS.filter((option) =>
+                    props.agent === 'opencode'
+                        ? option.value !== 'xhigh' && option.value !== 'ultra'
+                        : option.value !== 'max' && option.value !== 'ultra'
+                )).map((option) => (
                     <option key={option.value} value={option.value}>
                         {option.label}
                     </option>

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -39,6 +39,7 @@ import { OpencodeModelSelector } from './OpencodeModelSelector'
 import { ClaudeEffortSelector } from './ClaudeEffortSelector'
 import { shouldEnableOpencodeModelDiscovery } from './opencodeModelsGate'
 import { ReasoningEffortSelector } from './ReasoningEffortSelector'
+import { getCodexModelReasoningEffortOptions } from '@/components/AssistantChat/codexReasoningEffortOptions'
 import {
     loadPreferredAgent,
     loadPreferredYoloMode,
@@ -199,6 +200,31 @@ export function NewSession(props: {
         }
         return options
     }, [codexModelsState.models, model])
+    const codexReasoningEffortOptions = useMemo(() => {
+        if (agent !== 'codex') {
+            return undefined
+        }
+        const dynamicOptions = getCodexModelReasoningEffortOptions(model, codexModelsState.models)
+        if (!dynamicOptions) {
+            return undefined
+        }
+        return [
+            { value: 'default' as const, label: 'Default' },
+            ...dynamicOptions.map((option) => ({
+                value: option.value as CodexReasoningEffort,
+                label: option.name ?? option.value
+            }))
+        ]
+    }, [agent, codexModelsState.models, model])
+
+    useEffect(() => {
+        if (!codexReasoningEffortOptions || modelReasoningEffort === 'default') {
+            return
+        }
+        if (!codexReasoningEffortOptions.some((option) => option.value === modelReasoningEffort)) {
+            setModelReasoningEffort('default')
+        }
+    }, [codexReasoningEffortOptions, modelReasoningEffort])
     const cursorModelsState = useCursorModelsForMachine({
         api: props.api,
         machineId,
@@ -720,6 +746,7 @@ export function NewSession(props: {
                 agent={agent}
                 value={modelReasoningEffort}
                 isDisabled={isFormDisabled}
+                options={codexReasoningEffortOptions}
                 onChange={setModelReasoningEffort}
             />
             <YoloToggle

--- a/web/src/components/NewSession/types.ts
+++ b/web/src/components/NewSession/types.ts
@@ -10,7 +10,7 @@ import type { AgentFlavor, ClaudeEffortLevel } from '@hapi/protocol'
 
 export type AgentType = AgentFlavor
 export type SessionType = 'simple' | 'worktree'
-export type CodexReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+export type CodexReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
 export type ClaudeEffort = 'auto' | ClaudeEffortLevel
 
 function modelPresetOptions<TModel extends string>(
@@ -47,6 +47,7 @@ export const CODEX_REASONING_EFFORT_OPTIONS: { value: CodexReasoningEffort; labe
     { value: 'high', label: 'High' },
     { value: 'xhigh', label: 'XHigh' },
     { value: 'max', label: 'Max' },
+    { value: 'ultra', label: 'Ultra' },
 ]
 
 export const CLAUDE_EFFORT_OPTIONS: { value: ClaudeEffort; label: string }[] = [

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -23,6 +23,7 @@ import { isQueuedForInvocation, mergeMessages } from '@/lib/messages'
 import { inactiveSessionCanResume } from '@/lib/sessionResume'
 import { HappyComposer, type ComposerSendError } from '@/components/AssistantChat/HappyComposer'
 import { codexModelAdvertisesFastTier } from '@/components/AssistantChat/codexFastMode'
+import { getCodexModelReasoningEffortOptions } from '@/components/AssistantChat/codexReasoningEffortOptions'
 import type { PendingSchedule } from '@/components/AssistantChat/ScheduleTimePicker'
 import { resolvePendingSchedule } from '@/components/AssistantChat/ScheduleTimePicker'
 import { HappyThread } from '@/components/AssistantChat/HappyThread'
@@ -516,6 +517,12 @@ function SessionChatInner(props: SessionChatProps) {
         }
         return options
     }, [agentFlavor, codexModelsState.models])
+    const codexReasoningEffortOptions = useMemo(
+        () => agentFlavor === 'codex'
+            ? getCodexModelReasoningEffortOptions(props.session.model, codexModelsState.models)
+            : undefined,
+        [agentFlavor, props.session.model, codexModelsState.models]
+    )
     const opencodeModelsState = useOpencodeModels({
         api: props.api,
         sessionId: props.session.id,
@@ -1243,9 +1250,11 @@ function SessionChatInner(props: SessionChatProps) {
                         piModels={agentFlavor === 'pi' ? (piModelsState.availableModels.length > 0 ? piModelsState.availableModels : piCachedModels) : undefined}
                         piSelectedModel={agentFlavor === 'pi' ? piSelectedModel : undefined}
                         availableModelReasoningEffortOptions={
-                            agentFlavor === 'opencode' && opencodeReasoningEffortState.options.length > 0
-                                ? opencodeReasoningEffortState.options
-                                : undefined
+                            agentFlavor === 'codex'
+                                ? codexReasoningEffortOptions
+                                : agentFlavor === 'opencode' && opencodeReasoningEffortState.options.length > 0
+                                    ? opencodeReasoningEffortState.options
+                                    : undefined
                         }
                         active={props.session.active}
                         allowSendWhenInactive


### PR DESCRIPTION
## Summary

- accept Codex `max` and `ultra` reasoning efforts in CLI arguments, runtime session updates, and `/reasoning`
- derive new-session and active-session effort choices from the selected model's `supportedReasoningEfforts` catalog
- resolve `auto` through the catalog default model and reset unsupported new-session selections to Default

## Validation

- `bun typecheck`
- focused Codex CLI tests: 49 passed
- Codex reasoning-option tests: 8 passed
- complete web suite: 1,134 passed
- live Codex app-server smoke: `gpt-5.6-sol` with `ultra` completed successfully

`bun run test` reaches three unrelated failures in existing CLI scanner/skill-discovery tests (`skills.test.ts`, `sessionScanner.test.ts`, and `codexLocalLauncher.test.ts`); the changed CLI tests pass.

Closes #999
