### PR TITLE
feat(web): align session action menus

### DIFF
--- a/web/src/components/SessionExportDialog.tsx
+++ b/web/src/components/SessionExportDialog.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
 import type { ApiClient } from '@/api/client'
-import type { Session } from '@/types/api'
 import {
     downloadSessionExport,
     readSessionExportFormat,
@@ -21,7 +20,7 @@ import {
 type SessionExportDialogProps = {
     isOpen: boolean
     onClose: () => void
-    session: Session
+    sessionId: string
     api: ApiClient | null
 }
 
@@ -65,14 +64,14 @@ export function SessionExportDialog(props: SessionExportDialogProps) {
         abortRef.current = controller
 
         try {
-            const result = await downloadSessionExport(props.api, props.session.id, format, {
+            const result = await downloadSessionExport(props.api, props.sessionId, format, {
                 signal: controller.signal
             })
             toast.addToast({
                 title: t('session.export.toast.success.title'),
                 body: t('session.export.toast.success.body', { filename: result.filename }),
-                sessionId: props.session.id,
-                url: `/sessions/${props.session.id}`
+                sessionId: props.sessionId,
+                url: `/sessions/${props.sessionId}`
             })
             props.onClose()
         } catch (error) {
@@ -86,8 +85,8 @@ export function SessionExportDialog(props: SessionExportDialogProps) {
             toast.addToast({
                 title: t('session.export.toast.error.title'),
                 body: message,
-                sessionId: props.session.id,
-                url: `/sessions/${props.session.id}`
+                sessionId: props.sessionId,
+                url: `/sessions/${props.sessionId}`
             })
         } finally {
             if (abortRef.current === controller) {

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -291,7 +291,7 @@ export function SessionHeader(props: {
             <SessionExportDialog
                 isOpen={exportOpen}
                 onClose={() => setExportOpen(false)}
-                session={session}
+                sessionId={session.id}
                 api={api}
             />
 

--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import type { SessionSummary } from '@/types/api'
 import { I18nProvider } from '@/lib/i18n-context'
+import { ToastProvider } from '@/lib/toast-context'
 import { SessionList } from './SessionList'
 
 afterEach(() => cleanup())
@@ -38,9 +39,11 @@ function renderWithProviders(children: ReactNode) {
 
     return render(
         <QueryClientProvider client={queryClient}>
-            <I18nProvider>
-                {children}
-            </I18nProvider>
+            <ToastProvider>
+                <I18nProvider>
+                    {children}
+                </I18nProvider>
+            </ToastProvider>
         </QueryClientProvider>
     )
 }
@@ -98,6 +101,44 @@ describe('SessionList directory action', () => {
         )
 
         expect(screen.queryByRole('button', { name: 'New session in this directory' })).toBeNull()
+    })
+})
+
+describe('SessionList action menu parity', () => {
+    it.each([
+        ['running', true],
+        ['closed', false]
+    ] as const)('offers conversation export for a %s session', (_label, active) => {
+        const session = makeSession({
+            id: `session-${active ? 'running' : 'closed'}`,
+            active,
+            updatedAt: Date.now(),
+            metadata: {
+                path: '/home/ubuntu',
+                machineId: 'machine-1',
+                name: active ? 'Running session' : 'Closed session',
+                flavor: 'codex'
+            }
+        })
+
+        renderWithProviders(
+            <SessionList
+                sessions={[session]}
+                selectedSessionId={null}
+                onSelect={vi.fn()}
+                onNewSession={vi.fn()}
+                onRefresh={vi.fn()}
+                isLoading={false}
+                renderHeader={false}
+                api={null}
+            />
+        )
+
+        fireEvent.contextMenu(screen.getByRole('button', { name: new RegExp(active ? 'Running session' : 'Closed session') }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Export conversation' }))
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: 'Export conversation' })).toBeInTheDocument()
     })
 })
 

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -5,6 +5,7 @@ import { useLongPress } from '@/hooks/useLongPress'
 import { usePlatform } from '@/hooks/usePlatform'
 import { useSessionActions } from '@/hooks/mutations/useSessionActions'
 import { SessionActionMenu } from '@/components/SessionActionMenu'
+import { SessionExportDialog } from '@/components/SessionExportDialog'
 import { RenameSessionDialog } from '@/components/RenameSessionDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { CopyIcon, CheckIcon, ScheduleIcon } from '@/components/icons'
@@ -595,6 +596,7 @@ function SessionItem(props: {
     const [menuOpen, setMenuOpen] = useState(false)
     const [menuAnchorPoint, setMenuAnchorPoint] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
     const [renameOpen, setRenameOpen] = useState(false)
+    const [exportOpen, setExportOpen] = useState(false)
     const [archiveOpen, setArchiveOpen] = useState(false)
     const [deleteOpen, setDeleteOpen] = useState(false)
     const {
@@ -748,6 +750,7 @@ function SessionItem(props: {
                 onClose={() => setMenuOpen(false)}
                 sessionActive={s.active}
                 onRename={() => setRenameOpen(true)}
+                onExport={() => setExportOpen(true)}
                 onArchive={() => setArchiveOpen(true)}
                 onReopen={cursorReopenDisabledReason ? undefined : handleReopen}
                 reopenDisabledReason={cursorReopenDisabledReason}
@@ -775,6 +778,15 @@ function SessionItem(props: {
                 onRename={renameSession}
                 isPending={isPending}
             />
+
+            {exportOpen ? (
+                <SessionExportDialog
+                    isOpen={true}
+                    onClose={() => setExportOpen(false)}
+                    sessionId={s.id}
+                    api={api}
+                />
+            ) : null}
 
             <ConfirmDialog
                 isOpen={archiveOpen}


### PR DESCRIPTION
## Summary

Align the session-list context menu with the active session header by making **Export conversation** available from both entry points.

The lifecycle-specific actions remain intentionally different:

| Session state | Available actions after #1060 |
| --- | --- |
| Running | Rename, Export conversation, Copy resume command, Archive |
| Closed | Rename, Export conversation, Copy resume command, Reopen, Delete |

## Motivation

The session header already allows exporting both running and closed conversations, while the session-list context menu omits the export action. Users therefore have to open a conversation before they can export it, and the two menus expose different actions for the same session state.

## Changes

- Add **Export conversation** to the session-list context menu for both running and closed sessions.
- Open the existing export format dialog directly from a session row.
- Change `SessionExportDialog` to accept a `sessionId` instead of a full `Session` object.
  - The export flow only needs the ID.
  - Session-list summaries can use the dialog without fetching the full session first.
- Keep lifecycle actions state-specific:
  - running sessions retain Archive
  - closed sessions retain Reopen and Delete
- Add coverage for opening the export dialog from both running and closed session rows.

This PR is intentionally separate from #1060. It only closes the pre-existing export-action gap between the two menus; #1060 adds Copy resume command to both surfaces independently.

## Testing

- `bun typecheck`
- `bun run typecheck:web`
- `bun run test:web`
- `bun run --cwd web test src/components/SessionList.directory-action.test.tsx src/components/SessionActionMenu.test.tsx`
- `git diff --check`

`bun run test` was also attempted on Windows. The CLI suite exhausted the Bun process heap in `codexRemoteLauncher.test.ts` while the runner integration suite was still executing; the web suite and all checks relevant to this web-only change pass.

## AI disclosure

Implementation and tests were produced with OpenAI Codex (GPT-5.6).
