### PR TITLE
fix(opencode): preserve ACP text delta chunks

### DIFF
--- a/cli/src/agent/backends/acp/AcpMessageHandler.test.ts
+++ b/cli/src/agent/backends/acp/AcpMessageHandler.test.ts
@@ -377,6 +377,25 @@ describe('AcpMessageHandler', () => {
         expect(messages).toEqual([{ type: 'text', text: 'hello world' }]);
     });
 
+    it('preserves overlapping text chunks in delta mode', () => {
+        const messages: AgentMessage[] = [];
+        const handler = new AcpMessageHandler(
+            (message) => messages.push(message),
+            { textChunkMode: 'delta' }
+        );
+
+        for (const text of ['|-----|', '-----|', '-----|\n']) {
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.agentMessageChunk,
+                content: { type: 'text', text }
+            });
+        }
+
+        handler.flushText();
+
+        expect(messages).toEqual([{ type: 'text', text: '|-----|-----|-----|\n' }]);
+    });
+
     it('keeps existing tool name when update only has kind fallback', () => {
         const messages: AgentMessage[] = [];
         const handler = new AcpMessageHandler((message) => messages.push(message));

--- a/cli/src/agent/backends/acp/AcpMessageHandler.ts
+++ b/cli/src/agent/backends/acp/AcpMessageHandler.ts
@@ -358,6 +358,8 @@ function normalizePlanEntries(entries: unknown): PlanItem[] {
     return items;
 }
 
+export type AcpTextChunkMode = 'dedupe' | 'delta';
+
 function getSuffixPrefixOverlap(base: string, next: string): number {
     const maxOverlap = Math.min(base.length, next.length);
     for (let length = maxOverlap; length > 0; length -= 1) {
@@ -380,8 +382,14 @@ export class AcpMessageHandler {
     private lastReasoningSnapshotAt: number | null = null;
     private lastReasoningSnapshotText = '';
     private reasoningSnapshotEmitted = false;
+    private readonly textChunkMode: AcpTextChunkMode;
 
-    constructor(private readonly onMessage: (message: AgentMessage) => void) {}
+    constructor(
+        private readonly onMessage: (message: AgentMessage) => void,
+        options: { textChunkMode?: AcpTextChunkMode } = {}
+    ) {
+        this.textChunkMode = options.textChunkMode ?? 'dedupe';
+    }
 
     /**
      * Emits any buffered assistant text as a single message and clears the
@@ -444,6 +452,13 @@ export class AcpMessageHandler {
     }
 
     private appendTextChunk(text: string): void {
+        if (this.textChunkMode === 'delta') {
+            if (text) {
+                this.bufferedText += text;
+            }
+            return;
+        }
+
         if (!text) {
             return;
         }

--- a/cli/src/agent/backends/acp/AcpSdkBackend.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.ts
@@ -2,7 +2,7 @@ import type { AgentFlavor } from '@hapi/protocol';
 import type { AgentBackend, AgentMessage, AgentSessionConfig, PermissionRequest, PermissionResponse, PromptContent } from '@/agent/types';
 import { asString, isObject } from '@hapi/protocol';
 import { AcpStdioTransport, type AcpStderrError } from './AcpStdioTransport';
-import { AcpMessageHandler } from './AcpMessageHandler';
+import { AcpMessageHandler, type AcpTextChunkMode } from './AcpMessageHandler';
 import { ACP_SESSION_UPDATE_TYPES } from './constants';
 import { logger } from '@/ui/logger';
 import { withRetry } from '@/utils/time';
@@ -101,7 +101,12 @@ export class AcpSdkBackend implements AgentBackend {
     private static readonly LATE_FLUSH_QUIET_PERIOD_MS = 250;
     private static readonly LATE_FLUSH_WINDOW_MS = 6000;
 
-    constructor(private readonly options: { command: string; args?: string[]; env?: Record<string, string> }) {}
+    constructor(private readonly options: {
+        command: string;
+        args?: string[];
+        env?: Record<string, string>;
+        textChunkMode?: AcpTextChunkMode;
+    }) {}
 
     async initialize(): Promise<void> {
         if (this.transport) return;
@@ -401,7 +406,7 @@ export class AcpSdkBackend implements AgentBackend {
             AcpSdkBackend.PRE_PROMPT_UPDATE_DRAIN_TIMEOUT_MS
         );
         this.messageHandler?.drainBuffers();
-        this.messageHandler = new AcpMessageHandler(onUpdate);
+        this.messageHandler = new AcpMessageHandler(onUpdate, { textChunkMode: this.options.textChunkMode });
         this.isProcessingMessage = true;
         this.lastSessionUpdateAt = Date.now();
         this.latestUsageUpdate = null;

--- a/cli/src/opencode/utils/opencodeBackend.ts
+++ b/cli/src/opencode/utils/opencodeBackend.ts
@@ -21,6 +21,7 @@ export function createOpencodeBackend(opts: {
     return new AcpSdkBackend({
         command: 'opencode',
         args,
-        env: filterEnv(env)
+        env: filterEnv(env),
+        textChunkMode: 'delta'
     });
 }


### PR DESCRIPTION
## Summary

- add an ACP text chunk mode so backends can distinguish cumulative/overlapping text from true deltas
- keep the existing overlap-deduplication behavior as the default for other ACP backends
- configure OpenCode to concatenate `agent_message_chunk` text verbatim
- add a regression test using the overlapping markdown separator chunks observed from OpenCode

## Problem

OpenCode ACP 1.17.15 emits `agent_message_chunk` text as true delta chunks. `AcpMessageHandler` currently applies overlap deduplication to every ACP backend, assuming chunks may be cumulative or repeated.

That assumption corrupts valid OpenCode output whenever adjacent deltas happen to share a suffix/prefix. A captured markdown table separator arrived as:

```text
"|-----|"
"-----|"
"-----|\n"
```

Direct concatenation should produce:

```text
|-----|-----|-----|
```

Before this change, the second chunk is dropped because the current buffer ends with it, and the third chunk contributes only its newline because of suffix/prefix overlap. HAPI therefore emits only `|-----|\n`. The same behavior was observed removing repeated characters from table cells, a repeated heading prefix, and one space of code-block indentation.

The raw ACP stream and OpenCode's stored final message were correct; corruption occurred while buffering in `AcpMessageHandler`, before hub/web delivery.

## Before / after

| | Behavior |
|---|---|
| Before | Every ACP text chunk uses overlap deduplication; valid OpenCode delta boundaries can be removed. |
| After | OpenCode uses verbatim delta concatenation; other ACP backends retain the existing dedupe behavior by default. |

## Implementation

- introduce `AcpTextChunkMode = 'dedupe' | 'delta'`
- default `AcpMessageHandler` to `dedupe` for compatibility with cumulative ACP streams
- pass the mode through `AcpSdkBackend` when each turn's message handler is created
- set `textChunkMode: 'delta'` only in `createOpencodeBackend`

## Tests

- `bun typecheck` - passed (CLI, Web, Hub)
- focused ACP suites - 3 files, 105 tests passed
- Web suite - 140 files, 1162 tests passed
- Shared suite - 105 tests passed
- full CLI suite - 1158 passed, 1 unrelated existing Windows short-path/long-path symlink assertion failed
- Hub suite - 455 passed, 3 skipped, 7 unrelated existing Windows cross-platform tests failed (`acpVerifyProbe` / `cursorLegacyMigrator`)

## Reproduction environment

- HAPI base: `origin/main@8782b8a`
- OpenCode: `1.17.15`
- OS: Windows Server 2022 Datacenter, build 20348
- PowerShell: `7.6.2`
- Bun: `1.3.14`
- Node.js: `v24.13.0`

## AI assistance disclosure

Code and PR preparation used OpenAI Codex (GPT-5).