### PR TITLE
fix(codex): use supported safe-yolo approval policy

### DIFF
--- a/cli/src/codex/codexLocalLauncher.test.ts
+++ b/cli/src/codex/codexLocalLauncher.test.ts
@@ -247,7 +247,7 @@ describe('codexLocalLauncher', () => {
         expect(harness.launches).toHaveLength(1);
         expect(harness.launches[0]?.codexArgs).toEqual([
             '--ask-for-approval',
-            'on-failure',
+            'on-request',
             '--sandbox',
             'workspace-write',
             '--model',

--- a/cli/src/codex/utils/appServerConfig.test.ts
+++ b/cli/src/codex/utils/appServerConfig.test.ts
@@ -98,7 +98,7 @@ describe('appServerConfig', () => {
         });
     });
 
-    it('keeps on-failure approvals for safe-yolo threads', () => {
+    it('keeps supported escalation approvals for safe-yolo threads', () => {
         const params = buildThreadStartParams({
             cwd: '/workspace/project',
             mode: { permissionMode: 'safe-yolo', collaborationMode: 'default' },
@@ -106,7 +106,7 @@ describe('appServerConfig', () => {
         });
 
         expect(params.sandbox).toBe('workspace-write');
-        expect(params.approvalPolicy).toBe('on-failure');
+        expect(params.approvalPolicy).toBe('on-request');
     });
 
     it('allows MCP elicitation without enabling sandbox prompts for read-only threads', () => {
@@ -460,7 +460,7 @@ describe('appServerConfig', () => {
             cliOverrides: { sandbox: 'read-only', approvalPolicy: 'never' }
         });
 
-        expect(params.approvalPolicy).toBe('on-failure');
+        expect(params.approvalPolicy).toBe('on-request');
         expect(params.sandboxPolicy).toEqual({ type: 'workspaceWrite' });
         expect(params.collaborationMode).toEqual({
             mode: 'default',

--- a/cli/src/codex/utils/permissionModeConfig.test.ts
+++ b/cli/src/codex/utils/permissionModeConfig.test.ts
@@ -10,9 +10,9 @@ describe('resolveCodexPermissionModeConfig', () => {
         });
     });
 
-    it('keeps safe-yolo escalation on failure', () => {
+    it('keeps safe-yolo escalation available with a supported approval policy', () => {
         expect(resolveCodexPermissionModeConfig('safe-yolo')).toEqual({
-            approvalPolicy: 'on-failure',
+            approvalPolicy: 'on-request',
             sandbox: 'workspace-write',
             sandboxPolicy: { type: 'workspaceWrite' }
         });

--- a/cli/src/codex/utils/permissionModeConfig.ts
+++ b/cli/src/codex/utils/permissionModeConfig.ts
@@ -26,8 +26,10 @@ export function resolveCodexPermissionModeConfig(mode: CodexPermissionMode): Cod
             };
         case 'safe-yolo':
             return {
-                // Keep escalation available when the workspace-write sandbox blocks a command.
-                approvalPolicy: 'on-failure',
+                // Current Codex versions reject the removed `on-failure` policy. Keep
+                // escalation available through `on-request`; HAPI auto-approves these
+                // requests in safe-yolo mode.
+                approvalPolicy: 'on-request',
                 sandbox: 'workspace-write',
                 sandboxPolicy: { type: 'workspaceWrite' }
             };


### PR DESCRIPTION
## Summary

- replace Codex `safe-yolo`'s removed `on-failure` approval policy with `on-request`
- keep the existing `workspace-write` sandbox and HAPI auto-approval behavior
- update local launcher and app-server regression tests

## Problem

Codex CLI 0.144.x no longer accepts `on-failure`. Starting or resuming a HAPI Codex session in `safe-yolo` mode sends that value to `thread/start` or `thread/resume`, which fails immediately with:

```text
Invalid request: unknown variant `on-failure`, expected one of `untrusted`, `on-request`, `granular`, `never`
```

For resumed sessions, the user-facing result is:

```text
Task failed: Codex conversation <id> could not be resumed; no new conversation was created
```

`on-request` preserves sandbox escalation support, while HAPI's existing `CodexPermissionHandler` continues to auto-approve requests in `safe-yolo` mode.

## Testing

- `bun typecheck`
- `bun run test` (CLI, hub, web, and shared suites)

## AI disclosure

This focused fix and its tests were prepared with OpenAI Codex assistance and manually verified against Codex CLI 0.144.x behavior.
