### PR TITLE
perf(web): mount session row dialogs only while they are open

### DIFF
--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -957,13 +957,15 @@ function SessionItem(props: {
                 />
             ) : null}
 
-            <RenameSessionDialog
-                isOpen={renameOpen}
-                onClose={() => setRenameOpen(false)}
-                currentName={sessionName}
-                onRename={renameSession}
-                isPending={isPending}
-            />
+            {renameOpen ? (
+                <RenameSessionDialog
+                    isOpen={true}
+                    onClose={() => setRenameOpen(false)}
+                    currentName={sessionName}
+                    onRename={renameSession}
+                    isPending={isPending}
+                />
+            ) : null}
 
             {exportOpen ? (
                 <SessionExportDialog
@@ -974,29 +976,33 @@ function SessionItem(props: {
                 />
             ) : null}
 
-            <ConfirmDialog
-                isOpen={archiveOpen}
-                onClose={() => setArchiveOpen(false)}
-                title={t('dialog.archive.title')}
-                description={t('dialog.archive.description', { name: sessionName })}
-                confirmLabel={t('dialog.archive.confirm')}
-                confirmingLabel={t('dialog.archive.confirming')}
-                onConfirm={archiveSession}
-                isPending={isPending}
-                destructive
-            />
+            {archiveOpen ? (
+                <ConfirmDialog
+                    isOpen={true}
+                    onClose={() => setArchiveOpen(false)}
+                    title={t('dialog.archive.title')}
+                    description={t('dialog.archive.description', { name: sessionName })}
+                    confirmLabel={t('dialog.archive.confirm')}
+                    confirmingLabel={t('dialog.archive.confirming')}
+                    onConfirm={archiveSession}
+                    isPending={isPending}
+                    destructive
+                />
+            ) : null}
 
-            <ConfirmDialog
-                isOpen={deleteOpen}
-                onClose={() => setDeleteOpen(false)}
-                title={t('dialog.delete.title')}
-                description={t('dialog.delete.description', { name: sessionName })}
-                confirmLabel={t('dialog.delete.confirm')}
-                confirmingLabel={t('dialog.delete.confirming')}
-                onConfirm={deleteSession}
-                isPending={isPending}
-                destructive
-            />
+            {deleteOpen ? (
+                <ConfirmDialog
+                    isOpen={true}
+                    onClose={() => setDeleteOpen(false)}
+                    title={t('dialog.delete.title')}
+                    description={t('dialog.delete.description', { name: sessionName })}
+                    confirmLabel={t('dialog.delete.confirm')}
+                    confirmingLabel={t('dialog.delete.confirming')}
+                    onConfirm={deleteSession}
+                    isPending={isPending}
+                    destructive
+                />
+            ) : null}
         </>
     )
 }


### PR DESCRIPTION
## Problem

Every `SessionItem` renders its rename dialog and both confirm dialogs **unconditionally**, passing `isOpen` to keep them closed (`SessionList.tsx`). With 28 sessions that is **84 mounted Radix dialogs the user cannot see**, and each carries a `Presence` / `DialogProvider` / `DialogContent` / `DialogPortal` subtree that re-renders whenever the row does.

Measured against a live hub, those dialogs were **roughly half of the entire fiber tree** — 1680 nodes before, 886 after. Profiling a single `machine-updated` event (arrives every 20s per machine, carries only changed CPU/memory numbers) showed it re-rendering **1600+ dialog-internal components**:

```
Presence               3360
Dialog                 1680
DialogProvider         1680
DialogContent          1680
DialogPortal           1680
ConfirmDialog           848
RenameSessionDialog     416
```

## Fix

Mount them on demand. The same file **already does this** for `SessionExportDialog` and the reopen-error `ConfirmDialog`, so this only brings the remaining three in line with the pattern sitting right next to them.

`dialog.tsx` has no open/close transition (its only `transition-*` is the close button's hover color), so nothing animates on unmount.

## Measured effect

Real Chromium against a live hub, 70s steady state, stacked on top of the activeAt patch fix (#1232). The fiber-tree number is attributable to this change alone:

| | before | after |
|---|---|---|
| fiber tree | 1680 | **886** |
| components re-rendered | 54k | **15.5k** |
| long tasks | 26 / 2713ms | **0 / 0ms** |
| main thread blocked | 3.6% | **0.0%** |
| frame rate | 58.4 fps | **59.8 fps** |

Long tasks disappear entirely.

## Verification

Driven interactively in a real browser with real pointer events, not synthetic clicks:

- idle: **0** dialogs in the DOM (was 84)
- long-press a row → menu opens with Rename / Copy reference / Export conversation / Archive
- click Rename → dialog opens, input prefilled with the current session name
- Escape → dialog closes, back to 0 in the DOM

## Testing

- `tsc --noEmit -p web/tsconfig.json` clean
- Full `web` suite: 1598 pass, 0 fail