### PR TITLE
fix(web): keep mobile session header compact

### DIFF
--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -196,7 +196,7 @@ export function SessionHeader(props: {
                                 </span>
                             ) : null}
                             {reasoningLabel ? (
-                                <span data-testid="session-header-reasoning">
+                                <span data-testid="session-header-reasoning" className="hidden sm:inline">
                                     {reasoningLabel}
                                 </span>
                             ) : null}


### PR DESCRIPTION
## Summary

- Hide the `reasoning ...` label in `SessionHeader` below the `sm` breakpoint.
- Keep the label visible in the desktop header.
- Keep the composer `StatusBar` reasoning label unchanged on every viewport.

## Problem

The reasoning label added in #1016 can wrap onto a third header line on narrow mobile screens. This makes the session header noticeably taller, while the same reasoning value is already visible in the composer status bar.

Using the existing Tailwind `sm` breakpoint keeps the mobile header to its intended title + metadata layout without removing the desktop status information introduced by #1016.

## Test plan

- [x] `bun typecheck`
- [x] `bun run test:web` (158 files, 1279 tests)
- [x] Verify on a narrow mobile viewport that `SessionHeader` no longer shows `reasoning ...` or gains a third line.
- [x] Verify the composer `StatusBar` still shows the active reasoning effort on mobile.
- [x] Verify `SessionHeader` still shows the reasoning effort at desktop widths (`sm` and above).
- [x] Smoke-test the production Web/Hub build on ports 3016 and 3006.

## Related

- Follow-up to #1016
- Related issue: #1015

## AI disclosure

This change was prepared with OpenAI Codex (`gpt-5.6-sol`).
