### PR TITLE
fix(web): prioritize session names in narrow sidebar

### DIFF
--- a/web/src/components/SessionRowSummary.tsx
+++ b/web/src/components/SessionRowSummary.tsx
@@ -150,10 +150,13 @@ export function SessionRowSummary(props: {
 
     return (
         <div className={`flex w-full min-w-0 flex-col gap-1 ${className ?? ''}`}>
-            <div className={`flex items-center justify-between gap-3 ${!s.active ? 'opacity-50' : ''}`}>
+            <div className={`grid grid-cols-[minmax(9rem,1fr)_minmax(0,max-content)] items-center gap-2 ${!s.active ? 'opacity-50' : ''}`}>
                 <div className="flex min-w-0 items-center gap-2">
                     <AgentFlavorIcon flavor={s.metadata?.flavor} className="h-4 w-4 shrink-0 -translate-y-px" />
-                    <div className={`truncate text-sm font-medium ${s.active ? 'text-[var(--app-fg)]' : 'text-[var(--app-hint)]'}`}>
+                    <div
+                        className={`min-w-0 flex-1 truncate text-sm font-medium ${s.active ? 'text-[var(--app-fg)]' : 'text-[var(--app-hint)]'}`}
+                        title={sessionName}
+                    >
                         {sessionName}
                     </div>
                     {s.active && s.thinking ? (
@@ -194,20 +197,20 @@ export function SessionRowSummary(props: {
                         </span>
                     ) : null}
                 </div>
-                <div className="flex shrink-0 items-center gap-2 text-xs">
+                <div className="flex min-w-0 items-center justify-end gap-2 overflow-hidden text-xs">
                     {todoProgress ? (
-                        <span className="flex items-center gap-1 text-[var(--app-hint)]">
+                        <span className="flex shrink-0 items-center gap-1 text-[var(--app-hint)]">
                             <BulbIcon className="h-3 w-3" />
                             {todoProgress.completed}/{todoProgress.total}
                         </span>
                     ) : null}
                     {!attention && s.pendingRequestsCount > 0 ? (
-                        <span className="text-[var(--app-badge-warning-text)]">
+                        <span className="shrink-0 text-[var(--app-badge-warning-text)]">
                             {t('session.item.pending')} {s.pendingRequestsCount}
                         </span>
                     ) : null}
                     {timeLabel ? (
-                        <span className="tabular-nums text-[var(--app-hint)]">{timeLabel}</span>
+                        <span className="min-w-0 truncate whitespace-nowrap tabular-nums text-[var(--app-hint)]">{timeLabel}</span>
                     ) : null}
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- reserve a minimum-width primary column for the agent icon, session name, and live status
- let trailing metadata use the remaining width, with the timestamp truncating before the session name becomes unreadable
- expose the full session name through the native hover title

## Why

At the sidebar's minimum width, the session row used a flex layout whose trailing metadata was `shrink-0`. Todo progress and timestamps therefore forced the session name down to only a few visible characters, even though the name is the row's primary identifier.

The new two-column grid gives the primary content a `9rem` minimum track while the secondary track can shrink to the available space. This applies to both the resizable desktop sidebar and narrow mobile layouts without relying on viewport breakpoints.

## Impact

Session names remain recognizable in narrow sidebars. Status, todo progress, and pending-request indicators remain visible when possible; the lower-priority timestamp yields space first.

## Testing

- `bun typecheck`
- `bun run test` — 2,975 passed, 3 skipped, 0 failed
