### PR TITLE
fix(codex): expose HAPI threads to Codex Desktop

### DIFF
--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -81,6 +81,8 @@ export interface ThreadStartParams {
     baseInstructions?: string;
     developerInstructions?: string;
     personality?: string;
+    /** Client-supplied analytics classification persisted with the thread. */
+    threadSource?: string;
     ephemeral?: boolean;
     experimentalRawEvents?: boolean;
 }

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -13,6 +13,7 @@ const harness = vi.hoisted(() => ({
     collaborationModeResponse: { data: [{ mode: 'default' }, { mode: 'plan' }] } as unknown,
     failListCollaborationModes: false,
     startThreadIds: [] as string[],
+    startThreadParams: [] as Array<Record<string, unknown>>,
     resumeThreadIds: [] as string[],
     startTurnThreadIds: [] as string[],
     startTurnParams: [] as Array<Record<string, unknown>>,
@@ -99,9 +100,10 @@ vi.mock('./codexAppServerClient', () => {
             harness.requestHandlers.set(method, handler);
         }
 
-        async startThread(): Promise<{ thread: { id: string }; model: string }> {
+        async startThread(params?: Record<string, unknown>): Promise<{ thread: { id: string }; model: string }> {
             const id = `thread-${harness.startThreadIds.length + 1}`;
             harness.startThreadIds.push(id);
+            harness.startThreadParams.push(params ?? {});
             return { thread: { id }, model: 'gpt-5.4' };
         }
 
@@ -945,6 +947,7 @@ describe('codexRemoteLauncher', () => {
         harness.collaborationModeResponse = { data: [{ mode: 'default' }, { mode: 'plan' }] };
         harness.failListCollaborationModes = false;
         harness.startThreadIds = [];
+        harness.startThreadParams = [];
         harness.resumeThreadIds = [];
         harness.startTurnThreadIds = [];
         harness.startTurnParams = [];
@@ -1004,6 +1007,8 @@ describe('codexRemoteLauncher', () => {
         expect(exitReason).toBe('exit');
         expect(foundSessionIds).toContain('thread-1');
         expect(getModel()).toBe('gpt-5.4');
+        expect(harness.startThreadParams).toHaveLength(1);
+        expect(harness.startThreadParams[0]?.threadSource).toBe('user');
         expect(harness.initializeCalls).toEqual([{
             clientInfo: {
                 name: 'hapi-codex-client',

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -15,6 +15,7 @@ const harness = vi.hoisted(() => ({
     startThreadIds: [] as string[],
     startThreadParams: [] as Array<Record<string, unknown>>,
     resumeThreadIds: [] as string[],
+    resumeThreadParams: [] as Array<Record<string, unknown>>,
     startTurnThreadIds: [] as string[],
     startTurnParams: [] as Array<Record<string, unknown>>,
     startTurnErrors: [] as Error[],
@@ -107,9 +108,10 @@ vi.mock('./codexAppServerClient', () => {
             return { thread: { id }, model: 'gpt-5.4' };
         }
 
-        async resumeThread(params?: { threadId?: string }): Promise<{ thread: { id: string }; model: string }> {
-            const id = params?.threadId ?? 'thread-resumed';
+        async resumeThread(params?: Record<string, unknown>): Promise<{ thread: { id: string }; model: string }> {
+            const id = typeof params?.threadId === 'string' ? params.threadId : 'thread-resumed';
             harness.resumeThreadIds.push(id);
+            harness.resumeThreadParams.push(params ?? {});
             if (harness.failResumeThreadIds.includes(id)) {
                 throw new Error('resume failed');
             }
@@ -949,6 +951,7 @@ describe('codexRemoteLauncher', () => {
         harness.startThreadIds = [];
         harness.startThreadParams = [];
         harness.resumeThreadIds = [];
+        harness.resumeThreadParams = [];
         harness.startTurnThreadIds = [];
         harness.startTurnParams = [];
         harness.startTurnErrors = [];
@@ -1230,6 +1233,8 @@ describe('codexRemoteLauncher', () => {
 
         expect(exitReason).toBe('exit');
         expect(foundSessionIds).toEqual(['thread-1']);
+        expect(harness.startThreadParams).toHaveLength(1);
+        expect(harness.startThreadParams[0]?.threadSource).toBe('user');
         expect(harness.startTurnParams).toHaveLength(0);
         expect(harness.goalSetCalls).toEqual([{
             threadId: 'thread-1',
@@ -1486,6 +1491,8 @@ describe('codexRemoteLauncher', () => {
 
         expect(exitReason).toBe('exit');
         expect(harness.resumeThreadIds).toEqual(['thread-old']);
+        expect(harness.resumeThreadParams).toHaveLength(1);
+        expect(harness.resumeThreadParams[0]?.threadSource).toBeUndefined();
         expect(harness.startThreadIds).toEqual([]);
         expect(harness.startTurnThreadIds).toEqual([]);
         expect(session.sessionId).toBe('thread-old');

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -94,6 +94,7 @@ const SAME_THREAD_MAX_COMPACT_RETRIES = 1;
 const SAME_THREAD_COMPACT_TIMEOUT_MS = 10 * 60 * 1000;
 const CODEX_GOALS_UNSUPPORTED_MESSAGE = 'Codex goals are not supported by this Codex runtime. Upgrade Codex or enable features.goals.';
 const MAX_CODEX_GOAL_OBJECTIVE_CHARS = 4_000;
+const HAPI_TOP_LEVEL_THREAD_SOURCE = 'user';
 
 type GoalForwardSignature = {
     objective: string | null;
@@ -2773,7 +2774,10 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     mcpServers,
                     cliOverrides: session.codexCliOverrides
                 });
-                const threadResponse = await appServerClient.startThread(threadParams, {
+                const threadResponse = await appServerClient.startThread({
+                    ...threadParams,
+                    threadSource: HAPI_TOP_LEVEL_THREAD_SOURCE
+                }, {
                     signal: this.abortController.signal
                 });
                 const threadRecord = asRecord(threadResponse);
@@ -3023,7 +3027,10 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     }
 
                     if (!threadId) {
-                        const threadResponse = await appServerClient.startThread(threadParams, {
+                        const threadResponse = await appServerClient.startThread({
+                            ...threadParams,
+                            threadSource: HAPI_TOP_LEVEL_THREAD_SOURCE
+                        }, {
                             signal: this.abortController.signal
                         });
                         const threadRecord = asRecord(threadResponse);


### PR DESCRIPTION
Fixes #1019

## Summary

- classify every new top-level HAPI Codex thread as `threadSource: "user"`
- cover both normal first-turn creation and goal-first thread creation
- keep resume requests unchanged
- add launcher-level regression coverage for the exact `thread/start` payload

## Root cause

HAPI persisted valid Codex threads with the correct `cwd` and Git metadata, but omitted Codex app-server's supported `threadSource` field. Those threads were consequently stored with `threadSource=null` instead of the native top-level user classification expected for user-visible conversations.

## Verification

- [x] TDD red: regression test failed with `expected undefined to be "user"`
- [x] `bun run typecheck:cli`
- [x] focused `codexRemoteLauncher` suite: 54/54 passed
- [x] full workspace typecheck
- [x] hub tests: 459 passed
- [x] web tests: 1162 passed
- [x] shared tests: 105 passed
- [x] Codex CLI 0.144.1 app-server probe accepted the field and returned `threadSource: "user"`, correct `cwd`, and `source: "vscode"`

The full CLI run passed 1129 tests. Four unrelated runner integration assertions failed locally in the existing parallel spawn/stop stress flow; the changed Codex suite and all non-runner packages passed.
