### PR TITLE
fix(web): keep sticky workspace headers opaque

### DIFF
--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1297,7 +1297,7 @@ export function SessionList(props: {
                     return (
                         <div key={group.key}>
                             <div
-                                className="group/project sticky top-0 z-10 flex items-center gap-2 py-1.5 pl-2 pr-2 text-left rounded-lg transition-colors hover:bg-[var(--app-subtle-bg)] cursor-pointer min-w-0 w-full select-none"
+                                className="group/project sticky top-0 z-10 flex items-center gap-2 bg-[var(--app-bg)] py-1.5 pl-2 pr-2 text-left rounded-lg transition-colors hover:bg-[var(--app-subtle-bg)] cursor-pointer min-w-0 w-full select-none"
                                 onClick={() => toggleGroup(group.key, isCollapsed)}
                                 title={group.directory}
                             >


### PR DESCRIPTION
## What changed

Give sticky workspace headers an opaque app background.

## Why

When sessions scroll beneath a sticky workspace header, the header previously remained transparent. Session titles and status text showed through and overlapped the workspace name. This became especially visible after the narrow-sidebar layout from #1029 landed on `main` as `3cfb2ea`.

The existing hover background remains unchanged.

## Impact

Scrolling sessions are visually covered by the pinned workspace header instead of rendering through it.

## Verification

- `bun typecheck`
- `bun run test` (CLI: 1,524 passed; web: 1,560 passed; shared: 142 passed; hub passed)
- `git diff --check`
