### PR TITLE
fix(web): exit scratchlist mode after successful promote-to-queue

### DIFF
--- a/web/src/components/SessionChat.exit-mode.test.tsx
+++ b/web/src/components/SessionChat.exit-mode.test.tsx
@@ -17,9 +17,10 @@ import type { ScratchlistEntry } from '@/lib/scratchlist'
  * runtime hook and asserts both the setText call AND the exit-mode call
  * fire when the operator clicks promote-to-composer.
  *
- * Promote-to-queue does NOT exit the mode - the queue path bypasses the
- * scratchlist-mode wrapper entirely, and the operator may still want to
- * capture related notes.
+ * Promote-to-queue exits the mode too once the send is accepted (issue
+ * #959): the operator just messaged the agent, so the next composer
+ * submit should go to chat. A rejected send keeps the mode and the
+ * entry.
  */
 
 const setText = vi.fn()
@@ -71,9 +72,40 @@ describe('ScratchlistDrawerHost.onPromoteToComposer', () => {
         expect(onSend).not.toHaveBeenCalled()
     })
 
-    it('does NOT exit scratchlist mode when an entry is promoted to queue', async () => {
+    it('exits scratchlist mode when an entry is promoted to queue and the send is accepted', async () => {
         const onExitScratchlistMode = vi.fn()
         const onSend = vi.fn(async () => true)
+        const onMove = vi.fn()
+        const onDelete = vi.fn()
+
+        render(
+            <I18nProvider>
+                <ScratchlistDrawerHost
+                    entries={[makeEntry({ id: 'e1', text: 'send-to-queue text' })]}
+                    onMove={onMove}
+                    onDelete={onDelete}
+                    onSend={onSend}
+                    onExitScratchlistMode={onExitScratchlistMode}
+                />
+            </I18nProvider>,
+        )
+
+        const queueButtons = screen.getAllByRole('button', { name: /queue|send/i })
+        expect(queueButtons.length).toBeGreaterThan(0)
+        fireEvent.click(queueButtons[0]!)
+
+        // Allow the async onSend to settle
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(onSend).toHaveBeenCalledWith('send-to-queue text')
+        expect(onExitScratchlistMode).toHaveBeenCalledTimes(1)
+        expect(setText).not.toHaveBeenCalled()
+    })
+
+    it('keeps scratchlist mode when a promote-to-queue send is rejected', async () => {
+        const onExitScratchlistMode = vi.fn()
+        const onSend = vi.fn(async () => false)
         const onMove = vi.fn()
         const onDelete = vi.fn()
 

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -317,7 +317,8 @@ export function ScratchlistDrawerHost(props: {
     onDelete: ReturnType<typeof useScratchlist>['remove']
     onSend: (text: string, attachments?: AttachmentMetadata[], scheduledAt?: number | null) => Promise<boolean>
     /**
-     * Called when the operator promotes an entry to the composer.
+     * Called when the operator promotes an entry to the composer, or
+     * when a promote-to-queue send is accepted.
      *
      * Promoting means "I want to send this for real now" - so the host
      * MUST exit scratchlist mode, otherwise the next composer submit
@@ -336,10 +337,15 @@ export function ScratchlistDrawerHost(props: {
         // Promote-to-queue bypasses the scratchlist-mode wrapper by
         // calling props.onSend directly (the chat send), so the queue
         // entry lands in the conversation regardless of scratchlist
-        // mode. Mode itself stays on - the operator may still be
-        // capturing related notes.
-        return await props.onSend(text)
-    }, [props.onSend])
+        // mode. On an accepted send, exit scratchlist mode (same as
+        // promote-to-composer) so the operator can immediately type a
+        // follow-up; on a rejected send, keep the mode and the entry.
+        const sent = await props.onSend(text)
+        if (sent) {
+            props.onExitScratchlistMode()
+        }
+        return sent
+    }, [props.onSend, props.onExitScratchlistMode])
     return (
         <ScratchlistDrawer
             entries={props.entries}


### PR DESCRIPTION
Fixes #959

## Root cause

`ScratchlistDrawerHost.handlePromoteToQueue` intentionally kept scratchlist mode enabled after a successful send ("operator may still be capturing related notes"), so after promoting an entry via **Send to queue** the composer stayed in scratchlist routing (amber Send, drawer open) and the next submit went back into the scratchlist instead of the live chat.

## Fix

In `handlePromoteToQueue`, when `onSend(text)` resolves `true` (accepted), call `props.onExitScratchlistMode()` — same behavior as promote-to-composer. A rejected send (`onSend` returns `false`) keeps the mode and the entry, as before. Comments updated to match.

## Tests

- `web/src/components/SessionChat.exit-mode.test.tsx`: inverted the queue-path regression assertion (now expects exit on accepted send) and added a case asserting a rejected send does NOT exit.
- `bunx vitest run src/components/SessionChat.exit-mode.test.tsx` (from `web/`): 4/4 passing.
- `bun typecheck` (cli + web + hub): clean.

## Notes / risks

- Behavior change is scoped to the drawer host; `ScratchlistPanel` itself is untouched.
- Operators who promoted to queue mid-capture now have to re-enter scratchlist mode to keep capturing — this is the trade-off the issue explicitly requests (symmetry with promote-to-composer).
