### PR TITLE
fix(web): align inline tool detail spacing

### DIFF
--- a/web/src/components/ToolCard/ToolCard.tsx
+++ b/web/src/components/ToolCard/ToolCard.tsx
@@ -435,6 +435,11 @@ function ToolCardInner(props: ToolCardProps) {
         || ((permission.status === 'denied' || permission.status === 'canceled') && Boolean(permission.reason))
     ))
     const hasBody = showInline || taskSummary !== null || showsPermissionFooter
+    // Header/content padding already supplies 12-16px below timing; add only
+    // the remainder needed to match the detail dialog's 16px section gap.
+    const inlineBodySpacing = props.block.tool.state === 'pending'
+        ? 'mt-3'
+        : (subtitle ? 'mt-1' : 'mt-0')
     const stateColor = toolStatusColorClass(props.block.tool.state)
     const { suppressFocusRing, onTriggerPointerDown, onTriggerKeyDown, onTriggerBlur } = usePointerFocusRing()
     const openDetails = () => setDetailsOpen(true)
@@ -536,7 +541,10 @@ function ToolCardInner(props: ToolCardProps) {
                     {showInline ? (
                         CompactToolView ? (
                             <div
-                                className="mt-3 cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
+                                className={cn(
+                                    inlineBodySpacing,
+                                    'cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]'
+                                )}
                                 role="button"
                                 tabIndex={0}
                                 onClick={openDetailsFromInlinePreview}
@@ -545,7 +553,7 @@ function ToolCardInner(props: ToolCardProps) {
                                 <CompactToolView block={props.block} metadata={props.metadata} surface="inline" />
                             </div>
                         ) : (
-                            <div className="mt-3 flex flex-col gap-3">
+                            <div className={cn(inlineBodySpacing, 'flex flex-col gap-3')}>
                                 <div
                                     className="cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
                                     role="button"

--- a/web/src/components/ToolCard/toolCardSpacing.test.tsx
+++ b/web/src/components/ToolCard/toolCardSpacing.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { ApiClient } from '@/api/client'
+import type { ToolCallBlock } from '@/chat/types'
+import { ToolCard } from '@/components/ToolCard/ToolCard'
+import { I18nProvider } from '@/lib/i18n-context'
+
+function renderDetailedBash(command: string, state: 'pending' | 'completed' = 'completed') {
+    const completed = state === 'completed'
+    const block: ToolCallBlock = {
+        kind: 'tool-call',
+        id: 'tool-1',
+        localId: null,
+        createdAt: 1_000,
+        tool: {
+            id: 'tool-1',
+            name: 'Bash',
+            state,
+            input: { command },
+            createdAt: 1_000,
+            startedAt: completed ? 1_000 : null,
+            completedAt: completed ? 1_500 : null,
+            execStartedAt: null,
+            execCompletedAt: null,
+            description: null,
+            result: completed ? 'ok' : undefined,
+        },
+        children: [],
+    }
+
+    render(
+        <I18nProvider>
+            <ToolCard
+                api={{} as ApiClient}
+                sessionId="session-1"
+                metadata={null}
+                terminalToolDisplayMode="detailed"
+                disabled={false}
+                onDone={() => {}}
+                block={block}
+            />
+        </I18nProvider>
+    )
+
+    return screen.getByText('Input').parentElement?.parentElement
+}
+
+describe('ToolCard spacing', () => {
+    it('matches the dialog gap when the timing header has a subtitle', () => {
+        const inlineBody = renderDetailedBash('echo hello && pwd')
+
+        expect(inlineBody).toHaveClass('mt-1')
+        expect(inlineBody).not.toHaveClass('mt-3')
+    })
+
+    it('matches the dialog gap when the timing header has no subtitle', () => {
+        const inlineBody = renderDetailedBash('pwd')
+
+        expect(inlineBody).toHaveClass('mt-0')
+        expect(inlineBody).not.toHaveClass('mt-3')
+    })
+
+    it('keeps the original body spacing when pending tools have no timing summary', () => {
+        const inlineBody = renderDetailedBash('pwd', 'pending')
+
+        expect(inlineBody).toHaveClass('mt-3')
+    })
+})


### PR DESCRIPTION
### Summary

Align the vertical spacing between tool timing metadata and inline tool details with the spacing used in the detail dialog.

### Changes

- Reduce only the extra inline-body margin when a tool timing summary is present.
- Account for tool headers both with and without subtitles so the total section gap stays at 16px, matching the dialog's `gap-4` layout.
- Preserve the existing spacing for pending tools, which do not show timing metadata.
- Add regression coverage for subtitle, title-only, and pending tool cards.

### Testing

- `bun typecheck`
- `bun run test:web` (179 files, 1513 tests)
- `bun run build:web`
- `bun run --cwd web test src/components/ToolCard/toolCardSpacing.test.tsx`
- `git diff --check`

### AI disclosure

AI-assisted with OpenAI Codex (GPT-5.6).
