### PR TITLE
fix(web): select Standard for untouched Codex tier

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -35,6 +35,7 @@ import { useTranslation } from '@/lib/use-translation'
 import { getModelOptionsForFlavor, getNextModelForFlavor } from './modelOptions'
 import { getClaudeComposerEffortOptions } from './claudeEffortOptions'
 import { getCodexComposerReasoningEffortOptions } from './codexReasoningEffortOptions'
+import { getDisplayedCodexServiceTier } from './codexFastMode'
 import { getPiThinkingLevelOptions, getHighestThinkingLevel, isThinkingLevelSupported } from './piThinkingLevelOptions'
 import { groupModelsByProvider } from './piModelGroups'
 import { PiModelPanel } from './PiModelPanel'
@@ -259,6 +260,7 @@ export function HappyComposer(props: {
     const modelReasoningEffort = rawModelReasoningEffort ?? null
     const effort = rawEffort ?? null
     const serviceTier = rawServiceTier ?? null
+    const displayedServiceTier = getDisplayedCodexServiceTier(serviceTier)
 
     const api = useAssistantApi()
     const { composerEnterBehavior } = useComposerEnterBehavior()
@@ -1159,16 +1161,16 @@ export function HappyComposer(props: {
                                     >
                                         <div
                                             className={`flex h-4 w-4 items-center justify-center rounded-full border-2 ${
-                                                serviceTier === option.value
+                                                displayedServiceTier === option.value
                                                     ? 'border-[var(--app-link)]'
                                                     : 'border-[var(--app-hint)]'
                                             }`}
                                         >
-                                            {serviceTier === option.value && (
+                                            {displayedServiceTier === option.value && (
                                                 <div className="h-2 w-2 rounded-full bg-[var(--app-link)]" />
                                             )}
                                         </div>
-                                        <span className={serviceTier === option.value ? 'text-[var(--app-link)]' : ''}>
+                                        <span className={displayedServiceTier === option.value ? 'text-[var(--app-link)]' : ''}>
                                             {option.label}
                                         </span>
                                     </button>
@@ -1226,6 +1228,7 @@ export function HappyComposer(props: {
         modelReasoningEffort,
         effort,
         serviceTier,
+        displayedServiceTier,
         collaborationModeOptions,
         permissionModeOptions,
         handleCollaborationChange,

--- a/web/src/components/AssistantChat/codexFastMode.test.ts
+++ b/web/src/components/AssistantChat/codexFastMode.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { codexModelAdvertisesFastTier, isFastServiceTier } from './codexFastMode'
+import {
+    codexModelAdvertisesFastTier,
+    getDisplayedCodexServiceTier,
+    isFastServiceTier
+} from './codexFastMode'
 
 // Mirrors the real Codex catalog: the Fast tier's id is 'priority' and its
 // display name is 'Fast', so the CLI captures both as lowercased tokens
@@ -47,5 +51,16 @@ describe('isFastServiceTier', () => {
         expect(isFastServiceTier(null)).toBe(false)
         expect(isFastServiceTier(undefined)).toBe(false)
         expect(isFastServiceTier('standard')).toBe(false)
+    })
+})
+
+describe('getDisplayedCodexServiceTier', () => {
+    it('shows an untouched service tier as Standard', () => {
+        expect(getDisplayedCodexServiceTier(null)).toBe('standard')
+        expect(getDisplayedCodexServiceTier(undefined)).toBe('standard')
+    })
+
+    it('preserves an explicit Fast selection', () => {
+        expect(getDisplayedCodexServiceTier('fast')).toBe('fast')
     })
 })

--- a/web/src/components/AssistantChat/codexFastMode.ts
+++ b/web/src/components/AssistantChat/codexFastMode.ts
@@ -49,3 +49,7 @@ export function codexModelAdvertisesFastTier(
 export function isFastServiceTier(serviceTier?: string | null): boolean {
     return serviceTier?.trim().toLowerCase() === 'fast'
 }
+
+export function getDisplayedCodexServiceTier(serviceTier?: string | null): 'standard' | 'fast' {
+    return isFastServiceTier(serviceTier) ? 'fast' : 'standard'
+}


### PR DESCRIPTION
## Summary

- display an untouched/null Codex service tier as **Standard** in the Fast-mode radio group
- keep the original persisted `serviceTier` value unchanged
- add regression coverage for null/default and explicit Fast selections

## Why

The composer currently normalizes a missing service tier to `null`, while the radio options use only `standard` and `fast`. Comparing `null === 'standard'` and `null === 'fast'` leaves both radio buttons visually unselected.

This change separates display normalization from backend state: untouched sessions still persist `null`, but the two-option UI always has a valid selection.

Fixes #1002.

## Testing

- `bunx vitest run src/components/AssistantChat/codexFastMode.test.ts` — 9 passed
- `bun typecheck`
- `bun run build:web`
