### PR TITLE
fix(cli): buffer Pi prompts until RPC startup ready

### DIFF
--- a/cli/src/pi/loop.test.ts
+++ b/cli/src/pi/loop.test.ts
@@ -241,6 +241,39 @@ describe('wireTransportEvents', () => {
         expect(session.client.updateMetadata).toHaveBeenCalledWith(expect.any(Function));
     });
 
+    it('marks session ready on get_state response (drains buffered sends) — issue #1143', () => {
+        const transport = createMockTransport();
+        wireTransportEvents(transport, session, []);
+
+        // A prompt buffered before Pi finished startup must not run yet.
+        const buffered = vi.fn();
+        session.runWhenReady(buffered);
+        expect(buffered).not.toHaveBeenCalled();
+        expect(session.isReady).toBe(false);
+
+        emitEvent({
+            type: 'response',
+            command: 'get_state',
+            success: true,
+            data: { sessionId: 'pi-session-ready' },
+        });
+
+        // get_state landing is the ready signal — buffered work drains.
+        expect(session.isReady).toBe(true);
+        expect(buffered).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks session ready on get_state even when sessionId is absent', () => {
+        // Robustness: readiness must not hinge on Pi always echoing sessionId,
+        // otherwise a missing field would buffer prompts forever.
+        const transport = createMockTransport();
+        wireTransportEvents(transport, session, []);
+
+        emitEvent({ type: 'response', command: 'get_state', success: true, data: {} });
+
+        expect(session.isReady).toBe(true);
+    });
+
     it('handles error response — sends session event', () => {
         const transport = createMockTransport();
         wireTransportEvents(transport, session, []);

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -154,6 +154,13 @@ function handleResponse(
     switch (command) {
         case 'get_state': {
             handleGetState(response.data, session);
+            // Pi has finished startup init (this is the response that persists
+            // metadata.piSessionId — the signal working callers already wait
+            // for). Release any prompts buffered during the spawn window so they
+            // reach an initialized Pi session instead of wedging (issue #1143).
+            // markReady is idempotent; a missing sessionId still flips ready so
+            // buffered prompts are never swallowed forever.
+            session.markReady();
             break;
         }
         case 'set_model': {

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -335,8 +335,18 @@ export async function runPi(opts: {
                 if (localId) pendingLocalIds.push(localId);
                 transport.send({ type: 'prompt', message: formattedText });
             }
-        });
+        }, localId);
     });
+
+    // --- Cancel-queued-message handler ---
+    // A prompt buffered during the startup window (runWhenReady) can be cancelled
+    // by the hub before it drains. Without this, ApiSessionClient acks
+    // removed:false, the hub marks the row invoked, yet the closure would still
+    // fire the cancelled prompt on get_state. Dropping it from the buffer keeps
+    // the queued-message cancel contract intact (issue #1143 review — MAJOR).
+    // Once sent to Pi it cannot be recalled — return false (best-effort), which
+    // matches the other agents' queue.cancelByLocalId semantics.
+    apiSession.onCancelQueuedMessage((localId) => piSession.cancelBufferedMessage(localId));
 
     // --- Abort handler ---
     // Only cancel the current turn, keep session alive for next prompt.

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -14,6 +14,11 @@ import type { SlashCommandsResponse } from '@hapi/protocol/apiTypes';
 import type { ListPiModelsResponse } from '@hapi/protocol/apiTypes';
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 
+// Grace period before force-draining prompts buffered during Pi startup when no
+// get_state response arrives. Comfortably above the 10s Pi RPC timeout so a slow
+// but healthy startup still flips ready via get_state first (issue #1143).
+const PI_READY_FALLBACK_MS = 30_000;
+
 export async function runPi(opts: {
     startedBy?: 'runner' | 'terminal';
     startingMode?: 'local' | 'remote';
@@ -312,16 +317,25 @@ export async function runPi(opts: {
     // --- User message handler ---
     apiSession.onUserMessage((message, localId) => {
         const formattedText = formatMessageWithAttachments(message.content.text, message.content.attachments);
-        if (piSession.piIsStreaming) {
-            // Steer does not start a new turn, so the localId would never be
-            // drained by turn_start. Mark it consumed immediately so it does
-            // not poison the FIFO for the next real prompt.
-            transport.send({ type: 'steer', message: formattedText });
-            if (localId) piSession.emitMessagesConsumed([localId]);
-        } else {
-            if (localId) pendingLocalIds.push(localId);
-            transport.send({ type: 'prompt', message: formattedText });
-        }
+        // Gate the send behind Pi startup readiness. A prompt POSTed immediately
+        // after spawn (supported handoff pattern — hapi-ping-peer, intake
+        // scripts) would otherwise reach Pi before new_session/get_state finish
+        // and wedge the turn. runWhenReady delivers now if ready, else buffers
+        // FIFO until the first get_state response drains it (issue #1143).
+        // piIsStreaming is evaluated at delivery time so a message buffered
+        // before startup still takes the prompt path.
+        piSession.runWhenReady(() => {
+            if (piSession.piIsStreaming) {
+                // Steer does not start a new turn, so the localId would never be
+                // drained by turn_start. Mark it consumed immediately so it does
+                // not poison the FIFO for the next real prompt.
+                transport.send({ type: 'steer', message: formattedText });
+                if (localId) piSession.emitMessagesConsumed([localId]);
+            } else {
+                if (localId) pendingLocalIds.push(localId);
+                transport.send({ type: 'prompt', message: formattedText });
+            }
+        });
     });
 
     // --- Abort handler ---
@@ -351,6 +365,17 @@ export async function runPi(opts: {
 
     // --- Run ---
     let crashed = false;
+    // Fallback: if Pi never returns get_state (never flips ready), force-drain
+    // buffered prompts after a grace period rather than swallowing them forever.
+    // This degrades to pre-fix behaviour (send anyway) instead of something
+    // worse. markReady is idempotent, so a real get_state that lands first wins.
+    const readyFallback = setTimeout(() => {
+        if (!piSession.isReady) {
+            logger.debug('[pi] get_state ready signal not seen within grace — draining buffered messages');
+            piSession.markReady();
+        }
+    }, PI_READY_FALLBACK_MS);
+    readyFallback.unref?.();
     try {
         transport.start();
         transport.send({ type: 'new_session' });
@@ -395,6 +420,7 @@ export async function runPi(opts: {
         lifecycle.setSessionEndReason('error');
         logger.debug('[pi] Loop error:', error);
     } finally {
+        clearTimeout(readyFallback);
         if (!crashed && !lifecycle.hasExplicitSessionEndReason()) {
             lifecycle.setSessionEndReason('completed');
         }

--- a/cli/src/pi/session.test.ts
+++ b/cli/src/pi/session.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PiSession } from './session';
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+    },
+}));
+
+function createMockSession(): PiSession {
+    return new PiSession({
+        api: {} as any,
+        client: {
+            keepAlive: vi.fn(),
+            updateMetadata: vi.fn(),
+            sendAgentMessage: vi.fn(),
+            emitMessagesConsumed: vi.fn(),
+            sendSessionEvent: vi.fn(),
+        } as any,
+        path: '/tmp/test',
+        logPath: '/tmp/test.log',
+        startedBy: 'terminal',
+        startingMode: 'local',
+    });
+}
+
+// --- Ready gate + outbound buffer (Pi RPC ready-race, issue #1143) ---
+//
+// A prompt POSTed immediately after spawn used to be sent to Pi before
+// `new_session`/`get_state` finished, wedging the turn (agent_start then
+// silence). runWhenReady buffers such sends until markReady() (fired when Pi's
+// get_state response lands), then drains them FIFO.
+
+describe('PiSession ready gate', () => {
+    it('starts not ready', () => {
+        const session = createMockSession();
+        expect(session.isReady).toBe(false);
+    });
+
+    it('buffers work until markReady, then drains FIFO', () => {
+        const session = createMockSession();
+        const order: number[] = [];
+
+        session.runWhenReady(() => order.push(1));
+        session.runWhenReady(() => order.push(2));
+        session.runWhenReady(() => order.push(3));
+
+        // Nothing runs before ready.
+        expect(order).toEqual([]);
+
+        session.markReady();
+
+        // Drained in the order they were enqueued.
+        expect(order).toEqual([1, 2, 3]);
+        expect(session.isReady).toBe(true);
+    });
+
+    it('runs work immediately once ready', () => {
+        const session = createMockSession();
+        session.markReady();
+
+        const fn = vi.fn();
+        session.runWhenReady(fn);
+
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('markReady is idempotent — does not re-run drained work', () => {
+        const session = createMockSession();
+        const fn = vi.fn();
+        session.runWhenReady(fn);
+
+        session.markReady();
+        session.markReady();
+
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves FIFO across mixed buffered + post-ready enqueues', () => {
+        const session = createMockSession();
+        const order: string[] = [];
+
+        session.runWhenReady(() => order.push('buffered-1'));
+        session.runWhenReady(() => order.push('buffered-2'));
+        session.markReady();
+        session.runWhenReady(() => order.push('live-3'));
+
+        expect(order).toEqual(['buffered-1', 'buffered-2', 'live-3']);
+    });
+});

--- a/cli/src/pi/session.test.ts
+++ b/cli/src/pi/session.test.ts
@@ -90,3 +90,44 @@ describe('PiSession ready gate', () => {
         expect(order).toEqual(['buffered-1', 'buffered-2', 'live-3']);
     });
 });
+
+// --- cancel-queued-message contract (issue #1143 review — MAJOR) ---
+//
+// A prompt buffered during the startup window can be cancelled by the hub
+// before it drains. cancelBufferedMessage must drop it (so it never fires) and
+// report removed:true; anything already drained or unknown reports false so the
+// hub keeps the row as invoked (best-effort, like the other agents).
+
+describe('PiSession cancelBufferedMessage', () => {
+    it('drops a buffered send by localId so it never drains', () => {
+        const session = createMockSession();
+        const fired: string[] = [];
+
+        session.runWhenReady(() => fired.push('keep-1'), 'id-1');
+        session.runWhenReady(() => fired.push('cancel-2'), 'id-2');
+        session.runWhenReady(() => fired.push('keep-3'), 'id-3');
+
+        expect(session.cancelBufferedMessage('id-2')).toBe(true);
+
+        session.markReady();
+
+        // Cancelled prompt never fired; FIFO preserved for survivors.
+        expect(fired).toEqual(['keep-1', 'keep-3']);
+    });
+
+    it('returns false when the localId is not buffered', () => {
+        const session = createMockSession();
+        session.runWhenReady(() => {}, 'id-1');
+
+        expect(session.cancelBufferedMessage('unknown')).toBe(false);
+    });
+
+    it('returns false after the message has already drained', () => {
+        const session = createMockSession();
+        session.runWhenReady(() => {}, 'id-1');
+        session.markReady();
+
+        // Already sent to Pi — cannot be recalled.
+        expect(session.cancelBufferedMessage('id-1')).toBe(false);
+    });
+});

--- a/cli/src/pi/session.ts
+++ b/cli/src/pi/session.ts
@@ -46,6 +46,15 @@ export class PiSession {
     // RPC resolver — initialized by wireTransportEvents, session-scoped
     rpcResolver: PiRpcResolver | null = null;
 
+    // Startup ready gate (issue #1143). Pi's socket goes `active` (spawn success)
+    // before `pi --mode rpc` finishes `new_session`/`get_state`, so a prompt sent
+    // in that window reaches Pi before its session is initialized and wedges
+    // (agent_start, then silence). Outbound sends that assume a live Pi session
+    // are queued via runWhenReady() and drained FIFO once markReady() fires (on
+    // the first get_state response).
+    private piReady = false;
+    private readyQueue: Array<() => void> = [];
+
     private keepAliveInterval: NodeJS.Timeout | null = null;
 
     constructor(opts: {
@@ -74,6 +83,37 @@ export class PiSession {
         this.currentModel = undefined;
         this.initialModel = opts.model?.trim() || null;
         this.currentThinkingLevel = undefined;
+    }
+
+    /** True once Pi RPC startup has completed and buffered sends have drained. */
+    get isReady(): boolean {
+        return this.piReady;
+    }
+
+    /**
+     * Run `fn` now if Pi startup is ready, else buffer it FIFO until markReady().
+     * Used to gate outbound prompt/steer sends so they never reach Pi before its
+     * session is initialized (issue #1143).
+     */
+    runWhenReady(fn: () => void): void {
+        if (this.piReady) {
+            fn();
+            return;
+        }
+        this.readyQueue.push(fn);
+    }
+
+    /**
+     * Signal that Pi RPC startup is complete (first get_state response).
+     * Drains buffered sends in enqueue order. Idempotent — later get_state
+     * responses (or the startup fallback timer) are no-ops.
+     */
+    markReady(): void {
+        if (this.piReady) return;
+        this.piReady = true;
+        const queued = this.readyQueue;
+        this.readyQueue = [];
+        for (const fn of queued) fn();
     }
 
     startKeepAlive(): void {

--- a/cli/src/pi/session.ts
+++ b/cli/src/pi/session.ts
@@ -53,7 +53,10 @@ export class PiSession {
     // are queued via runWhenReady() and drained FIFO once markReady() fires (on
     // the first get_state response).
     private piReady = false;
-    private readyQueue: Array<() => void> = [];
+    // Buffered sends carry their localId so a cancel-queued-message that arrives
+    // while a prompt is still held (before drain) can drop it instead of firing
+    // a cancelled prompt on markReady (issue #1143 review — MAJOR).
+    private readyQueue: Array<{ localId?: string; fn: () => void }> = [];
 
     private keepAliveInterval: NodeJS.Timeout | null = null;
 
@@ -93,14 +96,28 @@ export class PiSession {
     /**
      * Run `fn` now if Pi startup is ready, else buffer it FIFO until markReady().
      * Used to gate outbound prompt/steer sends so they never reach Pi before its
-     * session is initialized (issue #1143).
+     * session is initialized (issue #1143). Pass the message `localId` so a
+     * cancel-queued-message can drop it while still buffered.
      */
-    runWhenReady(fn: () => void): void {
+    runWhenReady(fn: () => void, localId?: string): void {
         if (this.piReady) {
             fn();
             return;
         }
-        this.readyQueue.push(fn);
+        this.readyQueue.push({ localId, fn });
+    }
+
+    /**
+     * Drop a still-buffered send by localId (cancel-queued-message contract).
+     * Returns true if it was buffered and removed (so the hub un-queues the row),
+     * false if it was already drained/sent to Pi or never buffered (best-effort,
+     * mirrors the other agents' queue.cancelByLocalId semantics).
+     */
+    cancelBufferedMessage(localId: string): boolean {
+        const idx = this.readyQueue.findIndex((item) => item.localId === localId);
+        if (idx === -1) return false;
+        this.readyQueue.splice(idx, 1);
+        return true;
     }
 
     /**
@@ -113,7 +130,7 @@ export class PiSession {
         this.piReady = true;
         const queued = this.readyQueue;
         this.readyQueue = [];
-        for (const fn of queued) fn();
+        for (const { fn } of queued) fn();
     }
 
     startKeepAlive(): void {


### PR DESCRIPTION
## Summary

Fixes #1143.

After a hub spawn of `agent: pi`, the session goes `active` (and `POST /sessions/:id/messages` returns `ok: true`) **before** `pi --mode rpc` finishes its RPC startup (`new_session` / `get_state` → `metadata.piSessionId`). A prompt posted in that window reaches Pi before its session is initialized and wedges the turn: CLI logs `Prompt accepted`, Pi emits `agent_start`, then silence - no tool calls, no FS writes, `thinking` stuck. Waiting until `metadata.piSessionId` is set, then messaging, works.

Spawn + immediate handoff message is a supported pattern (`hapi-ping-peer`, peer-handoff / intake scripts wait for `active` then POST, with no Pi-specific ready gate). For Pi, `active` (socket `session-alive`) races ahead of RPC readiness.

## Fix

Add a startup ready gate to `PiSession` and route outbound prompt/steer sends through it:

- `runWhenReady(fn)` - runs `fn` now if Pi startup is ready, else buffers it FIFO.
- `markReady()` - fires on the first `get_state` response (the response that persists `metadata.piSessionId`, i.e. the signal working callers already wait for), then drains the buffer in enqueue order. Idempotent.
- A 30s unref'd fallback timer force-drains if `get_state` never lands, degrading to prior send-anyway behaviour rather than swallowing the message forever. `markReady` is idempotent so a real `get_state` that lands first wins.

`piIsStreaming` is evaluated at delivery time, so a message buffered before startup still takes the prompt path.

Precedent: Cursor ACP uses `session-ready` + `waitForSessionReady`; the OMP transport buffers sends until a ready handshake. Pi had neither.

## Scope

Deliberately gates only the prompt/steer path (the actual wedge). Discovery RPCs (`get_available_models`, `get_commands`) are already sent at startup and answered fine; `set_model`/`set_thinking_level` via `SetSessionConfig` have their own 409-retry contract. Kept the change minimal and focused on the root cause. No hub-side belt added - the CLI buffer alone satisfies the kill criteria and keeps wait-for-`piSessionId` callers working unchanged.

## Tests

- `cli/src/pi/session.test.ts` (new): ready gate starts closed, buffers FIFO, drains on `markReady`, runs immediately once ready, idempotent, preserves FIFO across mixed buffered + post-ready enqueues.
- `cli/src/pi/loop.test.ts`: `get_state` response marks the session ready and drains buffered sends; readiness flips even when `sessionId` is absent (no forever-buffer).

`bun typecheck` and `bun run test` green.

## Kill criteria

- [x] Instant post-spawn message on Pi never wedges (buffered until `get_state`, then delivered)
- [x] Existing wait-for-`piSessionId` callers keep working (`piSessionId` still persisted by `get_state`)
- [x] `bun typecheck` + `bun run test` green
- [x] No change to Upgrade / soup version governance - separate lane

Made with [Cursor](https://cursor.com)