### PR TITLE
fix(web): connect circular action icon arrowheads

### DIFF
--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -107,8 +107,8 @@ function ReopenIcon(props: { className?: string }) {
             strokeLinejoin="round"
             className={props.className}
         >
-            <path d="M3 12a9 9 0 1 0 3-6.7" />
-            <polyline points="3 4 3 10 9 10" />
+            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+            <path d="M3 3v5h5" />
         </svg>
     )
 }
@@ -127,10 +127,10 @@ function SyncIcon(props: { className?: string }) {
             strokeLinejoin="round"
             className={props.className}
         >
-            <path d="M3 12a9 9 0 0 1 15.5-6.2" />
-            <path d="M18 3v6h-6" />
-            <path d="M21 12a9 9 0 0 1-15.5 6.2" />
-            <path d="M6 21v-6h6" />
+            <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+            <path d="M21 3v5h-5" />
+            <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+            <path d="M3 21v-5h5" />
         </svg>
     )
 }

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -137,8 +137,8 @@ function RefreshIcon(props: { className?: string }) {
             strokeLinejoin="round"
             className={props.className}
         >
-            <path d="M21 12a9 9 0 1 1-2.64-6.36" />
-            <path d="M21 3v6h-6" />
+            <path d="M21 12a9 9 0 1 1-2.64-6.36L21 8" />
+            <path d="M21 3v5h-5" />
         </svg>
     )
 }


### PR DESCRIPTION
## Summary

- connect the session-list refresh arrowhead to its circular arc
- correct the arrowhead geometry for the Codex sync action
- correct the arrowhead geometry for the reopen-session action

## Problem

The custom SVG paths ended their circular arcs separately from the arrowheads. This left a visible gap on the session-list refresh icon and made the Codex sync and reopen icons look skewed, especially at mobile sizes.

## Testing

- `bun typecheck`
- `bun run --cwd web test SessionActionMenu.test.tsx` (10 tests passed)
- `bun run build:web`

## AI disclosure

AI-assisted implementation and review using OpenAI GPT-5.6-sol.
