### PR TITLE
fix(web): share picker titles match sidebar (name before summary)

### DIFF
--- a/web/src/lib/sessionTitle.test.ts
+++ b/web/src/lib/sessionTitle.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { getSessionTitle } from './sessionTitle'
+
+describe('getSessionTitle', () => {
+    it('prefers metadata.name over summary.text (sidebar / share picker parity)', () => {
+        expect(getSessionTitle({
+            id: 'abcdef0123456789',
+            metadata: {
+                name: 'hub runner version governance',
+                summary: { text: 'HAPI Skill Lookup' },
+                path: '/tmp/share-title-parity',
+            },
+        })).toBe('hub runner version governance')
+    })
+
+    it('falls back to summary when name is absent', () => {
+        expect(getSessionTitle({
+            id: 'abcdef0123456789',
+            metadata: {
+                summary: { text: 'HAPI Skill Lookup' },
+                path: '/tmp/share-title-parity',
+            },
+        })).toBe('HAPI Skill Lookup')
+    })
+
+    it('falls back to the last path segment when name and summary are absent', () => {
+        expect(getSessionTitle({
+            id: 'abcdef0123456789',
+            metadata: {
+                path: '/tmp/share-title-parity',
+            },
+        })).toBe('share-title-parity')
+    })
+
+    it('falls back to a short id when metadata is empty', () => {
+        expect(getSessionTitle({ id: 'abcdef0123456789' })).toBe('abcdef01')
+    })
+})

--- a/web/src/routes/share/index.tsx
+++ b/web/src/routes/share/index.tsx
@@ -10,6 +10,7 @@ import {
     type ShareTransferPayload,
 } from '@/lib/shareTransfer'
 import { setSharePendingTransfer } from '@/lib/sharePendingState'
+import { getSessionTitle } from '@/lib/sessionTitle'
 import type { SessionSummary } from '@/types/api'
 
 type LoadState =
@@ -27,13 +28,6 @@ function formatBytes(n: number): string {
     if (n < 1024) return `${n} B`
     if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
     return `${(n / (1024 * 1024)).toFixed(1)} MB`
-}
-
-function getSessionTitle(session: SessionSummary): string {
-    return session.metadata?.summary?.text
-        ?? session.metadata?.name
-        ?? session.metadata?.path
-        ?? session.id.slice(0, 8)
 }
 
 function SharePreview(props: { payload: ShareTransferPayload }) {


### PR DESCRIPTION
## Summary
- `/share` picker used a local `getSessionTitle` that preferred `metadata.summary.text` over `metadata.name`, so share-target rows disagreed with the session sidebar.
- Delete the local helper and import `@/lib/sessionTitle` (name → summary → path → id).
- Unit test locks name-vs-summary precedence for share/sidebar parity.
- Searchable picker behavior (#980 / #986) is unchanged — title parity only.

## Test plan
- [x] Peer-stack Playwright before: sidebar name vs `/share` summary
- [x] Peer-stack Playwright after: both show name
- [x] `bun typecheck` + web/hub unit tests
- [x] Operator dogfood on soup `:3006` / Android share sheet

## Proof
Before/after PNGs on https://github.com/tiann/hapi/issues/1218

## Issues
Closes #1218