### PR TITLE
fix: verify Cursor chat store before reopen

### DIFF
--- a/cli/src/api/apiMachine.test.ts
+++ b/cli/src/api/apiMachine.test.ts
@@ -106,7 +106,7 @@ describe('ApiMachineClient cursor-chat-store-status handler', () => {
             await callCursorChatStoreStatus(client, machine.id, {
                 workspacePath: '/work/project',
                 cursorSessionId: 'cursor-session',
-                homeDir: '/home/recorded-owner'
+                homeDir: '  /home/recorded-owner  '
             })
 
             expect(inspectCursorChatStoreMock).toHaveBeenCalledWith({
@@ -119,7 +119,7 @@ describe('ApiMachineClient cursor-chat-store-status handler', () => {
         }
     })
 
-    it('falls back to the CLI process home for old or empty homeDir metadata', async () => {
+    it('falls back to the CLI process home for old or whitespace-only homeDir metadata', async () => {
         const machine = makeMachine('cursor-store-fallback-machine')
         const client = new ApiMachineClient('cli-token', machine)
 
@@ -131,7 +131,7 @@ describe('ApiMachineClient cursor-chat-store-status handler', () => {
             await callCursorChatStoreStatus(client, machine.id, {
                 workspacePath: '/work/project',
                 cursorSessionId: 'cursor-session-empty',
-                homeDir: ''
+                homeDir: '   '
             })
 
             expect(inspectCursorChatStoreMock).toHaveBeenNthCalledWith(1, {

--- a/cli/src/api/apiMachine.test.ts
+++ b/cli/src/api/apiMachine.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, rmSync, mkdirSync, realpathSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 const ioMock = vi.hoisted(() => vi.fn())
 const listOpencodeModelsForCwdMock = vi.hoisted(() => vi.fn())
 const listGrokModelsForCwdMock = vi.hoisted(() => vi.fn())
+const inspectCursorChatStoreMock = vi.hoisted(() => vi.fn())
 
 vi.mock('socket.io-client', () => ({
     io: ioMock
@@ -21,6 +22,10 @@ vi.mock('../modules/common/opencodeModels', () => ({
 
 vi.mock('../modules/common/grokModels', () => ({
     listGrokModelsForCwd: listGrokModelsForCwdMock
+}))
+
+vi.mock('@/cursor/cursorChatStoreStatus', () => ({
+    inspectCursorChatStore: inspectCursorChatStoreMock
 }))
 
 import { ApiMachineClient, normalizeWindowsDriveRoot } from './apiMachine'
@@ -73,6 +78,77 @@ async function callListGrokModels(client: ApiMachineClient, machineId: string, c
     })
     return JSON.parse(raw) as unknown
 }
+
+async function callCursorChatStoreStatus(
+    client: ApiMachineClient,
+    machineId: string,
+    params: { workspacePath: string; cursorSessionId: string; homeDir?: string }
+): Promise<unknown> {
+    const manager = (client as unknown as { rpcHandlerManager: { handleRequest: (req: { method: string; params: string }) => Promise<string> } }).rpcHandlerManager
+    const raw = await manager.handleRequest({
+        method: `${machineId}:cursor-chat-store-status`,
+        params: JSON.stringify(params)
+    })
+    return JSON.parse(raw) as unknown
+}
+
+describe('ApiMachineClient cursor-chat-store-status handler', () => {
+    beforeEach(() => {
+        inspectCursorChatStoreMock.mockReset()
+        inspectCursorChatStoreMock.mockResolvedValue({ onDisk: false, store: null })
+    })
+
+    it('inspects stores under the recorded session owner home', async () => {
+        const machine = makeMachine('cursor-store-machine')
+        const client = new ApiMachineClient('cli-token', machine)
+
+        try {
+            await callCursorChatStoreStatus(client, machine.id, {
+                workspacePath: '/work/project',
+                cursorSessionId: 'cursor-session',
+                homeDir: '/home/recorded-owner'
+            })
+
+            expect(inspectCursorChatStoreMock).toHaveBeenCalledWith({
+                home: '/home/recorded-owner',
+                workspacePath: '/work/project',
+                cursorSessionId: 'cursor-session'
+            })
+        } finally {
+            client.shutdown()
+        }
+    })
+
+    it('falls back to the CLI process home for old or empty homeDir metadata', async () => {
+        const machine = makeMachine('cursor-store-fallback-machine')
+        const client = new ApiMachineClient('cli-token', machine)
+
+        try {
+            await callCursorChatStoreStatus(client, machine.id, {
+                workspacePath: '/work/project',
+                cursorSessionId: 'cursor-session-old'
+            })
+            await callCursorChatStoreStatus(client, machine.id, {
+                workspacePath: '/work/project',
+                cursorSessionId: 'cursor-session-empty',
+                homeDir: ''
+            })
+
+            expect(inspectCursorChatStoreMock).toHaveBeenNthCalledWith(1, {
+                home: homedir(),
+                workspacePath: '/work/project',
+                cursorSessionId: 'cursor-session-old'
+            })
+            expect(inspectCursorChatStoreMock).toHaveBeenNthCalledWith(2, {
+                home: homedir(),
+                workspacePath: '/work/project',
+                cursorSessionId: 'cursor-session-empty'
+            })
+        } finally {
+            client.shutdown()
+        }
+    })
+})
 
 describe('ApiMachineClient listOpencodeModelsForCwd handler', () => {
     let workspaceRoot: string

--- a/cli/src/api/apiMachine.ts
+++ b/cli/src/api/apiMachine.ts
@@ -31,6 +31,9 @@ import type { SpawnSessionOptions, SpawnSessionResult } from '../modules/common/
 import { applyVersionedAck } from './versionedUpdate'
 import { buildSocketIoExtraHeaderOptions } from './hubExtraHeaders'
 import { collectMachineHealth } from '@/utils/machineHealth'
+import { inspectCursorChatStore } from '@/cursor/cursorChatStoreStatus'
+import { homedir } from 'node:os'
+import type { CursorChatStoreStatus } from '@hapi/protocol/apiTypes'
 
 type MachineRpcHandlers = {
     spawnSession: (options: SpawnSessionOptions) => Promise<SpawnSessionResult>
@@ -44,6 +47,11 @@ interface PathExistsRequest {
 
 interface ListMachineDirectoryRequest {
     path: string
+}
+
+interface CursorChatStoreStatusRequest {
+    workspacePath: string
+    cursorSessionId: string
 }
 
 export function normalizeWindowsDriveRoot(path: string): string {
@@ -127,6 +135,15 @@ export class ApiMachineClient {
 
             return { exists }
         })
+
+        this.rpcHandlerManager.registerHandler<CursorChatStoreStatusRequest, CursorChatStoreStatus>(
+            RPC_METHODS.CursorChatStoreStatus,
+            async (params) => await inspectCursorChatStore({
+                home: homedir(),
+                workspacePath: typeof params?.workspacePath === 'string' ? params.workspacePath : '',
+                cursorSessionId: typeof params?.cursorSessionId === 'string' ? params.cursorSessionId : ''
+            })
+        )
 
         this.rpcHandlerManager.registerHandler<ListMachineDirectoryRequest, MachineListDirectoryResponse>(RPC_METHODS.ListMachineDirectory, async (params) => {
             if (!this.normalizedWorkspaceRoots?.length) {

--- a/cli/src/api/apiMachine.ts
+++ b/cli/src/api/apiMachine.ts
@@ -52,6 +52,7 @@ interface ListMachineDirectoryRequest {
 interface CursorChatStoreStatusRequest {
     workspacePath: string
     cursorSessionId: string
+    homeDir?: string
 }
 
 export function normalizeWindowsDriveRoot(path: string): string {
@@ -139,7 +140,9 @@ export class ApiMachineClient {
         this.rpcHandlerManager.registerHandler<CursorChatStoreStatusRequest, CursorChatStoreStatus>(
             RPC_METHODS.CursorChatStoreStatus,
             async (params) => await inspectCursorChatStore({
-                home: homedir(),
+                home: typeof params?.homeDir === 'string' && params.homeDir.length > 0
+                    ? params.homeDir
+                    : homedir(),
                 workspacePath: typeof params?.workspacePath === 'string' ? params.workspacePath : '',
                 cursorSessionId: typeof params?.cursorSessionId === 'string' ? params.cursorSessionId : ''
             })

--- a/cli/src/api/apiMachine.ts
+++ b/cli/src/api/apiMachine.ts
@@ -139,13 +139,14 @@ export class ApiMachineClient {
 
         this.rpcHandlerManager.registerHandler<CursorChatStoreStatusRequest, CursorChatStoreStatus>(
             RPC_METHODS.CursorChatStoreStatus,
-            async (params) => await inspectCursorChatStore({
-                home: typeof params?.homeDir === 'string' && params.homeDir.length > 0
-                    ? params.homeDir
-                    : homedir(),
-                workspacePath: typeof params?.workspacePath === 'string' ? params.workspacePath : '',
-                cursorSessionId: typeof params?.cursorSessionId === 'string' ? params.cursorSessionId : ''
-            })
+            async (params) => {
+                const recordedHome = typeof params?.homeDir === 'string' ? params.homeDir.trim() : ''
+                return await inspectCursorChatStore({
+                    home: recordedHome || homedir(),
+                    workspacePath: typeof params?.workspacePath === 'string' ? params.workspacePath : '',
+                    cursorSessionId: typeof params?.cursorSessionId === 'string' ? params.cursorSessionId : ''
+                })
+            }
         )
 
         this.rpcHandlerManager.registerHandler<ListMachineDirectoryRequest, MachineListDirectoryResponse>(RPC_METHODS.ListMachineDirectory, async (params) => {

--- a/cli/src/cursor/cursorChatStoreStatus.test.ts
+++ b/cli/src/cursor/cursorChatStoreStatus.test.ts
@@ -47,6 +47,37 @@ describe('inspectCursorChatStore', () => {
         })).resolves.toEqual({ onDisk: true, store: 'legacy' })
     })
 
+    it('finds a unique legacy store when the canonical workspace drawer is missing', async () => {
+        const home = await makeHome()
+        const store = join(home, '.cursor', 'chats', 'legacy-workspace-hash', 'cursor-3', 'store.db')
+        await mkdir(join(store, '..'), { recursive: true })
+        await writeFile(store, 'db')
+
+        await expect(inspectCursorChatStore({
+            home,
+            workspacePath: '/work/project-moved-since-chat-was-created',
+            cursorSessionId: 'cursor-3'
+        })).resolves.toEqual({ onDisk: true, store: 'legacy' })
+    })
+
+    it('reports missing when multiple non-canonical legacy stores are present', async () => {
+        const home = await makeHome()
+        const stores = [
+            join(home, '.cursor', 'chats', 'workspace-hash-a', 'cursor-4', 'store.db'),
+            join(home, '.cursor', 'chats', 'workspace-hash-b', 'cursor-4', 'store.db')
+        ]
+        for (const store of stores) {
+            await mkdir(join(store, '..'), { recursive: true })
+            await writeFile(store, 'db')
+        }
+
+        await expect(inspectCursorChatStore({
+            home,
+            workspacePath: '/work/unrelated-project',
+            cursorSessionId: 'cursor-4'
+        })).resolves.toEqual({ onDisk: false, store: null })
+    })
+
     it('reports missing without allowing cursorSessionId path traversal', async () => {
         const home = await makeHome()
 

--- a/cli/src/cursor/cursorChatStoreStatus.test.ts
+++ b/cli/src/cursor/cursorChatStoreStatus.test.ts
@@ -47,6 +47,26 @@ describe('inspectCursorChatStore', () => {
         })).resolves.toEqual({ onDisk: true, store: 'legacy' })
     })
 
+    it('hashes the raw workspace path without trimming valid path bytes', async () => {
+        const home = await makeHome()
+        const workspacePath = '/work/project '
+        const workspaceHash = createHash('md5').update(workspacePath).digest('hex')
+        const stores = [
+            join(home, '.cursor', 'chats', workspaceHash, 'cursor-spaced-path', 'store.db'),
+            join(home, '.cursor', 'chats', 'stale-workspace-hash', 'cursor-spaced-path', 'store.db')
+        ]
+        for (const store of stores) {
+            await mkdir(join(store, '..'), { recursive: true })
+            await writeFile(store, 'db')
+        }
+
+        await expect(inspectCursorChatStore({
+            home,
+            workspacePath,
+            cursorSessionId: 'cursor-spaced-path'
+        })).resolves.toEqual({ onDisk: true, store: 'legacy' })
+    })
+
     it('finds a unique legacy store when the canonical workspace drawer is missing', async () => {
         const home = await makeHome()
         const store = join(home, '.cursor', 'chats', 'legacy-workspace-hash', 'cursor-3', 'store.db')

--- a/cli/src/cursor/cursorChatStoreStatus.test.ts
+++ b/cli/src/cursor/cursorChatStoreStatus.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { createHash, randomUUID } from 'node:crypto'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { inspectCursorChatStore } from './cursorChatStoreStatus'
+
+const homes: string[] = []
+
+async function makeHome(): Promise<string> {
+    const home = join(tmpdir(), `hapi-cursor-store-${randomUUID()}`)
+    homes.push(home)
+    await mkdir(home, { recursive: true })
+    return home
+}
+
+afterEach(async () => {
+    await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })))
+})
+
+describe('inspectCursorChatStore', () => {
+    it('finds ACP store.db under the runner user home', async () => {
+        const home = await makeHome()
+        const store = join(home, '.cursor', 'acp-sessions', 'cursor-1', 'store.db')
+        await mkdir(join(store, '..'), { recursive: true })
+        await writeFile(store, 'db')
+
+        await expect(inspectCursorChatStore({
+            home,
+            workspacePath: '/work/project',
+            cursorSessionId: 'cursor-1'
+        })).resolves.toEqual({ onDisk: true, store: 'acp' })
+    })
+
+    it('finds legacy store.db by Cursor workspace hash', async () => {
+        const home = await makeHome()
+        const workspacePath = '/work/project'
+        const workspaceHash = createHash('md5').update(workspacePath).digest('hex')
+        const store = join(home, '.cursor', 'chats', workspaceHash, 'cursor-2', 'store.db')
+        await mkdir(join(store, '..'), { recursive: true })
+        await writeFile(store, 'db')
+
+        await expect(inspectCursorChatStore({
+            home,
+            workspacePath,
+            cursorSessionId: 'cursor-2'
+        })).resolves.toEqual({ onDisk: true, store: 'legacy' })
+    })
+
+    it('reports missing without allowing cursorSessionId path traversal', async () => {
+        const home = await makeHome()
+
+        await expect(inspectCursorChatStore({
+            home,
+            workspacePath: '/work/project',
+            cursorSessionId: '../../outside'
+        })).resolves.toEqual({ onDisk: false, store: null })
+    })
+})

--- a/cli/src/cursor/cursorChatStoreStatus.ts
+++ b/cli/src/cursor/cursorChatStoreStatus.ts
@@ -49,8 +49,8 @@ export async function inspectCursorChatStore(
     options: InspectCursorChatStoreOptions
 ): Promise<CursorChatStoreStatus> {
     const cursorSessionId = options.cursorSessionId.trim()
-    const workspacePath = options.workspacePath.trim()
-    if (!isSafeCursorSessionId(cursorSessionId) || !workspacePath) {
+    const workspacePath = options.workspacePath
+    if (!isSafeCursorSessionId(cursorSessionId) || workspacePath.length === 0) {
         return { onDisk: false, store: null }
     }
 

--- a/cli/src/cursor/cursorChatStoreStatus.ts
+++ b/cli/src/cursor/cursorChatStoreStatus.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { stat } from 'node:fs/promises'
+import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { CursorChatStoreStatus } from '@hapi/protocol/apiTypes'
 
@@ -21,6 +21,28 @@ async function isFile(path: string): Promise<boolean> {
     } catch {
         return false
     }
+}
+
+async function hasUniqueLegacyStore(home: string, cursorSessionId: string): Promise<boolean> {
+    const chatsRoot = join(home, '.cursor', 'chats')
+    let workspaceDrawers: string[]
+    try {
+        workspaceDrawers = await readdir(chatsRoot)
+    } catch {
+        return false
+    }
+
+    let matches = 0
+    for (const workspaceDrawer of workspaceDrawers) {
+        const candidate = join(chatsRoot, workspaceDrawer, cursorSessionId, 'store.db')
+        if (await isFile(candidate)) {
+            matches += 1
+            if (matches > 1) {
+                return false
+            }
+        }
+    }
+    return matches === 1
 }
 
 export async function inspectCursorChatStore(
@@ -53,6 +75,10 @@ export async function inspectCursorChatStore(
         'store.db'
     )
     if (await isFile(legacyStore)) {
+        return { onDisk: true, store: 'legacy' }
+    }
+
+    if (await hasUniqueLegacyStore(options.home, cursorSessionId)) {
         return { onDisk: true, store: 'legacy' }
     }
 

--- a/cli/src/cursor/cursorChatStoreStatus.ts
+++ b/cli/src/cursor/cursorChatStoreStatus.ts
@@ -1,0 +1,60 @@
+import { createHash } from 'node:crypto'
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { CursorChatStoreStatus } from '@hapi/protocol/apiTypes'
+
+type InspectCursorChatStoreOptions = {
+    home: string
+    workspacePath: string
+    cursorSessionId: string
+}
+
+function isSafeCursorSessionId(value: string): boolean {
+    return value !== '.'
+        && value !== '..'
+        && /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)
+}
+
+async function isFile(path: string): Promise<boolean> {
+    try {
+        return (await stat(path)).isFile()
+    } catch {
+        return false
+    }
+}
+
+export async function inspectCursorChatStore(
+    options: InspectCursorChatStoreOptions
+): Promise<CursorChatStoreStatus> {
+    const cursorSessionId = options.cursorSessionId.trim()
+    const workspacePath = options.workspacePath.trim()
+    if (!isSafeCursorSessionId(cursorSessionId) || !workspacePath) {
+        return { onDisk: false, store: null }
+    }
+
+    const acpStore = join(
+        options.home,
+        '.cursor',
+        'acp-sessions',
+        cursorSessionId,
+        'store.db'
+    )
+    if (await isFile(acpStore)) {
+        return { onDisk: true, store: 'acp' }
+    }
+
+    const workspaceHash = createHash('md5').update(workspacePath).digest('hex')
+    const legacyStore = join(
+        options.home,
+        '.cursor',
+        'chats',
+        workspaceHash,
+        cursorSessionId,
+        'store.db'
+    )
+    if (await isFile(legacyStore)) {
+        return { onDisk: true, store: 'legacy' }
+    }
+
+    return { onDisk: false, store: null }
+}

--- a/hub/src/sync/rpcGateway.test.ts
+++ b/hub/src/sync/rpcGateway.test.ts
@@ -5,11 +5,16 @@ import { RpcGateway, RpcTargetMissingError } from './rpcGateway'
 
 function createGateway() {
     const timeouts: number[] = []
+    const calls: Array<{ method: string; params: string }> = []
     const socket = {
         timeout(timeoutMs: number) {
             timeouts.push(timeoutMs)
             return {
                 async emitWithAck(_event: string, payload: { method: string; params: string }) {
+                    calls.push(payload)
+                    if (payload.method.endsWith(':cursor-chat-store-status')) {
+                        return JSON.stringify({ onDisk: false, store: null })
+                    }
                     return JSON.stringify({
                         success: true,
                         method: payload.method,
@@ -40,7 +45,8 @@ function createGateway() {
 
     return {
         gateway: new RpcGateway(io, rpcRegistry),
-        timeouts
+        timeouts,
+        calls
     }
 }
 
@@ -67,6 +73,26 @@ describe('RpcGateway RPC timeouts', () => {
         await gateway.listCursorModelsForMachine('machine-1')
 
         expect(timeouts).toEqual([120_000])
+    })
+
+    it('forwards the recorded session owner home to the Cursor store probe', async () => {
+        const { gateway, calls } = createGateway()
+
+        await gateway.getCursorChatStoreStatus(
+            'machine-1',
+            '/workspace/project',
+            'cursor-session',
+            '/home/recorded-owner'
+        )
+
+        expect(calls).toEqual([{
+            method: 'machine-1:cursor-chat-store-status',
+            params: JSON.stringify({
+                workspacePath: '/workspace/project',
+                cursorSessionId: 'cursor-session',
+                homeDir: '/home/recorded-owner'
+            })
+        }])
     })
 })
 
@@ -114,4 +140,3 @@ describe('RpcGateway no-target diagnostics (tiann/hapi#916)', () => {
         expect((error as RpcTargetMissingError).code).toBe('socket-disconnected')
     })
 })
-

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -1,11 +1,13 @@
 import type { AgentFlavor, CodexCollaborationMode, PermissionMode } from '@hapi/protocol/types'
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods'
+import { CursorChatStoreStatusSchema } from '@hapi/protocol/apiTypes'
 import type {
     CodexModelSummary,
     CodexModelsResponse,
     CommandResponse,
     CursorModelSummary,
     CursorModelsResponse,
+    CursorChatStoreStatus,
     DeleteUploadResponse,
     DirectoryEntry,
     FileReadResponse,
@@ -59,6 +61,7 @@ export type RpcCodexModel = CodexModelSummary
 export type RpcListCodexModelsResponse = CodexModelsResponse
 export type RpcCursorModel = CursorModelSummary
 export type RpcListCursorModelsResponse = CursorModelsResponse
+export type RpcCursorChatStoreStatus = CursorChatStoreStatus
 export type RpcOpencodeModel = OpencodeModelSummary
 export type RpcListOpencodeModelsResponse = OpencodeModelsResponse
 export type RpcListGrokModelsResponse = GrokModelsResponse
@@ -208,6 +211,19 @@ export class RpcGateway {
             exists[key] = value === true
         }
         return exists
+    }
+
+    async getCursorChatStoreStatus(
+        machineId: string,
+        workspacePath: string,
+        cursorSessionId: string
+    ): Promise<RpcCursorChatStoreStatus> {
+        const result = await this.machineRpc(
+            machineId,
+            RPC_METHODS.CursorChatStoreStatus,
+            { workspacePath, cursorSessionId }
+        )
+        return CursorChatStoreStatusSchema.parse(result)
     }
 
     async getGitStatus(sessionId: string, cwd?: string): Promise<RpcCommandResponse> {

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -216,12 +216,13 @@ export class RpcGateway {
     async getCursorChatStoreStatus(
         machineId: string,
         workspacePath: string,
-        cursorSessionId: string
+        cursorSessionId: string,
+        homeDir?: string
     ): Promise<RpcCursorChatStoreStatus> {
         const result = await this.machineRpc(
             machineId,
             RPC_METHODS.CursorChatStoreStatus,
-            { workspacePath, cursorSessionId }
+            { workspacePath, cursorSessionId, homeDir }
         )
         return CursorChatStoreStatusSchema.parse(result)
     }

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1617,6 +1617,7 @@ describe('session model', () => {
                     path: '/tmp/project',
                     host: 'cursor-host',
                     machineId: 'cursor-machine',
+                    homeDir: '/home/cursor-owner',
                     flavor: 'cursor',
                     cursorSessionId: 'cursor-thread-missing',
                     cursorSessionProtocol: 'acp'
@@ -1633,10 +1634,11 @@ describe('session model', () => {
             engine.handleMachineAlive({ machineId: 'cursor-machine', time: Date.now() })
 
             let spawnCalled = false
-            ;(engine as any).rpcGateway.getCursorChatStoreStatus = async () => ({
-                onDisk: false,
-                store: null
-            })
+            let probeArgs: unknown[] | null = null
+            ;(engine as any).rpcGateway.getCursorChatStoreStatus = async (...args: unknown[]) => {
+                probeArgs = args
+                return { onDisk: false, store: null }
+            }
             ;(engine as any).rpcGateway.spawnSession = async () => {
                 spawnCalled = true
                 return { type: 'success', sessionId: session.id }
@@ -1649,6 +1651,12 @@ describe('session model', () => {
                 message: 'Cursor chat data is no longer available on the recorded machine',
                 code: 'resume_unavailable'
             })
+            expect(probeArgs as unknown).toEqual([
+                'cursor-machine',
+                '/tmp/project',
+                'cursor-thread-missing',
+                '/home/cursor-owner'
+            ])
             expect(spawnCalled).toBe(false)
         } finally {
             engine.stop()
@@ -1671,6 +1679,7 @@ describe('session model', () => {
                     path: '/remote/project',
                     host: 'shared-host-label',
                     machineId: 'recorded-machine',
+                    homeDir: '/home/recorded-owner',
                     flavor: 'cursor',
                     cursorSessionId: 'cursor-thread-remote',
                     cursorSessionProtocol: 'acp'
@@ -1703,8 +1712,124 @@ describe('session model', () => {
             expect(captured as unknown).toEqual([
                 'recorded-machine',
                 '/remote/project',
-                'cursor-thread-remote'
+                'cursor-thread-remote',
+                '/home/recorded-owner'
             ])
+        } finally {
+            engine.stop()
+        }
+    })
+
+    it('does not probe a same-host machine when the recorded Cursor machine is offline', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'cursor-offline-recorded-machine-status',
+                {
+                    path: '/remote/project',
+                    host: 'shared-host-label',
+                    machineId: 'recorded-machine-offline',
+                    flavor: 'cursor',
+                    cursorSessionId: 'cursor-thread-offline',
+                    cursorSessionProtocol: 'acp'
+                },
+                null,
+                'default'
+            )
+            engine.getOrCreateMachine(
+                'recorded-machine-offline',
+                { host: 'shared-host-label', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.getOrCreateMachine(
+                'wrong-same-host-machine',
+                { host: 'shared-host-label', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'wrong-same-host-machine', time: Date.now() })
+
+            let probeCalled = false
+            ;(engine as any).rpcGateway.getCursorChatStoreStatus = async () => {
+                probeCalled = true
+                return { onDisk: true, store: 'acp' }
+            }
+
+            expect(await engine.getCursorChatStoreStatus(session.id, 'default')).toEqual({
+                type: 'error',
+                message: 'No machine online',
+                code: 'no_machine_online'
+            })
+            expect(probeCalled).toBe(false)
+        } finally {
+            engine.stop()
+        }
+    })
+
+    it('does not probe or spawn on a same-host machine when the recorded Cursor machine is offline', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'cursor-offline-recorded-machine-resume',
+                {
+                    path: '/remote/project',
+                    host: 'shared-host-label',
+                    machineId: 'recorded-machine-offline',
+                    flavor: 'cursor',
+                    cursorSessionId: 'cursor-thread-offline',
+                    cursorSessionProtocol: 'acp'
+                },
+                null,
+                'default'
+            )
+            engine.getOrCreateMachine(
+                'recorded-machine-offline',
+                { host: 'shared-host-label', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.getOrCreateMachine(
+                'wrong-same-host-machine',
+                { host: 'shared-host-label', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'wrong-same-host-machine', time: Date.now() })
+
+            let probeCalled = false
+            let spawnCalled = false
+            ;(engine as any).rpcGateway.getCursorChatStoreStatus = async () => {
+                probeCalled = true
+                return { onDisk: true, store: 'acp' }
+            }
+            ;(engine as any).rpcGateway.spawnSession = async () => {
+                spawnCalled = true
+                return { type: 'success', sessionId: session.id }
+            }
+            ;(engine as any).waitForSessionActive = async () => true
+
+            expect(await engine.resumeSession(session.id, 'default')).toEqual({
+                type: 'error',
+                message: 'No machine online',
+                code: 'no_machine_online'
+            })
+            expect(probeCalled).toBe(false)
+            expect(spawnCalled).toBe(false)
         } finally {
             engine.stop()
         }

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1187,6 +1187,7 @@ describe('session model', () => {
                 engine.handleSessionAlive({ sid: spawnedSessionId, time: Date.now() })
                 return { type: 'success', sessionId: spawnedSessionId }
             }
+            ;(engine as any).rpcGateway.getCursorChatStoreStatus = async () => ({ onDisk: true, store: 'acp' })
             ;(engine as any).waitForSessionActive = async () => true
             ;(engine as any).waitForSessionReady = async () => 'ended'
 
@@ -1319,6 +1320,7 @@ describe('session model', () => {
                 engine.handleSessionReady({ sid: spawnedSessionId, time: Date.now() })
                 return { type: 'success', sessionId: spawnedSessionId }
             }
+            ;(engine as any).rpcGateway.getCursorChatStoreStatus = async () => ({ onDisk: true, store: 'acp' })
             ;(engine as any).waitForSessionActive = async () => true
 
             const result = await engine.resumeSession(oldSession.id, 'default')
@@ -1387,6 +1389,7 @@ describe('session model', () => {
                 engine.handleSessionAlive({ sid: spawnedSessionId, time: Date.now() })
                 return { type: 'success', sessionId: spawnedSessionId }
             }
+            ;(engine as any).rpcGateway.getCursorChatStoreStatus = async () => ({ onDisk: true, store: 'legacy' })
             ;(engine as any).waitForSessionActive = async () => true
 
             const result = await engine.resumeSession(oldSession.id, 'default')
@@ -1593,6 +1596,115 @@ describe('session model', () => {
                 message: 'Resume session ID unavailable. Start a new session in this directory, or retry after the agent has initialized.',
                 code: 'resume_unavailable'
             })
+        } finally {
+            engine.stop()
+        }
+    })
+
+    it('refuses Cursor resume before spawning when the recorded chat store is missing', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'cursor-missing-store',
+                {
+                    path: '/tmp/project',
+                    host: 'cursor-host',
+                    machineId: 'cursor-machine',
+                    flavor: 'cursor',
+                    cursorSessionId: 'cursor-thread-missing',
+                    cursorSessionProtocol: 'acp'
+                },
+                null,
+                'default'
+            )
+            engine.getOrCreateMachine(
+                'cursor-machine',
+                { host: 'cursor-host', platform: 'linux', happyCliVersion: '0.1.0' },
+                null,
+                'default'
+            )
+            engine.handleMachineAlive({ machineId: 'cursor-machine', time: Date.now() })
+
+            let spawnCalled = false
+            ;(engine as any).rpcGateway.getCursorChatStoreStatus = async () => ({
+                onDisk: false,
+                store: null
+            })
+            ;(engine as any).rpcGateway.spawnSession = async () => {
+                spawnCalled = true
+                return { type: 'success', sessionId: session.id }
+            }
+
+            const result = await engine.resumeSession(session.id, 'default')
+
+            expect(result).toEqual({
+                type: 'error',
+                message: 'Cursor chat data is no longer available on the recorded machine',
+                code: 'resume_unavailable'
+            })
+            expect(spawnCalled).toBe(false)
+        } finally {
+            engine.stop()
+        }
+    })
+
+    it('probes Cursor chat data on the session recorded machine', async () => {
+        const store = new Store(':memory:')
+        const engine = new SyncEngine(
+            store,
+            {} as never,
+            new RpcRegistry(),
+            { broadcast() {} } as never
+        )
+
+        try {
+            const session = engine.getOrCreateSession(
+                'cursor-machine-scoped-store',
+                {
+                    path: '/remote/project',
+                    host: 'shared-host-label',
+                    machineId: 'recorded-machine',
+                    flavor: 'cursor',
+                    cursorSessionId: 'cursor-thread-remote',
+                    cursorSessionProtocol: 'acp'
+                },
+                null,
+                'default'
+            )
+            for (const machineId of ['other-machine', 'recorded-machine']) {
+                engine.getOrCreateMachine(
+                    machineId,
+                    { host: 'shared-host-label', platform: 'linux', happyCliVersion: '0.1.0' },
+                    null,
+                    'default'
+                )
+                engine.handleMachineAlive({ machineId, time: Date.now() })
+            }
+
+            let captured: unknown[] | null = null
+            ;(engine as any).rpcGateway.getCursorChatStoreStatus = async (...args: unknown[]) => {
+                captured = args
+                return { onDisk: true, store: 'acp' }
+            }
+
+            const result = await engine.getCursorChatStoreStatus(session.id, 'default')
+
+            expect(result).toEqual({
+                type: 'success',
+                status: { onDisk: true, store: 'acp' }
+            })
+            expect(captured as unknown).toEqual([
+                'recorded-machine',
+                '/remote/project',
+                'cursor-thread-remote'
+            ])
         } finally {
             engine.stop()
         }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -8,7 +8,7 @@
  */
 
 import { isKnownFlavor, type LocalResumeTarget, type ResumableSession } from '@hapi/protocol'
-import type { CursorMigrateOutcome, CursorMigrateToAcpRequest, SlashCommandsResponse } from '@hapi/protocol/apiTypes'
+import type { CursorChatStoreStatus, CursorMigrateOutcome, CursorMigrateToAcpRequest, SlashCommandsResponse } from '@hapi/protocol/apiTypes'
 import type { AgentFlavor, CodexCollaborationMode, DecryptedMessage, PermissionMode, Session, SyncEvent } from '@hapi/protocol/types'
 import { unwrapRoleWrappedRecordEnvelope } from '@hapi/protocol/messages'
 import type { Server } from 'socket.io'
@@ -36,6 +36,7 @@ import {
     type RpcListGrokReasoningEffortOptionsResponse,
     type RpcListOpencodeReasoningEffortOptionsResponse,
     type RpcCursorModel,
+    type RpcCursorChatStoreStatus,
     type RpcOpencodeModel,
     type RpcPathExistsResponse,
     type RpcReadFileResponse,
@@ -59,6 +60,7 @@ export type {
     RpcListGrokReasoningEffortOptionsResponse,
     RpcListOpencodeReasoningEffortOptionsResponse,
     RpcCursorModel,
+    RpcCursorChatStoreStatus,
     RpcOpencodeModel,
     RpcPathExistsResponse,
     RpcReadFileResponse,
@@ -81,6 +83,10 @@ export type LocalResumeTargetResult =
 export type LocalHandoffResult =
     | { type: 'success' }
     | { type: 'error'; message: string; code: 'session_not_found' | 'access_denied' | 'already_local' | 'handoff_failed' }
+
+export type CursorChatStoreStatusResult =
+    | { type: 'success'; status: CursorChatStoreStatus }
+    | { type: 'error'; message: string; code: 'session_not_found' | 'access_denied' | 'resume_unavailable' | 'no_machine_online' | 'probe_failed' }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
     return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -187,6 +193,59 @@ export class SyncEngine {
 
     getSessions(): Session[] {
         return this.sessionCache.getSessions()
+    }
+
+    private resolveOnlineMachineForSession(session: Session, namespace: string): Machine | null {
+        const onlineMachines = this.machineCache.getOnlineMachinesByNamespace(namespace)
+        if (session.metadata?.machineId) {
+            const exact = onlineMachines.find((machine) => machine.id === session.metadata?.machineId)
+            if (exact) return exact
+        }
+        if (session.metadata?.host) {
+            const hostMatch = onlineMachines.find((machine) => machine.metadata?.host === session.metadata?.host)
+            if (hostMatch) return hostMatch
+        }
+        return null
+    }
+
+    async getCursorChatStoreStatus(sessionId: string, namespace: string): Promise<CursorChatStoreStatusResult> {
+        const access = this.sessionCache.resolveSessionAccess(sessionId, namespace)
+        if (!access.ok) {
+            return {
+                type: 'error',
+                message: access.reason === 'access-denied' ? 'Session access denied' : 'Session not found',
+                code: access.reason === 'access-denied' ? 'access_denied' : 'session_not_found'
+            }
+        }
+
+        const metadata = access.session.metadata
+        if (metadata?.flavor !== 'cursor' || !metadata.path || !metadata.cursorSessionId) {
+            return {
+                type: 'error',
+                message: 'Cursor resume metadata is unavailable',
+                code: 'resume_unavailable'
+            }
+        }
+
+        const targetMachine = this.resolveOnlineMachineForSession(access.session, namespace)
+        if (!targetMachine) {
+            return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
+        }
+
+        try {
+            const status = await this.rpcGateway.getCursorChatStoreStatus(
+                targetMachine.id,
+                metadata.path,
+                metadata.cursorSessionId
+            )
+            return { type: 'success', status }
+        } catch (error) {
+            return {
+                type: 'error',
+                message: error instanceof Error ? error.message : 'Failed to inspect Cursor chat store',
+                code: 'probe_failed'
+            }
+        }
     }
 
     getSessionsByNamespace(namespace: string): Session[] {
@@ -1168,25 +1227,32 @@ export class SyncEngine {
 
         const metadata = session.metadata!
 
-        const onlineMachines = this.machineCache.getOnlineMachinesByNamespace(namespace)
-        if (onlineMachines.length === 0) {
+        const targetMachine = this.resolveOnlineMachineForSession(session, namespace)
+        if (!targetMachine) {
             return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
         }
 
-        const targetMachine = (() => {
-            if (metadata.machineId) {
-                const exact = onlineMachines.find((machine) => machine.id === metadata.machineId)
-                if (exact) return exact
+        if (flavor === 'cursor' && resumeToken) {
+            try {
+                const chatStatus = await this.rpcGateway.getCursorChatStoreStatus(
+                    targetMachine.id,
+                    directory,
+                    resumeToken
+                )
+                if (!chatStatus.onDisk) {
+                    return {
+                        type: 'error',
+                        message: 'Cursor chat data is no longer available on the recorded machine',
+                        code: 'resume_unavailable'
+                    }
+                }
+            } catch (error) {
+                return {
+                    type: 'error',
+                    message: error instanceof Error ? error.message : 'Failed to inspect Cursor chat store',
+                    code: 'resume_failed'
+                }
             }
-            if (metadata.host) {
-                const hostMatch = onlineMachines.find((machine) => machine.metadata?.host === metadata.host)
-                if (hostMatch) return hostMatch
-            }
-            return null
-        })()
-
-        if (!targetMachine) {
-            return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
         }
 
         const preferredPermissionMode = opts?.permissionMode

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -195,11 +195,16 @@ export class SyncEngine {
         return this.sessionCache.getSessions()
     }
 
-    private resolveOnlineMachineForSession(session: Session, namespace: string): Machine | null {
+    private resolveOnlineMachineForSession(
+        session: Session,
+        namespace: string,
+        options?: { strictMachineId?: boolean }
+    ): Machine | null {
         const onlineMachines = this.machineCache.getOnlineMachinesByNamespace(namespace)
         if (session.metadata?.machineId) {
             const exact = onlineMachines.find((machine) => machine.id === session.metadata?.machineId)
             if (exact) return exact
+            if (options?.strictMachineId) return null
         }
         if (session.metadata?.host) {
             const hostMatch = onlineMachines.find((machine) => machine.metadata?.host === session.metadata?.host)
@@ -227,7 +232,11 @@ export class SyncEngine {
             }
         }
 
-        const targetMachine = this.resolveOnlineMachineForSession(access.session, namespace)
+        const targetMachine = this.resolveOnlineMachineForSession(
+            access.session,
+            namespace,
+            { strictMachineId: true }
+        )
         if (!targetMachine) {
             return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
         }
@@ -236,7 +245,8 @@ export class SyncEngine {
             const status = await this.rpcGateway.getCursorChatStoreStatus(
                 targetMachine.id,
                 metadata.path,
-                metadata.cursorSessionId
+                metadata.cursorSessionId,
+                metadata.homeDir
             )
             return { type: 'success', status }
         } catch (error) {
@@ -1227,7 +1237,11 @@ export class SyncEngine {
 
         const metadata = session.metadata!
 
-        const targetMachine = this.resolveOnlineMachineForSession(session, namespace)
+        const targetMachine = this.resolveOnlineMachineForSession(
+            session,
+            namespace,
+            { strictMachineId: flavor === 'cursor' }
+        )
         if (!targetMachine) {
             return { type: 'error', message: 'No machine online', code: 'no_machine_online' }
         }
@@ -1237,7 +1251,8 @@ export class SyncEngine {
                 const chatStatus = await this.rpcGateway.getCursorChatStoreStatus(
                     targetMachine.id,
                     directory,
-                    resumeToken
+                    resumeToken,
+                    metadata.homeDir
                 )
                 if (!chatStatus.onDisk) {
                     return {

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -63,6 +63,7 @@ function createApp(session: Session, opts?: {
     getSessionExport?: (sessionId: string, session: Session) => unknown
     sessionExists?: boolean
     archiveSession?: (sessionId: string) => Promise<void>
+    getCursorChatStoreStatus?: SyncEngine['getCursorChatStoreStatus']
 }) {
     const applySessionConfigCalls: Array<[string, Record<string, unknown>]> = []
     const applySessionConfig = async (sessionId: string, config: Record<string, unknown>) => {
@@ -135,6 +136,10 @@ function createApp(session: Session, opts?: {
         listGrokReasoningEffortOptionsForSession,
         resumeSession,
         reopenSession,
+        getCursorChatStoreStatus: opts?.getCursorChatStoreStatus ?? (async () => ({
+            type: 'success' as const,
+            status: { onDisk: true, store: 'acp' as const }
+        })),
         archiveSession: archiveSessionMock,
         getSessionExport: opts?.getSessionExport ?? (() => ({
             type: 'success',
@@ -162,6 +167,29 @@ function createApp(session: Session, opts?: {
 }
 
 describe('sessions routes', () => {
+    it('returns the machine-scoped Cursor chat store status', async () => {
+        const session = createSession({
+            active: false,
+            metadata: {
+                path: '/tmp/project',
+                host: 'cursor-host',
+                flavor: 'cursor',
+                cursorSessionId: 'cursor-thread-1'
+            }
+        })
+        const { app } = createApp(session, {
+            getCursorChatStoreStatus: async () => ({
+                type: 'success',
+                status: { onDisk: false, store: null }
+            })
+        })
+
+        const response = await app.request('/api/sessions/session-1/cursor-chat-store')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ onDisk: false, store: null })
+    })
+
     it('exports an empty session conversation payload', async () => {
         const session = createSession()
         const { app } = createApp(session)

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -134,6 +134,33 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         return c.json({ session: sessionResult.session })
     })
 
+    app.get('/sessions/:id/cursor-chat-store', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine)
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+
+        const result = await engine.getCursorChatStoreStatus(
+            sessionResult.sessionId,
+            c.get('namespace')
+        )
+        if (result.type === 'error') {
+            const status = result.code === 'session_not_found' ? 404
+                : result.code === 'access_denied' ? 403
+                    : result.code === 'resume_unavailable' ? 409
+                        : result.code === 'no_machine_online' ? 503
+                            : 502
+            return c.json({ error: result.message, code: result.code }, status)
+        }
+
+        return c.json(result.status)
+    })
+
     app.post('/sessions/:id/resume', async (c) => {
         const engine = requireSyncEngine(c, getSyncEngine)
         if (engine instanceof Response) {

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -119,6 +119,13 @@ export const ReopenSessionMissingMetadataResponseSchema = z.object({
 
 export type ReopenSessionMissingMetadataResponse = z.infer<typeof ReopenSessionMissingMetadataResponseSchema>
 
+export const CursorChatStoreStatusSchema = z.object({
+    onDisk: z.boolean(),
+    store: z.enum(['legacy', 'acp']).nullable()
+})
+
+export type CursorChatStoreStatus = z.infer<typeof CursorChatStoreStatusSchema>
+
 export const SessionCollaborationModeRequestSchema = z.object({
     mode: CodexCollaborationModeSchema
 })

--- a/shared/src/rpcMethods.ts
+++ b/shared/src/rpcMethods.ts
@@ -10,6 +10,7 @@ export const RPC_METHODS = {
     StopRunner: 'stop-runner',
     ListMachineDirectory: 'list-directory',
     PathExists: 'path-exists',
+    CursorChatStoreStatus: 'cursor-chat-store-status',
     GitStatus: 'git-status',
     GitDiffNumstat: 'git-diff-numstat',
     GitDiffFile: 'git-diff-file',

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -79,4 +79,17 @@ describe('ApiClient error mapping', () => {
             expect(apiError.body).toContain('cursorSessionId')
         }
     })
+
+    it('loads the Cursor chat store status for the selected session', async () => {
+        fetchMock.mockResolvedValueOnce(
+            new Response(JSON.stringify({ onDisk: false, store: null }), { status: 200 })
+        )
+
+        const api = new ApiClient('test-token')
+        await expect(api.getCursorChatStoreStatus('session cursor')).resolves.toEqual({
+            onDisk: false,
+            store: null
+        })
+        expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/sessions/session%20cursor/cursor-chat-store')
+    })
 })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -27,6 +27,7 @@ import type {
     CodexModelsResponse,
     CursorMigrateOutcome,
     CursorMigrateToAcpRequest,
+    CursorChatStoreStatus,
     CursorModelsResponse,
     DeleteUploadResponse,
     FileReadResponse,
@@ -387,6 +388,12 @@ export class ApiClient {
             }
         )
         return response.sessionId
+    }
+
+    async getCursorChatStoreStatus(sessionId: string): Promise<CursorChatStoreStatus> {
+        return await this.request<CursorChatStoreStatus>(
+            `/api/sessions/${encodeURIComponent(sessionId)}/cursor-chat-store`
+        )
     }
 
     async sendMessage(sessionId: string, text: string, localId?: string | null, attachments?: AttachmentMetadata[], scheduledAt?: number | null): Promise<void> {

--- a/web/src/components/SessionActionMenu.test.tsx
+++ b/web/src/components/SessionActionMenu.test.tsx
@@ -52,6 +52,23 @@ describe('SessionActionMenu - Reopen action', () => {
         expect(screen.getByRole('menuitem', { name: /Delete/ })).toBeInTheDocument()
     })
 
+    it('renders a disabled Reopen item with an explanation when resume data is missing', () => {
+        const onClose = vi.fn()
+        renderMenu({
+            sessionActive: false,
+            onReopen: undefined,
+            reopenDisabledReason: 'Cursor chat data is no longer available on this machine.',
+            onClose,
+        })
+
+        const reopen = screen.getByRole('menuitem', { name: /Reopen/ })
+        expect(reopen).toHaveAttribute('aria-disabled', 'true')
+        expect(screen.getByRole('tooltip')).toHaveTextContent('Cursor chat data is no longer available')
+
+        fireEvent.click(reopen)
+        expect(onClose).not.toHaveBeenCalled()
+    })
+
     it('fires onReopen and closes the menu when the Reopen item is clicked', () => {
         const onReopen = vi.fn()
         const onClose = vi.fn()

--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -8,6 +8,7 @@ import {
     type CSSProperties
 } from 'react'
 import { useTranslation } from '@/lib/use-translation'
+import { HoverTooltip } from '@/components/HoverTooltip'
 
 type SessionActionMenuProps = {
     isOpen: boolean
@@ -17,6 +18,7 @@ type SessionActionMenuProps = {
     onExport?: () => void
     onArchive: () => void
     onReopen?: () => void
+    reopenDisabledReason?: string
     onDelete: () => void
     anchorPoint: { x: number; y: number }
     menuId?: string
@@ -143,6 +145,7 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         onExport,
         onArchive,
         onReopen,
+        reopenDisabledReason,
         onDelete,
         anchorPoint,
         menuId
@@ -318,16 +321,30 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
                     </button>
                 ) : (
                     <>
-                        {onReopen ? (
-                            <button
-                                type="button"
-                                role="menuitem"
-                                className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
-                                onClick={handleReopen}
+                        {onReopen || reopenDisabledReason ? (
+                            <HoverTooltip
+                                id={`${resolvedMenuId}-reopen-tooltip`}
+                                className="w-full [&>span:first-child]:w-full"
+                                align="start"
+                                revealOnParentFocusClass="group-focus-within:opacity-100 group-focus-within:visible"
+                                target={(
+                                    <button
+                                        type="button"
+                                        role="menuitem"
+                                        aria-disabled={reopenDisabledReason ? true : undefined}
+                                        aria-describedby={reopenDisabledReason ? `${resolvedMenuId}-reopen-tooltip` : undefined}
+                                        className={`${baseItemClassName} ${reopenDisabledReason
+                                            ? 'cursor-not-allowed opacity-50'
+                                            : 'hover:bg-[var(--app-subtle-bg)]'}`}
+                                        onClick={reopenDisabledReason ? undefined : handleReopen}
+                                    >
+                                        <ReopenIcon className="text-[var(--app-hint)]" />
+                                        {t('session.action.reopen')}
+                                    </button>
+                                )}
                             >
-                                <ReopenIcon className="text-[var(--app-hint)]" />
-                                {t('session.action.reopen')}
-                            </button>
+                                {reopenDisabledReason ?? t('session.action.reopen')}
+                            </HoverTooltip>
                         ) : null}
                         <button
                             type="button"

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -380,6 +380,7 @@ function hasAbortableAgentRun(blocks: readonly ChatBlock[]): boolean {
 type SessionChatProps = {
     api: ApiClient
     session: Session
+    cursorChatOnDisk?: boolean
     messages: DecryptedMessage[]
     pendingMessages?: DecryptedMessage[]
     messagesWarning: string | null
@@ -437,7 +438,11 @@ function SessionChatInner(props: SessionChatProps) {
     const { t } = useTranslation()
     const navigate = useNavigate()
     const sessionInactive = !props.session.active
-    const inactiveCanResume = inactiveSessionCanResume(props.session, props.messages.length)
+    const inactiveCanResume = inactiveSessionCanResume(
+        props.session,
+        props.messages.length,
+        props.cursorChatOnDisk
+    )
     const terminalSupported = isRemoteTerminalSupported(props.session.metadata)
     const normalizedCacheRef = useRef<Map<string, { source: DecryptedMessage; normalized: NormalizedMessage | null }>>(new Map())
     const blocksByIdRef = useRef<Map<string, ChatBlock>>(new Map())
@@ -1197,6 +1202,7 @@ function SessionChatInner(props: SessionChatProps) {
                 onToggleOutline={handleToggleOutline}
                 outlineActive={outlineOpen}
                 api={props.api}
+                canReopen={inactiveCanResume}
                 onSessionDeleted={props.onBack}
                 onSessionReopened={(newSessionId) => {
                     navigate({

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -381,6 +381,7 @@ type SessionChatProps = {
     api: ApiClient
     session: Session
     cursorChatOnDisk?: boolean
+    reopenDisabledReason?: string
     messages: DecryptedMessage[]
     pendingMessages?: DecryptedMessage[]
     messagesWarning: string | null
@@ -1203,6 +1204,7 @@ function SessionChatInner(props: SessionChatProps) {
                 outlineActive={outlineOpen}
                 api={props.api}
                 canReopen={inactiveCanResume}
+                reopenDisabledReason={props.reopenDisabledReason}
                 onSessionDeleted={props.onBack}
                 onSessionReopened={(newSessionId) => {
                     navigate({

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -106,6 +106,7 @@ export function SessionHeader(props: {
     outlineActive?: boolean
     api: ApiClient | null
     canReopen?: boolean
+    reopenDisabledReason?: string
     onSessionDeleted?: () => void
     onSessionReopened?: (newSessionId: string) => void
 }) {
@@ -273,6 +274,7 @@ export function SessionHeader(props: {
                 onExport={() => setExportOpen(true)}
                 onArchive={() => setArchiveOpen(true)}
                 onReopen={props.canReopen === false ? undefined : handleReopen}
+                reopenDisabledReason={props.reopenDisabledReason}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}
                 menuId={menuId}

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -105,6 +105,7 @@ export function SessionHeader(props: {
     onToggleOutline?: () => void
     outlineActive?: boolean
     api: ApiClient | null
+    canReopen?: boolean
     onSessionDeleted?: () => void
     onSessionReopened?: (newSessionId: string) => void
 }) {
@@ -271,7 +272,7 @@ export function SessionHeader(props: {
                 onRename={() => setRenameOpen(true)}
                 onExport={() => setExportOpen(true)}
                 onArchive={() => setArchiveOpen(true)}
-                onReopen={handleReopen}
+                onReopen={props.canReopen === false ? undefined : handleReopen}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}
                 menuId={menuId}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -590,11 +590,22 @@ function SessionItem(props: {
     const [renameOpen, setRenameOpen] = useState(false)
     const [archiveOpen, setArchiveOpen] = useState(false)
     const [deleteOpen, setDeleteOpen] = useState(false)
-    const { status: cursorChatStoreStatus } = useCursorChatStoreStatus({
+    const {
+        status: cursorChatStoreStatus,
+        isApplicable: cursorChatStoreApplicable,
+        error: cursorChatStoreError,
+    } = useCursorChatStoreStatus({
         api,
         session: s,
         enabled: menuOpen
     })
+    const cursorReopenDisabledReason = cursorChatStoreApplicable && cursorChatStoreStatus?.onDisk !== true
+        ? cursorChatStoreError
+            ? t('session.action.reopenCursorCheckFailed')
+            : cursorChatStoreStatus?.onDisk === false
+                ? t('session.action.reopenCursorMissing')
+                : t('session.action.reopenCursorChecking')
+        : undefined
 
     const { archiveSession, reopenSession, renameSession, deleteSession, isPending } = useSessionActions(
         api,
@@ -725,7 +736,8 @@ function SessionItem(props: {
                 sessionActive={s.active}
                 onRename={() => setRenameOpen(true)}
                 onArchive={() => setArchiveOpen(true)}
-                onReopen={cursorChatStoreStatus?.onDisk === false ? undefined : handleReopen}
+                onReopen={cursorReopenDisabledReason ? undefined : handleReopen}
+                reopenDisabledReason={cursorReopenDisabledReason}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}
             />

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -25,6 +25,7 @@ import { formatReopenError } from '@/lib/reopenError'
 import type { Machine } from '@/types/api'
 import { getMachinePlatform, presentMachineHealth } from '@/lib/machineHealth'
 import { MachineGroupHeader } from '@/components/MachineGroupHeader'
+import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStatus'
 
 type SessionGroup = {
     key: string
@@ -589,6 +590,11 @@ function SessionItem(props: {
     const [renameOpen, setRenameOpen] = useState(false)
     const [archiveOpen, setArchiveOpen] = useState(false)
     const [deleteOpen, setDeleteOpen] = useState(false)
+    const { status: cursorChatStoreStatus } = useCursorChatStoreStatus({
+        api,
+        session: s,
+        enabled: menuOpen
+    })
 
     const { archiveSession, reopenSession, renameSession, deleteSession, isPending } = useSessionActions(
         api,
@@ -719,7 +725,7 @@ function SessionItem(props: {
                 sessionActive={s.active}
                 onRename={() => setRenameOpen(true)}
                 onArchive={() => setArchiveOpen(true)}
-                onReopen={handleReopen}
+                onReopen={cursorChatStoreStatus?.onDisk === false ? undefined : handleReopen}
                 onDelete={() => setDeleteOpen(true)}
                 anchorPoint={menuAnchorPoint}
             />

--- a/web/src/hooks/queries/useCursorChatStoreStatus.ts
+++ b/web/src/hooks/queries/useCursorChatStoreStatus.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query'
+import type { ApiClient } from '@/api/client'
+import type { CursorChatStoreStatus, Session, SessionSummary } from '@/types/api'
+import { queryKeys } from '@/lib/query-keys'
+
+type CursorChatStoreSession = Pick<Session | SessionSummary, 'id' | 'active' | 'metadata'>
+
+export function useCursorChatStoreStatus(args: {
+    api: ApiClient | null
+    session: CursorChatStoreSession | null
+    enabled?: boolean
+}): {
+    status: CursorChatStoreStatus | undefined
+    isLoading: boolean
+    error: string | null
+} {
+    const { api, session } = args
+    const metadata = session?.metadata
+    const cursorSessionId = metadata && 'cursorSessionId' in metadata
+        ? metadata.cursorSessionId
+        : metadata && 'agentSessionId' in metadata
+            ? metadata.agentSessionId
+            : undefined
+    const shouldProbe = Boolean(
+        session
+        && !session.active
+        && metadata?.flavor === 'cursor'
+        && cursorSessionId
+        && metadata.path
+    )
+    const enabled = Boolean((args.enabled ?? true) && api && shouldProbe)
+    const sessionId = session?.id ?? 'unknown'
+
+    const query = useQuery({
+        queryKey: queryKeys.sessionCursorChatStore(sessionId),
+        queryFn: async () => {
+            if (!api || !session) {
+                throw new Error('Cursor session unavailable')
+            }
+            return await api.getCursorChatStoreStatus(session.id)
+        },
+        enabled,
+        staleTime: 5_000,
+        retry: false,
+    })
+
+    return {
+        status: query.data,
+        isLoading: query.isLoading,
+        error: query.error instanceof Error
+            ? query.error.message
+            : query.error
+                ? 'Failed to inspect Cursor chat store'
+                : null,
+    }
+}

--- a/web/src/hooks/queries/useCursorChatStoreStatus.ts
+++ b/web/src/hooks/queries/useCursorChatStoreStatus.ts
@@ -11,6 +11,7 @@ export function useCursorChatStoreStatus(args: {
     enabled?: boolean
 }): {
     status: CursorChatStoreStatus | undefined
+    isApplicable: boolean
     isLoading: boolean
     error: string | null
 } {
@@ -46,6 +47,7 @@ export function useCursorChatStoreStatus(args: {
 
     return {
         status: query.data,
+        isApplicable: shouldProbe,
         isLoading: query.isLoading,
         error: query.error instanceof Error
             ? query.error.message

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -159,6 +159,9 @@ export default {
   'session.action.export': 'Export conversation',
   'session.action.archive': 'Archive',
   'session.action.reopen': 'Reopen',
+  'session.action.reopenCursorChecking': 'Checking whether Cursor chat data is still available on the recorded machine.',
+  'session.action.reopenCursorMissing': 'Cursor chat data is no longer available on the recorded machine.',
+  'session.action.reopenCursorCheckFailed': 'Could not verify Cursor chat data on the recorded machine.',
   'session.action.delete': 'Delete',
   'session.action.copy': 'Copy',
 

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -159,6 +159,9 @@ export default {
   'session.action.export': '导出对话',
   'session.action.archive': '归档',
   'session.action.reopen': '重新打开',
+  'session.action.reopenCursorChecking': '正在检查记录设备上的 Cursor 聊天数据是否仍然可用。',
+  'session.action.reopenCursorMissing': '记录设备上的 Cursor 聊天数据已不可用。',
+  'session.action.reopenCursorCheckFailed': '无法验证记录设备上的 Cursor 聊天数据。',
   'session.action.delete': '删除',
   'session.action.copy': '复制',
 

--- a/web/src/lib/query-keys.ts
+++ b/web/src/lib/query-keys.ts
@@ -17,6 +17,7 @@ export const queryKeys = {
     slashCommands: (sessionId: string) => ['slash-commands', sessionId] as const,
     sessionCodexModels: (sessionId: string) => ['session-codex-models', sessionId] as const,
     sessionCursorModels: (sessionId: string) => ['session-cursor-models', sessionId] as const,
+    sessionCursorChatStore: (sessionId: string) => ['session-cursor-chat-store', sessionId] as const,
     sessionPiModels: (sessionId: string) => ['session-pi-models', sessionId] as const,
     machineCursorModels: (machineId: string) => ['machine-cursor-models', machineId] as const,
     sessionOpencodeModels: (sessionId: string) => ['session-opencode-models', sessionId] as const,

--- a/web/src/lib/sessionResume.test.ts
+++ b/web/src/lib/sessionResume.test.ts
@@ -67,6 +67,17 @@ describe('sessionResume', () => {
         }), 5)).toBe(true)
     })
 
+    it('rejects cursor resume when the recorded chat store is missing on its machine', () => {
+        expect(inactiveSessionCanResume(makeSession({
+            metadata: {
+                path: '/tmp/project',
+                host: 'localhost',
+                flavor: 'cursor',
+                cursorSessionId: 'cursor-thread-1',
+            },
+        }), 5, false)).toBe(false)
+    })
+
     it('resolveAgentSessionIdFromMetadata still returns cursorSessionId regardless of protocol', () => {
         expect(resolveAgentSessionIdFromMetadata({
             path: '/p',

--- a/web/src/lib/sessionResume.test.ts
+++ b/web/src/lib/sessionResume.test.ts
@@ -78,6 +78,17 @@ describe('sessionResume', () => {
         }), 5, false)).toBe(false)
     })
 
+    it('does not apply Cursor chat store status to other agent flavors', () => {
+        expect(inactiveSessionCanResume(makeSession({
+            metadata: {
+                path: '/tmp/project',
+                host: 'localhost',
+                flavor: 'codex',
+                codexSessionId: 'codex-thread-1',
+            },
+        }), 5, false)).toBe(true)
+    })
+
     it('resolveAgentSessionIdFromMetadata still returns cursorSessionId regardless of protocol', () => {
         expect(resolveAgentSessionIdFromMetadata({
             path: '/p',

--- a/web/src/lib/sessionResume.test.ts
+++ b/web/src/lib/sessionResume.test.ts
@@ -64,7 +64,18 @@ describe('sessionResume', () => {
                 flavor: 'cursor',
                 cursorSessionId: 'cursor-thread-1',
             },
-        }), 5)).toBe(true)
+        }), 5, true)).toBe(true)
+    })
+
+    it('conservatively rejects cursor resume until the chat store is verified', () => {
+        expect(inactiveSessionCanResume(makeSession({
+            metadata: {
+                path: '/tmp/project',
+                host: 'localhost',
+                flavor: 'cursor',
+                cursorSessionId: 'cursor-thread-1',
+            },
+        }), 5)).toBe(false)
     })
 
     it('rejects cursor resume when the recorded chat store is missing on its machine', () => {

--- a/web/src/lib/sessionResume.ts
+++ b/web/src/lib/sessionResume.ts
@@ -34,6 +34,7 @@ export function resolveAgentSessionIdFromMetadata(
 export function inactiveSessionCanResume(
     session: Session,
     userMessageCount: number,
+    cursorChatOnDisk?: boolean,
 ): boolean {
     if (session.active) {
         return true
@@ -42,6 +43,10 @@ export function inactiveSessionCanResume(
         return false
     }
     if (resolveAgentSessionIdFromMetadata(session.metadata)) {
+        const flavor = isKnownFlavor(session.metadata.flavor) ? session.metadata.flavor : 'claude'
+        if (flavor === 'cursor' && cursorChatOnDisk === false) {
+            return false
+        }
         return true
     }
     const flavor = isKnownFlavor(session.metadata.flavor) ? session.metadata.flavor : 'claude'

--- a/web/src/lib/sessionResume.ts
+++ b/web/src/lib/sessionResume.ts
@@ -44,8 +44,8 @@ export function inactiveSessionCanResume(
     }
     if (resolveAgentSessionIdFromMetadata(session.metadata)) {
         const flavor = isKnownFlavor(session.metadata.flavor) ? session.metadata.flavor : 'claude'
-        if (flavor === 'cursor' && cursorChatOnDisk === false) {
-            return false
+        if (flavor === 'cursor') {
+            return cursorChatOnDisk === true
         }
         return true
     }

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -28,6 +28,7 @@ import { useSidebarResize } from '@/hooks/useSidebarResize'
 import { useMessages } from '@/hooks/queries/useMessages'
 import { useMachines } from '@/hooks/queries/useMachines'
 import { useSession } from '@/hooks/queries/useSession'
+import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStatus'
 import { useSessions } from '@/hooks/queries/useSessions'
 import { useSlashCommands } from '@/hooks/queries/useSlashCommands'
 import { useSkills } from '@/hooks/queries/useSkills'
@@ -632,6 +633,7 @@ function SessionPage() {
         error: sessionError,
         refetch: refetchSession,
     } = useSession(api, sessionId)
+    const { status: cursorChatStoreStatus } = useCursorChatStoreStatus({ api, session })
     const {
         messages,
         pendingMessages,
@@ -781,7 +783,7 @@ function SessionPage() {
             if (!api || !session || session.active) {
                 return currentSessionId
             }
-            if (!inactiveSessionCanResume(session, messages.length)) {
+            if (!inactiveSessionCanResume(session, messages.length, cursorChatStoreStatus?.onDisk)) {
                 // #918: surface as a session_inactive ApiError so the
                 // onError consumer's classifier renders the Reopen
                 // affordance.  `status: 409` mirrors the hub guard for
@@ -918,6 +920,7 @@ function SessionPage() {
         <SessionChat
             api={api}
             session={session}
+            cursorChatOnDisk={cursorChatStoreStatus?.onDisk}
             messages={messages}
             pendingMessages={pendingMessages}
             messagesWarning={messagesWarning}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -633,7 +633,11 @@ function SessionPage() {
         error: sessionError,
         refetch: refetchSession,
     } = useSession(api, sessionId)
-    const { status: cursorChatStoreStatus } = useCursorChatStoreStatus({ api, session })
+    const {
+        status: cursorChatStoreStatus,
+        isApplicable: cursorChatStoreApplicable,
+        error: cursorChatStoreError,
+    } = useCursorChatStoreStatus({ api, session })
     const {
         messages,
         pendingMessages,
@@ -729,6 +733,16 @@ function SessionPage() {
         })()
     }, [api, queryClient, navigate, addToast, t])
 
+    const cursorReopenDisabledReason = cursorChatStoreApplicable && cursorChatStoreStatus?.onDisk !== true
+        ? cursorChatStoreError
+            ? t('session.action.reopenCursorCheckFailed')
+            : cursorChatStoreStatus?.onDisk === false
+                ? t('session.action.reopenCursorMissing')
+                : t('session.action.reopenCursorChecking')
+        : undefined
+    const canOfferInactiveReopen = session
+        ? inactiveSessionCanResume(session, messages.length, cursorChatStoreStatus?.onDisk)
+        : false
     const rawSendError = sendErrors[sessionId] ?? null
     const sendError: ComposerSendError | null = rawSendError
         ? {
@@ -736,7 +750,7 @@ function SessionPage() {
             text: rawSendError.text,
             message: rawSendError.message,
             scheduledAt: rawSendError.scheduledAt,
-            action: rawSendError.code === 'session_inactive'
+            action: rawSendError.code === 'session_inactive' && canOfferInactiveReopen
                 ? {
                     label: t('chat.sendError.sessionInactive.action'),
                     onClick: () => reopenFromErrorAffordance(sessionId),
@@ -921,6 +935,7 @@ function SessionPage() {
             api={api}
             session={session}
             cursorChatOnDisk={cursorChatStoreStatus?.onDisk}
+            reopenDisabledReason={cursorReopenDisabledReason}
             messages={messages}
             pendingMessages={pendingMessages}
             messagesWarning={messagesWarning}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -14,6 +14,7 @@ export type {
     CommandResponse,
     CursorModelsResponse,
     CursorModelSummary,
+    CursorChatStoreStatus,
     DeleteUploadResponse,
     DirectoryEntry,
     FileReadResponse,


### PR DESCRIPTION
Closes #841

## Summary
- add a machine-scoped Cursor chat-store status RPC and session API for ACP and legacy stores
- guard backend reopen/resume when the recorded Cursor store is missing
- conservatively disable Reopen while status is unknown or unavailable, with an explanatory tooltip
- preserve existing resume behavior for non-Cursor agents

## Root cause
Cursor resume eligibility was derived only from session metadata. It did not verify that the native Cursor `store.db` still existed on the machine that owned the session, so the UI offered a Reopen action that could not succeed.

## Test plan
- [x] regression test added before the implementation
- [x] ACP/legacy discovery, machine routing, failure, UI gating, and non-Cursor coverage added
- [x] focused CLI, hub, and web tests pass
- [x] `bun typecheck && bun run test`
- [x] real E2E: created a Cursor ACP session and `store.db`, archived it, verified Reopen enabled, deleted the store, then verified status `onDisk: false`, backend `409 resume_unavailable`, and disabled browser action with tooltip
