### PR TITLE
fix(hub): set explicit PWA cache policy

### DIFF
--- a/hub/src/web/server.ts
+++ b/hub/src/web/server.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import { cors } from 'hono/cors'
 import { logger } from 'hono/logger'
 import { join } from 'node:path'
@@ -32,6 +32,7 @@ import type { WebSocketData } from '@socket.io/bun-engine'
 import { loadEmbeddedAssetMap, type EmbeddedWebAsset } from './embeddedAssets'
 import { isBunCompiled } from '../utils/bunCompiled'
 import type { Store } from '../store'
+import { getWebAssetCacheControl } from './webAssetCache'
 
 // Normalise upstream close codes before forwarding to the browser client.
 // Codes 1005/1006/1015 are reserved and cannot be sent in a close frame;
@@ -193,9 +194,14 @@ function findWebappDistDir(): { distDir: string; indexHtmlPath: string } {
 function serveEmbeddedAsset(asset: EmbeddedWebAsset): Response {
     return new Response(Bun.file(asset.sourcePath), {
         headers: {
-            'Content-Type': asset.mimeType
+            'Content-Type': asset.mimeType,
+            'Cache-Control': getWebAssetCacheControl(asset.path)
         }
     })
+}
+
+function applyWebAssetCacheControl(c: Context, path: string): void {
+    c.header('Cache-Control', getWebAssetCacheControl(path))
 }
 
 function createWebApp(options: {
@@ -328,7 +334,10 @@ from GitHub Pages instead of through the relay tunnel.
         return app
     }
 
-    app.use('/assets/*', serveStatic({ root: distDir }))
+    app.use('/assets/*', serveStatic({
+        root: distDir,
+        onFound: (_path, c) => applyWebAssetCacheControl(c, c.req.path)
+    }))
 
     app.use('*', async (c, next) => {
         if (c.req.path.startsWith('/api')) {
@@ -336,7 +345,10 @@ from GitHub Pages instead of through the relay tunnel.
             return
         }
 
-        return await serveStatic({ root: distDir })(c, next)
+        return await serveStatic({
+            root: distDir,
+            onFound: (_path, staticContext) => applyWebAssetCacheControl(staticContext, staticContext.req.path)
+        })(c, next)
     })
 
     app.get('*', async (c, next) => {
@@ -345,7 +357,11 @@ from GitHub Pages instead of through the relay tunnel.
             return
         }
 
-        return await serveStatic({ root: distDir, path: 'index.html' })(c, next)
+        return await serveStatic({
+            root: distDir,
+            path: 'index.html',
+            onFound: (_path, staticContext) => applyWebAssetCacheControl(staticContext, '/index.html')
+        })(c, next)
     })
 
     return app

--- a/hub/src/web/webAssetCache.test.ts
+++ b/hub/src/web/webAssetCache.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test'
+import { getWebAssetCacheControl } from './webAssetCache'
+
+describe('getWebAssetCacheControl', () => {
+    it('requires app-shell entrypoints to revalidate', () => {
+        for (const path of ['/sw.js', '/index.html', '/manifest.webmanifest']) {
+            expect(getWebAssetCacheControl(path)).toBe('no-cache, no-store, must-revalidate')
+        }
+    })
+
+    it('allows fingerprinted assets to be cached immutably', () => {
+        expect(getWebAssetCacheControl('/assets/index-B9KpkXam.js'))
+            .toBe('public, max-age=31536000, immutable')
+    })
+})

--- a/hub/src/web/webAssetCache.ts
+++ b/hub/src/web/webAssetCache.ts
@@ -1,0 +1,8 @@
+const IMMUTABLE_ASSET_CACHE_CONTROL = 'public, max-age=31536000, immutable'
+const MUTABLE_ASSET_CACHE_CONTROL = 'no-cache, no-store, must-revalidate'
+
+export function getWebAssetCacheControl(path: string): string {
+    return path.startsWith('/assets/')
+        ? IMMUTABLE_ASSET_CACHE_CONTROL
+        : MUTABLE_ASSET_CACHE_CONTROL
+}


### PR DESCRIPTION
## Summary

- require mutable PWA app-shell entrypoints to revalidate instead of inheriting proxy/browser defaults
- cache Vite fingerprinted `/assets/*` files for one year as immutable
- apply the same policy to embedded-release assets and filesystem-served development assets

## Why

The hub currently sends no cache policy for embedded web assets. A reverse proxy or browser can therefore keep an old `sw.js` fresh after a HAPI upgrade. That service worker continues to precache/serve the previous app shell even while the origin's `index.html` points at a new fingerprinted bundle.

This change is provider-neutral: it uses only the standard `Cache-Control` header. CDN-specific cache directives and purge operations remain deployment concerns.

## Testing

- `bun typecheck`
- `bun run test:hub` — 455 passed, 3 skipped, 0 failed
- `bun test hub/src/web/webAssetCache.test.ts` — 2 passed
- `bun run build:web`
- local hub smoke test:
  - `/sw.js`, `/`, `/manifest.webmanifest` → `Cache-Control: no-cache, no-store, must-revalidate`
  - `/assets/index-<hash>.js` → `Cache-Control: public, max-age=31536000, immutable`

Full local monorepo run reached CLI 1115/1115 and Hub 455/455; one existing Web `StorageEvent` test fails only in this Node environment because its mocked `localStorage` is not a native jsdom `Storage` object. No Web code is changed here; CI is left as the authoritative clean-environment run.
