### PR TITLE
fix(web): avoid session misclicks during live reordering

### DIFF
--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -219,6 +219,53 @@ describe('SessionList action menu parity', () => {
     })
 })
 
+describe('SessionList selection', () => {
+    it('does not select the row that moves under the pointer during a live reorder', () => {
+        const onSelect = vi.fn()
+        const first = makeSession({
+            id: 'session-first',
+            active: true,
+            updatedAt: 200,
+            metadata: { path: '/work/hapi', name: 'First session', flavor: 'codex' }
+        })
+        const second = makeSession({
+            id: 'session-second',
+            active: true,
+            updatedAt: 100,
+            metadata: { path: '/work/hapi', name: 'Second session', flavor: 'codex' }
+        })
+
+        const renderList = (sessions: SessionSummary[]) => (
+            <QueryClientProvider client={new QueryClient()}>
+                <I18nProvider>
+                    <SessionList
+                        sessions={sessions}
+                        selectedSessionId={null}
+                        onSelect={onSelect}
+                        onNewSession={vi.fn()}
+                        onRefresh={vi.fn()}
+                        isLoading={false}
+                        renderHeader={false}
+                        api={null}
+                    />
+                </I18nProvider>
+            </QueryClientProvider>
+        )
+
+        const { rerender } = render(renderList([first, second]))
+        fireEvent.mouseDown(screen.getByRole('button', { name: /First session/ }), { button: 0 })
+
+        rerender(renderList([
+            { ...first, updatedAt: 200 },
+            { ...second, updatedAt: 300 }
+        ]))
+
+        fireEvent.mouseUp(screen.getByRole('button', { name: /Second session/ }), { button: 0 })
+
+        expect(onSelect).not.toHaveBeenCalled()
+    })
+})
+
 describe('SessionList collapse behavior', () => {
     function renderSessionList(sessions: SessionSummary[], selectedSessionId = 'session-running') {
         return (

--- a/web/src/hooks/useLongPress.test.tsx
+++ b/web/src/hooks/useLongPress.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLongPress } from './useLongPress'
+
+function LongPressButton(props: { onClick: () => void; onLongPress: () => void }) {
+    const handlers = useLongPress({
+        onClick: props.onClick,
+        onLongPress: props.onLongPress,
+    })
+
+    return <button type="button" {...handlers}>Session</button>
+}
+
+describe('useLongPress', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('uses the native click event for a regular activation', () => {
+        const onClick = vi.fn()
+        render(<LongPressButton onClick={onClick} onLongPress={vi.fn()} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Session' }))
+
+        expect(onClick).toHaveBeenCalledOnce()
+    })
+
+    it('suppresses the click emitted after a long press', () => {
+        const onClick = vi.fn()
+        const onLongPress = vi.fn()
+        render(<LongPressButton onClick={onClick} onLongPress={onLongPress} />)
+        const button = screen.getByRole('button', { name: 'Session' })
+
+        fireEvent.mouseDown(button, { button: 0, clientX: 10, clientY: 20 })
+        vi.advanceTimersByTime(500)
+        fireEvent.mouseUp(button, { button: 0 })
+        fireEvent.click(button)
+
+        expect(onLongPress).toHaveBeenCalledWith({ x: 10, y: 20 })
+        expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('cancels the pending long press when release lands on another element', () => {
+        const onLongPress = vi.fn()
+        render(<LongPressButton onClick={vi.fn()} onLongPress={onLongPress} />)
+
+        fireEvent.mouseDown(screen.getByRole('button', { name: 'Session' }), { button: 0 })
+        fireEvent.mouseUp(document.body, { button: 0 })
+        vi.advanceTimersByTime(500)
+
+        expect(onLongPress).not.toHaveBeenCalled()
+    })
+})

--- a/web/src/hooks/useLongPress.ts
+++ b/web/src/hooks/useLongPress.ts
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 type UseLongPressOptions = {
     onLongPress: (point: { x: number; y: number }) => void
@@ -15,6 +15,8 @@ type UseLongPressHandlers = {
     onTouchStart: React.TouchEventHandler
     onTouchEnd: React.TouchEventHandler
     onTouchMove: React.TouchEventHandler
+    onTouchCancel: React.TouchEventHandler
+    onClick: React.MouseEventHandler
     onContextMenu: React.MouseEventHandler
     onKeyDown: React.KeyboardEventHandler
 }
@@ -26,15 +28,25 @@ export function useLongPress(options: UseLongPressOptions): UseLongPressHandlers
     const isLongPressRef = useRef(false)
     const touchMoved = useRef(false)
     const pressPointRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+    const globalEndListenersRef = useRef<Array<{
+        type: 'mouseup' | 'touchend' | 'touchcancel'
+        listener: EventListener
+    }>>([])
 
     const clearTimer = useCallback(() => {
         if (timerRef.current) {
             clearTimeout(timerRef.current)
             timerRef.current = null
         }
+        for (const { type, listener } of globalEndListenersRef.current) {
+            window.removeEventListener(type, listener)
+        }
+        globalEndListenersRef.current = []
     }, [])
 
-    const startTimer = useCallback((clientX: number, clientY: number) => {
+    useEffect(() => clearTimer, [clearTimer])
+
+    const startTimer = useCallback((clientX: number, clientY: number, input: 'mouse' | 'touch') => {
         if (disabled) return
 
         clearTimer()
@@ -46,48 +58,71 @@ export function useLongPress(options: UseLongPressOptions): UseLongPressHandlers
             isLongPressRef.current = true
             onLongPress(pressPointRef.current)
         }, threshold)
+
+        const endTypes = input === 'mouse'
+            ? ['mouseup'] as const
+            : ['touchend', 'touchcancel'] as const
+        // The pressed element can move under a stationary pointer (for example
+        // when a live session list re-sorts), so it may never receive the end
+        // event itself. Always cancel the timer from the window as well.
+        for (const type of endTypes) {
+            const listener = () => clearTimer()
+            globalEndListenersRef.current.push({ type, listener })
+            window.addEventListener(type, listener, { once: true })
+        }
     }, [disabled, clearTimer, onLongPress, threshold])
 
-    const handleEnd = useCallback((shouldTriggerClick: boolean) => {
+    const handleEnd = useCallback(() => {
         clearTimer()
-
-        if (shouldTriggerClick && !isLongPressRef.current && !touchMoved.current && onClick) {
-            onClick()
-        }
-
-        isLongPressRef.current = false
-        touchMoved.current = false
-    }, [clearTimer, onClick])
+    }, [clearTimer])
 
     const onMouseDown = useCallback<React.MouseEventHandler>((e) => {
         if (e.button !== 0) return
-        startTimer(e.clientX, e.clientY)
+        startTimer(e.clientX, e.clientY, 'mouse')
     }, [startTimer])
 
     const onMouseUp = useCallback<React.MouseEventHandler>(() => {
-        handleEnd(!isLongPressRef.current)
+        handleEnd()
     }, [handleEnd])
 
     const onMouseLeave = useCallback<React.MouseEventHandler>(() => {
-        handleEnd(false)
+        handleEnd()
     }, [handleEnd])
 
     const onTouchStart = useCallback<React.TouchEventHandler>((e) => {
         const touch = e.touches[0]
-        startTimer(touch.clientX, touch.clientY)
+        startTimer(touch.clientX, touch.clientY, 'touch')
     }, [startTimer])
 
     const onTouchEnd = useCallback<React.TouchEventHandler>((e) => {
         if (isLongPressRef.current) {
             e.preventDefault()
         }
-        handleEnd(!isLongPressRef.current)
+        handleEnd()
     }, [handleEnd])
 
     const onTouchMove = useCallback<React.TouchEventHandler>(() => {
         touchMoved.current = true
         clearTimer()
     }, [clearTimer])
+
+    const onTouchCancel = useCallback<React.TouchEventHandler>(() => {
+        touchMoved.current = true
+        clearTimer()
+    }, [clearTimer])
+
+    const handleClick = useCallback<React.MouseEventHandler>((e) => {
+        if (isLongPressRef.current || touchMoved.current) {
+            e.preventDefault()
+            isLongPressRef.current = false
+            touchMoved.current = false
+            return
+        }
+        // Use the browser's click target instead of treating any mouseup as a
+        // click. If sibling rows swap between press and release, native click
+        // targeting will not activate the row that merely moved underneath.
+        onClick?.()
+    }, [onClick])
 
     const onContextMenu = useCallback<React.MouseEventHandler>((e) => {
         if (!disabled) {
@@ -113,6 +148,8 @@ export function useLongPress(options: UseLongPressOptions): UseLongPressHandlers
         onTouchStart,
         onTouchEnd,
         onTouchMove,
+        onTouchCancel,
+        onClick: handleClick,
         onContextMenu,
         onKeyDown
     }


### PR DESCRIPTION
## Summary

- prevent a session row from being selected solely because it moved under the pointer during a live sidebar reorder
- use the browser's native click targeting for normal activation while preserving long-press behavior
- cancel pending long-press timers even when the pressed element does not receive the release event
- add regression coverage for live session reordering and the long-press hook

## Root cause

Active sessions can reorder whenever SSE updates change `updatedAt`. The long-press hook previously invoked `onClick` from each row's `mouseup` handler without verifying that the press began on that same row.

If a row moved between mouse down and mouse up, the row newly positioned under the stationary pointer handled `mouseup` and navigated to the wrong session.

## Testing

- `bun typecheck`
- `bun run test`

## AI disclosure

This change was developed with assistance from OpenAI Codex. The reported behavior was reproduced with a regression test, and the resulting diff was reviewed and validated with the repository's full typecheck and test suites.
