### PR TITLE
fix(cli): run SDK metadata extraction in a temp cwd

### DIFF
--- a/cli/src/claude/sdk/metadataExtractor.test.ts
+++ b/cli/src/claude/sdk/metadataExtractor.test.ts
@@ -1,0 +1,43 @@
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+const queryMock = vi.fn()
+
+vi.mock('./query', () => ({
+    query: (config: unknown) => queryMock(config)
+}))
+
+function fakeInitQuery() {
+    return (async function* () {
+        yield {
+            type: 'system',
+            subtype: 'init',
+            tools: ['Bash'],
+            slash_commands: ['/help']
+        }
+    })()
+}
+
+describe('extractSDKMetadata', () => {
+    it('captures tools and slash commands from the init message', async () => {
+        queryMock.mockImplementation(fakeInitQuery)
+
+        const { extractSDKMetadata } = await import('./metadataExtractor')
+        const metadata = await extractSDKMetadata()
+
+        expect(metadata).toEqual({ tools: ['Bash'], slashCommands: ['/help'] })
+    })
+
+    it('runs the extraction query in a temp cwd outside the user project (#250)', async () => {
+        queryMock.mockImplementation(fakeInitQuery)
+
+        const { extractSDKMetadata } = await import('./metadataExtractor')
+        await extractSDKMetadata()
+
+        const config = queryMock.mock.calls[0][0] as { options: { cwd: string } }
+        expect(config.options.cwd).toBe(join(tmpdir(), 'hapi-sdk-metadata'))
+        expect(existsSync(config.options.cwd)).toBe(true)
+    })
+})

--- a/cli/src/claude/sdk/metadataExtractor.ts
+++ b/cli/src/claude/sdk/metadataExtractor.ts
@@ -3,6 +3,9 @@
  * Captures available tools and slash commands from Claude SDK initialization
  */
 
+import { mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { query } from './query'
 import type { SDKSystemMessage } from './types'
 import { logger } from '@/ui/logger'
@@ -11,6 +14,16 @@ export interface SDKMetadata {
     tools?: string[]
     slashCommands?: string[]
 }
+
+/**
+ * Dedicated working directory for the metadata extraction query.
+ * Claude Code writes a session jsonl under ~/.claude/projects/<cwd-slug>/
+ * as soon as the process starts, before we can abort it. Running the
+ * extraction in the user's project directory therefore pollutes their
+ * Claude session history with empty 'hello' sessions (#250). A temp
+ * directory keeps those artifacts out of the user's projects.
+ */
+const metadataExtractionCwd = join(tmpdir(), 'hapi-sdk-metadata')
 
 /**
  * Extract SDK metadata by running a minimal query and capturing the init message
@@ -23,11 +36,15 @@ export async function extractSDKMetadata(): Promise<SDKMetadata> {
         logger.debug('[metadataExtractor] Starting SDK metadata extraction')
         
         // Run SDK with minimal tools allowed
+        // cwd must be outside the user's project so the session jsonl Claude
+        // Code writes on startup does not pollute their session history
+        mkdirSync(metadataExtractionCwd, { recursive: true })
         const sdkQuery = query({
             prompt: 'hello',
             options: {
                 allowedTools: ['Bash(echo)'],
                 maxTurns: 1,
+                cwd: metadataExtractionCwd,
                 abort: abortController.signal
             }
         })


### PR DESCRIPTION
Fixes #250

## Root cause

Every Claude session launch triggers `extractSDKMetadataAsync` (`cli/src/claude/runClaude.ts`), which runs a minimal SDK query with `prompt: 'hello'`. The query spawned Claude Code without a `cwd`, i.e. in the user's project directory. Claude Code writes a session `.jsonl` under `~/.claude/projects/<cwd-slug>/` as soon as the process starts, so aborting the query after the init message was too late — each launch left an empty 'hello' session file in the user's project history.

## Fix

Give the metadata extraction query a dedicated temp working directory (`<os.tmpdir()>/hapi-sdk-metadata`, created with `mkdirSync recursive`) so the throwaway session jsonl lands under the tmp project's slug instead of the user's project. Only `cli/src/claude/sdk/metadataExtractor.ts` changed, plus a new unit test.

## Testing

- `bun typecheck` (cli + web + hub) — clean
- New `metadataExtractor.test.ts` — 2 passed (asserts metadata capture and that the query runs in the temp cwd)
- `bunx vitest run src/claude/sdk` — 14 passed
- Full CLI suite — 155 files / 1480 tests passed

## Trade-offs / known limitations

- **Project-level capabilities are no longer visible in extracted metadata.** `cwd` affects the init message's `slashCommands` (project-level `.claude/commands`) and project-scoped MCP config. Extracting in a temp dir means the web UI may no longer list project-local slash commands for Claude sessions. I judged this acceptable: the alternative (keeping the project cwd and deleting the jsonl afterwards, or caching per process) either still pollutes on first launch or requires fragile deletion of files under `~/.claude`. Happy to switch to a cleanup-based approach if project-level command discovery matters more.
- The throwaway jsonl files still accumulate, but under `~/.claude/projects/-tmp-hapi-sdk-metadata/` (tmp-backed, out of the user's way) instead of inside each user project.
- The other empty-session types mentioned in the issue (`file-history-snapshot`, `progress` only) come from real session files, not the metadata extractor, and are out of scope here.