### PR TITLE
fix(web): dedupe React so hook-using deps stop crashing

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -145,7 +145,24 @@ export default defineConfig({
         })
     ],
     base,
+    optimizeDeps: {
+        // dev 下 VitePWA 会给每个页面注入 service worker 注册，而 sw.ts 里的
+        // workbox 依赖要等 SW 真正注册后才被 Vite 发现，触发一次「optimized
+        // dependencies changed → reloading」的整页刷新。这个刷新会打断当时
+        // 正在跑的 e2e（表现为元素凭空消失）。提前声明即可在启动时一次预构建。
+        include: [
+            'workbox-precaching',
+            'workbox-routing',
+            'workbox-strategies',
+            'workbox-expiration'
+        ]
+    },
     resolve: {
+        // 单例 React 兜底：workspace 里个别依赖（如 @radix-ui/react-popover）
+        // 没被链进 web/node_modules，只能从仓库根解析，于是拿到与应用代码
+        // 不同的那份 react 实例。两份 React 同时存在会让带 hook 的第三方
+        // 组件在渲染时抛 "Invalid hook call"，并连累整棵 React 树卸载。
+        dedupe: ['react', 'react-dom'],
         alias: {
             '@': resolve(__dirname, 'src')
         }


### PR DESCRIPTION
## What

Two Vite dev/build config additions:

1. `resolve.dedupe: ['react', 'react-dom']`
2. `optimizeDeps.include` for the four workbox packages

## Why (1): duplicate React silently breaks any hook-using dependency

`@radix-ui/react-popover` is declared in `web/package.json`, but it is **not linked into `web/node_modules`** — only `react-dialog` and `react-slot` are:

```
$ ls web/node_modules/@radix-ui/
react-dialog  react-slot
```

So it resolves React from the repo root instead, which is a physically different copy from the one app code imports:

```
web app imports react →  node_modules/.bun/react@19.2.3/node_modules/react
react-popover imports →  node_modules/react
```

Two React instances make every hook-using third-party component throw `Invalid hook call` on render. Without an error boundary React then unmounts the **whole tree**, so the symptom is a blank page rather than a visible error.

Re-running `bun install` does not change the layout, so this is not stale local state.

### Impact: this was already failing 20 tests on main

| | `main` | with this patch |
|---|---|---|
| Failing | **8 files / 20 tests** | **0** |
| Passing | 1483 | 1560 |
| Total collected | 1503 | **1560** |

The collected total goes *up* by 57 because the affected files were dying during import — their tests were never counted at all.

```bash
cd web && npm run test
# main:       Test Files 8 failed | 173 passed (181)
#             Tests     20 failed | 1483 passed (1503)
# this patch: Test Files 181 passed (181)
#             Tests     1560 passed (1560)
```

I found this while building a feature that renders a Radix Popover — the component white-screened the entire page. The failing tests on main turned out to be the same root cause.

## Why (2): dev service worker forces a mid-run page reload

`VitePWA` `devOptions.enabled: true` injects SW registration into every served page. The workbox imports inside `sw.ts` are only discovered *after* registration, so Vite re-optimizes deps and issues `optimized dependencies changed → reloading`. On a cold cache this reliably kills whichever e2e test is in flight (elements vanish mid-assertion).

Declaring the four workbox packages in `optimizeDeps.include` pre-bundles them at startup instead. This affects all e2e fixtures, not any one suite.

## Verification

- `npm run test` — 1560/1560 pass (was 1483/1503 with 20 failures)
- `npm run typecheck` — clean
- `npm run build` — succeeds, PWA manifest generated normally
- `npm run test:mermaid-lightbox:e2e` — 15/15 pass

## Note

`resolve.dedupe` is a safety net, not a substitute for fixing the install layout. If the real fix is to make bun link `@radix-ui/react-popover` into `web/node_modules`, I'm happy to change direction — but the dedupe is worth keeping regardless, since it makes the app resilient to this class of hoisting difference.