### PR TITLE
feat(web): copy agent resume commands

### DIFF
--- a/shared/src/sessionSummary.test.ts
+++ b/shared/src/sessionSummary.test.ts
@@ -77,6 +77,46 @@ describe('toSessionSummary', () => {
         expect(summary.metadata?.agentSessionId).toBe('grok-session-1')
     })
 
+    it('uses the native id matching the current flavor instead of a stale id', () => {
+        const summary = toSessionSummary(makeSession({
+            metadata: {
+                path: '/proj',
+                host: 'local',
+                flavor: 'cursor',
+                codexSessionId: 'stale-codex-id',
+                cursorSessionId: 'cursor-session-1'
+            }
+        }))
+
+        expect(summary.metadata?.agentSessionId).toBe('cursor-session-1')
+    })
+
+    it('does not fall back to a stale cross-agent id for a known flavor', () => {
+        const summary = toSessionSummary(makeSession({
+            metadata: {
+                path: '/proj',
+                host: 'local',
+                flavor: 'pi',
+                codexSessionId: 'stale-codex-id'
+            }
+        }))
+
+        expect(summary.metadata?.agentSessionId).toBeUndefined()
+    })
+
+    it('includes piSessionId as the native resume token', () => {
+        const summary = toSessionSummary(makeSession({
+            metadata: {
+                path: '/proj',
+                host: 'local',
+                flavor: 'pi',
+                piSessionId: 'pi-session-1'
+            }
+        }))
+
+        expect(summary.metadata?.agentSessionId).toBe('pi-session-1')
+    })
+
     it('includes pending request kinds and background task count', () => {
         const summary = toSessionSummary(makeSession({
             backgroundTaskCount: 2,

--- a/shared/src/sessionSummary.ts
+++ b/shared/src/sessionSummary.ts
@@ -1,4 +1,4 @@
-import type { Session, WorktreeMetadata } from './schemas'
+import type { Metadata, Session, WorktreeMetadata } from './schemas'
 
 export type PendingRequestKind = 'permission' | 'input'
 
@@ -105,6 +105,41 @@ export function getPendingRequestKinds(session: Session): PendingRequestKind[] {
         : Array.from(kinds)
 }
 
+const AGENT_SESSION_ID_FIELD_BY_FLAVOR = {
+    claude: 'claudeSessionId',
+    codex: 'codexSessionId',
+    gemini: 'geminiSessionId',
+    opencode: 'opencodeSessionId',
+    grok: 'grokSessionId',
+    cursor: 'cursorSessionId',
+    kimi: 'kimiSessionId',
+    pi: 'piSessionId'
+} as const satisfies Record<string, keyof Metadata>
+
+function getSummaryAgentSessionId(metadata: Metadata): string | undefined {
+    const flavor = metadata.flavor?.trim().toLowerCase()
+    const flavorField = flavor
+        ? AGENT_SESSION_ID_FIELD_BY_FLAVOR[flavor as keyof typeof AGENT_SESSION_ID_FIELD_BY_FLAVOR]
+        : undefined
+    if (flavorField) {
+        const flavorSessionId = metadata[flavorField]
+        return typeof flavorSessionId === 'string' && flavorSessionId.trim()
+            ? flavorSessionId.trim()
+            : undefined
+    }
+
+    // Legacy fallback only applies when the stored flavor is missing or unknown.
+    return metadata.codexSessionId
+        ?? metadata.claudeSessionId
+        ?? metadata.geminiSessionId
+        ?? metadata.opencodeSessionId
+        ?? metadata.grokSessionId
+        ?? metadata.cursorSessionId
+        ?? metadata.kimiSessionId
+        ?? metadata.piSessionId
+        ?? undefined
+}
+
 export function toSessionSummary(session: Session): SessionSummary {
     const pendingRequestsCount = session.agentState?.requests ? Object.keys(session.agentState.requests).length : 0
 
@@ -115,14 +150,7 @@ export function toSessionSummary(session: Session): SessionSummary {
         summary: session.metadata.summary ? { text: session.metadata.summary.text } : undefined,
         flavor: session.metadata.flavor ?? null,
         worktree: session.metadata.worktree,
-        agentSessionId: session.metadata.codexSessionId
-            ?? session.metadata.claudeSessionId
-            ?? session.metadata.geminiSessionId
-            ?? session.metadata.opencodeSessionId
-            ?? session.metadata.grokSessionId
-            ?? session.metadata.cursorSessionId
-            ?? session.metadata.kimiSessionId
-            ?? undefined,
+        agentSessionId: getSummaryAgentSessionId(session.metadata),
         lifecycleState: session.metadata.lifecycleState
     } : null
 

--- a/web/src/components/SessionActionMenu.test.tsx
+++ b/web/src/components/SessionActionMenu.test.tsx
@@ -89,3 +89,39 @@ describe('SessionActionMenu - Reopen action', () => {
         expect(screen.queryByRole('menuitem', { name: /Archive/ })).toBeNull()
     })
 })
+
+describe('SessionActionMenu - Copy resume command action', () => {
+    it('renders the item only when a resume command can be copied', () => {
+        const { rerender } = renderMenu()
+
+        expect(screen.queryByRole('menuitem', { name: 'Copy resume command' })).toBeNull()
+
+        rerender(
+            <I18nProvider>
+                <SessionActionMenu
+                    isOpen={true}
+                    onClose={vi.fn()}
+                    sessionActive={true}
+                    onRename={vi.fn()}
+                    onCopyResumeCommand={vi.fn()}
+                    onArchive={vi.fn()}
+                    onDelete={vi.fn()}
+                    anchorPoint={{ x: 0, y: 0 }}
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.getByRole('menuitem', { name: 'Copy resume command' })).toBeInTheDocument()
+    })
+
+    it('copies through the provided callback and closes the menu', () => {
+        const onCopyResumeCommand = vi.fn()
+        const onClose = vi.fn()
+        renderMenu({ onCopyResumeCommand, onClose })
+
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Copy resume command' }))
+
+        expect(onCopyResumeCommand).toHaveBeenCalledTimes(1)
+        expect(onClose).toHaveBeenCalledTimes(1)
+    })
+})

--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -16,6 +16,7 @@ type SessionActionMenuProps = {
     sessionActive: boolean
     onRename: () => void
     onExport?: () => void
+    onCopyResumeCommand?: () => void
     onArchive: () => void
     onReopen?: () => void
     reopenDisabledReason?: string
@@ -86,6 +87,26 @@ function DownloadIcon(props: { className?: string }) {
     )
 }
 
+function CopyIcon(props: { className?: string }) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={props.className}
+        >
+            <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+            <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+        </svg>
+    )
+}
+
 function ReopenIcon(props: { className?: string }) {
     return (
         <svg
@@ -143,6 +164,7 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         sessionActive,
         onRename,
         onExport,
+        onCopyResumeCommand,
         onArchive,
         onReopen,
         reopenDisabledReason,
@@ -174,6 +196,11 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
     const handleExport = () => {
         onClose()
         onExport?.()
+    }
+
+    const handleCopyResumeCommand = () => {
+        onClose()
+        onCopyResumeCommand?.()
     }
 
     const handleDelete = () => {
@@ -306,6 +333,18 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
                     >
                         <DownloadIcon className="text-[var(--app-hint)]" />
                         {t('session.action.export')}
+                    </button>
+                ) : null}
+
+                {onCopyResumeCommand ? (
+                    <button
+                        type="button"
+                        role="menuitem"
+                        className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
+                        onClick={handleCopyResumeCommand}
+                    >
+                        <CopyIcon className="text-[var(--app-hint)]" />
+                        {t('session.action.copyResumeCommand')}
                     </button>
                 ) : null}
 

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -14,6 +14,9 @@ import { useTranslation } from '@/lib/use-translation'
 import { AgentFlavorIcon } from '@/components/AgentFlavorIcon'
 import { isFastServiceTier } from '@/components/AssistantChat/codexFastMode'
 import { getSessionTitle } from '@/lib/sessionTitle'
+import { getAgentResumeCommand } from '@/lib/agentSessionId'
+import { safeCopyToClipboard } from '@/lib/clipboard'
+import { useToast } from '@/lib/toast-context'
 
 function FilesIcon(props: { className?: string }) {
     return (
@@ -98,8 +101,10 @@ export function SessionHeader(props: {
     onSessionReopened?: (newSessionId: string) => void
 }) {
     const { t } = useTranslation()
+    const toast = useToast()
     const { session, api, onSessionDeleted, onSessionReopened } = props
     const title = useMemo(() => getSessionTitle(session), [session])
+    const resumeCommand = getAgentResumeCommand(session.metadata)
     const worktreeBranch = session.metadata?.worktree?.branch
     const modelLabel = getSessionModelLabel(session)
     const agentFlavor = session.metadata?.flavor ?? null
@@ -148,6 +153,27 @@ export function SessionHeader(props: {
             setMenuAnchorPoint({ x: rect.right, y: rect.bottom })
         }
         setMenuOpen((open) => !open)
+    }
+
+    const handleCopyResumeCommand = async () => {
+        if (!resumeCommand) return
+
+        try {
+            await safeCopyToClipboard(resumeCommand)
+            toast.addToast({
+                title: t('session.copyResumeCommand.toast.success.title'),
+                body: t('session.copyResumeCommand.toast.success.body'),
+                sessionId: session.id,
+                url: `/sessions/${session.id}`
+            })
+        } catch {
+            toast.addToast({
+                title: t('session.copyResumeCommand.toast.error.title'),
+                body: t('session.copyResumeCommand.toast.error.body'),
+                sessionId: session.id,
+                url: `/sessions/${session.id}`
+            })
+        }
     }
 
     // In Telegram, don't render header (Telegram provides its own)
@@ -259,6 +285,7 @@ export function SessionHeader(props: {
                 sessionActive={session.active}
                 onRename={() => setRenameOpen(true)}
                 onExport={() => setExportOpen(true)}
+                onCopyResumeCommand={resumeCommand ? handleCopyResumeCommand : undefined}
                 onArchive={() => setArchiveOpen(true)}
                 onReopen={props.canReopen === false ? undefined : handleReopen}
                 reopenDisabledReason={props.reopenDisabledReason}

--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import type { SessionSummary } from '@/types/api'
 import { I18nProvider } from '@/lib/i18n-context'
+import { ToastProvider, useToast } from '@/lib/toast-context'
 import { SessionList } from './SessionList'
 
 afterEach(() => cleanup())
@@ -38,11 +39,19 @@ function renderWithProviders(children: ReactNode) {
 
     return render(
         <QueryClientProvider client={queryClient}>
-            <I18nProvider>
-                {children}
-            </I18nProvider>
+            <ToastProvider>
+                <I18nProvider>
+                    {children}
+                    <ToastProbe />
+                </I18nProvider>
+            </ToastProvider>
         </QueryClientProvider>
     )
+}
+
+function ToastProbe() {
+    const { toasts } = useToast()
+    return <>{toasts.map((toast) => <div key={toast.id}>{toast.title}</div>)}</>
 }
 
 describe('SessionList directory action', () => {
@@ -101,6 +110,86 @@ describe('SessionList directory action', () => {
     })
 })
 
+describe('SessionList resume command action', () => {
+    it('copies the native resume command from the session row menu', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText }
+        })
+        const session = makeSession({
+            id: 'session-codex',
+            updatedAt: Date.now(),
+            metadata: {
+                path: '/home/ubuntu',
+                machineId: 'machine-1',
+                name: 'Codex session',
+                flavor: 'codex',
+                agentSessionId: 'thread-123'
+            }
+        })
+
+        renderWithProviders(
+            <SessionList
+                sessions={[session]}
+                selectedSessionId={null}
+                onSelect={vi.fn()}
+                onNewSession={vi.fn()}
+                onRefresh={vi.fn()}
+                isLoading={false}
+                renderHeader={false}
+                api={null}
+            />
+        )
+
+        fireEvent.contextMenu(screen.getByRole('button', { name: /Codex session/ }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Copy resume command' }))
+
+        await waitFor(() => expect(writeText).toHaveBeenCalledWith('codex resume thread-123'))
+        expect(await screen.findByText('Resume command copied')).toBeInTheDocument()
+    })
+
+    it('shows an error toast when clipboard access fails', async () => {
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) }
+        })
+        Object.defineProperty(document, 'execCommand', {
+            configurable: true,
+            value: vi.fn().mockReturnValue(false)
+        })
+        const session = makeSession({
+            id: 'session-codex',
+            updatedAt: Date.now(),
+            metadata: {
+                path: '/home/ubuntu',
+                machineId: 'machine-1',
+                name: 'Codex session',
+                flavor: 'codex',
+                agentSessionId: 'thread-123'
+            }
+        })
+
+        renderWithProviders(
+            <SessionList
+                sessions={[session]}
+                selectedSessionId={null}
+                onSelect={vi.fn()}
+                onNewSession={vi.fn()}
+                onRefresh={vi.fn()}
+                isLoading={false}
+                renderHeader={false}
+                api={null}
+            />
+        )
+
+        fireEvent.contextMenu(screen.getByRole('button', { name: /Codex session/ }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Copy resume command' }))
+
+        expect(await screen.findByText('Could not copy resume command')).toBeInTheDocument()
+    })
+})
+
 describe('SessionList collapse behavior', () => {
     function renderSessionList(sessions: SessionSummary[], selectedSessionId = 'session-running') {
         return (
@@ -110,18 +199,20 @@ describe('SessionList collapse behavior', () => {
                     mutations: { retry: false },
                 }
             })}>
-                <I18nProvider>
-                    <SessionList
-                        sessions={sessions}
-                        selectedSessionId={selectedSessionId}
-                        onSelect={vi.fn()}
-                        onNewSession={vi.fn()}
-                        onRefresh={vi.fn()}
-                        isLoading={false}
-                        renderHeader={false}
-                        api={null}
-                    />
-                </I18nProvider>
+                <ToastProvider>
+                    <I18nProvider>
+                        <SessionList
+                            sessions={sessions}
+                            selectedSessionId={selectedSessionId}
+                            onSelect={vi.fn()}
+                            onNewSession={vi.fn()}
+                            onRefresh={vi.fn()}
+                            isLoading={false}
+                            renderHeader={false}
+                            api={null}
+                        />
+                    </I18nProvider>
+                </ToastProvider>
             </QueryClientProvider>
         )
     }

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -27,6 +27,9 @@ import type { Machine } from '@/types/api'
 import { getMachinePlatform, presentMachineHealth } from '@/lib/machineHealth'
 import { MachineGroupHeader } from '@/components/MachineGroupHeader'
 import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStatus'
+import { getResumeCommand } from '@/lib/agentSessionId'
+import { safeCopyToClipboard } from '@/lib/clipboard'
+import { useToast } from '@/lib/toast-context'
 
 type SessionGroup = {
     key: string
@@ -590,6 +593,7 @@ function SessionItem(props: {
     showDetailedStatus?: boolean
 }) {
     const { t } = useTranslation()
+    const toast = useToast()
     const { session: s, onSelect, showPath = true, api, selected = false, showDetailedStatus = false } = props
     const { haptic } = usePlatform()
     const [menuOpen, setMenuOpen] = useState(false)
@@ -650,6 +654,27 @@ function SessionItem(props: {
     })
 
     const sessionName = getSessionTitle(s)
+    const resumeCommand = getResumeCommand(s.metadata?.flavor, s.metadata?.agentSessionId)
+    const handleCopyResumeCommand = async () => {
+        if (!resumeCommand) return
+
+        try {
+            await safeCopyToClipboard(resumeCommand)
+            toast.addToast({
+                title: t('session.copyResumeCommand.toast.success.title'),
+                body: t('session.copyResumeCommand.toast.success.body'),
+                sessionId: s.id,
+                url: `/sessions/${s.id}`
+            })
+        } catch {
+            toast.addToast({
+                title: t('session.copyResumeCommand.toast.error.title'),
+                body: t('session.copyResumeCommand.toast.error.body'),
+                sessionId: s.id,
+                url: `/sessions/${s.id}`
+            })
+        }
+    }
     const worktreeLabel = getWorktreeSessionLabel(s)
     const todoProgress = getTodoProgress(s)
     const attention = useMemo(
@@ -748,6 +773,7 @@ function SessionItem(props: {
                 onClose={() => setMenuOpen(false)}
                 sessionActive={s.active}
                 onRename={() => setRenameOpen(true)}
+                onCopyResumeCommand={resumeCommand ? handleCopyResumeCommand : undefined}
                 onArchive={() => setArchiveOpen(true)}
                 onReopen={cursorReopenDisabledReason ? undefined : handleReopen}
                 reopenDisabledReason={cursorReopenDisabledReason}

--- a/web/src/lib/agentSessionId.test.ts
+++ b/web/src/lib/agentSessionId.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import type { Metadata } from '@/types/api'
+import { getAgentResumeCommand, getAgentSessionId, getResumeCommand } from '@/lib/agentSessionId'
+
+function metadata(overrides: Partial<Metadata>): Metadata {
+    return { path: '/work', host: 'host', ...overrides }
+}
+
+describe('getAgentSessionId', () => {
+    it.each([
+        ['claude', 'claudeSessionId', 'claude-id'],
+        ['codex', 'codexSessionId', 'codex-id'],
+        ['gemini', 'geminiSessionId', 'gemini-id'],
+        ['opencode', 'opencodeSessionId', 'opencode-id'],
+        ['grok', 'grokSessionId', 'grok-id'],
+        ['cursor', 'cursorSessionId', 'cursor-id'],
+        ['kimi', 'kimiSessionId', 'kimi-id'],
+        ['pi', 'piSessionId', 'pi-id']
+    ] as const)('returns the %s session id', (flavor, field, id) => {
+        expect(getAgentSessionId(metadata({ flavor, [field]: ` ${id} ` }))).toBe(id)
+    })
+
+    it('prefers the id matching the current flavor over stale ids from another agent', () => {
+        expect(getAgentSessionId(metadata({
+            flavor: 'cursor',
+            codexSessionId: 'stale-codex-id',
+            cursorSessionId: 'cursor-id'
+        }))).toBe('cursor-id')
+    })
+
+    it('falls back to the available native id for unknown or missing flavors', () => {
+        expect(getAgentSessionId(metadata({ flavor: 'custom', piSessionId: 'pi-id' }))).toBe('pi-id')
+    })
+
+    it('returns null when no native agent session id is available', () => {
+        expect(getAgentSessionId(metadata({ flavor: 'codex' }))).toBeNull()
+        expect(getAgentSessionId(null)).toBeNull()
+    })
+})
+
+describe('getAgentResumeCommand', () => {
+    it.each([
+        ['claude', 'claudeSessionId', 'claude --resume claude-id'],
+        ['codex', 'codexSessionId', 'codex resume codex-id'],
+        ['opencode', 'opencodeSessionId', 'opencode -s opencode-id'],
+        ['grok', 'grokSessionId', 'grok --resume grok-id'],
+        ['cursor', 'cursorSessionId', 'agent resume cursor-id'],
+        ['kimi', 'kimiSessionId', 'kimi --session kimi-id'],
+        ['pi', 'piSessionId', 'pi --session-id pi-id']
+    ] as const)('builds the %s native resume command', (flavor, field, command) => {
+        expect(getAgentResumeCommand(metadata({ flavor, [field]: `${flavor}-id` }))).toBe(command)
+    })
+
+    it('does not build a command for an unknown flavor or a mismatched stale id', () => {
+        expect(getAgentResumeCommand(metadata({ flavor: 'custom', codexSessionId: 'codex-id' }))).toBeNull()
+        expect(getAgentResumeCommand(metadata({ flavor: 'cursor', codexSessionId: 'codex-id' }))).toBeNull()
+    })
+
+    it('does not build a command for retired Gemini sessions', () => {
+        expect(getAgentResumeCommand(metadata({
+            flavor: 'gemini',
+            geminiSessionId: 'gemini-id'
+        }))).toBeNull()
+        expect(getResumeCommand('gemini', 'gemini-id')).toBeNull()
+    })
+
+    it.each([
+        'thread-id; rm -rf /',
+        'thread-id && whoami',
+        '$(whoami)',
+        '`whoami`',
+        'thread id',
+        "thread'id",
+        'thread"id'
+    ])('rejects an unsafe native session id: %s', (sessionId) => {
+        expect(getResumeCommand('codex', sessionId)).toBeNull()
+    })
+
+    it('builds the same command from flattened session-summary metadata', () => {
+        expect(getResumeCommand(' codex ', ' thread-id ')).toBe('codex resume thread-id')
+        expect(getResumeCommand('custom', 'thread-id')).toBeNull()
+    })
+})

--- a/web/src/lib/agentSessionId.ts
+++ b/web/src/lib/agentSessionId.ts
@@ -1,0 +1,80 @@
+import type { Metadata } from '@/types/api'
+
+const SESSION_ID_FIELD_BY_FLAVOR = {
+    claude: 'claudeSessionId',
+    codex: 'codexSessionId',
+    gemini: 'geminiSessionId',
+    opencode: 'opencodeSessionId',
+    grok: 'grokSessionId',
+    cursor: 'cursorSessionId',
+    kimi: 'kimiSessionId',
+    pi: 'piSessionId'
+} as const satisfies Record<string, keyof Metadata>
+
+const SESSION_ID_FIELDS = Object.values(SESSION_ID_FIELD_BY_FLAVOR)
+
+function readSessionId(metadata: Metadata, field: keyof Metadata | undefined): string | null {
+    if (!field) return null
+    const value = metadata[field]
+    return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export function getAgentSessionId(metadata: Metadata | null | undefined): string | null {
+    if (!metadata) return null
+
+    const flavor = metadata.flavor?.trim().toLowerCase()
+    const flavorField = flavor
+        ? SESSION_ID_FIELD_BY_FLAVOR[flavor as keyof typeof SESSION_ID_FIELD_BY_FLAVOR]
+        : undefined
+    const flavorSessionId = readSessionId(metadata, flavorField)
+    if (flavorSessionId) return flavorSessionId
+
+    for (const field of SESSION_ID_FIELDS) {
+        const sessionId = readSessionId(metadata, field)
+        if (sessionId) return sessionId
+    }
+
+    return null
+}
+
+const RESUME_COMMAND_BY_FLAVOR = {
+    claude: (id: string) => `claude --resume ${id}`,
+    codex: (id: string) => `codex resume ${id}`,
+    opencode: (id: string) => `opencode -s ${id}`,
+    grok: (id: string) => `grok --resume ${id}`,
+    cursor: (id: string) => `agent resume ${id}`,
+    kimi: (id: string) => `kimi --session ${id}`,
+    pi: (id: string) => `pi --session-id ${id}`
+} as const satisfies Partial<Record<keyof typeof SESSION_ID_FIELD_BY_FLAVOR, (id: string) => string>>
+
+const SAFE_RESUME_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
+
+export function getAgentResumeCommand(metadata: Metadata | null | undefined): string | null {
+    if (!metadata) return null
+
+    const flavor = metadata.flavor?.trim().toLowerCase()
+    if (!flavor || !(flavor in RESUME_COMMAND_BY_FLAVOR)) return null
+
+    const sessionId = readSessionId(
+        metadata,
+        SESSION_ID_FIELD_BY_FLAVOR[flavor as keyof typeof SESSION_ID_FIELD_BY_FLAVOR]
+    )
+    if (!sessionId) return null
+
+    return getResumeCommand(flavor, sessionId)
+}
+
+export function getResumeCommand(flavor: string | null | undefined, sessionId: string | null | undefined): string | null {
+    const normalizedFlavor = flavor?.trim().toLowerCase()
+    const normalizedSessionId = sessionId?.trim()
+    if (
+        !normalizedFlavor
+        || !normalizedSessionId
+        || !SAFE_RESUME_ID_PATTERN.test(normalizedSessionId)
+        || !(normalizedFlavor in RESUME_COMMAND_BY_FLAVOR)
+    ) {
+        return null
+    }
+
+    return RESUME_COMMAND_BY_FLAVOR[normalizedFlavor as keyof typeof RESUME_COMMAND_BY_FLAVOR](normalizedSessionId)
+}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -157,6 +157,7 @@ export default {
   // Session actions
   'session.action.rename': 'Rename',
   'session.action.export': 'Export conversation',
+  'session.action.copyResumeCommand': 'Copy resume command',
   'session.action.archive': 'Archive',
   'session.action.reopen': 'Reopen',
   'session.action.reopenCursorChecking': 'Checking whether Cursor chat data is still available on the recorded machine.',
@@ -164,6 +165,10 @@ export default {
   'session.action.reopenCursorCheckFailed': 'Could not verify Cursor chat data on the recorded machine.',
   'session.action.delete': 'Delete',
   'session.action.copy': 'Copy',
+  'session.copyResumeCommand.toast.success.title': 'Resume command copied',
+  'session.copyResumeCommand.toast.success.body': 'The agent resume command is now on your clipboard.',
+  'session.copyResumeCommand.toast.error.title': 'Could not copy resume command',
+  'session.copyResumeCommand.toast.error.body': 'Clipboard access was unavailable. Please try again.',
 
   // Dialogs
   'dialog.uri.title': 'Open this link?',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -157,6 +157,7 @@ export default {
   // Session actions
   'session.action.rename': '重命名',
   'session.action.export': '导出对话',
+  'session.action.copyResumeCommand': '复制恢复命令',
   'session.action.archive': '归档',
   'session.action.reopen': '重新打开',
   'session.action.reopenCursorChecking': '正在检查记录设备上的 Cursor 聊天数据是否仍然可用。',
@@ -164,6 +165,10 @@ export default {
   'session.action.reopenCursorCheckFailed': '无法验证记录设备上的 Cursor 聊天数据。',
   'session.action.delete': '删除',
   'session.action.copy': '复制',
+  'session.copyResumeCommand.toast.success.title': '已复制恢复命令',
+  'session.copyResumeCommand.toast.success.body': 'Agent 恢复命令已复制到剪贴板。',
+  'session.copyResumeCommand.toast.error.title': '无法复制恢复命令',
+  'session.copyResumeCommand.toast.error.body': '剪贴板当前不可用，请重试。',
 
   // Dialogs
   'dialog.uri.title': '打开此链接？',


### PR DESCRIPTION
## Summary

Add a **Copy resume command** action to both session action menus: the active session header and the session-list context menu.

The copied text is a directly runnable, agent-native command rather than a HAPI URL or bare session ID, for example:

```text
codex resume 019f68ed-6462-7ea2-b717-964f14615f64
```

## Motivation

HAPI already stores each coding agent's native conversation ID, but retrieving it currently requires exporting the conversation as JSON and locating an agent-specific metadata field such as `codexSessionId` or `claudeSessionId`.

Copying a ready-to-run command makes it easier to continue the same conversation directly in the corresponding local CLI while keeping the agent identity unambiguous.

## Changes

- Add **Copy resume command** to both session action-menu entry points.
- Resolve the native session ID from full session metadata in the session header.
- Reuse the flattened `agentSessionId` from session summaries in the session list.
- Resolve summary IDs by current agent flavor, avoiding stale IDs left by another integration and including Pi sessions.
- Hide the action when the flavor is unknown, retired (Gemini), the matching native ID is missing, or no command can be generated.
- Reject native IDs outside a conservative shell-safe character set instead of interpolating arbitrary metadata into executable commands.
- Generate the command syntax used by each supported integration:

| Agent | Copied command |
| --- | --- |
| Claude | `claude --resume <id>` |
| Codex | `codex resume <id>` |
| OpenCode | `opencode -s <id>` |
| Grok | `grok --resume <id>` |
| Cursor | `agent resume <id>` |
| Kimi | `kimi --session <id>` |
| Pi | `pi --session-id <id>` |

- Add English and Simplified Chinese labels and clipboard-result feedback.
- Add focused coverage for command generation, menu visibility/callback behavior, unsafe IDs, retired Gemini sessions, stale mixed-agent metadata, Pi summaries, and copying from the session-list menu.

This is intentionally separate from a broader effort to make every action in the header and session-list menus identical. Unlike #951, this action copies an agent-native resume command rather than a cross-session HAPI reference.

## Testing

- `bun typecheck`
- `bun run test:web`
- `bun test shared/src/sessionSummary.test.ts`
- `bun run --cwd web test src/lib/agentSessionId.test.ts src/components/SessionList.directory-action.test.tsx src/components/SessionActionMenu.test.tsx`
- `git diff --check`

## AI disclosure

Implementation and tests were produced with OpenAI Codex (GPT-5.6).

