### PR TITLE
fix(web): reasoning overflow and settings label spacing

### DIFF
--- a/web/src/components/assistant-ui/reasoning.tsx
+++ b/web/src/components/assistant-ui/reasoning.tsx
@@ -96,7 +96,7 @@ export const ReasoningGroup: FC<PropsWithChildren> = ({ children }) => {
                     isOpen ? 'max-h-[5000px] opacity-100' : 'max-h-0 opacity-0'
                 )}
             >
-                <div className="border-t border-[var(--app-divider)] px-3.5 py-3">
+                <div className="max-h-[60vh] overflow-y-auto overscroll-contain border-t border-[var(--app-divider)] px-3.5 py-3">
                     {children}
                 </div>
             </div>

--- a/web/src/components/settings/SettingsPrimitives.tsx
+++ b/web/src/components/settings/SettingsPrimitives.tsx
@@ -74,8 +74,8 @@ export function SettingsChoiceGroup<T extends string | number>(props: {
 }) {
     const columns = props.columns === 5 ? 'grid-cols-5' : props.columns === 4 ? 'grid-cols-2 sm:grid-cols-4' : 'grid-cols-2'
     return (
-        <fieldset className="px-3 py-3">
-            <legend className="mb-2 text-[var(--app-fg)]">{props.label}</legend>
+        <div className="px-3 py-3">
+            <div className="mb-2 text-[var(--app-fg)]">{props.label}</div>
             <div role="radiogroup" aria-label={props.label} className={`grid ${columns} gap-2`}>
                 {props.options.map((option) => {
                     const selected = props.value === option.value
@@ -96,7 +96,7 @@ export function SettingsChoiceGroup<T extends string | number>(props: {
                     )
                 })}
             </div>
-        </fieldset>
+        </div>
     )
 }
 

--- a/web/src/routes/settings/chat.tsx
+++ b/web/src/routes/settings/chat.tsx
@@ -22,8 +22,8 @@ function ChatSurfaceColorControl(props: {
     const { t } = useTranslation()
     const pickerValue = getChatSurfaceColorPickerValue(props.preference)
     return (
-        <fieldset className="px-3 py-3">
-            <legend className="mb-2 text-[var(--app-fg)]">{props.label}</legend>
+        <div className="px-3 py-3">
+            <div className="mb-2 text-[var(--app-fg)]">{props.label}</div>
             <div role="radiogroup" aria-label={props.label} className="grid grid-cols-2 gap-2 sm:grid-cols-4">
                 {getChatSurfaceColorPresetOptions().map((option) => {
                     const preference = toPresetChatSurfaceColorPreference(option.value)
@@ -40,7 +40,7 @@ function ChatSurfaceColorControl(props: {
                 {t('settings.chat.surfaceColor.custom')}
                 <input type="color" value={pickerValue} onChange={(event) => props.onCustomChange(event.target.value)} className="h-9 w-12 cursor-pointer border-0 bg-transparent p-0" />
             </label>
-        </fieldset>
+        </div>
     )
 }
 

--- a/web/src/routes/settings/display.tsx
+++ b/web/src/routes/settings/display.tsx
@@ -23,8 +23,8 @@ function ColorThemePicker() {
     const { colorTheme, setColorTheme } = useColorTheme()
 
     return (
-        <fieldset className="px-3 py-3">
-            <legend className="mb-2 text-[var(--app-fg)]">{t('settings.display.colorTheme')}</legend>
+        <div className="px-3 py-3">
+            <div className="mb-2 text-[var(--app-fg)]">{t('settings.display.colorTheme')}</div>
             <div role="radiogroup" aria-label={t('settings.display.colorTheme')} className="grid grid-cols-2 gap-2 sm:grid-cols-4">
                 {getColorThemeOptions().map((option) => (
                     <ColorThemeOption
@@ -36,7 +36,7 @@ function ColorThemePicker() {
                     />
                 ))}
             </div>
-        </fieldset>
+        </div>
     )
 }
 


### PR DESCRIPTION
This PR contains two independent UI fixes.

**Reasoning block growing without bound**
The reasoning/thinking panel had no real height limit — its content
wrapper only used max-h-[5000px] as a trick to animate the open/close
transition. A long reasoning trace rendered at up to 5000px of actual
height directly in the message list, pushing the whole page taller
than the viewport and dragging the composer along when scrolling.
Capped the content at 60vh with its own overflow-y-auto and
overscroll-contain so it scrolls internally instead of growing the
page.

**Settings choice-group labels hugging the top edge**
The language, appearance, and color-theme pickers wrapped their label
and options in a fieldset/legend pair for the py-3 padding, but a
legend renders inside the fieldset's border area and ignores the
container's padding-top, so the label sat flush against the top edge
instead of leaving space above it. Swapped fieldset/legend for plain
divs; the existing role="radiogroup" and aria-label already label the
group for assistive tech.