### PR TITLE
fix(web): prevent narrow session tooltips

### DIFF
--- a/web/src/components/HoverTooltip.test.tsx
+++ b/web/src/components/HoverTooltip.test.tsx
@@ -9,6 +9,18 @@ import {
 afterEach(() => cleanup())
 
 describe('HoverTooltip keyboard wiring', () => {
+    it('sizes short localized tooltips to their content up to the maximum width', () => {
+        render(
+            <HoverTooltip id="attention-tooltip" target={<span>dot</span>}>
+                有新活动
+            </HoverTooltip>
+        )
+
+        const tooltip = screen.getByRole('tooltip', { hidden: true })
+        expect(tooltip.className).toContain('w-max')
+        expect(tooltip.className).toContain('max-w-[14rem]')
+    })
+
     it('applies parent row focus-visible reveal classes', () => {
         render(
             <HoverTooltip

--- a/web/src/components/HoverTooltip.tsx
+++ b/web/src/components/HoverTooltip.tsx
@@ -72,7 +72,7 @@ export function HoverTooltip(props: {
                 id={props.id}
                 className={cn(
                     'pointer-events-none absolute z-30 whitespace-normal',
-                    spansRow ? 'max-w-none' : 'max-w-[14rem]',
+                    spansRow ? 'max-w-none' : 'w-max max-w-[14rem]',
                     'rounded-md border border-[var(--app-border)] bg-[var(--app-secondary-bg)]',
                     'px-2 py-1 text-xs leading-snug text-[var(--app-fg)] shadow-lg',
                     side === 'top' ? 'bottom-full mb-1' : 'top-full mt-1',


### PR DESCRIPTION
## Summary

- size non-row hover tooltips to their intrinsic content width
- retain the existing `14rem` maximum so detailed attention and schedule tooltips still wrap
- cover short localized tooltip copy with a regression test

## Problem

Session attention indicators use an 8px dot as the containing block for an absolutely positioned tooltip. Non-row tooltips had only a maximum width, so their auto width could collapse to the narrow trigger. CJK copy such as `有新活动` then wrapped one character per line and appeared vertical.

## Fix

Add Tailwind's `w-max` to non-row tooltip panels while keeping `max-w-[14rem]`. Short labels now use their max-content width, while longer rich tooltip content remains bounded and wraps normally. Row-spanning tooltips keep their existing sizing behavior.

Related: #940, #941

## Test plan

- [x] `bun typecheck`
- [x] `bun run test:web` (158 files, 1298 tests)
- [x] Regression test verifies localized non-row tooltips receive both `w-max` and `max-w-[14rem]`
- [x] Manual browser check: hover an unread session dot and confirm `有新活动` renders horizontally

## AI disclosure

AI-assisted implementation and PR drafting: OpenAI Codex (`gpt-5.6-sol`).
