### PR TITLE
fix(web): stop voice backend detection from raising the error banner

### DIFF
--- a/web/src/realtime/VoiceBackendSession.test.tsx
+++ b/web/src/realtime/VoiceBackendSession.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { VoiceBackendSession } from '@/realtime/VoiceBackendSession'
+import type { ApiClient } from '@/api/client'
+
+const fetchVoiceBackendMock = vi.fn()
+
+vi.mock('@/api/voice', () => ({
+    fetchVoiceBackend: (api: ApiClient) => fetchVoiceBackendMock(api),
+}))
+
+vi.mock('@/realtime/RealtimeVoiceSession', () => ({
+    RealtimeVoiceSession: () => null,
+}))
+
+vi.mock('@/realtime/GeminiLiveVoiceSession', () => ({
+    GeminiLiveVoiceSession: () => null,
+}))
+
+vi.mock('@/realtime/QwenVoiceSession', () => ({
+    QwenVoiceSession: () => null,
+}))
+
+const api = {} as ApiClient
+
+describe('VoiceBackendSession', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('does not report a voice error when backend detection fails', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const detectionError = new Error('HTTP 404 : 404 Not Found')
+        fetchVoiceBackendMock.mockRejectedValue(detectionError)
+        const onStatusChange = vi.fn()
+
+        render(<VoiceBackendSession api={api} micMuted={false} onStatusChange={onStatusChange} />)
+
+        await waitFor(() => {
+            expect(consoleError).toHaveBeenCalledWith(expect.any(String), detectionError)
+        })
+        expect(onStatusChange).not.toHaveBeenCalled()
+
+        consoleError.mockRestore()
+    })
+
+    it('reports the detected backend as ready', async () => {
+        fetchVoiceBackendMock.mockResolvedValue({ backend: 'elevenlabs', backends: ['elevenlabs'] })
+        const onStatusChange = vi.fn()
+
+        render(<VoiceBackendSession api={api} micMuted={false} onStatusChange={onStatusChange} />)
+
+        await waitFor(() => {
+            expect(fetchVoiceBackendMock).toHaveBeenCalledWith(api)
+        })
+        expect(onStatusChange).not.toHaveBeenCalled()
+    })
+})

--- a/web/src/realtime/VoiceBackendSession.tsx
+++ b/web/src/realtime/VoiceBackendSession.tsx
@@ -36,8 +36,10 @@ export function VoiceBackendSession(props: VoiceBackendSessionProps) {
             }
         }).catch((err: unknown) => {
             if (!cancelled) {
-                const msg = err instanceof Error ? err.message : 'Could not detect voice backend'
-                props.onStatusChange?.('error', msg)
+                // Detection runs on mount for every session, not in response to a user action,
+                // so it must not raise the global voice error banner. Leaving `backend` null
+                // keeps `onReadyChange` false, which disables the voice button.
+                console.error('Could not detect voice backend:', err)
             }
         })
         return () => {


### PR DESCRIPTION
## Problem

Opening any session chat can flash a full-width red banner reading `HTTP 404 : 404 Not Found`, with no relation to anything the user did.

`SessionChat` mounts `VoiceBackendSession` unconditionally (`voice` comes from the always-present `VoiceProvider`), so the `GET /voice/backend` probe fires on every session page load. When that probe fails, `VoiceBackendSession` reported it through `onStatusChange('error', err.message)`, which drives the global `VoiceErrorBanner` — a raw transport-level string shown to users who never touched voice.

The 404 is easy to hit in practice: the route was added in 0.19.0 (59c29e8), so any hub older than that returns Hono's default 404 body. `client.ts` then formats it as `HTTP ${status} ${statusText}: ${body}`, and since `statusText` is empty over HTTP/2 the result is the odd-looking `HTTP 404 : 404 Not Found`.

## Fix

Log the detection failure instead of routing it to the error banner. Backend detection is a background capability probe, not a user-initiated action.

Nothing is swallowed: `onReadyChange(true)` is only called once a backend session registers, so a failed probe leaves the voice button disabled (`SessionChat.tsx` gates `onVoiceToggle` on `voiceBackendReady`). Errors from actually starting a voice session are untouched and still surface in the banner.

## Tests

Added `web/src/realtime/VoiceBackendSession.test.tsx` covering that a rejected probe logs rather than calling `onStatusChange`.

- `bun run typecheck` in `web/` passes.
- The new test passes. Note: `AgentFlavorIcon`, `AgentSelector` and `SessionList.directory-action` tests already fail on `main` at this commit, unrelated to this change.