### PR TITLE
feat(cli,web): show Claude Code's away recap in local-mode chat

### DIFF
--- a/cli/src/claude/claudeLocalLauncher.test.ts
+++ b/cli/src/claude/claudeLocalLauncher.test.ts
@@ -96,6 +96,16 @@ describe('claudeLocalLauncher message filtering', () => {
         expect(sentMessages).toHaveLength(2)
     })
 
+    it('forwards away_summary (auto recap) system messages', async () => {
+        const { session, sentMessages } = createSessionStub()
+        await claudeLocalLauncher(session as never)
+
+        harness.scannerOnMessage!({ type: 'system', subtype: 'away_summary', uuid: '1', content: 'recap text' })
+
+        expect(sentMessages).toHaveLength(1)
+        expect(sentMessages[0]).toMatchObject({ subtype: 'away_summary', content: 'recap text' })
+    })
+
     it('forwards normal conversation messages', async () => {
         const { session, sentMessages } = createSessionStub()
         await claudeLocalLauncher(session as never)

--- a/cli/src/claude/types.test.ts
+++ b/cli/src/claude/types.test.ts
@@ -81,4 +81,21 @@ describe("RawJSONLinesSchema", () => {
             expect((parsed as Record<string, unknown>).futureBreakdown).toEqual({ tokens: { in: 1, out: 2 } });
         });
     });
+
+    describe("system / away_summary record", () => {
+        it("preserves the recap text in `content` (not declared on the base schema, relies on passthrough)", () => {
+            // Claude code's away_summary record carries the recap text in `content`.
+            // If Zod strips undeclared fields, the recap text never reaches the hub/web.
+            const parsed = RawJSONLinesSchema.parse({
+                type: "system",
+                subtype: "away_summary",
+                uuid: "evt-4",
+                content: "Building X, next: wire up Y.",
+                timestamp: "2026-07-12T00:00:00.000Z",
+                isMeta: false
+            });
+            if (parsed.type !== "system") throw new Error("expected system record");
+            expect((parsed as Record<string, unknown>).content).toBe("Building X, next: wire up Y.");
+        });
+    });
 });

--- a/cli/src/claude/utils/chatVisibility.test.ts
+++ b/cli/src/claude/utils/chatVisibility.test.ts
@@ -13,6 +13,7 @@ describe('isClaudeChatVisibleMessage', () => {
         expect(isClaudeChatVisibleMessage({ type: 'system', subtype: 'api_error' })).toBe(true)
         expect(isClaudeChatVisibleMessage({ type: 'system', subtype: 'microcompact_boundary' })).toBe(true)
         expect(isClaudeChatVisibleMessage({ type: 'system', subtype: 'compact_boundary' })).toBe(true)
+        expect(isClaudeChatVisibleMessage({ type: 'system', subtype: 'away_summary' })).toBe(true)
     })
 
     it('keeps conversation messages visible', () => {

--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -10,7 +10,13 @@ const VISIBLE_CLAUDE_SYSTEM_SUBTYPES = new Set([
     'api_error',
     'turn_duration',
     'microcompact_boundary',
-    'compact_boundary'
+    'compact_boundary',
+    // Auto-generated recap Claude Code's local TUI writes to the transcript on
+    // window blur/focus (5min+ idle). Only observed via the local launcher's
+    // transcript scan — SDK/remote mode never emits it. Chat-visible here also
+    // means CLI-forwarded, web-rendered, and included in session export
+    // (parity with turn_duration / compact_boundary).
+    'away_summary'
 ])
 
 export function isRoleWrappedRecord(value: unknown): value is RoleWrappedRecord {

--- a/web/src/chat/normalize.test.ts
+++ b/web/src/chat/normalize.test.ts
@@ -71,6 +71,65 @@ describe('normalizeDecryptedMessage', () => {
         })
     })
 
+    it('normalizes away_summary (auto recap) system output into a recap event', () => {
+        const message = makeMessage({
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: {
+                    type: 'system',
+                    subtype: 'away_summary',
+                    uuid: 'sys-3',
+                    content: 'Building the login flow, next: wire up the submit handler.'
+                }
+            }
+        })
+
+        expect(normalizeDecryptedMessage(message)).toMatchObject({
+            id: 'msg-1',
+            role: 'event',
+            isSidechain: false,
+            content: {
+                type: 'recap',
+                text: 'Building the login flow, next: wire up the submit handler.'
+            }
+        })
+    })
+
+    it('skips away_summary with empty content instead of emitting a bare recap row', () => {
+        const message = makeMessage({
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: {
+                    type: 'system',
+                    subtype: 'away_summary',
+                    uuid: 'sys-4',
+                    content: ''
+                }
+            }
+        })
+
+        expect(normalizeDecryptedMessage(message)).toBeNull()
+    })
+
+    it('skips away_summary with whitespace-only content instead of emitting a bare recap row', () => {
+        const message = makeMessage({
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: {
+                    type: 'system',
+                    subtype: 'away_summary',
+                    uuid: 'sys-5',
+                    content: '   '
+                }
+            }
+        })
+
+        expect(normalizeDecryptedMessage(message)).toBeNull()
+    })
+
     it('keeps the stringify fallback for unknown non-system agent payloads', () => {
         const message = makeMessage({
             role: 'agent',

--- a/web/src/chat/normalizeAgent.ts
+++ b/web/src/chat/normalizeAgent.ts
@@ -421,6 +421,10 @@ export function isSkippableAgentContent(content: unknown): boolean {
     const data = isObject(content.data) ? content.data : null
     if (!data) return false
     if (Boolean(data.isMeta) || Boolean(data.isCompactSummary)) return true
+    // A recap with no text is pure noise — drop it here rather than let it reach
+    // the away_summary branch (a bare "recap:" row) or, via a null return, fall
+    // through to the raw-JSON stringify fallback in normalize.ts.
+    if (data.type === 'system' && data.subtype === 'away_summary' && !asString(data.content)?.trim()) return true
     return !isClaudeChatVisibleMessage({ type: data.type, subtype: data.subtype })
 }
 
@@ -489,6 +493,22 @@ export function normalizeAgentRecord(
                     type: 'turn-duration',
                     durationMs: asNumber(data.durationMs) ?? 0,
                     targetMessageId: asString(data.messageId) ?? undefined
+                },
+                isSidechain: false,
+                meta
+            }
+        }
+        if (data.type === 'system' && data.subtype === 'away_summary') {
+            // Recap text lives in `content`. Empty recaps are dropped upstream by
+            // isSkippableAgentContent, so content is a non-empty string here.
+            return {
+                id: messageId,
+                localId,
+                createdAt,
+                role: 'event',
+                content: {
+                    type: 'recap',
+                    text: asString(data.content) ?? ''
                 },
                 isSidechain: false,
                 meta

--- a/web/src/chat/presentation.test.ts
+++ b/web/src/chat/presentation.test.ts
@@ -135,7 +135,7 @@ describe('getEventPresentation — thread goals', () => {
 })
 
 describe('getEventPresentation — recap (away_summary)', () => {
-    it('formats the auto-generated away recap with a recap: prefix, distinct from manual /recap', () => {
+    it('formats the recap with a recap: prefix', () => {
         const result = getEventPresentation({
             type: 'recap',
             text: 'Building the login flow, next: wire up the submit handler.'

--- a/web/src/chat/presentation.test.ts
+++ b/web/src/chat/presentation.test.ts
@@ -134,6 +134,18 @@ describe('getEventPresentation — thread goals', () => {
     })
 })
 
+describe('getEventPresentation — recap (away_summary)', () => {
+    it('formats the auto-generated away recap with a recap: prefix, distinct from manual /recap', () => {
+        const result = getEventPresentation({
+            type: 'recap',
+            text: 'Building the login flow, next: wire up the submit handler.'
+        })
+
+        expect(result.icon).toBe('💭')
+        expect(result.text).toBe('recap: Building the login flow, next: wire up the submit handler.')
+    })
+})
+
 describe('formatResetTime', () => {
     it('formats a unix timestamp to a non-empty string', () => {
         const result = formatResetTime(1774278000)

--- a/web/src/chat/presentation.ts
+++ b/web/src/chat/presentation.ts
@@ -201,9 +201,7 @@ export function getEventPresentation(event: AgentEvent): EventPresentation {
         return { icon: '📦', text: 'Conversation compacted' }
     }
     if (event.type === 'recap') {
-        // Lowercase `recap:` intentionally mirrors Claude Code's own TUI recap
-        // label; the 💭 icon and centered system row already distinguish it from
-        // the manual /recap assistant bubble.
+        // Lowercase `recap:` intentionally mirrors Claude Code's own TUI recap label.
         const text = typeof event.text === 'string' ? event.text : ''
         return { icon: '💭', text: `recap: ${text}` }
     }

--- a/web/src/chat/presentation.ts
+++ b/web/src/chat/presentation.ts
@@ -200,6 +200,13 @@ export function getEventPresentation(event: AgentEvent): EventPresentation {
     if (event.type === 'compact') {
         return { icon: '📦', text: 'Conversation compacted' }
     }
+    if (event.type === 'recap') {
+        // Lowercase `recap:` intentionally mirrors Claude Code's own TUI recap
+        // label; the 💭 icon and centered system row already distinguish it from
+        // the manual /recap assistant bubble.
+        const text = typeof event.text === 'string' ? event.text : ''
+        return { icon: '💭', text: `recap: ${text}` }
+    }
     if (event.type === 'thread-goal-updated') {
         return formatThreadGoalEvent(event)
     }

--- a/web/src/chat/types.ts
+++ b/web/src/chat/types.ts
@@ -25,9 +25,7 @@ export type AgentEvent =
     | { type: 'turn-duration'; durationMs: number; targetMessageId?: string }
     | { type: 'microcompact'; trigger: string; preTokens: number; tokensSaved: number }
     | { type: 'compact'; trigger: string; preTokens: number }
-    // Claude Code's automatic away-summary recap (TUI window blur 5min+, then
-    // focus). Distinct from the manual `/recap` slash command, which HAPI
-    // already renders as a regular assistant bubble.
+    // Claude Code's automatic away-summary recap (TUI window blur 5min+, then focus).
     | { type: 'recap'; text: string }
     | { type: 'thread-goal-updated'; goal: ThreadGoal; threadId?: string; turnId?: string }
     | { type: 'thread-goal-cleared'; threadId?: string }

--- a/web/src/chat/types.ts
+++ b/web/src/chat/types.ts
@@ -25,6 +25,10 @@ export type AgentEvent =
     | { type: 'turn-duration'; durationMs: number; targetMessageId?: string }
     | { type: 'microcompact'; trigger: string; preTokens: number; tokensSaved: number }
     | { type: 'compact'; trigger: string; preTokens: number }
+    // Claude Code's automatic away-summary recap (TUI window blur 5min+, then
+    // focus). Distinct from the manual `/recap` slash command, which HAPI
+    // already renders as a regular assistant bubble.
+    | { type: 'recap'; text: string }
     | { type: 'thread-goal-updated'; goal: ThreadGoal; threadId?: string; turnId?: string }
     | { type: 'thread-goal-cleared'; threadId?: string }
     | ({ type: string } & Record<string, unknown>)


### PR DESCRIPTION
## Problem

In local mode, Claude Code's own TUI writes an automatic "away summary" recap into the session transcript whenever the window blurs and later regains focus after 5+ minutes idle. HAPI's local launcher already scans that transcript, but `VISIBLE_CLAUDE_SYSTEM_SUBTYPES` doesn't include `away_summary`, so the record never reaches the hub. Even if it did, the web client had no rendering branch for it, so it would fall through to the raw-JSON stringify fallback. The practical effect: local-mode users never see the recap Claude Code already generated for them.

## Solution

- Add `away_summary` to `VISIBLE_CLAUDE_SYSTEM_SUBTYPES` so the local launcher forwards it to the hub the same way it already does for `turn_duration`, `compact_boundary`, etc.
- Add a `recap` `AgentEvent` on the web side, with a `normalizeAgent` branch mirroring the existing `turn_duration`/`compact` subtype branches, and a presentation entry that prefixes the text with `recap:` (💭 icon). No new render component: it flows through the existing generic system-event row (`SystemMessage.tsx` + `getEventPresentation`) that every other system subtype already uses.
- A recap with empty or whitespace-only content is dropped before it reaches the render branch, so it never shows up as a bare `recap:` row.

This only affects the local-mode launcher path (transcript scan). Remote/SDK sessions don't emit this subtype, so there's no behavior change there.

## Tests

- `shared`: Zod passthrough test confirming `RawJSONLinesSchema` preserves the recap `content` field for `system`/`away_summary` records.
- `cli`: `chatVisibility` test for the new subtype, and a `claudeLocalLauncher` test confirming the scanner forwards `away_summary` messages.
- `web`: `normalizeAgent` tests for turning `away_summary` into a `recap` event and for dropping empty- and whitespace-only-content recaps, plus a presentation test for the `recap:` prefix formatting.
- Manually verified end-to-end in an isolated hub+web instance: injected the exact message envelope the local launcher forwards for an away_summary record and confirmed the chat renders the `recap: ...` row (screenshot below).

## Screenshot

![hapi-away-recap-local-mode.png](https://github.com/user-attachments/assets/d87942b7-ea20-44c5-9d41-1690a2482e68)

