### PR TITLE
fix(hub): archive active sessions with stale metadata

### DIFF
--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -1167,6 +1167,28 @@ describe('sessions routes', () => {
             expect(calls).toEqual(['session-1'])
         })
 
+        it('archives an active session with stale archived lifecycle metadata', async () => {
+            const calls: string[] = []
+            const session = createSession({
+                active: true,
+                metadata: {
+                    path: '/tmp/project',
+                    host: 'localhost',
+                    flavor: 'codex',
+                    lifecycleState: 'archived'
+                }
+            })
+            const { app } = createApp(session, {
+                archiveSession: async (sessionId: string) => { calls.push(sessionId) }
+            })
+
+            const response = await app.request('/api/sessions/session-1/archive', { method: 'POST' })
+
+            expect(response.status).toBe(200)
+            expect(calls).toEqual(['session-1'])
+            expect(await response.json()).toEqual({ ok: true })
+        })
+
         it('returns 2xx and skips archiveSession when the row is already archived (idempotent)', async () => {
             let called = false
             const session = createSession({

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -339,7 +339,7 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         }
 
         const lifecycleState = sessionResult.session.metadata?.lifecycleState
-        if (lifecycleState === 'archived') {
+        if (!sessionResult.session.active && lifecycleState === 'archived') {
             return c.json({ ok: true, alreadyArchived: true })
         }
 


### PR DESCRIPTION
## Problem

A session can reconnect after its persisted lifecycle metadata has already been marked archived. The reconnecting CLI makes the session active again, but the archive endpoint currently treats the archived metadata alone as proof that there is nothing left to stop. An Archive request then reports success without sending the kill RPC, so the live CLI remains attached.

## Solution

Treat the already-archived response as idempotent only when the session is also inactive. Active sessions continue through the existing archive path, while the existing inactive-and-archived no-op, inactive-and-running cleanup, and inactive non-running conflict behavior remain unchanged.

## Usage

No configuration or workflow changes are required. Use the existing Archive action; active sessions now continue through the normal archive path even if their persisted lifecycle metadata is already archived.

## Tests

Added a route regression test for an active session with archived lifecycle metadata, asserting that the archive engine is called and the endpoint returns the normal success response. Existing route tests cover the complementary inactive states.

`bun typecheck` and `bun run test` pass. Manually verified end to end in an isolated Hub/Web stack with a reconnecting fake Codex CLI.

---

AI disclosure (per `CONTRIBUTING.md`): OpenAI Codex was used to assist with implementation, testing, and drafting this pull request.
