### PR TITLE
fix(cli): stop skill_lookup $name user-turn prepend (prompt-injection FP)

### DIFF
--- a/cli/src/agent/runners/runAgentSession.test.ts
+++ b/cli/src/agent/runners/runAgentSession.test.ts
@@ -180,8 +180,10 @@ describe('runAgentSession', () => {
 
         const firstPrompt = JSON.stringify(harness.prompts[0])
         const secondPrompt = JSON.stringify(harness.prompts[1])
-        expect(firstPrompt).toContain('$name')
-        expect(firstPrompt).toContain('skill_lookup')
+        expect(firstPrompt).toContain('first')
+        expect(firstPrompt).not.toContain('skill_lookup')
+        expect(firstPrompt).not.toContain('$name')
+        expect(secondPrompt).toContain('second')
         expect(secondPrompt).not.toContain('skill_lookup')
     })
 })

--- a/cli/src/agent/runners/runAgentSession.ts
+++ b/cli/src/agent/runners/runAgentSession.ts
@@ -16,8 +16,6 @@ import { PermissionModeSchema } from '@hapi/protocol/schemas';
 import { isPermissionModeAllowedForFlavor } from '@hapi/protocol';
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 import type { SessionEndReason } from '@hapi/protocol';
-import { SKILL_LOOKUP_INSTRUCTION } from '@/modules/common/skillLookupInstruction';
-
 function emitReadyIfIdle(props: {
     queueSize: () => number;
     shouldExit: boolean;
@@ -101,8 +99,6 @@ export async function runAgentSession(opts: {
     let thinking = false;
     let shouldExit = false;
     let waitAbortController: AbortController | null = null;
-    let skillLookupInstructionSent = false;
-
     const syncKeepAlive = () => {
         session.keepAlive(thinking, 'remote', {
             permissionMode: currentPermissionMode
@@ -180,15 +176,11 @@ export async function runAgentSession(opts: {
                 continue;
             }
 
-            let messageText = batch.message;
-            if (!skillLookupInstructionSent && !messageText.trimStart().startsWith('/')) {
-                messageText = `${SKILL_LOOKUP_INSTRUCTION}\n\n${messageText}`;
-                skillLookupInstructionSent = true;
-            }
-
+            // skill_lookup discovery lives on the MCP tool description — do not
+            // prepend instructions onto user turns (prompt-injection false positive).
             const promptContent: PromptContent[] = [{
                 type: 'text',
-                text: messageText
+                text: batch.message
             }];
 
             thinking = true;

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -768,8 +768,10 @@ describe('cursorAcpRemoteLauncher', () => {
         await cursorAcpRemoteLauncher(session);
 
         expect(harness.promptCalls).toBe(2);
-        expect(JSON.stringify(harness.prompts[0])).toContain('$name');
-        expect(JSON.stringify(harness.prompts[0])).toContain('skill_lookup');
+        expect(JSON.stringify(harness.prompts[0])).toContain('first');
+        expect(JSON.stringify(harness.prompts[0])).not.toContain('skill_lookup');
+        expect(JSON.stringify(harness.prompts[0])).not.toContain('$name');
+        expect(JSON.stringify(harness.prompts[1])).toContain('second');
         expect(JSON.stringify(harness.prompts[1])).not.toContain('skill_lookup');
     });
 });

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -30,8 +30,6 @@ import { cursorPassThroughStatusMessage, parseCursorSpecialCommand } from './cur
 import { buildCursorModelsSeedPayload, seedCursorModelsCache } from '@/modules/common/cursorModels';
 import { readSharedCursorModelsCache } from '@/modules/common/cursorModelsSharedCache';
 import type { AcpSdkBackend } from '@/agent/backends/acp';
-import { SKILL_LOOKUP_INSTRUCTION } from '@/modules/common/skillLookupInstruction';
-
 class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     private readonly session: CursorSession;
     private backend: ReturnType<typeof createCursorAcpBackend> | null = null;
@@ -48,8 +46,6 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     private spawnedWithAutoReview = false;
     /** Avoid re-queueing `/auto-review` on every mid-session mode sync. */
     private autoReviewSlashQueued = false;
-    private skillLookupInstructionSent = false;
-
     constructor(session: CursorSession) {
         super(process.env.DEBUG ? session.logPath : undefined);
         this.session = session;
@@ -243,15 +239,11 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             }
             messageBuffer.addMessage(batch.message, 'user');
 
-            let messageText = batch.message;
-            if (!this.skillLookupInstructionSent && !messageText.trimStart().startsWith('/')) {
-                messageText = `${SKILL_LOOKUP_INSTRUCTION}\n\n${messageText}`;
-                this.skillLookupInstructionSent = true;
-            }
-
+            // skill_lookup discovery lives on the MCP tool description — do not
+            // prepend instructions onto user turns (prompt-injection false positive).
             const promptContent: PromptContent[] = [{
                 type: 'text',
-                text: messageText
+                text: batch.message
             }];
 
             session.onThinkingChange(true);

--- a/cli/src/kimi/kimiRemoteLauncher.test.ts
+++ b/cli/src/kimi/kimiRemoteLauncher.test.ts
@@ -73,12 +73,13 @@ describe('kimiRemoteLauncher skill lookup instruction', () => {
         harness.prompts = []
     })
 
-    it('injects the instruction only on the first prompt', async () => {
+    it('does not prepend skill_lookup instructions onto user turns', async () => {
         await kimiRemoteLauncher(createSession() as never, { model: 'kimi-k2' })
 
         expect(harness.prompts).toHaveLength(2)
-        expect(JSON.stringify(harness.prompts[0])).toContain('$name')
-        expect(JSON.stringify(harness.prompts[0])).toContain('skill_lookup')
+        expect(JSON.stringify(harness.prompts[0])).toContain('first')
+        expect(JSON.stringify(harness.prompts[0])).not.toContain('skill_lookup')
+        expect(JSON.stringify(harness.prompts[0])).not.toContain('$name')
         expect(JSON.stringify(harness.prompts[1])).not.toContain('skill_lookup')
     })
 })

--- a/cli/src/kimi/kimiRemoteLauncher.ts
+++ b/cli/src/kimi/kimiRemoteLauncher.ts
@@ -10,8 +10,6 @@ import type { PermissionMode } from './types';
 import { createKimiBackend } from './utils/kimiBackend';
 import { KimiPermissionHandler } from './utils/permissionHandler';
 import { resolveKimiRuntimeConfig } from './utils/config';
-import { SKILL_LOOKUP_INSTRUCTION } from '@/modules/common/skillLookupInstruction';
-
 class KimiRemoteLauncher extends RemoteLauncherBase {
     private readonly session: KimiSession;
     private readonly model?: string;
@@ -24,8 +22,6 @@ class KimiRemoteLauncher extends RemoteLauncherBase {
     private currentBackendModel: string | null = null;
     private setModelSupported: boolean | undefined = undefined;
     private lastDisplayedToolCall = new Map<string, string>();
-    private skillLookupInstructionSent = false;
-
     constructor(session: KimiSession, opts: { model?: string }) {
         super(process.env.DEBUG ? session.logPath : undefined);
         this.session = session;
@@ -171,15 +167,11 @@ class KimiRemoteLauncher extends RemoteLauncherBase {
             this.applyDisplayMode(batch.mode.permissionMode, batch.mode.model);
             messageBuffer.addMessage(batch.message, 'user');
 
-            let messageText = batch.message;
-            if (!this.skillLookupInstructionSent && !messageText.trimStart().startsWith('/')) {
-                messageText = `${SKILL_LOOKUP_INSTRUCTION}\n\n${messageText}`;
-                this.skillLookupInstructionSent = true;
-            }
-
+            // skill_lookup discovery lives on the MCP tool description — do not
+            // prepend instructions onto user turns (prompt-injection false positive).
             const promptContent: PromptContent[] = [{
                 type: 'text',
-                text: messageText
+                text: batch.message
             }];
 
             session.onThinkingChange(true);

--- a/cli/src/modules/common/skillLookupInstruction.ts
+++ b/cli/src/modules/common/skillLookupInstruction.ts
@@ -1,2 +1,11 @@
+/**
+ * Discovery copy for agents that can host a durable system / instructions block
+ * (OpenCode, Grok). Do **not** prepend this to user turns — that path looks like
+ * prompt injection on Cursor ACP and similar remotes (tiann/hapi#1095).
+ *
+ * Cursor / Kimi / generic ACP rely on the `skill_lookup` MCP tool description
+ * (and Cursor's native `.cursor/mcp.json` overlay where session/new mcpServers
+ * are ignored) instead of a user-message prepend.
+ */
 export const SKILL_LOOKUP_INSTRUCTION =
     'When a user message starts with "$name", call HAPI\'s skill_lookup tool with "name" (without "$") before acting.'


### PR DESCRIPTION
## Summary
- Stop prepending `SKILL_LOOKUP_INSTRUCTION` onto the first user turn for Cursor ACP, Kimi, and generic ACP remotes.
- That glued-on line was treated as prompt injection (and on Cursor, `session/new` mcpServers are ignored anyway — tool discovery belongs on the MCP tool description / system prompt).
- OpenCode and Grok keep the instruction in their system-prompt helpers. The `skill_lookup` tool description already carries the `$name` guidance.

Fixes #1095

## Test plan
- [x] `bunx vitest run` on cursor / kimi / runAgentSession / opencode systemPrompt suites (23 passed)
- [x] Dogfood: Cursor remote session first user message no longer starts with the `$name` instruction line
