### PR TITLE
fix(web): prevent duplicate session creation

### DIFF
--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
     spawnSession: vi.fn(),
     onSuccess: vi.fn(),
     notification: vi.fn(),
+    checkPathsExists: vi.fn(),
     codexModelsLoading: false,
     directoryExists: undefined as boolean | undefined
 }))
@@ -44,7 +45,7 @@ vi.mock('@/hooks/useRecentPaths', () => ({
 vi.mock('@/hooks/useMachinePathsExists', () => ({
     useMachinePathsExists: () => ({
         pathExistence: { 'C:\\repo': mocks.directoryExists },
-        checkPathsExists: async () => ({ 'C:\\repo': mocks.directoryExists })
+        checkPathsExists: mocks.checkPathsExists
     })
 }))
 vi.mock('@/hooks/useDirectorySuggestions', () => ({
@@ -152,6 +153,8 @@ describe('NewSession launch preferences', () => {
         mocks.spawnSession.mockReset()
         mocks.onSuccess.mockReset()
         mocks.notification.mockReset()
+        mocks.checkPathsExists.mockReset()
+        mocks.checkPathsExists.mockImplementation(async () => ({ 'C:\\repo': mocks.directoryExists }))
         mocks.codexModelsLoading = false
         mocks.directoryExists = true
         savePreferredAgent('codex')
@@ -274,6 +277,34 @@ describe('NewSession launch preferences', () => {
             effort: 'auto',
             modelReasoningEffort: 'max'
         })
+    })
+
+    it('spawns only once when Create is activated twice during directory validation', async () => {
+        let finishDirectoryCheck!: (result: Record<string, boolean>) => void
+        mocks.checkPathsExists.mockReturnValue(new Promise((resolve) => {
+            finishDirectoryCheck = resolve
+        }))
+        mocks.spawnSession.mockResolvedValue({ type: 'success', sessionId: 'session-1' })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        const create = screen.getByTestId('create')
+        fireEvent.click(create)
+        fireEvent.click(create)
+        finishDirectoryCheck({ 'C:\\repo': true })
+
+        await waitFor(() => expect(mocks.onSuccess).toHaveBeenCalledWith('session-1'))
+        expect(mocks.checkPathsExists).toHaveBeenCalledTimes(1)
+        expect(mocks.spawnSession).toHaveBeenCalledTimes(1)
     })
 
     it('does not save changed launch settings when creation fails', async () => {

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -147,7 +147,9 @@ export function NewSession(props: {
     const [codexImportError, setCodexImportError] = useState<string | null>(null)
     const [isImportingCodexSession, setIsImportingCodexSession] = useState(false)
     const [isCodexImportDialogOpen, setIsCodexImportDialogOpen] = useState(false)
-    const isFormDisabled = Boolean(isPending || props.isLoading || isImportingCodexSession)
+    const [isCreating, setIsCreating] = useState(false)
+    const createInFlightRef = useRef(false)
+    const isFormDisabled = Boolean(isCreating || isPending || props.isLoading || isImportingCodexSession)
     const worktreeInputRef = useRef<HTMLInputElement>(null)
     const preserveRestoredDraftRef = useRef(false)
 
@@ -877,8 +879,10 @@ export function NewSession(props: {
     }, [suggestions, selectedIndex, moveUp, moveDown, clearSuggestions, handleSuggestionSelect])
 
     async function handleCreate() {
-        if (!machineId || !trimmedDirectory) return
+        if (!machineId || !trimmedDirectory || createInFlightRef.current) return
 
+        createInFlightRef.current = true
+        setIsCreating(true)
         setError(null)
         try {
             const existsResult = await checkPathsExists([trimmedDirectory])
@@ -998,6 +1002,9 @@ export function NewSession(props: {
             setIsImportingCodexSession(false)
             haptic.notification('error')
             setError(e instanceof Error ? e.message : 'Failed to create session')
+        } finally {
+            createInFlightRef.current = false
+            setIsCreating(false)
         }
     }
 
@@ -1217,7 +1224,7 @@ export function NewSession(props: {
             ) : null}
 
             <ActionButtons
-                isPending={isPending || isImportingCodexSession}
+                isPending={isCreating || isPending || isImportingCodexSession}
                 canCreate={canCreate}
                 isDisabled={isFormDisabled}
                 createLabel={createLabel}


### PR DESCRIPTION
## Summary

- claim Create Session synchronously before its first async validation
- disable the form and show creating state for the full validation/spawn operation
- ignore concurrent Create activations until the current attempt finishes
- cover the slow directory-validation double-submit race

## Root cause

`handleCreate()` awaited `checkPathsExists()` before calling the TanStack spawn mutation. The mutation's `isPending` flag was therefore still false during directory validation, leaving Create enabled. A second activation started another handler, and both handlers independently reached `/spawn`.

## Impact

A double-click/double-tap or repeated activation on a slow connection could start two agent processes. The shared form means this was not Codex-specific even though Codex exposed the report.

## Validation

- `bun typecheck` — pass
- `bun run --cwd web test --run src/components/NewSession/index.test.tsx` — 9 passed
- `git diff --check` — pass
- `bun run test` — unrelated existing CLI integration/flaky suites fail in this long-running local HAPI environment; the changed web suite passes. CI is the clean-environment full-suite gate.

Fixes #1220

AI disclosure: Codex assisted with root-cause analysis, implementation, regression testing, and PR drafting. The diff and test results were manually reviewed.
