### PR TITLE
feat(session): add structured external refs and PR chip

### DIFF
--- a/cli/src/agent/sessionFactory.test.ts
+++ b/cli/src/agent/sessionFactory.test.ts
@@ -198,6 +198,82 @@ describe('bootstrapExistingSession', () => {
         )
     })
 
+    it('preserves externalRefs when bootstrap rebuild omits them', async () => {
+        const session = createSession()
+        const existingMetadata = session.metadata
+        if (!existingMetadata) throw new Error('expected test session metadata')
+        const externalRefs = [{
+            kind: 'github_pr' as const,
+            repo: 'tiann/hapi',
+            number: 1160,
+            url: 'https://github.com/tiann/hapi/pull/1160',
+            role: 'primary' as const
+        }]
+        session.metadata = {
+            ...existingMetadata,
+            externalRefs
+        }
+        const sessionClient = { updateMetadata: vi.fn() }
+        getSessionMock.mockResolvedValue(session)
+        getOrCreateMachineMock.mockResolvedValue({ id: 'machine-1' })
+        sessionSyncClientMock.mockReturnValue(sessionClient)
+        readSettingsMock.mockResolvedValue({ machineId: 'machine-1' })
+
+        const result = await bootstrapExistingSession({
+            sessionId: 'hapi-session-1',
+            flavor: 'codex',
+            workingDirectory: '/tmp/project'
+        })
+
+        expect(result.metadata.externalRefs).toEqual(externalRefs)
+        const updateHandler = sessionClient.updateMetadata.mock.calls[0][0]
+        expect(updateHandler(session.metadata).externalRefs).toEqual(externalRefs)
+    })
+
+    it('lets metadataOverrides replace or clear externalRefs on bootstrap', async () => {
+        const session = createSession()
+        const existingMetadata = session.metadata
+        if (!existingMetadata) throw new Error('expected test session metadata')
+        session.metadata = {
+            ...existingMetadata,
+            externalRefs: [{
+                kind: 'github_pr',
+                repo: 'tiann/hapi',
+                number: 1160,
+                url: 'https://github.com/tiann/hapi/pull/1160',
+                role: 'primary'
+            }]
+        }
+        const replacement = [{
+            kind: 'github_pr' as const,
+            repo: 'owner/other',
+            number: 9,
+            url: 'https://github.com/owner/other/pull/9',
+            role: 'primary' as const
+        }]
+        const sessionClient = { updateMetadata: vi.fn() }
+        getSessionMock.mockResolvedValue(session)
+        getOrCreateMachineMock.mockResolvedValue({ id: 'machine-1' })
+        sessionSyncClientMock.mockReturnValue(sessionClient)
+        readSettingsMock.mockResolvedValue({ machineId: 'machine-1' })
+
+        const replaced = await bootstrapExistingSession({
+            sessionId: 'hapi-session-1',
+            flavor: 'codex',
+            workingDirectory: '/tmp/project',
+            metadataOverrides: { externalRefs: replacement }
+        })
+        expect(replaced.metadata.externalRefs).toEqual(replacement)
+
+        const cleared = await bootstrapExistingSession({
+            sessionId: 'hapi-session-1',
+            flavor: 'codex',
+            workingDirectory: '/tmp/project',
+            metadataOverrides: { externalRefs: [] }
+        })
+        expect(cleared.metadata.externalRefs).toEqual([])
+    })
+
     it('advertises remote terminal capability in session metadata', () => {
         const metadata = buildSessionMetadata({
             flavor: 'codex',

--- a/cli/src/agent/sessionFactory.ts
+++ b/cli/src/agent/sessionFactory.ts
@@ -115,6 +115,8 @@ function pickExistingSessionMetadata(metadata: Metadata | null | undefined): Par
     if (metadata.piAvailableModels !== undefined) preserved.piAvailableModels = metadata.piAvailableModels
     // Preserve provider-qualified Pi model selection (disambiguates duplicate modelIds).
     if (metadata.piSelectedModel !== undefined) preserved.piSelectedModel = metadata.piSelectedModel
+    // Preserve structured PR links across resume/bootstrap rebuilds (tiann/hapi#1160).
+    if (metadata.externalRefs !== undefined) preserved.externalRefs = metadata.externalRefs
 
     return preserved
 }

--- a/hub/src/store/sessions.test.ts
+++ b/hub/src/store/sessions.test.ts
@@ -92,6 +92,102 @@ describe('getOrCreateSession: requested identity', () => {
 })
 
 describe('updateSessionMetadata: protocol resume token preservation', () => {
+    it('preserves externalRefs when a sparse replacement omits them', () => {
+        const store = makeStore()
+        const externalRefs = [{
+            kind: 'github_pr',
+            repo: 'tiann/hapi',
+            number: 1160,
+            url: 'https://github.com/tiann/hapi/pull/1160',
+            role: 'primary'
+        }]
+        const session = store.sessions.getOrCreateSession(
+            'external-refs-preserve',
+            {
+                path: '/tmp/project',
+                host: 'example',
+                flavor: 'cursor',
+                externalRefs
+            },
+            null,
+            'default'
+        )
+
+        const result = store.sessions.updateSessionMetadata(
+            session.id,
+            {
+                path: '/tmp/project',
+                host: 'example',
+                flavor: 'cursor',
+                lifecycleState: 'running'
+            },
+            session.metadataVersion,
+            'default'
+        )
+        expect(result.result).toBe('success')
+        expect(getMetadata(store, session.id)?.externalRefs).toEqual(externalRefs)
+        store.close()
+    })
+
+    it('lets an explicit externalRefs write win, including clearing with []', () => {
+        const store = makeStore()
+        const session = store.sessions.getOrCreateSession(
+            'external-refs-explicit',
+            {
+                path: '/tmp/project',
+                host: 'example',
+                flavor: 'cursor',
+                externalRefs: [{
+                    kind: 'github_pr',
+                    repo: 'tiann/hapi',
+                    number: 1160,
+                    url: 'https://github.com/tiann/hapi/pull/1160',
+                    role: 'primary'
+                }]
+            },
+            null,
+            'default'
+        )
+
+        const replacement = [{
+            kind: 'github_pr',
+            repo: 'owner/other',
+            number: 42,
+            url: 'https://github.com/owner/other/pull/42',
+            role: 'secondary'
+        }]
+        let version = session.metadataVersion
+        let result = store.sessions.updateSessionMetadata(
+            session.id,
+            {
+                path: '/tmp/project',
+                host: 'example',
+                flavor: 'cursor',
+                externalRefs: replacement
+            },
+            version,
+            'default'
+        )
+        expect(result.result).toBe('success')
+        if (result.result === 'success') version = result.version
+        expect(getMetadata(store, session.id)?.externalRefs).toEqual(replacement)
+
+        result = store.sessions.updateSessionMetadata(
+            session.id,
+            {
+                path: '/tmp/project',
+                host: 'example',
+                flavor: 'cursor',
+                externalRefs: []
+            },
+            version,
+            'default'
+        )
+        expect(result.result).toBe('success')
+        expect(getMetadata(store, session.id)?.externalRefs).toEqual([])
+        store.close()
+    })
+
     it('preserves cursorSessionId when archive payload omits it (Cursor crash-archive)', () => {
         const store = makeStore()
         const session = store.sessions.getOrCreateSession(

--- a/hub/src/store/sessions.ts
+++ b/hub/src/store/sessions.ts
@@ -36,6 +36,10 @@ import { updateVersionedField } from './versionedUpdates'
 //     write-once-keep semantics. Mirror of pickExistingSessionMetadata
 //     in cli/src/agent/sessionFactory.ts.
 //
+//   - CONTRIBUTION_FIELDS: structured session↔PR links (externalRefs).
+//     Sparse resume/bootstrap writes must not wipe a prior primary PR
+//     association. tiann/hapi#1160 / PR #1161.
+//
 // `cursorSessionProtocol` is paired with `cursorSessionId`: protocol is
 // tied to a specific chat id, so a write that explicitly sets a new
 // `cursorSessionId` must drop a stale prior protocol. Handled in
@@ -62,6 +66,8 @@ const SIMPLE_RESUME_TOKENS = [
     'cursorSessionId',
     'kimiSessionId'
 ] as const
+
+const CONTRIBUTION_FIELDS = ['externalRefs'] as const
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -126,6 +132,7 @@ export function mergeSessionMetadata(prior: unknown, next: unknown): unknown {
     merged = carryForwardIfMissing(prior, next, merged, PARSE_IDENTITY_FIELDS)
     merged = carryForwardIfMissing(prior, next, merged, ROUTING_FIELDS)
     merged = carryForwardIfMissing(prior, next, merged, SIMPLE_RESUME_TOKENS)
+    merged = carryForwardIfMissing(prior, next, merged, CONTRIBUTION_FIELDS)
     merged = preserveCursorProtocolPair(prior, next, merged)
     return merged ?? next
 }

--- a/hub/src/sync/sessionCache.mergeExternalRefs.test.ts
+++ b/hub/src/sync/sessionCache.mergeExternalRefs.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test'
+import { mergeSessionMetadataForSessionMerge } from './sessionCache'
+
+const prRef = {
+    kind: 'github_pr' as const,
+    repo: 'tiann/hapi',
+    number: 1160,
+    url: 'https://github.com/tiann/hapi/pull/1160',
+    role: 'primary' as const
+}
+
+describe('mergeSessionMetadataForSessionMerge externalRefs', () => {
+    it('preserves externalRefs from the old row when the new row omits them', () => {
+        const oldMetadata = {
+            path: '/old',
+            host: 'old-host',
+            name: 'PR session',
+            externalRefs: [prRef]
+        }
+        const newMetadata = {
+            path: '/new',
+            host: 'new-host',
+            flavor: 'cursor'
+        }
+
+        const merged = mergeSessionMetadataForSessionMerge(oldMetadata, newMetadata) as Record<string, unknown>
+
+        expect(merged.externalRefs).toEqual([prRef])
+        expect(merged.path).toBe('/new')
+        expect(merged.flavor).toBe('cursor')
+        expect(merged.name).toBe('PR session')
+    })
+
+    it('lets the new row win when it explicitly sets externalRefs', () => {
+        const oldMetadata = {
+            path: '/old',
+            host: 'old-host',
+            externalRefs: [prRef]
+        }
+        const replacement = [{
+            kind: 'github_pr' as const,
+            repo: 'owner/other',
+            number: 42,
+            url: 'https://github.com/owner/other/pull/42',
+            role: 'primary' as const
+        }]
+        const newMetadata = {
+            path: '/new',
+            host: 'new-host',
+            externalRefs: replacement
+        }
+
+        const merged = mergeSessionMetadataForSessionMerge(oldMetadata, newMetadata) as Record<string, unknown>
+
+        expect(merged.externalRefs).toEqual(replacement)
+    })
+
+    it('lets an explicit empty externalRefs array clear the old refs', () => {
+        const oldMetadata = {
+            path: '/old',
+            host: 'old-host',
+            externalRefs: [prRef]
+        }
+        const newMetadata = {
+            path: '/new',
+            host: 'new-host',
+            externalRefs: []
+        }
+
+        const merged = mergeSessionMetadataForSessionMerge(oldMetadata, newMetadata) as Record<string, unknown>
+
+        expect(merged.externalRefs).toEqual([])
+    })
+})

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -14,6 +14,69 @@ const QUEUED_MESSAGE_THINKING_GRACE_MS = 15_000
 const METADATA_RETRY_ATTEMPTS = 5
 type RuntimeConfigKey = 'permissionMode' | 'model' | 'modelReasoningEffort' | 'effort' | 'serviceTier' | 'collaborationMode'
 
+/**
+ * Metadata merge used when consolidating an old session row into a replacement
+ * (resume/reopen). Carry forward display/contribution fields the new row omitted.
+ * Explicit keys on `newMetadata` always win — including empty `externalRefs: []`.
+ * tiann/hapi#1160 / PR #1161.
+ */
+export function mergeSessionMetadataForSessionMerge(
+    oldMetadata: unknown | null,
+    newMetadata: unknown | null
+): unknown | null {
+    if (!oldMetadata || typeof oldMetadata !== 'object') {
+        return newMetadata
+    }
+    if (!newMetadata || typeof newMetadata !== 'object') {
+        return oldMetadata
+    }
+
+    const oldObj = oldMetadata as Record<string, unknown>
+    const newObj = newMetadata as Record<string, unknown>
+    const merged: Record<string, unknown> = { ...newObj }
+    let changed = false
+
+    if (typeof oldObj.name === 'string' && typeof newObj.name !== 'string') {
+        merged.name = oldObj.name
+        changed = true
+    }
+
+    const oldSummary = oldObj.summary as { text?: unknown; updatedAt?: unknown } | undefined
+    const newSummary = newObj.summary as { text?: unknown; updatedAt?: unknown } | undefined
+    const oldUpdatedAt = typeof oldSummary?.updatedAt === 'number' ? oldSummary.updatedAt : null
+    const newUpdatedAt = typeof newSummary?.updatedAt === 'number' ? newSummary.updatedAt : null
+    if (oldUpdatedAt !== null && (newUpdatedAt === null || oldUpdatedAt > newUpdatedAt)) {
+        merged.summary = oldSummary
+        changed = true
+    }
+
+    if (oldObj.worktree && !newObj.worktree) {
+        merged.worktree = oldObj.worktree
+        changed = true
+    }
+
+    if (typeof oldObj.path === 'string' && typeof newObj.path !== 'string') {
+        merged.path = oldObj.path
+        changed = true
+    }
+    if (typeof oldObj.host === 'string' && typeof newObj.host !== 'string') {
+        merged.host = oldObj.host
+        changed = true
+    }
+    if (typeof oldObj.preferredPermissionMode === 'string' && typeof newObj.preferredPermissionMode !== 'string') {
+        merged.preferredPermissionMode = oldObj.preferredPermissionMode
+        changed = true
+    }
+
+    // Preserve structured PR links when the replacement row never set them.
+    if (Array.isArray(oldObj.externalRefs) && !Object.prototype.hasOwnProperty.call(newObj, 'externalRefs')) {
+        merged.externalRefs = oldObj.externalRefs
+        changed = true
+    }
+
+    return changed ? merged : newMetadata
+}
+
 export class SessionCache {
     private readonly sessions: Map<string, Session> = new Map()
     private readonly lastBroadcastAtBySessionId: Map<string, number> = new Map()
@@ -1092,51 +1155,7 @@ export class SessionCache {
     }
 
     private mergeSessionMetadata(oldMetadata: unknown | null, newMetadata: unknown | null): unknown | null {
-        if (!oldMetadata || typeof oldMetadata !== 'object') {
-            return newMetadata
-        }
-        if (!newMetadata || typeof newMetadata !== 'object') {
-            return oldMetadata
-        }
-
-        const oldObj = oldMetadata as Record<string, unknown>
-        const newObj = newMetadata as Record<string, unknown>
-        const merged: Record<string, unknown> = { ...newObj }
-        let changed = false
-
-        if (typeof oldObj.name === 'string' && typeof newObj.name !== 'string') {
-            merged.name = oldObj.name
-            changed = true
-        }
-
-        const oldSummary = oldObj.summary as { text?: unknown; updatedAt?: unknown } | undefined
-        const newSummary = newObj.summary as { text?: unknown; updatedAt?: unknown } | undefined
-        const oldUpdatedAt = typeof oldSummary?.updatedAt === 'number' ? oldSummary.updatedAt : null
-        const newUpdatedAt = typeof newSummary?.updatedAt === 'number' ? newSummary.updatedAt : null
-        if (oldUpdatedAt !== null && (newUpdatedAt === null || oldUpdatedAt > newUpdatedAt)) {
-            merged.summary = oldSummary
-            changed = true
-        }
-
-        if (oldObj.worktree && !newObj.worktree) {
-            merged.worktree = oldObj.worktree
-            changed = true
-        }
-
-        if (typeof oldObj.path === 'string' && typeof newObj.path !== 'string') {
-            merged.path = oldObj.path
-            changed = true
-        }
-        if (typeof oldObj.host === 'string' && typeof newObj.host !== 'string') {
-            merged.host = oldObj.host
-            changed = true
-        }
-        if (typeof oldObj.preferredPermissionMode === 'string' && typeof newObj.preferredPermissionMode !== 'string') {
-            merged.preferredPermissionMode = oldObj.preferredPermissionMode
-            changed = true
-        }
-
-        return changed ? merged : newMetadata
+        return mergeSessionMetadataForSessionMerge(oldMetadata, newMetadata)
     }
 
     private persistPreferredPermissionMode(session: Session, permissionMode: PermissionMode): void {

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -160,6 +160,39 @@ function createApp(session: Session, opts?: {
 }
 
 describe('sessions routes', () => {
+    it('returns structured externalRefs for a session', async () => {
+        const externalRefs = [{
+            kind: 'github_pr' as const,
+            repo: 'tiann/hapi',
+            number: 1160,
+            url: 'https://github.com/tiann/hapi/pull/1160',
+            role: 'primary' as const
+        }]
+        const session = createSession({
+            metadata: {
+                path: '/tmp/project',
+                host: 'localhost',
+                flavor: 'cursor',
+                externalRefs
+            }
+        })
+        const { app } = createApp(session)
+
+        const response = await app.request('/api/sessions/session-1/external-refs')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ externalRefs })
+    })
+
+    it('returns an empty externalRefs array when metadata has none', async () => {
+        const { app } = createApp(createSession())
+
+        const response = await app.request('/api/sessions/session-1/external-refs')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ externalRefs: [] })
+    })
+
     it('returns the machine-scoped Cursor chat store status', async () => {
         const session = createSession({
             active: false,

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -139,6 +139,21 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         return c.json({ session: sessionResult.session })
     })
 
+    app.get('/sessions/:id/external-refs', (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine)
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+
+        const externalRefs = sessionResult.session.metadata?.externalRefs ?? []
+        return c.json({ externalRefs })
+    })
+
     app.get('/sessions/:id/cursor-chat-store', async (c) => {
         const engine = requireSyncEngine(c, getSyncEngine)
         if (engine instanceof Response) {

--- a/shared/src/externalRefs.ts
+++ b/shared/src/externalRefs.ts
@@ -1,0 +1,16 @@
+import type { ExternalRef, GithubPrExternalRef } from './schemas'
+
+/**
+ * Primary GitHub PR chip source. Title/emoji parsing is intentionally not used.
+ */
+export function getPrimaryGithubPrRef(
+    refs: readonly ExternalRef[] | null | undefined
+): GithubPrExternalRef | null {
+    if (!refs?.length) return null
+    for (const ref of refs) {
+        if (ref.kind === 'github_pr' && ref.role === 'primary') {
+            return ref
+        }
+    }
+    return null
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './scratchlistAttachments'
 export * from './apiTypes'
 export * from './cursorCliSku'
+export * from './externalRefs'
 export * from './messages'
 export * from './buildInfo'
 export * from './effort'

--- a/shared/src/schemas.externalRefs.test.ts
+++ b/shared/src/schemas.externalRefs.test.ts
@@ -29,6 +29,21 @@ describe('ExternalRefSchema', () => {
         expect(ExternalRefSchema.safeParse({ ...validPr, number: -1 }).success).toBe(false)
     })
 
+    it('rejects URLs that do not match the declared GitHub PR identity', () => {
+        expect(ExternalRefSchema.safeParse({
+            ...validPr,
+            url: 'https://example.test/phish'
+        }).success).toBe(false)
+        expect(ExternalRefSchema.safeParse({
+            ...validPr,
+            url: 'https://github.com/other/repo/pull/1160'
+        }).success).toBe(false)
+        expect(ExternalRefSchema.safeParse({
+            ...validPr,
+            url: 'https://github.com/tiann/hapi/pull/999'
+        }).success).toBe(false)
+    })
+
     it('rejects unknown kinds', () => {
         expect(ExternalRefSchema.safeParse({ ...validPr, kind: 'gitlab_mr' }).success).toBe(false)
     })

--- a/shared/src/schemas.externalRefs.test.ts
+++ b/shared/src/schemas.externalRefs.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { ExternalRefSchema, MetadataSchema } from './schemas'
+import { getPrimaryGithubPrRef } from './externalRefs'
+
+describe('ExternalRefSchema', () => {
+    const validPr = {
+        kind: 'github_pr' as const,
+        repo: 'tiann/hapi',
+        number: 1160,
+        url: 'https://github.com/tiann/hapi/pull/1160',
+        role: 'primary' as const
+    }
+
+    it('accepts a github_pr ref', () => {
+        const parsed = ExternalRefSchema.safeParse(validPr)
+        expect(parsed.success).toBe(true)
+        if (parsed.success) {
+            expect(parsed.data).toEqual(validPr)
+        }
+    })
+
+    it('rejects invalid repo shape', () => {
+        expect(ExternalRefSchema.safeParse({ ...validPr, repo: 'not-a-repo' }).success).toBe(false)
+        expect(ExternalRefSchema.safeParse({ ...validPr, repo: '/hapi' }).success).toBe(false)
+    })
+
+    it('rejects non-positive PR numbers', () => {
+        expect(ExternalRefSchema.safeParse({ ...validPr, number: 0 }).success).toBe(false)
+        expect(ExternalRefSchema.safeParse({ ...validPr, number: -1 }).success).toBe(false)
+    })
+
+    it('rejects unknown kinds', () => {
+        expect(ExternalRefSchema.safeParse({ ...validPr, kind: 'gitlab_mr' }).success).toBe(false)
+    })
+})
+
+describe('MetadataSchema.externalRefs', () => {
+    const base = { path: '/tmp', host: 'test' }
+
+    it('accepts optional externalRefs array', () => {
+        const parsed = MetadataSchema.safeParse({
+            ...base,
+            externalRefs: [{
+                kind: 'github_pr',
+                repo: 'owner/name',
+                number: 42,
+                url: 'https://github.com/owner/name/pull/42',
+                role: 'secondary'
+            }]
+        })
+        expect(parsed.success).toBe(true)
+        if (parsed.success) {
+            expect(parsed.data.externalRefs).toHaveLength(1)
+            expect(parsed.data.externalRefs?.[0]?.number).toBe(42)
+        }
+    })
+
+    it('rejects malformed externalRefs entries', () => {
+        expect(MetadataSchema.safeParse({
+            ...base,
+            externalRefs: [{ kind: 'github_pr', repo: 'x', number: 1 }]
+        }).success).toBe(false)
+    })
+})
+
+describe('getPrimaryGithubPrRef', () => {
+    it('returns the primary github_pr ref', () => {
+        const primary = {
+            kind: 'github_pr' as const,
+            repo: 'a/b',
+            number: 1,
+            url: 'https://github.com/a/b/pull/1',
+            role: 'primary' as const
+        }
+        const secondary = {
+            kind: 'github_pr' as const,
+            repo: 'a/b',
+            number: 2,
+            url: 'https://github.com/a/b/pull/2',
+            role: 'secondary' as const
+        }
+        expect(getPrimaryGithubPrRef([secondary, primary])).toEqual(primary)
+    })
+
+    it('returns null when no primary github_pr exists', () => {
+        expect(getPrimaryGithubPrRef(undefined)).toBeNull()
+        expect(getPrimaryGithubPrRef([])).toBeNull()
+        expect(getPrimaryGithubPrRef([{
+            kind: 'github_pr',
+            repo: 'a/b',
+            number: 9,
+            url: 'https://github.com/a/b/pull/9',
+            role: 'secondary'
+        }])).toBeNull()
+    })
+})

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -25,6 +25,31 @@ export const WorktreeMetadataSchema = z.object({
 
 export type WorktreeMetadata = z.infer<typeof WorktreeMetadataSchema>
 
+/** owner/name — GitHub-style repo slug (no leading slash, exactly one slash). */
+const GithubRepoSlugSchema = z.string().regex(
+    /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/,
+    'expected owner/name'
+)
+
+/**
+ * Structured link from a HAPI session to an external contribution surface.
+ * v1: GitHub pull requests only. Do not parse session titles for this identity.
+ * tiann/hapi#1160.
+ */
+export const GithubPrExternalRefSchema = z.object({
+    kind: z.literal('github_pr'),
+    repo: GithubRepoSlugSchema,
+    number: z.number().int().positive(),
+    url: z.string().url(),
+    role: z.enum(['primary', 'secondary'])
+})
+
+export type GithubPrExternalRef = z.infer<typeof GithubPrExternalRefSchema>
+
+/** Expand with more kinds via discriminatedUnion when needed. */
+export const ExternalRefSchema = GithubPrExternalRefSchema
+export type ExternalRef = z.infer<typeof ExternalRefSchema>
+
 export const MetadataSchema = z.object({
     path: z.string(),
     host: z.string(),
@@ -77,7 +102,9 @@ export const MetadataSchema = z.object({
     // field stores only modelId (shared across all flavors); this preserves
     // the provider so web can resolve the exact model when two providers
     // share a modelId.
-    piSelectedModel: z.object({ provider: z.string(), modelId: z.string() }).nullable().optional()
+    piSelectedModel: z.object({ provider: z.string(), modelId: z.string() }).nullable().optional(),
+    // Structured session↔contribution links (e.g. GitHub PRs). tiann/hapi#1160.
+    externalRefs: z.array(ExternalRefSchema).optional()
 })
 
 export type Metadata = z.infer<typeof MetadataSchema>

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -42,6 +42,15 @@ export const GithubPrExternalRefSchema = z.object({
     number: z.number().int().positive(),
     url: z.string().url(),
     role: z.enum(['primary', 'secondary'])
+}).superRefine((ref, ctx) => {
+    const expectedUrl = `https://github.com/${ref.repo}/pull/${ref.number}`
+    if (ref.url !== expectedUrl) {
+        ctx.addIssue({
+            code: 'custom',
+            path: ['url'],
+            message: 'expected GitHub PR URL matching repo and number'
+        })
+    }
 })
 
 export type GithubPrExternalRef = z.infer<typeof GithubPrExternalRefSchema>

--- a/shared/src/sessionSummary.test.ts
+++ b/shared/src/sessionSummary.test.ts
@@ -105,6 +105,25 @@ describe('toSessionSummary', () => {
         expect(summary.metadata?.lifecycleState).toBe('archived')
     })
 
+    it('includes externalRefs in summary metadata', () => {
+        const externalRefs = [{
+            kind: 'github_pr' as const,
+            repo: 'tiann/hapi',
+            number: 1160,
+            url: 'https://github.com/tiann/hapi/pull/1160',
+            role: 'primary' as const
+        }]
+        const summary = toSessionSummary(makeSession({
+            metadata: {
+                path: '/proj',
+                host: 'local',
+                externalRefs
+            }
+        }))
+
+        expect(summary.metadata?.externalRefs).toEqual(externalRefs)
+    })
+
     it('includes structured pendingRequests for hover-tooltip copy', () => {
         const summary = toSessionSummary(makeSession({
             updatedAt: 5000,

--- a/shared/src/sessionSummary.ts
+++ b/shared/src/sessionSummary.ts
@@ -1,4 +1,4 @@
-import type { Session, WorktreeMetadata } from './schemas'
+import type { ExternalRef, Session, WorktreeMetadata } from './schemas'
 
 export type PendingRequestKind = 'permission' | 'input'
 
@@ -38,6 +38,8 @@ export type SessionSummaryMetadata = {
     worktree?: WorktreeMetadata
     agentSessionId?: string
     lifecycleState?: string
+    /** Structured contribution links (GitHub PRs, …). tiann/hapi#1160. */
+    externalRefs?: ExternalRef[]
 }
 
 export type SessionSummary = {
@@ -124,7 +126,8 @@ export function toSessionSummary(session: Session): SessionSummary {
             ?? session.metadata.cursorSessionId
             ?? session.metadata.kimiSessionId
             ?? undefined,
-        lifecycleState: session.metadata.lifecycleState
+        lifecycleState: session.metadata.lifecycleState,
+        externalRefs: session.metadata.externalRefs
     } : null
 
     const todoProgress = session.todos?.length ? {

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -4,6 +4,8 @@ export type {
     AgentStateRequest,
     AttachmentMetadata,
     DecryptedMessage,
+    ExternalRef,
+    GithubPrExternalRef,
     Metadata,
     Machine,
     MachineHealth,

--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -12,6 +12,8 @@ import {
     isSidebarEmptySessionStub,
     normalizeSearch,
     prepareSidebarSessions,
+    sessionListItemButtonClassName,
+    sessionListItemWrapperClassName,
     sessionMatchesQuery,
     sessionMatchesTimeRange,
     shouldShowSessionInSidebar
@@ -451,5 +453,14 @@ describe('expandSelectedSessionCollapseOverrides', () => {
         })
 
         expect(result.has('sessions::machine-1::/work/hapi')).toBe(false)
+    })
+})
+
+describe('session list row focus group classes', () => {
+    it('puts group/session-row on the focusable button, not the wrapper', () => {
+        expect(sessionListItemButtonClassName()).toContain('group/session-row')
+        expect(sessionListItemWrapperClassName(false)).not.toContain('group/session-row')
+        expect(sessionListItemWrapperClassName(true)).toContain('bg-[var(--app-secondary-bg)]')
+        expect(sessionListItemWrapperClassName(true)).not.toContain('group/session-row')
     })
 })

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -32,6 +32,15 @@ import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStat
 import { SessionPrChip } from '@/components/SessionPrChip'
 import { getPrimaryGithubPrRef } from '@hapi/protocol'
 
+export function sessionListItemWrapperClassName(selected: boolean): string {
+    return `session-list-item flex w-full items-stretch rounded-lg transition-colors${selected ? ' bg-[var(--app-secondary-bg)]' : ''}`
+}
+
+/** Focusable row control — owns `group/session-row` for keyboard tooltip reveal. */
+export function sessionListItemButtonClassName(): string {
+    return 'group/session-row flex min-w-0 flex-1 flex-col gap-1 px-2.5 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)] select-none rounded-lg'
+}
+
 type SessionGroup = {
     key: string
     directory: string
@@ -862,12 +871,12 @@ function SessionItem(props: {
     return (
         <>
             <div
-                className={`session-list-item flex w-full items-stretch rounded-lg transition-colors ${selected ? 'bg-[var(--app-secondary-bg)]' : ''}`}
+                className={sessionListItemWrapperClassName(selected)}
             >
                 <button
                     type="button"
                     {...longPressHandlers}
-                    className="group/session-row flex min-w-0 flex-1 flex-col gap-1 px-2.5 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)] select-none rounded-lg"
+                    className={sessionListItemButtonClassName()}
                     style={{ WebkitTouchCallout: 'none' }}
                     aria-current={selected ? 'page' : undefined}
                     aria-describedby={describedBy}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -29,6 +29,8 @@ import { getMachinePlatform, presentMachineHealth } from '@/lib/machineHealth'
 import { MachineFilterBar } from '@/components/MachineFilterBar'
 import { useSessionListMachineFilter } from '@/hooks/useSessionListMachineFilter'
 import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStatus'
+import { SessionPrChip } from '@/components/SessionPrChip'
+import { getPrimaryGithubPrRef } from '@hapi/protocol'
 
 type SessionGroup = {
     key: string
@@ -838,6 +840,7 @@ function SessionItem(props: {
     const sessionName = getSessionTitle(s)
     const worktreeLabel = getWorktreeSessionLabel(s)
     const todoProgress = getTodoProgress(s)
+    const primaryPrRef = getPrimaryGithubPrRef(s.metadata?.externalRefs)
     const attention = useMemo(
         () => showDetailedStatus
             ? classifySessionAttention(s, {
@@ -858,76 +861,85 @@ function SessionItem(props: {
     )
     return (
         <>
-            <button
-                type="button"
-                {...longPressHandlers}
-                className={`session-list-item group/session-row flex w-full flex-col gap-1 py-2 pl-2.5 pr-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)] select-none rounded-lg ${selected ? 'bg-[var(--app-secondary-bg)]' : ''}`}
-                style={{ WebkitTouchCallout: 'none' }}
-                aria-current={selected ? 'page' : undefined}
-                aria-describedby={describedBy}
+            <div
+                className={`session-list-item flex w-full items-stretch rounded-lg transition-colors ${selected ? 'bg-[var(--app-secondary-bg)]' : ''}`}
             >
-                <div className={`flex items-center justify-between gap-3 ${!s.active ? 'opacity-50' : ''}`}>
-                    <div className="flex items-center gap-2 min-w-0">
-                        <AgentFlavorIcon flavor={s.metadata?.flavor} className="h-4 w-4 shrink-0 -translate-y-px" />
-                        <div className={`truncate text-sm font-medium ${s.active ? 'text-[var(--app-fg)]' : 'text-[var(--app-hint)]'}`}>
-                            {sessionName}
-                        </div>
-                        {s.active && s.thinking ? (
-                            <LoaderIcon className="h-3.5 w-3.5 shrink-0 text-[var(--app-hint)] animate-spin-slow" />
-                        ) : attention ? (
-                            <SessionAttentionIndicator
-                                attention={attention}
-                                summary={s}
-                                label={attentionLabel ?? ''}
-                                tooltipId={attentionId!}
-                            />
-                        ) : null}
-                        {hasScheduleTooltip ? (
-                            <HoverTooltip
-                                id={scheduleId!}
-                                target={<ScheduleIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />}
-                                side="bottom"
-                                align="start"
-                                className="shrink-0"
-                                revealOnParentFocusClass={SESSION_ROW_TOOLTIP_FOCUS_CLASS}
-                            >
-                                <span className="block">
-                                    <span className="block font-medium">{scheduledLabel}</span>
-                                    <span className="mt-1 block text-[var(--app-hint)]">
-                                        {formatScheduledTooltipDetail(s, t)}
+                <button
+                    type="button"
+                    {...longPressHandlers}
+                    className="group/session-row flex min-w-0 flex-1 flex-col gap-1 px-2.5 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)] select-none rounded-lg"
+                    style={{ WebkitTouchCallout: 'none' }}
+                    aria-current={selected ? 'page' : undefined}
+                    aria-describedby={describedBy}
+                >
+                    <div className={`flex items-center justify-between gap-3 ${!s.active ? 'opacity-50' : ''}`}>
+                        <div className="flex items-center gap-2 min-w-0">
+                            <AgentFlavorIcon flavor={s.metadata?.flavor} className="h-4 w-4 shrink-0 -translate-y-px" />
+                            <div className={`truncate text-sm font-medium ${s.active ? 'text-[var(--app-fg)]' : 'text-[var(--app-hint)]'}`}>
+                                {sessionName}
+                            </div>
+                            {s.active && s.thinking ? (
+                                <LoaderIcon className="h-3.5 w-3.5 shrink-0 text-[var(--app-hint)] animate-spin-slow" />
+                            ) : attention ? (
+                                <SessionAttentionIndicator
+                                    attention={attention}
+                                    summary={s}
+                                    label={attentionLabel ?? ''}
+                                    tooltipId={attentionId!}
+                                />
+                            ) : null}
+                            {hasScheduleTooltip ? (
+                                <HoverTooltip
+                                    id={scheduleId!}
+                                    target={<ScheduleIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />}
+                                    side="bottom"
+                                    align="start"
+                                    className="shrink-0"
+                                    revealOnParentFocusClass={SESSION_ROW_TOOLTIP_FOCUS_CLASS}
+                                >
+                                    <span className="block">
+                                        <span className="block font-medium">{scheduledLabel}</span>
+                                        <span className="mt-1 block text-[var(--app-hint)]">
+                                            {formatScheduledTooltipDetail(s, t)}
+                                        </span>
                                     </span>
+                                </HoverTooltip>
+                            ) : null}
+                        </div>
+                        <div className="flex items-center gap-2 shrink-0 text-xs">
+                            {todoProgress ? (
+                                <span className="flex items-center gap-1 text-[var(--app-hint)]">
+                                    <BulbIcon className="h-3 w-3" />
+                                    {todoProgress.completed}/{todoProgress.total}
                                 </span>
-                            </HoverTooltip>
-                        ) : null}
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0 text-xs">
-                        {todoProgress ? (
-                            <span className="flex items-center gap-1 text-[var(--app-hint)]">
-                                <BulbIcon className="h-3 w-3" />
-                                {todoProgress.completed}/{todoProgress.total}
+                            ) : null}
+                            {!attention && s.pendingRequestsCount > 0 ? (
+                                <span className="text-[var(--app-badge-warning-text)]">
+                                    {t('session.item.pending')} {s.pendingRequestsCount}
+                                </span>
+                            ) : null}
+                            <span className="tabular-nums text-[var(--app-hint)]">
+                                {getSessionTimeLabel(s, t)}
                             </span>
-                        ) : null}
-                        {!attention && s.pendingRequestsCount > 0 ? (
-                            <span className="text-[var(--app-badge-warning-text)]">
-                                {t('session.item.pending')} {s.pendingRequestsCount}
-                            </span>
-                        ) : null}
-                        <span className="tabular-nums text-[var(--app-hint)]">
-                            {getSessionTimeLabel(s, t)}
-                        </span>
+                        </div>
                     </div>
-                </div>
-                {showPath || worktreeLabel ? (
-                    <div
-                        className="truncate text-xs text-[var(--app-hint)]"
-                        title={worktreeLabel
-                            ? s.metadata?.worktree?.worktreePath ?? s.metadata?.path
-                            : undefined}
-                    >
-                        {worktreeLabel ?? s.metadata?.path ?? s.id}
+                    {showPath || worktreeLabel ? (
+                        <div
+                            className="truncate text-xs text-[var(--app-hint)]"
+                            title={worktreeLabel
+                                ? s.metadata?.worktree?.worktreePath ?? s.metadata?.path
+                                : undefined}
+                        >
+                            {worktreeLabel ?? s.metadata?.path ?? s.id}
+                        </div>
+                    ) : null}
+                </button>
+                {primaryPrRef ? (
+                    <div className={`flex shrink-0 items-start pt-2.5 pr-2.5 ${!s.active ? 'opacity-50' : ''}`}>
+                        <SessionPrChip refs={s.metadata?.externalRefs} />
                     </div>
                 ) : null}
-            </button>
+            </div>
 
             <SessionActionMenu
                 isOpen={menuOpen}

--- a/web/src/components/SessionPrChip.test.ts
+++ b/web/src/components/SessionPrChip.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { formatGithubPrChipLabel } from './SessionPrChip'
+import { getPrimaryGithubPrRef } from '@hapi/protocol'
+
+describe('SessionPrChip helpers', () => {
+    it('formats the chip label from the PR number only', () => {
+        expect(formatGithubPrChipLabel({
+            kind: 'github_pr',
+            repo: 'tiann/hapi',
+            number: 1160,
+            url: 'https://github.com/tiann/hapi/pull/1160',
+            role: 'primary'
+        })).toBe('#1160')
+    })
+
+    it('does not infer a PR from title-like strings (structured refs only)', () => {
+        // Callers must pass metadata.externalRefs — never parse "PR #1160" titles.
+        expect(getPrimaryGithubPrRef(undefined)).toBeNull()
+        expect(getPrimaryGithubPrRef([])).toBeNull()
+    })
+})

--- a/web/src/components/SessionPrChip.tsx
+++ b/web/src/components/SessionPrChip.tsx
@@ -1,0 +1,45 @@
+import type { ExternalRef, GithubPrExternalRef } from '@/types/api'
+import { getPrimaryGithubPrRef } from '@hapi/protocol'
+import { cn } from '@/lib/utils'
+import { useTranslation } from '@/lib/use-translation'
+
+export type SessionPrChipProps = {
+    refs: readonly ExternalRef[] | null | undefined
+    className?: string
+}
+
+export function formatGithubPrChipLabel(ref: GithubPrExternalRef): string {
+    return `#${ref.number}`
+}
+
+/**
+ * Clickable primary GitHub PR chip for session list rows.
+ * Identity comes from structured `externalRefs` only — never from title text.
+ */
+export function SessionPrChip(props: SessionPrChipProps) {
+    const { t } = useTranslation()
+    const primary = getPrimaryGithubPrRef(props.refs)
+    if (!primary) return null
+
+    return (
+        <a
+            href={primary.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="session-pr-chip"
+            title={`${primary.repo}#${primary.number}`}
+            aria-label={t('session.item.prChip', { number: primary.number })}
+            onClick={(event) => event.stopPropagation()}
+            onPointerDown={(event) => event.stopPropagation()}
+            className={cn(
+                'inline-flex shrink-0 items-center rounded-md border border-[var(--app-border)]',
+                'bg-[var(--app-subtle-bg)] px-1.5 py-0.5 text-[11px] font-medium tabular-nums',
+                'text-[var(--app-link)] hover:opacity-90 focus-visible:outline-none',
+                'focus-visible:ring-2 focus-visible:ring-[var(--app-link)]',
+                props.className
+            )}
+        >
+            {formatGithubPrChipLabel(primary)}
+        </a>
+    )
+}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -130,6 +130,7 @@ export default {
   'session.item.model': 'model',
   'session.item.worktree': 'worktree',
   'session.item.pending': 'pending',
+  'session.item.prChip': 'PR {number}',
   'session.item.thinking': 'thinking',
   'session.item.permission': 'Permission required',
   'session.item.needsInput': 'Needs input',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -130,6 +130,7 @@ export default {
   'session.item.model': '模型',
   'session.item.worktree': '工作树',
   'session.item.pending': '待处理',
+  'session.item.prChip': 'PR {number}',
   'session.item.thinking': '思考中',
   'session.item.permission': '需要权限',
   'session.item.needsInput': '需要输入',

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -49,6 +49,8 @@ export type {
     AgentState,
     AttachmentMetadata,
     CodexCollaborationMode,
+    ExternalRef,
+    GithubPrExternalRef,
     Metadata,
     PermissionMode,
     Machine,


### PR DESCRIPTION
## Summary

- Add optional `metadata.externalRefs` with a structured `github_pr` shape (`repo`, `number`, `url`, `role`) so session↔PR identity is not scraped from titles.
- Project refs into `SessionSummary` and show a clickable primary-PR chip (`#N`) on session list rows.
- Add `GET /api/sessions/:id/external-refs` (JWT web auth) returning `{ externalRefs }`.

Writable via existing session create / `update-metadata` paths. No title/emoji parsing.

## Test plan

- [x] `bun typecheck`
- [x] shared + hub unit tests for schema / summary / route
- [x] peer-stack Playwright (`e2e/peer/1160-session-external-refs-pr-chip.spec.ts` on fork main)
- [x] Operator dogfood: expanded session group and reviewed the clickable PR chip on the peer stack

## Issues

Fixes #1160