### PR TITLE
fix(shared): hide tool_progress heartbeat events from chat delivery

### DIFF
--- a/cli/src/claude/utils/chatVisibility.test.ts
+++ b/cli/src/claude/utils/chatVisibility.test.ts
@@ -25,4 +25,8 @@ describe('isClaudeChatVisibleMessage', () => {
     it('hides rate_limit_event messages from chat delivery', () => {
         expect(isClaudeChatVisibleMessage({ type: 'rate_limit_event' } as any)).toBe(false)
     })
+
+    it('hides tool_progress heartbeat messages from chat delivery', () => {
+        expect(isClaudeChatVisibleMessage({ type: 'tool_progress' } as any)).toBe(false)
+    })
 })

--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -49,6 +49,10 @@ export function isClaudeChatVisibleMessage(message: { type: unknown; subtype?: u
         return false
     }
 
+    if (message.type === 'tool_progress') {
+        return false
+    }
+
     if (message.type !== 'system') {
         return true
     }


### PR DESCRIPTION

## Problem

While a sidechain (subagent, Task tool) runs a long Bash command, the Claude
Agent SDK periodically emits a `tool_progress` heartbeat event on the
transcript/stream. `isClaudeChatVisibleMessage()` (`shared/src/messages.ts`)
only special-cases `system` and `rate_limit_event` message types and defaults
everything else to visible, so this new event type falls through and its raw
JSON body renders directly in the chat, e.g.:

```json
{ "type": "output", "data": { "type": "tool_progress", "uuid": "...", "parentUuid": "...", "isSidechain": true, "tool_use_id": "...", "elapsed_time_seconds": 32, "message": "Bash tool running for 32s..." } }
```

## Solution

Same pattern as the existing `rate_limit_event` filter (#423, `fix: filter
rate_limit_event from Claude Remote/Local chat paths`): add an explicit
`tool_progress` deny branch to `isClaudeChatVisibleMessage()`. Because this
function is the single gate consumed by the CLI local launcher, the CLI
chat-visibility re-export, and both web `normalizeAgent.ts` call sites, the
fix propagates to local- and remote-mode sessions alike without touching any
of those call sites.

## Screenshots

| Before | After |
|---|---|
| ![raw JSON leaking into chat before the fix](https://github.com/user-attachments/assets/96f4e3ee-698c-4c8c-bf45-6710cb57ee40) | ![heartbeat hidden after the fix](https://github.com/user-attachments/assets/37c128ba-8548-4adc-9a62-d2688609d030) |

The Task subagent card renders identically `running` in both (spinner + elapsed timer) — the only difference is the raw JSON heartbeat text underneath it.

## Tests

- Added `hides tool_progress heartbeat messages from chat delivery` next to
  the existing `rate_limit_event` case in
  `cli/src/claude/utils/chatVisibility.test.ts`.
- `bun run test` (root): cli 1364 tests / hub 499 tests / web 1297 tests /
  shared 114 tests, all passing.
- `bun typecheck`: clean across cli/web/hub.
- Isolated E2E stack (fake CLI over Socket.IO `/cli` namespace + Playwright):
  injected an assistant message with a running Task (subagent) tool_use block
  (no `tool_result` yet, so the ToolCard renders in its `running` state — the
  spinner + elapsed timer) followed by a `tool_progress` heartbeat for that
  subagent's sidechain, once with the fix reverted and once with the fix
  applied. Screenshots above reproduce the shape of the original bug report
  (a running subagent tool card with raw JSON leaking underneath it) — the
  Task card renders identically running in both captures, and the only
  difference between before/after is that the heartbeat JSON text underneath
  it disappears once the fix is applied.
