### PR TITLE
fix(web): improve session date picker visibility

### DIFF
--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -248,7 +248,7 @@ describe('SessionList time filter', () => {
         fireEvent.click(filterButton)
         const startDate = screen.getByRole('button', { name: new Date(2026, 6, 1).toLocaleDateString() })
         fireEvent.click(startDate)
-        expect(startDate).toHaveClass('bg-[var(--app-link)]', 'text-[var(--app-bg)]')
+        expect(startDate).toHaveClass('bg-[var(--app-button)]', 'text-[var(--app-button-text)]')
         expect(startDate).not.toHaveClass('text-white')
         expect(screen.getByText('Select end date')).toBeInTheDocument()
         fireEvent.click(screen.getByRole('button', { name: `${new Date(2026, 6, 18).toLocaleDateString()}, has session activity` }))

--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -195,6 +195,35 @@ describe('SessionList time filter', () => {
         expect(screen.queryByRole('button', { name: /Old session/ })).toBeNull()
     })
 
+    it('highlights today without requiring hover or session activity', () => {
+        const old = makeSession({
+            id: 'old',
+            updatedAt: new Date(2020, 0, 1).getTime(),
+            metadata: { path: '/work/old', name: 'Old session' }
+        })
+
+        renderWithProviders(
+            <SessionList
+                sessions={[old]}
+                selectedSessionId={null}
+                onSelect={vi.fn()}
+                onNewSession={vi.fn()}
+                onRefresh={vi.fn()}
+                isLoading={false}
+                renderHeader={false}
+                api={null}
+            />
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'Filter sessions by last activity' }))
+        const today = screen.getByRole('button', { name: new Date(2026, 6, 18).toLocaleDateString() })
+        const anotherDay = screen.getByRole('button', { name: new Date(2026, 6, 17).toLocaleDateString() })
+
+        expect(today).toHaveClass('bg-[var(--app-subtle-bg)]')
+        expect(today).toHaveAttribute('aria-current', 'date')
+        expect(anotherDay).not.toHaveAttribute('aria-current')
+    })
+
     it('uses the first calendar click as start and the second as end', () => {
         const session = makeSession({
             id: 'session-1',
@@ -217,7 +246,10 @@ describe('SessionList time filter', () => {
 
         const filterButton = screen.getByRole('button', { name: 'Filter sessions by last activity' })
         fireEvent.click(filterButton)
-        fireEvent.click(screen.getByRole('button', { name: new Date(2026, 6, 1).toLocaleDateString() }))
+        const startDate = screen.getByRole('button', { name: new Date(2026, 6, 1).toLocaleDateString() })
+        fireEvent.click(startDate)
+        expect(startDate).toHaveClass('bg-[var(--app-link)]', 'text-[var(--app-bg)]')
+        expect(startDate).not.toHaveClass('text-white')
         expect(screen.getByText('Select end date')).toBeInTheDocument()
         fireEvent.click(screen.getByRole('button', { name: `${new Date(2026, 6, 18).toLocaleDateString()}, has session activity` }))
 

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -639,7 +639,7 @@ function SessionDateRangePicker(props: {
                             title={hasSessionActivity ? activityLabel : undefined}
                             className={cn(
                                 'h-8 rounded-lg text-xs transition-colors',
-                                isEndpoint && 'bg-[var(--app-link)] text-[var(--app-bg)]',
+                                isEndpoint && 'bg-[var(--app-button)] text-[var(--app-button-text)]',
                                 isInRange && 'bg-[var(--app-link)]/15 text-[var(--app-link)]',
                                 !isEndpoint && !isInRange && isToday && 'bg-[var(--app-subtle-bg)]',
                                 !isEndpoint && !isInRange && hasSessionActivity && 'text-[var(--app-fg)] hover:bg-[var(--app-subtle-bg)]',

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -574,6 +574,7 @@ function SessionDateRangePicker(props: {
     const { t } = useTranslation()
     const initialDate = parseLocalDate(props.start) ?? new Date()
     const [visibleMonth, setVisibleMonth] = useState(() => new Date(initialDate.getFullYear(), initialDate.getMonth(), 1))
+    const today = formatDateValue(new Date())
     const firstWeekday = new Date(visibleMonth.getFullYear(), visibleMonth.getMonth(), 1).getDay()
     const daysInMonth = new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() + 1, 0).getDate()
     const weekdays = Array.from({ length: 7 }, (_, day) => (
@@ -620,6 +621,7 @@ function SessionDateRangePicker(props: {
                 {Array.from({ length: daysInMonth }, (_, index) => {
                     const date = new Date(visibleMonth.getFullYear(), visibleMonth.getMonth(), index + 1)
                     const value = formatDateValue(date)
+                    const isToday = value === today
                     const isEndpoint = value === props.start || value === props.end
                     const isInRange = Boolean(props.start && props.end && value > props.start && value < props.end)
                     const hasSessionActivity = props.sessionActivityDates.has(value)
@@ -633,11 +635,13 @@ function SessionDateRangePicker(props: {
                             type="button"
                             onClick={() => selectDate(value)}
                             aria-label={activityLabel}
+                            aria-current={isToday ? 'date' : undefined}
                             title={hasSessionActivity ? activityLabel : undefined}
                             className={cn(
                                 'h-8 rounded-lg text-xs transition-colors',
-                                isEndpoint && 'bg-[var(--app-link)] text-white',
+                                isEndpoint && 'bg-[var(--app-link)] text-[var(--app-bg)]',
                                 isInRange && 'bg-[var(--app-link)]/15 text-[var(--app-link)]',
+                                !isEndpoint && !isInRange && isToday && 'bg-[var(--app-subtle-bg)]',
                                 !isEndpoint && !isInRange && hasSessionActivity && 'text-[var(--app-fg)] hover:bg-[var(--app-subtle-bg)]',
                                 !isEndpoint && !isInRange && !hasSessionActivity && 'text-[var(--app-hint)] hover:bg-[var(--app-subtle-bg)]'
                             )}


### PR DESCRIPTION
## Summary

Keeps the current day visually identifiable in the session date-range picker.

- gives today's date the existing subtle calendar background without requiring hover
- preserves the stronger selected endpoint and in-range styles
- keeps selected date numbers readable across light, dark, and OLED themes
- exposes the current date semantically with `aria-current="date"`

## Motivation

The session date picker distinguishes days with session activity, but the current day otherwise looks like any other date until the pointer hovers over it. A persistent, low-emphasis background makes today easy to find without competing with the selected range. Selected endpoints also previously paired the theme link background with a fixed white foreground, which made the date number disappear in the default dark theme where the link color is white.

## Test plan

- [x] Focused date-picker tests: `12 passed`
- [x] Full web test suite: `1616 passed`
- [x] Monorepo TypeScript checks: `bun typecheck`
- [x] Production build: `bun run build`
- [x] Port 3016 deployment responds successfully and serves the updated asset

## AI disclosure

Implementation and tests were assisted by OpenAI Codex (GPT-5.6).
