### PR TITLE
fix(web): distinguish worktree sessions in sidebar

### DIFF
--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -61,6 +61,23 @@ describe('getWorktreeSessionLabel', () => {
 
         expect(getWorktreeSessionLabel(session)).toBeNull()
     })
+
+    it('falls back to the worktree directory name when metadata name is blank', () => {
+        const session = makeSession({
+            id: 'windows-worktree-session',
+            metadata: {
+                path: 'C:\\work\\hapi-worktrees\\fix-resume',
+                worktree: {
+                    basePath: 'C:\\work\\hapi',
+                    branch: 'fix/resume',
+                    name: '   ',
+                    worktreePath: 'C:\\work\\hapi-worktrees\\fix-resume\\'
+                }
+            }
+        })
+
+        expect(getWorktreeSessionLabel(session)).toBe('fix-resume')
+    })
 })
 
 describe('deduplicateSessionsByAgentId', () => {

--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -288,6 +288,24 @@ describe('session list search helpers', () => {
         expect(sessionMatchesQuery(session, normalizeSearch('desktop'), 'desktop')).toBe(true)
         expect(sessionMatchesQuery(session, normalizeSearch('missing'), 'desktop')).toBe(false)
     })
+
+    it('matches the displayed worktree label and worktree path', () => {
+        const session = makeSession({
+            id: 'worktree-session',
+            metadata: {
+                path: '/work/hapi',
+                worktree: {
+                    basePath: '/work/hapi',
+                    branch: 'fix/sidebar-search',
+                    name: 'sidebar-search',
+                    worktreePath: '/work/hapi-worktrees/fix-sidebar-search'
+                }
+            }
+        })
+
+        expect(sessionMatchesQuery(session, normalizeSearch('sidebar-search'), 'desktop')).toBe(true)
+        expect(sessionMatchesQuery(session, normalizeSearch('hapi-worktrees'), 'desktop')).toBe(true)
+    })
 })
 
 describe('getVisibleSessionPreview', () => {

--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -6,6 +6,7 @@ import {
     filterActiveSessionsOnly,
     getNextSessionVisibleCount,
     getSessionDedupKey,
+    getWorktreeSessionLabel,
     getVisibleSessionPreview,
     isSidebarEmptySessionStub,
     normalizeSearch,
@@ -33,6 +34,34 @@ function makeSession(overrides: Partial<SessionSummary> & { id: string }): Sessi
         ...overrides
     }
 }
+
+describe('getWorktreeSessionLabel', () => {
+    it('returns the worktree name for sessions grouped under a shared repository', () => {
+        const session = makeSession({
+            id: 'worktree-session',
+            metadata: {
+                path: '/work/hapi-worktrees/fix-resume',
+                worktree: {
+                    basePath: '/work/hapi',
+                    branch: 'fix/resume',
+                    name: 'fix-resume',
+                    worktreePath: '/work/hapi-worktrees/fix-resume'
+                }
+            }
+        })
+
+        expect(getWorktreeSessionLabel(session)).toBe('fix-resume')
+    })
+
+    it('does not add a subtitle to ordinary sessions', () => {
+        const session = makeSession({
+            id: 'ordinary-session',
+            metadata: { path: '/work/hapi' }
+        })
+
+        expect(getWorktreeSessionLabel(session)).toBeNull()
+    })
+})
 
 describe('deduplicateSessionsByAgentId', () => {
     it('deduplicates sessions with the same agentSessionId', () => {

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -453,6 +453,22 @@ export function getSessionTitle(session: SessionSummary): string {
     return session.id.slice(0, 8)
 }
 
+export function getWorktreeSessionLabel(session: SessionSummary): string | null {
+    const worktree = session.metadata?.worktree
+    if (!worktree) {
+        return null
+    }
+
+    const name = worktree.name.trim()
+    if (name) {
+        return name
+    }
+
+    const path = (worktree.worktreePath ?? session.metadata?.path ?? '').replace(/[\\/]+$/, '')
+    const parts = path.split(/[\\/]+/).filter(Boolean)
+    return parts.at(-1) ?? null
+}
+
 function getTodoProgress(session: SessionSummary): { completed: number; total: number } | null {
     if (!session.todoProgress) return null
     if (session.todoProgress.completed === session.todoProgress.total) return null
@@ -626,6 +642,7 @@ function SessionItem(props: {
     })
 
     const sessionName = getSessionTitle(s)
+    const worktreeLabel = getWorktreeSessionLabel(s)
     const todoProgress = getTodoProgress(s)
     const attention = useMemo(
         () => showDetailedStatus
@@ -706,9 +723,14 @@ function SessionItem(props: {
                         </span>
                     </div>
                 </div>
-                {showPath ? (
-                    <div className="truncate text-xs text-[var(--app-hint)]">
-                        {s.metadata?.path ?? s.id}
+                {showPath || worktreeLabel ? (
+                    <div
+                        className="truncate text-xs text-[var(--app-hint)]"
+                        title={worktreeLabel
+                            ? s.metadata?.worktree?.worktreePath ?? s.metadata?.path
+                            : undefined}
+                    >
+                        {worktreeLabel ?? s.metadata?.path ?? s.id}
                     </div>
                 ) : null}
             </button>

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -483,9 +483,11 @@ export function sessionMatchesQuery(session: SessionSummary, query: string, mach
     if (!query) return true
     const searchable = [
         getSessionTitle(session),
+        getWorktreeSessionLabel(session),
         session.id,
         session.metadata?.path,
         session.metadata?.worktree?.basePath,
+        session.metadata?.worktree?.worktreePath,
         session.metadata?.name,
         session.metadata?.summary?.text,
         session.metadata?.flavor,


### PR DESCRIPTION
Closes #782

## Summary
- show each worktree session's worktree name as a secondary sidebar label while keeping sessions grouped under the base repository
- fall back to the worktree path basename when metadata has no usable name
- keep the complete worktree path available through the label title

## Root cause
The grouped session row rendered only the session title when `showPath` was false, so sibling worktree sessions could not be distinguished reliably.

## Test plan
- [x] regression test added before the implementation
- [x] fallback-path coverage added after green
- [x] focused SessionList tests pass
- [x] `bun typecheck && bun run test`
- [x] real E2E: source hub/runner created a real Codex worktree session; Chromium verified the visible label and full-path title
