### PR TITLE
fix(web): budget subagent messages separately from top-level history

### DIFF
--- a/web/src/lib/message-window-store.test.ts
+++ b/web/src/lib/message-window-store.test.ts
@@ -1030,6 +1030,67 @@ describe('history view and older pagination', () => {
         expect(kept.some((message) => message.id === 'top-0')).toBe(true)
         expect(kept.some((message) => message.id === 'top-9')).toBe(true)
     })
+
+    it('refetches the latest page when returning to the tail after a subagent overflow', async () => {
+        const id = sessionId('sidechain-recovery')
+        const getMessages = vi.fn(async () => latestResponse(
+            [makeAgentMessage({ id: 'top-0', seq: 1, at: 1 })],
+            { epoch: 7 }
+        )) as unknown as ApiClient['getMessages']
+        await syncTailMessages(createApi(getMessages), id)
+        expect(getMessageWindowState(id).epoch).toBe(7)
+
+        setMessageViewMode(id, 'history')
+        ingestIncomingMessages(id, Array.from({ length: SIDECHAIN_WINDOW_SIZE + 50 }, (_, index) =>
+            makeSidechainMessage(`side-${index}`, index + 100, index + 100)
+        ))
+        // Suppressing the reset while reading history leaves the window short of
+        // the transcript. Without redeeming that debt on the way back, the Task
+        // card would stay permanently incomplete.
+        expect(getMessageWindowState(id).epoch).toBe(7)
+
+        setMessageViewMode(id, 'tail')
+
+        expect(getMessageWindowState(id).epoch).toBe(null)
+    })
+
+    it('drops subagent messages left past the newest surviving top-level row', () => {
+        const id = sessionId('sidechain-orphan-tail')
+        ingestIncomingMessages(id, [makeAgentMessage({ id: 'anchor', seq: 1, at: 1 })])
+        setMessageViewMode(id, 'history')
+        // Prepend keeps the oldest top-level rows and drops the newest, so any
+        // subagent that started after the last survivor has lost its Task card.
+        // tracer.ts would render those parentless rows at the top level.
+        ingestIncomingMessages(id, [
+            ...Array.from({ length: HISTORY_WINDOW_SIZE + 20 }, (_, index) =>
+                makeAgentMessage({ id: `top-${index}`, seq: index + 2, at: index + 2 })
+            ),
+            ...Array.from({ length: 30 }, (_, index) =>
+                makeSidechainMessage(`late-side-${index}`, index + 5_000, index + 5_000)
+            )
+        ])
+
+        const kept = getMessageWindowState(id).messages
+        const keptTopSeq = kept
+            .filter((message) => !message.id.startsWith('late-side-'))
+            .map((message) => message.seq ?? 0)
+        expect(Math.max(...keptTopSeq)).toBeLessThan(5_000)
+        expect(kept.some((message) => message.id.startsWith('late-side-'))).toBe(false)
+    })
+
+    it('handles a window that holds nothing but subagent messages', () => {
+        const id = sessionId('sidechain-only')
+        setMessageViewMode(id, 'history')
+        ingestIncomingMessages(id, Array.from({ length: SIDECHAIN_WINDOW_SIZE + 50 }, (_, index) =>
+            makeSidechainMessage(`side-${index}`, index + 1, index + 1)
+        ))
+
+        const state = getMessageWindowState(id)
+        // No top-level row exists to anchor the span, so the budget alone applies
+        // and the reset stays deferred rather than firing on every overflow.
+        expect(state.messages).toHaveLength(SIDECHAIN_WINDOW_SIZE)
+        expect(state.viewMode).toBe('history')
+    })
 })
 
 describe('optimistic and queued-message operations', () => {

--- a/web/src/lib/message-window-store.test.ts
+++ b/web/src/lib/message-window-store.test.ts
@@ -3,6 +3,7 @@ import type { ApiClient } from '@/api/client'
 import type { DecryptedMessage, MessagesResponse } from '@/types/api'
 import {
     HISTORY_WINDOW_SIZE,
+    SIDECHAIN_WINDOW_SIZE,
     VISIBLE_WINDOW_SIZE,
     activateMessageWindow,
     appendOptimisticMessage,
@@ -89,6 +90,29 @@ function makeAgentRunMessage(id: string, seq: number, at: number): DecryptedMess
                     agentId: 'agent-1',
                     status: 'running',
                     activity: id
+                }
+            }
+        },
+        createdAt: at,
+        invokedAt: at
+    } as DecryptedMessage
+}
+
+function makeSidechainMessage(id: string, seq: number, at: number): DecryptedMessage {
+    return {
+        id,
+        seq,
+        localId: null,
+        content: {
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: {
+                    type: 'assistant',
+                    isSidechain: true,
+                    uuid: id,
+                    parentToolUseId: 'task-tool-1',
+                    message: { content: [{ type: 'text', text: id }] }
                 }
             }
         },
@@ -938,6 +962,73 @@ describe('history view and older pagination', () => {
         ])
 
         expect(getMessageWindowState(id).messages.some((message) => message.id === 'root')).toBe(true)
+    })
+
+    it('protects top-level rows from a subagent flood', () => {
+        const id = sessionId('sidechain-budget')
+        const topLevel = Array.from({ length: 20 }, (_, index) =>
+            makeUserMessage({ id: `top-${index}`, seq: index + 1, invokedAt: index + 1, createdAt: index + 1 })
+        )
+        // One subagent run is far larger than the whole top-level budget, but it
+        // folds into a single Task card, so it must not evict any of it.
+        const sidechain = Array.from({ length: VISIBLE_WINDOW_SIZE + 100 }, (_, index) =>
+            makeSidechainMessage(`side-${index}`, index + 100, index + 100)
+        )
+        ingestIncomingMessages(id, [...topLevel, ...sidechain])
+
+        const kept = getMessageWindowState(id).messages
+        for (const message of topLevel) {
+            expect(kept.some((candidate) => candidate.id === message.id)).toBe(true)
+        }
+    })
+
+    it('drops subagent messages that fall behind the oldest surviving top-level row', () => {
+        const id = sessionId('sidechain-orphan')
+        // Sidechain rows sit at seq 1..50, below every top-level row that will
+        // survive the trim. Their Task card is gone, and tracer.ts renders a
+        // parentless sidechain message at the top level, so keeping them would
+        // spill a subagent transcript into the timeline as loose rows.
+        const stranded = Array.from({ length: 50 }, (_, index) =>
+            makeSidechainMessage(`stranded-${index}`, index + 1, index + 1)
+        )
+        const topLevel = Array.from({ length: VISIBLE_WINDOW_SIZE + 10 }, (_, index) =>
+            makeUserMessage({
+                id: `top-${index}`,
+                seq: index + 1_000,
+                invokedAt: index + 1_000,
+                createdAt: index + 1_000
+            })
+        )
+        ingestIncomingMessages(id, [...stranded, ...topLevel])
+
+        const kept = getMessageWindowState(id).messages
+        expect(kept.some((message) => message.id.startsWith('stranded-'))).toBe(false)
+    })
+
+    it('does not force a latest reset when only subagent messages overflow', async () => {
+        const id = sessionId('sidechain-no-reset')
+        const history = Array.from({ length: 10 }, (_, index) =>
+            makeAgentMessage({ id: `top-${index}`, seq: index + 1, at: index + 1 })
+        )
+        ingestIncomingMessages(id, history)
+        setMessageViewMode(id, 'history')
+        // A subagent run overflows its own budget, dropping its newest rows.
+        // Treating that as "the tail left the window" would arm requiresLatestReset,
+        // and the next tail sync would replace the window with the latest page —
+        // discarding the history the reader had scrolled back to.
+        ingestIncomingMessages(id, Array.from({ length: SIDECHAIN_WINDOW_SIZE + 50 }, (_, index) =>
+            makeSidechainMessage(`side-${index}`, index + 100, index + 100)
+        ))
+
+        const getMessages = vi.fn(async () => latestResponse(
+            [makeAgentMessage({ id: 'newest', seq: 9_000, at: 9_000 })],
+            { epoch: 0, hasMore: true }
+        )) as unknown as ApiClient['getMessages']
+        await syncTailMessages(createApi(getMessages), id)
+
+        const kept = getMessageWindowState(id).messages
+        expect(kept.some((message) => message.id === 'top-0')).toBe(true)
+        expect(kept.some((message) => message.id === 'top-9')).toBe(true)
     })
 })
 

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -25,6 +25,10 @@ export const VISIBLE_WINDOW_SIZE = 400
 export const HISTORY_WINDOW_SIZE = 600
 const AGENT_RUN_WINDOW_SIZE = 800
 const OLDER_LOAD_WINDOW_SIZE = 800
+// Subagent transcripts get their own budget: they fold into a single Task card,
+// so they must not consume the top-level budget that decides how far back the
+// user can scroll. Sized to hold several full runs while still bounding memory.
+export const SIDECHAIN_WINDOW_SIZE = 4000
 const PAGE_SIZE = 200
 
 type MessagePosition = {
@@ -413,19 +417,53 @@ function sliceForTrim<T>(
         : { kept: items.slice(items.length - limit), dropped: items.slice(0, items.length - limit) }
 }
 
-function isCodexAgentRunMessage(message: DecryptedMessage): boolean {
+function agentPayload(message: DecryptedMessage): { type?: unknown; data?: unknown } | null {
     const outer = message.content
     if (!outer || typeof outer !== 'object' || (outer as { role?: unknown }).role !== 'agent') {
-        return false
+        return null
     }
     const content = (outer as { content?: unknown }).content
-    if (!content || typeof content !== 'object') return false
-    const payload = content as { type?: unknown; data?: unknown }
+    if (!content || typeof content !== 'object') return null
+    return content as { type?: unknown; data?: unknown }
+}
+
+function isCodexAgentRunMessage(message: DecryptedMessage): boolean {
+    const payload = agentPayload(message)
+    if (!payload) return false
     if (payload.type !== 'codex' || !payload.data || typeof payload.data !== 'object') {
         return false
     }
     const type = (payload.data as { type?: unknown }).type
     return type === 'agent-run-start' || type === 'agent-run-update' || type === 'agent-run-trace'
+}
+
+/**
+ * A subagent's own transcript. The SDK emits one message per step, but the
+ * timeline folds the whole run into a single Task card (tracer.ts groups them
+ * by `parentToolUseId`), so these cost the reader nothing to keep and nothing
+ * to drop — yet under a single budget they crowd out the top-level messages
+ * that actually render as rows.
+ *
+ * Read straight off the stored payload, the same field `normalizeAgent` reads.
+ * This is deliberately a per-message property and not the reducer's grouping:
+ * the reducer is stateful (a sidechain message only resolves to a Task once its
+ * `tool_use` has been seen), which the store cannot and should not reproduce.
+ */
+function isSidechainMessage(message: DecryptedMessage): boolean {
+    const payload = agentPayload(message)
+    if (!payload || !payload.data || typeof payload.data !== 'object') return false
+    return (payload.data as { isSidechain?: unknown }).isSidechain === true
+}
+
+function oldestSeqOf(messages: DecryptedMessage[]): number | null {
+    let oldest: number | null = null
+    for (const message of messages) {
+        if (typeof message.seq !== 'number') continue
+        if (oldest === null || message.seq < oldest) {
+            oldest = message.seq
+        }
+    }
+    return oldest
 }
 
 function trimPreservingQueued(
@@ -437,13 +475,46 @@ function trimPreservingQueued(
     const queuedIds = new Set(queued.map((message) => message.id))
     const nonQueued = messages.filter((message) => !queuedIds.has(message.id))
     const agentRuns = nonQueued.filter(isCodexAgentRunMessage)
-    const regular = nonQueued.filter((message) => !isCodexAgentRunMessage(message))
+    const rest = nonQueued.filter((message) => !isCodexAgentRunMessage(message))
+    const sidechain = rest.filter(isSidechainMessage)
+    const regular = rest.filter((message) => !isSidechainMessage(message))
     const regularTrim = sliceForTrim(regular, Math.max(0, regularLimit - queued.length), mode)
     const agentRunTrim = sliceForTrim(agentRuns, AGENT_RUN_WINDOW_SIZE, mode)
+    const sidechainTrim = trimSidechain(sidechain, regularTrim.kept, mode)
     return {
-        kept: mergeMessages([...regularTrim.kept, ...agentRunTrim.kept], queued),
-        dropped: [...regularTrim.dropped, ...agentRunTrim.dropped]
+        kept: mergeMessages(
+            [...regularTrim.kept, ...agentRunTrim.kept, ...sidechainTrim.kept],
+            queued
+        ),
+        dropped: [...regularTrim.dropped, ...agentRunTrim.dropped, ...sidechainTrim.dropped]
     }
+}
+
+/**
+ * Subagent messages are capped separately so a long run cannot evict top-level
+ * history, but they must not outlive the Task card that owns them: `tracer.ts`
+ * falls back to rendering a sidechain message at the top level when it cannot
+ * resolve a parent, so a subagent transcript whose `tool_use` was trimmed away
+ * would spill into the timeline as loose rows. Dropping anything older than the
+ * oldest surviving top-level message keeps every kept sidechain message inside
+ * the span its parent can still live in.
+ */
+function trimSidechain(
+    sidechain: DecryptedMessage[],
+    keptRegular: DecryptedMessage[],
+    mode: 'append' | 'prepend'
+): { kept: DecryptedMessage[]; dropped: DecryptedMessage[] } {
+    const boundary = oldestSeqOf(keptRegular)
+    const orphaned: DecryptedMessage[] = []
+    const inSpan = boundary === null
+        ? sidechain
+        : sidechain.filter((message) => {
+            if (typeof message.seq !== 'number' || message.seq >= boundary) return true
+            orphaned.push(message)
+            return false
+        })
+    const trimmed = sliceForTrim(inSpan, SIDECHAIN_WINDOW_SIZE, mode)
+    return { kept: trimmed.kept, dropped: [...orphaned, ...trimmed.dropped] }
 }
 
 function optimisticMessage(message: DecryptedMessage): boolean {
@@ -510,7 +581,19 @@ function mergeIntoWindow(
             oldestPositionSeq: oldest?.seq ?? next.oldestPositionSeq
         })
     }
+    // Prepend means the window overflowed at the tail, so the newest messages
+    // are the ones that left, and the window can no longer answer "what is the
+    // session doing now" — hence the reset. Subagent rows are exempt: they fold
+    // into a Task card rather than rendering as the live tail, and trimming them
+    // against their own budget always drops the newest of *them*. Letting that
+    // arm the reset would refetch the latest page and yank the reader back to
+    // the tail they deliberately scrolled away from.
     const newest = derivePosition(kept, 'newest')
+    const keptTailNewest = derivePosition(kept.filter((message) => !isSidechainMessage(message)), 'newest')
+    const mergedTailNewest = derivePosition(merged.filter((message) => !isSidechainMessage(message)), 'newest')
+    if (keptTailNewest && mergedTailNewest && comparePosition(keptTailNewest, mergedTailNewest) >= 0) {
+        return next
+    }
     next = buildState(next, {
         requiresLatestReset: true,
         newestPositionAt: newest?.at ?? null,

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -43,6 +43,9 @@ type InternalState = MessageWindowState & {
     newestPositionSeq: number | null
     unseenIds: Set<string>
     requiresLatestReset: boolean
+    // A subagent transcript overflowed its budget while the reader was in
+    // history mode. Deferred rather than acted on: see mergeIntoWindow.
+    sidechainOverflowed: boolean
     syncGeneration: number
     olderGeneration: number
 }
@@ -229,6 +232,7 @@ function createState(sessionId: string): InternalState {
         newestPositionSeq: null,
         unseenIds: new Set(),
         requiresLatestReset: false,
+        sidechainOverflowed: false,
         syncGeneration: 0,
         olderGeneration: 0
     }
@@ -379,6 +383,7 @@ function buildState(
         | 'newestPositionSeq'
         | 'unseenIds'
         | 'requiresLatestReset'
+        | 'sidechainOverflowed'
         | 'syncGeneration'
         | 'olderGeneration'
         | 'historyVersion'
@@ -466,6 +471,17 @@ function oldestSeqOf(messages: DecryptedMessage[]): number | null {
     return oldest
 }
 
+function newestSeqOf(messages: DecryptedMessage[]): number | null {
+    let newest: number | null = null
+    for (const message of messages) {
+        if (typeof message.seq !== 'number') continue
+        if (newest === null || message.seq > newest) {
+            newest = message.seq
+        }
+    }
+    return newest
+}
+
 function trimPreservingQueued(
     messages: DecryptedMessage[],
     regularLimit: number,
@@ -480,7 +496,7 @@ function trimPreservingQueued(
     const regular = rest.filter((message) => !isSidechainMessage(message))
     const regularTrim = sliceForTrim(regular, Math.max(0, regularLimit - queued.length), mode)
     const agentRunTrim = sliceForTrim(agentRuns, AGENT_RUN_WINDOW_SIZE, mode)
-    const sidechainTrim = trimSidechain(sidechain, regularTrim.kept, mode)
+    const sidechainTrim = trimSidechain(sidechain, regularTrim, mode)
     return {
         kept: mergeMessages(
             [...regularTrim.kept, ...agentRunTrim.kept, ...sidechainTrim.kept],
@@ -495,24 +511,43 @@ function trimPreservingQueued(
  * history, but they must not outlive the Task card that owns them: `tracer.ts`
  * falls back to rendering a sidechain message at the top level when it cannot
  * resolve a parent, so a subagent transcript whose `tool_use` was trimmed away
- * would spill into the timeline as loose rows. Dropping anything older than the
- * oldest surviving top-level message keeps every kept sidechain message inside
- * the span its parent can still live in.
+ * would spill into the timeline as loose rows.
+ *
+ * The surviving top-level rows define the span a parent can still live in, and
+ * both of its edges matter. The old edge always does. The new edge only does
+ * under `prepend`, which drops the *newest* top-level rows — a subagent that
+ * started after the last surviving row has lost its parent. Applying that edge
+ * under `append` would be wrong in the opposite direction: a subagent running
+ * right now legitimately sits past every top-level row, and cutting there would
+ * empty the live Task card.
+ *
+ * Both edges are conservative — a sidechain message past the new edge may still
+ * have a parent inside the window — but over-trimming a folded card while the
+ * reader is looking at older history costs nothing they can see, and
+ * `sidechainOverflowed` restores the full transcript when they return to the tail.
  */
 function trimSidechain(
     sidechain: DecryptedMessage[],
-    keptRegular: DecryptedMessage[],
+    regularTrim: { kept: DecryptedMessage[]; dropped: DecryptedMessage[] },
     mode: 'append' | 'prepend'
 ): { kept: DecryptedMessage[]; dropped: DecryptedMessage[] } {
-    const boundary = oldestSeqOf(keptRegular)
+    const low = oldestSeqOf(regularTrim.kept)
+    const high = mode === 'prepend' && regularTrim.dropped.length > 0
+        ? newestSeqOf(regularTrim.kept)
+        : null
     const orphaned: DecryptedMessage[] = []
-    const inSpan = boundary === null
-        ? sidechain
-        : sidechain.filter((message) => {
-            if (typeof message.seq !== 'number' || message.seq >= boundary) return true
+    const inSpan = sidechain.filter((message) => {
+        if (typeof message.seq !== 'number') return true
+        if (low !== null && message.seq < low) {
             orphaned.push(message)
             return false
-        })
+        }
+        if (high !== null && message.seq > high) {
+            orphaned.push(message)
+            return false
+        }
+        return true
+    })
     const trimmed = sliceForTrim(inSpan, SIDECHAIN_WINDOW_SIZE, mode)
     return { kept: trimmed.kept, dropped: [...orphaned, ...trimmed.dropped] }
 }
@@ -583,16 +618,18 @@ function mergeIntoWindow(
     }
     // Prepend means the window overflowed at the tail, so the newest messages
     // are the ones that left, and the window can no longer answer "what is the
-    // session doing now" — hence the reset. Subagent rows are exempt: they fold
-    // into a Task card rather than rendering as the live tail, and trimming them
-    // against their own budget always drops the newest of *them*. Letting that
-    // arm the reset would refetch the latest page and yank the reader back to
-    // the tail they deliberately scrolled away from.
+    // session doing now" — hence the reset.
+    //
+    // Subagent rows are the exception. They fold into a Task card rather than
+    // rendering as the live tail, and trimming them against their own budget
+    // always drops the newest of *them*. Resetting there would refetch the
+    // latest page and yank the reader back to the tail they deliberately
+    // scrolled away from. But the window really is incomplete afterwards, so
+    // the need for a refetch is recorded and deferred to `enterTailMode`,
+    // which runs once the reader has chosen to come back.
     const newest = derivePosition(kept, 'newest')
-    const keptTailNewest = derivePosition(kept.filter((message) => !isSidechainMessage(message)), 'newest')
-    const mergedTailNewest = derivePosition(merged.filter((message) => !isSidechainMessage(message)), 'newest')
-    if (keptTailNewest && mergedTailNewest && comparePosition(keptTailNewest, mergedTailNewest) >= 0) {
-        return next
+    if (!dropped.some((message) => !isSidechainMessage(message))) {
+        return buildState(next, { sidechainOverflowed: true })
     }
     next = buildState(next, {
         requiresLatestReset: true,
@@ -823,7 +860,11 @@ async function waitForTailSyncDrain(
 
 function enterTailMode(previous: InternalState): InternalState {
     const { kept, dropped } = trimPreservingQueued(previous.messages, VISIBLE_WINDOW_SIZE, 'append')
-    const forceLatest = previous.requiresLatestReset
+    // A subagent that overflowed while the reader was in history mode left the
+    // window short of its transcript. Refetching was deferred to avoid pulling
+    // them out of the history they were reading; coming back to the tail is
+    // that moment, so the deferred reset is redeemed here.
+    const forceLatest = previous.requiresLatestReset || previous.sidechainOverflowed
     const oldest = dropped.length > 0
         ? derivePosition(kept, 'oldest')
         : readPosition(previous.oldestPositionAt, previous.oldestPositionSeq)
@@ -833,6 +874,8 @@ function enterTailMode(previous: InternalState): InternalState {
         viewMode: 'tail',
         unseenIds: new Set(),
         epoch: forceLatest ? null : previous.epoch,
+        requiresLatestReset: forceLatest,
+        sidechainOverflowed: false,
         oldestPositionAt: oldest?.at ?? null,
         oldestPositionSeq: oldest?.seq ?? null,
         newestPositionAt: forceLatest ? null : previous.newestPositionAt,
@@ -843,7 +886,7 @@ function enterTailMode(previous: InternalState): InternalState {
 export function activateMessageWindow(sessionId: string): void {
     updateState(sessionId, (previous) => {
         const { kept } = trimPreservingQueued(previous.messages, VISIBLE_WINDOW_SIZE, 'append')
-        const forceLatest = previous.requiresLatestReset
+        const forceLatest = previous.requiresLatestReset || previous.sidechainOverflowed
         if (
             previous.viewMode === 'tail'
             && previous.unseenIds.size === 0


### PR DESCRIPTION
## Problem

Scrolling up through a long session stalls after a few pages, and the history that *did* load is then thrown away.

The message window budgets raw `DecryptedMessage`s, but the timeline renders **folded** blocks. A subagent run emits one message per step and renders as a single Task card, so the two units disagree by orders of magnitude — and the budget is spent in the units the reader never sees.

Measured against a real session (`sqlite3` on the hub's `hapi.db`):

| | messages | share |
|---|---|---|
| sidechain (subagent) | 2655 | **96%** |
| top-level | 90 | 4% |
| total | 2745 | |

The 800-message budget bought roughly 43 top-level rows. The other ~1900 messages were unreachable — not because the session was too long, but because one subagent run can spend the entire budget on rows that collapse into a single card.

The distribution across sessions is wide enough that no single total works: 0%, 11%, 26%, 50%, 69%, 96% sidechain in the six largest sessions on this hub.

## Reproduction

Driving the real UI with Playwright, scrolling to the top and waiting 3.5s per round:

| round | `scrollHeight` | request |
|---|---|---|
| 1 | 2956 → 4209 | `beforeSeq=2508&limit=200` |
| 2 | → 5272 | `beforeSeq=2308` |
| 3 | 5272 (unchanged) | `beforeSeq=2108`, then nothing |
| 4 | 5272 (stalled) | — |
| 5 | **→ 2365** | — |
| 6 | 2365 | — |

Round 5 is the second half of the bug: loaded history is discarded, text length dropping 7356 → 3466. The scroll container itself is fine — `scrollTop` holds where you put it, and scrolling down to the bottom works.

## Approach

Give sidechain messages their own budget, exactly the way `AGENT_RUN_WINDOW_SIZE` already fences off Codex agent-run messages. `isSidechainMessage` reads the same stored field `normalizeAgent` reads — deliberately a per-message property, not the reducer's grouping, which is stateful and belongs in the reducer.

Two consequences that don't fall out for free:

**Sidechain messages must not outlive their Task card.** `tracer.ts:139` renders a parentless sidechain message at the top level, so a transcript whose `tool_use` was trimmed away would spill into the timeline as loose rows — inverting the bug rather than fixing it. `trimSidechain` drops anything older than the oldest surviving top-level row, keeping every retained sidechain message inside the span its parent can still occupy.

**Trimming them must not arm `requiresLatestReset`.** That flag means "the window no longer holds the live tail", and the next tail sync acts on it by refetching the latest page and replacing the window — which is precisely the discard observed in round 5 above. Trimming a subagent against its own budget always drops the newest of *them*, so the reset check now compares the newest **non-sidechain** message before and after the trim.

## Result

Same probe, after:

| round | `scrollHeight` | request |
|---|---|---|
| 1 | 14412 → 15466 | `beforeSeq=2637` |
| 2 | → 16719 | `beforeSeq=2437` |
| 3 | → 17782 | `beforeSeq=2237` |
| 4 | → 18887 | `beforeSeq=2037` |
| 5 | — | `beforeSeq=1837` |

Five pages instead of three, monotonically growing, no discard.

## Testing

Three tests in `message-window-store.test.ts`, each verified to fail when its own half of the change is disabled:

- `protects top-level rows from a subagent flood` — fails when the sidechain bucket is removed
- `drops subagent messages that fall behind the oldest surviving top-level row` — fails when the orphan boundary is removed
- `does not force a latest reset when only subagent messages overflow` — drives the real `syncTailMessages` path; fails when the reset check is removed

`31 passed` in this file (28 before). `bun run typecheck` clean.
