### PR TITLE
fix: stop context/cache stats from jumping (subagent usage + stripped context_window)

### DIFF
--- a/cli/src/claude/types.ts
+++ b/cli/src/claude/types.ts
@@ -6,13 +6,18 @@
 import { z } from "zod";
 
 // Usage statistics for assistant messages - used in apiSession.ts
+// `passthrough` for the same reason as RawMessageSchema below: the SDK path
+// injects `context_window` onto this object (sdkToLogConverter.ts) and Anthropic
+// keeps adding usage breakdowns. Under Zod's default `strip`, the local-JSONL
+// path silently dropped `context_window`, which made the web status bar fall
+// back to a heuristic denominator for local sessions only.
 export const UsageSchema = z.object({
   input_tokens: z.number().int().nonnegative(),
   cache_creation_input_tokens: z.number().int().nonnegative().optional(),
   cache_read_input_tokens: z.number().int().nonnegative().optional(),
   output_tokens: z.number().int().nonnegative(),
   service_tier: z.string().optional(),
-});
+}).passthrough();
 
 // `passthrough` keeps fields the SDK adds going forward (e.g. `model`, future
 // usage breakdowns) so the hub forwards them verbatim. Without it, Zod's

--- a/web/src/chat/reducer.test.ts
+++ b/web/src/chat/reducer.test.ts
@@ -166,6 +166,53 @@ describe('reduceChatBlocks', () => {
         })
     })
 
+    it('ignores Claude subagent usage when calculating parent latest usage', () => {
+        // Claude never stamps scope_role, so a Task subagent's assistant
+        // messages look like ordinary parent usage apart from isSidechain.
+        // Letting them through made the status bar's ctx numerator collapse
+        // while a subagent ran and snap back when the parent resumed.
+        const messages: NormalizedMessage[] = [
+            {
+                id: 'parent-turn',
+                localId: null,
+                createdAt: 1_700_000_000_000,
+                role: 'agent',
+                content: [],
+                isSidechain: false,
+                usage: {
+                    input_tokens: 500,
+                    output_tokens: 20,
+                    cache_read_input_tokens: 120_000,
+                    context_window: 200_000
+                }
+            },
+            {
+                id: 'subagent-turn',
+                localId: null,
+                createdAt: 1_700_000_001_000,
+                role: 'agent',
+                content: [],
+                isSidechain: true,
+                parentToolUseId: 'tc-task-1',
+                usage: {
+                    input_tokens: 300,
+                    output_tokens: 5,
+                    cache_read_input_tokens: 8_000,
+                    context_window: 200_000
+                }
+            }
+        ] as NormalizedMessage[]
+
+        const reduced = reduceChatBlocks(messages, null)
+
+        expect(reduced.latestUsage).toMatchObject({
+            inputTokens: 500,
+            outputTokens: 20,
+            cacheRead: 120_000,
+            contextSize: 120_500
+        })
+    })
+
     it('keeps active goals visible across later normal user messages', () => {
         const reduced = reduceChatBlocks([
             goalMessage('goal-active', 'active', 1),

--- a/web/src/chat/reducer.ts
+++ b/web/src/chat/reducer.ts
@@ -15,8 +15,19 @@ function calculateContextSize(usage: UsageData): number {
     return (usage.cache_creation_input_tokens || 0) + (usage.cache_read_input_tokens || 0) + usage.input_tokens
 }
 
-function isUsageVisibleInParentContext(usage: UsageData): boolean {
-    return usage.scope_role !== 'child'
+/**
+ * Whether a message's usage describes the *parent* thread's context.
+ *
+ * A Task subagent runs with its own, much smaller context, so letting its usage
+ * through makes the status bar's numerator collapse mid-run and snap back when
+ * the parent resumes. `scope_role` alone cannot catch this: Claude never stamps
+ * it (see sdkToLogConverter.ts), and Codex drops child `token_count` events in
+ * the CLI before they reach us — so the guard never actually fires on any path.
+ * `isSidechain` is the signal that survives both.
+ */
+function isUsageVisibleInParentContext(msg: NormalizedMessage): boolean {
+    if (msg.isSidechain) return false
+    return msg.usage?.scope_role !== 'child'
 }
 
 export type LatestUsage = {
@@ -160,7 +171,7 @@ export function reduceChatBlocks(
     let latestUsage: LatestUsage | null = null
     for (let i = normalized.length - 1; i >= 0; i--) {
         const msg = normalized[i]
-        if (msg.usage && isUsageVisibleInParentContext(msg.usage)) {
+        if (msg.usage && isUsageVisibleInParentContext(msg)) {
             latestUsage = {
                 inputTokens: msg.usage.input_tokens,
                 outputTokens: msg.usage.output_tokens,


### PR DESCRIPTION
The status bar's `ctx 82k/1.0M (8%)` visibly jumps around during normal use. Two independent causes, one per commit.

## 1. The numerator flips to the subagent's context

`latestUsage` (`web/src/chat/reducer.ts`) scans the normalized messages backwards for the most recent usage. That array **includes sidechain messages**, and there is no `isSidechain` check — so while a `Task` subagent runs, its usage becomes the parent's numerator, then snaps back when the parent resumes.

The `scope_role !== 'child'` guard that looks like it handles this **never fires on any path**:

| producer | emits `scope_role: 'child'`? |
|---|---|
| Claude SDK | never sets `scope_role` at all |
| Claude local JSONL | never sets it |
| Codex / ACP / Pi | child `token_count` is dropped in the CLI (`codexRemoteLauncher.ts:1477`) before it can reach the web layer |

So the guard is unreachable in practice, and `isSidechain` is the signal that actually survives.

This is already known to the codebase — `cli/src/claude/utils/sdkToLogConverter.ts:308-313`:

> the web status bar's latestUsage picks the most recent usage message without filtering sidechains (Claude usage carries no `scope_role`), so a subagent's smaller window would otherwise make the footer denominator visibly drop while it runs.

That workaround forces the main session's `context_window` onto sidechain messages, which fixes the **denominator only**. The numerator was left unguarded, which is why the denominator holds steady at `1.0M` while the `82k` jumps.

## 2. The denominator differs between local and remote sessions

`UsageSchema` (`cli/src/claude/types.ts`) is a plain `z.object`, so Zod's default `strip` drops every undeclared key. `sessionScanner.ts:278` forwards `parsed.data` rather than the raw line, so on the local-JSONL path `usage` is truncated to its five declared fields and `context_window` — injected on the SDK path by `sdkToLogConverter` — never survives.

`StatusBar` then falls back to `getContextBudgetTokens`, which subtracts `CONTEXT_HEADROOM_TOKENS = 10_000`. Same model, same session: `1.0M` remote, `990k` local.

`RawMessageSchema` immediately below already carries `.passthrough()`, with a comment explaining that the metadata pipeline lost `message.model` and `messageId` exactly this way. The nested usage object just never got the same treatment.

## Testing

New regression test in `reducer.test.ts` builds a parent turn followed by a sidechain turn and asserts the parent's usage wins. Verified it **fails on the unfixed code** (`expected { inputTokens: 300 } to match { inputTokens: 500 }` — 300 being the subagent's) before it passes.

The pre-existing `scope_role: 'child'` test is kept, but note it only covers a shape no producer currently emits.

```
web:  185 files / 1616 tests passing (baseline 1615, +1 new)
cli:  1399 passing / 13 failing — identical to the main baseline,
      all in cursorLegacyRemoteLauncher.test.ts, unrelated to this change
```

`typecheck` clean in both `web/` and `cli/`.

## Not addressed here

Same investigation turned up several other caliber mismatches in the usage pipeline (`info.last` vs `info.total` between the status bar and the inline token card, `MessageMetadata` ignoring cache tokens so Claude turns under-report by 10-100x, the two percentages in `StatusBar` rounding different quantities). Those are numerically wrong but don't cause the jumping, so they're kept out of this PR.