### PR TITLE
test(cli): stabilize runner integration timeouts

### DIFF
--- a/cli/src/test/setup.ts
+++ b/cli/src/test/setup.ts
@@ -25,5 +25,8 @@ process.env.HAPI_API_URL = `http://127.0.0.1:${config.port}`
 process.env.CLI_API_TOKEN = config.token
 process.env.HAPI_HOME = config.tmpHome
 process.env.HAPI_BUN_EXEC = config.bunExec
+// The stress test starts 20 real CLI children. On slower/loaded machines their
+// session webhooks can take longer than the production control-client default.
+process.env.HAPI_RUNNER_HTTP_TIMEOUT ??= '60000'
 // Keep heartbeat short so the version-mismatch test doesn't need to wait 60s
 process.env.HAPI_RUNNER_HEARTBEAT_INTERVAL ??= '30000'


### PR DESCRIPTION
## Summary

- give runner integration tests a 60s control-client timeout while preserving the 10s production default
- let spawned runner/CLI children inherit the test-only timeout from Vitest setup
- prevent the 20-session stress test from timing out before child session webhooks arrive on slower or loaded hosts

## Root cause

`controlClient.ts` reads `HAPI_RUNNER_HTTP_TIMEOUT`, but the integration test setup did not set it, so the stress test used the 10s production default. When 20 real Bun children took longer than 10s to initialize, every `/spawn-session` request aborted; teardown then raced the still-starting children and caused cascading runner failures in later tests.

## Tests

- Reproduction before fix: runner stress test failed with 20 `/spawn-session` timeouts and `expected [] to have a length of 20`
- `TMPDIR=/tmp/hapi-runner-timeout-stress-tmp bun run test src/runner/runner.integration.test.ts -t 'stress test: spawn / stop'` — passed
- `TMPDIR=/tmp/hapi-runner-timeout-suite-tmp bun run test src/runner/runner.integration.test.ts` — 12 passed
- `bun typecheck`
- `TMPDIR=/tmp/hapi-runner-timeout-cli-unit-tmp bun run test:cli -- --exclude src/runner/runner.integration.test.ts` — 1103 passed

## AI disclosure

Investigation and implementation were performed with OpenAI Codex under user supervision.
