### PR TITLE
fix(cli): reset stale kitty keyboard modes before Ink renders

### DIFF
--- a/cli/src/modules/common/remote/RemoteLauncherBase.ts
+++ b/cli/src/modules/common/remote/RemoteLauncherBase.ts
@@ -1,7 +1,7 @@
 import { render } from 'ink';
 import type { ReactElement } from 'react';
 import { MessageBuffer } from '@/ui/ink/messageBuffer';
-import { restoreTerminalState } from '@/ui/terminalState';
+import { resetTerminalInputModes, restoreTerminalState } from '@/ui/terminalState';
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 
 export type RemoteLauncherExitReason = 'switch' | 'exit';
@@ -52,6 +52,7 @@ export abstract class RemoteLauncherBase {
 
     protected setupTerminal(handlers: RemoteLauncherTerminalHandlers): void {
         if (this.hasTTY) {
+            resetTerminalInputModes();
             console.clear();
             this.inkInstance = render(this.createDisplay({
                 messageBuffer: this.messageBuffer,

--- a/cli/src/ui/ink/useSwitchControls.test.ts
+++ b/cli/src/ui/ink/useSwitchControls.test.ts
@@ -191,7 +191,7 @@ describe('useSwitchControls', () => {
         await triggerInput(' ', {});
         expect(latestState?.confirmationMode).toBe('switch');
 
-        await triggerInput('\u001b[1:3u', {});
+        await triggerInput('[1;1:3u', {});
         expect(latestState?.confirmationMode).toBe('switch');
         expect(latestState?.actionInProgress).toBe(null);
     });
@@ -200,16 +200,16 @@ describe('useSwitchControls', () => {
         const onSwitch = vi.fn();
         await mount({ onSwitch });
 
-        await triggerInput('\u001b[32u', {});
+        await triggerInput('[32u', {});
         expect(latestState?.confirmationMode).toBe('switch');
     });
 
-    it('accepts CSI u space sequences with modifiers', async () => {
+    it('does not treat modified CSI u space sequences as a switch request', async () => {
         const onSwitch = vi.fn();
         await mount({ onSwitch });
 
-        await triggerInput('\u001b[32;2u', {});
-        expect(latestState?.confirmationMode).toBe('switch');
+        await triggerInput('[32;2u', {});
+        expect(latestState?.confirmationMode).toBe(null);
     });
 
     it('ignores CSI u key-release space sequences', async () => {
@@ -219,7 +219,7 @@ describe('useSwitchControls', () => {
         await triggerInput(' ', {});
         expect(latestState?.confirmationMode).toBe('switch');
 
-        await triggerInput('\u001b[32;2:3u', {});
+        await triggerInput('[32;2:3u', {});
         expect(latestState?.confirmationMode).toBe('switch');
         expect(onSwitch).not.toHaveBeenCalled();
     });
@@ -239,7 +239,7 @@ describe('useSwitchControls', () => {
         await triggerInput(' ', {});
         expect(latestState?.confirmationMode).toBe('switch');
 
-        await triggerInput('', { sequence: '\u001b[1:3u' });
+        await triggerInput('', { sequence: '[1;1:3u' });
         expect(latestState?.confirmationMode).toBe('switch');
     });
 
@@ -247,9 +247,34 @@ describe('useSwitchControls', () => {
         const onSwitch = vi.fn();
         await mount({ onSwitch });
 
-        await triggerInput('\u001b[3:3u', {});
+        await triggerInput('[3;1:3u', {});
         expect(onSwitch).not.toHaveBeenCalled();
         expect(latestState?.confirmationMode).toBe(null);
+    });
+
+    it('confirms exit when Ctrl-C uses CSI u encoding', async () => {
+        const onExit = vi.fn();
+        await mount({ onExit });
+
+        await triggerInput('[99;5u', {});
+        expect(latestState?.confirmationMode).toBe('exit');
+
+        await triggerInputWithTimers('[99;5u', {}, 100);
+        expect(latestState?.actionInProgress).toBe('exiting');
+        expect(onExit).toHaveBeenCalledOnce();
+    });
+
+    it('does not clear confirmation for focus or mouse reporting', async () => {
+        const onSwitch = vi.fn();
+        await mount({ onSwitch });
+
+        await triggerInput(' ', {});
+        expect(latestState?.confirmationMode).toBe('switch');
+
+        await triggerInput('[I', {});
+        await triggerInput('[<35;10;5M', {});
+        expect(latestState?.confirmationMode).toBe('switch');
+        expect(onSwitch).not.toHaveBeenCalled();
     });
 
     it('clears confirmation after timeout', async () => {

--- a/cli/src/ui/ink/useSwitchControls.ts
+++ b/cli/src/ui/ink/useSwitchControls.ts
@@ -7,6 +7,44 @@ type ExtendedKey = Key & {
     name?: string;
 };
 
+type ParsedEscapeKey = {
+    code: number;
+    mods: number;
+    event: number;
+};
+
+const ESC = '\u001b';
+
+function parseCsiU(sequence: string): ParsedEscapeKey | null {
+    const match = /^\[(\d+)(?::\d+)*(?:;(\d+)(?::(\d+))?)?u$/.exec(sequence);
+    if (!match) {
+        return null;
+    }
+
+    return {
+        code: Number(match[1]),
+        mods: match[2] ? Number(match[2]) : 1,
+        event: match[3] ? Number(match[3]) : 1
+    };
+}
+
+function parseModifyOtherKeys(sequence: string): ParsedEscapeKey | null {
+    const match = /^\[27;(\d+);(\d+)~$/.exec(sequence);
+    if (!match) {
+        return null;
+    }
+
+    return {
+        code: Number(match[2]),
+        mods: Number(match[1]),
+        event: 1
+    };
+}
+
+function isEscapeSequence(input: string): boolean {
+    return input.startsWith(ESC) || /^\[[?<>=]?[\d;:]*[A-Za-z~]$/.test(input);
+}
+
 export type ConfirmationMode = 'exit' | 'switch' | null;
 export type ActionInProgress = 'exiting' | 'switching' | null;
 
@@ -62,7 +100,15 @@ export function useSwitchControls(opts: {
             return;
         }
 
-        if (key.ctrl && input === 'c') {
+        const keySequence = readKeyString(key, 'sequence');
+        const keyName = readKeyString(key, 'name');
+        const sequence = keySequence ?? input;
+        const parsedEscapeKey = parseCsiU(sequence) ?? parseModifyOtherKeys(sequence);
+        const isCsiUCtrlC = parsedEscapeKey?.code === 99
+            && Boolean((parsedEscapeKey.mods - 1) & 4)
+            && parsedEscapeKey.event !== 3;
+
+        if ((key.ctrl && input === 'c') || isCsiUCtrlC) {
             if (!onExit) {
                 if (confirmationMode) {
                     resetConfirmation();
@@ -85,19 +131,12 @@ export function useSwitchControls(opts: {
             return;
         }
 
-        const keySequence = readKeyString(key, 'sequence');
-        const keyName = readKeyString(key, 'name');
-        const sequence = keySequence ?? input;
-        const sequenceString = typeof sequence === 'string' ? sequence : '';
-        const isKeyRelease = sequenceString.length > 0
-            && /^\u001b\[[0-9;]*:3u$/.test(sequenceString);
-        const csiUMatch = sequenceString.length > 0
-            ? sequenceString.match(/^\u001b\[(\d+)(?:;(\d+))?u$/)
-            : null;
-        const csiUCodepoint = csiUMatch ? Number(csiUMatch[1]) : null;
-        const isCsiUSpace = csiUCodepoint === 32;
-        const isSpace = Boolean(onSwitch) && !isKeyRelease && (input === ' ' || keyName === 'space' || isCsiUSpace);
-        const hasPrintableInput = typeof input === 'string' && input.length > 0;
+        const isKeyRelease = parsedEscapeKey?.event === 3;
+        const isCsiUSpace = parsedEscapeKey?.code === 32
+            && parsedEscapeKey.mods <= 1
+            && !isKeyRelease;
+        const isSpace = Boolean(onSwitch) && (input === ' ' || keyName === 'space' || isCsiUSpace);
+        const hasPrintableInput = input.length > 0 && !isEscapeSequence(input);
 
         if (isSpace) {
             if (confirmationMode === 'switch') {

--- a/cli/src/ui/terminalState.test.ts
+++ b/cli/src/ui/terminalState.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resetTerminalInputModes, restoreTerminalState } from './terminalState';
 
-const resetSequence = '\x1b[<u\x1b[=0;1u\x1b[>4;0m\x1b[?1004l\x1b[?2004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l';
+const resetSequence = '\x1b[=0;1u\x1b[>4;0m\x1b[?1004l\x1b[?2004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l';
 
 describe('terminal input state', () => {
     const originalStdoutIsTTY = process.stdout.isTTY;

--- a/cli/src/ui/terminalState.test.ts
+++ b/cli/src/ui/terminalState.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resetTerminalInputModes, restoreTerminalState } from './terminalState';
+
+const resetSequence = '\x1b[<u\x1b[=0;1u\x1b[>4;0m\x1b[?1004l\x1b[?2004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l';
+
+describe('terminal input state', () => {
+    const originalStdoutIsTTY = process.stdout.isTTY;
+    const originalStdinIsTTY = process.stdin.isTTY;
+    const originalSetRawMode = Object.getOwnPropertyDescriptor(process.stdin, 'setRawMode');
+
+    afterEach(() => {
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: originalStdoutIsTTY });
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: originalStdinIsTTY });
+        if (originalSetRawMode) {
+            Object.defineProperty(process.stdin, 'setRawMode', originalSetRawMode);
+        } else {
+            Reflect.deleteProperty(process.stdin, 'setRawMode');
+        }
+        vi.restoreAllMocks();
+    });
+
+    it('clears keyboard, focus, paste, and mouse reporting modes', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+        const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+        resetTerminalInputModes();
+
+        expect(writeSpy).toHaveBeenCalledWith(resetSequence);
+    });
+
+    it('resets input modes before leaving raw mode', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+        Object.defineProperty(process.stdin, 'setRawMode', {
+            configurable: true,
+            value: () => process.stdin
+        });
+        const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        const rawModeSpy = vi.spyOn(process.stdin, 'setRawMode').mockImplementation(() => process.stdin);
+
+        restoreTerminalState();
+
+        expect(writeSpy.mock.invocationCallOrder[0])
+            .toBeLessThan(rawModeSpy.mock.invocationCallOrder[0]);
+        expect(rawModeSpy).toHaveBeenCalledWith(false);
+    });
+});

--- a/cli/src/ui/terminalState.ts
+++ b/cli/src/ui/terminalState.ts
@@ -1,5 +1,4 @@
 const RESET_INPUT_MODES = [
-    '\x1b[<u',
     '\x1b[=0;1u',
     '\x1b[>4;0m',
     '\x1b[?1004l',

--- a/cli/src/ui/terminalState.ts
+++ b/cli/src/ui/terminalState.ts
@@ -1,11 +1,23 @@
-export function restoreTerminalState(): void {
+const RESET_INPUT_MODES = [
+    '\x1b[<u',
+    '\x1b[=0;1u',
+    '\x1b[>4;0m',
+    '\x1b[?1004l',
+    '\x1b[?2004l',
+    '\x1b[?1000l',
+    '\x1b[?1002l',
+    '\x1b[?1003l',
+    '\x1b[?1006l'
+].join('');
+
+export function resetTerminalInputModes(): void {
     if (process.stdout.isTTY) {
-        // Disable kitty keyboard protocol / CSI u key release reporting if enabled.
-        process.stdout.write('\x1b[>4;0m');
-        // Disable focus reporting to avoid stray ^[[I on mode switches.
-        process.stdout.write('\x1b[?1004l');
-        process.stdout.write('\x1b[?2004l');
+        process.stdout.write(RESET_INPUT_MODES);
     }
+}
+
+export function restoreTerminalState(): void {
+    resetTerminalInputModes();
     if (process.stdin.isTTY) {
         try {
             process.stdin.setRawMode(false);


### PR DESCRIPTION
## Summary

- reset kitty keyboard protocol, modifyOtherKeys, focus, paste, and mouse input modes before rendering the remote Ink UI
- parse Ink 6 CSI-u and modifyOtherKeys input in the post-ESC-stripping form, including CSI-u Ctrl-C
- keep switch confirmation active for key releases, focus reports, and mouse reports

## Testing

- `bun node_modules/vitest/vitest.mjs run --root cli src/ui/terminalState.test.ts src/ui/ink/useSwitchControls.test.ts`

## Validation notes

- `bun run typecheck` is currently blocked on unchanged `cli/src/runtime/embeddedAssets.bun.ts` import assertions under the locked TypeScript 5.9.3.
- `bun run test` is currently blocked in this environment because Bun 1.3.6 did not create the workspace `vitest` executable shim after installation; the focused tests above passed when invoked through the installed Vitest entry point.

## AI disclosure

This PR was prepared with assistance from OpenAI Codex (GPT-5).
