### PR TITLE
perf(web): skip session cache writes that only move activeAt

### DIFF
--- a/web/src/hooks/useSSE.test.ts
+++ b/web/src/hooks/useSSE.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { SessionSummary } from '@/types/api'
-import { isGlobalScopedMessageStreamEvent, isRenderIrrelevantPatch } from './useSSE'
+import type { Session } from '@/types/api'
+import { isGlobalScopedMessageStreamEvent, isRenderIrrelevantPatch, isRenderIrrelevantSessionPatch } from './useSSE'
 
 function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
     return {
@@ -68,5 +69,51 @@ describe('isRenderIrrelevantPatch', () => {
         const next = makeSummary({ ...change, activeAt: 11_000 })
 
         expect(isRenderIrrelevantPatch(current, next)).toBe(false)
+    })
+})
+
+describe('isRenderIrrelevantSessionPatch', () => {
+    const session = {
+        id: 'session-1',
+        active: true,
+        thinking: false,
+        activeAt: 1_000,
+        updatedAt: 2_000,
+        model: 'opus',
+        effort: null,
+        permissionMode: 'default',
+        serviceTier: null
+    } as unknown as Session
+
+    it('treats a keep-alive that only moves activeAt as irrelevant', () => {
+        expect(isRenderIrrelevantSessionPatch(session, {
+            active: true,
+            thinking: false,
+            activeAt: 11_000,
+            model: 'opus',
+            effort: null,
+            permissionMode: 'default',
+            serviceTier: null
+        })).toBe(true)
+    })
+
+    it('reports a changed field as relevant even alongside a new activeAt', () => {
+        expect(isRenderIrrelevantSessionPatch(session, {
+            thinking: true,
+            activeAt: 11_000
+        })).toBe(false)
+    })
+
+    it('reports a field the session does not carry yet as relevant', () => {
+        // scratchlistUpdatedAt is absent from the cached session, so the patch
+        // genuinely adds information and must not be dropped.
+        expect(isRenderIrrelevantSessionPatch(session, {
+            activeAt: 11_000,
+            scratchlistUpdatedAt: 5_000
+        })).toBe(false)
+    })
+
+    it('treats an empty patch as irrelevant', () => {
+        expect(isRenderIrrelevantSessionPatch(session, {})).toBe(true)
     })
 })

--- a/web/src/hooks/useSSE.test.ts
+++ b/web/src/hooks/useSSE.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from 'vitest'
-import { isGlobalScopedMessageStreamEvent } from './useSSE'
+import type { SessionSummary } from '@/types/api'
+import { isGlobalScopedMessageStreamEvent, isRenderIrrelevantPatch } from './useSSE'
+
+function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+    return {
+        id: 'session-1',
+        active: true,
+        thinking: false,
+        activeAt: 1_000,
+        updatedAt: 2_000,
+        metadata: null,
+        todoProgress: null,
+        pendingRequestsCount: 0,
+        pendingRequestKinds: [],
+        pendingRequests: [],
+        backgroundTaskCount: 0,
+        futureScheduledMessageCount: 0,
+        nextScheduledAt: null,
+        model: null,
+        effort: null,
+        ...overrides
+    } as SessionSummary
+}
 
 describe('useSSE scope handling', () => {
     it('treats message stream events as global-scoped skips', () => {
@@ -17,5 +39,34 @@ describe('useSSE scope handling', () => {
 
     it('processes message stream events on full-scoped connections', () => {
         expect(isGlobalScopedMessageStreamEvent('full', 'message-received')).toBe(false)
+    })
+})
+
+describe('isRenderIrrelevantPatch', () => {
+    it('treats a keep-alive that only moves activeAt as irrelevant', () => {
+        const current = makeSummary({ activeAt: 1_000 })
+        const next = makeSummary({ activeAt: 11_000 })
+
+        expect(isRenderIrrelevantPatch(current, next)).toBe(true)
+    })
+
+    it('treats an identical summary as irrelevant', () => {
+        expect(isRenderIrrelevantPatch(makeSummary(), makeSummary())).toBe(true)
+    })
+
+    it.each([
+        ['active', { active: false }],
+        ['thinking', { thinking: true }],
+        ['updatedAt', { updatedAt: 9_999 }],
+        ['backgroundTaskCount', { backgroundTaskCount: 3 }],
+        ['model', { model: 'opus' }],
+        ['modelReasoningEffort', { modelReasoningEffort: 'high' }],
+        ['effort', { effort: 'medium' }],
+        ['pendingRequestsCount', { pendingRequestsCount: 2 }]
+    ] as Array<[string, Partial<SessionSummary>]>)('reports %s changes as relevant', (_field, change) => {
+        const current = makeSummary()
+        const next = makeSummary({ ...change, activeAt: 11_000 })
+
+        expect(isRenderIrrelevantPatch(current, next)).toBe(false)
     })
 })

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -59,6 +59,26 @@ function isSessionRecord(value: unknown): value is Session {
     return SessionSchema.safeParse(value).success
 }
 
+/**
+ * True when the only difference between two summaries is `activeAt`.
+ *
+ * The CLI keep-alive makes the hub re-broadcast a full session patch about
+ * every 10s per active session even when nothing changed, and `activeAt` is
+ * the sole field that moves. No component reads `activeAt` - the list shows
+ * `updatedAt` and sorts on active/pendingRequestsCount/updatedAt - so storing
+ * it costs a new object identity and a full list re-render for nothing.
+ */
+export function isRenderIrrelevantPatch(current: SessionSummary, next: SessionSummary): boolean {
+    return current.active === next.active
+        && current.thinking === next.thinking
+        && current.updatedAt === next.updatedAt
+        && current.backgroundTaskCount === next.backgroundTaskCount
+        && current.model === next.model
+        && current.modelReasoningEffort === next.modelReasoningEffort
+        && current.effort === next.effort
+        && current.pendingRequestsCount === next.pendingRequestsCount
+}
+
 function getSessionPatch(value: unknown): SessionPatch | null {
     const parsed = SessionPatchSchema.safeParse(value)
     if (!parsed.success) {
@@ -370,6 +390,13 @@ export function useSSE(options: {
                 }
 
                 patched = true
+                // The keep-alive patch repeats every field every ~10s per active
+                // session, and `activeAt` is the only one that actually moves.
+                // Nothing renders `activeAt`, so writing a new object for it just
+                // hands React Query a fresh reference and re-renders the list.
+                if (isRenderIrrelevantPatch(current, nextSummary)) {
+                    return previous
+                }
                 nextSessions[index] = nextSummary
                 nextSessions.sort(sortSessionSummaries)
                 return { ...previous, sessions: nextSessions }

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -55,6 +55,27 @@ function sortSessionSummaries(left: SessionSummary, right: SessionSummary): numb
     return right.updatedAt - left.updatedAt
 }
 
+/**
+ * True when applying `patch` to `session` would change nothing that renders.
+ *
+ * Same reasoning as {@link isRenderIrrelevantPatch}, for the session-detail
+ * cache: the keep-alive patch repeats every field it knows about, so compare
+ * each one against the value already stored and ignore `activeAt`, which has
+ * no reader.
+ */
+export function isRenderIrrelevantSessionPatch(session: Session, patch: SessionPatch): boolean {
+    const current = session as unknown as Record<string, unknown>
+    for (const [key, value] of Object.entries(patch)) {
+        if (key === 'activeAt') {
+            continue
+        }
+        if (current[key] !== value) {
+            return false
+        }
+    }
+    return true
+}
+
 function isSessionRecord(value: unknown): value is Session {
     return SessionSchema.safeParse(value).success
 }
@@ -411,6 +432,9 @@ export function useSSE(options: {
                     return previous
                 }
                 patched = true
+                if (isRenderIrrelevantSessionPatch(previous.session, patch)) {
+                    return previous
+                }
                 return {
                     ...previous,
                     session: {


### PR DESCRIPTION
## Problem

The CLI emits `session-alive` every 2s per session (`cli/src/agent/sessionBase.ts:79`), and the hub re-broadcasts a full `SessionPatch` on a 10s floor even when nothing changed (`hub/src/sync/sessionCache.ts:302`, the `|| (now - lastBroadcastAt > 10_000)` clause). So every active session produces a patch roughly every 10s whose only moving field is `activeAt`.

Captured from a live hub: **92 of 94** `session-updated` events in 60s differed by nothing but that timestamp.

`patchSessionSummary` rebuilt the summary, re-sorted the entire list and returned a fresh object for each one. That new reference alone is enough for React Query to notify every subscriber, and the session list has no memoized components, so the tree re-rendered on every keep-alive.

## Why this is safe

Nothing renders `activeAt`:

- the list timestamp comes from `updatedAt` — `SessionList.tsx:766`, `getSessionTimeLabel`
- sorting keys on `active` / `pendingRequestsCount` / `updatedAt` — `sortSessionSummaries`, `useSSE.ts:48-56`
- the active indicator, row dimming and thinking spinner all read the boolean `active`, not `activeAt`
- no `useMemo`/`useEffect` dependency array references it

Across `web/src` non-test code `activeAt` appears only as a value written into cache; there is no reader. Keeping the previous reference when only `activeAt` moved therefore changes **no visible output**.

## Measured effect

Real Chromium against a live hub with 28 sessions, 75s of steady state each, comparable event volume (107 vs 106 keep-alives):

| | before | after |
|---|---|---|
| React commits | 211 | **39** (−81%) |
| components re-rendered | 293k | **54k** (−81%) |
| long tasks | 75 / 7440ms | **26 / 2713ms** |
| main thread blocked | 9.9% | **3.6%** |
| dropped frames | 75 | **26** |
| frame rate | 55.8 fps | **58.4 fps** |

Verified the instrumentation itself was not the cause: a control run without the React hook attached showed the same long-task total (72 / 7443ms).

## Notes

This is a client-side change only. The hub keeps broadcasting exactly what it does today, so `activeAt` freshness on the wire is unchanged — the patch is simply not written to cache when it cannot affect rendering.

Remaining re-render load after this change is dominated by `machine-updated` (66%), which has the same shape in `upsertMachine`; left for a separate change.

## Testing

- 10 new unit tests on the extracted predicate: activeAt-only patches, identical summaries, and one case per field that must still count as relevant
- `tsc --noEmit -p web/tsconfig.json` clean
- Full `web` suite: 1570 pass, 0 fail