### PR TITLE
feat(pi): add 'max' thinking level

### DIFF
--- a/shared/src/piThinkingLevel.ts
+++ b/shared/src/piThinkingLevel.ts
@@ -1,6 +1,6 @@
 // Pi thinking levels (from Pi's rpc-types.ts ThinkingLevel)
 // Controls how much reasoning/thinking the model performs.
-export const PI_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const
+export const PI_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const
 export type PiThinkingLevel = typeof PI_THINKING_LEVELS[number]
 
 export const PI_THINKING_LEVEL_LABELS: Record<PiThinkingLevel, string> = {
@@ -10,4 +10,5 @@ export const PI_THINKING_LEVEL_LABELS: Record<PiThinkingLevel, string> = {
     medium: 'Medium',
     high: 'High',
     xhigh: 'XHigh',
+    max: 'Max'
 }

--- a/web/src/components/AssistantChat/PiThinkingLevelPanel.tsx
+++ b/web/src/components/AssistantChat/PiThinkingLevelPanel.tsx
@@ -3,7 +3,7 @@ import type { PiThinkingLevelMap } from '@/types/api'
 import { FloatingOverlay } from '@/components/ChatInput/FloatingOverlay'
 import { isThinkingLevelSupported } from './piThinkingLevelOptions'
 
-const ALL_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const
+const ALL_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const
 
 /**
  * Determine which thinking levels a model supports.

--- a/web/src/components/AssistantChat/piThinkingLevelOptions.ts
+++ b/web/src/components/AssistantChat/piThinkingLevelOptions.ts
@@ -61,7 +61,8 @@ export function isThinkingLevelSupported(level: string, map?: PiThinkingLevelMap
     if (level === 'xhigh' || level === 'max') {
         if (!map || !(level in map)) return false
         return map[level] !== null
-    
+    }
+
     if (!map || !(level in map)) return true
     return map[level] !== null
 }

--- a/web/src/components/AssistantChat/piThinkingLevelOptions.ts
+++ b/web/src/components/AssistantChat/piThinkingLevelOptions.ts
@@ -57,16 +57,16 @@ export function getPiThinkingLevelOptions(
 
 /** Check whether a thinking level is supported by the model's thinkingLevelMap */
 export function isThinkingLevelSupported(level: string, map?: PiThinkingLevelMap): boolean {
-    // xhigh requires explicit opt-in via the map
-    if (level === 'xhigh') {
+    // xhigh and max require explicit opt-in via the map
+    if (level === 'xhigh' || level === 'max') {
         if (!map || !(level in map)) return false
         return map[level] !== null
-    }
+    
     if (!map || !(level in map)) return true
     return map[level] !== null
 }
 
-/** A level is excluded if it maps to `null` in the thinkingLevelMap, or xhigh without explicit opt-in */
+/** A level is excluded if it maps to `null` in the thinkingLevelMap, or xhigh/max without explicit opt-in */
 function isLevelExcluded(level: string, map?: PiThinkingLevelMap): boolean {
     return !isThinkingLevelSupported(level, map)
 }


### PR DESCRIPTION
## Problem

Pi's `--thinking` flag accepts 7 levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. However, hapi only defines 6 levels in `PI_THINKING_LEVELS` (missing `max`), so models that support `max` thinking cannot expose it in the UI.

## Changes

- Add `'max'` to `PI_THINKING_LEVELS` and `PI_THINKING_LEVEL_LABELS` in `shared/src/piThinkingLevel.ts`
- Update `ALL_LEVELS` in `PiThinkingLevelPanel.tsx` to include `max`
- Update `isThinkingLevelSupported()` in `piThinkingLevelOptions.ts` so `max` (like `xhigh`) requires explicit opt-in via the model's `thinkingLevelMap`

## Behavior

- Models that include `max` in their `thinkingLevelMap` will now show it as a selectable thinking level
- Models without `max` in their map are unaffected (opt-in required, same as `xhigh`)
- No breaking changes to existing behavior