### PR TITLE
fix(cli): gate main package release on platform packages being live

### DIFF
--- a/cli/scripts/prepare-npm-packages.ts
+++ b/cli/scripts/prepare-npm-packages.ts
@@ -179,9 +179,9 @@ async function preparePlatform(
     const destBin = join(binDir, platform.binName);
 
     if (!existsSync(srcBin)) {
-        console.warn(`Warning: Binary not found: ${srcBin}`);
-        console.warn(`  Run 'bun run build:exe:all' first to build binaries.`);
-        return;
+        console.error(`Error: Binary not found: ${srcBin}`);
+        console.error(`  Run 'bun run build:exe:all' first to build binaries.`);
+        process.exit(1);
     }
 
     copyFileSync(srcBin, destBin);

--- a/cli/scripts/release-all.ts
+++ b/cli/scripts/release-all.ts
@@ -4,9 +4,10 @@
  * 1. Bump version
  * 2. Build binaries (with embedded web assets)
  * 3. Publish platform packages first (so lockfile can resolve them)
- * 4. Publish main package
- * 5. bun install --lockfile-only --os=* --cpu=* (to lock all platform packages)
- * 6. Git commit + tag + push
+ * 4. Verify all platform packages are live on npm
+ * 5. Publish main package
+ * 6. bun install --lockfile-only --os=* --cpu=* (to lock all platform packages)
+ * 7. Git commit + tag + push
  */
 
 import { execSync } from 'node:child_process';
@@ -55,6 +56,37 @@ function updateBuildInfoVersion(nextVersion: string): void {
 
     if (!dryRun) {
         writeFileSync(buildInfoPath, updated);
+    }
+}
+
+async function waitForPlatformPackages(platforms: string[], expectedVersion: string): Promise<void> {
+    const timeoutMs = 10 * 60 * 1000;
+    const intervalMs = 15_000;
+    const deadline = Date.now() + timeoutMs;
+    const pending = new Set(platforms.map(platform => `@twsxtd/hapi-${platform}`));
+
+    while (pending.size > 0) {
+        for (const name of [...pending]) {
+            try {
+                const published = execSync(`npm view ${name} version`, { encoding: 'utf-8' }).trim();
+                if (published === expectedVersion) {
+                    console.log(`   ✓ ${name}@${expectedVersion} is live on npm`);
+                    pending.delete(name);
+                }
+            } catch {
+                // Not published yet, keep waiting
+            }
+        }
+        if (pending.size === 0) {
+            return;
+        }
+        if (Date.now() >= deadline) {
+            console.error(`❌ Timed out waiting for platform packages on npm: ${[...pending].join(', ')}`);
+            console.error('   The main package was NOT published. Publish the missing platform packages and re-run with --publish-npm.');
+            process.exit(1);
+        }
+        console.log(`   ⏳ Waiting for: ${[...pending].join(', ')} (retry in ${intervalMs / 1000}s)...`);
+        await new Promise(resolve => setTimeout(resolve, intervalMs));
     }
 }
 
@@ -130,8 +162,18 @@ async function main(): Promise<void> {
         run(`npm publish --access public${dryRun ? ' --dry-run' : ''}`, npmDir);
     }
 
-    // Step 4: Publish main package
-    console.log('\n📤 Step 4: Publishing main package...');
+    // Step 4: Verify all platform packages are live on npm before publishing the main package.
+    // The main package pins platform packages via optionalDependencies, so publishing it first
+    // would let users install a version whose platform binary does not exist yet.
+    if (dryRun) {
+        console.log('\n🔍 Step 4: Skipping platform package verification (dry-run)');
+    } else {
+        console.log('\n🔍 Step 4: Verifying platform packages are live on npm...');
+        await waitForPlatformPackages(platforms, version);
+    }
+
+    // Step 5: Publish main package
+    console.log('\n📤 Step 5: Publishing main package...');
     const mainNpmDir = join(projectRoot, 'npm', 'main');
     run(`npm publish --access public${dryRun ? ' --dry-run' : ''}`, mainNpmDir);
 
@@ -141,12 +183,12 @@ async function main(): Promise<void> {
         return;
     }
 
-    // Step 5: bun install to get complete lockfile
-    console.log('\n📥 Step 5: Updating lockfile for all platform packages...');
+    // Step 6: bun install to get complete lockfile
+    console.log('\n📥 Step 6: Updating lockfile for all platform packages...');
 
     await runWithTimeoutRetry('bun install --lockfile-only --os=* --cpu=*', repoRoot);
-    // Step 6: Git commit + tag + push
-    console.log('\n📝 Step 6: Creating git commit and tag...');
+    // Step 7: Git commit + tag + push
+    console.log('\n📝 Step 7: Creating git commit and tag...');
     run(`git add .`, repoRoot);
     run(`git commit -m "Release version ${version}"`, repoRoot);
     run(`git tag v${version}`, repoRoot);


### PR DESCRIPTION
Fixes #1149

## Root cause

The release flow had no gate between publishing platform packages and the main package: `prepare-npm-packages.ts` only warned and continued when a platform binary was missing, and `release-all.ts` published the main package immediately after the platform publishes without verifying they were actually live on npm. For 0.23.4 this shipped the main package while platform packages were never published, leaving users with an old binary running against a new schema.

## Fix

- `cli/scripts/prepare-npm-packages.ts`: missing platform binary is now a hard failure (`process.exit(1)`) instead of warn-and-continue, so a broken/incomplete build aborts the release before anything is published.
- `cli/scripts/release-all.ts`: new step between platform publishes and the main publish — poll `npm view @twsxtd/hapi-<platform> version` for all 5 platforms until each matches the release version (15s interval, 10min total timeout). On timeout the script exits non-zero with a hint to re-run with `--publish-npm`, so the main package can never be published against missing platform packages. Skipped in `--dry-run` mode.

## Out of scope

The deeper robustness issue mentioned in #1149 (old exe hitting a new schema, Windows self-update hardening) is intentionally not addressed here.

## Validation

- `bun typecheck` — passes (note: `cli/scripts/` is excluded from the cli tsconfig, so these scripts are not covered by it; verified separately that the touched files introduce no new tsc errors under a strict ad-hoc invocation)
- `bun run test` (cli) — 154 files / 1478 tests passed
- Smoke: `bun run scripts/release-all.ts` with no args prints usage and exits 1
- No automated test added: these are release-only scripts that cannot be exercised end-to-end locally (they publish to npm and push git tags); the verification logic is deliberately kept simple for manual review. The real gate will be exercised by the next release.

## Risks / trade-offs

- If npm registry propagation is slow, a healthy release now waits up to 10 minutes; on timeout the release aborts safely before the main package is published and can be resumed with `--publish-npm`.