### PR TITLE
fix(web): allow reasoning scroll chaining

### DIFF
--- a/web/src/components/assistant-ui/reasoning.tsx
+++ b/web/src/components/assistant-ui/reasoning.tsx
@@ -96,7 +96,7 @@ export const ReasoningGroup: FC<PropsWithChildren> = ({ children }) => {
                     isOpen ? 'max-h-[5000px] opacity-100' : 'max-h-0 opacity-0'
                 )}
             >
-                <div className="max-h-[60vh] overflow-y-auto overscroll-contain border-t border-[var(--app-divider)] px-3.5 py-3">
+                <div className="max-h-[60vh] overflow-y-auto border-t border-[var(--app-divider)] px-3.5 py-3">
                     {children}
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- allow wheel and touchpad scrolling to pass from the Reasoning panel to the chat viewport at the panel boundaries
- keep the existing `60vh` height cap and internal scrolling from #1166

## Testing

- `bun typecheck`
- `bun run test:web`