### PR TITLE
fix(web): align outline close button styling

### DIFF
--- a/web/src/components/AssistantChat/HappyThread.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.test.tsx
@@ -107,7 +107,9 @@ describe('ConversationOutlinePanel', () => {
         const onClose = vi.fn()
         renderPanel({ onClose })
 
-        fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+        const closeButton = screen.getByRole('button', { name: 'Close' })
+        expect(closeButton).toHaveClass('border', 'rounded-md', 'h-9', 'w-9')
+        fireEvent.click(closeButton)
 
         expect(onClose).toHaveBeenCalledTimes(1)
     })

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -218,15 +218,16 @@ export function ConversationOutlinePanel(props: {
                             )}
                         </Button>
                     ) : null}
-                    <button
+                    <Button
+                        variant="outline"
                         type="button"
                         onClick={props.onClose}
                         aria-label={t('button.close')}
                         title={t('button.close')}
-                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--app-hint)] transition-colors hover:bg-[var(--app-secondary-bg)] hover:text-[var(--app-fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
+                        className="h-9 w-9 shrink-0 px-0"
                     >
                         <CloseIcon className="h-4 w-4" />
-                    </button>
+                    </Button>
                 </div>
                 {normalizedSearchQuery.length > 0 ? (
                     <div className="mt-1.5 text-right text-xs text-[var(--app-hint)]" aria-live="polite">


### PR DESCRIPTION
## Summary

- style the conversation outline close action with the shared outline button variant
- match the close action's size, border, corner radius, and hover treatment to the adjacent load-earlier action
- keep the existing accessible label, tooltip, and close behavior unchanged
- add focused coverage for the close button's visible outline styling

## Testing

- `bun typecheck`
- `bun run test:web`
- `bun run build:web`
- `git diff --check`
- manually verified on the mobile layout at port 3016
