### PR TITLE
feat(web): support project and global pinned sessions

### DIFF
--- a/hub/src/store/index.ts
+++ b/hub/src/store/index.ts
@@ -357,6 +357,7 @@ export class Store {
                 team_state TEXT,
                 team_state_updated_at INTEGER,
                 pinned INTEGER NOT NULL DEFAULT 0,
+                global_pinned INTEGER NOT NULL DEFAULT 0,
                 active INTEGER DEFAULT 0,
                 active_at INTEGER,
                 seq INTEGER DEFAULT 0
@@ -846,6 +847,9 @@ export class Store {
         if (columns.size === 0) return
         if (!columns.has('pinned')) {
             this.db.exec('ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0')
+        }
+        if (!columns.has('global_pinned')) {
+            this.db.exec('ALTER TABLE sessions ADD COLUMN global_pinned INTEGER NOT NULL DEFAULT 0')
         }
     }
 

--- a/hub/src/store/index.ts
+++ b/hub/src/store/index.ts
@@ -33,7 +33,7 @@ export { SessionStore } from './sessionStore'
 export { UserStore } from './userStore'
 export { UsageStore } from './usageStore'
 
-const SCHEMA_VERSION: number = 21
+const SCHEMA_VERSION: number = 22
 const REQUIRED_TABLES = [
     'sessions',
     'machines',
@@ -289,6 +289,7 @@ export class Store {
             18: () => this.migrateFromV18ToV19(),
             19: () => this.migrateFromV19ToV20(),
             20: () => this.migrateFromV20ToV21(),
+            21: () => this.migrateFromV21ToV22(),
         })
 
         if (currentVersion === 0) {
@@ -837,6 +838,14 @@ export class Store {
             DELETE FROM usage_events;
             DELETE FROM usage_scan_state;
         `)
+    }
+
+    private migrateFromV21ToV22(): void {
+        const columns = this.getSessionColumnNames()
+        if (columns.size === 0) return
+        if (!columns.has('pinned')) {
+            this.db.exec('ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0')
+        }
     }
 
     private getSessionColumnNames(): Set<string> {

--- a/hub/src/store/index.ts
+++ b/hub/src/store/index.ts
@@ -356,6 +356,7 @@ export class Store {
                 todos_updated_at INTEGER,
                 team_state TEXT,
                 team_state_updated_at INTEGER,
+                pinned INTEGER NOT NULL DEFAULT 0,
                 active INTEGER DEFAULT 0,
                 active_at INTEGER,
                 seq INTEGER DEFAULT 0

--- a/hub/src/store/migration-v13.test.ts
+++ b/hub/src/store/migration-v13.test.ts
@@ -10,7 +10,7 @@ describe('Store V12/V13→V14 schema reconciliation', () => {
         const store = new Store(':memory:')
         expect(tableExists(store, 'message_epochs')).toBe(true)
         expect(tableExists(store, 'session_scratchlist')).toBe(true)
-        expect(getUserVersion(store)).toBe(21)
+        expect(getUserVersion(store)).toBe(22)
         store.close()
     })
 
@@ -34,7 +34,7 @@ describe('Store V12/V13→V14 schema reconciliation', () => {
             store = new Store(dbPath)
             expect(tableExists(store, 'message_epochs')).toBe(true)
             expect(tableExists(store, 'session_scratchlist')).toBe(true)
-            expect(getUserVersion(store)).toBe(21)
+            expect(getUserVersion(store)).toBe(22)
             expect(store.messages.getMessageEpoch('session-1')).toBe(0)
             expect(store.messages.getMessages('session-1')).toHaveLength(1)
         } finally {
@@ -72,7 +72,7 @@ describe('Store V12/V13→V14 schema reconciliation', () => {
             store = new Store(dbPath)
             expect(tableExists(store, 'message_epochs')).toBe(true)
             expect(tableExists(store, 'session_scratchlist')).toBe(true)
-            expect(getUserVersion(store)).toBe(21)
+            expect(getUserVersion(store)).toBe(22)
             expect(store.messages.getMessages('session-1')).toHaveLength(1)
         } finally {
             store?.close()

--- a/hub/src/store/migration-v15.test.ts
+++ b/hub/src/store/migration-v15.test.ts
@@ -47,7 +47,7 @@ describe('Store V14→V15 migration: scratchlist attachments column', () => {
         }
     })
 
-    it('V15 DB reopen is idempotent: schema unchanged', () => {
+    it('latest DB reopen is idempotent: schema unchanged', () => {
         const dir = mkdtempSync(join(tmpdir(), 'hapi-migration-v15-idempotent-'))
         const dbPath = join(dir, 'test.db')
         let store1: Store | undefined

--- a/hub/src/store/migration-v15.test.ts
+++ b/hub/src/store/migration-v15.test.ts
@@ -19,7 +19,7 @@ describe('Store V14→V15 migration: scratchlist attachments column', () => {
         expect(cols).toContain('attachments')
         expect(getColumns(store, 'usage_events')).toContain('last_input_tokens')
         expect(getColumns(store, 'usage_scan_state')).toContain('last_seq')
-        expect(getUserVersion(store)).toBe(21)
+        expect(getUserVersion(store)).toBe(22)
         store.close()
     })
 
@@ -40,7 +40,7 @@ describe('Store V14→V15 migration: scratchlist attachments column', () => {
             expect(cols).toContain('attachments')
             expect(getColumns(store, 'usage_events')).toContain('last_input_tokens')
             expect(getColumns(store, 'usage_scan_state')).toContain('last_seq')
-            expect(getUserVersion(store)).toBe(21)
+            expect(getUserVersion(store)).toBe(22)
         } finally {
             store?.close()
             rmSync(dir, { recursive: true, force: true })
@@ -60,7 +60,7 @@ describe('Store V14→V15 migration: scratchlist attachments column', () => {
             store2 = new Store(dbPath)
             const cols2 = getColumns(store2, 'session_scratchlist')
             expect(cols2).toEqual(cols1)
-            expect(getUserVersion(store2)).toBe(21)
+            expect(getUserVersion(store2)).toBe(22)
         } finally {
             store2?.close()
             store1?.close()

--- a/hub/src/store/migration-v18.test.ts
+++ b/hub/src/store/migration-v18.test.ts
@@ -38,7 +38,11 @@ describe('Store V18->V19 migration: usage scan state', () => {
             const usageRows = internalDb.prepare('SELECT COUNT(*) AS count FROM usage_events').get() as { count: number }
 
             expect(table?.name).toBe('usage_scan_state')
+<<<<<<< HEAD
             expect(version.user_version).toBe(21)
+=======
+        expect(version.user_version).toBe(20)
+>>>>>>> cdb1873c (test(hub): expect schema v20 after migration)
             expect(usageRows.count).toBe(0)
         } finally {
             store?.close()

--- a/hub/src/store/migration-v18.test.ts
+++ b/hub/src/store/migration-v18.test.ts
@@ -38,11 +38,7 @@ describe('Store V18->V19 migration: usage scan state', () => {
             const usageRows = internalDb.prepare('SELECT COUNT(*) AS count FROM usage_events').get() as { count: number }
 
             expect(table?.name).toBe('usage_scan_state')
-<<<<<<< HEAD
-            expect(version.user_version).toBe(21)
-=======
-        expect(version.user_version).toBe(20)
->>>>>>> cdb1873c (test(hub): expect schema v20 after migration)
+            expect(version.user_version).toBe(22)
             expect(usageRows.count).toBe(0)
         } finally {
             store?.close()

--- a/hub/src/store/migration-v19.test.ts
+++ b/hub/src/store/migration-v19.test.ts
@@ -37,7 +37,7 @@ describe('Store V19->current migration: usage re-index', () => {
             const scanRows = internalDb.prepare('SELECT COUNT(*) AS count FROM usage_scan_state').get() as { count: number }
             const usageRows = internalDb.prepare('SELECT COUNT(*) AS count FROM usage_events').get() as { count: number }
 
-            expect(version.user_version).toBe(21)
+            expect(version.user_version).toBe(22)
             expect(scanRows.count).toBe(0)
             expect(usageRows.count).toBe(0)
         } finally {

--- a/hub/src/store/migration-v20.test.ts
+++ b/hub/src/store/migration-v20.test.ts
@@ -43,7 +43,7 @@ describe('Store V20->V21 migration: usage semantics re-index', () => {
             store = new Store(dbPath)
             const internalDb = (store as unknown as { db: Database }).db
             const count = (table: string): number => (internalDb.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number }).count
-            expect((internalDb.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(21)
+            expect((internalDb.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(22)
             expect(count('usage_events')).toBe(0)
             expect(count('usage_scan_state')).toBe(0)
             expect(store.messages.getMessages(session.id)).toHaveLength(1)

--- a/hub/src/store/migration-v22.test.ts
+++ b/hub/src/store/migration-v22.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 })
 
 describe('schema migration v21 to v22', () => {
-    it('adds the pinned column with an unpinned default', () => {
+    it('adds pinned and global_pinned columns with unpinned defaults', () => {
         const dir = mkdtempSync(join(tmpdir(), 'hapi-migration-v22-'))
         tempDirs.push(dir)
         const dbPath = join(dir, 'hapi.db')
@@ -22,12 +22,14 @@ describe('schema migration v21 to v22', () => {
         new Store(dbPath).close()
         const legacy = new Database(dbPath)
         legacy.exec('ALTER TABLE sessions DROP COLUMN pinned')
+        legacy.exec('ALTER TABLE sessions DROP COLUMN global_pinned')
         legacy.exec('PRAGMA user_version = 21')
         legacy.close()
 
         const migrated = new Store(dbPath)
         const session = migrated.sessions.getOrCreateSession('migration-pin', {}, null, 'default')
         expect(session.pinned).toBe(false)
+        expect(session.globalPinned).toBe(false)
         migrated.close()
     })
 })

--- a/hub/src/store/migration-v22.test.ts
+++ b/hub/src/store/migration-v22.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { Database } from 'bun:sqlite'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Store } from './index'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true })
+    }
+})
+
+describe('schema migration v21 to v22', () => {
+    it('adds the pinned column with an unpinned default', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'hapi-migration-v22-'))
+        tempDirs.push(dir)
+        const dbPath = join(dir, 'hapi.db')
+
+        new Store(dbPath).close()
+        const legacy = new Database(dbPath)
+        legacy.exec('ALTER TABLE sessions DROP COLUMN pinned')
+        legacy.exec('PRAGMA user_version = 21')
+        legacy.close()
+
+        const migrated = new Store(dbPath)
+        const session = migrated.sessions.getOrCreateSession('migration-pin', {}, null, 'default')
+        expect(session.pinned).toBe(false)
+        migrated.close()
+    })
+})

--- a/hub/src/store/sessionStore.ts
+++ b/hub/src/store/sessionStore.ts
@@ -14,6 +14,8 @@ import {
     setSessionServiceTier,
     setSessionActive,
     setSessionPinned,
+    setSessionPinMode,
+    type SessionPinMode,
     setSessionTeamState,
     setSessionTodos,
     replaceSessionTodos,
@@ -104,6 +106,10 @@ export class SessionStore {
 
     setSessionPinned(id: string, pinned: boolean, namespace: string): boolean {
         return setSessionPinned(this.db, id, pinned, namespace)
+    }
+
+    setSessionPinMode(id: string, mode: SessionPinMode, namespace: string): boolean {
+        return setSessionPinMode(this.db, id, mode, namespace)
     }
 
     touchSessionUpdatedAt(id: string, updatedAt: number, namespace: string): boolean {

--- a/hub/src/store/sessionStore.ts
+++ b/hub/src/store/sessionStore.ts
@@ -13,6 +13,7 @@ import {
     setSessionModelReasoningEffort,
     setSessionServiceTier,
     setSessionActive,
+    setSessionPinned,
     setSessionTeamState,
     setSessionTodos,
     replaceSessionTodos,
@@ -99,6 +100,10 @@ export class SessionStore {
 
     setSessionActive(id: string, active: boolean, activeAt: number, namespace: string): boolean {
         return setSessionActive(this.db, id, active, activeAt, namespace)
+    }
+
+    setSessionPinned(id: string, pinned: boolean, namespace: string): boolean {
+        return setSessionPinned(this.db, id, pinned, namespace)
     }
 
     touchSessionUpdatedAt(id: string, updatedAt: number, namespace: string): boolean {

--- a/hub/src/store/sessions.test.ts
+++ b/hub/src/store/sessions.test.ts
@@ -32,6 +32,24 @@ describe('getOrCreateSession: active_at', () => {
     })
 })
 
+describe('session pinning', () => {
+    it('persists pin state without changing session recency', () => {
+        const store = makeStore()
+        const session = store.sessions.getOrCreateSession('pin-test', {}, null, 'default')
+
+        expect(session.pinned).toBe(false)
+        expect(store.sessions.setSessionPinned(session.id, true, 'default')).toBe(true)
+
+        const pinned = store.sessions.getSession(session.id)
+        expect(pinned?.pinned).toBe(true)
+        expect(pinned?.updatedAt).toBe(session.updatedAt)
+
+        expect(store.sessions.setSessionPinned(session.id, false, 'other')).toBe(false)
+        expect(store.sessions.getSession(session.id)?.pinned).toBe(true)
+        store.close()
+    })
+})
+
 describe('getOrCreateSession: requested identity', () => {
     it('creates and idempotently reloads a client-requested id', () => {
         const store = makeStore()

--- a/hub/src/store/sessions.test.ts
+++ b/hub/src/store/sessions.test.ts
@@ -33,19 +33,26 @@ describe('getOrCreateSession: active_at', () => {
 })
 
 describe('session pinning', () => {
-    it('persists pin state without changing session recency', () => {
+    it('persists project and global pin modes without changing session recency', () => {
         const store = makeStore()
         const session = store.sessions.getOrCreateSession('pin-test', {}, null, 'default')
 
         expect(session.pinned).toBe(false)
-        expect(store.sessions.setSessionPinned(session.id, true, 'default')).toBe(true)
+        expect(session.globalPinned).toBe(false)
+        expect(store.sessions.setSessionPinMode(session.id, 'project', 'default')).toBe(true)
 
-        const pinned = store.sessions.getSession(session.id)
-        expect(pinned?.pinned).toBe(true)
-        expect(pinned?.updatedAt).toBe(session.updatedAt)
+        const projectPinned = store.sessions.getSession(session.id)
+        expect(projectPinned?.pinned).toBe(true)
+        expect(projectPinned?.globalPinned).toBe(false)
+        expect(projectPinned?.updatedAt).toBe(session.updatedAt)
 
-        expect(store.sessions.setSessionPinned(session.id, false, 'other')).toBe(false)
-        expect(store.sessions.getSession(session.id)?.pinned).toBe(true)
+        expect(store.sessions.setSessionPinMode(session.id, 'global', 'default')).toBe(true)
+        const globalPinned = store.sessions.getSession(session.id)
+        expect(globalPinned?.pinned).toBe(false)
+        expect(globalPinned?.globalPinned).toBe(true)
+
+        expect(store.sessions.setSessionPinMode(session.id, 'none', 'other')).toBe(false)
+        expect(store.sessions.getSession(session.id)?.globalPinned).toBe(true)
         store.close()
     })
 })

--- a/hub/src/store/sessions.ts
+++ b/hub/src/store/sessions.ts
@@ -139,6 +139,7 @@ type DbSessionRow = {
     machine_id: string | null
     created_at: number
     updated_at: number
+    pinned: number
     metadata: string | null
     metadata_version: number
     agent_state: string | null
@@ -164,6 +165,7 @@ function toStoredSession(row: DbSessionRow): StoredSession {
         machineId: row.machine_id,
         createdAt: row.created_at,
         updatedAt: row.updated_at,
+        pinned: row.pinned === 1,
         metadata: safeJsonParse(row.metadata),
         metadataVersion: row.metadata_version,
         agentState: safeJsonParse(row.agent_state),
@@ -615,6 +617,15 @@ export function setSessionActive(
     } catch {
         return false
     }
+}
+
+export function setSessionPinned(db: Database, id: string, pinned: boolean, namespace: string): boolean {
+    const result = db.prepare(`
+        UPDATE sessions
+        SET pinned = @pinned
+        WHERE id = @id AND namespace = @namespace AND pinned != @pinned
+    `).run({ id, namespace, pinned: pinned ? 1 : 0 })
+    return result.changes === 1
 }
 
 export function touchSessionUpdatedAt(

--- a/hub/src/store/sessions.ts
+++ b/hub/src/store/sessions.ts
@@ -140,6 +140,7 @@ type DbSessionRow = {
     created_at: number
     updated_at: number
     pinned: number
+    global_pinned: number
     metadata: string | null
     metadata_version: number
     agent_state: string | null
@@ -166,6 +167,7 @@ function toStoredSession(row: DbSessionRow): StoredSession {
         createdAt: row.created_at,
         updatedAt: row.updated_at,
         pinned: row.pinned === 1,
+        globalPinned: row.global_pinned === 1,
         metadata: safeJsonParse(row.metadata),
         metadataVersion: row.metadata_version,
         agentState: safeJsonParse(row.agent_state),
@@ -619,13 +621,25 @@ export function setSessionActive(
     }
 }
 
-export function setSessionPinned(db: Database, id: string, pinned: boolean, namespace: string): boolean {
+export type SessionPinMode = 'none' | 'project' | 'global'
+
+export function setSessionPinMode(db: Database, id: string, mode: SessionPinMode, namespace: string): boolean {
+    const pinned = mode === 'project' ? 1 : 0
+    const globalPinned = mode === 'global' ? 1 : 0
     const result = db.prepare(`
         UPDATE sessions
-        SET pinned = @pinned
-        WHERE id = @id AND namespace = @namespace AND pinned != @pinned
-    `).run({ id, namespace, pinned: pinned ? 1 : 0 })
+        SET pinned = @pinned,
+            global_pinned = @global_pinned
+        WHERE id = @id
+          AND namespace = @namespace
+          AND (pinned != @pinned OR global_pinned != @global_pinned)
+    `).run({ id, namespace, pinned, global_pinned: globalPinned })
     return result.changes === 1
+}
+
+/** @deprecated Prefer setSessionPinMode — kept for project-pin merge helpers. */
+export function setSessionPinned(db: Database, id: string, pinned: boolean, namespace: string): boolean {
+    return setSessionPinMode(db, id, pinned ? 'project' : 'none', namespace)
 }
 
 export function touchSessionUpdatedAt(

--- a/hub/src/store/types.ts
+++ b/hub/src/store/types.ts
@@ -5,6 +5,7 @@ export type StoredSession = {
     machineId: string | null
     createdAt: number
     updatedAt: number
+    pinned: boolean
     metadata: unknown | null
     metadataVersion: number
     agentState: unknown | null

--- a/hub/src/store/types.ts
+++ b/hub/src/store/types.ts
@@ -6,6 +6,7 @@ export type StoredSession = {
     createdAt: number
     updatedAt: number
     pinned: boolean
+    globalPinned: boolean
     metadata: unknown | null
     metadataVersion: number
     agentState: unknown | null

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -1187,6 +1187,13 @@ export class SessionCache {
             }
         }
 
+        if (oldStored.pinned && !newStored.pinned) {
+            const updated = this.store.sessions.setSessionPinned(newSessionId, true, namespace)
+            if (!updated) {
+                throw new Error('Failed to preserve session pin during merge')
+            }
+        }
+
         if (oldStored.todos !== null && oldStored.todosUpdatedAt !== null) {
             this.store.sessions.setSessionTodos(
                 newSessionId,

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -181,6 +181,7 @@ export class SessionCache {
             seq: stored.seq,
             createdAt: stored.createdAt,
             updatedAt: stored.updatedAt,
+            pinned: stored.pinned,
             active: existing?.active ?? stored.active,
             // Legacy / idle rows may still have active_at NULL in SQLite.
             // Public Session.activeAt is always a number for CLI Zod parse.
@@ -220,6 +221,13 @@ export class SessionCache {
         for (const session of sessions) {
             this.refreshSession(session.id)
         }
+    }
+
+    setSessionPinned(sessionId: string, pinned: boolean): void {
+        const session = this.sessions.get(sessionId) ?? this.refreshSession(sessionId)
+        if (!session) throw new Error('Session not found')
+        this.store.sessions.setSessionPinned(sessionId, pinned, session.namespace)
+        this.refreshSession(sessionId)
     }
 
     markSessionActive(sessionId: string, time: number = Date.now()): void {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -1187,7 +1187,9 @@ export class SessionCache {
             }
         }
 
-        if (oldStored.pinned) {
+        const latestSourcePinned =
+            this.store.sessions.getSessionByNamespace(oldSessionId, namespace)?.pinned === true
+        if (latestSourcePinned) {
             const latest = this.store.sessions.getSessionByNamespace(newSessionId, namespace)
             if (!latest) {
                 throw new Error('Session not found for merge')

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -1204,11 +1204,19 @@ export class SessionCache {
                 throw new Error('Session not found for merge')
             }
             const latestMode = latest.globalPinned ? 'global' : latest.pinned ? 'project' : 'none'
-            if (latestMode !== latestSourceMode) {
-                const updated = this.store.sessions.setSessionPinMode(newSessionId, latestSourceMode, namespace)
+            // Prefer the stronger pin: global > project > none. Never downgrade a
+            // concurrently (or already) global-pinned target to project-only.
+            const desiredMode =
+                latestSourceMode === 'global' || latestMode === 'global'
+                    ? 'global' as const
+                    : latestSourceMode === 'project' || latestMode === 'project'
+                        ? 'project' as const
+                        : 'none' as const
+            if (desiredMode !== latestMode) {
+                const updated = this.store.sessions.setSessionPinMode(newSessionId, desiredMode, namespace)
                 const now = this.store.sessions.getSessionByNamespace(newSessionId, namespace)
                 const nowMode = now?.globalPinned ? 'global' : now?.pinned ? 'project' : 'none'
-                if (!updated && nowMode !== latestSourceMode) {
+                if (!updated && nowMode !== desiredMode) {
                     throw new Error('Failed to preserve session pin during merge')
                 }
             }

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -1187,10 +1187,17 @@ export class SessionCache {
             }
         }
 
-        if (oldStored.pinned && !newStored.pinned) {
-            const updated = this.store.sessions.setSessionPinned(newSessionId, true, namespace)
-            if (!updated) {
-                throw new Error('Failed to preserve session pin during merge')
+        if (oldStored.pinned) {
+            const latest = this.store.sessions.getSessionByNamespace(newSessionId, namespace)
+            if (!latest) {
+                throw new Error('Session not found for merge')
+            }
+            if (!latest.pinned) {
+                const updated = this.store.sessions.setSessionPinned(newSessionId, true, namespace)
+                const nowPinned = this.store.sessions.getSessionByNamespace(newSessionId, namespace)?.pinned === true
+                if (!updated && !nowPinned) {
+                    throw new Error('Failed to preserve session pin during merge')
+                }
             }
         }
 

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -182,6 +182,7 @@ export class SessionCache {
             createdAt: stored.createdAt,
             updatedAt: stored.updatedAt,
             pinned: stored.pinned,
+            globalPinned: stored.globalPinned,
             active: existing?.active ?? stored.active,
             // Legacy / idle rows may still have active_at NULL in SQLite.
             // Public Session.activeAt is always a number for CLI Zod parse.
@@ -224,9 +225,13 @@ export class SessionCache {
     }
 
     setSessionPinned(sessionId: string, pinned: boolean): void {
+        this.setSessionPinMode(sessionId, pinned ? 'project' : 'none')
+    }
+
+    setSessionPinMode(sessionId: string, mode: 'none' | 'project' | 'global'): void {
         const session = this.sessions.get(sessionId) ?? this.refreshSession(sessionId)
         if (!session) throw new Error('Session not found')
-        this.store.sessions.setSessionPinned(sessionId, pinned, session.namespace)
+        this.store.sessions.setSessionPinMode(sessionId, mode, session.namespace)
         this.refreshSession(sessionId)
     }
 
@@ -1187,17 +1192,23 @@ export class SessionCache {
             }
         }
 
-        const latestSourcePinned =
-            this.store.sessions.getSessionByNamespace(oldSessionId, namespace)?.pinned === true
-        if (latestSourcePinned) {
+        const latestSource = this.store.sessions.getSessionByNamespace(oldSessionId, namespace)
+        const latestSourceMode = latestSource?.globalPinned
+            ? 'global' as const
+            : latestSource?.pinned
+                ? 'project' as const
+                : 'none' as const
+        if (latestSourceMode !== 'none') {
             const latest = this.store.sessions.getSessionByNamespace(newSessionId, namespace)
             if (!latest) {
                 throw new Error('Session not found for merge')
             }
-            if (!latest.pinned) {
-                const updated = this.store.sessions.setSessionPinned(newSessionId, true, namespace)
-                const nowPinned = this.store.sessions.getSessionByNamespace(newSessionId, namespace)?.pinned === true
-                if (!updated && !nowPinned) {
+            const latestMode = latest.globalPinned ? 'global' : latest.pinned ? 'project' : 'none'
+            if (latestMode !== latestSourceMode) {
+                const updated = this.store.sessions.setSessionPinMode(newSessionId, latestSourceMode, namespace)
+                const now = this.store.sessions.getSessionByNamespace(newSessionId, namespace)
+                const nowMode = now?.globalPinned ? 'global' : now?.pinned ? 'project' : 'none'
+                if (!updated && nowMode !== latestSourceMode) {
                     throw new Error('Failed to preserve session pin during merge')
                 }
             }

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -338,6 +338,40 @@ describe('session model', () => {
         expect(cache.getSession(newSession.id)?.pinned).toBe(true)
     })
 
+    it('preserves the latest source pin when it changes during a merge', async () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+
+        const oldSession = cache.getOrCreateSession(
+            'session-source-pin-race-old',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        const newSession = cache.getOrCreateSession(
+            'session-source-pin-race-new',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+
+        const getSessionByNamespace = store.sessions.getSessionByNamespace.bind(store.sessions)
+        let sourceReads = 0
+        store.sessions.getSessionByNamespace = ((sessionId, namespace) => {
+            if (sessionId === oldSession.id && ++sourceReads === 2) {
+                store.sessions.setSessionPinned(oldSession.id, true, 'default')
+            }
+            return getSessionByNamespace(sessionId, namespace)
+        }) as typeof store.sessions.getSessionByNamespace
+
+        await cache.mergeSessions(oldSession.id, newSession.id, 'default')
+
+        expect(store.sessions.getSession(oldSession.id)).toBeNull()
+        expect(store.sessions.getSession(newSession.id)?.pinned).toBe(true)
+        expect(cache.getSession(newSession.id)?.pinned).toBe(true)
+    })
+
     it('persists applied session model updates, including clear-to-auto', () => {
         const store = new Store(':memory:')
         const events: SyncEvent[] = []

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -306,6 +306,38 @@ describe('session model', () => {
         expect(cache.getSession(newSession.id)?.pinned).toBe(true)
     })
 
+    it('accepts a merge target pinned concurrently during pin preservation', async () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+
+        const oldSession = cache.getOrCreateSession(
+            'session-pin-race-old',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        const newSession = cache.getOrCreateSession(
+            'session-pin-race-new',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        store.sessions.setSessionPinned(oldSession.id, true, 'default')
+
+        const setSessionPinned = store.sessions.setSessionPinned.bind(store.sessions)
+        store.sessions.setSessionPinned = ((sessionId, pinned, namespace) => {
+            setSessionPinned(sessionId, pinned, namespace)
+            return false
+        }) as typeof store.sessions.setSessionPinned
+
+        await cache.mergeSessions(oldSession.id, newSession.id, 'default')
+
+        expect(store.sessions.getSession(oldSession.id)).toBeNull()
+        expect(store.sessions.getSession(newSession.id)?.pinned).toBe(true)
+        expect(cache.getSession(newSession.id)?.pinned).toBe(true)
+    })
+
     it('persists applied session model updates, including clear-to-auto', () => {
         const store = new Store(':memory:')
         const events: SyncEvent[] = []

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -280,6 +280,32 @@ describe('session model', () => {
         expect(store.sessions.getSession(newSession.id)?.serviceTier).toBe('fast')
     })
 
+    it('preserves pin from old session when merging into resumed session', async () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+
+        const oldSession = cache.getOrCreateSession(
+            'session-pin-old',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        store.sessions.setSessionPinned(oldSession.id, true, 'default')
+        const newSession = cache.getOrCreateSession(
+            'session-pin-new',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+
+        await cache.mergeSessions(oldSession.id, newSession.id, 'default')
+
+        expect(store.sessions.getSession(oldSession.id)).toBeNull()
+        expect(store.sessions.getSession(newSession.id)?.pinned).toBe(true)
+        expect(cache.getSession(newSession.id)?.pinned).toBe(true)
+    })
+
     it('persists applied session model updates, including clear-to-auto', () => {
         const store = new Store(':memory:')
         const events: SyncEvent[] = []

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -291,7 +291,7 @@ describe('session model', () => {
             null,
             'default'
         )
-        store.sessions.setSessionPinned(oldSession.id, true, 'default')
+        store.sessions.setSessionPinMode(oldSession.id, 'project', 'default')
         const newSession = cache.getOrCreateSession(
             'session-pin-new',
             { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
@@ -303,7 +303,63 @@ describe('session model', () => {
 
         expect(store.sessions.getSession(oldSession.id)).toBeNull()
         expect(store.sessions.getSession(newSession.id)?.pinned).toBe(true)
+        expect(store.sessions.getSession(newSession.id)?.globalPinned).toBe(false)
         expect(cache.getSession(newSession.id)?.pinned).toBe(true)
+    })
+
+    it('preserves global pin from old session when merging into resumed session', async () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+
+        const oldSession = cache.getOrCreateSession(
+            'session-global-pin-old',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        store.sessions.setSessionPinMode(oldSession.id, 'global', 'default')
+        const newSession = cache.getOrCreateSession(
+            'session-global-pin-new',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+
+        await cache.mergeSessions(oldSession.id, newSession.id, 'default')
+
+        expect(store.sessions.getSession(oldSession.id)).toBeNull()
+        expect(store.sessions.getSession(newSession.id)?.pinned).toBe(false)
+        expect(store.sessions.getSession(newSession.id)?.globalPinned).toBe(true)
+        expect(cache.getSession(newSession.id)?.globalPinned).toBe(true)
+    })
+
+    it('keeps a global-pinned merge target when the source is only project-pinned', async () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+
+        const oldSession = cache.getOrCreateSession(
+            'session-pin-downgrade-old',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        store.sessions.setSessionPinMode(oldSession.id, 'project', 'default')
+        const newSession = cache.getOrCreateSession(
+            'session-pin-downgrade-new',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        store.sessions.setSessionPinMode(newSession.id, 'global', 'default')
+
+        await cache.mergeSessions(oldSession.id, newSession.id, 'default')
+
+        expect(store.sessions.getSession(oldSession.id)).toBeNull()
+        expect(store.sessions.getSession(newSession.id)?.pinned).toBe(false)
+        expect(store.sessions.getSession(newSession.id)?.globalPinned).toBe(true)
+        expect(cache.getSession(newSession.id)?.globalPinned).toBe(true)
     })
 
     it('accepts a merge target pinned concurrently during pin preservation', async () => {
@@ -323,19 +379,55 @@ describe('session model', () => {
             null,
             'default'
         )
-        store.sessions.setSessionPinned(oldSession.id, true, 'default')
+        store.sessions.setSessionPinMode(oldSession.id, 'project', 'default')
 
-        const setSessionPinned = store.sessions.setSessionPinned.bind(store.sessions)
-        store.sessions.setSessionPinned = ((sessionId, pinned, namespace) => {
-            setSessionPinned(sessionId, pinned, namespace)
+        const setSessionPinMode = store.sessions.setSessionPinMode.bind(store.sessions)
+        store.sessions.setSessionPinMode = ((sessionId, mode, namespace) => {
+            setSessionPinMode(sessionId, mode, namespace)
             return false
-        }) as typeof store.sessions.setSessionPinned
+        }) as typeof store.sessions.setSessionPinMode
 
         await cache.mergeSessions(oldSession.id, newSession.id, 'default')
 
         expect(store.sessions.getSession(oldSession.id)).toBeNull()
         expect(store.sessions.getSession(newSession.id)?.pinned).toBe(true)
         expect(cache.getSession(newSession.id)?.pinned).toBe(true)
+    })
+
+    it('keeps a concurrent global pin on the merge target when the source is project-pinned', async () => {
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+
+        const oldSession = cache.getOrCreateSession(
+            'session-pin-global-race-old',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        const newSession = cache.getOrCreateSession(
+            'session-pin-global-race-new',
+            { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        store.sessions.setSessionPinMode(oldSession.id, 'project', 'default')
+
+        const getSessionByNamespace = store.sessions.getSessionByNamespace.bind(store.sessions)
+        let targetReads = 0
+        store.sessions.getSessionByNamespace = ((sessionId, namespace) => {
+            if (sessionId === newSession.id && ++targetReads === 1) {
+                store.sessions.setSessionPinMode(newSession.id, 'global', 'default')
+            }
+            return getSessionByNamespace(sessionId, namespace)
+        }) as typeof store.sessions.getSessionByNamespace
+
+        await cache.mergeSessions(oldSession.id, newSession.id, 'default')
+
+        expect(store.sessions.getSession(oldSession.id)).toBeNull()
+        expect(store.sessions.getSession(newSession.id)?.pinned).toBe(false)
+        expect(store.sessions.getSession(newSession.id)?.globalPinned).toBe(true)
+        expect(cache.getSession(newSession.id)?.globalPinned).toBe(true)
     })
 
     it('preserves the latest source pin when it changes during a merge', async () => {
@@ -360,7 +452,7 @@ describe('session model', () => {
         let sourceReads = 0
         store.sessions.getSessionByNamespace = ((sessionId, namespace) => {
             if (sessionId === oldSession.id && ++sourceReads === 2) {
-                store.sessions.setSessionPinned(oldSession.id, true, 'default')
+                store.sessions.setSessionPinMode(oldSession.id, 'project', 'default')
             }
             return getSessionByNamespace(sessionId, namespace)
         }) as typeof store.sessions.getSessionByNamespace

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -305,6 +305,10 @@ export class SyncEngine {
         this.sessionCache.setSessionPinned(sessionId, pinned)
     }
 
+    setSessionPinMode(sessionId: string, mode: 'none' | 'project' | 'global'): void {
+        this.sessionCache.setSessionPinMode(sessionId, mode)
+    }
+
     getFutureScheduledMessageCounts(sessionIds: string[], now: number = Date.now()): Map<string, number> {
         return this.store.messages.countFutureScheduledBySessionIds(sessionIds, now)
     }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -301,6 +301,10 @@ export class SyncEngine {
         return this.sessionCache.getSessionsByNamespace(namespace)
     }
 
+    setSessionPinned(sessionId: string, pinned: boolean): void {
+        this.sessionCache.setSessionPinned(sessionId, pinned)
+    }
+
     getFutureScheduledMessageCounts(sessionIds: string[], now: number = Date.now()): Map<string, number> {
         return this.store.messages.countFutureScheduledBySessionIds(sessionIds, now)
     }

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -67,6 +67,7 @@ function createApp(session: Session, opts?: {
     forkConversation?: SyncEngine['forkConversation']
     rewindConversation?: SyncEngine['rewindConversation']
     setSessionPinned?: (sessionId: string, pinned: boolean) => void
+    setSessionPinMode?: (sessionId: string, mode: 'none' | 'project' | 'global') => void
 }) {
     const applySessionConfigCalls: Array<[string, Record<string, unknown>]> = []
     const applySessionConfig = async (sessionId: string, config: Record<string, unknown>) => {
@@ -138,6 +139,7 @@ function createApp(session: Session, opts?: {
         })),
         archiveSession: archiveSessionMock,
         setSessionPinned: opts?.setSessionPinned ?? (() => {}),
+        setSessionPinMode: opts?.setSessionPinMode ?? (() => {}),
         getSessionExport: opts?.getSessionExport ?? (() => ({
             type: 'success',
             payload: {
@@ -167,20 +169,20 @@ function createApp(session: Session, opts?: {
 }
 
 describe('sessions routes', () => {
-    it('updates the persisted pin state', async () => {
-        const calls: Array<[string, boolean]> = []
+    it('updates the persisted pin mode', async () => {
+        const calls: Array<[string, 'none' | 'project' | 'global']> = []
         const { app } = createApp(createSession(), {
-            setSessionPinned: (sessionId, pinned) => calls.push([sessionId, pinned])
+            setSessionPinMode: (sessionId, mode) => calls.push([sessionId, mode])
         })
 
         const response = await app.request('/api/sessions/session-1/pin', {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ pinned: true })
+            body: JSON.stringify({ mode: 'global' })
         })
 
         expect(response.status).toBe(200)
-        expect(calls).toEqual([['session-1', true]])
+        expect(calls).toEqual([['session-1', 'global']])
     })
 
     it('rejects an invalid pin body', async () => {
@@ -188,7 +190,7 @@ describe('sessions routes', () => {
         const response = await app.request('/api/sessions/session-1/pin', {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ pinned: 'yes' })
+            body: JSON.stringify({ mode: 'yes' })
         })
 
         expect(response.status).toBe(400)

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -66,6 +66,7 @@ function createApp(session: Session, opts?: {
     getCursorChatStoreStatus?: SyncEngine['getCursorChatStoreStatus']
     forkConversation?: SyncEngine['forkConversation']
     rewindConversation?: SyncEngine['rewindConversation']
+    setSessionPinned?: (sessionId: string, pinned: boolean) => void
 }) {
     const applySessionConfigCalls: Array<[string, Record<string, unknown>]> = []
     const applySessionConfig = async (sessionId: string, config: Record<string, unknown>) => {
@@ -136,6 +137,7 @@ function createApp(session: Session, opts?: {
             status: { onDisk: true, store: 'acp' as const }
         })),
         archiveSession: archiveSessionMock,
+        setSessionPinned: opts?.setSessionPinned ?? (() => {}),
         getSessionExport: opts?.getSessionExport ?? (() => ({
             type: 'success',
             payload: {
@@ -165,6 +167,33 @@ function createApp(session: Session, opts?: {
 }
 
 describe('sessions routes', () => {
+    it('updates the persisted pin state', async () => {
+        const calls: Array<[string, boolean]> = []
+        const { app } = createApp(createSession(), {
+            setSessionPinned: (sessionId, pinned) => calls.push([sessionId, pinned])
+        })
+
+        const response = await app.request('/api/sessions/session-1/pin', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pinned: true })
+        })
+
+        expect(response.status).toBe(200)
+        expect(calls).toEqual([['session-1', true]])
+    })
+
+    it('rejects an invalid pin body', async () => {
+        const { app } = createApp(createSession())
+        const response = await app.request('/api/sessions/session-1/pin', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pinned: 'yes' })
+        })
+
+        expect(response.status).toBe(400)
+    })
+
     it('returns the machine-scoped Cursor chat store status', async () => {
         const session = createSession({
             active: false,

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -5,6 +5,7 @@ import {
     getPermissionModesForFlavor,
     isPermissionModeAllowedForFlavor,
     RenameSessionRequestSchema,
+    SetSessionPinnedRequestSchema,
     ResumeSessionRequestSchema,
     RewindConversationRequestSchema,
     SCRATCHLIST_MAX_ENTRIES,
@@ -88,6 +89,9 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
                 // Peer discovery wants newest activity first before limit truncation.
                 if (order === 'updatedAt') {
                     return b.updatedAt - a.updatedAt
+                }
+                if (Boolean(a.pinned) !== Boolean(b.pinned)) {
+                    return a.pinned ? -1 : 1
                 }
                 // Active sessions first (web session list)
                 if (a.active !== b.active) {
@@ -788,6 +792,23 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
             }
             return c.json({ error: message }, 500)
         }
+    })
+
+    app.put('/sessions/:id/pin', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) return engine
+
+        const sessionResult = requireSessionFromParam(c, engine)
+        if (sessionResult instanceof Response) return sessionResult
+
+        const body = await c.req.json().catch(() => null)
+        const parsed = SetSessionPinnedRequestSchema.safeParse(body)
+        if (!parsed.success) {
+            return c.json({ error: 'Invalid body: pinned is required' }, 400)
+        }
+
+        engine.setSessionPinned(sessionResult.sessionId, parsed.data.pinned)
+        return c.json({ ok: true })
     })
 
     app.delete('/sessions/:id', async (c) => {

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -90,6 +90,9 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
                 if (order === 'updatedAt') {
                     return b.updatedAt - a.updatedAt
                 }
+                if (Boolean(a.globalPinned) !== Boolean(b.globalPinned)) {
+                    return a.globalPinned ? -1 : 1
+                }
                 if (Boolean(a.pinned) !== Boolean(b.pinned)) {
                     return a.pinned ? -1 : 1
                 }
@@ -804,10 +807,10 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         const body = await c.req.json().catch(() => null)
         const parsed = SetSessionPinnedRequestSchema.safeParse(body)
         if (!parsed.success) {
-            return c.json({ error: 'Invalid body: pinned is required' }, 400)
+            return c.json({ error: 'Invalid body: mode must be none, project, or global' }, 400)
         }
 
-        engine.setSessionPinned(sessionResult.sessionId, parsed.data.pinned)
+        engine.setSessionPinMode(sessionResult.sessionId, parsed.data.mode)
         return c.json({ ok: true })
     })
 

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -308,6 +308,12 @@ export const RenameSessionRequestSchema = z.object({
 
 export type RenameSessionRequest = z.infer<typeof RenameSessionRequestSchema>
 
+export const SetSessionPinnedRequestSchema = z.object({
+    pinned: z.boolean()
+})
+
+export type SetSessionPinnedRequest = z.infer<typeof SetSessionPinnedRequestSchema>
+
 /**
  * An empty string clears the custom name, so unlike session rename there is no
  * `min(1)`: the machine falls back to its hostname. The length ceiling is

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -309,10 +309,11 @@ export const RenameSessionRequestSchema = z.object({
 export type RenameSessionRequest = z.infer<typeof RenameSessionRequestSchema>
 
 export const SetSessionPinnedRequestSchema = z.object({
-    pinned: z.boolean()
+    mode: z.enum(['none', 'project', 'global'])
 })
 
 export type SetSessionPinnedRequest = z.infer<typeof SetSessionPinnedRequestSchema>
+export type SessionPinMode = SetSessionPinnedRequest['mode']
 
 /**
  * An empty string clears the custom name, so unlike session rename there is no

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -299,6 +299,7 @@ export const SessionSchema = z.object({
     seq: z.number(),
     createdAt: z.number(),
     updatedAt: z.number(),
+    pinned: z.boolean().optional(),
     active: z.boolean(),
     // Hub may still emit null for legacy SQLite rows; keep output type number.
     activeAt: z.number().nullish().transform((value) => value ?? 0),

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -300,6 +300,7 @@ export const SessionSchema = z.object({
     createdAt: z.number(),
     updatedAt: z.number(),
     pinned: z.boolean().optional(),
+    globalPinned: z.boolean().optional(),
     active: z.boolean(),
     // Hub may still emit null for legacy SQLite rows; keep output type number.
     activeAt: z.number().nullish().transform((value) => value ?? 0),

--- a/shared/src/sessionSummary.test.ts
+++ b/shared/src/sessionSummary.test.ts
@@ -71,7 +71,9 @@ describe('getPendingRequestKinds', () => {
 describe('toSessionSummary', () => {
     it('includes the pinned state', () => {
         expect(toSessionSummary(makeSession({ pinned: true })).pinned).toBe(true)
+        expect(toSessionSummary(makeSession({ globalPinned: true })).globalPinned).toBe(true)
         expect(toSessionSummary(makeSession()).pinned).toBe(false)
+        expect(toSessionSummary(makeSession()).globalPinned).toBe(false)
     })
 
     it('uses grokSessionId as the native resume token', () => {

--- a/shared/src/sessionSummary.test.ts
+++ b/shared/src/sessionSummary.test.ts
@@ -69,6 +69,11 @@ describe('getPendingRequestKinds', () => {
 })
 
 describe('toSessionSummary', () => {
+    it('includes the pinned state', () => {
+        expect(toSessionSummary(makeSession({ pinned: true })).pinned).toBe(true)
+        expect(toSessionSummary(makeSession()).pinned).toBe(false)
+    })
+
     it('uses grokSessionId as the native resume token', () => {
         const summary = toSessionSummary(makeSession({
             metadata: {

--- a/shared/src/sessionSummary.ts
+++ b/shared/src/sessionSummary.ts
@@ -52,6 +52,7 @@ export type SessionSummary = {
     activeAt: number
     updatedAt: number
     pinned?: boolean
+    globalPinned?: boolean
     metadata: SessionSummaryMetadata | null
     /** Watermarks for structured SSE patches (PR #897). List cache must gate
      *  without requiring a detail query — otherwise global SSE forces O(N)
@@ -208,6 +209,7 @@ export function toSessionSummary(session: Session): SessionSummary {
         activeAt: session.activeAt,
         updatedAt: session.updatedAt,
         pinned: session.pinned ?? false,
+        globalPinned: session.globalPinned ?? false,
         metadata: toSessionSummaryMetadata(session.metadata),
         metadataVersion: session.metadataVersion,
         agentStateVersion: session.agentStateVersion,

--- a/shared/src/sessionSummary.ts
+++ b/shared/src/sessionSummary.ts
@@ -51,6 +51,7 @@ export type SessionSummary = {
     thinking: boolean
     activeAt: number
     updatedAt: number
+    pinned?: boolean
     metadata: SessionSummaryMetadata | null
     /** Watermarks for structured SSE patches (PR #897). List cache must gate
      *  without requiring a detail query — otherwise global SSE forces O(N)
@@ -206,6 +207,7 @@ export function toSessionSummary(session: Session): SessionSummary {
         thinking: session.thinking,
         activeAt: session.activeAt,
         updatedAt: session.updatedAt,
+        pinned: session.pinned ?? false,
         metadata: toSessionSummaryMetadata(session.metadata),
         metadataVersion: session.metadataVersion,
         agentStateVersion: session.agentStateVersion,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -916,6 +916,13 @@ export class ApiClient {
         })
     }
 
+    async setSessionPinned(sessionId: string, pinned: boolean): Promise<void> {
+        await this.request(`/api/sessions/${encodeURIComponent(sessionId)}/pin`, {
+            method: 'PUT',
+            body: JSON.stringify({ pinned })
+        })
+    }
+
     async deleteSession(sessionId: string): Promise<void> {
         await this.request(`/api/sessions/${encodeURIComponent(sessionId)}`, {
             method: 'DELETE'

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -916,10 +916,10 @@ export class ApiClient {
         })
     }
 
-    async setSessionPinned(sessionId: string, pinned: boolean): Promise<void> {
+    async setSessionPinMode(sessionId: string, mode: 'none' | 'project' | 'global'): Promise<void> {
         await this.request(`/api/sessions/${encodeURIComponent(sessionId)}/pin`, {
             method: 'PUT',
-            body: JSON.stringify({ pinned })
+            body: JSON.stringify({ mode })
         })
     }
 

--- a/web/src/components/SessionActionMenu.test.tsx
+++ b/web/src/components/SessionActionMenu.test.tsx
@@ -40,6 +40,33 @@ beforeEach(() => {
     vi.clearAllMocks()
 })
 
+describe('SessionActionMenu - Pin action', () => {
+    it('renders pin and unpin labels and invokes the action', () => {
+        const onTogglePin = vi.fn()
+        const { rerender } = renderMenu({ onTogglePin, sessionPinned: false })
+
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin session' }))
+        expect(onTogglePin).toHaveBeenCalledOnce()
+
+        rerender(
+            <I18nProvider>
+                <SessionActionMenu
+                    isOpen={true}
+                    onClose={vi.fn()}
+                    sessionActive={false}
+                    sessionPinned={true}
+                    onTogglePin={onTogglePin}
+                    onRename={vi.fn()}
+                    onArchive={vi.fn()}
+                    onDelete={vi.fn()}
+                    anchorPoint={{ x: 0, y: 0 }}
+                />
+            </I18nProvider>
+        )
+        expect(screen.getByRole('menuitem', { name: 'Unpin session' })).toBeInTheDocument()
+    })
+})
+
 describe('SessionActionMenu - Reopen action', () => {
     it('renders the Reopen item on inactive sessions when onReopen is provided', () => {
         renderMenu({ sessionActive: false })

--- a/web/src/components/SessionActionMenu.test.tsx
+++ b/web/src/components/SessionActionMenu.test.tsx
@@ -53,6 +53,8 @@ describe('SessionActionMenu - Pin action', () => {
                 <SessionActionMenu
                     isOpen={true}
                     onClose={vi.fn()}
+                    sessionId="session-1"
+                    sessionTitle="Session 1"
                     sessionActive={false}
                     sessionPinned={true}
                     onTogglePin={onTogglePin}

--- a/web/src/components/SessionActionMenu.test.tsx
+++ b/web/src/components/SessionActionMenu.test.tsx
@@ -41,12 +41,15 @@ beforeEach(() => {
 })
 
 describe('SessionActionMenu - Pin action', () => {
-    it('renders pin and unpin labels and invokes the action', () => {
-        const onTogglePin = vi.fn()
-        const { rerender } = renderMenu({ onTogglePin, sessionPinned: false })
+    it('renders project and global pin actions', () => {
+        const onSetPinMode = vi.fn()
+        const { rerender } = renderMenu({ onSetPinMode, sessionPinned: false, sessionGlobalPinned: false })
 
-        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin session' }))
-        expect(onTogglePin).toHaveBeenCalledOnce()
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin in project' }))
+        expect(onSetPinMode).toHaveBeenCalledWith('project')
+
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin globally' }))
+        expect(onSetPinMode).toHaveBeenCalledWith('global')
 
         rerender(
             <I18nProvider>
@@ -57,7 +60,8 @@ describe('SessionActionMenu - Pin action', () => {
                     sessionTitle="Session 1"
                     sessionActive={false}
                     sessionPinned={true}
-                    onTogglePin={onTogglePin}
+                    sessionGlobalPinned={true}
+                    onSetPinMode={onSetPinMode}
                     onRename={vi.fn()}
                     onArchive={vi.fn()}
                     onDelete={vi.fn()}
@@ -65,7 +69,8 @@ describe('SessionActionMenu - Pin action', () => {
                 />
             </I18nProvider>
         )
-        expect(screen.getByRole('menuitem', { name: 'Unpin session' })).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: 'Unpin from project' })).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: 'Unpin globally' })).toBeInTheDocument()
     })
 })
 

--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -21,6 +21,8 @@ type SessionActionMenuProps = {
     sessionTitle: string
     sessionActive: boolean
     onRename: () => void
+    sessionPinned?: boolean
+    onTogglePin?: () => void
     onExport?: () => void
     onSyncCodex?: () => void
     onSyncPi?: () => void
@@ -48,6 +50,18 @@ function EditIcon(props: { className?: string }) {
         >
             <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
             <path d="m15 5 4 4" />
+        </svg>
+    )
+}
+
+function PinIcon(props: { className?: string; filled?: boolean }) {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+            fill={props.filled ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2"
+            strokeLinecap="round" strokeLinejoin="round" className={props.className}>
+            <path d="M12 17v5" />
+            <path d="M5 17h14" />
+            <path d="M7 4V2h10v2l-2 5v4l2 2H7l2-2V9Z" />
         </svg>
     )
 }
@@ -175,6 +189,8 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         sessionTitle,
         sessionActive,
         onRename,
+        sessionPinned = false,
+        onTogglePin,
         onExport,
         onSyncCodex,
         onSyncPi,
@@ -204,6 +220,11 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         } catch {
             haptic.notification('error')
         }
+    }
+
+    const handleTogglePin = () => {
+        onClose()
+        onTogglePin?.()
     }
 
     const handleArchive = () => {
@@ -361,6 +382,18 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
                     <CopyIcon className="h-[18px] w-[18px] text-[var(--app-hint)]" />
                     {t('session.action.copyReference')}
                 </button>
+
+                {onTogglePin ? (
+                    <button
+                        type="button"
+                        role="menuitem"
+                        className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
+                        onClick={handleTogglePin}
+                    >
+                        <PinIcon filled={sessionPinned} className="text-[var(--app-hint)]" />
+                        {t(sessionPinned ? 'session.action.unpin' : 'session.action.pin')}
+                    </button>
+                ) : null}
 
                 {onExport ? (
                     <button

--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -22,7 +22,8 @@ type SessionActionMenuProps = {
     sessionActive: boolean
     onRename: () => void
     sessionPinned?: boolean
-    onTogglePin?: () => void
+    sessionGlobalPinned?: boolean
+    onSetPinMode?: (mode: 'none' | 'project' | 'global') => void
     onExport?: () => void
     onSyncCodex?: () => void
     onSyncPi?: () => void
@@ -190,7 +191,8 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         sessionActive,
         onRename,
         sessionPinned = false,
-        onTogglePin,
+        sessionGlobalPinned = false,
+        onSetPinMode,
         onExport,
         onSyncCodex,
         onSyncPi,
@@ -222,9 +224,9 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         }
     }
 
-    const handleTogglePin = () => {
+    const handleSetPinMode = (mode: 'none' | 'project' | 'global') => {
         onClose()
-        onTogglePin?.()
+        onSetPinMode?.(mode)
     }
 
     const handleArchive = () => {
@@ -383,16 +385,27 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
                     {t('session.action.copyReference')}
                 </button>
 
-                {onTogglePin ? (
-                    <button
-                        type="button"
-                        role="menuitem"
-                        className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
-                        onClick={handleTogglePin}
-                    >
-                        <PinIcon filled={sessionPinned} className="text-[var(--app-hint)]" />
-                        {t(sessionPinned ? 'session.action.unpin' : 'session.action.pin')}
-                    </button>
+                {onSetPinMode ? (
+                    <>
+                        <button
+                            type="button"
+                            role="menuitem"
+                            className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
+                            onClick={() => handleSetPinMode(sessionPinned ? 'none' : 'project')}
+                        >
+                            <PinIcon filled={sessionPinned} className="text-[var(--app-hint)]" />
+                            {t(sessionPinned ? 'session.action.unpinProject' : 'session.action.pinProject')}
+                        </button>
+                        <button
+                            type="button"
+                            role="menuitem"
+                            className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
+                            onClick={() => handleSetPinMode(sessionGlobalPinned ? 'none' : 'global')}
+                        >
+                            <PinIcon filled={sessionGlobalPinned} className="text-[var(--app-hint)]" />
+                            {t(sessionGlobalPinned ? 'session.action.unpinGlobal' : 'session.action.pinGlobal')}
+                        </button>
+                    </>
                 ) : null}
 
                 {onExport ? (

--- a/web/src/components/SessionHeader.test.tsx
+++ b/web/src/components/SessionHeader.test.tsx
@@ -4,13 +4,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Session } from '@/types/api'
 import type { ApiClient } from '@/api/client'
 import { I18nProvider } from '@/lib/i18n-context'
-import { ToastProvider } from '@/lib/toast-context'
+import { ToastProvider, useToast } from '@/lib/toast-context'
 import { resolveSessionHeaderMachineLabel, SessionHeader } from './SessionHeader'
 
 afterEach(() => {
     cleanup()
     localStorage.clear()
 })
+
+function ToastMessages() {
+    const { toasts } = useToast()
+    return <>{toasts.map((toast) => <div key={toast.id}>{toast.title}: {toast.body}</div>)}</>
+}
 
 function baseSession(overrides: Partial<Session> = {}): Session {
     return {
@@ -309,5 +314,28 @@ describe('SessionHeader', () => {
         fireEvent.click(screen.getByRole('menuitem', { name: 'Pin session' }))
 
         await waitFor(() => expect(setSessionPinned).toHaveBeenCalledWith('session-pin', true))
+    })
+
+    it('shows an error toast when toggling the pin fails', async () => {
+        const api = {
+            getScratchlist: vi.fn().mockResolvedValue({ entries: [] }),
+            setSessionPinned: vi.fn().mockRejectedValue(new Error('Network unavailable'))
+        } as unknown as ApiClient
+
+        render(
+            <QueryClientProvider client={new QueryClient()}>
+                <ToastProvider>
+                    <I18nProvider>
+                        <SessionHeader session={baseSession({ pinned: false })} onBack={vi.fn()} api={api} />
+                        <ToastMessages />
+                    </I18nProvider>
+                </ToastProvider>
+            </QueryClientProvider>
+        )
+
+        fireEvent.click(screen.getByTitle('More actions'))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin session' }))
+
+        expect(await screen.findByText('Could not update pin: Network unavailable')).toBeInTheDocument()
     })
 })

--- a/web/src/components/SessionHeader.test.tsx
+++ b/web/src/components/SessionHeader.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Session } from '@/types/api'
+import type { ApiClient } from '@/api/client'
 import { I18nProvider } from '@/lib/i18n-context'
 import { ToastProvider } from '@/lib/toast-context'
 import { resolveSessionHeaderMachineLabel, SessionHeader } from './SessionHeader'
@@ -265,5 +266,48 @@ describe('SessionHeader', () => {
         } finally {
             vi.useRealTimers()
         }
+    })
+
+    it('toggles pin state from the header action menu', async () => {
+        const setSessionPinned = vi.fn().mockResolvedValue(undefined)
+        const api = {
+            getScratchlist: vi.fn().mockResolvedValue({ entries: [] }),
+            setSessionPinned
+        } as unknown as ApiClient
+        const session: Session = {
+            id: 'session-pin',
+            namespace: 'default',
+            seq: 0,
+            createdAt: 0,
+            updatedAt: 0,
+            active: false,
+            activeAt: 0,
+            metadata: { flavor: 'codex', path: '/repo', host: 'machine' },
+            metadataVersion: 0,
+            agentState: null,
+            agentStateVersion: 0,
+            thinking: false,
+            thinkingAt: 0,
+            model: null,
+            modelReasoningEffort: null,
+            effort: null,
+            serviceTier: null,
+            pinned: false
+        }
+
+        render(
+            <QueryClientProvider client={new QueryClient()}>
+                <ToastProvider>
+                    <I18nProvider>
+                        <SessionHeader session={session} onBack={vi.fn()} api={api} />
+                    </I18nProvider>
+                </ToastProvider>
+            </QueryClientProvider>
+        )
+
+        fireEvent.click(screen.getByTitle('More actions'))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin session' }))
+
+        await waitFor(() => expect(setSessionPinned).toHaveBeenCalledWith('session-pin', true))
     })
 })

--- a/web/src/components/SessionHeader.test.tsx
+++ b/web/src/components/SessionHeader.test.tsx
@@ -274,10 +274,10 @@ describe('SessionHeader', () => {
     })
 
     it('toggles pin state from the header action menu', async () => {
-        const setSessionPinned = vi.fn().mockResolvedValue(undefined)
+        const setSessionPinMode = vi.fn().mockResolvedValue(undefined)
         const api = {
             getScratchlist: vi.fn().mockResolvedValue({ entries: [] }),
-            setSessionPinned
+            setSessionPinMode
         } as unknown as ApiClient
         const session: Session = {
             id: 'session-pin',
@@ -297,7 +297,8 @@ describe('SessionHeader', () => {
             modelReasoningEffort: null,
             effort: null,
             serviceTier: null,
-            pinned: false
+            pinned: false,
+            globalPinned: false
         }
 
         render(
@@ -311,15 +312,15 @@ describe('SessionHeader', () => {
         )
 
         fireEvent.click(screen.getByTitle('More actions'))
-        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin session' }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin globally' }))
 
-        await waitFor(() => expect(setSessionPinned).toHaveBeenCalledWith('session-pin', true))
+        await waitFor(() => expect(setSessionPinMode).toHaveBeenCalledWith('session-pin', 'global'))
     })
 
     it('shows an error toast when toggling the pin fails', async () => {
         const api = {
             getScratchlist: vi.fn().mockResolvedValue({ entries: [] }),
-            setSessionPinned: vi.fn().mockRejectedValue(new Error('Network unavailable'))
+            setSessionPinMode: vi.fn().mockRejectedValue(new Error('Network unavailable'))
         } as unknown as ApiClient
 
         render(
@@ -334,7 +335,7 @@ describe('SessionHeader', () => {
         )
 
         fireEvent.click(screen.getByTitle('More actions'))
-        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin session' }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Pin in project' }))
 
         expect(await screen.findByText('Could not update pin: Network unavailable')).toBeInTheDocument()
     })

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -220,7 +220,7 @@ export function SessionHeader(props: {
     const [isSyncingCodex, setIsSyncingCodex] = useState(false)
     const [isSyncingPi, setIsSyncingPi] = useState(false)
 
-    const { archiveSession, reopenSession, renameSession, deleteSession, isPending } = useSessionActions(
+    const { archiveSession, reopenSession, renameSession, setPinned, deleteSession, isPending } = useSessionActions(
         api,
         session.id,
         session.metadata?.flavor ?? null
@@ -499,7 +499,9 @@ export function SessionHeader(props: {
                 sessionId={session.id}
                 sessionTitle={title}
                 sessionActive={session.active}
+                sessionPinned={session.pinned}
                 onRename={() => setRenameOpen(true)}
+                onTogglePin={api ? () => void setPinned(!session.pinned) : undefined}
                 onExport={() => setExportOpen(true)}
                 onSyncCodex={api && codexSessionId ? handleSyncCodex : undefined}
                 onSyncPi={api && piSessionId && !session.active ? handleSyncPi : undefined}

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -226,6 +226,19 @@ export function SessionHeader(props: {
         session.metadata?.flavor ?? null
     )
     const [reopenError, setReopenError] = useState<string | null>(null)
+
+    const handleTogglePin = async () => {
+        try {
+            await setPinned(!session.pinned)
+        } catch (error) {
+            addToast({
+                title: t('session.action.pinFailed'),
+                body: error instanceof Error ? error.message : t('dialog.error.default'),
+                sessionId: session.id,
+                url: `/sessions/${session.id}`
+            })
+        }
+    }
     // tiann/hapi#893: surface the scratchlist entry count in the
     // delete-confirm copy so the operator knows what cascades when they
     // confirm. Read-only hook reuses the cache filled by SessionChat -
@@ -501,7 +514,7 @@ export function SessionHeader(props: {
                 sessionActive={session.active}
                 sessionPinned={session.pinned}
                 onRename={() => setRenameOpen(true)}
-                onTogglePin={api ? () => void setPinned(!session.pinned) : undefined}
+                onTogglePin={api ? () => void handleTogglePin() : undefined}
                 onExport={() => setExportOpen(true)}
                 onSyncCodex={api && codexSessionId ? handleSyncCodex : undefined}
                 onSyncPi={api && piSessionId && !session.active ? handleSyncPi : undefined}

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -220,16 +220,16 @@ export function SessionHeader(props: {
     const [isSyncingCodex, setIsSyncingCodex] = useState(false)
     const [isSyncingPi, setIsSyncingPi] = useState(false)
 
-    const { archiveSession, reopenSession, renameSession, setPinned, deleteSession, isPending } = useSessionActions(
+    const { archiveSession, reopenSession, renameSession, setPinMode, deleteSession, isPending } = useSessionActions(
         api,
         session.id,
         session.metadata?.flavor ?? null
     )
     const [reopenError, setReopenError] = useState<string | null>(null)
 
-    const handleTogglePin = async () => {
+    const handleSetPinMode = async (mode: 'none' | 'project' | 'global') => {
         try {
-            await setPinned(!session.pinned)
+            await setPinMode(mode)
         } catch (error) {
             addToast({
                 title: t('session.action.pinFailed'),
@@ -512,9 +512,10 @@ export function SessionHeader(props: {
                 sessionId={session.id}
                 sessionTitle={title}
                 sessionActive={session.active}
-                sessionPinned={session.pinned}
+                sessionPinned={Boolean(session.pinned)}
+                sessionGlobalPinned={Boolean(session.globalPinned)}
                 onRename={() => setRenameOpen(true)}
-                onTogglePin={api ? () => void handleTogglePin() : undefined}
+                onSetPinMode={api ? (mode) => void handleSetPinMode(mode) : undefined}
                 onExport={() => setExportOpen(true)}
                 onSyncCodex={api && codexSessionId ? handleSyncCodex : undefined}
                 onSyncPi={api && piSessionId && !session.active ? handleSyncPi : undefined}

--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -359,18 +359,20 @@ describe('SessionList collapse behavior', () => {
                     mutations: { retry: false },
                 }
             })}>
-                <I18nProvider>
-                    <SessionList
-                        sessions={sessions}
-                        selectedSessionId={selectedSessionId}
-                        onSelect={vi.fn()}
-                        onNewSession={vi.fn()}
-                        onRefresh={vi.fn()}
-                        isLoading={false}
-                        renderHeader={false}
-                        api={null}
-                    />
-                </I18nProvider>
+                <ToastProvider>
+                    <I18nProvider>
+                        <SessionList
+                            sessions={sessions}
+                            selectedSessionId={selectedSessionId}
+                            onSelect={vi.fn()}
+                            onNewSession={vi.fn()}
+                            onRefresh={vi.fn()}
+                            isLoading={false}
+                            renderHeader={false}
+                            api={null}
+                        />
+                    </I18nProvider>
+                </ToastProvider>
             </QueryClientProvider>
         )
     }

--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -472,6 +472,30 @@ describe('SessionList collapse behavior', () => {
         expect(getProjectPanel().getAttribute('data-open')).toBeNull()
     })
 
+    it('keeps project-pinned active sessions in their project group when the preference is on', () => {
+        localStorage.setItem('hapi-pin-in-progress-sessions', 'true')
+        const sessions = [
+            makeSession({
+                id: 'session-pinned-running',
+                active: true,
+                thinking: true,
+                pinned: true,
+                updatedAt: 100,
+                metadata: { path: '/work/hapi', name: 'Pinned running task', flavor: 'codex' },
+            }),
+            makeSession({
+                id: 'session-idle',
+                updatedAt: 50,
+                metadata: { path: '/work/hapi', name: 'Idle task', flavor: 'codex' },
+            }),
+        ]
+        render(renderSessionList(sessions, null))
+
+        expect(screen.queryByTitle('In progress')).toBeNull()
+        expect(getProjectPanel().getAttribute('data-open')).toBe('true')
+        expect(screen.getByRole('button', { name: /Pinned running task/ })).toBeInTheDocument()
+    })
+
     it('does not label quiet active sessions as Idle', () => {
         const sessions = [
             makeSession({

--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -559,6 +559,27 @@ describe('SessionList collapse behavior', () => {
         })
     })
 
+    it('keeps an inactive project-pinned group expanded with no selection', () => {
+        const sessions = [
+            makeSession({
+                id: 'session-pinned',
+                pinned: true,
+                updatedAt: 100,
+                metadata: { path: '/work/hapi', name: 'Pinned task', flavor: 'codex' },
+            }),
+            makeSession({
+                id: 'session-idle',
+                updatedAt: 50,
+                metadata: { path: '/work/hapi', name: 'Idle task', flavor: 'codex' },
+            }),
+        ]
+        render(renderSessionList(sessions, null))
+
+        expect(getProjectPanel().getAttribute('data-open')).toBe('true')
+        expect(screen.getByRole('button', { name: /Pinned task/ })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Idle task/ })).toBeInTheDocument()
+    })
+
     it('keeps the running section open while searching even when collapsed', () => {
         localStorage.setItem('hapi-pin-in-progress-sessions', 'true')
         const sessions = [

--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -144,6 +144,26 @@ describe('deduplicateSessionsByAgentId', () => {
         expect(result[0].id).toBe('a') // selected wins despite older updatedAt
     })
 
+    it('preserves a pinned session when deduplicating by recency', () => {
+        const sessions = [
+            makeSession({ id: 'pinned', pinned: true, metadata: { path: '/p', agentSessionId: 'thread-1' }, updatedAt: 100 }),
+            makeSession({ id: 'recent', metadata: { path: '/p', agentSessionId: 'thread-1' }, updatedAt: 200 })
+        ]
+        const result = deduplicateSessionsByAgentId(sessions)
+        expect(result).toHaveLength(1)
+        expect(result[0].id).toBe('pinned')
+    })
+
+    it('keeps the selected inactive session ahead of a pinned duplicate', () => {
+        const sessions = [
+            makeSession({ id: 'selected', metadata: { path: '/p', agentSessionId: 'thread-1' }, updatedAt: 100 }),
+            makeSession({ id: 'pinned', pinned: true, metadata: { path: '/p', agentSessionId: 'thread-1' }, updatedAt: 200 })
+        ]
+        const result = deduplicateSessionsByAgentId(sessions, 'selected')
+        expect(result).toHaveLength(1)
+        expect(result[0].id).toBe('selected')
+    })
+
     it('active always wins over selected inactive', () => {
         const sessions = [
             makeSession({ id: 'a', metadata: { path: '/p', agentSessionId: 'thread-1' }, updatedAt: 200 }),

--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -328,6 +328,16 @@ describe('prepareSidebarSessions', () => {
         expect(result.map(session => session.id).sort()).toEqual(['real', 'stub'])
     })
 
+    it('keeps a pinned inactive stub visible', () => {
+        const sessions = [
+            makeSession({ id: 'pinned-stub', pinned: true, metadata: { path: '/work/hapi' } }),
+            makeSession({ id: 'stub', metadata: { path: '/work/hapi' } })
+        ]
+
+        const result = prepareSidebarSessions(sessions)
+        expect(result.map(session => session.id)).toEqual(['pinned-stub'])
+    })
+
     it('deduplicates before filtering stubs', () => {
         const sessions = [
             makeSession({ id: 'stub', metadata: { path: '/work/hapi' } }),
@@ -349,11 +359,12 @@ describe('prepareSidebarSessions', () => {
 })
 
 describe('shouldShowSessionInSidebar', () => {
-    it('always shows active and selected sessions', () => {
+    it('always shows active, selected, and pinned sessions', () => {
         const stub = makeSession({ id: 'stub', metadata: { path: '/work/hapi' } })
         expect(shouldShowSessionInSidebar(stub)).toBe(false)
         expect(shouldShowSessionInSidebar(stub, 'stub')).toBe(true)
         expect(shouldShowSessionInSidebar({ ...stub, active: true })).toBe(true)
+        expect(shouldShowSessionInSidebar({ ...stub, pinned: true })).toBe(true)
     })
 })
 

--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -20,6 +20,7 @@ import {
     prepareSidebarSessions,
     sessionMatchesQuery,
     sessionMatchesTimeRange,
+    shouldShowPinnedDivider,
     shouldShowSessionInSidebar
 } from './SessionList'
 
@@ -88,6 +89,27 @@ describe('getWorktreeSessionLabel', () => {
         })
 
         expect(getWorktreeSessionLabel(session)).toBe('fix-resume')
+    })
+})
+
+describe('shouldShowPinnedDivider', () => {
+    it('shows one divider at the visible pinned-to-unpinned boundary', () => {
+        const sessions = [
+            makeSession({ id: 'pinned-a', pinned: true }),
+            makeSession({ id: 'pinned-b', pinned: true }),
+            makeSession({ id: 'regular-a' }),
+            makeSession({ id: 'regular-b' })
+        ]
+
+        expect(sessions.map((_, index) => shouldShowPinnedDivider(sessions, index)))
+            .toEqual([false, false, true, false])
+    })
+
+    it('does not show a divider when all visible sessions have the same pin state', () => {
+        expect(shouldShowPinnedDivider([
+            makeSession({ id: 'a' }),
+            makeSession({ id: 'b' })
+        ], 1)).toBe(false)
     })
 })
 

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -41,6 +41,7 @@ type SessionGroup = {
     sessions: SessionSummary[]
     latestUpdatedAt: number
     hasActiveSession: boolean
+    hasPinnedSession: boolean
 }
 
 const RUNNING_BUCKETS = [
@@ -147,6 +148,7 @@ type MachineGroup = {
     projectGroups: SessionGroup[]
     totalSessions: number
     hasActiveSession: boolean
+    hasPinnedSession: boolean
     latestUpdatedAt: number
 }
 
@@ -281,6 +283,7 @@ function groupSessionsByDirectory(sessions: SessionSummary[]): SessionGroup[] {
     return Array.from(groups.entries())
         .map(([key, group]) => {
             const sortedSessions = [...group.sessions].sort((a, b) => {
+                if (Boolean(a.pinned) !== Boolean(b.pinned)) return a.pinned ? -1 : 1
                 const rankA = a.active ? (a.pendingRequestsCount > 0 ? 0 : 1) : 2
                 const rankB = b.active ? (b.pendingRequestsCount > 0 ? 0 : 1) : 2
                 if (rankA !== rankB) return rankA - rankB
@@ -291,6 +294,7 @@ function groupSessionsByDirectory(sessions: SessionSummary[]): SessionGroup[] {
                 -Infinity
             )
             const hasActiveSession = group.sessions.some(s => s.active)
+            const hasPinnedSession = group.sessions.some(s => s.pinned)
             const displayName = getGroupDisplayName(group.directory)
 
             return {
@@ -300,10 +304,14 @@ function groupSessionsByDirectory(sessions: SessionSummary[]): SessionGroup[] {
                 machineId: group.machineId,
                 sessions: sortedSessions,
                 latestUpdatedAt,
-                hasActiveSession
+                hasActiveSession,
+                hasPinnedSession
             }
         })
         .sort((a, b) => {
+            if (a.hasPinnedSession !== b.hasPinnedSession) {
+                return a.hasPinnedSession ? -1 : 1
+            }
             if (a.hasActiveSession !== b.hasActiveSession) {
                 return a.hasActiveSession ? -1 : 1
             }
@@ -342,6 +350,7 @@ function groupByMachine(
                 projectGroups: [],
                 totalSessions: 0,
                 hasActiveSession: false,
+                hasPinnedSession: false,
                 latestUpdatedAt: 0,
             }
             map.set(key, mg)
@@ -349,9 +358,11 @@ function groupByMachine(
         mg.projectGroups.push(g)
         mg.totalSessions += g.sessions.length
         if (g.hasActiveSession) mg.hasActiveSession = true
+        if (g.hasPinnedSession) mg.hasPinnedSession = true
         if (g.latestUpdatedAt > mg.latestUpdatedAt) mg.latestUpdatedAt = g.latestUpdatedAt
     }
     return [...map.values()].sort((a, b) => {
+        if (a.hasPinnedSession !== b.hasPinnedSession) return a.hasPinnedSession ? -1 : 1
         if (a.hasActiveSession !== b.hasActiveSession) return a.hasActiveSession ? -1 : 1
         return b.latestUpdatedAt - a.latestUpdatedAt
     })
@@ -545,6 +556,11 @@ export function getVisibleSessionPreview(
     }
 
     return visible
+}
+
+export function shouldShowPinnedDivider(sessions: SessionSummary[], index: number): boolean {
+    if (index <= 0 || index >= sessions.length) return false
+    return Boolean(sessions[index - 1]?.pinned) && !sessions[index]?.pinned
 }
 
 function CalendarIcon(props: { className?: string }) {
@@ -872,7 +888,7 @@ function SessionItem(props: {
                 : t('session.action.reopenCursorChecking')
         : undefined
 
-    const { archiveSession, reopenSession, renameSession, deleteSession, isPending } = useSessionActions(
+    const { archiveSession, reopenSession, renameSession, deleteSession, setPinned, isPending } = useSessionActions(
         api,
         s.id,
         s.metadata?.flavor ?? null
@@ -956,6 +972,8 @@ function SessionItem(props: {
                 sessionId={s.id}
                 sessionTitle={sessionName}
                 sessionActive={s.active}
+                sessionPinned={s.pinned}
+                onTogglePin={() => void setPinned(!s.pinned)}
                 onRename={() => setRenameOpen(true)}
                 onExport={() => setExportOpen(true)}
                 onArchive={() => setArchiveOpen(true)}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -12,17 +12,10 @@ import { CopyIcon, CheckIcon } from '@/components/icons'
 
 function PinnedSectionIcon(props: { className?: string }) {
     return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            className={props.className}
-            aria-hidden="true"
-        >
-            {/* Keep the pin head optically centered; stem is shorter than the menu icon. */}
-            <path d="M12 16v4" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
-            <path d="M6 16h12" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
-            <path d="M8 4V2h8v2l-1.5 4.5V12l1.5 1.5H8L9.5 12V8.5Z" />
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className={props.className} aria-hidden="true">
+            <path d="M12 17v5" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
+            <path d="M5 17h14" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
+            <path d="M7 4V2h10v2l-2 5v4l2 2H7l2-2V9Z" />
         </svg>
     )
 }

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1668,10 +1668,11 @@ export function SessionList(props: {
                             title={t('sessions.pinnedSection')}
                         >
                             <ChevronIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" collapsed={pinnedSectionCollapsed && !isFiltering} />
-                            <PinnedSectionIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" />
-                            <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                            <span className="min-w-0 truncate text-sm font-medium">
                                 {t('sessions.pinnedSection')}
                             </span>
+                            <PinnedSectionIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" />
+                            <span className="min-w-0 flex-1" aria-hidden="true" />
                             <span className="shrink-0 text-[11px] tabular-nums text-[var(--app-hint)]">
                                 ({globalPinnedSessions.length})
                             </span>
@@ -1826,7 +1827,7 @@ export function SessionList(props: {
                                         <div key={s.id} className="contents">
                                             {shouldShowPinnedDivider(visibleGroupSessions, index) ? (
                                                 <div
-                                                    className="ml-2 my-1 border-t border-[var(--app-border)]"
+                                                    className="ml-2.5 mr-2 my-1 border-t border-[var(--app-border)]"
                                                     aria-hidden="true"
                                                 />
                                             ) : null}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -30,6 +30,7 @@ import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStat
 import { SessionRowSummary } from '@/components/SessionRowSummary'
 import { Spinner } from '@/components/Spinner'
 import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
+import { useToast } from '@/lib/toast-context'
 
 export { getWorktreeSessionLabel } from '@/lib/sessionWorktreeLabel'
 
@@ -95,6 +96,7 @@ function SessionsEmptyState(props: {
     onBrowse?: () => void
 }) {
     const { t } = useTranslation()
+    const { addToast } = useToast()
     return (
         <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
             <svg
@@ -897,6 +899,19 @@ function SessionItem(props: {
     )
     const [reopenError, setReopenError] = useState<string | null>(null)
 
+    const handleTogglePin = async () => {
+        try {
+            await setPinned(!s.pinned)
+        } catch (error) {
+            addToast({
+                title: t('session.action.pinFailed'),
+                body: error instanceof Error ? error.message : t('dialog.error.default'),
+                sessionId: s.id,
+                url: `/sessions/${s.id}`
+            })
+        }
+    }
+
     const handleReopen = async () => {
         setReopenError(null)
         try {
@@ -975,7 +990,7 @@ function SessionItem(props: {
                 sessionTitle={sessionName}
                 sessionActive={s.active}
                 sessionPinned={s.pinned}
-                onTogglePin={() => void setPinned(!s.pinned)}
+                onTogglePin={() => void handleTogglePin()}
                 onRename={() => setRenameOpen(true)}
                 onExport={() => setExportOpen(true)}
                 onArchive={() => setArchiveOpen(true)}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -12,10 +12,17 @@ import { CopyIcon, CheckIcon } from '@/components/icons'
 
 function PinnedSectionIcon(props: { className?: string }) {
     return (
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className={props.className} aria-hidden="true">
-            <path d="M12 17v5" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
-            <path d="M5 17h14" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
-            <path d="M7 4V2h10v2l-2 5v4l2 2H7l2-2V9Z" />
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className={props.className}
+            aria-hidden="true"
+        >
+            {/* Keep the pin head optically centered; stem is shorter than the menu icon. */}
+            <path d="M12 16v4" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
+            <path d="M6 16h12" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
+            <path d="M8 4V2h8v2l-1.5 4.5V12l1.5 1.5H8L9.5 12V8.5Z" />
         </svg>
     )
 }
@@ -1668,10 +1675,12 @@ export function SessionList(props: {
                             title={t('sessions.pinnedSection')}
                         >
                             <ChevronIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" collapsed={pinnedSectionCollapsed && !isFiltering} />
-                            <span className="min-w-0 truncate text-sm font-medium">
-                                {t('sessions.pinnedSection')}
+                            <span className="inline-flex min-w-0 items-center gap-1">
+                                <span className="min-w-0 truncate text-sm font-medium">
+                                    {t('sessions.pinnedSection')}
+                                </span>
+                                <PinnedSectionIcon className="h-3.5 w-3.5 shrink-0 -translate-y-px text-[var(--app-hint)]" />
                             </span>
-                            <PinnedSectionIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" />
                             <span className="min-w-0 flex-1" aria-hidden="true" />
                             <span className="shrink-0 text-[11px] tabular-nums text-[var(--app-hint)]">
                                 ({globalPinnedSessions.length})

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1296,7 +1296,7 @@ export function SessionList(props: {
         const hasSelectedSession = selectedSessionId
             ? group.sessions.some(session => session.id === selectedSessionId)
             : false
-        return !group.hasActiveSession && !hasSelectedSession
+        return !group.hasActiveSession && !group.hasPinnedSession && !hasSelectedSession
     }
 
     const toggleGroup = (groupKey: string, isCollapsed: boolean) => {

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -196,6 +196,8 @@ export function deduplicateSessionsByAgentId(sessions: SessionSummary[], selecte
             // Among inactive duplicates, keep the selected one visible
             if (a.id === selectedSessionId) return -1
             if (b.id === selectedSessionId) return 1
+            // Preserve an explicit pin when otherwise choosing by recency
+            if (Boolean(a.pinned) !== Boolean(b.pinned)) return a.pinned ? -1 : 1
             return b.updatedAt - a.updatedAt
         })
         result.push(group[0])

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -225,7 +225,7 @@ export function isSidebarEmptySessionStub(session: SessionSummary): boolean {
 
 export function shouldShowSessionInSidebar(session: SessionSummary, selectedSessionId?: string | null): boolean {
     if (session.id === selectedSessionId) return true
-    if (session.active) return true
+    if (session.active || session.pinned) return true
     return !isSidebarEmptySessionStub(session)
 }
 

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1252,7 +1252,7 @@ export function SessionList(props: {
             return buckets
         }
         for (const session of machineFilteredSessions) {
-            if (session.globalPinned) {
+            if (session.globalPinned || session.pinned) {
                 continue
             }
             if (!session.active) {
@@ -1277,7 +1277,7 @@ export function SessionList(props: {
         () => groupSessionsByDirectory(
             machineFilteredSessions.filter((session) => {
                 if (session.globalPinned) return false
-                if (pinInProgressSessions && isPinnedInProgressSession(session)) return false
+                if (pinInProgressSessions && !session.pinned && isPinnedInProgressSession(session)) return false
                 return true
             })
         ),

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -9,6 +9,16 @@ import { SessionExportDialog } from '@/components/SessionExportDialog'
 import { RenameSessionDialog } from '@/components/RenameSessionDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { CopyIcon, CheckIcon } from '@/components/icons'
+
+function PinnedSectionIcon(props: { className?: string }) {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className={props.className} aria-hidden="true">
+            <path d="M12 17v5" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
+            <path d="M5 17h14" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
+            <path d="M7 4V2h10v2l-2 5v4l2 2H7l2-2V9Z" />
+        </svg>
+    )
+}
 import { cn } from '@/lib/utils'
 import { useTranslation } from '@/lib/use-translation'
 import { DEFAULT_SESSION_PREVIEW_LIMIT, useSessionPreviewLimit } from '@/hooks/useSessionPreviewLimit'
@@ -198,6 +208,7 @@ export function deduplicateSessionsByAgentId(sessions: SessionSummary[], selecte
             if (a.id === selectedSessionId) return -1
             if (b.id === selectedSessionId) return 1
             // Preserve an explicit pin when otherwise choosing by recency
+            if (Boolean(a.globalPinned) !== Boolean(b.globalPinned)) return a.globalPinned ? -1 : 1
             if (Boolean(a.pinned) !== Boolean(b.pinned)) return a.pinned ? -1 : 1
             return b.updatedAt - a.updatedAt
         })
@@ -226,7 +237,7 @@ export function isSidebarEmptySessionStub(session: SessionSummary): boolean {
 
 export function shouldShowSessionInSidebar(session: SessionSummary, selectedSessionId?: string | null): boolean {
     if (session.id === selectedSessionId) return true
-    if (session.active || session.pinned) return true
+    if (session.active || session.pinned || session.globalPinned) return true
     return !isSidebarEmptySessionStub(session)
 }
 
@@ -892,16 +903,16 @@ function SessionItem(props: {
                 : t('session.action.reopenCursorChecking')
         : undefined
 
-    const { archiveSession, reopenSession, renameSession, deleteSession, setPinned, isPending } = useSessionActions(
+    const { archiveSession, reopenSession, renameSession, deleteSession, setPinMode, isPending } = useSessionActions(
         api,
         s.id,
         s.metadata?.flavor ?? null
     )
     const [reopenError, setReopenError] = useState<string | null>(null)
 
-    const handleTogglePin = async () => {
+    const handleSetPinMode = async (mode: 'none' | 'project' | 'global') => {
         try {
-            await setPinned(!s.pinned)
+            await setPinMode(mode)
         } catch (error) {
             addToast({
                 title: t('session.action.pinFailed'),
@@ -989,8 +1000,9 @@ function SessionItem(props: {
                 sessionId={s.id}
                 sessionTitle={sessionName}
                 sessionActive={s.active}
-                sessionPinned={s.pinned}
-                onTogglePin={() => void handleTogglePin()}
+                sessionPinned={Boolean(s.pinned)}
+                sessionGlobalPinned={Boolean(s.globalPinned)}
+                onSetPinMode={(mode) => void handleSetPinMode(mode)}
                 onRename={() => setRenameOpen(true)}
                 onExport={() => setExportOpen(true)}
                 onArchive={() => setArchiveOpen(true)}
@@ -1226,6 +1238,11 @@ export function SessionList(props: {
             ),
         [unreadFilteredSessions, activeMachineFilter]
     )
+    const globalPinnedSessions = useMemo(() => {
+        return machineFilteredSessions
+            .filter((session) => Boolean(session.globalPinned))
+            .sort((a, b) => b.updatedAt - a.updatedAt)
+    }, [machineFilteredSessions])
     const runningSessions = useMemo(() => {
         const buckets: Record<'working' | 'pending', SessionSummary[]> = {
             working: [],
@@ -1235,6 +1252,9 @@ export function SessionList(props: {
             return buckets
         }
         for (const session of machineFilteredSessions) {
+            if (session.globalPinned) {
+                continue
+            }
             if (!session.active) {
                 continue
             }
@@ -1255,9 +1275,11 @@ export function SessionList(props: {
         + runningSessions.pending.length
     const groups = useMemo(
         () => groupSessionsByDirectory(
-            pinInProgressSessions
-                ? machineFilteredSessions.filter((session) => !isPinnedInProgressSession(session))
-                : machineFilteredSessions
+            machineFilteredSessions.filter((session) => {
+                if (session.globalPinned) return false
+                if (pinInProgressSessions && isPinnedInProgressSession(session)) return false
+                return true
+            })
         ),
         [machineFilteredSessions, pinInProgressSessions]
     )
@@ -1265,6 +1287,7 @@ export function SessionList(props: {
         () => new Map()
     )
     const [runningSectionCollapsed, setRunningSectionCollapsed] = useState(false)
+    const [pinnedSectionCollapsed, setPinnedSectionCollapsed] = useState(false)
     const autoExpandedSelectedSessionKeyRef = useRef<string | null>(null)
     const isGroupCollapsed = (group: SessionGroup): boolean => {
         if (isFiltering) return false
@@ -1622,9 +1645,57 @@ export function SessionList(props: {
                     />
                 ) : null}
 
-                {props.sessions.length > 0 && (isFiltering || activeMachineFilter !== null || showUnreadOnly) && groups.length === 0 && runningSessionTotal === 0 ? (
+                {props.sessions.length > 0 && (isFiltering || activeMachineFilter !== null || showUnreadOnly) && groups.length === 0 && runningSessionTotal === 0 && globalPinnedSessions.length === 0 ? (
                     <div className="px-4 py-8 text-center text-sm text-[var(--app-hint)]">
                         {t('sessions.search.noResults')}
+                    </div>
+                ) : null}
+
+                {globalPinnedSessions.length > 0 ? (
+                    <div key="pinned-section">
+                        <div
+                            className="group/pinned flex min-w-0 w-full select-none cursor-pointer items-center gap-2 rounded-lg py-1.5 pl-2 pr-2 transition-colors hover:bg-[var(--app-secondary-bg)]"
+                            role="button"
+                            tabIndex={0}
+                            aria-expanded={!pinnedSectionCollapsed || isFiltering}
+                            onClick={() => setPinnedSectionCollapsed((value) => !value)}
+                            onKeyDown={(event) => {
+                                if (event.key === 'Enter' || event.key === ' ') {
+                                    event.preventDefault()
+                                    setPinnedSectionCollapsed((value) => !value)
+                                }
+                            }}
+                            title={t('sessions.pinnedSection')}
+                        >
+                            <ChevronIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" collapsed={pinnedSectionCollapsed && !isFiltering} />
+                            <PinnedSectionIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" />
+                            <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                                {t('sessions.pinnedSection')}
+                            </span>
+                            <span className="shrink-0 text-[11px] tabular-nums text-[var(--app-hint)]">
+                                ({globalPinnedSessions.length})
+                            </span>
+                        </div>
+                        <div className="collapsible-panel" data-open={(!pinnedSectionCollapsed || isFiltering) || undefined}>
+                            <div className="collapsible-inner">
+                                <div className="flex flex-col gap-0.5 ml-3 pl-1 py-1">
+                                    {globalPinnedSessions.map((s) => (
+                                        <SessionItem
+                                            key={s.id}
+                                            session={s}
+                                            onSelect={props.onSelect}
+                                            showPath={false}
+                                            api={api}
+                                            selected={s.id === selectedSessionId}
+                                            showDetailedStatus={showDetailedStatus}
+                                            inRunningSection
+                                            projectLabel={getGroupDisplayName(s.metadata?.worktree?.basePath ?? s.metadata?.path ?? 'Other')}
+                                            machineLabel={resolveMachineLabel(s.metadata?.machineId ?? null)}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 ) : null}
 

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -96,7 +96,6 @@ function SessionsEmptyState(props: {
     onBrowse?: () => void
 }) {
     const { t } = useTranslation()
-    const { addToast } = useToast()
     return (
         <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
             <svg
@@ -867,6 +866,7 @@ function SessionItem(props: {
     machineLabel?: string
 }) {
     const { t } = useTranslation()
+    const { addToast } = useToast()
     const { session: s, onSelect, showPath = true, api, selected = false, showDetailedStatus = false, inRunningSection = false, projectLabel, machineLabel } = props
     const { haptic } = usePlatform()
     const [menuOpen, setMenuOpen] = useState(false)

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1734,16 +1734,23 @@ export function SessionList(props: {
                             <div className="collapsible-panel" data-open={!isCollapsed || undefined}>
                                 <div className="collapsible-inner">
                                 <div className="flex flex-col gap-0.5 ml-3 pl-1 py-1">
-                                    {visibleGroupSessions.map((s) => (
-                                        <SessionItem
-                                            key={s.id}
-                                            session={s}
-                                            onSelect={props.onSelect}
-                                            showPath={false}
-                                            api={api}
-                                            selected={s.id === selectedSessionId}
-                                            showDetailedStatus={showDetailedStatus}
-                                        />
+                                    {visibleGroupSessions.map((s, index) => (
+                                        <div key={s.id} className="contents">
+                                            {shouldShowPinnedDivider(visibleGroupSessions, index) ? (
+                                                <div
+                                                    className="ml-2 my-1 border-t border-[var(--app-border)]"
+                                                    aria-hidden="true"
+                                                />
+                                            ) : null}
+                                            <SessionItem
+                                                session={s}
+                                                onSelect={props.onSelect}
+                                                showPath={false}
+                                                api={api}
+                                                selected={s.id === selectedSessionId}
+                                                showDetailedStatus={showDetailedStatus}
+                                            />
+                                        </div>
                                     ))}
                                     {group.sessions.length > sessionPreviewLimit && (hiddenSessionCount > 0 || canShowFewerSessions) ? (
                                         <div className="ml-2.5 mr-2 my-1 flex gap-1.5">

--- a/web/src/hooks/mutations/useSessionActions.ts
+++ b/web/src/hooks/mutations/useSessionActions.ts
@@ -27,6 +27,7 @@ export function useSessionActions(
     setEffort: (effort: string | null) => Promise<void>
     setServiceTier: (serviceTier: string | null) => Promise<void>
     renameSession: (name: string) => Promise<void>
+    setPinned: (pinned: boolean) => Promise<void>
     deleteSession: () => Promise<void>
     isPending: boolean
 } {
@@ -234,6 +235,14 @@ export function useSessionActions(
         onSuccess: () => void invalidateSession(),
     })
 
+    const pinMutation = useMutation({
+        mutationFn: async (pinned: boolean) => {
+            if (!api || !sessionId) throw new Error('Session unavailable')
+            await api.setSessionPinned(sessionId, pinned)
+        },
+        onSuccess: () => void invalidateSession(),
+    })
+
     const deleteMutation = useMutation({
         mutationFn: async () => {
             if (!api || !sessionId) {
@@ -262,6 +271,7 @@ export function useSessionActions(
         setEffort: effortMutation.mutateAsync,
         setServiceTier: serviceTierMutation.mutateAsync,
         renameSession: renameMutation.mutateAsync,
+        setPinned: pinMutation.mutateAsync,
         deleteSession: deleteMutation.mutateAsync,
         isPending: abortMutation.isPending
             || archiveMutation.isPending
@@ -275,6 +285,7 @@ export function useSessionActions(
             || effortMutation.isPending
             || serviceTierMutation.isPending
             || renameMutation.isPending
+            || pinMutation.isPending
             || deleteMutation.isPending,
     }
 }

--- a/web/src/hooks/mutations/useSessionActions.ts
+++ b/web/src/hooks/mutations/useSessionActions.ts
@@ -27,7 +27,7 @@ export function useSessionActions(
     setEffort: (effort: string | null) => Promise<void>
     setServiceTier: (serviceTier: string | null) => Promise<void>
     renameSession: (name: string) => Promise<void>
-    setPinned: (pinned: boolean) => Promise<void>
+    setPinMode: (mode: 'none' | 'project' | 'global') => Promise<void>
     deleteSession: () => Promise<void>
     isPending: boolean
 } {
@@ -236,9 +236,9 @@ export function useSessionActions(
     })
 
     const pinMutation = useMutation({
-        mutationFn: async (pinned: boolean) => {
+        mutationFn: async (mode: 'none' | 'project' | 'global') => {
             if (!api || !sessionId) throw new Error('Session unavailable')
-            await api.setSessionPinned(sessionId, pinned)
+            await api.setSessionPinMode(sessionId, mode)
         },
         onSuccess: () => void invalidateSession(),
     })
@@ -271,7 +271,7 @@ export function useSessionActions(
         setEffort: effortMutation.mutateAsync,
         setServiceTier: serviceTierMutation.mutateAsync,
         renameSession: renameMutation.mutateAsync,
-        setPinned: pinMutation.mutateAsync,
+        setPinMode: pinMutation.mutateAsync,
         deleteSession: deleteMutation.mutateAsync,
         isPending: abortMutation.isPending
             || archiveMutation.isPending

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -93,6 +93,9 @@ const RECONNECT_SLOW_MAX_DELAY_MS = 300_000
 const INVALIDATION_BATCH_MS = 16
 
 function sortSessionSummaries(left: SessionSummary, right: SessionSummary): number {
+    if (Boolean(left.globalPinned) !== Boolean(right.globalPinned)) {
+        return left.globalPinned ? -1 : 1
+    }
     if (Boolean(left.pinned) !== Boolean(right.pinned)) {
         return left.pinned ? -1 : 1
     }

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -93,6 +93,9 @@ const RECONNECT_SLOW_MAX_DELAY_MS = 300_000
 const INVALIDATION_BATCH_MS = 16
 
 function sortSessionSummaries(left: SessionSummary, right: SessionSummary): number {
+    if (Boolean(left.pinned) !== Boolean(right.pinned)) {
+        return left.pinned ? -1 : 1
+    }
     if (left.active !== right.active) {
         return left.active ? -1 : 1
     }

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -228,9 +228,12 @@ export default {
 
   // Session actions
   'session.action.rename': 'Rename',
-  'session.action.pin': 'Pin session',
-  'session.action.unpin': 'Unpin session',
+  'session.action.pinProject': 'Pin in project',
+  'session.action.unpinProject': 'Unpin from project',
+  'session.action.pinGlobal': 'Pin globally',
+  'session.action.unpinGlobal': 'Unpin globally',
   'session.action.pinFailed': 'Could not update pin',
+  'sessions.pinnedSection': 'Pinned',
   'session.action.export': 'Export conversation',
   'session.action.syncCodex': 'Sync from Codex',
   'session.action.syncPi': 'Sync Pi history',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -228,6 +228,8 @@ export default {
 
   // Session actions
   'session.action.rename': 'Rename',
+  'session.action.pin': 'Pin session',
+  'session.action.unpin': 'Unpin session',
   'session.action.export': 'Export conversation',
   'session.action.syncCodex': 'Sync from Codex',
   'session.action.syncPi': 'Sync Pi history',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -230,6 +230,7 @@ export default {
   'session.action.rename': 'Rename',
   'session.action.pin': 'Pin session',
   'session.action.unpin': 'Unpin session',
+  'session.action.pinFailed': 'Could not update pin',
   'session.action.export': 'Export conversation',
   'session.action.syncCodex': 'Sync from Codex',
   'session.action.syncPi': 'Sync Pi history',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -233,7 +233,7 @@ export default {
   'session.action.pinGlobal': 'Pin globally',
   'session.action.unpinGlobal': 'Unpin globally',
   'session.action.pinFailed': 'Could not update pin',
-  'sessions.pinnedSection': 'Pinned',
+  'sessions.pinnedSection': 'Pinned sessions',
   'session.action.export': 'Export conversation',
   'session.action.syncCodex': 'Sync from Codex',
   'session.action.syncPi': 'Sync Pi history',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -233,7 +233,7 @@ export default {
   'session.action.pinGlobal': '全局置顶',
   'session.action.unpinGlobal': '取消全局置顶',
   'session.action.pinFailed': '无法更新置顶状态',
-  'sessions.pinnedSection': '置顶',
+  'sessions.pinnedSection': '置顶会话',
   'session.action.export': '导出对话',
   'session.action.syncCodex': '从 Codex 同步',
   'session.action.syncPi': '同步 Pi 历史',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -230,6 +230,7 @@ export default {
   'session.action.rename': '重命名',
   'session.action.pin': '置顶会话',
   'session.action.unpin': '取消置顶',
+  'session.action.pinFailed': '无法更新置顶状态',
   'session.action.export': '导出对话',
   'session.action.syncCodex': '从 Codex 同步',
   'session.action.syncPi': '同步 Pi 历史',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -228,6 +228,8 @@ export default {
 
   // Session actions
   'session.action.rename': '重命名',
+  'session.action.pin': '置顶会话',
+  'session.action.unpin': '取消置顶',
   'session.action.export': '导出对话',
   'session.action.syncCodex': '从 Codex 同步',
   'session.action.syncPi': '同步 Pi 历史',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -228,9 +228,12 @@ export default {
 
   // Session actions
   'session.action.rename': '重命名',
-  'session.action.pin': '置顶会话',
-  'session.action.unpin': '取消置顶',
+  'session.action.pinProject': '项目置顶',
+  'session.action.unpinProject': '取消项目置顶',
+  'session.action.pinGlobal': '全局置顶',
+  'session.action.unpinGlobal': '取消全局置顶',
   'session.action.pinFailed': '无法更新置顶状态',
+  'sessions.pinnedSection': '置顶',
   'session.action.export': '导出对话',
   'session.action.syncCodex': '从 Codex 同步',
   'session.action.syncPi': '同步 Pi 历史',


### PR DESCRIPTION
## Summary

- Add persistent, namespace-scoped session pin state in Hub SQLite (`pinned` + `global_pinned`).
- Support two mutually exclusive pin modes from the sidebar context menu and selected-session header menu: **project pin** and **global pin**.
- Keep project-pinned sessions first inside their project group (with a divider); float globally pinned sessions into a top-level **Pinned sessions** section that shows the project path.
- Promote projects/machines that contain project pins; keep inactive project-pinned groups expanded by default so pins stay easy to find after reload.

## Implementation

- Rebased onto current `main`. Keep main's usage migrations at v20/v21; add pin columns via **v21→v22** and bump `SCHEMA_VERSION` to 22.
- Extend `PUT /api/sessions/:id/pin` to accept `{ mode: 'none' | 'project' | 'global' }` with shared Zod validation; sync pin changes over REST/SSE.
- Preserve the stronger pin mode when consolidating/merging sessions (`global` > `project` > `none`), including concurrent target updates during merge.
- English and Simplified Chinese labels; surface pin request failures as toasts.

## Testing

- GitHub `test` and `pr-review` checks on tip (`fd06296d`)
- `bun test hub/src/sync/sessionModel.test.ts -t pin` (6 passed; merge/global precedence and race coverage)
- `bun run test src/components/SessionList.directory-action.test.tsx -t project-pinned` from `web` (inactive project-pinned group stays expanded)
- Earlier dual-pin validation also covered related hub/web/shared unit paths and a live preview deploy on the task environment

## UI

- Project pin stays inside the existing machine → project → session hierarchy.
- Global pin moves the session into the top **Pinned sessions** group (shows project path; same glance pattern as In progress).
- Modes are mutually exclusive: choosing one clears the other; unpin sets `none`.

## Compatibility

- Does not overwrite main's v20/v21 usage-cache migrations (#1359 / #1390).
- Addresses the schema collision called out during dogfood of the earlier single-mode pin design.

Closes #532.
Related to the pin/favorite portion of #477.

## AI assistance

Developed with assistance from Cursor. Changes were reviewed locally and validated with the checks above.