### PR TITLE
fix(pi): use per-model context window for status bar display

### DIFF
--- a/web/src/components/SessionChat.test.ts
+++ b/web/src/components/SessionChat.test.ts
@@ -4,6 +4,7 @@ import {
     buildGoalStateMessages,
     isScratchlistHotkeyBlockedTarget,
     isScratchlistToggleHotkey,
+    resolvePiContextWindow,
     shouldAutoClearPendingSchedule,
     shouldRouteToScratchlist,
 } from './SessionChat'
@@ -43,6 +44,25 @@ describe('applyModelChangeWithReasoningRollback', () => {
         expect(setModelReasoningEffort).toHaveBeenCalledOnce()
         expect(setModelReasoningEffort).toHaveBeenCalledWith(null)
         expect(setModel).toHaveBeenCalledWith('gpt-next')
+    })
+})
+
+describe('resolvePiContextWindow', () => {
+    const models = [
+        { provider: 'provider-a', modelId: 'shared-model', contextWindow: 100_000 },
+        { provider: 'provider-b', modelId: 'shared-model', contextWindow: 200_000 },
+    ]
+
+    it('uses the provider-qualified selected model when model ids collide', () => {
+        expect(resolvePiContextWindow(
+            models,
+            { provider: 'provider-b', modelId: 'shared-model' },
+            'shared-model',
+        )).toBe(200_000)
+    })
+
+    it('falls back to the legacy model id when selected-model metadata is absent', () => {
+        expect(resolvePiContextWindow(models, undefined, 'shared-model')).toBe(100_000)
     })
 })
 

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -72,6 +72,21 @@ import { isRemoteTerminalSupported } from '@/utils/terminalSupport'
 
 type SessionModelSelection = { provider: string; modelId: string } | string | null
 
+export function resolvePiContextWindow(
+    models: PiModelSummary[] | undefined,
+    selectedModel: { provider: string; modelId: string } | null | undefined,
+    legacyModelId: string
+): number | undefined {
+    const model = selectedModel
+        ? models?.find((candidate) => (
+            candidate.provider === selectedModel.provider
+            && candidate.modelId === selectedModel.modelId
+        ))
+        : models?.find((candidate) => candidate.modelId === legacyModelId)
+
+    return model?.contextWindow
+}
+
 export async function applyModelChangeWithReasoningRollback(args: {
     model: SessionModelSelection
     previousModelReasoningEffort: string | null
@@ -648,6 +663,11 @@ function SessionChatInner(props: SessionChatProps) {
     // Provider-qualified selected model — disambiguates when two providers
     // share a modelId (hub persists this alongside the legacy modelId string).
     const piSelectedModel = piMetadata?.piSelectedModel as { provider: string; modelId: string } | null | undefined
+    const piModels = agentFlavor === 'pi' ? (piModelsState.availableModels.length > 0 ? piModelsState.availableModels : piCachedModels) : undefined
+    const piContextWindow = useMemo(() => {
+        if (agentFlavor !== 'pi' || !props.session.model) return undefined
+        return resolvePiContextWindow(piModels, piSelectedModel, props.session.model)
+    }, [agentFlavor, piModels, piSelectedModel, props.session.model])
     const cursorCatalogReadinessArgs = useMemo(() => ({
         sessionLoading: cursorModelsState.isLoading,
         machineLoading: machineCursorModelsState.isLoading,
@@ -1329,7 +1349,7 @@ function SessionChatInner(props: SessionChatProps) {
                                         // so Pi model changes go through the dedicated picker only.
                                         : undefined
                         }
-                        piModels={agentFlavor === 'pi' ? (piModelsState.availableModels.length > 0 ? piModelsState.availableModels : piCachedModels) : undefined}
+                        piModels={piModels}
                         piSelectedModel={agentFlavor === 'pi' ? piSelectedModel : undefined}
                         availableModelReasoningEffortOptions={
                             agentFlavor === 'codex'
@@ -1350,7 +1370,7 @@ function SessionChatInner(props: SessionChatProps) {
                         backgroundTaskCount={props.session.backgroundTaskCount}
                         contextSize={reduced.latestUsage?.contextSize}
                         contextCacheRead={reduced.latestUsage?.cacheRead}
-                        contextWindow={reduced.latestUsage?.contextWindow}
+                        contextWindow={reduced.latestUsage?.contextWindow ?? piContextWindow}
                         controlledByUser={controlledByUser}
                         onCollaborationModeChange={
                             codexCollaborationModeSupported && props.session.active && !controlledByUser


### PR DESCRIPTION
## Problem

The Pi context bar always displays usage against a hardcoded 190k token budget (`DEFAULT_PI_CONTEXT_WINDOW_TOKENS - CONTEXT_HEADROOM_TOKENS = 200000 - 10000`), regardless of the actual model's context window. For example, a model with 128k context window would show incorrect percentages.

Pi reports each model's `contextWindow` via `get_available_models`, and this data is already stored in `piAvailableModels` metadata — but it was never used for the status bar.

## Root Cause

Pi's `turn_end` usage events don't include `context_window` (unlike Claude/Codex which report it via ACP usage updates). So `reduced.latestUsage?.contextWindow` is always `null` for Pi sessions, causing the fallback to the hardcoded default.

## Changes

In `SessionChat.tsx`:
- Compute `piContextWindow` by looking up the current model's `contextWindow` from `piAvailableModels`
- Pass it as a fallback: `contextWindow={reduced.latestUsage?.contextWindow ?? piContextWindow}`
- Extract the `piModels` variable to avoid duplicate computation

## Behavior

- Pi sessions now show context usage against the correct model-specific context window
- Falls back to the 200k default only when model metadata is unavailable
- No changes to Claude, Codex, or other session types