### PR TITLE
fix: recover Codex resume ID from stored messages

### DIFF
--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -16,6 +16,131 @@ function createPublisher(events: SyncEvent[]): EventPublisher {
     } as unknown as EventPublisher
 }
 
+function productionCodexMessage(event: Record<string, unknown>): Record<string, unknown> {
+    return {
+        role: 'agent',
+        content: {
+            type: 'codex',
+            data: event
+        }
+    }
+}
+
+function productionCodexContextResetMessage(): Record<string, unknown> {
+    return {
+        role: 'agent',
+        content: {
+            id: 'context-reset-event',
+            type: 'event',
+            data: {
+                type: 'message',
+                message: 'Context was reset'
+            }
+        }
+    }
+}
+
+function productionCodexScope(
+    role: 'parent' | 'child',
+    threadId: string,
+    parentThreadId?: string
+): Record<string, unknown> {
+    const parent = parentThreadId
+        ? { parent_thread_id: parentThreadId, parentThreadId }
+        : {}
+    return {
+        thread_id: threadId,
+        threadId,
+        ...parent,
+        scope_role: role,
+        scopeRole: role,
+        scope: { role, thread_id: threadId, threadId, ...parent }
+    }
+}
+
+async function runCodexResumeScenario(
+    messages: Record<string, unknown>[],
+    codexSessionId?: string,
+    options?: {
+        archived?: boolean
+        concurrentMetadata?: Record<string, unknown>
+    }
+) {
+    const store = new Store(':memory:')
+    const engine = new SyncEngine(
+        store,
+        {} as never,
+        new RpcRegistry(),
+        { broadcast() {} } as never
+    )
+    const session = engine.getOrCreateSession(
+        'session-codex-resume-from-messages',
+        {
+            path: '/tmp/project',
+            host: 'localhost',
+            machineId: 'machine-1',
+            flavor: 'codex',
+            ...(codexSessionId ? { codexSessionId } : {}),
+            ...(options?.archived
+                ? {
+                    lifecycleState: 'archived',
+                    archivedBy: 'cli',
+                    archiveReason: 'Context reset before exit'
+                }
+                : {})
+        },
+        null,
+        'default',
+        'gpt-5'
+    )
+    engine.getOrCreateMachine(
+        'machine-1',
+        { host: 'localhost', platform: 'linux', happyCliVersion: '0.1.0' },
+        null,
+        'default'
+    )
+    engine.handleMachineAlive({ machineId: 'machine-1', time: Date.now() })
+
+    for (const message of messages) {
+        store.messages.addMessage(session.id, message)
+    }
+    if (options?.concurrentMetadata) {
+        const current = store.sessions.getSessionByNamespace(session.id, 'default')!
+        const result = store.sessions.updateSessionMetadata(
+            session.id,
+            { ...current.metadata!, ...options.concurrentMetadata },
+            current.metadataVersion,
+            'default',
+            { touchUpdatedAt: false }
+        )
+        if (result.result !== 'success') throw new Error('Failed to prepare stale metadata fixture')
+    }
+    const before = store.sessions.getSession(session.id)!
+    const capturedResumeSessionIds: Array<string | undefined> = []
+    ;(engine as any).rpcGateway.spawnSession = async (...args: Parameters<SyncEngine['spawnSession']>) => {
+        capturedResumeSessionIds.push(args[8])
+        return { type: 'success', sessionId: session.id }
+    }
+    ;(engine as any).waitForSessionActive = async () => true
+
+    try {
+        const result = options?.archived
+            ? await engine.reopenSession(session.id, 'default')
+            : await engine.resumeSession(session.id, 'default')
+        const after = store.sessions.getSession(session.id)!
+        return {
+            result,
+            capturedResumeSessionIds,
+            before,
+            after,
+            persistedCodexSessionId: (after.metadata as { codexSessionId?: string } | null)?.codexSessionId,
+            cachedCodexSessionId: engine.getSession(session.id)?.metadata?.codexSessionId
+        }
+    } finally {
+        engine.stop()
+    }
+}
+
 describe('session model', () => {
     it('includes explicit model in session summaries', () => {
         const store = new Store(':memory:')
@@ -1015,6 +1140,191 @@ describe('session model', () => {
         } finally {
             engine.stop()
         }
+    })
+
+    it('recovers the explicit Codex parent thread when a newer child event exists', async () => {
+        const rootThreadId = '33333333-3333-4333-8333-333333333333'
+        const childThreadId = '44444444-4444-4444-8444-444444444444'
+        const outcome = await runCodexResumeScenario([
+            productionCodexMessage({
+                type: 'token_count',
+                ...productionCodexScope('parent', rootThreadId)
+            }),
+            productionCodexMessage({
+                type: 'agent-run-trace',
+                ...productionCodexScope('child', childThreadId, rootThreadId)
+            })
+        ])
+
+        expect(outcome.result).toEqual({ type: 'success', sessionId: outcome.after.id })
+        expect(outcome.capturedResumeSessionIds).toEqual([rootThreadId])
+        expect([
+            outcome.persistedCodexSessionId,
+            outcome.cachedCodexSessionId,
+            outcome.after.metadataVersion,
+            outcome.after.updatedAt
+        ]).toEqual([
+            rootThreadId,
+            rootThreadId,
+            outcome.before.metadataVersion + 1,
+            outcome.before.updatedAt
+        ])
+    })
+
+    it('prefers the Codex resume ID already stored in metadata', async () => {
+        const metadataThreadId = 'metadata-codex-thread'
+        const messageThreadId = '55555555-5555-4555-8555-555555555555'
+        const outcome = await runCodexResumeScenario(
+            [productionCodexMessage(productionCodexScope('parent', messageThreadId))],
+            metadataThreadId
+        )
+
+        expect(outcome.result).toEqual({ type: 'success', sessionId: outcome.after.id })
+        expect(outcome.capturedResumeSessionIds).toEqual([metadataThreadId])
+        expect(outcome.after).toMatchObject({
+            metadata: { codexSessionId: metadataThreadId },
+            metadataVersion: outcome.before.metadataVersion,
+            updatedAt: outcome.before.updatedAt
+        })
+    })
+
+    it('does not recover a Codex thread from before an explicit context reset', async () => {
+        const oldThreadId = '88888888-8888-4888-8888-888888888888'
+        const outcome = await runCodexResumeScenario([
+            productionCodexMessage(productionCodexScope('parent', oldThreadId)),
+            productionCodexContextResetMessage()
+        ], undefined, { archived: true })
+
+        expect(outcome.result).toMatchObject({ type: 'error', code: 'resume_unavailable' })
+        expect(outcome.capturedResumeSessionIds).toEqual([])
+        expect(outcome.persistedCodexSessionId).toBeUndefined()
+        expect(outcome.after.metadata).toMatchObject({
+            lifecycleState: 'archived',
+            archivedBy: 'cli',
+            archiveReason: 'Context reset before exit'
+        })
+    })
+
+    it('recovers a new Codex parent thread created after a context reset', async () => {
+        const oldThreadId = '88888888-8888-4888-8888-888888888888'
+        const newThreadId = '99999999-9999-4999-8999-999999999999'
+        const outcome = await runCodexResumeScenario([
+            productionCodexMessage(productionCodexScope('parent', oldThreadId)),
+            productionCodexContextResetMessage(),
+            productionCodexMessage(productionCodexScope('parent', newThreadId))
+        ])
+
+        expect(outcome.result).toEqual({ type: 'success', sessionId: outcome.after.id })
+        expect(outcome.capturedResumeSessionIds).toEqual([newThreadId])
+        expect(outcome.persistedCodexSessionId).toBe(newThreadId)
+    })
+
+    it('does not treat raw user /clear text as a Codex context reset boundary', async () => {
+        const threadId = '88888888-8888-4888-8888-888888888888'
+        const outcome = await runCodexResumeScenario([
+            productionCodexMessage(productionCodexScope('parent', threadId)),
+            { role: 'user', content: { type: 'text', text: '/clear' } }
+        ])
+
+        expect(outcome.result).toEqual({ type: 'success', sessionId: outcome.after.id })
+        expect(outcome.capturedResumeSessionIds).toEqual([threadId])
+        expect(outcome.persistedCodexSessionId).toBe(threadId)
+    })
+
+    it('prefers a Codex resume ID written concurrently during recovery persistence', async () => {
+        const messageThreadId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+        const concurrentThreadId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+        const outcome = await runCodexResumeScenario(
+            [productionCodexMessage(productionCodexScope('parent', messageThreadId))],
+            undefined,
+            {
+                concurrentMetadata: { codexSessionId: concurrentThreadId }
+            }
+        )
+
+        expect(outcome.result).toEqual({ type: 'success', sessionId: outcome.after.id })
+        expect(outcome.capturedResumeSessionIds).toEqual([concurrentThreadId])
+        expect([
+            outcome.persistedCodexSessionId,
+            outcome.cachedCodexSessionId,
+            outcome.after.metadataVersion,
+            outcome.after.updatedAt
+        ]).toEqual([
+            concurrentThreadId,
+            concurrentThreadId,
+            outcome.before.metadataVersion,
+            outcome.before.updatedAt
+        ])
+    })
+
+    it('retries Codex recovery persistence after an unrelated concurrent metadata write', async () => {
+        const messageThreadId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+        const outcome = await runCodexResumeScenario(
+            [productionCodexMessage(productionCodexScope('parent', messageThreadId))],
+            undefined,
+            {
+                concurrentMetadata: { name: 'Concurrent rename' }
+            }
+        )
+
+        expect(outcome.result).toEqual({ type: 'success', sessionId: outcome.after.id })
+        expect(outcome.capturedResumeSessionIds).toEqual([messageThreadId])
+        expect(outcome.after.metadata).toMatchObject({
+            codexSessionId: messageThreadId,
+            name: 'Concurrent rename'
+        })
+        expect([
+            outcome.cachedCodexSessionId,
+            outcome.after.metadataVersion,
+            outcome.after.updatedAt
+        ]).toEqual([
+            messageThreadId,
+            outcome.before.metadataVersion + 1,
+            outcome.before.updatedAt
+        ])
+    })
+
+    const safeParentThreadId = '66666666-6666-4666-8666-666666666666'
+    const otherThreadId = '77777777-7777-4777-8777-777777777777'
+    const explicitParentEvent = productionCodexScope('parent', safeParentThreadId)
+    const rejectedCodexRecoveryCases: Array<[string, Record<string, unknown>[]]> = [
+        ['child-only event, including parent_thread_id', [
+            productionCodexMessage(productionCodexScope('child', otherThreadId, safeParentThreadId))
+        ]],
+        ['roleless event', [productionCodexMessage({
+            thread_id: safeParentThreadId,
+            scope: { threadId: safeParentThreadId }
+        })]],
+        ['malformed UUID', [productionCodexMessage(productionCodexScope('parent', 'not-a-uuid'))]],
+        ['conflicting role aliases', [productionCodexMessage({
+            ...explicitParentEvent,
+            scopeRole: 'child'
+        })]],
+        ['conflicting thread IDs', [productionCodexMessage({
+            ...explicitParentEvent,
+            scope: { role: 'parent', thread_id: otherThreadId, threadId: otherThreadId }
+        })]],
+        ['valid and malformed thread aliases', [productionCodexMessage({
+            ...explicitParentEvent,
+            threadId: 'not-a-uuid'
+        })]],
+        ['unrelated nested payload', [productionCodexMessage({ payload: explicitParentEvent })]],
+        ['non-production outer envelopes', [
+            { role: 'user', content: { type: 'codex', data: explicitParentEvent } },
+            { role: 'agent', content: { type: 'output', data: explicitParentEvent } }
+        ]]
+    ]
+
+    it.each(rejectedCodexRecoveryCases)('does not recover a Codex resume ID from %s', async (name, messages) => {
+        const outcome = await runCodexResumeScenario(messages)
+
+        expect(outcome.result).toMatchObject({ type: 'error', code: 'resume_unavailable' })
+        expect([
+            outcome.capturedResumeSessionIds,
+            outcome.persistedCodexSessionId,
+            outcome.after.metadataVersion,
+            outcome.after.updatedAt
+        ]).toEqual([[], undefined, outcome.before.metadataVersion, outcome.before.updatedAt])
     })
 
     it('does not let stale default resume option override persisted Codex yolo', async () => {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -842,7 +842,9 @@ export class SyncEngine {
         }
 
         const flavor = this.resolveFlavor(session)
-        if (flavor === 'codex') return metadata.codexSessionId ?? null
+        if (flavor === 'codex') {
+            return metadata.codexSessionId ?? this.recoverCodexSessionIdFromMessages(session.id, namespace)
+        }
         if (flavor === 'gemini') return metadata.geminiSessionId ?? null
         if (flavor === 'opencode') return metadata.opencodeSessionId ?? null
         if (flavor === 'grok') return metadata.grokSessionId ?? null
@@ -1495,10 +1497,60 @@ export class SyncEngine {
             const found = this.extractClaudeSessionId(messages[i].content)
             if (!found) continue
 
-            this.persistRecoveredAgentSessionId(sessionId, namespace, 'claudeSessionId', found)
-            return found
+            return this.persistRecoveredAgentSessionId(sessionId, namespace, 'claudeSessionId', found)
         }
         return null
+    }
+
+    private recoverCodexSessionIdFromMessages(sessionId: string, namespace: string): string | null {
+        const messages = this.messageService.getMessages(sessionId, 200)
+        for (let i = messages.length - 1; i >= 0; i -= 1) {
+            const content = messages[i].content
+            if (this.isCodexContextResetMessage(content)) return null
+
+            const found = this.extractCodexParentThreadId(content)
+            if (!found) continue
+
+            return this.persistRecoveredAgentSessionId(sessionId, namespace, 'codexSessionId', found)
+        }
+        return null
+    }
+
+    private isCodexContextResetMessage(value: unknown): boolean {
+        const message = asRecord(value)
+        const content = asRecord(message?.content)
+        const event = asRecord(content?.data)
+        return message?.role === 'agent'
+            && content?.type === 'event'
+            && event?.type === 'message'
+            && event.message === 'Context was reset'
+    }
+
+    private extractCodexParentThreadId(value: unknown): string | null {
+        const message = asRecord(value)
+        const content = asRecord(message?.content)
+        const event = asRecord(content?.data)
+        if (message?.role !== 'agent' || content?.type !== 'codex' || !event) {
+            return null
+        }
+
+        const scope = asRecord(event.scope)
+        const roles = [event.scope_role, event.scopeRole, scope?.role]
+            .filter((role) => role !== undefined)
+        if (roles.length === 0 || roles.some((role) => role !== 'parent')) {
+            return null
+        }
+
+        const threadIds: string[] = []
+        for (const threadId of [event.thread_id, event.threadId, scope?.thread_id, scope?.threadId]) {
+            if (threadId === undefined) continue
+
+            const normalized = this.normalizeAgentSessionId(threadId)
+            if (!normalized) return null
+            threadIds.push(normalized)
+        }
+        const uniqueThreadIds = [...new Set(threadIds)]
+        return uniqueThreadIds.length === 1 ? uniqueThreadIds[0] : null
     }
 
     private extractClaudeSessionId(value: unknown): string | null {
@@ -1542,12 +1594,16 @@ export class SyncEngine {
         namespace: string,
         field: 'claudeSessionId' | 'codexSessionId',
         agentSessionId: string
-    ): void {
+    ): string {
         for (let attempt = 0; attempt < 2; attempt += 1) {
             const latest = this.sessionCache.getSessionByNamespace(sessionId, namespace)
                 ?? this.sessionCache.refreshSession(sessionId)
-            if (!latest?.metadata) return
-            if (latest.metadata[field] === agentSessionId) return
+            if (!latest?.metadata) return agentSessionId
+
+            const existingAgentSessionId = latest.metadata[field]
+            if (typeof existingAgentSessionId === 'string') {
+                return existingAgentSessionId
+            }
 
             const result = this.store.sessions.updateSessionMetadata(
                 sessionId,
@@ -1558,12 +1614,20 @@ export class SyncEngine {
             )
             if (result.result === 'success') {
                 this.sessionCache.refreshSession(sessionId)
-                return
+                return agentSessionId
             }
             if (result.result !== 'version-mismatch') {
-                return
+                return agentSessionId
+            }
+
+            this.sessionCache.refreshSession(sessionId)
+            const refreshed = this.sessionCache.getSessionByNamespace(sessionId, namespace)
+            const authoritativeAgentSessionId = refreshed?.metadata?.[field]
+            if (typeof authoritativeAgentSessionId === 'string') {
+                return authoritativeAgentSessionId
             }
         }
+        return agentSessionId
     }
 
     private hasSameAgentSessionIds(

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -1495,7 +1495,7 @@ export class SyncEngine {
             const found = this.extractClaudeSessionId(messages[i].content)
             if (!found) continue
 
-            this.persistRecoveredClaudeSessionId(sessionId, namespace, found)
+            this.persistRecoveredAgentSessionId(sessionId, namespace, 'claudeSessionId', found)
             return found
         }
         return null
@@ -1507,7 +1507,7 @@ export class SyncEngine {
         }
 
         const obj = value as Record<string, unknown>
-        const direct = this.normalizeClaudeSessionId(obj.session_id) ?? this.normalizeClaudeSessionId(obj.sessionId)
+        const direct = this.normalizeAgentSessionId(obj.session_id) ?? this.normalizeAgentSessionId(obj.sessionId)
         if (direct) {
             return direct
         }
@@ -1527,7 +1527,7 @@ export class SyncEngine {
         return null
     }
 
-    private normalizeClaudeSessionId(value: unknown): string | null {
+    private normalizeAgentSessionId(value: unknown): string | null {
         if (typeof value !== 'string') {
             return null
         }
@@ -1537,16 +1537,21 @@ export class SyncEngine {
             : null
     }
 
-    private persistRecoveredClaudeSessionId(sessionId: string, namespace: string, claudeSessionId: string): void {
+    private persistRecoveredAgentSessionId(
+        sessionId: string,
+        namespace: string,
+        field: 'claudeSessionId' | 'codexSessionId',
+        agentSessionId: string
+    ): void {
         for (let attempt = 0; attempt < 2; attempt += 1) {
             const latest = this.sessionCache.getSessionByNamespace(sessionId, namespace)
                 ?? this.sessionCache.refreshSession(sessionId)
             if (!latest?.metadata) return
-            if (latest.metadata.claudeSessionId === claudeSessionId) return
+            if (latest.metadata[field] === agentSessionId) return
 
             const result = this.store.sessions.updateSessionMetadata(
                 sessionId,
-                { ...latest.metadata, claudeSessionId },
+                { ...latest.metadata, [field]: agentSessionId },
                 latest.metadataVersion,
                 namespace,
                 { touchUpdatedAt: false }

--- a/web/src/lib/sessionResume.test.ts
+++ b/web/src/lib/sessionResume.test.ts
@@ -150,15 +150,21 @@ describe('sessionResume', () => {
         }), 3)).toBe(true)
     })
 
+    it('inactiveSessionCanResume allows codex resume by message recovery when no codexSessionId is stored', () => {
+        expect(inactiveSessionCanResume(makeSession({
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+        }), 3)).toBe(true)
+    })
+
     it('inactiveSessionCanResume allows claude recovery when flavor is missing (defaults to claude)', () => {
         expect(inactiveSessionCanResume(makeSession({
             metadata: { path: '/tmp/project', host: 'localhost' },
         }), 3)).toBe(true)
     })
 
-    it('inactiveSessionCanResume rejects non-claude flavors with messages but no flavor-specific id (no recovery path)', () => {
+    it('inactiveSessionCanResume rejects non-recovering flavors with messages but no flavor-specific id', () => {
         expect(inactiveSessionCanResume(makeSession({
-            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'codex' },
+            metadata: { path: '/tmp/project', host: 'localhost', flavor: 'grok' },
         }), 3)).toBe(false)
     })
 })

--- a/web/src/lib/sessionResume.ts
+++ b/web/src/lib/sessionResume.ts
@@ -27,9 +27,9 @@ export function resolveAgentSessionIdFromMetadata(
 /**
  * Whether an inactive session can be activated via resume (or fresh spawn on first send).
  * Matches hub: resume with agent id, or fresh spawn when path exists, no agent id, no user messages.
- * Claude with messages but no `claudeSessionId` is allowed because hub
- * `recoverClaudeSessionIdFromMessages` reconstructs the resume id from the
- * stored message log (only the claude path has this recovery fallback).
+ * Claude and Codex with messages but no flavor-specific id may attempt the
+ * hub-authoritative stored-message recovery path; the hub still rejects logs
+ * without a safe resume id.
  */
 export function inactiveSessionCanResume(
     session: Session,
@@ -50,7 +50,7 @@ export function inactiveSessionCanResume(
         return true
     }
     const flavor = isKnownFlavor(session.metadata.flavor) ? session.metadata.flavor : 'claude'
-    if (flavor === 'claude' && userMessageCount > 0) {
+    if ((flavor === 'claude' || flavor === 'codex') && userMessageCount > 0) {
         return true
     }
     return userMessageCount === 0


### PR DESCRIPTION
## Problem

An inactive Codex session can lose `metadata.codexSessionId` while its stored HAPI messages still contain the root thread UUID. The Hub currently treats that session as non-resumable, and the Web only exposes its stored-message recovery path for Claude, so Reopen ends in `resume_unavailable` or is not offered at all.

Codex child-agent events also contain their own thread UUIDs and can be newer than the parent event. Recovering an arbitrary nested `thread_id` could therefore resume the wrong conversation.

## Solution

Extend the existing Claude recovery pattern to Codex while keeping the extraction fail-closed:

- inspect only the production `agent -> codex -> data` envelope from the newest 200 stored messages;
- accept only events whose supplied role aliases all identify an explicit `parent`;
- require every supplied direct/scope thread ID alias to be a valid UUID and to normalize to one value;
- skip newer child events and stop before any explicit stored `Context was reset` boundary;
- persist the recovered root UUID through the existing versioned metadata update, refreshing after a CAS conflict and preferring an ID written concurrently, while leaving `updatedAt` unchanged; and
- let the Web offer a Hub-authoritative recovery attempt for Codex sessions with stored messages.

Existing metadata still wins without scanning or rewriting stored messages. Child-only, roleless, malformed, conflicting, and pre-reset events remain non-resumable.

## Usage

No configuration or migration is required. Open the inactive Codex session and choose **More actions -> Reopen**. HAPI resumes it only when the stored log contains a valid parent thread after the newest reset boundary; otherwise the Hub keeps the session inactive.

## Before / after

| Before | After |
|---|---|
| The archived session cannot be resumed and its action menu has no Reopen item. | Before any click, the same archived fixture offers Reopen in the action menu. |
| ![Before: inactive Codex session menu without Reopen](https://github.com/user-attachments/assets/8691e640-bce7-40c9-b4fe-647942826953) | ![After: inactive Codex session menu with Reopen](https://github.com/user-attachments/assets/509e7722-db50-42bf-a3f2-92ac4a1834a2) |

## Tests

- Hub regression coverage: metadata precedence, older parent/newer child selection, explicit reset boundaries, CAS retry/concurrent metadata precedence, persistence, `updatedAt` stability, and child/roleless/malformed/conflicting fail-closed cases.
- Web regression coverage: Codex stored-message recovery eligibility while preserving conservative behavior for flavors without a recovery path.
- `bunx bun@1.3.14 typecheck`
- `bunx bun@1.3.14 run test`
- Isolated Hub/Web/Playwright E2E with a fake online runner: baseline REST reopen returned `409 resume_unavailable`; in the fixed single-click flow one spawn RPC carried the root UUID, persisted it, cleared the archived lifecycle, and exposed Archive.

---

AI disclosure (per `CONTRIBUTING.md`): OpenAI Codex was used to assist with implementation, testing, and drafting this pull request.
