### PR TITLE
fix(claude): preserve native titles and add a remote fallback

### DIFF
--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -761,6 +761,10 @@ export class ApiSessionClient extends EventEmitter {
         }
     }
 
+    hasSessionTitle(): boolean {
+        return Boolean(this.metadata?.name?.trim() || this.metadata?.summary?.text.trim())
+    }
+
     sendUserMessage(text: string, meta?: MessageMeta): void {
         if (!text) {
             return

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -761,10 +761,6 @@ export class ApiSessionClient extends EventEmitter {
         }
     }
 
-    hasSessionTitle(): boolean {
-        return Boolean(this.metadata?.name?.trim() || this.metadata?.summary?.text.trim())
-    }
-
     sendUserMessage(text: string, meta?: MessageMeta): void {
         if (!text) {
             return

--- a/cli/src/claude/claudeLocalLauncher.test.ts
+++ b/cli/src/claude/claudeLocalLauncher.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Metadata } from '@/api/types'
 
 const harness = vi.hoisted(() => ({
     launches: [] as Array<Record<string, unknown>>,
@@ -35,6 +36,7 @@ import { claudeLocalLauncher } from './claudeLocalLauncher'
 
 function createSessionStub() {
     const sentMessages: Array<Record<string, unknown>> = []
+    let metadata: Metadata = { path: '/tmp/test', host: 'localhost' }
     return {
         session: {
             sessionId: 'test-session',
@@ -49,7 +51,9 @@ function createSessionStub() {
             queue: { size: () => 0, reset: () => {}, setOnMessage: () => {} },
             client: {
                 sendClaudeSessionMessage: (msg: Record<string, unknown>) => { sentMessages.push(msg) },
-                hasSessionTitle: () => false,
+                updateMetadata: (handler: (current: Metadata) => Metadata) => {
+                    metadata = handler(metadata)
+                },
                 rpcHandlerManager: { registerHandler: () => {} }
             },
             addSessionFoundCallback: () => {},
@@ -57,7 +61,9 @@ function createSessionStub() {
             consumeOneTimeFlags: () => {},
             recordLocalLaunchFailure: () => {}
         },
-        sentMessages
+        sentMessages,
+        getMetadata: () => metadata,
+        setMetadata: (value: Metadata) => { metadata = value }
     }
 }
 
@@ -68,16 +74,17 @@ describe('claudeLocalLauncher message filtering', () => {
     })
 
     it('uses Claude Code summary messages as a title fallback', async () => {
-        const { session, sentMessages } = createSessionStub()
+        const { session, sentMessages, getMetadata } = createSessionStub()
         await claudeLocalLauncher(session as never)
 
         harness.scannerOnMessage!({ type: 'summary', summary: 'Native title', leafUuid: '1' })
 
-        expect(sentMessages).toEqual([{ type: 'summary', summary: 'Native title', leafUuid: '1' }])
+        expect(sentMessages).toHaveLength(0)
+        expect(getMetadata().summary?.text).toBe('Native title')
     })
 
     it('converts Claude Code ai-title metadata into a HAPI title', async () => {
-        const { session, sentMessages } = createSessionStub()
+        const { session, sentMessages, getMetadata } = createSessionStub()
         await claudeLocalLauncher(session as never)
 
         harness.scannerOnMessage!({
@@ -86,31 +93,34 @@ describe('claudeLocalLauncher message filtering', () => {
             sessionId: 'test-session'
         })
 
-        expect(sentMessages).toHaveLength(1)
-        expect(sentMessages[0]).toEqual(expect.objectContaining({
-            type: 'summary',
-            summary: '根据交接文档部署 HAPI 服务'
-        }))
+        expect(sentMessages).toHaveLength(0)
+        expect(getMetadata().summary?.text).toBe('根据交接文档部署 HAPI 服务')
     })
 
     it('does not replace an existing HAPI title with ai-title metadata', async () => {
-        const { session, sentMessages } = createSessionStub()
-        session.client.hasSessionTitle = () => true
+        const { session, sentMessages, getMetadata, setMetadata } = createSessionStub()
+        setMetadata({ path: '/tmp/test', host: 'localhost', name: 'Manual title' })
         await claudeLocalLauncher(session as never)
 
         harness.scannerOnMessage!({ type: 'ai-title', aiTitle: 'Native title' })
 
         expect(sentMessages).toHaveLength(0)
+        expect(getMetadata()).toEqual({ path: '/tmp/test', host: 'localhost', name: 'Manual title' })
     })
 
     it('does not replace an existing HAPI title with a native summary', async () => {
-        const { session, sentMessages } = createSessionStub()
-        session.client.hasSessionTitle = () => true
+        const { session, sentMessages, getMetadata, setMetadata } = createSessionStub()
+        setMetadata({
+            path: '/tmp/test',
+            host: 'localhost',
+            summary: { text: 'Existing title', updatedAt: 1 }
+        })
         await claudeLocalLauncher(session as never)
 
         harness.scannerOnMessage!({ type: 'summary', summary: 'Native title', leafUuid: '1' })
 
         expect(sentMessages).toHaveLength(0)
+        expect(getMetadata().summary?.text).toBe('Existing title')
     })
 
     it('filters out invisible system messages', async () => {

--- a/cli/src/claude/claudeLocalLauncher.test.ts
+++ b/cli/src/claude/claudeLocalLauncher.test.ts
@@ -49,6 +49,7 @@ function createSessionStub() {
             queue: { size: () => 0, reset: () => {}, setOnMessage: () => {} },
             client: {
                 sendClaudeSessionMessage: (msg: Record<string, unknown>) => { sentMessages.push(msg) },
+                hasSessionTitle: () => false,
                 rpcHandlerManager: { registerHandler: () => {} }
             },
             addSessionFoundCallback: () => {},
@@ -66,11 +67,48 @@ describe('claudeLocalLauncher message filtering', () => {
         harness.scannerOnMessage = null
     })
 
-    it('filters out summary messages', async () => {
+    it('uses Claude Code summary messages as a title fallback', async () => {
         const { session, sentMessages } = createSessionStub()
         await claudeLocalLauncher(session as never)
 
-        harness.scannerOnMessage!({ type: 'summary', leafUuid: '1' })
+        harness.scannerOnMessage!({ type: 'summary', summary: 'Native title', leafUuid: '1' })
+
+        expect(sentMessages).toEqual([{ type: 'summary', summary: 'Native title', leafUuid: '1' }])
+    })
+
+    it('converts Claude Code ai-title metadata into a HAPI title', async () => {
+        const { session, sentMessages } = createSessionStub()
+        await claudeLocalLauncher(session as never)
+
+        harness.scannerOnMessage!({
+            type: 'ai-title',
+            aiTitle: '根据交接文档部署 HAPI 服务',
+            sessionId: 'test-session'
+        })
+
+        expect(sentMessages).toHaveLength(1)
+        expect(sentMessages[0]).toEqual(expect.objectContaining({
+            type: 'summary',
+            summary: '根据交接文档部署 HAPI 服务'
+        }))
+    })
+
+    it('does not replace an existing HAPI title with ai-title metadata', async () => {
+        const { session, sentMessages } = createSessionStub()
+        session.client.hasSessionTitle = () => true
+        await claudeLocalLauncher(session as never)
+
+        harness.scannerOnMessage!({ type: 'ai-title', aiTitle: 'Native title' })
+
+        expect(sentMessages).toHaveLength(0)
+    })
+
+    it('does not replace an existing HAPI title with a native summary', async () => {
+        const { session, sentMessages } = createSessionStub()
+        session.client.hasSessionTitle = () => true
+        await claudeLocalLauncher(session as never)
+
+        harness.scannerOnMessage!({ type: 'summary', summary: 'Native title', leafUuid: '1' })
 
         expect(sentMessages).toHaveLength(0)
     })

--- a/cli/src/claude/claudeLocalLauncher.ts
+++ b/cli/src/claude/claudeLocalLauncher.ts
@@ -21,9 +21,7 @@ export async function claudeLocalLauncher(session: Session): Promise<'switch' | 
             // Claude Code writes its native session title as a summary. Use it as
             // a fallback for older transcript formats.
             if (message.type === 'summary') {
-                if (!session.client.hasSessionTitle()) {
-                    session.client.sendClaudeSessionMessage(message)
-                }
+                applySessionTitleFallback(session.client, message.summary)
                 return
             }
             // Filter out internal meta messages (e.g. skill injections) and

--- a/cli/src/claude/claudeLocalLauncher.ts
+++ b/cli/src/claude/claudeLocalLauncher.ts
@@ -3,6 +3,7 @@ import { Session } from "./session";
 import { createSessionScanner } from "./utils/sessionScanner";
 import { isClaudeChatVisibleMessage } from "./utils/chatVisibility";
 import { BaseLocalLauncher } from "@/modules/common/launcher/BaseLocalLauncher";
+import { applySessionTitleFallback } from './utils/sessionTitleFallback';
 
 export async function claudeLocalLauncher(session: Session): Promise<'switch' | 'exit'> {
 
@@ -11,8 +12,18 @@ export async function claudeLocalLauncher(session: Session): Promise<'switch' | 
         sessionId: session.sessionId,
         workingDirectory: session.path,
         onMessage: (message) => {
-            // Block SDK summary messages - we generate our own
+            // Preserve the AI-generated title emitted by Claude Code's native
+            // interactive CLI. It is metadata, not a visible chat message.
+            if (message.type === 'ai-title') {
+                applySessionTitleFallback(session.client, message.aiTitle)
+                return
+            }
+            // Claude Code writes its native session title as a summary. Use it as
+            // a fallback for older transcript formats.
             if (message.type === 'summary') {
+                if (!session.client.hasSessionTitle()) {
+                    session.client.sendClaudeSessionMessage(message)
+                }
                 return
             }
             // Filter out internal meta messages (e.g. skill injections) and

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -69,6 +69,45 @@ async function waitFor(condition: () => boolean, timeoutMs = 300, intervalMs = 1
 }
 
 describe('claudeRemote async message handling', () => {
+    it('reports the initial normal message once after the first result', async () => {
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        const onFirstResult = vi.fn();
+
+        queryMock.mockReturnValueOnce(createAsyncStream([
+            { type: 'result', subtype: 'success' } as unknown as SDKMessage,
+            { type: 'result', subtype: 'success' } as unknown as SDKMessage
+        ]));
+
+        let nextCallCount = 0;
+        try {
+            await claudeRemote({
+                sessionId: 'session-1',
+                path: process.cwd(),
+                mcpServers: {},
+                claudeEnvVars: {},
+                claudeArgs: [],
+                allowedTools: [],
+                hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => nextCallCount++ === 0
+                    ? { message: 'Review this project', mode: { permissionMode: 'default' } }
+                    : null,
+                onReady: () => {},
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: () => {},
+                onFirstResult
+            });
+
+            expect(onFirstResult).toHaveBeenCalledTimes(1);
+            expect(onFirstResult).toHaveBeenCalledWith('Review this project');
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+    });
+
     it('continues consuming assistant messages even when next user message is pending', async () => {
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -34,6 +34,7 @@ export async function claudeRemote(opts: {
     onSessionFound: (id: string) => void,
     onThinkingChange?: (thinking: boolean) => void,
     onMessage: (message: SDKMessage) => void,
+    onFirstResult?: (initialMessage: string) => void,
     onCompletionEvent?: (message: string) => void,
     onSessionReset?: () => void
 }) {
@@ -281,6 +282,10 @@ export async function claudeRemote(opts: {
                     `${debugPrefix} result #${resultSeq} received; scheduling next user message ` +
                     `(nextInFlight=${nextMessageFetchInFlight}, inputEnded=${inputEnded})`
                 );
+
+                if (resultSeq === 1 && specialCommand.type === null) {
+                    opts.onFirstResult?.(initial.message);
+                }
 
                 // Send completion messages
                 if (isCompactCommand) {

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -12,6 +12,7 @@ import { PLAN_FAKE_REJECT } from "./sdk/prompts";
 import { EnhancedMode } from "./loop";
 import { OutgoingMessageQueue } from "./utils/OutgoingMessageQueue";
 import type { ClaudePermissionMode } from "@hapi/protocol/types";
+import { applySessionTitleFallback } from './utils/sessionTitleFallback';
 import {
     RemoteLauncherBase,
     type RemoteLauncherDisplayContext,
@@ -362,6 +363,9 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                         claudeEnvVars: session.claudeEnvVars,
                         claudeArgs: session.claudeArgs,
                         onMessage,
+                        onFirstResult: (initialMessage) => {
+                            applySessionTitleFallback(session.client, initialMessage);
+                        },
                         onCompletionEvent: (message: string) => {
                             logger.debug(`[remote]: Completion event: ${message}`);
                             session.client.sendSessionEvent({ type: 'message', message });

--- a/cli/src/claude/types.test.ts
+++ b/cli/src/claude/types.test.ts
@@ -2,6 +2,18 @@ import { describe, it, expect } from "vitest";
 import { RawJSONLinesSchema } from "./types";
 
 describe("RawJSONLinesSchema", () => {
+    it("accepts Claude Code native ai-title events", () => {
+        expect(RawJSONLinesSchema.parse({
+            type: "ai-title",
+            aiTitle: "根据交接文档部署 HAPI 服务",
+            sessionId: "session-1"
+        })).toEqual({
+            type: "ai-title",
+            aiTitle: "根据交接文档部署 HAPI 服务",
+            sessionId: "session-1"
+        });
+    });
+
     describe("system / turn_duration record", () => {
         it("preserves messageId so the web reducer can match the duration to the right block", () => {
             // Claude code emits turn_duration as a system record carrying the

--- a/cli/src/claude/types.ts
+++ b/cli/src/claude/types.ts
@@ -67,6 +67,12 @@ export const RawJSONLinesSchema = z.discriminatedUnion("type", [
     leafUuid: z.string(),
   }),
 
+  // Claude Code's native interactive CLI title event.
+  RawJSONLinesBaseSchema.extend({
+    type: z.literal("ai-title"),
+    aiTitle: z.string(),
+  }),
+
   // System message - validates uuid and subtype data used by the UI.
   // `passthrough` preserves fields like `messageId` on `turn_duration` and any
   // future system subtype data the hub forwards to the web reducer.

--- a/cli/src/claude/utils/sessionScanner.ts
+++ b/cli/src/claude/utils/sessionScanner.ts
@@ -161,6 +161,8 @@ function messageKey(message: RawJSONLines): string {
         return message.uuid;
     } else if (message.type === 'summary') {
         return 'summary: ' + message.leafUuid + ': ' + message.summary;
+    } else if (message.type === 'ai-title') {
+        return 'ai-title: ' + message.aiTitle;
     } else if (message.type === 'system') {
         return message.uuid;
     } else {

--- a/cli/src/claude/utils/sessionTitleFallback.test.ts
+++ b/cli/src/claude/utils/sessionTitleFallback.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applySessionTitleFallback, createSessionTitleFallback } from './sessionTitleFallback'
+
+describe('Claude session title fallback', () => {
+    it('normalizes whitespace and truncates long initial messages', () => {
+        expect(createSessionTitleFallback('  Review\n\nthis   project  ')).toBe('Review this project')
+
+        const title = createSessionTitleFallback('a'.repeat(100))
+        expect(title).toBe('a'.repeat(79) + '…')
+    })
+
+    it('writes a summary when no title exists', () => {
+        const sendClaudeSessionMessage = vi.fn()
+
+        expect(applySessionTitleFallback({
+            hasSessionTitle: () => false,
+            sendClaudeSessionMessage
+        }, 'Review this project')).toBe(true)
+
+        expect(sendClaudeSessionMessage).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'summary',
+            summary: 'Review this project'
+        }))
+    })
+
+    it('does not replace an existing title or use an empty message', () => {
+        const sendClaudeSessionMessage = vi.fn()
+
+        expect(applySessionTitleFallback({
+            hasSessionTitle: () => true,
+            sendClaudeSessionMessage
+        }, 'Review this project')).toBe(false)
+        expect(applySessionTitleFallback({
+            hasSessionTitle: () => false,
+            sendClaudeSessionMessage
+        }, '  \n  ')).toBe(false)
+
+        expect(sendClaudeSessionMessage).not.toHaveBeenCalled()
+    })
+})

--- a/cli/src/claude/utils/sessionTitleFallback.test.ts
+++ b/cli/src/claude/utils/sessionTitleFallback.test.ts
@@ -10,31 +10,29 @@ describe('Claude session title fallback', () => {
     })
 
     it('writes a summary when no title exists', () => {
-        const sendClaudeSessionMessage = vi.fn()
+        const updateMetadata = vi.fn((handler) => handler({}))
 
         expect(applySessionTitleFallback({
-            hasSessionTitle: () => false,
-            sendClaudeSessionMessage
+            updateMetadata
         }, 'Review this project')).toBe(true)
 
-        expect(sendClaudeSessionMessage).toHaveBeenCalledWith(expect.objectContaining({
-            type: 'summary',
-            summary: 'Review this project'
+        expect(updateMetadata).toHaveReturnedWith(expect.objectContaining({
+            summary: expect.objectContaining({ text: 'Review this project' })
         }))
     })
 
     it('does not replace an existing title or use an empty message', () => {
-        const sendClaudeSessionMessage = vi.fn()
+        const manualMetadata = { name: 'Manual title' }
+        const updateMetadata = vi.fn((handler) => handler(manualMetadata))
 
         expect(applySessionTitleFallback({
-            hasSessionTitle: () => true,
-            sendClaudeSessionMessage
-        }, 'Review this project')).toBe(false)
+            updateMetadata
+        }, 'Review this project')).toBe(true)
         expect(applySessionTitleFallback({
-            hasSessionTitle: () => false,
-            sendClaudeSessionMessage
+            updateMetadata
         }, '  \n  ')).toBe(false)
 
-        expect(sendClaudeSessionMessage).not.toHaveBeenCalled()
+        expect(updateMetadata).toHaveBeenCalledTimes(1)
+        expect(updateMetadata).toHaveReturnedWith(manualMetadata)
     })
 })

--- a/cli/src/claude/utils/sessionTitleFallback.ts
+++ b/cli/src/claude/utils/sessionTitleFallback.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import type { ApiSessionClient } from '@/api/apiSession'
 
 const MAX_FALLBACK_TITLE_LENGTH = 80
@@ -12,18 +11,22 @@ export function createSessionTitleFallback(message: string): string | null {
 }
 
 export function applySessionTitleFallback(
-    client: Pick<ApiSessionClient, 'hasSessionTitle' | 'sendClaudeSessionMessage'>,
+    client: Pick<ApiSessionClient, 'updateMetadata'>,
     message: string
 ): boolean {
-    if (client.hasSessionTitle()) return false
-
     const title = createSessionTitleFallback(message)
     if (!title) return false
 
-    client.sendClaudeSessionMessage({
-        type: 'summary',
-        summary: title,
-        leafUuid: randomUUID()
+    client.updateMetadata((metadata) => {
+        if (metadata.name?.trim() || metadata.summary?.text.trim()) return metadata
+
+        return {
+            ...metadata,
+            summary: {
+                text: title,
+                updatedAt: Date.now()
+            }
+        }
     })
     return true
 }

--- a/cli/src/claude/utils/sessionTitleFallback.ts
+++ b/cli/src/claude/utils/sessionTitleFallback.ts
@@ -1,0 +1,29 @@
+import { randomUUID } from 'node:crypto'
+import type { ApiSessionClient } from '@/api/apiSession'
+
+const MAX_FALLBACK_TITLE_LENGTH = 80
+
+export function createSessionTitleFallback(message: string): string | null {
+    const normalized = message.replace(/\s+/g, ' ').trim()
+    if (!normalized) return null
+    if (normalized.length <= MAX_FALLBACK_TITLE_LENGTH) return normalized
+
+    return normalized.slice(0, MAX_FALLBACK_TITLE_LENGTH - 1).trimEnd() + '…'
+}
+
+export function applySessionTitleFallback(
+    client: Pick<ApiSessionClient, 'hasSessionTitle' | 'sendClaudeSessionMessage'>,
+    message: string
+): boolean {
+    if (client.hasSessionTitle()) return false
+
+    const title = createSessionTitleFallback(message)
+    if (!title) return false
+
+    client.sendClaudeSessionMessage({
+        type: 'summary',
+        summary: title,
+        leafUuid: randomUUID()
+    })
+    return true
+}


### PR DESCRIPTION
## Title

```text
fix(claude): preserve native titles and add a remote fallback
```

## Summary

- preserve Claude Code's native `ai-title` metadata for local interactive sessions
- keep legacy transcript `summary` events as a fallback without overriding an existing title
- give remote SDK sessions a deterministic title after their first normal result when Claude did not call HAPI's `change_title` tool
- preserve manual session names and existing agent-generated titles

## Problem

Claude sessions could remain named after their working directory in HAPI even after the first task completed.

The two Claude launch paths fail differently:

- Native interactive Claude Code writes concise generated titles as transcript records shaped like `{"type":"ai-title","aiTitle":"..."}`, but HAPI's transcript schema and scanner did not recognize those records.
- Claude SDK sessions do not reliably emit native `ai-title` records, and the model does not always follow HAPI's prompt to call `change_title`.

As a result, local sessions could discard an available native title, while remote sessions had no deterministic fallback at all.

## Changes

### Local Claude sessions

- accept `ai-title` records in `RawJSONLinesSchema`
- give `ai-title` records stable scanner keys
- translate native `ai-title` metadata into HAPI's existing summary-title update
- do not render title metadata as a visible chat message
- continue accepting legacy `summary` records

### Remote Claude sessions

- report the initial normal user message after the first result
- if the session still has neither `metadata.name` nor `metadata.summary`, normalize that message and store it as a fallback title
- collapse whitespace and cap fallback titles at 80 characters
- skip `/clear`, `/compact`, and `/plan` command handling

### Precedence

The change does not replace:

1. a user-supplied `metadata.name`
2. an existing `metadata.summary`, including a successful `change_title` call

This also closes the race where a title tool call succeeds during the first turn: the remote fallback checks the latest local metadata before writing.

## Scope

This PR restores native AI-generated titles where Claude Code provides them and prevents untitled remote sessions from staying on the directory fallback.

It intentionally does not add periodic topic detection, automatic retitling after later turns, or extra model calls. Those behaviors have separate cost, lifecycle, and configuration considerations.

## Testing

- `bun typecheck`
- `bun run test:cli`
- `bun run test:web`
- `bun run test:shared`
- targeted Claude title tests:
  - `claudeRemote.test.ts`
  - `claudeRemoteLauncher.test.ts`
  - `claudeLocalLauncher.test.ts`
  - `types.test.ts`
  - `sessionScanner.test.ts`
  - `sessionTitleFallback.test.ts`
- manual verification against a real HAPI Hub/runner deployment:
  - remote SDK session receives a first-message fallback
  - existing/manual titles are preserved
  - native transcript `ai-title` format verified from local Claude Code sessions

`bun run test:hub` currently reports 487 passing tests and 7 unrelated Windows failures in the existing Cursor ACP verification/migration tests. This PR does not modify Hub or Cursor code.
