### PR TITLE
feat(web): remember new-session model and effort

### DIFF
--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ApiClient } from '@/api/client'
+import type { Machine } from '@/types/api'
+import { saveNewSessionFormDraft } from './newSessionFormDraft'
+import {
+    loadPreferredLaunchSettings,
+    savePreferredAgent,
+    savePreferredLaunchSettings
+} from './preferences'
+
+const mocks = vi.hoisted(() => ({
+    spawnSession: vi.fn(),
+    onSuccess: vi.fn(),
+    notification: vi.fn()
+}))
+
+vi.mock('@/lib/use-translation', () => ({
+    useTranslation: () => ({ t: (key: string) => key })
+}))
+vi.mock('@/hooks/usePlatform', () => ({
+    usePlatform: () => ({ haptic: { notification: mocks.notification } })
+}))
+vi.mock('@/hooks/mutations/useSpawnSession', () => ({
+    useSpawnSession: () => ({
+        spawnSession: mocks.spawnSession,
+        isPending: false,
+        error: null
+    })
+}))
+vi.mock('@/hooks/queries/useSessions', () => ({
+    useSessions: () => ({ sessions: [] })
+}))
+vi.mock('@/hooks/useRecentPaths', () => ({
+    useRecentPaths: () => ({
+        getRecentPaths: () => [],
+        addRecentPath: vi.fn(),
+        getLastUsedMachineId: () => null,
+        setLastUsedMachineId: vi.fn()
+    })
+}))
+vi.mock('@/hooks/useMachinePathsExists', () => ({
+    useMachinePathsExists: () => ({
+        pathExistence: { 'C:\\repo': true },
+        checkPathsExists: async () => ({ 'C:\\repo': true })
+    })
+}))
+vi.mock('@/hooks/useDirectorySuggestions', () => ({
+    useDirectorySuggestions: () => []
+}))
+vi.mock('@/hooks/useActiveSuggestions', () => ({
+    useActiveSuggestions: () => [[], -1, vi.fn(), vi.fn(), vi.fn()]
+}))
+vi.mock('@/hooks/queries/useCodexModels', () => ({
+    useCodexModels: () => ({
+        models: [
+            {
+                id: 'gpt-5.6-sol',
+                displayName: 'GPT-5.6 Sol',
+                isDefault: true,
+                supportedReasoningEfforts: ['low', 'high', 'xhigh']
+            },
+            {
+                id: 'gpt-5.6-terra',
+                displayName: 'GPT-5.6 Terra',
+                isDefault: false,
+                supportedReasoningEfforts: ['low', 'high', 'max']
+            }
+        ],
+        isLoading: false,
+        error: null
+    })
+}))
+vi.mock('@/hooks/queries/useCursorModelsForMachine', () => ({
+    useCursorModelsForMachine: () => ({
+        availableModels: [],
+        cliModelSkus: [],
+        currentModelId: null,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+    })
+}))
+vi.mock('@/hooks/queries/useOpencodeModelsForCwd', () => ({
+    useOpencodeModelsForCwd: () => ({
+        availableModels: [],
+        currentModelId: null,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn()
+    })
+}))
+vi.mock('@/hooks/queries/useGrokModelsForCwd', () => ({
+    useGrokModelsForCwd: () => ({
+        availableModels: [],
+        currentModelId: null,
+        autoPermissionModeSupported: null,
+        isLoading: false,
+        error: null
+    })
+}))
+vi.mock('../../utils/formatRunnerSpawnError', () => ({
+    formatRunnerSpawnError: () => null
+}))
+vi.mock('@/components/CodexSessionSyncDialog', () => ({
+    CodexSessionSyncDialog: () => null
+}))
+vi.mock('./DirectorySection', () => ({ DirectorySection: () => null }))
+vi.mock('./MachineSelector', () => ({ MachineSelector: () => null }))
+vi.mock('./SessionTypeSelector', () => ({ SessionTypeSelector: () => null }))
+vi.mock('./GrokPermissionModeSelector', () => ({ GrokPermissionModeSelector: () => null }))
+vi.mock('./YoloToggle', () => ({ YoloToggle: () => null }))
+vi.mock('./OpencodeModelSelector', () => ({ OpencodeModelSelector: () => null }))
+vi.mock('./LaunchEffortSelector', () => ({
+    LaunchEffortSelector: (props: { effort: string }) => (
+        <div data-testid="launch-effort">{props.effort}</div>
+    )
+}))
+vi.mock('./ModelSelector', () => ({
+    ModelSelector: (props: { model: string; onModelChange: (model: string) => void }) => (
+        <button type="button" data-testid="model" onClick={() => props.onModelChange('gpt-5.6-terra')}>
+            {props.model}
+        </button>
+    )
+}))
+vi.mock('./ReasoningEffortSelector', () => ({
+    ReasoningEffortSelector: (props: { value: string; onChange: (effort: string) => void }) => (
+        <button type="button" data-testid="reasoning" onClick={() => props.onChange('max')}>
+            {props.value}
+        </button>
+    )
+}))
+vi.mock('./ActionButtons', () => ({
+    ActionButtons: (props: { onCreate: () => void; canCreate: boolean }) => (
+        <button type="button" data-testid="create" disabled={!props.canCreate} onClick={props.onCreate}>
+            create
+        </button>
+    )
+}))
+
+import { NewSession } from './index'
+
+const machine = { id: 'machine-1' } as Machine
+const api = {} as ApiClient
+
+describe('NewSession launch preferences', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        sessionStorage.clear()
+        mocks.spawnSession.mockReset()
+        mocks.onSuccess.mockReset()
+        mocks.notification.mockReset()
+        savePreferredAgent('codex')
+    })
+
+    it('restores the last successful model and reasoning effort for the machine and agent', async () => {
+        savePreferredLaunchSettings('machine-1', 'codex', {
+            model: 'gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'xhigh'
+        })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('model')).toHaveTextContent('gpt-5.6-sol')
+            expect(screen.getByTestId('reasoning')).toHaveTextContent('xhigh')
+        })
+    })
+
+    it('saves changed launch settings only after creation succeeds', async () => {
+        mocks.spawnSession.mockResolvedValue({ type: 'success', sessionId: 'session-1' })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        expect(loadPreferredLaunchSettings('machine-1', 'codex')).toBeNull()
+        fireEvent.click(screen.getByTestId('model'))
+        fireEvent.click(screen.getByTestId('reasoning'))
+        expect(loadPreferredLaunchSettings('machine-1', 'codex')).toBeNull()
+        fireEvent.click(screen.getByTestId('create'))
+
+        await waitFor(() => expect(mocks.onSuccess).toHaveBeenCalledWith('session-1'))
+        expect(loadPreferredLaunchSettings('machine-1', 'codex')).toEqual({
+            model: 'gpt-5.6-terra',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'max'
+        })
+    })
+
+    it('does not save changed launch settings when creation fails', async () => {
+        mocks.spawnSession.mockResolvedValue({ type: 'error', message: 'spawn failed' })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        fireEvent.click(screen.getByTestId('model'))
+        fireEvent.click(screen.getByTestId('reasoning'))
+        fireEvent.click(screen.getByTestId('create'))
+
+        await waitFor(() => expect(mocks.notification).toHaveBeenCalledWith('error'))
+        expect(mocks.onSuccess).not.toHaveBeenCalled()
+        expect(loadPreferredLaunchSettings('machine-1', 'codex')).toBeNull()
+    })
+
+    it('keeps the browse-return draft ahead of the saved launch preference', async () => {
+        savePreferredAgent('claude')
+        savePreferredLaunchSettings('machine-1', 'codex', {
+            model: 'gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'xhigh'
+        })
+        saveNewSessionFormDraft({
+            agent: 'codex',
+            model: 'gpt-5.6-terra',
+            cursorSelectedBase: 'auto',
+            machineId: 'machine-1',
+            effort: 'auto',
+            modelReasoningEffort: 'max',
+            yoloMode: false,
+            grokPermissionMode: 'default',
+            sessionType: 'simple',
+            worktreeName: ''
+        })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('model')).toHaveTextContent('gpt-5.6-terra')
+            expect(screen.getByTestId('reasoning')).toHaveTextContent('max')
+        })
+    })
+})

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -12,7 +12,8 @@ import {
 const mocks = vi.hoisted(() => ({
     spawnSession: vi.fn(),
     onSuccess: vi.fn(),
-    notification: vi.fn()
+    notification: vi.fn(),
+    codexModelsLoading: false
 }))
 
 vi.mock('@/lib/use-translation', () => ({
@@ -67,7 +68,7 @@ vi.mock('@/hooks/queries/useCodexModels', () => ({
                 supportedReasoningEfforts: ['low', 'high', 'max']
             }
         ],
-        isLoading: false,
+        isLoading: mocks.codexModelsLoading,
         error: null
     })
 }))
@@ -150,6 +151,7 @@ describe('NewSession launch preferences', () => {
         mocks.spawnSession.mockReset()
         mocks.onSuccess.mockReset()
         mocks.notification.mockReset()
+        mocks.codexModelsLoading = false
         savePreferredAgent('codex')
     })
 
@@ -176,6 +178,36 @@ describe('NewSession launch preferences', () => {
             expect(screen.getByTestId('model')).toHaveTextContent('gpt-5.6-sol')
             expect(screen.getByTestId('reasoning')).toHaveTextContent('xhigh')
         })
+    })
+
+    it.each([
+        ['model', 'gpt-5.6-sol', 'default'],
+        ['reasoning effort', 'auto', 'xhigh']
+    ])('disables creation while a remembered dynamic %s is being validated', async (
+        _setting,
+        model,
+        modelReasoningEffort
+    ) => {
+        mocks.codexModelsLoading = true
+        savePreferredLaunchSettings('machine-1', 'codex', {
+            model,
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort
+        })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        await waitFor(() => expect(screen.getByTestId('create')).toBeDisabled())
     })
 
     it('saves changed launch settings only after creation succeeds', async () => {

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -13,7 +13,8 @@ const mocks = vi.hoisted(() => ({
     spawnSession: vi.fn(),
     onSuccess: vi.fn(),
     notification: vi.fn(),
-    codexModelsLoading: false
+    codexModelsLoading: false,
+    directoryExists: undefined as boolean | undefined
 }))
 
 vi.mock('@/lib/use-translation', () => ({
@@ -42,8 +43,8 @@ vi.mock('@/hooks/useRecentPaths', () => ({
 }))
 vi.mock('@/hooks/useMachinePathsExists', () => ({
     useMachinePathsExists: () => ({
-        pathExistence: { 'C:\\repo': true },
-        checkPathsExists: async () => ({ 'C:\\repo': true })
+        pathExistence: { 'C:\\repo': mocks.directoryExists },
+        checkPathsExists: async () => ({ 'C:\\repo': mocks.directoryExists })
     })
 }))
 vi.mock('@/hooks/useDirectorySuggestions', () => ({
@@ -152,6 +153,7 @@ describe('NewSession launch preferences', () => {
         mocks.onSuccess.mockReset()
         mocks.notification.mockReset()
         mocks.codexModelsLoading = false
+        mocks.directoryExists = true
         savePreferredAgent('codex')
     })
 
@@ -195,6 +197,41 @@ describe('NewSession launch preferences', () => {
             effort: 'auto',
             modelReasoningEffort
         })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        await waitFor(() => expect(screen.getByTestId('create')).toBeDisabled())
+    })
+
+    it.each([
+        ['grok', {
+            model: 'grok-4',
+            cursorSelectedBase: 'auto',
+            effort: 'high',
+            modelReasoningEffort: 'default'
+        }],
+        ['opencode', {
+            model: 'provider/model',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'high'
+        }]
+    ] as const)('disables creation while %s cwd existence is unresolved', async (
+        agent,
+        settings
+    ) => {
+        mocks.directoryExists = undefined
+        savePreferredAgent(agent)
+        savePreferredLaunchSettings('machine-1', agent, settings)
 
         render(
             <NewSession

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -963,7 +963,28 @@ export function NewSession(props: {
         }
     }
 
-    const canCreate = Boolean(machineId && trimmedDirectory && !isFormDisabled && !missingWorktreeDirectory)
+    const isLaunchPreferenceValidationPending =
+        (agent === 'codex'
+            && (model !== 'auto' || modelReasoningEffort !== 'default')
+            && codexModelsState.isLoading)
+        || (agent === 'cursor'
+            && (model !== 'auto' || cursorSelectedBase !== 'auto')
+            && cursorModelsState.isLoading)
+        || (agent === 'grok'
+            && deferredDirectoryExists === true
+            && (model !== 'auto' || effort !== 'auto')
+            && grokModelsState.isLoading)
+        || (agent === 'opencode'
+            && deferredDirectoryExists === true
+            && opencodeSelectedModel !== null
+            && opencodeModelsState.isLoading)
+    const canCreate = Boolean(
+        machineId
+        && trimmedDirectory
+        && !isFormDisabled
+        && !missingWorktreeDirectory
+        && !isLaunchPreferenceValidationPending
+    )
 
     return (
         <div className="flex flex-col divide-y divide-[var(--app-divider)]">

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -971,13 +971,19 @@ export function NewSession(props: {
             && (model !== 'auto' || cursorSelectedBase !== 'auto')
             && cursorModelsState.isLoading)
         || (agent === 'grok'
-            && deferredDirectoryExists === true
+            && deferredDirectory !== ''
             && (model !== 'auto' || effort !== 'auto')
-            && grokModelsState.isLoading)
+            && (
+                deferredDirectoryExists === undefined
+                || (deferredDirectoryExists === true && grokModelsState.isLoading)
+            ))
         || (agent === 'opencode'
-            && deferredDirectoryExists === true
+            && deferredDirectory !== ''
             && opencodeSelectedModel !== null
-            && opencodeModelsState.isLoading)
+            && (
+                deferredDirectoryExists === undefined
+                || (deferredDirectoryExists === true && opencodeModelsState.isLoading)
+            ))
     const canCreate = Boolean(
         machineId
         && trimmedDirectory

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -16,6 +16,7 @@ import { useRecentPaths } from '@/hooks/useRecentPaths'
 import { useTranslation } from '@/lib/use-translation'
 import { getCodexModelReasoningEfforts } from '@/lib/codexModelCapabilities'
 import {
+    buildNewSessionCursorModelCatalog,
     buildNewSessionCursorPickerState,
     isCursorEffortWireAllowed,
     resolveCursorBaseFromWire,
@@ -46,8 +47,11 @@ import { buildGrokEffortOptions, buildGrokModelOptions, shouldEnableGrokModelDis
 import { ReasoningEffortSelector } from './ReasoningEffortSelector'
 import {
     loadPreferredAgent,
+    loadPreferredLaunchSettings,
     loadPreferredYoloMode,
+    resolvePreferredLaunchSettings,
     savePreferredAgent,
+    savePreferredLaunchSettings,
     savePreferredYoloMode,
 } from './preferences'
 import { SessionTypeSelector } from './SessionTypeSelector'
@@ -124,6 +128,7 @@ export function NewSession(props: {
     const pendingCursorBaseRef = useRef<string | null>(null)
     const [effort, setEffort] = useState<LaunchEffort>('auto')
     const [modelReasoningEffort, setModelReasoningEffort] = useState<CodexReasoningEffort>('default')
+    const [opencodeSelectedModel, setOpencodeSelectedModel] = useState<string | null>(null)
     const [yoloMode, setYoloMode] = useState(loadPreferredYoloMode)
     const [grokPermissionMode, setGrokPermissionMode] = useState<GrokPermissionMode>('default')
     const [sessionType, setSessionType] = useState<SessionType>('simple')
@@ -139,6 +144,7 @@ export function NewSession(props: {
     const [isCodexImportDialogOpen, setIsCodexImportDialogOpen] = useState(false)
     const isFormDisabled = Boolean(isPending || props.isLoading || isImportingCodexSession)
     const worktreeInputRef = useRef<HTMLInputElement>(null)
+    const preserveRestoredDraftRef = useRef(false)
 
     useEffect(() => {
         if (sessionType === 'worktree') {
@@ -147,6 +153,9 @@ export function NewSession(props: {
     }, [sessionType])
 
     useEffect(() => {
+        if (preserveRestoredDraftRef.current) {
+            return
+        }
         setEffort('auto')
         setModelReasoningEffort('default')
         setGrokPermissionMode('default')
@@ -206,11 +215,15 @@ export function NewSession(props: {
             return
         }
         restoredFromBrowseRef.current = true
+        preserveRestoredDraftRef.current = true
         setAgent(draft.agent)
         setModel(draft.model)
         setCursorSelectedBase(draft.cursorSelectedBase)
         setEffort(draft.effort)
         setModelReasoningEffort(draft.modelReasoningEffort)
+        setOpencodeSelectedModel(
+            draft.agent === 'opencode' && draft.model !== 'auto' ? draft.model : null
+        )
         setYoloMode(draft.yoloMode)
         setGrokPermissionMode(draft.grokPermissionMode)
         setSessionType(draft.sessionType)
@@ -249,7 +262,6 @@ export function NewSession(props: {
         machineId,
         enabled: agent === 'codex' && Boolean(machineId)
     })
-    const [opencodeSelectedModel, setOpencodeSelectedModel] = useState<string | null>(null)
     const runnerSpawnError = useMemo(
         () => formatRunnerSpawnError(selectedMachine),
         [selectedMachine]
@@ -287,6 +299,20 @@ export function NewSession(props: {
         }
         setModelReasoningEffort('default')
     }, [agent, codexSupportedReasoningEfforts, modelReasoningEffort])
+
+    useEffect(() => {
+        if (
+            agent !== 'codex'
+            || model === 'auto'
+            || codexModelsState.isLoading
+            || codexModelsState.error
+        ) {
+            return
+        }
+        if (!codexModelsState.models.some((candidate) => candidate.id === model)) {
+            setModel('auto')
+        }
+    }, [agent, codexModelsState.error, codexModelsState.isLoading, codexModelsState.models, model])
     const cursorModelsState = useCursorModelsForMachine({
         api: props.api,
         machineId,
@@ -300,6 +326,42 @@ export function NewSession(props: {
         ),
         [cursorModelsState.availableModels, cursorModelsState.cliModelSkus, model]
     )
+    const availableCursorCatalog = useMemo(
+        () => buildNewSessionCursorModelCatalog(
+            cursorModelsState.availableModels,
+            'auto',
+            cursorModelsState.cliModelSkus
+        ),
+        [cursorModelsState.availableModels, cursorModelsState.cliModelSkus]
+    )
+
+    useEffect(() => {
+        if (
+            agent !== 'cursor'
+            || cursorModelsState.isLoading
+            || cursorModelsState.error
+        ) {
+            return
+        }
+        if (model !== 'auto' && !availableCursorCatalog.wireToBase.has(model)) {
+            setModel('auto')
+            setCursorSelectedBase('auto')
+            return
+        }
+        if (
+            cursorSelectedBase !== 'auto'
+            && !availableCursorCatalog.variantsByBase.has(cursorSelectedBase)
+        ) {
+            setCursorSelectedBase('auto')
+        }
+    }, [
+        agent,
+        availableCursorCatalog,
+        cursorModelsState.error,
+        cursorModelsState.isLoading,
+        cursorSelectedBase,
+        model
+    ])
 
     const cursorBaseSelectValue = useMemo(
         () => resolveNewSessionCursorBaseSelectValue(cursorPicker, cursorSelectedBase),
@@ -464,21 +526,105 @@ export function NewSession(props: {
         }
     }, [agent, grokPermissionMode, grokModelsState.autoPermissionModeSupported])
     useEffect(() => {
-        // Auto-pick the OpenCode default model when discovery finishes, so the
-        // form has a sensible value if the user hits Enter without scrolling.
-        if (agent !== 'opencode') return
-        if (opencodeSelectedModel !== null) return
-        const fallback = opencodeModelsState.currentModelId
+        // Restore a remembered model when it is still advertised for this cwd;
+        // otherwise auto-pick the backend default.
+        if (
+            agent !== 'opencode'
+            || deferredDirectoryExists !== true
+            || opencodeModelsState.isLoading
+            || opencodeModelsState.error
+        ) {
+            return
+        }
+        if (
+            opencodeSelectedModel !== null
+            && opencodeModelsState.availableModels.some(
+                (candidate) => candidate.modelId === opencodeSelectedModel
+            )
+        ) {
+            return
+        }
+        const rememberedModel = machineId
+            ? loadPreferredLaunchSettings(machineId, 'opencode')?.model
+            : null
+        const rememberedModelAvailable = rememberedModel
+            && rememberedModel !== 'auto'
+            && opencodeModelsState.availableModels.some(
+                (candidate) => candidate.modelId === rememberedModel
+            )
+        const fallback = (rememberedModelAvailable ? rememberedModel : null)
+            ?? opencodeModelsState.currentModelId
             ?? opencodeModelsState.availableModels[0]?.modelId
             ?? null
-        if (fallback) {
-            setOpencodeSelectedModel(fallback)
-        }
-    }, [agent, opencodeSelectedModel, opencodeModelsState.currentModelId, opencodeModelsState.availableModels])
+        setOpencodeSelectedModel(fallback)
+    }, [
+        agent,
+        deferredDirectoryExists,
+        opencodeModelsState.availableModels,
+        opencodeModelsState.currentModelId,
+        opencodeModelsState.error,
+        opencodeModelsState.isLoading,
+        opencodeSelectedModel,
+        machineId
+    ])
     useEffect(() => {
         // Reset selection when agent / machine / directory changes; new probe = new defaults.
+        if (preserveRestoredDraftRef.current) {
+            return
+        }
         setOpencodeSelectedModel(null)
     }, [agent, machineId, deferredDirectory])
+
+    useEffect(() => {
+        if (!machineId || preserveRestoredDraftRef.current) {
+            return
+        }
+
+        const preferred = resolvePreferredLaunchSettings(
+            agent,
+            loadPreferredLaunchSettings(machineId, agent)
+        )
+
+        setModel(agent === 'opencode' ? 'auto' : preferred.model)
+        setCursorSelectedBase(preferred.cursorSelectedBase)
+        setEffort(preferred.effort)
+        setModelReasoningEffort(preferred.modelReasoningEffort)
+        setOpencodeSelectedModel(
+            agent === 'opencode' && preferred.model !== 'auto' ? preferred.model : null
+        )
+    }, [agent, machineId])
+
+    useEffect(() => {
+        if (
+            agent !== 'grok'
+            || deferredDirectoryExists !== true
+            || grokModelsState.isLoading
+            || grokModelsState.error
+        ) {
+            return
+        }
+        if (
+            model !== 'auto'
+            && !grokModelsState.availableModels.some((candidate) => candidate.modelId === model)
+        ) {
+            setModel('auto')
+        }
+        if (
+            effort !== 'auto'
+            && !grokEffortOptions.some((option) => option.value === effort)
+        ) {
+            setEffort('auto')
+        }
+    }, [
+        agent,
+        deferredDirectoryExists,
+        effort,
+        grokEffortOptions,
+        grokModelsState.availableModels,
+        grokModelsState.error,
+        grokModelsState.isLoading,
+        model
+    ])
 
     const currentDirectoryExists = trimmedDirectory ? pathExistence[trimmedDirectory] : undefined
     const needsDirectoryCreationWarning = sessionType === 'simple' && trimmedDirectory !== '' && currentDirectoryExists === false
@@ -559,7 +705,13 @@ export function NewSession(props: {
         [codexImportSessions, selectedCodexImportSessionId]
     )
 
+    const handleAgentChange = useCallback((newAgent: AgentType) => {
+        preserveRestoredDraftRef.current = false
+        setAgent(newAgent)
+    }, [])
+
     const handleMachineChange = useCallback((newMachineId: string) => {
+        preserveRestoredDraftRef.current = false
         setMachineId(newMachineId)
         setModel('auto')
         setCursorSelectedBase('auto')
@@ -610,7 +762,7 @@ export function NewSession(props: {
         }
         saveNewSessionFormDraft({
             agent,
-            model,
+            model: agent === 'opencode' ? (opencodeSelectedModel ?? 'auto') : model,
             cursorSelectedBase,
             machineId,
             effort,
@@ -625,6 +777,7 @@ export function NewSession(props: {
         props.onChooseFolder,
         agent,
         model,
+        opencodeSelectedModel,
         cursorSelectedBase,
         machineId,
         effort,
@@ -735,6 +888,12 @@ export function NewSession(props: {
             const resolvedModelReasoningEffort = (agent === 'codex' || agent === 'opencode') && modelReasoningEffort !== 'default'
                 ? modelReasoningEffort
                 : undefined
+            const preferredLaunchSettings = {
+                model: agent === 'opencode' ? (opencodeSelectedModel ?? 'auto') : model,
+                cursorSelectedBase,
+                effort,
+                modelReasoningEffort
+            }
 
             if (agent === 'codex' && selectedCodexImportSession) {
                 setIsImportingCodexSession(true)
@@ -759,6 +918,7 @@ export function NewSession(props: {
                     )
                     haptic.notification('success')
                     markCodexSessionsImported([selectedCodexImportSession.id])
+                    savePreferredLaunchSettings(machineId, agent, preferredLaunchSettings)
                     clearNewSessionFormDraft()
                     setLastUsedMachineId(machineId)
                     addRecentPath(machineId, trimmedDirectory)
@@ -786,6 +946,7 @@ export function NewSession(props: {
 
             if (result.type === 'success') {
                 haptic.notification('success')
+                savePreferredLaunchSettings(machineId, agent, preferredLaunchSettings)
                 clearNewSessionFormDraft()
                 setLastUsedMachineId(machineId)
                 addRecentPath(machineId, trimmedDirectory)
@@ -845,7 +1006,7 @@ export function NewSession(props: {
             <AgentSelector
                 agent={agent}
                 isDisabled={isFormDisabled}
-                onAgentChange={setAgent}
+                onAgentChange={handleAgentChange}
             />
             {agent === 'codex' ? (
                 <CodexImportSelectButton

--- a/web/src/components/NewSession/preferences.test.ts
+++ b/web/src/components/NewSession/preferences.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
     loadPreferredAgent,
+    loadPreferredLaunchSettings,
     loadPreferredYoloMode,
+    resolvePreferredLaunchSettings,
     savePreferredAgent,
+    savePreferredLaunchSettings,
     savePreferredYoloMode,
 } from './preferences'
 
@@ -36,5 +39,127 @@ describe('NewSession preferences', () => {
 
         expect(localStorage.getItem('hapi:newSession:agent')).toBe('gemini')
         expect(localStorage.getItem('hapi:newSession:yolo')).toBe('true')
+    })
+
+    it('round-trips launch settings per machine and agent', () => {
+        savePreferredLaunchSettings('machine-1', 'codex', {
+            model: 'gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'xhigh'
+        })
+        savePreferredLaunchSettings('machine-1', 'claude', {
+            model: 'opus',
+            cursorSelectedBase: 'auto',
+            effort: 'high',
+            modelReasoningEffort: 'default'
+        })
+        savePreferredLaunchSettings('machine-2', 'codex', {
+            model: 'gpt-5.6-terra',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'max'
+        })
+
+        expect(loadPreferredLaunchSettings('machine-1', 'codex')).toEqual({
+            model: 'gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'xhigh'
+        })
+        expect(loadPreferredLaunchSettings('machine-1', 'claude')).toEqual({
+            model: 'opus',
+            cursorSelectedBase: 'auto',
+            effort: 'high',
+            modelReasoningEffort: 'default'
+        })
+        expect(loadPreferredLaunchSettings('machine-2', 'codex')).toEqual({
+            model: 'gpt-5.6-terra',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'max'
+        })
+    })
+
+    it('returns null when no launch settings were saved for the target', () => {
+        savePreferredLaunchSettings('machine-1', 'codex', {
+            model: 'gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'high'
+        })
+
+        expect(loadPreferredLaunchSettings('machine-2', 'codex')).toBeNull()
+        expect(loadPreferredLaunchSettings('machine-1', 'claude')).toBeNull()
+    })
+
+    it('fills missing optional launch fields from older stored values', () => {
+        localStorage.setItem(
+            'hapi:newSession:launchSettings:v1:machine-1:codex',
+            JSON.stringify({ model: 'gpt-5.6-sol' })
+        )
+
+        expect(loadPreferredLaunchSettings('machine-1', 'codex')).toEqual({
+            model: 'gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'default'
+        })
+    })
+
+    it('ignores malformed launch settings', () => {
+        localStorage.setItem(
+            'hapi:newSession:launchSettings:v1:machine-1:codex',
+            '{not-json'
+        )
+        expect(loadPreferredLaunchSettings('machine-1', 'codex')).toBeNull()
+
+        localStorage.setItem(
+            'hapi:newSession:launchSettings:v1:machine-1:codex',
+            JSON.stringify({ model: 42 })
+        )
+        expect(loadPreferredLaunchSettings('machine-1', 'codex')).toBeNull()
+    })
+
+    it('falls back when remembered static Claude options are no longer available', () => {
+        expect(resolvePreferredLaunchSettings('claude', {
+            model: 'retired-model',
+            cursorSelectedBase: 'auto',
+            effort: 'ultra',
+            modelReasoningEffort: 'default'
+        })).toEqual({
+            model: 'auto',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'default'
+        })
+    })
+
+    it('keeps dynamic model values for catalog validation after restore', () => {
+        expect(resolvePreferredLaunchSettings('codex', {
+            model: 'gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'xhigh'
+        })).toEqual({
+            model: 'gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'xhigh'
+        })
+    })
+
+    it('drops an OpenCode reasoning value that is not offered at launch', () => {
+        expect(resolvePreferredLaunchSettings('opencode', {
+            model: 'provider/model',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'xhigh'
+        })).toEqual({
+            model: 'provider/model',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'default'
+        })
     })
 })

--- a/web/src/components/NewSession/preferences.ts
+++ b/web/src/components/NewSession/preferences.ts
@@ -1,8 +1,23 @@
 import { CREATABLE_AGENT_FLAVORS } from '@hapi/protocol'
-import type { AgentType } from './types'
+import {
+    CLAUDE_EFFORT_OPTIONS,
+    CODEX_REASONING_EFFORT_OPTIONS,
+    MODEL_OPTIONS,
+    type AgentType,
+    type CodexReasoningEffort,
+    type LaunchEffort
+} from './types'
 
 const AGENT_STORAGE_KEY = 'hapi:newSession:agent'
 const YOLO_STORAGE_KEY = 'hapi:newSession:yolo'
+const LAUNCH_SETTINGS_STORAGE_PREFIX = 'hapi:newSession:launchSettings:v1'
+
+export type PreferredLaunchSettings = {
+    model: string
+    cursorSelectedBase: string
+    effort: LaunchEffort
+    modelReasoningEffort: CodexReasoningEffort
+}
 
 // Only launchable flavors are valid defaults; a stale 'gemini' preference
 // (no longer creatable) falls back to 'claude'.
@@ -41,5 +56,94 @@ export function savePreferredYoloMode(enabled: boolean): void {
         localStorage.setItem(YOLO_STORAGE_KEY, enabled ? 'true' : 'false')
     } catch {
         // Ignore storage errors
+    }
+}
+
+function launchSettingsStorageKey(machineId: string, agent: AgentType): string {
+    return `${LAUNCH_SETTINGS_STORAGE_PREFIX}:${encodeURIComponent(machineId)}:${agent}`
+}
+
+export function loadPreferredLaunchSettings(
+    machineId: string,
+    agent: AgentType
+): PreferredLaunchSettings | null {
+    try {
+        const raw = localStorage.getItem(launchSettingsStorageKey(machineId, agent))
+        if (!raw) {
+            return null
+        }
+        const parsed = JSON.parse(raw) as Partial<PreferredLaunchSettings>
+        if (!parsed || typeof parsed !== 'object' || typeof parsed.model !== 'string') {
+            return null
+        }
+        return {
+            model: parsed.model,
+            cursorSelectedBase: typeof parsed.cursorSelectedBase === 'string'
+                ? parsed.cursorSelectedBase
+                : 'auto',
+            effort: typeof parsed.effort === 'string' ? parsed.effort : 'auto',
+            modelReasoningEffort: typeof parsed.modelReasoningEffort === 'string'
+                ? parsed.modelReasoningEffort
+                : 'default'
+        }
+    } catch {
+        return null
+    }
+}
+
+export function savePreferredLaunchSettings(
+    machineId: string,
+    agent: AgentType,
+    settings: PreferredLaunchSettings
+): void {
+    try {
+        localStorage.setItem(
+            launchSettingsStorageKey(machineId, agent),
+            JSON.stringify(settings)
+        )
+    } catch {
+        // Ignore storage errors
+    }
+}
+
+function resolvePreferredOptionValue(
+    preferredValue: string,
+    availableValues: readonly string[],
+    fallbackValue: string
+): string {
+    return availableValues.includes(preferredValue) ? preferredValue : fallbackValue
+}
+
+export function resolvePreferredLaunchSettings(
+    agent: AgentType,
+    preferred: PreferredLaunchSettings | null
+): PreferredLaunchSettings {
+    const preferredModel = preferred?.model ?? 'auto'
+    const staticModelValues = MODEL_OPTIONS[agent].map((option) => option.value)
+    const model = staticModelValues.length > 0 && agent !== 'codex'
+        ? resolvePreferredOptionValue(preferredModel, staticModelValues, 'auto')
+        : preferredModel
+    const effort = agent === 'claude'
+        ? resolvePreferredOptionValue(
+            preferred?.effort ?? 'auto',
+            CLAUDE_EFFORT_OPTIONS.map((option) => option.value),
+            'auto'
+        )
+        : (preferred?.effort ?? 'auto')
+    const modelReasoningEffort = agent === 'opencode'
+        ? resolvePreferredOptionValue(
+            preferred?.modelReasoningEffort ?? 'default',
+            CODEX_REASONING_EFFORT_OPTIONS
+                .filter((option) => option.value !== 'xhigh')
+                .map((option) => option.value),
+            'default'
+        )
+        : (preferred?.modelReasoningEffort ?? 'default')
+
+    return {
+        model,
+        cursorSelectedBase: preferred?.cursorSelectedBase ?? 'auto',
+        effort,
+        modelReasoningEffort
     }
 }


### PR DESCRIPTION
## Summary

- remember the last successfully launched model and effort settings per machine and agent
- restore those settings when reopening New Session or switching machines/agents
- validate remembered values against current static and dynamically discovered options
- preserve the existing Browse-return form draft as the highest-priority state

## Problem

New Session already remembers the selected agent and YOLO mode, but model and effort selections reset to `Default` whenever the form is reopened. Repeatedly choosing the same launch configuration is unnecessary friction, while a single global model preference would be unsafe because model catalogs can differ by machine, agent, and working directory.

## Implementation

- store launch preferences in versioned `localStorage` entries keyed by machine id and agent
- write preferences only after session creation succeeds, including the Codex import-and-resume path
- restore model, Cursor base, Claude/Grok effort, and Codex/OpenCode reasoning effort when the machine or agent changes
- validate static options immediately and dynamic Codex, Cursor, Grok, and OpenCode values after their catalogs load, falling back to current defaults when a saved value is unavailable
- keep the existing `sessionStorage` Browse-return draft ahead of saved preferences so in-progress form changes are not overwritten

## Notes

- preferences remain browser-local and origin-local; no Hub schema or API changes are required
- machine and agent keys are isolated, so one runner's model choice does not leak into another runner or agent
- cancelled and failed launches do not overwrite the last successful preference

## Testing

- `bun typecheck`
- `bun run test:web` (159 files, 1312 tests)
- `bun run build:web`
- `bun run test:shared` (114 tests)
- CLI suite excluding the hanging runner integration test and Windows symlink-only tests (142 files, 1310 tests)
- Hub suite excluding existing Windows/POSIX-specific Cursor probe and migrator tests (35 files, 416 tests)
- `git diff --check`

## AI disclosure

Implementation, tests, review, and PR drafting were assisted by OpenAI Codex.
