### PR TITLE
fix(web): show composer status for Cursor

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -27,7 +27,7 @@ import { useComposerDraft } from '@/hooks/useComposerDraft'
 import { useComposerEnterBehavior } from '@/hooks/useComposerEnterBehavior'
 import { FloatingOverlay } from '@/components/ChatInput/FloatingOverlay'
 import { Autocomplete } from '@/components/ChatInput/Autocomplete'
-import { shouldShowComposerStatusBar, StatusBar } from '@/components/AssistantChat/StatusBar'
+import { StatusBar } from '@/components/AssistantChat/StatusBar'
 import { ComposerButtons } from '@/components/AssistantChat/ComposerButtons'
 import type { PendingSchedule } from '@/components/AssistantChat/ScheduleTimePicker'
 import { AttachmentItem } from '@/components/AssistantChat/AttachmentItem'
@@ -1273,25 +1273,23 @@ export function HappyComposer(props: {
                 <ComposerPrimitive.Root className="relative" onSubmit={handleSubmit}>
                     {overlays}
 
-                    {shouldShowComposerStatusBar(agentFlavor) ? (
-                        <StatusBar
-                            active={active}
-                            thinking={thinking}
-                            agentState={agentState}
-                            backgroundTaskCount={backgroundTaskCount}
-                            contextSize={contextSize}
-                            contextCacheRead={contextCacheRead}
-                            contextWindow={contextWindow}
-                            model={model}
-                            modelReasoningEffort={modelReasoningEffort}
-                            serviceTier={serviceTier}
-                            permissionMode={permissionMode}
-                            collaborationMode={collaborationMode}
-                            threadGoal={threadGoal}
-                            agentFlavor={agentFlavor}
-                            voiceStatus={voiceStatus}
-                        />
-                    ) : null}
+                    <StatusBar
+                        active={active}
+                        thinking={thinking}
+                        agentState={agentState}
+                        backgroundTaskCount={backgroundTaskCount}
+                        contextSize={contextSize}
+                        contextCacheRead={contextCacheRead}
+                        contextWindow={contextWindow}
+                        model={model}
+                        modelReasoningEffort={modelReasoningEffort}
+                        serviceTier={serviceTier}
+                        permissionMode={permissionMode}
+                        collaborationMode={collaborationMode}
+                        threadGoal={threadGoal}
+                        agentFlavor={agentFlavor}
+                        voiceStatus={voiceStatus}
+                    />
 
                     {sendError ? (
                         <div

--- a/web/src/components/AssistantChat/StatusBar.test.ts
+++ b/web/src/components/AssistantChat/StatusBar.test.ts
@@ -1,17 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shouldShowCodexFastBadge, shouldShowComposerStatusBar } from './StatusBar'
-
-describe('shouldShowComposerStatusBar', () => {
-    it('hides the composer status bar for Cursor sessions', () => {
-        expect(shouldShowComposerStatusBar('cursor')).toBe(false)
-    })
-
-    it('shows the composer status bar for other agents', () => {
-        expect(shouldShowComposerStatusBar('claude')).toBe(true)
-        expect(shouldShowComposerStatusBar('codex')).toBe(true)
-        expect(shouldShowComposerStatusBar(null)).toBe(true)
-    })
-})
+import { shouldShowCodexFastBadge } from './StatusBar'
 
 describe('shouldShowCodexFastBadge', () => {
     it('uses only the effective service tier', () => {

--- a/web/src/components/AssistantChat/StatusBar.tsx
+++ b/web/src/components/AssistantChat/StatusBar.tsx
@@ -132,11 +132,6 @@ export function shouldShowCodexFastBadge(
     return agentFlavor === 'codex' && isFastServiceTier(serviceTier)
 }
 
-/** Cursor native ACP does not emit usage_update; hide the bar to avoid empty/misleading UI. */
-export function shouldShowComposerStatusBar(agentFlavor: string | null | undefined): boolean {
-    return agentFlavor !== 'cursor'
-}
-
 export function StatusBar(props: {
     active: boolean
     thinking: boolean


### PR DESCRIPTION
## Summary

- show the existing composer status bar for Cursor sessions
- reuse the shared online, thinking, permission, and background-task indicators
- keep context usage conditional, so Cursor shows it only when ACP supplies usage data

## Root cause

The composer hid the entire status bar for Cursor because Cursor native ACP usually does not emit `usage_update`. That also hid status information HAPI already knows independently of usage.

## Impact

Cursor sessions now get the same available operational status as other agent flavors without inventing context or quota data. Enterprise-only Cursor quota APIs remain out of scope.

## Related

- Related to #846 (cross-flavor usage/quota gauges; this PR does not implement quota collection)
- Related to #645 (composer context usage visibility)
- Related to #484 (composer status bar)

## Validation

- `bun typecheck`
- `bun run test` — CLI 1543, Hub 673, Web 1613, Shared 142 passed; 3 Hub integration tests skipped

## AI disclosure

Code and PR text were prepared with OpenAI Codex.
