### PR TITLE
fix(codex): clear completed safety review prompt

### DIFF
--- a/cli/src/codex/utils/appServerEventConverter.test.ts
+++ b/cli/src/codex/utils/appServerEventConverter.test.ts
@@ -946,6 +946,20 @@ describe('AppServerEventConverter', () => {
             faster_model: 'gpt-5.4-mini'
         }]);
 
+        expect(converter.handleNotification('model/safetyBuffering/updated', {
+            threadId: 'thread-1',
+            turnId: 'turn-1',
+            showBufferingUi: false
+        })).toEqual([{
+            type: 'model_safety_buffering',
+            thread_id: 'thread-1',
+            turn_id: 'turn-1',
+            use_cases: [],
+            reasons: [],
+            show_buffering_ui: false,
+            faster_model: null
+        }]);
+
         expect(converter.handleNotification('model/rerouted', {
             threadId: 'thread-1',
             turnId: 'turn-1',

--- a/cli/src/codex/utils/appServerEventConverter.ts
+++ b/cli/src/codex/utils/appServerEventConverter.ts
@@ -791,12 +791,12 @@ export class AppServerEventConverter {
         if (method === 'model/safetyBuffering/updated') {
             const model = asString(paramsRecord.model);
             const showBufferingUi = asBoolean(paramsRecord.showBufferingUi ?? paramsRecord.show_buffering_ui);
-            if (!model || showBufferingUi === null) {
+            if (showBufferingUi === null || (showBufferingUi && !model)) {
                 return events;
             }
             events.push(scoped({
                 type: 'model_safety_buffering',
-                model,
+                ...(model ? { model } : {}),
                 use_cases: extractStringArray(paramsRecord.useCases ?? paramsRecord.use_cases),
                 reasons: extractStringArray(paramsRecord.reasons),
                 show_buffering_ui: showBufferingUi,


### PR DESCRIPTION
## Summary

- forward Codex safety-buffering hide updates even when `model` is omitted
- keep requiring `model` when showing the safety-buffering UI
- cover the model-less completion notification with a regression test

Fixes #1155

## Testing

- `bun test cli/src/codex/utils/appServerEventConverter.test.ts` (45 passed)
- `bun typecheck`
- `bun run test` (CLI 1451, Hub 508, Web 1390, Shared 115 passed; 3 Hub integration tests skipped)
