### PR TITLE
fix(web): center active scratchlist icon

### DIFF
--- a/web/src/components/AssistantChat/ComposerButtons.tsx
+++ b/web/src/components/AssistantChat/ComposerButtons.tsx
@@ -217,8 +217,10 @@ function ScratchlistToggleIcon() {
             strokeLinecap="round"
             strokeLinejoin="round"
         >
-            <path d="M3.5 2.5h6L12.5 5.5v8a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-10a1 1 0 0 1 1-1Z" />
-            <path d="M9.5 2.5v3h3M5 8.5h6M5 11h4" />
+            <g transform="translate(0.5 -0.5)">
+                <path d="M3.5 2.5h6L12.5 5.5v8a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-10a1 1 0 0 1 1-1Z" />
+                <path d="M9.5 2.5v3h3M5 8.5h6M5 11h4" />
+            </g>
         </svg>
     )
 }


### PR DESCRIPTION
### Summary

Center the scratchlist document glyph inside its composer toolbar button, most noticeably when scratchlist mode paints the button amber.

### Changes

- Offset the custom scratchlist SVG artwork by half a unit to match the center of its view box.
- Keep the existing icon size, stroke styling, button dimensions, and interaction behavior unchanged.

### Root cause

The document artwork was centered at (7.5, 8.5) inside a 0 0 16 16 view box whose center is (8, 8). The inactive transparent button made the mismatch subtle, while the active circular background exposed the left/down offset.

### Test plan

- [x] bun run --cwd web test ComposerButtons
- [x] bun run typecheck
- [x] bun run build:web
- [x] git diff --check
- [x] Manually verify inactive and active scratchlist states on the desktop composer at the 3016 test deployment.
- [x] Confirm the active icon remains centered in the mobile composer.

### AI assistance

Implementation and PR text were prepared with OpenAI Codex (GPT-5.6).
