### PR TITLE
feat(opencode): accept -s/--session as resume aliases

### DIFF
--- a/cli/src/commands/agentCommandOptions.test.ts
+++ b/cli/src/commands/agentCommandOptions.test.ts
@@ -68,6 +68,30 @@ describe('parseRemoteAgentCommandOptions', () => {
         expect(() => parseRemoteAgentCommandOptions(['--model'], OPENCODE_PERMISSION_MODES)).toThrow('Missing --model value')
         expect(() => parseRemoteAgentCommandOptions(['--model-reasoning-effort'], OPENCODE_PERMISSION_MODES)).toThrow('Missing --model-reasoning-effort value')
     })
+
+    it('accepts OpenCode-native -s / --session as resume aliases', () => {
+        expect(parseRemoteAgentCommandOptions(
+            ['-s', 'opencode-sess-1'],
+            OPENCODE_PERMISSION_MODES
+        ).resumeSessionId).toBe('opencode-sess-1')
+
+        expect(parseRemoteAgentCommandOptions(
+            ['--session', 'opencode-sess-2'],
+            OPENCODE_PERMISSION_MODES
+        ).resumeSessionId).toBe('opencode-sess-2')
+    })
+
+    it('rejects -s / --session with no value', () => {
+        expect(() => parseRemoteAgentCommandOptions(['-s'], OPENCODE_PERMISSION_MODES)).toThrow('Missing -s value')
+        expect(() => parseRemoteAgentCommandOptions(['--session'], OPENCODE_PERMISSION_MODES)).toThrow('Missing --session value')
+    })
+
+    it('a later -s overrides a prior --resume (last-write-wins)', () => {
+        expect(parseRemoteAgentCommandOptions(
+            ['--resume', 'first', '-s', 'second'],
+            OPENCODE_PERMISSION_MODES
+        ).resumeSessionId).toBe('second')
+    })
 })
 
 describe('parseRemoteAgentCommandOptions — pi flavor', () => {

--- a/cli/src/commands/agentCommandOptions.ts
+++ b/cli/src/commands/agentCommandOptions.ts
@@ -43,6 +43,13 @@ export function parseRemoteAgentCommandOptions<TPermissionMode extends Permissio
                 throw new Error('Missing --resume value')
             }
             options.resumeSessionId = sessionId
+        } else if (arg === '-s' || arg === '--session') {
+            // OpenCode-native resume flags (hapi opencode -s / --session <id>)
+            const sessionId = args[++i]
+            if (!sessionId) {
+                throw new Error(`Missing ${arg} value`)
+            }
+            options.resumeSessionId = sessionId
         } else if (arg === '--session-id') {
             // Pi uses --session-id for exact session resume (RPC mode)
             const sessionId = args[++i]


### PR DESCRIPTION
## Summary
- Accept OpenCode-native -s / --session <id> as aliases for --resume, mapping them to resumeSessionId
- Makes alias opencode="hapi opencode" work with the familiar opencode -s <id> resume flow
- Local still spawns opencode --session <id>; remote keeps the existing ACP session/load path

## Motivation
Many users alias OpenCode through HAPI:
```bash
alias opencode="hapi opencode"
```
OpenCode’s native resume flags are `-s / --session`, but HAPI previously only accepted `--resume`, so -s was ignored under that alias. This change adds OpenCode-native flag compatibility.

## Usage
```bash
hapi opencode -s <opencodeSessionId>
hapi opencode --session <opencodeSessionId>
hapi opencode --resume <opencodeSessionId> # still supported
```