### PR TITLE
fix(hub,web): query Codex models via machine RPC instead of session cwd

### DIFF
--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -294,10 +294,6 @@ export class RpcGateway {
         }
     }
 
-    async listCodexModelsForSession(sessionId: string): Promise<RpcListCodexModelsResponse> {
-        return await this.sessionRpc(sessionId, RPC_METHODS.ListCodexModels, {}, MODEL_LIST_RPC_TIMEOUT_MS) as RpcListCodexModelsResponse
-    }
-
     async listCodexModelsForMachine(machineId: string): Promise<RpcListCodexModelsResponse> {
         return await this.machineRpc(machineId, RPC_METHODS.ListCodexModels, {}, MODEL_LIST_RPC_TIMEOUT_MS) as RpcListCodexModelsResponse
     }

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -1696,10 +1696,6 @@ export class SyncEngine {
         return await this.rpcGateway.listSkills(sessionId, flavor)
     }
 
-    async listCodexModelsForSession(sessionId: string): Promise<RpcListCodexModelsResponse> {
-        return await this.rpcGateway.listCodexModelsForSession(sessionId)
-    }
-
     async listCodexModelsForMachine(machineId: string): Promise<RpcListCodexModelsResponse> {
         return await this.rpcGateway.listCodexModelsForMachine(machineId)
     }

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -69,12 +69,6 @@ function createApp(session: Session, opts?: {
     const applySessionConfig = async (sessionId: string, config: Record<string, unknown>) => {
         applySessionConfigCalls.push([sessionId, config])
     }
-    const listCodexModelsForSession = async () => ({
-        success: true,
-        models: [
-            { id: 'gpt-5.5', displayName: 'GPT-5.5', isDefault: true }
-        ]
-    })
     const listOpencodeModelsForSession = async () => ({
         success: true,
         availableModels: [
@@ -128,7 +122,6 @@ function createApp(session: Session, opts?: {
             ? { ok: true, sessionId: session.id, session }
             : { ok: false, reason: 'not-found' },
         applySessionConfig,
-        listCodexModelsForSession,
         listCursorModelsForSession,
         listOpencodeModelsForSession,
         listOpencodeReasoningEffortOptionsForSession,
@@ -715,20 +708,6 @@ describe('sessions routes', () => {
         })
         expect(localResponse.status).toBe(409)
         expect(localApp.applySessionConfigCalls).toEqual([])
-    })
-
-    it('returns Codex models for active Codex sessions', async () => {
-        const { app } = createApp(createSession())
-
-        const response = await app.request('/api/sessions/session-1/codex-models')
-
-        expect(response.status).toBe(200)
-        expect(await response.json()).toEqual({
-            success: true,
-            models: [
-                { id: 'gpt-5.5', displayName: 'GPT-5.5', isDefault: true }
-            ]
-        })
     })
 
     it('returns OpenCode reasoning effort options for active OpenCode sessions', async () => {

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -766,36 +766,6 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
         }
     })
 
-    app.get('/sessions/:id/codex-models', async (c) => {
-        const engine = requireSyncEngine(c, getSyncEngine)
-        if (engine instanceof Response) {
-            return engine
-        }
-
-        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
-        if (sessionResult instanceof Response) {
-            return sessionResult
-        }
-
-        const flavor = sessionResult.session.metadata?.flavor ?? 'claude'
-        if (flavor !== 'codex') {
-            return c.json({
-                success: false,
-                error: 'Codex models are only available for Codex sessions'
-            }, 400)
-        }
-
-        try {
-            const result = await engine.listCodexModelsForSession(sessionResult.sessionId)
-            return c.json(result)
-        } catch (error) {
-            return c.json({
-                success: false,
-                error: error instanceof Error ? error.message : 'Failed to list Codex models'
-            }, 500)
-        }
-    })
-
     app.get('/sessions/:id/opencode-models', async (c) => {
         const engine = requireSyncEngine(c, getSyncEngine)
         if (engine instanceof Response) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -653,12 +653,6 @@ export class ApiClient {
         )
     }
 
-    async getSessionCodexModels(sessionId: string): Promise<CodexModelsResponse> {
-        return await this.request<CodexModelsResponse>(
-            `/api/sessions/${encodeURIComponent(sessionId)}/codex-models`
-        )
-    }
-
     async getSessionOpencodeModels(sessionId: string): Promise<OpencodeModelsResponse> {
         return await this.request<OpencodeModelsResponse>(
             `/api/sessions/${encodeURIComponent(sessionId)}/opencode-models`

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -540,7 +540,7 @@ function SessionChatInner(props: SessionChatProps) {
     const codexCollaborationModeSupported = agentFlavor === 'codex' && !controlledByUser
     const codexModelsState = useCodexModels({
         api: props.api,
-        sessionId: props.session.id,
+        machineId: props.session.metadata?.machineId ?? null,
         enabled: agentFlavor === 'codex' && props.session.active && !controlledByUser
     })
     const effectiveCodexServiceTier = agentFlavor === 'codex'

--- a/web/src/hooks/queries/useCodexModels.ts
+++ b/web/src/hooks/queries/useCodexModels.ts
@@ -5,7 +5,6 @@ import { queryKeys } from '@/lib/query-keys'
 
 export function useCodexModels(args: {
     api: ApiClient | null
-    sessionId?: string | null
     machineId?: string | null
     enabled?: boolean
 }): {
@@ -13,20 +12,15 @@ export function useCodexModels(args: {
     isLoading: boolean
     error: string | null
 } {
-    const { api, sessionId, machineId } = args
-    const enabled = Boolean(args.enabled && api && (sessionId || machineId))
-    const queryKey = sessionId
-        ? queryKeys.sessionCodexModels(sessionId)
-        : queryKeys.machineCodexModels(machineId ?? 'unknown')
+    const { api, machineId } = args
+    const enabled = Boolean(args.enabled && api && machineId)
+    const queryKey = queryKeys.machineCodexModels(machineId ?? 'unknown')
 
     const query = useQuery({
         queryKey,
         queryFn: async () => {
             if (!api) {
                 throw new Error('API unavailable')
-            }
-            if (sessionId) {
-                return await api.getSessionCodexModels(sessionId)
             }
             if (machineId) {
                 return await api.getMachineCodexModels(machineId)

--- a/web/src/lib/query-keys.ts
+++ b/web/src/lib/query-keys.ts
@@ -15,7 +15,6 @@ export const queryKeys = {
         staged ? 'staged' : 'unstaged'
     ] as const,
     slashCommands: (sessionId: string) => ['slash-commands', sessionId] as const,
-    sessionCodexModels: (sessionId: string) => ['session-codex-models', sessionId] as const,
     sessionCursorModels: (sessionId: string) => ['session-cursor-models', sessionId] as const,
     sessionCursorChatStore: (sessionId: string) => ['session-cursor-chat-store', sessionId] as const,
     sessionPiModels: (sessionId: string) => ['session-pi-models', sessionId] as const,


### PR DESCRIPTION
Fixes #1072

## Root cause

`SessionChat` passed `sessionId` to `useCodexModels`, which fetched models via `/api/sessions/:id/codex-models` → session-scoped RPC. The CLI then ran `listCodexModels` in the session process cwd, so a missing directory or project-level Codex config could skew or break the model list shown in an existing session's chat.

## Fix

- `web/src/components/SessionChat.tsx`: pass `machineId: session.metadata?.machineId ?? null` to `useCodexModels` instead of `sessionId` (machine-scoped RPC runs in a neutral cwd, same as the NewSession flow already does).
- Removed the now-unused session-scoped path, allowed by the repo's no-backward-compatibility convention:
  - `useCodexModels`: dropped the `sessionId` branch
  - `web/src/lib/query-keys.ts`: dropped `sessionCodexModels`
  - `web/src/api/client.ts`: dropped `getSessionCodexModels`
  - `hub/src/web/routes/sessions.ts`: dropped `GET /api/sessions/:id/codex-models`
  - `hub/src/sync/rpcGateway.ts` / `syncEngine.ts`: dropped `listCodexModelsForSession`
  - `hub/src/web/routes/sessions.test.ts`: dropped the session-route test and mock

## Testing

- `bun typecheck` (cli, web, hub): clean
- hub: `bun run test` — 508 pass, 0 fail (incl. `sessions.test.ts`, `machines.test.ts`)
- web: `bun run test` — 1424 pass, 0 fail (incl. `NewSession/index.test.tsx`)

## Notes / trade-offs

- `GET /api/sessions/:id/codex-models` is removed (breaking); the machine-scoped `/api/machines/:id/codex-models` already covers all consumers.
- If a session's metadata lacks `machineId`, the query stays disabled and the model picker simply has no catalog entries — no error surfaced.