### PR TITLE
fix(web): add missing exec timestamps to ToolCard test fixture

### DIFF
--- a/web/src/components/ToolCard/ToolCard.test.ts
+++ b/web/src/components/ToolCard/ToolCard.test.ts
@@ -29,6 +29,8 @@ function makeToolCallChild(overrides: Partial<ToolCallBlock> = {}): ToolCallBloc
             createdAt: 0,
             startedAt: 0,
             completedAt: 0,
+            execStartedAt: null,
+            execCompletedAt: null,
             description: null
         },
         children: [],


### PR DESCRIPTION
## Problem

`bun typecheck` fails on `main`:

```
src/components/ToolCard/ToolCard.test.ts(24,9): error TS2739: Type '{ id: string; name: string; state: "completed"; input: {}; createdAt: number; startedAt: number; completedAt: number; description: null; }' is missing the following properties from type 'ChatToolCall': execStartedAt, execCompletedAt
```

The `test` workflow runs `bun typecheck` before `bun run test`, so the job stops there and the `test` check goes red for any PR whose workflow runs after this point (#1054 and #1056 so far). PRs whose workflow last ran earlier still show a green check.

#1036 made `execStartedAt` and `execCompletedAt` required on `ChatToolCall` and updated the fixtures that existed at the time. My #1045 added a new fixture to `ToolCard.test.ts`, written against a base from before those fields existed, and the two landed about a minute apart - so each branch type-checked cleanly against its own base and the gap only appears with both on `main`. Sorry for the noise.

## Fix

Set both fields to `null` in the fixture, matching the sibling fixtures in `ToolGroupCard.test.ts` and `groupedPresentation.test.ts`, since these cases do not exercise tool execution duration.

## Tests

On this branch `bun typecheck` is clean and `bun run test` passes across cli, hub, web and shared.

@tiann - flagging for visibility since this blocks the `test` check for new runs.

---

AI disclosure (per CONTRIBUTING.md): Claude Opus 4.8.
