### PR TITLE
fix(web): hide offline banner while hub SSE is connected

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -141,6 +141,7 @@ function AppInner() {
     const { isSyncing, startSync, endSync } = useSyncingState()
     const [sseDisconnected, setSseDisconnected] = useState(false)
     const [sseDisconnectReason, setSseDisconnectReason] = useState<string | null>(null)
+    const [sseConnected, setSseConnected] = useState(false)
     const syncTokenRef = useRef(0)
     const isFirstConnectRef = useRef(true)
     const baseUrlRef = useRef(baseUrl)
@@ -204,6 +205,7 @@ function AppInner() {
 
     const handleSseConnect = useCallback(() => {
         // Clear disconnected state on successful connection
+        setSseConnected(true)
         setSseDisconnected(false)
         setSseDisconnectReason(null)
 
@@ -244,6 +246,7 @@ function AppInner() {
     }, [api, queryClient, selectedSessionId, startSync, endSync])
 
     const handleSseDisconnect = useCallback((reason: string) => {
+        setSseConnected(false)
         // Only show reconnecting banner if we've already connected once
         if (!isFirstConnectRef.current) {
             setSseDisconnected(true)
@@ -457,7 +460,7 @@ function AppInner() {
                     reason={sseDisconnectReason}
                 />
                 <VoiceErrorBanner />
-                <OfflineBanner />
+                <OfflineBanner sseConnected={sseConnected} />
                 <div className="h-full min-h-0 flex flex-col">
                     <Outlet />
                 </div>

--- a/web/src/components/OfflineBanner.tsx
+++ b/web/src/components/OfflineBanner.tsx
@@ -1,11 +1,13 @@
 import { useOnlineStatus } from '@/hooks/useOnlineStatus'
 import { useTranslation } from '@/lib/use-translation'
 
-export function OfflineBanner() {
+export function OfflineBanner({ sseConnected }: { sseConnected: boolean }) {
     const { t } = useTranslation()
     const isOnline = useOnlineStatus()
 
-    if (isOnline) {
+    // navigator.onLine can report offline while the hub is still reachable
+    // (e.g. Telegram WebView), so only show when the SSE stream is down too
+    if (isOnline || sseConnected) {
         return null
     }
 

--- a/web/src/components/ReconnectingBanner.tsx
+++ b/web/src/components/ReconnectingBanner.tsx
@@ -1,4 +1,3 @@
-import { useOnlineStatus } from '@/hooks/useOnlineStatus'
 import { useTranslation } from '@/lib/use-translation'
 
 function getReasonLabel(reason: string, t: (key: string) => string): string {
@@ -25,11 +24,9 @@ export function ReconnectingBanner({
     reason?: string | null
 }) {
     const { t } = useTranslation()
-    const isOnline = useOnlineStatus()
     const reasonLabel = reason ? getReasonLabel(reason, t) : null
 
-    // Don't show if offline (OfflineBanner takes precedence) or if not reconnecting
-    if (!isReconnecting || !isOnline) {
+    if (!isReconnecting) {
         return null
     }
 


### PR DESCRIPTION
Fixes #1050

## Root cause
`OfflineBanner` relied solely on `navigator.onLine`, which can report offline while the hub is perfectly reachable (e.g. Telegram WebView, some mobile browsers). Meanwhile `ReconnectingBanner` was explicitly suppressed whenever the online hint was true, so an SSE drop with a healthy-looking `navigator.onLine` showed neither banner — or the wrong one.

## Fix
- `App.tsx`: track SSE connection state (`sseConnected`) via the existing connect/disconnect handlers and pass it to `OfflineBanner`.
- `OfflineBanner.tsx`: only render when `navigator.onLine === false && !sseConnected` — a live SSE connection is proof the hub is reachable.
- `ReconnectingBanner.tsx`: drop the `!isOnline` suppression so an SSE drop surfaces the reconnecting banner regardless of `navigator.onLine`.

## Testing
- `bun typecheck` (cli + web + hub) clean.
- No web test suite for these components (repo convention: necessary tests only); behavior verified by code inspection of the SSE handler wiring in `App.tsx`.

## Trade-offs
- If the browser is truly offline and SSE drops after having been connected, both banners can render simultaneously (both are `fixed top-0 z-50` and may overlap). The state is transient and self-heals on reconnect.