### PR TITLE
fix(cursor): nest extension request outcome in JSON-RPC result

### DIFF
--- a/cli/src/cursor/utils/cursorExtensionAdapter.test.ts
+++ b/cli/src/cursor/utils/cursorExtensionAdapter.test.ts
@@ -75,8 +75,10 @@ describe('CursorExtensionAdapter', () => {
         });
         expect(handled).toBe(true);
         await expect(pending).resolves.toEqual({
-            outcome: 'answered',
-            answers: [{ questionId: 'q1', selectedOptionIds: ['opt-a'] }]
+            outcome: {
+                outcome: 'answered',
+                answers: [{ questionId: 'q1', selectedOptionIds: ['opt-a'] }]
+            }
         });
     });
 
@@ -90,7 +92,7 @@ describe('CursorExtensionAdapter', () => {
             decision: 'denied'
         });
 
-        await expect(pending).resolves.toEqual({ outcome: 'cancelled' });
+        await expect(pending).resolves.toEqual({ outcome: { outcome: 'cancelled' } });
     });
 
     it('resolves create_plan approval as accepted', async () => {
@@ -106,7 +108,7 @@ describe('CursorExtensionAdapter', () => {
             decision: 'approved'
         });
 
-        await expect(pending).resolves.toEqual({ outcome: 'accepted' });
+        await expect(pending).resolves.toEqual({ outcome: { outcome: 'accepted' } });
     });
 
     it('resolves create_plan denial as rejected', async () => {
@@ -119,7 +121,7 @@ describe('CursorExtensionAdapter', () => {
             decision: 'denied'
         });
 
-        await expect(pending).resolves.toEqual({ outcome: 'rejected' });
+        await expect(pending).resolves.toEqual({ outcome: { outcome: 'rejected' } });
     });
 
     it('returns false from handlePermissionResponse for unrelated permission ids', async () => {
@@ -198,8 +200,8 @@ describe('CursorExtensionAdapter', () => {
 
         await adapter.cancelAll('User aborted');
 
-        await expect(askPending).resolves.toEqual({ outcome: 'cancelled' });
-        await expect(planPending).resolves.toEqual({ outcome: 'cancelled' });
+        await expect(askPending).resolves.toEqual({ outcome: { outcome: 'cancelled' } });
+        await expect(planPending).resolves.toEqual({ outcome: { outcome: 'cancelled' } });
         expect(getAgentState().requests).toEqual({});
         expect(getAgentState().completedRequests).toMatchObject({
             'q-cancel': { status: 'canceled', decision: 'abort' },

--- a/cli/src/cursor/utils/cursorExtensionAdapter.ts
+++ b/cli/src/cursor/utils/cursorExtensionAdapter.ts
@@ -101,21 +101,25 @@ export class CursorExtensionAdapter {
         this.pending.delete(response.id);
 
         const decision = response.decision ?? (response.approved ? 'approved' : 'denied');
+        // Cursor ACP extension methods expect the result nested as
+        // { outcome: { outcome: ... } }; a flat result reads as cancelled.
         if (pending.tool === 'CursorAskQuestion') {
             if (decision === 'abort' || decision === 'denied') {
-                pending.respond({ outcome: 'cancelled' });
+                pending.respond({ outcome: { outcome: 'cancelled' } });
             } else {
                 pending.respond({
-                    outcome: 'answered',
-                    answers: formatQuestionAnswers(pending.arguments, response.answers)
+                    outcome: {
+                        outcome: 'answered',
+                        answers: formatQuestionAnswers(pending.arguments, response.answers)
+                    }
                 });
             }
         } else if (decision === 'abort') {
-            pending.respond({ outcome: 'cancelled' });
+            pending.respond({ outcome: { outcome: 'cancelled' } });
         } else if (decision === 'denied') {
-            pending.respond({ outcome: 'rejected' });
+            pending.respond({ outcome: { outcome: 'rejected' } });
         } else {
-            pending.respond({ outcome: 'accepted' });
+            pending.respond({ outcome: { outcome: 'accepted' } });
         }
 
         const status = response.approved ? 'approved' : 'denied';
@@ -205,11 +209,7 @@ export class CursorExtensionAdapter {
         this.pending.clear();
 
         for (const [id, pending] of entries) {
-            pending.respond(
-                pending.tool === 'CursorAskQuestion'
-                    ? { outcome: 'cancelled' }
-                    : { outcome: 'cancelled' }
-            );
+            pending.respond({ outcome: { outcome: 'cancelled' } });
 
             this.session.updateAgentState((currentState) => {
                 const requestEntry = currentState.requests?.[id];


### PR DESCRIPTION
## Summary

Fixes #1044

**Root cause:** Cursor ACP extension methods (`cursor/ask_question`, `cursor/create_plan`) expect the JSON-RPC result nested as `{ outcome: { outcome: ... } }`, but `CursorExtensionAdapter` returned a flat `{ outcome: 'accepted' }`. Cursor read `result.outcome.outcome` as `undefined` and fell back to `cancelled`, so remotely approving a CreatePlan request was treated as a cancellation.

**Fix:** Wrap every `respond(...)` result in `handleResponse` and `cancelAll` with the nested `outcome` envelope, matching the shape already used by the standard ACP permission path in `AcpSdkBackend.respondToPermission`.

## Changes

- `cli/src/cursor/utils/cursorExtensionAdapter.ts` — nest all extension request results (`accepted`/`rejected`/`cancelled`/`answered`) one level deeper; simplified the dead ternary in `cancelAll` (both branches were identical).
- `cli/src/cursor/utils/cursorExtensionAdapter.test.ts` — updated assertions to the nested structure, including the approval → `{ outcome: { outcome: 'accepted' } }` regression case for `cursor/create_plan`.

## Testing

- `bun typecheck` — clean across cli/web/hub.
- `bunx vitest run src/cursor/utils/cursorExtensionAdapter.test.ts` — 10/10 passed.

## Notes / risks

- Behavior change is scoped to the Cursor ACP adapter responses; the hub/web permission flow (agent state, completedRequests) is untouched.
- Assumes Cursor expects `answers` inside the nested `outcome` object for `answered`, consistent with the permission-path precedent; worth a smoke test against a live Cursor session if possible.