### PR TITLE
fix(web): align session agent icons with text

### DIFF
--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -238,7 +238,7 @@ export function SessionHeader(props: {
                         </div>
                         <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-[var(--app-hint)]">
                             <span className="inline-flex items-center gap-1">
-                                <AgentFlavorIcon flavor={session.metadata?.flavor} className="h-3.5 w-3.5 shrink-0" />
+                                <AgentFlavorIcon flavor={session.metadata?.flavor} className="h-3.5 w-3.5 shrink-0 -translate-y-px" />
                                 {session.metadata?.flavor?.trim() || 'unknown'}
                             </span>
                             {modelLabel ? (

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -874,7 +874,7 @@ function SessionItem(props: {
             >
                 <div className={`flex items-center justify-between gap-3 ${!s.active ? 'opacity-50' : ''}`}>
                     <div className="flex items-center gap-2 min-w-0">
-                        <AgentFlavorIcon flavor={s.metadata?.flavor} className="h-4 w-4 shrink-0" />
+                        <AgentFlavorIcon flavor={s.metadata?.flavor} className="h-4 w-4 shrink-0 -translate-y-px" />
                         <div className={`truncate text-sm font-medium ${s.active ? 'text-[var(--app-fg)]' : 'text-[var(--app-hint)]'}`}>
                             {sessionName}
                         </div>


### PR DESCRIPTION
## Summary

- apply the same 1px optical offset to agent flavor icons in the session header and session list
- keep the existing icon sizes, spacing, and row layout unchanged

## Problem

Agent flavor icons sit slightly below the visual center of their neighboring text in both the session header metadata and session list rows. The existing flex alignment centers the icon and text boxes geometrically, but the square brand artwork still appears low relative to the text glyphs, especially on mobile.

## Testing

- `bun typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run test:web` (165 files, 1394 tests)
- manual verification on the mobile web UI in the session header and session list
