### PR TITLE
fix(web): select Standard for untouched Codex service tier

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -35,6 +35,7 @@ import { useTranslation } from '@/lib/use-translation'
 import { getModelOptionsForFlavor, getNextModelForFlavor } from './modelOptions'
 import { getClaudeComposerEffortOptions } from './claudeEffortOptions'
 import { getCodexComposerReasoningEffortOptions } from './codexReasoningEffortOptions'
+import { getDisplayedCodexServiceTier } from './codexFastMode'
 import { getPiThinkingLevelOptions, getHighestThinkingLevel, isThinkingLevelSupported } from './piThinkingLevelOptions'
 import { groupModelsByProvider } from './piModelGroups'
 import { PiModelPanel } from './PiModelPanel'
@@ -259,6 +260,7 @@ export function HappyComposer(props: {
     const modelReasoningEffort = rawModelReasoningEffort ?? null
     const effort = rawEffort ?? null
     const serviceTier = rawServiceTier ?? null
+    const displayedServiceTier = getDisplayedCodexServiceTier(serviceTier)
 
     const api = useAssistantApi()
     const { composerEnterBehavior } = useComposerEnterBehavior()
@@ -1159,16 +1161,16 @@ export function HappyComposer(props: {
                                     >
                                         <div
                                             className={`flex h-4 w-4 items-center justify-center rounded-full border-2 ${
-                                                serviceTier === option.value
+                                                displayedServiceTier === option.value
                                                     ? 'border-[var(--app-link)]'
                                                     : 'border-[var(--app-hint)]'
                                             }`}
                                         >
-                                            {serviceTier === option.value && (
+                                            {displayedServiceTier === option.value && (
                                                 <div className="h-2 w-2 rounded-full bg-[var(--app-link)]" />
                                             )}
                                         </div>
-                                        <span className={serviceTier === option.value ? 'text-[var(--app-link)]' : ''}>
+                                        <span className={displayedServiceTier === option.value ? 'text-[var(--app-link)]' : ''}>
                                             {option.label}
                                         </span>
                                     </button>
@@ -1225,7 +1227,7 @@ export function HappyComposer(props: {
         model,
         modelReasoningEffort,
         effort,
-        serviceTier,
+        displayedServiceTier,
         collaborationModeOptions,
         permissionModeOptions,
         handleCollaborationChange,

--- a/web/src/components/AssistantChat/codexFastMode.test.ts
+++ b/web/src/components/AssistantChat/codexFastMode.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { codexModelAdvertisesFastTier, isFastServiceTier } from './codexFastMode'
+import {
+    codexModelAdvertisesFastTier,
+    getDisplayedCodexServiceTier,
+    isFastServiceTier
+} from './codexFastMode'
 
 // Mirrors the real Codex catalog: the Fast tier's id is 'priority' and its
 // display name is 'Fast', so the CLI captures both as lowercased tokens
@@ -47,5 +51,17 @@ describe('isFastServiceTier', () => {
         expect(isFastServiceTier(null)).toBe(false)
         expect(isFastServiceTier(undefined)).toBe(false)
         expect(isFastServiceTier('standard')).toBe(false)
+    })
+})
+
+describe('getDisplayedCodexServiceTier', () => {
+    it('displays untouched and explicit non-fast tiers as standard', () => {
+        expect(getDisplayedCodexServiceTier(null)).toBe('standard')
+        expect(getDisplayedCodexServiceTier(undefined)).toBe('standard')
+        expect(getDisplayedCodexServiceTier('standard')).toBe('standard')
+    })
+
+    it('preserves the fast selection', () => {
+        expect(getDisplayedCodexServiceTier('fast')).toBe('fast')
     })
 })

--- a/web/src/components/AssistantChat/codexFastMode.ts
+++ b/web/src/components/AssistantChat/codexFastMode.ts
@@ -49,3 +49,12 @@ export function codexModelAdvertisesFastTier(
 export function isFastServiceTier(serviceTier?: string | null): boolean {
     return serviceTier?.trim().toLowerCase() === 'fast'
 }
+
+/**
+ * The persisted null tier means the user has not chosen an override. The
+ * current two-option control still needs a visible selection, so display that
+ * untouched state as Standard without changing the value sent to the backend.
+ */
+export function getDisplayedCodexServiceTier(serviceTier?: string | null): 'standard' | 'fast' {
+    return isFastServiceTier(serviceTier) ? 'fast' : 'standard'
+}


### PR DESCRIPTION
## Summary

- normalize an untouched Codex service tier to `standard` for radio display only
- preserve the original `null` tier for backend/persistence semantics
- add regression coverage for untouched, explicit Standard, and Fast tiers

Fixes #1002

## Tests

- `bun typecheck`
- `bun run test:web` — 1133 passed
- `bun run test:shared` — 105 passed
- `TMPDIR=/tmp/hapi-issue-1002-final-test-tmp HAPI_RUNNER_HTTP_TIMEOUT=60000 bun run test` — CLI 1115 passed; Hub 453 passed / 3 skipped; Web later hit an unrelated `useThemeColors` async cleanup flake, and a clean Web rerun passed 1133/1133
- `VITE_REQUIRE_HUB_URL=1 bun run --cwd web build`

## AI disclosure

Implementation and tests were produced with OpenAI Codex under user supervision.
