### PR TITLE
fix(codex): accept thread-matching stale terminal events during same-thread recovery

### DIFF
--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -43,6 +43,7 @@ const harness = vi.hoisted(() => ({
     failNextCompact: false,
     deferCompactCompletion: false,
     deferThreadStatusNotifications: false,
+    staleTerminalAfterRecovery: null as null | 'retry' | 'compact',
     emitChildThreadEvents: false,
     emitChildUsageEvents: false,
     emitChildGoalEvent: false,
@@ -888,6 +889,31 @@ vi.mock('./codexAppServerClient', () => {
                 }
             }
 
+            if (harness.staleTerminalAfterRecovery && harness.startTurnThreadIds.length === 2) {
+                const assistantMessage = {
+                    item: {
+                        id: `stale-${harness.staleTerminalAfterRecovery}-message`,
+                        type: 'agentMessage',
+                        content: [{ type: 'text', text: `done after ${harness.staleTerminalAfterRecovery}` }]
+                    },
+                    threadId,
+                    turnId: 'turn-1'
+                };
+                harness.notifications.push({ method: 'item/completed', params: assistantMessage });
+                this.notificationHandler?.('item/completed', assistantMessage);
+
+                const staleCompleted = {
+                    msg: {
+                        type: 'task_complete',
+                        thread_id: threadId,
+                        turn_id: 'turn-1'
+                    }
+                };
+                harness.notifications.push({ method: 'codex/event/task_complete', params: staleCompleted });
+                this.notificationHandler?.('codex/event/task_complete', staleCompleted);
+                return { turn: { id: turnId } };
+            }
+
             const completed = { status: 'Completed', turn: { id: turnId } };
             harness.notifications.push({ method: 'turn/completed', params: completed });
             this.notificationHandler?.('turn/completed', completed);
@@ -1127,6 +1153,7 @@ describe('codexRemoteLauncher', () => {
         harness.failNextCompact = false;
         harness.deferCompactCompletion = false;
         harness.deferThreadStatusNotifications = false;
+        harness.staleTerminalAfterRecovery = null;
         harness.emitChildThreadEvents = false;
         harness.emitChildUsageEvents = false;
         harness.emitChildGoalEvent = false;
@@ -1916,6 +1943,23 @@ describe('codexRemoteLauncher', () => {
         });
     });
 
+    it('emits ready when same-thread retry completes with a stale terminal turn id', async () => {
+        harness.remainingThreadSystemErrors = 1;
+        harness.staleTerminalAfterRecovery = 'retry';
+        const { session, sessionEvents, codexMessages } = createSessionStub(['first message']);
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.startTurnThreadIds).toEqual(['thread-1', 'thread-1']);
+        expect(codexMessages).toContainEqual(expect.objectContaining({
+            type: 'message',
+            message: 'done after retry'
+        }));
+        expect(sessionEvents.filter((event) => event.type === 'ready').length).toBeGreaterThanOrEqual(1);
+        expect(session.thinking).toBe(false);
+    });
+
     it('compacts the same thread before retrying context-window overflow', async () => {
         harness.remainingThreadSystemErrors = 1;
         harness.nextThreadSystemErrorMessage = "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.";
@@ -1933,6 +1977,25 @@ describe('codexRemoteLauncher', () => {
             type: 'message',
             message: "Task failed: Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying."
         });
+        expect(session.thinking).toBe(false);
+    });
+
+    it('emits ready when same-thread compact recovery completes with a stale terminal turn id', async () => {
+        harness.remainingThreadSystemErrors = 1;
+        harness.nextThreadSystemErrorMessage = "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.";
+        harness.staleTerminalAfterRecovery = 'compact';
+        const { session, sessionEvents, codexMessages } = createSessionStub(['first message']);
+
+        const exitReason = await codexRemoteLauncher(session as never);
+
+        expect(exitReason).toBe('exit');
+        expect(harness.compactThreadIds).toEqual(['thread-1']);
+        expect(harness.startTurnThreadIds).toEqual(['thread-1', 'thread-1']);
+        expect(codexMessages).toContainEqual(expect.objectContaining({
+            type: 'message',
+            message: 'done after compact'
+        }));
+        expect(sessionEvents.filter((event) => event.type === 'ready').length).toBeGreaterThanOrEqual(1);
         expect(session.thinking).toBe(false);
     });
 

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -2445,9 +2445,19 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 return;
             }
 
+            const allowSameThreadTerminalRecovery = msg.terminal_source === 'thread_status'
+                || sameThreadRetryAttempt > 0
+                || sameThreadCompactAttempt > 0;
+
             if (isTerminalEvent && eventTurnId && eventTurnId === lastFinalizedTurnId) {
-                logger.debug(`[Codex] Ignoring duplicate terminal event for turn ${eventTurnId}`);
-                return;
+                const isSameThreadRecoveryTerminal = allowSameThreadTerminalRecovery
+                    && Boolean(eventThreadId)
+                    && Boolean(this.currentThreadId)
+                    && eventThreadId === this.currentThreadId;
+                if (!isSameThreadRecoveryTerminal) {
+                    logger.debug(`[Codex] Ignoring duplicate terminal event for turn ${eventTurnId}`);
+                    return;
+                }
             }
 
             if (msgType === 'task_started') {
@@ -2631,7 +2641,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     allowAnonymousTerminalEvent,
                     eventThreadId,
                     currentThreadId: this.currentThreadId,
-                    allowMatchingThreadIdTerminalEvent: msg.terminal_source === 'thread_status'
+                    allowMatchingThreadIdTerminalEvent: allowSameThreadTerminalRecovery
                 })) {
                     logger.debug(
                         `[Codex] Ignoring terminal event ${msgType} without matching turn context; ` +

--- a/cli/src/codex/utils/terminalEventGuard.test.ts
+++ b/cli/src/codex/utils/terminalEventGuard.test.ts
@@ -80,6 +80,32 @@ describe('shouldIgnoreTerminalEvent', () => {
         expect(ignored).toBe(true);
     });
 
+    it('accepts stale-turn terminal events for the current thread when explicitly allowed', () => {
+        const ignored = shouldIgnoreTerminalEvent({
+            eventTurnId: 'turn-old',
+            currentTurnId: 'turn-current',
+            turnInFlight: true,
+            eventThreadId: 'thread-1',
+            currentThreadId: 'thread-1',
+            allowMatchingThreadIdTerminalEvent: true
+        });
+
+        expect(ignored).toBe(false);
+    });
+
+    it('still ignores stale-turn terminal events for a different thread when thread matching is allowed', () => {
+        const ignored = shouldIgnoreTerminalEvent({
+            eventTurnId: 'turn-old',
+            currentTurnId: 'turn-current',
+            turnInFlight: true,
+            eventThreadId: 'thread-old',
+            currentThreadId: 'thread-1',
+            allowMatchingThreadIdTerminalEvent: true
+        });
+
+        expect(ignored).toBe(true);
+    });
+
     it('accepts terminal events that match the current turn id', () => {
         const ignored = shouldIgnoreTerminalEvent({
             eventTurnId: 'turn-current',

--- a/cli/src/codex/utils/terminalEventGuard.ts
+++ b/cli/src/codex/utils/terminalEventGuard.ts
@@ -10,19 +10,22 @@ export type TerminalEventGuardInput = {
 
 export function shouldIgnoreTerminalEvent(input: TerminalEventGuardInput): boolean {
     const allowAnonymousTerminalEvent = input.allowAnonymousTerminalEvent === true;
+    const allowMatchingThreadIdTerminalEvent = input.allowMatchingThreadIdTerminalEvent === true;
+    const hasMatchingThreadId = Boolean(
+        input.eventThreadId
+        && input.currentThreadId
+        && input.eventThreadId === input.currentThreadId
+    );
 
     if (input.eventTurnId) {
-        return Boolean(input.currentTurnId && input.eventTurnId !== input.currentTurnId);
+        if (!input.currentTurnId || input.eventTurnId === input.currentTurnId) {
+            return false;
+        }
+        return !(allowMatchingThreadIdTerminalEvent && hasMatchingThreadId);
     }
 
     if (input.currentTurnId) {
-        const allowMatchingThreadIdTerminalEvent = input.allowMatchingThreadIdTerminalEvent === true;
-        if (
-            allowMatchingThreadIdTerminalEvent &&
-            input.eventThreadId &&
-            input.currentThreadId &&
-            input.eventThreadId === input.currentThreadId
-        ) {
+        if (allowMatchingThreadIdTerminalEvent && hasMatchingThreadId) {
             return false;
         }
         return true;


### PR DESCRIPTION
Fixes #1070

## Root cause

After a same-thread retry/compact recovery opens a new Codex turn, a terminal event carrying the previous `turn_id` never finalizes the new turn: `shouldIgnoreTerminalEvent()` unconditionally ignores stale-turn events, and the launcher only passed `allowMatchingThreadIdTerminalEvent` for `terminal_source === 'thread_status'`. The session then stays non-ready (`thinking` stuck, no `ready`).

## Fix

Following the fork patch referenced in the issue (mouriya-s-lab/hapi@6c675985):

- `cli/src/codex/utils/terminalEventGuard.ts`: a stale-turn terminal event is accepted when the event thread matches the current thread and the caller explicitly allows it (`allowMatchingThreadIdTerminalEvent`). Events for a different thread are still ignored.
- `cli/src/codex/codexRemoteLauncher.ts`: the allow condition is extended to `terminal_source === 'thread_status' || sameThreadRetryAttempt > 0 || sameThreadCompactAttempt > 0`, i.e. thread-matching stale terminal events are accepted while a same-thread recovery is in flight so the turn finalizes and `ready` is emitted.

Deviation from the fork patch (code drift since the issue was filed): on current `main` the stale event is dropped even earlier by the `lastFinalizedTurnId` duplicate-terminal check, before it ever reaches the guard. The same recovery exemption was therefore added to that check as well; without it the new regression tests time out exactly as the production session does.

Note on issue wording: the issue text frames stale terminal events as something that must stay scoped to the active turn, but the fork patch's actual semantics are the opposite for the recovery window — accept thread-matching stale terminal events so the session recovers `ready`. This PR follows the fork semantics.

## Tests

- New launcher regression tests in `cli/src/codex/codexRemoteLauncher.test.ts`: same-thread retry and same-thread compact recovery completing with a stale `turn_id` both emit `ready` and clear `thinking`.
- New unit tests in `cli/src/codex/utils/terminalEventGuard.test.ts` for the thread-match exemption (accepted on matching thread, still ignored on different thread).
- `bun typecheck` — passes.
- `bunx vitest run src/codex/codexRemoteLauncher.test.ts src/codex/utils/terminalEventGuard.test.ts` — 79/79 pass.
- `bun run test` (cli, full suite) — 154 files / 1482 tests pass.

## Known trade-offs / risks

- During the recovery window (retry/compact attempt counters > 0), a genuinely duplicate late terminal event from the old turn on the same thread is now accepted and finalizes the in-flight recovery turn. This is the fork's intended trade-off: the app-server only emits old-`turn_id` terminal events on this recovery path.
- Unrelated pre-existing flake: `src/modules/common/cursorModels.test.ts` ("does not spawn agent --list-models while ACP transport is active") failed in 2 of 4 full-suite runs on this branch and passes standalone on both this branch and a clean `origin/main` baseline; it touches no Codex code and appears load/ordering sensitive.