### PR TITLE
fix(web): keep session sidebar stable after selection

### DIFF
--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -321,4 +321,29 @@ describe('SessionList collapse behavior', () => {
             expect(getProjectPanel().getAttribute('data-open')).toBe('true')
         })
     })
+
+    it('keeps the previous selected path open when selection moves', async () => {
+        const sessions = [
+            makeSession({
+                id: 'session-first',
+                updatedAt: 100,
+                metadata: { path: '/work/first', name: 'First task', flavor: 'codex' },
+            }),
+            makeSession({
+                id: 'session-second',
+                updatedAt: 90,
+                metadata: { path: '/work/second', name: 'Second task', flavor: 'codex' },
+            })
+        ]
+        const { rerender } = render(renderSessionList(sessions, 'session-first'))
+        const firstPanel = screen.getByTitle('/work/first').nextElementSibling
+
+        expect(firstPanel?.getAttribute('data-open')).toBe('true')
+
+        rerender(renderSessionList(sessions, 'session-second'))
+
+        await waitFor(() => {
+            expect(firstPanel?.getAttribute('data-open')).toBe('true')
+        })
+    })
 })

--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -441,9 +441,9 @@ describe('expandSelectedSessionCollapseOverrides', () => {
             machineId: 'machine-1'
         })
 
-        expect(result.has('machine-1::/work/hapi')).toBe(false)
+        expect(result.get('machine-1::/work/hapi')).toBe(false)
         expect(result.get('sessions::machine-1::/work/hapi')).toBe(true)
-        expect(result.has('machine::machine-1')).toBe(false)
+        expect(result.get('machine::machine-1')).toBe(false)
     })
 
     it('leaves missing session preview override unset', () => {

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -283,15 +283,16 @@ export function expandSelectedSessionCollapseOverrides(
     const next = new Map(overrides)
     let changed = false
 
-    // Expand project group if collapsed. Project and machine keys use true = collapsed.
-    if (overrides.has(group.key) && overrides.get(group.key)) {
-        next.delete(group.key)
+    // Keep auto-expanded paths open after selection moves so content above the
+    // clicked row does not collapse and displace the sidebar viewport.
+    if (overrides.get(group.key) !== false) {
+        next.set(group.key, false)
         changed = true
     }
 
     const machineKey = `machine::${group.machineId ?? UNKNOWN_MACHINE_ID}`
-    if (overrides.has(machineKey) && overrides.get(machineKey)) {
-        next.delete(machineKey)
+    if (overrides.get(machineKey) !== false) {
+        next.set(machineKey, false)
         changed = true
     }
 


### PR DESCRIPTION
## Summary

- keep project and machine paths opened by session selection explicitly expanded
- prevent the previously selected path from collapsing and permanently displacing the scrolled sidebar
- add a regression test for selection moving between inactive project paths

## Root cause

The selected path was only implicitly open while it contained `selectedSessionId`. Selecting another session removed that implicit condition, so the previous path collapsed with the shared height animation and moved content beneath the unchanged sidebar viewport.

## Validation

- `bun typecheck`
- `bun run test` — CLI 1461 passed; Hub 508 passed, 3 skipped; Web 1391 passed; Shared 115 passed
- focused `SessionList` suites — 44 passed

Fixes #1169
