### PR TITLE
fix(web): keep sticky workspace headers opaque and aligned

### DIFF
--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -88,6 +88,43 @@ describe('SessionList directory action', () => {
         })
     })
 
+    it('keeps the sticky project header opaque and aligned with the list viewport', () => {
+        const session = makeSession({
+            id: 'session-1',
+            updatedAt: Date.now(),
+            metadata: {
+                path: '/home/ubuntu',
+                name: 'Greeting',
+                flavor: 'codex',
+            }
+        })
+
+        renderWithProviders(
+            <SessionList
+                sessions={[session]}
+                selectedSessionId={null}
+                onSelect={vi.fn()}
+                onNewSession={vi.fn()}
+                onRefresh={vi.fn()}
+                isLoading={false}
+                renderHeader={false}
+                api={null}
+            />
+        )
+
+        const projectHeader = screen.getByTitle('/home/ubuntu')
+        expect(projectHeader).toHaveClass('bg-[var(--app-bg)]')
+        expect(projectHeader).toHaveClass('hover:bg-[var(--app-secondary-bg)]')
+        expect(projectHeader).not.toHaveClass('hover:bg-[var(--app-subtle-bg)]')
+
+        const listContent = projectHeader.parentElement?.parentElement
+        expect(listContent).not.toHaveClass('pt-1')
+
+        const searchInput = screen.getByPlaceholderText(/Search sessions/)
+        const searchWrapper = searchInput.parentElement?.parentElement
+        expect(searchWrapper).toHaveClass('pb-1')
+    })
+
     it('hides the directory action for sessions without path metadata', () => {
         renderWithProviders(
             <SessionList

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -677,7 +677,7 @@ function SessionListSearch(props: {
     const [datePickerOpen, setDatePickerOpen] = useState(false)
     const hasDateRange = Boolean(props.customStart && props.customEnd)
     return (
-        <div className="px-2 pb-2">
+        <div className="px-2 pb-1">
             <div className="relative min-w-0">
                 <div className="pointer-events-none absolute inset-y-0 left-2.5 flex items-center text-[var(--app-hint)]">
                     <SearchIcon className="h-3.5 w-3.5" />
@@ -1281,7 +1281,7 @@ export function SessionList(props: {
             </div>
 
             <div className="app-scroll-y session-list-scrollbar-left min-h-0 flex-1">
-            <div className="mx-auto flex w-full max-w-content flex-col gap-1 pl-1.5 pr-2 pt-1 pb-2">
+            <div className="mx-auto flex w-full max-w-content flex-col gap-1 pl-1.5 pr-2 pb-2">
                 {groups.map((group) => {
                     const isCollapsed = isGroupCollapsed(group)
                     const visibleGroupSessions = getVisibleGroupSessions(group)
@@ -1297,7 +1297,7 @@ export function SessionList(props: {
                     return (
                         <div key={group.key}>
                             <div
-                                className="group/project sticky top-0 z-10 flex items-center gap-2 bg-[var(--app-bg)] py-1.5 pl-2 pr-2 text-left rounded-lg transition-colors hover:bg-[var(--app-subtle-bg)] cursor-pointer min-w-0 w-full select-none"
+                                className="group/project sticky top-0 z-10 flex items-center gap-2 bg-[var(--app-bg)] py-1.5 pl-2 pr-2 text-left rounded-lg transition-colors hover:bg-[var(--app-secondary-bg)] cursor-pointer min-w-0 w-full select-none"
                                 onClick={() => toggleGroup(group.key, isCollapsed)}
                                 title={group.directory}
                             >


### PR DESCRIPTION
## What changed

- Keep sticky workspace headers opaque while hovered by using the solid secondary app background instead of the translucent subtle background.
- Remove the scrollable list's top padding so workspace headers and the left scrollbar begin at the same vertical position.
- Reduce the single-machine search-to-list gap to a fixed 4px; the spacing no longer contracts when the list starts scrolling.
- Add regression coverage for the normal and hover backgrounds and for the fixed-versus-scrollable spacing classes.

## Why

Follow-up to #1207. That change made the default sticky workspace header opaque, but left its existing `hover:bg-[var(--app-subtle-bg)]` class unchanged. `--app-subtle-bg` is translucent, so hovering replaced the solid background and allowed session titles and timestamps to show through again.

The list also placed 4px of top spacing inside the scrollable viewport. That padding scrolled away before the workspace header became sticky, making the gap below the search controls visibly contract. It also offset the first header from the top edge where the left scrollbar begins.

Keeping the remaining spacing in the fixed controls and starting the list content at the viewport edge makes the layout stable before and after the header sticks.

## Impact

This only changes session-sidebar presentation. Session grouping, collapse behavior, filtering, and scrolling logic are unchanged.

## Verification

- `bun typecheck`
- `bun run test`
- `bun run build:web`
- `git diff --check`
- Manual verification in light and dark themes, including sticky scrolling and hover states

## AI disclosure

OpenAI Codex (`gpt-5.6-sol`) assisted with investigation, implementation, testing, and PR preparation.
