### PR TITLE
fix(web): local-mode permission UX + stop OpenCode 500 spam

### DIFF
--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -244,6 +244,7 @@ export function HappyThread(props: {
     sessionId: string
     metadata: SessionMetadataSummary | null
     disabled: boolean
+    controlledByUser?: boolean
     onRefresh: () => void
     onRetryMessage?: (localId: string) => void
     onFlushPending: () => void
@@ -680,6 +681,7 @@ export function HappyThread(props: {
             metadata: props.metadata,
             terminalToolDisplayMode,
             disabled: props.disabled,
+            controlledByUser: props.controlledByUser === true,
             onRefresh: props.onRefresh,
             onRetryMessage: props.onRetryMessage,
             hasMoreMessages: props.hasMoreMessages,

--- a/web/src/components/AssistantChat/context.tsx
+++ b/web/src/components/AssistantChat/context.tsx
@@ -10,6 +10,7 @@ export type HappyChatContextValue = {
     metadata: SessionMetadataSummary | null
     terminalToolDisplayMode: TerminalToolDisplayMode
     disabled: boolean
+    controlledByUser?: boolean
     onRefresh: () => void
     onRetryMessage?: (localId: string) => void
     hasMoreMessages: boolean

--- a/web/src/components/AssistantChat/messages/ToolMessage.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.tsx
@@ -205,7 +205,8 @@ function HappyNestedBlockList(props: {
                                 sessionId={ctx.sessionId}
                                 metadata={ctx.metadata}
                                 terminalToolDisplayMode={ctx.terminalToolDisplayMode}
-                                disabled={ctx.disabled}
+                                disabled={ctx.disabled || ctx.controlledByUser === true}
+                                controlledByUser={ctx.controlledByUser === true}
                                 onDone={ctx.onRefresh}
                                 block={block}
                             />
@@ -316,7 +317,8 @@ export function HappyToolMessage(props: ToolCallMessagePartProps) {
                 sessionId={ctx.sessionId}
                 metadata={ctx.metadata}
                 terminalToolDisplayMode={ctx.terminalToolDisplayMode}
-                disabled={ctx.disabled}
+                disabled={ctx.disabled || ctx.controlledByUser === true}
+                controlledByUser={ctx.controlledByUser === true}
                 onDone={ctx.onRefresh}
                 block={block}
             />

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -583,12 +583,13 @@ function SessionChatInner(props: SessionChatProps) {
     const opencodeModelsState = useOpencodeModels({
         api: props.api,
         sessionId: props.session.id,
-        enabled: agentFlavor === 'opencode' && props.session.active
+        // Local mode has no session RPC handlers for models/effort lists.
+        enabled: agentFlavor === 'opencode' && props.session.active && !controlledByUser
     })
     const opencodeReasoningEffortState = useOpencodeReasoningEffortOptions({
         api: props.api,
         sessionId: props.session.id,
-        enabled: agentFlavor === 'opencode' && props.session.active
+        enabled: agentFlavor === 'opencode' && props.session.active && !controlledByUser
     })
     const opencodeModelOptions = useMemo(() => {
         if (agentFlavor !== 'opencode') {

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -786,15 +786,23 @@ function SessionChatInner(props: SessionChatProps) {
             getSession: () => props.session as { agentState?: { requests?: Record<string, unknown> } } | null,
             sendMessage: (_sessionId: string, message: string) => props.onSend(message),
             approvePermission: async (_sessionId: string, requestId: string) => {
+                // Local mode has no permission RPC / reverse channel; refuse rather than
+                // letting voice tools look like remote approval succeeded.
+                if (props.session.agentState?.controlledByUser === true) {
+                    throw new Error(t('tool.waitingForLocalApproval'))
+                }
                 await props.api.approvePermission(props.session.id, requestId)
                 props.onRefresh()
             },
             denyPermission: async (_sessionId: string, requestId: string) => {
+                if (props.session.agentState?.controlledByUser === true) {
+                    throw new Error(t('tool.waitingForLocalApproval'))
+                }
                 await props.api.denyPermission(props.session.id, requestId)
                 props.onRefresh()
             }
         })
-    }, [props.session, props.api, props.onSend, props.onRefresh])
+    }, [props.session, props.api, props.onSend, props.onRefresh, t])
 
     useEffect(() => {
         registerVoiceHooksStore(
@@ -839,6 +847,12 @@ function SessionChatInner(props: SessionChatProps) {
         const requests = props.session.agentState?.requests ?? {}
         const currentIds = new Set(Object.keys(requests))
 
+        // Local-mode permissions are terminal-only; do not prompt voice to approve them.
+        if (props.session.agentState?.controlledByUser === true) {
+            prevRequestIdsRef.current = currentIds
+            return
+        }
+
         for (const [requestId, request] of Object.entries(requests)) {
             if (!prevRequestIdsRef.current.has(requestId)) {
                 voiceHooks.onPermissionRequested(
@@ -851,7 +865,7 @@ function SessionChatInner(props: SessionChatProps) {
         }
 
         prevRequestIdsRef.current = currentIds
-    }, [props.session.agentState?.requests, props.session.id])
+    }, [props.session.agentState?.requests, props.session.agentState?.controlledByUser, props.session.id])
 
     const handleVoiceToggle = useCallback(async () => {
         if (!voice) return
@@ -1265,6 +1279,7 @@ function SessionChatInner(props: SessionChatProps) {
                         sessionId={props.session.id}
                         metadata={props.session.metadata}
                         disabled={sessionInactive}
+                        controlledByUser={controlledByUser}
                         onRefresh={props.onRefresh}
                         onRetryMessage={props.onRetryMessage}
                         onFlushPending={props.onFlushPending}

--- a/web/src/components/ToolCard/AskUserQuestionFooter.tsx
+++ b/web/src/components/ToolCard/AskUserQuestionFooter.tsx
@@ -88,6 +88,7 @@ export function AskUserQuestionFooter(props: {
     sessionId: string
     tool: ChatToolCall
     disabled: boolean
+    controlledByUser?: boolean
     onDone: () => void
 }) {
     const { t } = useTranslation()
@@ -122,6 +123,16 @@ export function AskUserQuestionFooter(props: {
 
     if (!permission || permission.status !== 'pending') return null
     if (!isAskUserQuestionToolName(props.tool.name)) return null
+
+    if (props.controlledByUser === true) {
+        return (
+            <div className="rounded-2xl border border-[var(--app-border)] bg-[var(--app-bg)] p-3">
+                <div className="text-xs font-medium text-[var(--app-hint)]">
+                    {t('tool.waitingForLocalApproval')}
+                </div>
+            </div>
+        )
+    }
 
     const run = async (action: () => Promise<void>, hapticType: 'success' | 'error') => {
         if (props.disabled) return

--- a/web/src/components/ToolCard/PermissionFooter.test.tsx
+++ b/web/src/components/ToolCard/PermissionFooter.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import type { ChatToolCall } from '@/chat/types'
+import { PermissionFooter } from '@/components/ToolCard/PermissionFooter'
+import { I18nProvider } from '@/lib/i18n-context'
+
+function renderWithI18n(ui: ReactElement) {
+    return render(<I18nProvider>{ui}</I18nProvider>)
+}
+
+function makeTool(overrides?: Partial<ChatToolCall>): ChatToolCall {
+    return {
+        id: 'tool-1',
+        name: 'Bash',
+        state: 'running',
+        input: { command: 'ls' },
+        createdAt: 0,
+        startedAt: 0,
+        completedAt: null,
+        execStartedAt: null,
+        execCompletedAt: null,
+        description: null,
+        result: null,
+        permission: {
+            id: 'perm-1',
+            status: 'pending',
+        },
+        ...overrides,
+    }
+}
+
+describe('PermissionFooter local mode', () => {
+    it('hides remote approval actions and explains local-only approval', () => {
+        const approvePermission = vi.fn()
+        const denyPermission = vi.fn()
+
+        renderWithI18n(
+            <PermissionFooter
+                api={{ approvePermission, denyPermission } as never}
+                sessionId="session-1"
+                metadata={{ path: 'repo', host: 'local', flavor: 'opencode' }}
+                tool={makeTool()}
+                disabled={false}
+                controlledByUser
+                onDone={vi.fn()}
+            />
+        )
+
+        expect(screen.getByText('Approve this in the local terminal, or switch to remote mode first.')).toBeTruthy()
+        expect(screen.queryByRole('button', { name: 'Allow' })).toBeNull()
+        expect(screen.queryByRole('button', { name: 'Deny' })).toBeNull()
+        expect(approvePermission).not.toHaveBeenCalled()
+        expect(denyPermission).not.toHaveBeenCalled()
+    })
+
+    it('shows remote approval actions when not controlled by user', () => {
+        renderWithI18n(
+            <PermissionFooter
+                api={{ approvePermission: vi.fn(), denyPermission: vi.fn() } as never}
+                sessionId="session-1"
+                metadata={{ path: 'repo', host: 'local', flavor: 'opencode' }}
+                tool={makeTool()}
+                disabled={false}
+                controlledByUser={false}
+                onDone={vi.fn()}
+            />
+        )
+
+        expect(screen.getByRole('button', { name: 'Yes' })).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Yes For Session' })).toBeTruthy()
+        expect(screen.getByRole('button', { name: 'Abort' })).toBeTruthy()
+    })
+})

--- a/web/src/components/ToolCard/PermissionFooter.tsx
+++ b/web/src/components/ToolCard/PermissionFooter.tsx
@@ -101,6 +101,7 @@ export function PermissionFooter(props: {
     metadata: SessionMetadataSummary | null
     tool: ChatToolCall
     disabled: boolean
+    controlledByUser?: boolean
     onDone: () => void
 }) {
     const { t } = useTranslation()
@@ -118,9 +119,11 @@ export function PermissionFooter(props: {
 
     const summary = formatPermissionSummary(permission, props.tool.name, props.tool.input, codex, t)
     const isPending = permission.status === 'pending'
+    const localOnly = props.controlledByUser === true
+    const actionsDisabled = props.disabled || localOnly
 
     const run = async (action: () => Promise<void>, hapticType: 'success' | 'error') => {
-        if (props.disabled) return
+        if (actionsDisabled) return
         setError(null)
         try {
             await action()
@@ -217,7 +220,9 @@ export function PermissionFooter(props: {
 
     return (
         <div className="rounded-2xl border border-[var(--app-border)] bg-[var(--app-bg)] p-3">
-            <div className="text-xs font-medium text-[var(--app-hint)]">{summary}</div>
+            <div className="text-xs font-medium text-[var(--app-hint)]">
+                {localOnly ? t('tool.waitingForLocalApproval') : summary}
+            </div>
 
             {error ? (
                 <div className="mt-2 rounded-xl border border-[var(--app-badge-error-border)] bg-[var(--app-badge-error-bg)] px-3 py-2 text-xs text-[var(--app-badge-error-text)]">
@@ -225,68 +230,70 @@ export function PermissionFooter(props: {
                 </div>
             ) : null}
 
-            <div className="mt-3 flex flex-col gap-1.5">
-                {codex ? (
-                    <>
-                        <PermissionRowButton
-                            label={t('tool.yes')}
-                            tone="allow"
-                            loading={loading === 'allow'}
-                            disabled={props.disabled || loading !== null || loadingForSession}
-                            onClick={() => codexApprove('approved')}
-                        />
-                        <PermissionRowButton
-                            label={t('tool.yesForSession')}
-                            tone="muted"
-                            loading={loadingForSession}
-                            disabled={props.disabled || loading !== null || loadingForSession}
-                            onClick={() => codexApprove('approved_for_session')}
-                        />
-                        <PermissionRowButton
-                            label={t('tool.abortLabel')}
-                            tone="deny"
-                            loading={loading === 'abort'}
-                            disabled={props.disabled || loading !== null || loadingForSession}
-                            onClick={codexAbort}
-                        />
-                    </>
-                ) : (
-                    <>
-                        <PermissionRowButton
-                            label={t('tool.allow')}
-                            tone="allow"
-                            loading={loading === 'allow'}
-                            disabled={props.disabled || loading !== null || loadingAllEdits || loadingForSession}
-                            onClick={approve}
-                        />
-                        {canAllowForSession ? (
+            {!localOnly ? (
+                <div className="mt-3 flex flex-col gap-1.5">
+                    {codex ? (
+                        <>
                             <PermissionRowButton
-                                label={t('tool.allowForSession')}
+                                label={t('tool.yes')}
+                                tone="allow"
+                                loading={loading === 'allow'}
+                                disabled={actionsDisabled || loading !== null || loadingForSession}
+                                onClick={() => codexApprove('approved')}
+                            />
+                            <PermissionRowButton
+                                label={t('tool.yesForSession')}
                                 tone="muted"
                                 loading={loadingForSession}
-                                disabled={props.disabled || loading !== null || loadingAllEdits || loadingForSession}
-                                onClick={approveForSession}
+                                disabled={actionsDisabled || loading !== null || loadingForSession}
+                                onClick={() => codexApprove('approved_for_session')}
                             />
-                        ) : null}
-                        {canAllowAllEdits ? (
                             <PermissionRowButton
-                                label={t('tool.allowAll')}
-                                tone="muted"
-                                loading={loadingAllEdits}
-                                disabled={props.disabled || loading !== null || loadingAllEdits || loadingForSession}
-                                onClick={approveAllEdits}
+                                label={t('tool.abortLabel')}
+                                tone="deny"
+                                loading={loading === 'abort'}
+                                disabled={actionsDisabled || loading !== null || loadingForSession}
+                                onClick={codexAbort}
                             />
-                        ) : null}
-                        <PermissionRowButton
-                            label={t('tool.deny')}
-                            tone="deny"
-                            loading={loading === 'deny'}
-                            disabled={props.disabled || loading !== null || loadingAllEdits || loadingForSession}
-                            onClick={deny}
-                        />
-                    </>
-                )}
-            </div>
+                        </>
+                    ) : (
+                        <>
+                            <PermissionRowButton
+                                label={t('tool.allow')}
+                                tone="allow"
+                                loading={loading === 'allow'}
+                                disabled={actionsDisabled || loading !== null || loadingAllEdits || loadingForSession}
+                                onClick={approve}
+                            />
+                            {canAllowForSession ? (
+                                <PermissionRowButton
+                                    label={t('tool.allowForSession')}
+                                    tone="muted"
+                                    loading={loadingForSession}
+                                    disabled={actionsDisabled || loading !== null || loadingAllEdits || loadingForSession}
+                                    onClick={approveForSession}
+                                />
+                            ) : null}
+                            {canAllowAllEdits ? (
+                                <PermissionRowButton
+                                    label={t('tool.allowAll')}
+                                    tone="muted"
+                                    loading={loadingAllEdits}
+                                    disabled={actionsDisabled || loading !== null || loadingAllEdits || loadingForSession}
+                                    onClick={approveAllEdits}
+                                />
+                            ) : null}
+                            <PermissionRowButton
+                                label={t('tool.deny')}
+                                tone="deny"
+                                loading={loading === 'deny'}
+                                disabled={actionsDisabled || loading !== null || loadingAllEdits || loadingForSession}
+                                onClick={deny}
+                            />
+                        </>
+                    )}
+                </div>
+            ) : null}
         </div>
     )
 }

--- a/web/src/components/ToolCard/RequestUserInputFooter.tsx
+++ b/web/src/components/ToolCard/RequestUserInputFooter.tsx
@@ -69,6 +69,7 @@ export function RequestUserInputFooter(props: {
     sessionId: string
     tool: ChatToolCall
     disabled: boolean
+    controlledByUser?: boolean
     onDone: () => void
 }) {
     const { t } = useTranslation()
@@ -96,6 +97,16 @@ export function RequestUserInputFooter(props: {
 
     if (!permission || permission.status !== 'pending') return null
     if (!isRequestUserInputToolName(props.tool.name)) return null
+
+    if (props.controlledByUser === true) {
+        return (
+            <div className="rounded-2xl border border-[var(--app-border)] bg-[var(--app-bg)] p-3">
+                <div className="text-xs font-medium text-[var(--app-hint)]">
+                    {t('tool.waitingForLocalApproval')}
+                </div>
+            </div>
+        )
+    }
 
     const run = async (action: () => Promise<void>, hapticType: 'success' | 'error') => {
         if (props.disabled) return

--- a/web/src/components/ToolCard/ToolCard.tsx
+++ b/web/src/components/ToolCard/ToolCard.tsx
@@ -261,6 +261,7 @@ type ToolCardProps = {
     metadata: SessionMetadataSummary | null
     terminalToolDisplayMode: TerminalToolDisplayMode
     disabled: boolean
+    controlledByUser?: boolean
     onDone: () => void
     block: ToolCallBlock
 }
@@ -492,6 +493,7 @@ function ToolCardInner(props: ToolCardProps) {
                             sessionId={props.sessionId}
                             tool={props.block.tool}
                             disabled={props.disabled}
+                            controlledByUser={props.controlledByUser === true}
                             onDone={props.onDone}
                         />
                     ) : isRequestUserInput && permission?.status === 'pending' ? (
@@ -500,6 +502,7 @@ function ToolCardInner(props: ToolCardProps) {
                             sessionId={props.sessionId}
                             tool={props.block.tool}
                             disabled={props.disabled}
+                            controlledByUser={props.controlledByUser === true}
                             onDone={props.onDone}
                         />
                     ) : (
@@ -509,6 +512,7 @@ function ToolCardInner(props: ToolCardProps) {
                             metadata={props.metadata}
                             tool={props.block.tool}
                             disabled={props.disabled}
+                            controlledByUser={props.controlledByUser === true}
                             onDone={props.onDone}
                         />
                     )}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -403,6 +403,7 @@ export default {
   'tool.question': 'Question',
   'tool.selectOption': 'Please select at least one option or type an answer.',
   'tool.waitingForApproval': 'Waiting for approval…',
+  'tool.waitingForLocalApproval': 'Approve this in the local terminal, or switch to remote mode first.',
   'tool.canceled': 'Canceled',
   'tool.approvedForSession': 'Approved For Session',
   'tool.aborted': 'Aborted',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -407,6 +407,7 @@ export default {
   'tool.question': '问题',
   'tool.selectOption': '请至少选择一个选项或输入答案。',
   'tool.waitingForApproval': '等待审批…',
+  'tool.waitingForLocalApproval': '请在本地终端中审批，或先切换到远程模式。',
   'tool.canceled': '已取消',
   'tool.approvedForSession': '本会话已批准',
   'tool.aborted': '已中止',

--- a/web/src/realtime/realtimeClientTools.test.ts
+++ b/web/src/realtime/realtimeClientTools.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { realtimeClientTools, registerSessionStore } from './realtimeClientTools'
+
+vi.mock('./RealtimeSession', () => ({
+    getCurrentRealtimeSessionId: () => 'session-1',
+}))
+
+vi.mock('./voiceConfig', () => ({
+    VOICE_CONFIG: {
+        ENABLE_DEBUG_LOGGING: false,
+    },
+}))
+
+afterEach(() => {
+    registerSessionStore(null)
+})
+
+describe('realtimeClientTools processPermissionRequest local mode', () => {
+    it('returns an error when local-mode approval is refused by the session store', async () => {
+        const approvePermission = vi.fn(async () => {
+            throw new Error('Approve this in the local terminal, or switch to remote mode first.')
+        })
+        const denyPermission = vi.fn()
+
+        registerSessionStore({
+            getSession: () => ({
+                agentState: {
+                    controlledByUser: true,
+                    requests: {
+                        'perm-1': { tool: 'Bash' },
+                    },
+                },
+            }),
+            sendMessage: vi.fn(),
+            approvePermission,
+            denyPermission,
+        })
+
+        const result = await realtimeClientTools.processPermissionRequest({ decision: 'allow' })
+
+        expect(result).toBe('error (failed to allow permission)')
+        expect(approvePermission).toHaveBeenCalledWith('session-1', 'perm-1')
+        expect(denyPermission).not.toHaveBeenCalled()
+    })
+
+    it('approves when remote session store accepts the decision', async () => {
+        const approvePermission = vi.fn(async () => {})
+        const denyPermission = vi.fn()
+
+        registerSessionStore({
+            getSession: () => ({
+                agentState: {
+                    controlledByUser: false,
+                    requests: {
+                        'perm-1': { tool: 'Bash' },
+                    },
+                },
+            }),
+            sendMessage: vi.fn(),
+            approvePermission,
+            denyPermission,
+        })
+
+        const result = await realtimeClientTools.processPermissionRequest({ decision: 'allow' })
+
+        expect(result).toContain('done')
+        expect(approvePermission).toHaveBeenCalledWith('session-1', 'perm-1')
+    })
+})


### PR DESCRIPTION
## Summary

Local mode (`agentState.controlledByUser === true`) cannot remotely approve permissions or list OpenCode models/effort options (no session RPC handlers). The web UI still presented those controls and polled those endpoints, which looked broken and flooded the hub with 500s.

This PR makes local mode honest in the UI and stops the useless session RPCs.

### Commits

1. `fix(web): hide remote permission actions in local mode`
2. `fix(web): skip OpenCode model/effort queries in local mode`

## Problem

### 1) Local OpenCode looks remotely approvable

- Local OpenCode mirrors `permission.asked` into `agentState.requests`, so the web shows pending permissions.
- Local launcher only registers Abort/Switch RPC; `permission` is remote-only.
- Users could still click Allow/Deny (and voice could try to approve), but nothing could complete the request in the TUI.

### 2) Local OpenCode floods hub with 500s

- SessionChat enabled:

  - `GET /api/sessions/:id/opencode-models`
  - `GET /api/sessions/:id/opencode-reasoning-effort-options`

  for every active OpenCode session, including local.
- Those handlers exist only in the remote launcher.
- Missing handler → `RpcTargetMissingError` → HTTP 500.
- React Query retry + 1s discovery polling multiplies the noise.

## Changes

### Permission UX (local mode)

- Plumb `controlledByUser` through chat context → tool cards.
- Hide remote approval actions in:
  - `PermissionFooter`
  - `AskUserQuestionFooter`
  - `RequestUserInputFooter`
- Show local guidance instead:
  - EN: "Approve this in the local terminal, or switch to remote mode first."
  - ZH: "请在本地终端中审批，或先切换到远程模式。"
- Voice path:
  - refuse `approvePermission` / `denyPermission` when local
  - do not notify voice of local pending permissions

### OpenCode query gating (local mode)

- Gate both session queries with `&& !controlledByUser`, matching existing Grok/Codex local gating:
  - `useOpencodeModels`
  - `useOpencodeReasoningEffortOptions`

## Out of scope

- Enabling remote approval while still in local mode
- Registering permission/model RPC handlers in the local launcher
- Hub hard-reject for missing permission RPC (frontend-only defense)
