### PR TITLE
test(cursor): isolate cursor-models shared-cache tests to stop parallel-run flake

### DIFF
--- a/cli/src/modules/common/cursorModels.test.ts
+++ b/cli/src/modules/common/cursorModels.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { setCursorAcpModelsSnapshot } from '@/cursor/utils/cursorAcpModelsBridge'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Isolate the on-disk cursor-models cache to this file's own HAPI_HOME so
+// parallel vitest workers don't race on the shared $HAPI_HOME/cache path
+// (see heavygee/hapi#101).
+process.env.HAPI_HOME = mkdtempSync(join(tmpdir(), 'hapi-cursor-models-'))
 
 const { spawnMock } = vi.hoisted(() => ({
     spawnMock: vi.fn()

--- a/cli/src/modules/common/cursorModelsSharedCache.test.ts
+++ b/cli/src/modules/common/cursorModelsSharedCache.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, describe, expect, test } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
     readSharedCursorModelsCache,
     writeSharedCursorModelsCache,
     _resetSharedCursorModelsCacheForTests
 } from './cursorModelsSharedCache';
+
+// Isolate the on-disk cursor-models cache to this file's own HAPI_HOME so
+// parallel vitest workers don't race on the shared $HAPI_HOME/cache path
+// (see heavygee/hapi#101).
+process.env.HAPI_HOME = mkdtempSync(join(tmpdir(), 'hapi-cursor-models-shared-cache-'));
 
 afterEach(() => {
     _resetSharedCursorModelsCacheForTests();


### PR DESCRIPTION
## Summary

Fixes a flaky failure in the CLI test suite:

```
cursorModels.test.ts > buildCursorModelsSeedPayload > inherits cliModelSkus from shared cache when ACP snapshot has none
AssertionError: expected undefined to deeply equal [ 'gpt-5.5-medium', 'gpt-5.5-high' ]
```

The four `cursorModels*` test files share one on-disk cache path (`$HAPI_HOME/cache/cursor-models.json`, defaulting to `/tmp/hapi` when `HAPI_HOME` is unset). Two of them already isolate it - `cursorModelsStaleLock.test.ts` (PID-namespaced home) and `handlers/cursorModels.test.ts` (unique temp home with save/restore) - but `cursorModels.test.ts` and `cursorModelsSharedCache.test.ts` do not.

Under vitest's parallel file execution, `cursorModelsSharedCache`'s `afterEach(_resetSharedCursorModelsCacheForTests)` `rmSync`s that shared file between the other file's write and read, so the read returns `null` and `cliModelSkus` is `undefined`. It passes in isolation and fails at random in the full parallel suite.

## Root cause (deterministic proof)

Both un-isolated files resolve to the same path with `HAPI_HOME` unset; one file's reset deletes the other's write:

```
after A write, read.cliModelSkus = [ 'gpt-5.5-medium', 'gpt-5.5-high' ]
after B reset (rmSync same path), A reads = null   => cliModelSkus undefined
```

Parallel scheduling just decides whether B's reset lands inside A's write->read window.

## Fix

Give the two un-isolated files their own `mkdtemp` `HAPI_HOME` at module load, matching the pattern the other two already use. `mkdtempSync` guarantees a unique dir regardless of worker-process reuse, so no two files collide.

Post-fix, the same interleaving leaves A's write intact:

```
A reads after B reset = [ 'gpt-5.5-medium', 'gpt-5.5-high' ]   => intact
```

Test-isolation only; no product/behavior change (source `cursorModelsSharedCache.ts` is untouched).

## Test plan

- [x] `bun typecheck` clean (cli + web + hub)
- [x] Full `cli` suite: `cursorModels*` green across 2 runs + 25 targeted parallel runs of all four cache files
- [x] Deterministic pre/post interleaving proof (above)
- [x] Diff is exactly the two test files

Note: the pre-existing 1-minute `runner.integration.test.ts > should detect version mismatch and kill old runner` failure is environment-dependent and unrelated to this change (no runner code touched).
