### PR TITLE
test(cursor): remove per-file temp HAPI homes after cursor-models suites

### DIFF
--- a/cli/src/modules/common/cursorModels.test.ts
+++ b/cli/src/modules/common/cursorModels.test.ts
@@ -1,13 +1,23 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterAll, afterEach, describe, expect, test, vi } from 'vitest'
 import { setCursorAcpModelsSnapshot } from '@/cursor/utils/cursorAcpModelsBridge'
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 // Isolate the on-disk cursor-models cache to this file's own HAPI_HOME so
 // parallel vitest workers don't race on the shared $HAPI_HOME/cache path
 // (see heavygee/hapi#101).
-process.env.HAPI_HOME = mkdtempSync(join(tmpdir(), 'hapi-cursor-models-'))
+const previousHapiHome = process.env.HAPI_HOME
+const testHapiHome = mkdtempSync(join(tmpdir(), 'hapi-cursor-models-'))
+process.env.HAPI_HOME = testHapiHome
+
+// Remove the per-file temp root after the suite so runs don't leak dirs into
+// the system temp dir (afterEach only clears the cache file inside it).
+afterAll(() => {
+    if (previousHapiHome === undefined) delete process.env.HAPI_HOME
+    else process.env.HAPI_HOME = previousHapiHome
+    rmSync(testHapiHome, { recursive: true, force: true })
+})
 
 const { spawnMock } = vi.hoisted(() => ({
     spawnMock: vi.fn()

--- a/cli/src/modules/common/cursorModelsSharedCache.test.ts
+++ b/cli/src/modules/common/cursorModelsSharedCache.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, test } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { afterAll, afterEach, describe, expect, test } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -11,10 +11,20 @@ import {
 // Isolate the on-disk cursor-models cache to this file's own HAPI_HOME so
 // parallel vitest workers don't race on the shared $HAPI_HOME/cache path
 // (see heavygee/hapi#101).
-process.env.HAPI_HOME = mkdtempSync(join(tmpdir(), 'hapi-cursor-models-shared-cache-'));
+const previousHapiHome = process.env.HAPI_HOME;
+const testHapiHome = mkdtempSync(join(tmpdir(), 'hapi-cursor-models-shared-cache-'));
+process.env.HAPI_HOME = testHapiHome;
 
 afterEach(() => {
     _resetSharedCursorModelsCacheForTests();
+});
+
+// Remove the per-file temp root after the suite so runs don't leak dirs into
+// the system temp dir (afterEach only clears the cache file inside it).
+afterAll(() => {
+    if (previousHapiHome === undefined) delete process.env.HAPI_HOME;
+    else process.env.HAPI_HOME = previousHapiHome;
+    rmSync(testHapiHome, { recursive: true, force: true });
 });
 
 describe('cursorModelsSharedCache', () => {

--- a/cli/src/modules/common/cursorModelsStaleLock.test.ts
+++ b/cli/src/modules/common/cursorModelsStaleLock.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, test, vi } from 'vitest';
@@ -46,6 +46,9 @@ describe('listCursorModels stale ACP lock', () => {
         } else {
             process.env.HAPI_HOME = previousHome;
         }
+        // Remove the per-file temp home so runs don't leak dirs into the system
+        // temp dir (the test creates it under tmpdir() but never cleaned it up).
+        rmSync(testHome, { recursive: true, force: true });
     });
 
     test('runs cold ACP probe after clearing a stale cross-process lock', async () => {


### PR DESCRIPTION
Fast-follow to #1268 addressing the HAPI Bot `[Minor]` finding on that PR.

## What / why

The per-file HAPI homes created by the cursor-models test cluster were never removed, so every run leaked a directory into the system temp dir (`afterEach` only cleared the cache file *inside* them). Over many runs this litters `/tmp` with `hapi-cursor-models-*` dirs.

This restores the previous `HAPI_HOME` and recursively removes each per-file temp root in teardown:

- `cursorModels.test.ts` - `afterAll` restore + `rmSync` (the file the bot flagged)
- `cursorModelsSharedCache.test.ts` - `afterAll` restore + `rmSync` (the file the bot flagged)
- `cursorModelsStaleLock.test.ts` - same latent leak (`join(tmpdir(), 'hapi-cursor-models-lock-<pid>')` was never cleaned) - folded in so the whole cluster is leak-free

No source/runtime change - test hygiene only.

## Verification

- `bun typecheck` clean (cli+web+hub).
- 22 cursor-models tests pass.
- Ran the cluster 3x with a pre-cleaned `/tmp`: **0** leaked `hapi-cursor-models-*` dirs after each run (before the fix, one dir leaked per run per file).

The one unrelated `runner.integration.test.ts` failure on my machine reproduces identically on pristine `upstream/main` (live-runner-daemon collision, environment-specific) and passed in CI on the #1268 merge commit - not touched by this diff.

Made with [Cursor](https://cursor.com)