### PR TITLE
feat(codex): support app-server profile configuration

### DIFF
--- a/cli/src/codex/codexAppServerClient.test.ts
+++ b/cli/src/codex/codexAppServerClient.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveCodexAppServerCommand } from './codexAppServerClient';
+
+const originalAppServerBin = process.env.HAPI_CODEX_APP_SERVER_BIN;
+const originalCodexProfile = process.env.HAPI_CODEX_PROFILE;
+
+afterEach(() => {
+    if (originalAppServerBin === undefined) {
+        delete process.env.HAPI_CODEX_APP_SERVER_BIN;
+    } else {
+        process.env.HAPI_CODEX_APP_SERVER_BIN = originalAppServerBin;
+    }
+
+    if (originalCodexProfile === undefined) {
+        delete process.env.HAPI_CODEX_PROFILE;
+    } else {
+        process.env.HAPI_CODEX_PROFILE = originalCodexProfile;
+    }
+});
+
+describe('resolveCodexAppServerCommand', () => {
+    it('starts app-server without a profile by default', () => {
+        process.env.HAPI_CODEX_APP_SERVER_BIN = '/tmp/codex';
+        delete process.env.HAPI_CODEX_PROFILE;
+
+        expect(resolveCodexAppServerCommand()).toEqual({
+            command: '/tmp/codex',
+            args: ['app-server']
+        });
+    });
+
+    it('starts app-server with the configured Codex profile', () => {
+        process.env.HAPI_CODEX_APP_SERVER_BIN = '/tmp/codex';
+        process.env.HAPI_CODEX_PROFILE = ' tapsvc ';
+
+        expect(resolveCodexAppServerCommand()).toEqual({
+            command: '/tmp/codex',
+            args: ['--profile', 'tapsvc', 'app-server']
+        });
+    });
+});

--- a/cli/src/codex/codexAppServerClient.ts
+++ b/cli/src/codex/codexAppServerClient.ts
@@ -85,6 +85,11 @@ type CodexCommandCandidate = {
     version: number[] | null;
 };
 
+export type CodexAppServerCommand = {
+    command: string;
+    args: string[];
+};
+
 function parseCodexVersion(output: string): number[] | null {
     const match = /(\d+)\.(\d+)\.(\d+)(?:[-+][^\s]+)?/u.exec(output);
     if (!match) return null;
@@ -115,9 +120,15 @@ function compareVersion(a: number[] | null, b: number[] | null): number {
     return 0;
 }
 
-function resolveCodexAppServerCommand(): string {
+export function resolveCodexAppServerCommand(): CodexAppServerCommand {
+    const profile = process.env.HAPI_CODEX_PROFILE?.trim();
+    const args = profile ? ['--profile', profile, 'app-server'] : ['app-server'];
+
     if (process.env.HAPI_CODEX_APP_SERVER_BIN) {
-        return process.env.HAPI_CODEX_APP_SERVER_BIN;
+        return {
+            command: process.env.HAPI_CODEX_APP_SERVER_BIN,
+            args
+        };
     }
 
     const candidates: CodexCommandCandidate[] = [{
@@ -154,7 +165,10 @@ function resolveCodexAppServerCommand(): string {
             version: candidate.version?.join('.') ?? null
         }))
     });
-    return best.command;
+    return {
+        command: best.command,
+        args
+    };
 }
 
 export class CodexAppServerClient extends JsonLineParser {
@@ -179,8 +193,8 @@ export class CodexAppServerClient extends JsonLineParser {
         }
 
         const codexCommand = resolveCodexAppServerCommand();
-        logger.debug(`[CodexAppServer] Starting ${codexCommand} app-server`);
-        this.process = spawn(codexCommand, ['app-server'], {
+        logger.debug(`[CodexAppServer] Starting ${codexCommand.command} ${codexCommand.args.join(' ')}`);
+        this.process = spawn(codexCommand.command, codexCommand.args, {
             env: Object.keys(process.env).reduce((acc, key) => {
                 const value = process.env[key];
                 if (typeof value === 'string') acc[key] = value;


### PR DESCRIPTION
## What changed

- add `HAPI_CODEX_PROFILE` for Codex app-server sessions
- launch the remote backend as `codex --profile <name> app-server` when configured
- preserve the existing `codex app-server` behavior when the variable is unset
- cover both command shapes with focused tests

## Why

`hapi codex --profile <name>` already forwards the profile in local mode, but remote runner sessions use Codex app-server and ignore general Codex CLI arguments. This left runner-managed sessions without a way to select a Codex config profile.

The environment variable gives each runner machine a default profile without extending the hub RPC or session persistence schema.

## Validation

- `cd cli && bunx vitest run src/codex/codexAppServerClient.test.ts`
- `bun typecheck`
- `bun run test:hub`
- `bun run test:shared`
- verified the installed Codex CLI accepts `codex --profile tapsvc app-server --help`

The full CLI suite passed the new test and all Codex/runner coverage, but one existing Kimi config test read the operator's legacy `~/.kimi/config.toml` and failed its "nothing configured" assertion. The web suite had one unrelated jsdom `StorageEvent.storageArea` type failure; 1,413 other web tests passed.
