### PR TITLE
fix(web): keep session preview fold while searching

### DIFF
--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -7,7 +7,10 @@ import { I18nProvider } from '@/lib/i18n-context'
 import { ToastProvider } from '@/lib/toast-context'
 import { SessionList } from './SessionList'
 
-afterEach(() => cleanup())
+afterEach(() => {
+    cleanup()
+    localStorage.removeItem('hapi-session-preview-limit')
+})
 
 function makeSession(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
     return {
@@ -225,7 +228,7 @@ describe('SessionList action menu parity', () => {
 })
 
 describe('SessionList collapse behavior', () => {
-    function renderSessionList(sessions: SessionSummary[], selectedSessionId = 'session-running') {
+    function renderSessionList(sessions: SessionSummary[], selectedSessionId: string | null = 'session-running') {
         return (
             <QueryClientProvider client={new QueryClient({
                 defaultOptions: {
@@ -345,5 +348,33 @@ describe('SessionList collapse behavior', () => {
         await waitFor(() => {
             expect(firstPanel?.getAttribute('data-open')).toBe('true')
         })
+    })
+
+    it('keeps the configured session preview fold while searching', () => {
+        localStorage.setItem('hapi-session-preview-limit', '2')
+        const sessions = Array.from({ length: 4 }, (_, index) => makeSession({
+            id: `matching-${index + 1}`,
+            updatedAt: 100 - index,
+            metadata: {
+                path: '/work/hapi',
+                name: `Matching task ${index + 1}`,
+                flavor: 'codex',
+            },
+        }))
+
+        render(renderSessionList(sessions, null))
+        fireEvent.change(screen.getByPlaceholderText('Search sessions…'), {
+            target: { value: 'Matching task' },
+        })
+
+        expect(screen.getByRole('button', { name: /Matching task 1/ })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Matching task 2/ })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /Matching task 3/ })).toBeNull()
+        expect(screen.queryByRole('button', { name: /Matching task 4/ })).toBeNull()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show 2 more' }))
+
+        expect(screen.getByRole('button', { name: /Matching task 3/ })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Matching task 4/ })).toBeInTheDocument()
     })
 })

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1150,7 +1150,6 @@ export function SessionList(props: {
         return getVisibleSessionPreview(
             group.sessions,
             {
-                expanded: isFiltering,
                 selectedSessionId,
                 limit: getGroupVisibleCount(group)
             }
@@ -1341,7 +1340,7 @@ export function SessionList(props: {
                                             showDetailedStatus={showDetailedStatus}
                                         />
                                     ))}
-                                    {!isFiltering && group.sessions.length > sessionPreviewLimit && (hiddenSessionCount > 0 || canCollapseSessions) ? (
+                                    {group.sessions.length > sessionPreviewLimit && (hiddenSessionCount > 0 || canCollapseSessions) ? (
                                         <button
                                             type="button"
                                             onClick={() => hiddenSessionCount > 0


### PR DESCRIPTION
Fixes #1068

## Root cause

While filtering (search query or date range active), `SessionList` passed `expanded: isFiltering` to `getVisibleSessionPreview`, forcing every directory group to render all of its sessions, and hid the `Show more`/`Show less` button behind `!isFiltering`. The user's per-group preview fold was therefore ignored whenever the list was filtered.

## Fix

Remove both filtering-time interventions (2 lines) so filtering only narrows which sessions appear in a group; the configured preview limit and the user's `Show more`/`Show less` state now apply equally during filtering. Matches the reference patch linked in the issue (fork commit 167af3dc, adapted: `isSearching` has since been renamed to `isFiltering`).

## Tests

- Added a regression test in `web/src/components/SessionList.directory-action.test.tsx`: with a preview limit of 2 and 4 matching sessions in one directory, searching shows only the first 2 matches, and `Show 2 more` reveals the rest.
- `bun typecheck` clean; full web vitest suite passes (169 files, 1425 tests).

## Trade-offs

While a filter is active, matching sessions beyond the preview limit are folded and require `Show more` to reveal — this is the behavior requested by the issue author.