### PR TITLE
fix(ci): restore fork PR Codex review after checkout backport

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -85,12 +85,16 @@ jobs:
         env:
           HAPI_BOT_LOGINS: ${{ vars.HAPI_BOT_LOGINS }}
 
+      # Codex reviews the PR merge ref under pull_request_target (needs base-repo
+      # secrets). GitHub's 2026-07-20 checkout backport refuses fork PR checkouts
+      # here unless explicitly opted in: https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/
       - name: Checkout repository
         if: steps.check_bot.outputs.has_review_for_current_head != 'true'
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Pre-fetch base and head refs
         if: steps.check_bot.outputs.has_review_for_current_head != 'true'


### PR DESCRIPTION
## Summary
- GitHub enforced a safer `actions/checkout` default on **2026-07-20**: fork PR refs are refused under `pull_request_target` unless `allow-unsafe-pr-checkout: true` is set ([changelog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/)).
- This repo’s Codex PR Review workflow still checks out `refs/pull/*/merge` under `pull_request_target` (last touched 2026-03; no opt-out). Floating `@v4` picked up the backport automatically, so **new fork-PR reviews started failing around 15:40 UTC today** with the checkout refusal (not only heavygee — other fork PRs hit the same error).
- Opt in explicitly so HAPI Bot can keep reviewing fork contributions. Codex needs base-repo secrets (`OPENAI_API_KEY`) plus the merge ref; that is the intended `pull_request_target` use case. Please treat this as a deliberate security exception (flag is meant to be review-visible).

## Not a product change
Workflow-only. No app code.

## Test plan
- [ ] After merge, re-run Codex PR Review on any open fork PR (e.g. #1086) and confirm checkout succeeds
- [ ] Confirm a tip review posts (findings or “No findings”)