### PR TITLE
fix(web): only show Codex Fast badge for fast tier

### DIFF
--- a/web/src/components/AssistantChat/StatusBar.test.ts
+++ b/web/src/components/AssistantChat/StatusBar.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shouldShowComposerStatusBar } from './StatusBar'
+import { shouldShowCodexFastBadge, shouldShowComposerStatusBar } from './StatusBar'
 
 describe('shouldShowComposerStatusBar', () => {
     it('hides the composer status bar for Cursor sessions', () => {
@@ -10,5 +10,15 @@ describe('shouldShowComposerStatusBar', () => {
         expect(shouldShowComposerStatusBar('claude')).toBe(true)
         expect(shouldShowComposerStatusBar('codex')).toBe(true)
         expect(shouldShowComposerStatusBar(null)).toBe(true)
+    })
+})
+
+describe('shouldShowCodexFastBadge', () => {
+    it('uses only the effective service tier', () => {
+        expect(shouldShowCodexFastBadge('codex', undefined)).toBe(false)
+        expect(shouldShowCodexFastBadge('codex', 'standard')).toBe(false)
+        expect(shouldShowCodexFastBadge('codex', 'fast')).toBe(true)
+        expect(shouldShowCodexFastBadge('codex', 'priority')).toBe(true)
+        expect(shouldShowCodexFastBadge('claude', 'fast')).toBe(false)
     })
 })

--- a/web/src/components/AssistantChat/StatusBar.tsx
+++ b/web/src/components/AssistantChat/StatusBar.tsx
@@ -125,14 +125,11 @@ function formatTokenCount(value: number): string {
     return String(value)
 }
 
-function isCodexFastMode(model?: string | null, effort?: string | null): boolean {
-    const normalizedEffort = effort?.trim().toLowerCase()
-    if (normalizedEffort === 'none' || normalizedEffort === 'minimal' || normalizedEffort === 'low') {
-        return true
-    }
-
-    const normalizedModel = model?.trim().toLowerCase() ?? ''
-    return normalizedModel.includes('mini') || normalizedModel.includes('fast')
+export function shouldShowCodexFastBadge(
+    agentFlavor: string | null | undefined,
+    serviceTier: string | null | undefined
+): boolean {
+    return agentFlavor === 'codex' && isFastServiceTier(serviceTier)
 }
 
 /** Cursor native ACP does not emit usage_update; hide the bar to avoid empty/misleading UI. */
@@ -210,13 +207,7 @@ export function StatusBar(props: {
     const codexReasoningLabel = shouldShowCodexReasoningLabel(props.agentFlavor)
         ? formatCodexReasoningLabel(props.modelReasoningEffort)
         : null
-    // Prefer the explicit service tier (the real Fast-mode toggle) when set;
-    // fall back to the effort/model heuristic only when the tier is unknown.
-    const codexFastMode = props.agentFlavor === 'codex'
-        ? (props.serviceTier != null
-            ? isFastServiceTier(props.serviceTier)
-            : isCodexFastMode(props.model, props.modelReasoningEffort))
-        : false
+    const codexFastMode = shouldShowCodexFastBadge(props.agentFlavor, props.serviceTier)
     const goalLabel = props.agentFlavor === 'codex' && props.threadGoal
         ? props.threadGoal.status === 'active'
             ? 'goal'


### PR DESCRIPTION
Closes #1004

## Summary
- remove the Codex Fast badge heuristic based on model names and reasoning effort
- render Fast only from the effective service tier
- preserve #1179 catalog-default behavior and recognize both canonical priority and legacy fast
- keep explicit Standard and non-Codex sessions unbadged

## Why
Codex Fast is a service tier. Low reasoning and mini model variants are not Fast. An unset session override may still resolve to catalog-default Fast, so this fix consumes the effective tier calculated by #1179 instead of deleting that behavior.

## Validation
- bun typecheck
- bun run test
  - CLI: 1474 passed
  - Hub: 509 passed, 3 skipped
  - Web: 1417 passed
  - Shared: 115 passed
- focused StatusBar/Fast-mode suites: 13 passed
- git diff --check

## AI disclosure
Implementation and tests were produced with AI assistance under user supervision.
