### PR TITLE
docs: remove sunset Gemini CLI launch references

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -8,7 +8,6 @@ Run Claude Code, Codex, Cursor Agent, Grok Build, or OpenCode sessions from your
 - Starts Codex mode for OpenAI-based sessions.
 - Starts Cursor Agent mode for Cursor CLI sessions.
 - Starts Grok Build locally or via ACP for remote sessions.
-- Starts Gemini mode via ACP (Anthropic Code Plugins).
 - Starts OpenCode mode via ACP and its plugin hook system.
 - Provides an MCP stdio bridge for external tools.
 - Manages a background runner for long-running sessions.
@@ -32,8 +31,6 @@ Run Claude Code, Codex, Cursor Agent, Grok Build, or OpenCode sessions from your
   Supports `hapi cursor resume <chatId>`, `hapi cursor --continue`, `--mode plan|ask`, `--yolo`, `--model`.
   Local and remote modes supported; remote uses `agent -p` with stream-json.
 - `hapi grok` - Start Grok Build mode. See `src/grok/runGrok.ts`.
-- `hapi gemini` - Start Gemini mode via ACP. See `src/agent/runners/runAgentSession.ts`.
-  Note: Gemini runs in remote mode only; it waits for messages from the hub UI/Telegram.
 - `hapi opencode` - Start OpenCode mode via ACP. See `src/opencode/runOpencode.ts`.
   Note: OpenCode supports local and remote modes; local mode streams via OpenCode plugins.
 - `hapi resume [sessionId]` - List resumable sessions for this machine or resume one locally.
@@ -156,7 +153,7 @@ bun run build:single-exe
 - `src/codex/` - Codex mode integration.
 - `src/cursor/` - Cursor Agent integration.
 - `src/grok/` - Grok Build native TUI + ACP integration.
-- `src/agent/` - Multi-agent support (Gemini via ACP).
+- `src/agent/` - Shared support for ACP-compatible agents.
 - `src/opencode/` - OpenCode ACP + hook integration.
 - `src/runner/` - Background service.
 - `src/commands/` - CLI command handlers.

--- a/cli/src/runner/README.md
+++ b/cli/src/runner/README.md
@@ -84,7 +84,6 @@ The runner supports spawning sessions with different AI agents:
 |-------|---------|-------------------|
 | `claude` (default) | `hapi claude` | `CLAUDE_CODE_OAUTH_TOKEN` |
 | `codex` | `hapi codex` | `CODEX_HOME` (temp directory with `auth.json`) |
-| `gemini` | `hapi gemini` | - |
 | `grok` | `hapi grok` | Grok CLI login or `XAI_API_KEY` |
 | `opencode` | `hapi opencode` | OpenCode config (no token injection) |
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -4,7 +4,7 @@
 
 ### What is HAPI?
 
-HAPI is a local-first, self-hosted platform for running and controlling AI coding agents (Claude Code, Codex, Gemini, OpenCode) remotely. It lets you start coding sessions on your computer and monitor/control them from your phone.
+HAPI is a local-first, self-hosted platform for running and controlling AI coding agents (Claude Code, Codex, Cursor Agent, Grok Build, and OpenCode) remotely. It lets you start coding sessions on your computer and monitor/control them from your phone.
 
 ### What does HAPI stand for?
 
@@ -19,7 +19,7 @@ Yes, HAPI is open source and free to use under the AGPL-3.0-only license.
 - **Claude Code** (recommended)
 - **OpenAI Codex**
 - **Cursor Agent**
-- **Google Gemini**
+- **Grok Build**
 - **OpenCode**
 
 ## Setup & Installation

--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -47,7 +47,7 @@ HAPI consists of three interconnected components that work together to provide r
 
 ### HAPI CLI
 
-The CLI is a wrapper around AI coding agents (Claude Code, Codex, Cursor Agent, Gemini, OpenCode). It:
+The CLI is a wrapper around AI coding agents (Claude Code, Codex, Cursor Agent, Grok Build, OpenCode). It:
 
 - Starts and manages coding sessions
 - Registers sessions with the HAPI hub
@@ -59,7 +59,7 @@ The CLI is a wrapper around AI coding agents (Claude Code, Codex, Cursor Agent, 
 hapi              # Start Claude Code session
 hapi codex       # Start OpenAI Codex session
 hapi cursor      # Start Cursor Agent session
-hapi gemini      # Start Google Gemini session
+hapi grok        # Start Grok Build session
 hapi opencode    # Start OpenCode session
 hapi runner start # Run background service for remote session spawning
 ```

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,7 +4,7 @@ Install the HAPI CLI and set up the hub.
 
 ## Prerequisites
 
-- Claude Code, OpenAI Codex CLI, Cursor Agent CLI, Google Gemini CLI, or OpenCode CLI installed
+- Claude Code, OpenAI Codex CLI, Cursor Agent CLI, Grok Build CLI, or OpenCode CLI installed
 
 Verify your CLI is installed:
 
@@ -18,8 +18,8 @@ codex --version
 # For Cursor Agent CLI
 agent --version
 
-# For Google Gemini CLI
-gemini --version
+# For Grok Build CLI
+grok --version
 
 # For OpenCode CLI
 opencode --version
@@ -31,7 +31,7 @@ HAPI has three components:
 
 | Component | Role | Required |
 |-----------|------|----------|
-| **CLI** | Wraps AI agents (Claude/Codex/Cursor/Gemini/OpenCode), runs sessions | Yes |
+| **CLI** | Wraps AI agents (Claude/Codex/Cursor/Grok/OpenCode), runs sessions | Yes |
 | **Hub** | Central coordinator: persistence, real-time sync, remote access | Yes |
 | **Runner** | Background service for remote session spawning | Optional |
 

--- a/docs/guide/voice-assistant.md
+++ b/docs/guide/voice-assistant.md
@@ -10,7 +10,7 @@ The voice assistant lets you:
 - **Approve permissions by voice** - Say "yes" or "no" to approve or deny permission requests
 - **Monitor progress** - Receive spoken updates when tasks complete or errors occur
 
-The assistant bridges voice communication with your active coding agent (Claude Code, Codex, Gemini, or OpenCode), relaying your requests and summarizing responses in natural speech.
+The assistant bridges voice communication with your active coding agent (Claude Code, Codex, Cursor Agent, Grok Build, or OpenCode), relaying your requests and summarizing responses in natural speech.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- remove stale documentation that still advertises `hapi gemini`
- update supported-agent lists to the current Claude/Codex/Cursor/Grok/OpenCode set
- describe `cli/src/agent` as shared ACP support rather than Gemini-specific code
- leave Gemini Live voice and legacy-session compatibility documentation/code untouched

## Context

Gemini CLI launch support was removed in #953, but several user-facing and CLI READMEs still documented it as available.

## Verification

- `bun typecheck`
- `bun run test` — CLI 1379, hub 505, web 1297, shared 115 tests passed
