### PR TITLE
fix(web): extend hover-reveal info affordance to touch devices

### DIFF
--- a/web/src/components/AssistantChat/messages/MessageActions.test.tsx
+++ b/web/src/components/AssistantChat/messages/MessageActions.test.tsx
@@ -67,4 +67,53 @@ describe('MessageActions', () => {
 
         expect(screen.queryByRole('button', { name: 'Message details' })).toBeNull()
     })
+
+    it('keeps the info button reachable on touch devices (no hover-only class)', () => {
+        renderActions({
+            align: 'start',
+            copyText: 'message body',
+            metadata: { durationMs: 1250, model: 'gpt-5.2-codex' }
+        })
+
+        const button = screen.getByRole('button', { name: 'Message details' })
+        expect(button.className.split(' ')).not.toContain('happy-message-actions-desktop-only')
+    })
+
+    it('keeps the action row reachable on touch devices for tool-only messages with metadata', () => {
+        // Tool-only assistant turns (no trailing text) have no copyText, but
+        // can still carry model/duration metadata from the first tool block
+        // in the response group (see assistant-runtime.ts toThreadMessageLike).
+        renderActions({
+            align: 'start',
+            copyText: undefined,
+            metadata: { durationMs: 1250, model: 'gpt-5.2-codex' }
+        })
+
+        const button = screen.getByRole('button', { name: 'Message details' })
+        const row = button.closest('.happy-message-actions')
+        expect(row).not.toBeNull()
+        expect(row!.className.split(' ')).not.toContain('happy-message-actions-desktop-only-row')
+    })
+
+    it('keeps the timestamp reachable on touch devices (no hover-only class)', () => {
+        renderActions({ align: 'start', copyText: 'message body' })
+
+        const time = document.querySelector('time')
+        expect(time).not.toBeNull()
+        const wrapper = time!.parentElement!
+        expect(wrapper.className.split(' ')).not.toContain('happy-message-actions-desktop-only')
+    })
+
+    it('keeps the row reachable on touch devices even with neither copy text nor metadata (timestamp-only row)', () => {
+        // DesktopTimestamp always renders inside the row regardless of
+        // canCopy/hasMetadata, so the row is never actually empty -- hiding
+        // it via the hover-only row class would hide a real timestamp.
+        renderActions({ align: 'end', copyText: undefined, metadata: undefined })
+
+        const time = document.querySelector('time')
+        expect(time).not.toBeNull()
+        const row = time!.closest('.happy-message-actions')
+        expect(row).not.toBeNull()
+        expect(row!.className.split(' ')).not.toContain('happy-message-actions-desktop-only-row')
+    })
 })

--- a/web/src/components/AssistantChat/messages/MessageActions.tsx
+++ b/web/src/components/AssistantChat/messages/MessageActions.tsx
@@ -22,8 +22,7 @@ export function MessageActions({ align, copyText, metadata }: MessageActionsProp
         <div
             className={cn(
                 'happy-message-actions mt-1 flex h-5 items-center gap-1',
-                align === 'end' ? 'justify-end' : 'justify-start',
-                !canCopy && 'happy-message-actions-desktop-only-row'
+                align === 'end' ? 'justify-end' : 'justify-start'
             )}
         >
             {align === 'end' ? <DesktopTimestamp /> : null}
@@ -46,7 +45,7 @@ export function MessageActions({ align, copyText, metadata }: MessageActionsProp
 
 function DesktopTimestamp() {
     return (
-        <span className="happy-message-actions-desktop-only ml-1 items-center">
+        <span className="inline-flex ml-1 items-center">
             <MessageTimestamp className="text-[10px] leading-none text-[var(--app-hint)]" />
         </span>
     )
@@ -61,7 +60,7 @@ function MessageInfoPopover({ metadata }: { metadata: Omit<MessageMetadataProps,
                     type="button"
                     title={t('message.info')}
                     aria-label={t('message.info')}
-                    className="happy-message-actions-desktop-only h-5 w-5 items-center justify-center rounded text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
+                    className="flex h-5 w-5 items-center justify-center rounded text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
                 >
                     <InfoIcon className="h-3.5 w-3.5" />
                 </button>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -433,11 +433,6 @@ body {
     margin-top: max(0px, calc((var(--app-chat-line-height) - var(--app-message-action-size)) / 2));
 }
 
-.happy-message-actions-desktop-only,
-.happy-message-actions-desktop-only-row {
-    display: none;
-}
-
 @media (hover: hover) and (pointer: fine) {
     .happy-message-actions {
         opacity: 0;
@@ -449,14 +444,6 @@ body {
     .happy-message:focus-within .happy-message-actions {
         opacity: 1;
         pointer-events: auto;
-    }
-
-    .happy-message-actions-desktop-only {
-        display: inline-flex;
-    }
-
-    .happy-message-actions-desktop-only-row {
-        display: flex;
     }
 }
 


### PR DESCRIPTION
### Problem

`4c76668a` moved the per-message model/duration/token popover (and the message timestamp) into a hover-reveal affordance alongside the copy button, which is a nice density win on desktop. On touch-only viewports there's no `hover` state to trigger though, so the info button and timestamp never render at all -- there's no way to reach the model/duration/token details, or even see when a regular assistant reply was sent, from a phone.

A related edge case: a response made up entirely of tool calls (no trailing text) has nothing to copy, and the action row for that case was also gated behind the same hover-only visibility, so even a tap-reachable info button would have been hidden behind an invisible row.

### Solution

Give the info trigger and the timestamp the same always-visible treatment the copy button already uses, so they participate in the parent row's existing hover-reveal opacity transition on desktop instead of being unconditionally hidden. Since the timestamp is now always present in the row regardless of whether there's copy text or metadata, the row itself is never actually empty of content, so the row-level hover-only gate is removed too -- keeping it around would have kept hiding a real timestamp on touch devices for messages with neither copy text nor metadata (e.g. a captionless attachment). That leaves the two `happy-message-actions-desktop-only*` CSS classes with no remaining consumers, so they're dropped from `index.css` along with the affordance change.

Desktop behavior is unchanged -- the row still fades in on hover/focus via the existing `.happy-message-actions` opacity rule (governed by `opacity`/`pointer-events`, not `display`, so there's no new empty-box artifact pre-hover). Mobile now shows the copy icon, info icon, and timestamp inline at all times, and tapping the info icon opens the same popover as a desktop click.

### Tests

Added four Vitest cases to `MessageActions.test.tsx`: the info button no longer carries the hover-only class, the timestamp no longer carries the hover-only class, the action row stays reachable for a tool-only response that still carries display metadata, and the row stays reachable even with neither copy text nor metadata (timestamp-only). Full workspace suite (`bun run test`) and `bun typecheck` pass unchanged.

Manually verified end-to-end on both desktop and mobile (iPhone 13) viewports against an isolated hub -- the info button and timestamp are invisible pre-fix on mobile and visible post-fix, and tapping the info icon opens the popover with duration/model/usage; desktop hover-reveal behavior is unaffected.

### Screenshots

| Mobile -- before (bug: no info button, no timestamp) | Mobile -- after (both reachable) |
|---|---|
| ![before-mobile-view.png](https://github.com/user-attachments/assets/b9f86640-74b9-4507-81d6-5514ef21f976) | ![after-mobile-view.png](https://github.com/user-attachments/assets/e6fec29a-b075-46c9-aea8-c05cd1e72e5b) |

| Mobile -- tapping the info icon opens the popover | Desktop -- before hover (unchanged) |
|---|---|
| ![after-mobile-popover-open.png](https://github.com/user-attachments/assets/dc8722cc-cace-4a85-9c09-9632a4f51f42) | ![after-desktop-before-hover.png](https://github.com/user-attachments/assets/30cebd81-b9a8-4f51-9401-0ff95dc20e02) |

| Desktop -- after hover (unchanged) | Desktop -- popover open (unchanged) |
|---|---|
| ![after-desktop-after-hover.png](https://github.com/user-attachments/assets/37b0ee14-0d5c-4cee-a8ec-669d0a5fe369) | ![after-desktop-popover-open.png](https://github.com/user-attachments/assets/7b96593a-3e9a-4acf-99f7-16cddb16bb2a) |
