### PR TITLE
fix(cli): mark synthetic SDK user messages as meta

### DIFF
--- a/cli/src/claude/sdk/types.ts
+++ b/cli/src/claude/sdk/types.ts
@@ -17,6 +17,13 @@ export interface SDKMessage {
 export interface SDKUserMessage extends SDKMessage {
     type: 'user'
     parent_tool_use_id?: string
+    /**
+     * Set by Claude Code on user-role messages it injects itself (skill bodies,
+     * compact continuation summaries) rather than relaying from the human. The
+     * on-disk transcript spells the same thing `isMeta`.
+     */
+    isSynthetic?: boolean
+    isMeta?: boolean
     message: {
         role: 'user'
         content: string | Array<{

--- a/cli/src/claude/utils/sdkToLogConverter.test.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.test.ts
@@ -69,6 +69,52 @@ describe('SDKToLogConverter', () => {
             expect(logMessage?.type).toBe('user')
             expect((logMessage as any).message.content).toHaveLength(2)
         })
+
+        it('should mark synthetic user messages as meta', () => {
+            // Skill injections arrive over stream-json as plain-text user messages
+            // flagged with isSynthetic. The on-disk transcript flags the same event
+            // with isMeta, which is what every downstream filter looks for.
+            const sdkMessage: SDKUserMessage = {
+                type: 'user',
+                isSynthetic: true,
+                message: {
+                    role: 'user',
+                    content: [
+                        { type: 'text', text: 'Base directory for this skill: /home/user/.claude/skills/foo' }
+                    ]
+                }
+            }
+
+            const logMessage = converter.convert(sdkMessage)
+
+            expect(logMessage?.type).toBe('user')
+            expect(logMessage?.isMeta).toBe(true)
+        })
+
+        it('should preserve isMeta on user messages', () => {
+            const sdkMessage: SDKUserMessage = {
+                type: 'user',
+                isMeta: true,
+                message: {
+                    role: 'user',
+                    content: 'injected context'
+                }
+            }
+
+            expect(converter.convert(sdkMessage)?.isMeta).toBe(true)
+        })
+
+        it('should not mark genuine user messages as meta', () => {
+            const sdkMessage: SDKUserMessage = {
+                type: 'user',
+                message: {
+                    role: 'user',
+                    content: 'Hello Claude'
+                }
+            }
+
+            expect(converter.convert(sdkMessage)?.isMeta).toBeUndefined()
+        })
     })
 
     describe('Assistant messages', () => {

--- a/cli/src/claude/utils/sdkToLogConverter.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.ts
@@ -271,6 +271,16 @@ export class SDKToLogConverter {
                     message: userMsg.message
                 }
 
+                // Claude Code injects its own user-role turns (skill bodies, compact
+                // continuation summaries). Over stream-json they are flagged
+                // `isSynthetic`, while the on-disk transcript the local launcher reads
+                // flags them `isMeta`. Normalize to `isMeta` so both paths hit the same
+                // downstream filters — otherwise the injected text reaches the web UI
+                // and is rendered as if the human had typed it.
+                if (userMsg.isSynthetic === true || userMsg.isMeta === true) {
+                    logMessage.isMeta = true
+                }
+
                 // Check if this is a tool result and add mode if available
                 if (Array.isArray(userMsg.message.content)) {
                     for (const content of userMsg.message.content) {


### PR DESCRIPTION
## Problem

In remote mode, invoking a skill renders the entire skill document as a **user message bubble** in the web UI, as if the human had pasted it into the chat. The tool card itself renders correctly; the injected body shows up right after it.

The cause is a field-name mismatch between the two transcript sources, and a converter that drops the flag.

Claude Code injects its own user-role turns (skill bodies, compact continuation summaries). The on-disk JSONL flags them `isMeta`:

```json
{"type":"user","isMeta":true,"sourceToolUseID":"toolu_01…",
 "message":{"role":"user","content":[{"type":"text","text":"Base directory for this skill: …"}]}}
```

The stream-json the SDK path consumes flags the same event `isSynthetic` instead — captured from a real session:

```json
{"type":"user","message":{"role":"user","content":[{"type":"text",
  "text":"Base directory for this skill: /home/…/skills/brainstorming"}]},
 "parent_tool_use_id":null,"isSynthetic":true}
```

`sdkToLogConverter`'s `case 'user'` copied only `message`, so the flag was silently discarded and the emitted line had neither `isMeta` nor `isSynthetic`. Every downstream guard then let it through:

- `OutgoingMessageQueue.ts:124` — checks `!logMessage.isMeta`, which is `undefined`, so it forwards.
- `apiSession.ts:88` — `isExternalUserMessage` checks `isMeta`, then falls back to a prefix allowlist (`<system-reminder>`, `<task-notification>`, …). A skill body is bare markdown starting with `Base directory for this skill:`, so it matches nothing and is classified as genuine human input.
- The web UI receives `role:'user'` and renders a user bubble.

This is why **local mode is unaffected**: `claudeLocalLauncher.ts:29` sees `isMeta` on the JSONL and drops the message, covered by `claudeLocalLauncher.test.ts:167` (`'filters out isMeta messages (e.g. skill injections)'`). The SDK path simply never had an equivalent.

## Fix

Normalize `isSynthetic` (and a passthrough `isMeta`) onto the converted line, restoring parity with the transcript path. No new filtering logic is introduced — the three existing `isMeta` guards start working as they were already written to.

This also covers compact continuation summaries, which carry the same `isSynthetic` flag over stream-json and were leaking through remote mode for the same reason.

## Tests

Three cases added to `sdkToLogConverter.test.ts`: `isSynthetic` maps to `isMeta`, an explicit `isMeta` survives, and a genuine user message stays unflagged.

- `bun run typecheck` in `cli/` passes.
- `bun test` in `cli/`: 1054 pass / 110 fail. The same 110 fail on `main` at this commit (1051 pass there — the delta is exactly the three new tests), so no regression.

## Follow-up (not in this PR)

`web/src/chat/normalizeAgent.ts:360-376` turns *any* non-sidechain user message whose content is entirely text blocks into `role:'user'`. That branch is the backstop this bug slipped past, and its stated premise — "isExternalUserMessage rejects array content" — is not accurate, since `extractRawUserTextContent` handles arrays. It has no test coverage. Worth tightening separately; with this fix the message no longer reaches the web layer at all.