### PR TITLE
feat(web): streamline context usage display

### DIFF
--- a/web/src/components/AssistantChat/StatusBar.popover.test.tsx
+++ b/web/src/components/AssistantChat/StatusBar.popover.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { I18nProvider } from '@/lib/i18n-context'
+import { StatusBar } from './StatusBar'
+
+describe('StatusBar context details popover', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('opens from the mobile-accessible context trigger and keeps the requested detail order', async () => {
+        localStorage.setItem('hapi-lang', 'zh-CN')
+        render(
+            <I18nProvider>
+                <StatusBar
+                    active
+                    thinking={false}
+                    agentState={null}
+                    contextSize={90_000}
+                    contextCacheRead={86_000}
+                    contextWindow={258_000}
+                />
+            </I18nProvider>
+        )
+
+        const trigger = screen.getByRole('button', { name: '上下文详情' })
+        expect(trigger.textContent).toBe('ctx 258k · 65% leftctx 90k/258k · 65% left')
+        expect(trigger.className.split(' ')).not.toContain('hidden')
+
+        fireEvent.click(trigger)
+
+        const cacheLine = await screen.findByText('缓存：86k')
+        const details = cacheLine.parentElement
+        expect(details?.textContent).toBe('缓存：86k使用：90k（35%）剩余：168k（65%）')
+        expect(screen.queryByText('上下文详情')).toBeNull()
+    })
+
+    it('localizes the popover content without localizing the external left label', async () => {
+        localStorage.setItem('hapi-lang', 'en')
+        render(
+            <I18nProvider>
+                <StatusBar
+                    active
+                    thinking={false}
+                    agentState={null}
+                    contextSize={90_000}
+                    contextCacheRead={86_000}
+                    contextWindow={258_000}
+                />
+            </I18nProvider>
+        )
+
+        const trigger = screen.getByRole('button', { name: 'Context details' })
+        expect(trigger.textContent).toContain('ctx 258k · 65% left')
+
+        fireEvent.click(trigger)
+
+        const cacheLine = await screen.findByText('Cache: 86k')
+        expect(cacheLine.parentElement?.textContent).toBe('Cache: 86kUsed: 90k (35%)Remaining: 168k (65%)')
+    })
+})

--- a/web/src/components/AssistantChat/StatusBar.popover.test.tsx
+++ b/web/src/components/AssistantChat/StatusBar.popover.test.tsx
@@ -24,8 +24,10 @@ describe('StatusBar context details popover', () => {
         )
 
         const trigger = screen.getByRole('button', { name: '上下文详情' })
-        expect(trigger.textContent).toBe('ctx 258k · 65% leftctx 90k/258k · 65% left')
+        expect(trigger.textContent).toBe('ctx 258k · 65% left35% · 90k/258k')
         expect(trigger.className.split(' ')).not.toContain('hidden')
+        const progressTrack = trigger.querySelector('[aria-hidden="true"]')
+        expect((progressTrack?.firstElementChild as HTMLElement | null)?.style.width).toBe('35%')
 
         fireEvent.click(trigger)
 

--- a/web/src/components/AssistantChat/StatusBar.test.ts
+++ b/web/src/components/AssistantChat/StatusBar.test.ts
@@ -8,8 +8,8 @@ import {
 } from './StatusBar'
 
 describe('context usage labels', () => {
-    it('keeps the desktop label compact and expresses remaining capacity in English', () => {
-        expect(formatContextUsageLabel(90_000, 258_000)).toBe('ctx 90k/258k · 65% left')
+    it('keeps the desktop label compact and expresses used capacity', () => {
+        expect(formatContextUsageLabel(90_000, 258_000)).toBe('35% · 90k/258k')
     })
 
     it('uses the compact middle-dot mobile label with a fixed English suffix', () => {
@@ -27,7 +27,7 @@ describe('context usage labels', () => {
     })
 
     it('keeps external and detailed percentages complementary at rounding midpoints', () => {
-        expect(formatContextUsageLabel(69, 200)).toBe('ctx 69/200 · 65% left')
+        expect(formatContextUsageLabel(69, 200)).toBe('35% · 69/200')
         expect(formatCompactContextUsageLabel(69, 200)).toBe('ctx 200 · 65% left')
         expect(getContextUsageDetails(69, 200, 0)).toMatchObject({
             usedPercentage: 35,

--- a/web/src/components/AssistantChat/StatusBar.test.ts
+++ b/web/src/components/AssistantChat/StatusBar.test.ts
@@ -1,5 +1,40 @@
 import { describe, expect, it } from 'vitest'
-import { shouldShowCodexFastBadge, shouldShowComposerStatusBar } from './StatusBar'
+import {
+    formatCompactContextUsageLabel,
+    formatContextUsageLabel,
+    getContextUsageDetails,
+    shouldShowCodexFastBadge,
+    shouldShowComposerStatusBar
+} from './StatusBar'
+
+describe('context usage labels', () => {
+    it('keeps the desktop label compact and expresses remaining capacity in English', () => {
+        expect(formatContextUsageLabel(90_000, 258_000)).toBe('ctx 90k/258k · 65% left')
+    })
+
+    it('uses the compact middle-dot mobile label with a fixed English suffix', () => {
+        expect(formatCompactContextUsageLabel(186_000, 262_000)).toBe('ctx 262k · 29% left')
+    })
+
+    it('orders cache, used, and remaining metrics for the desktop details', () => {
+        expect(getContextUsageDetails(90_000, 258_000, 86_000)).toEqual({
+            cacheRead: '86k',
+            used: '90k',
+            usedPercentage: 35,
+            remaining: '168k',
+            remainingPercentage: 65
+        })
+    })
+
+    it('keeps external and detailed percentages complementary at rounding midpoints', () => {
+        expect(formatContextUsageLabel(69, 200)).toBe('ctx 69/200 · 65% left')
+        expect(formatCompactContextUsageLabel(69, 200)).toBe('ctx 200 · 65% left')
+        expect(getContextUsageDetails(69, 200, 0)).toMatchObject({
+            usedPercentage: 35,
+            remainingPercentage: 65
+        })
+    })
+})
 
 describe('shouldShowComposerStatusBar', () => {
     it('hides the composer status bar for Cursor sessions', () => {

--- a/web/src/components/AssistantChat/StatusBar.tsx
+++ b/web/src/components/AssistantChat/StatusBar.tsx
@@ -134,9 +134,9 @@ function getContextPercentages(contextSize: number, maxContextSize: number): {
 }
 
 export function formatContextUsageLabel(contextSize: number, maxContextSize: number | null | undefined): string {
-    if (!maxContextSize) return `ctx ${formatTokenCount(contextSize)}`
-    const { remainingPercentage } = getContextPercentages(contextSize, maxContextSize)
-    return `ctx ${formatTokenCount(contextSize)}/${formatTokenCount(maxContextSize)} · ${remainingPercentage}% left`
+    if (!maxContextSize) return `${formatTokenCount(contextSize)} used`
+    const { usedPercentage } = getContextPercentages(contextSize, maxContextSize)
+    return `${usedPercentage}% · ${formatTokenCount(contextSize)}/${formatTokenCount(maxContextSize)}`
 }
 
 export function formatCompactContextUsageLabel(contextSize: number, maxContextSize: number | null | undefined): string {
@@ -235,6 +235,7 @@ export function StatusBar(props: {
         const maxContextSize = props.contextWindow ?? getContextBudgetTokens(props.model, props.agentFlavor)
         return getContextUsageDetails(props.contextSize, maxContextSize, props.contextCacheRead)
     }, [props.contextSize, props.contextCacheRead, props.contextWindow, props.model, props.agentFlavor])
+    const contextUsedPercentage = contextUsageDetails?.usedPercentage ?? null
 
     const permissionMode = props.permissionMode
     const displayPermissionMode = permissionMode
@@ -282,7 +283,20 @@ export function StatusBar(props: {
                                 className={`min-w-0 cursor-pointer whitespace-nowrap rounded-sm bg-transparent p-0 text-[10px] outline-none focus-visible:ring-1 focus-visible:ring-[var(--app-link)] ${contextWarning?.color ?? 'text-[var(--app-hint)]'}`}
                             >
                                 <span className="sm:hidden">{compactContextUsageLabel}</span>
-                                <span className="hidden sm:inline">{contextUsageLabel}</span>
+                                <span className="hidden items-center gap-2 sm:inline-flex">
+                                    {contextUsedPercentage !== null ? (
+                                        <span
+                                            aria-hidden="true"
+                                            className="h-1 w-12 shrink-0 overflow-hidden rounded-full bg-[var(--app-link-muted)]"
+                                        >
+                                            <span
+                                                className="block h-full rounded-full bg-current"
+                                                style={{ width: `${contextUsedPercentage}%` }}
+                                            />
+                                        </span>
+                                    ) : null}
+                                    <span>{contextUsageLabel}</span>
+                                </span>
                             </button>
                         </Popover.Trigger>
                         <Popover.Portal>

--- a/web/src/components/AssistantChat/StatusBar.tsx
+++ b/web/src/components/AssistantChat/StatusBar.tsx
@@ -5,6 +5,7 @@ import {
     isPermissionModeAllowedForFlavor
 } from '@hapi/protocol'
 import type { PermissionModeTone } from '@hapi/protocol'
+import * as Popover from '@radix-ui/react-popover'
 import { useMemo } from 'react'
 import type { AgentState, CodexCollaborationMode, PermissionMode } from '@/types/api'
 import type { ConversationStatus } from '@/realtime/types'
@@ -105,17 +106,16 @@ function getConnectionStatus(
     }
 }
 
-function getContextWarning(contextSize: number, maxContextSize: number, t: (key: string, params?: Record<string, string | number>) => string): { text: string; color: string } | null {
+function getContextWarning(contextSize: number, maxContextSize: number): { color: string } | null {
     const percentageUsed = (contextSize / maxContextSize) * 100
     const percentageRemaining = Math.max(0, 100 - percentageUsed)
 
-    const percent = Math.round(percentageRemaining)
     if (percentageRemaining <= 5) {
-        return { text: t('misc.percentLeft', { percent }), color: 'text-red-500' }
+        return { color: 'text-red-500' }
     } else if (percentageRemaining <= 10) {
-        return { text: t('misc.percentLeft', { percent }), color: 'text-amber-500' }
+        return { color: 'text-amber-500' }
     } else {
-        return { text: t('misc.percentLeft', { percent }), color: 'text-[var(--app-hint)]' }
+        return { color: 'text-[var(--app-hint)]' }
     }
 }
 
@@ -123,6 +123,57 @@ function formatTokenCount(value: number): string {
     if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
     if (value >= 1_000) return `${Math.round(value / 1_000)}k`
     return String(value)
+}
+
+function getContextPercentages(contextSize: number, maxContextSize: number): {
+    usedPercentage: number
+    remainingPercentage: number
+} {
+    const usedPercentage = Math.min(100, Math.max(0, Math.round((contextSize / maxContextSize) * 100)))
+    return { usedPercentage, remainingPercentage: 100 - usedPercentage }
+}
+
+export function formatContextUsageLabel(contextSize: number, maxContextSize: number | null | undefined): string {
+    if (!maxContextSize) return `ctx ${formatTokenCount(contextSize)}`
+    const { remainingPercentage } = getContextPercentages(contextSize, maxContextSize)
+    return `ctx ${formatTokenCount(contextSize)}/${formatTokenCount(maxContextSize)} · ${remainingPercentage}% left`
+}
+
+export function formatCompactContextUsageLabel(contextSize: number, maxContextSize: number | null | undefined): string {
+    if (!maxContextSize) return `ctx ${formatTokenCount(contextSize)}`
+    const { remainingPercentage } = getContextPercentages(contextSize, maxContextSize)
+    return `ctx ${formatTokenCount(maxContextSize)} · ${remainingPercentage}% left`
+}
+
+export function getContextUsageDetails(
+    contextSize: number,
+    maxContextSize: number | null | undefined,
+    contextCacheRead: number | null | undefined
+): {
+    cacheRead: string | null
+    used: string
+    usedPercentage: number | null
+    remaining: string | null
+    remainingPercentage: number | null
+} {
+    if (!maxContextSize) {
+        return {
+            cacheRead: contextCacheRead && contextCacheRead > 0 ? formatTokenCount(contextCacheRead) : null,
+            used: formatTokenCount(contextSize),
+            usedPercentage: null,
+            remaining: null,
+            remainingPercentage: null
+        }
+    }
+
+    const { usedPercentage, remainingPercentage } = getContextPercentages(contextSize, maxContextSize)
+    return {
+        cacheRead: contextCacheRead && contextCacheRead > 0 ? formatTokenCount(contextCacheRead) : null,
+        used: formatTokenCount(contextSize),
+        usedPercentage,
+        remaining: formatTokenCount(Math.max(0, maxContextSize - contextSize)),
+        remainingPercentage
+    }
 }
 
 export function shouldShowCodexFastBadge(
@@ -165,28 +216,25 @@ export function StatusBar(props: {
             if (props.contextSize === undefined) return null
             const maxContextSize = props.contextWindow ?? getContextBudgetTokens(props.model, props.agentFlavor)
             if (!maxContextSize) return null
-            return getContextWarning(props.contextSize, maxContextSize, t)
+            return getContextWarning(props.contextSize, maxContextSize)
         },
-        [props.contextSize, props.contextWindow, props.model, props.agentFlavor, t]
+        [props.contextSize, props.contextWindow, props.model, props.agentFlavor]
     )
     const contextUsageLabel = useMemo(() => {
         if (props.contextSize === undefined) return null
         const maxContextSize = props.contextWindow ?? getContextBudgetTokens(props.model, props.agentFlavor)
-        if (!maxContextSize) return `ctx ${formatTokenCount(props.contextSize)}`
-        const percentageUsed = Math.min(100, Math.round((props.contextSize / maxContextSize) * 100))
-        return `ctx ${formatTokenCount(props.contextSize)}/${formatTokenCount(maxContextSize)} (${percentageUsed}%)`
+        return formatContextUsageLabel(props.contextSize, maxContextSize)
     }, [props.contextSize, props.contextWindow, props.model, props.agentFlavor])
     const compactContextUsageLabel = useMemo(() => {
         if (props.contextSize === undefined) return null
         const maxContextSize = props.contextWindow ?? getContextBudgetTokens(props.model, props.agentFlavor)
-        if (!maxContextSize) return `ctx ${formatTokenCount(props.contextSize)}`
-        const percentageLeft = Math.max(0, Math.round(100 - (props.contextSize / maxContextSize) * 100))
-        return `ctx ${formatTokenCount(maxContextSize).toUpperCase()}, ${percentageLeft}% left`
+        return formatCompactContextUsageLabel(props.contextSize, maxContextSize)
     }, [props.contextSize, props.contextWindow, props.model, props.agentFlavor])
-    const cacheHitLabel = useMemo(() => {
-        if (!props.contextCacheRead || props.contextCacheRead <= 0) return null
-        return `cache ${formatTokenCount(props.contextCacheRead)}`
-    }, [props.contextCacheRead])
+    const contextUsageDetails = useMemo(() => {
+        if (props.contextSize === undefined) return null
+        const maxContextSize = props.contextWindow ?? getContextBudgetTokens(props.model, props.agentFlavor)
+        return getContextUsageDetails(props.contextSize, maxContextSize, props.contextCacheRead)
+    }, [props.contextSize, props.contextCacheRead, props.contextWindow, props.model, props.agentFlavor])
 
     const permissionMode = props.permissionMode
     const displayPermissionMode = permissionMode
@@ -226,19 +274,51 @@ export function StatusBar(props: {
                     </span>
                 </div>
                 {contextUsageLabel ? (
-                    <span className={`min-w-0 whitespace-nowrap text-[10px] ${contextWarning?.color ?? 'text-[var(--app-hint)]'}`}>
-                        <span className="sm:hidden">
-                            {compactContextUsageLabel}
-                        </span>
-                        <span className="hidden sm:inline">
-                            {contextUsageLabel}{contextWarning ? ` · ${contextWarning.text}` : ''}
-                        </span>
-                    </span>
-                ) : null}
-                {cacheHitLabel ? (
-                    <span className="hidden whitespace-nowrap text-[10px] text-[var(--app-hint)] sm:inline">
-                        {cacheHitLabel}
-                    </span>
+                    <Popover.Root>
+                        <Popover.Trigger asChild>
+                            <button
+                                type="button"
+                                aria-label={t('misc.contextDetails')}
+                                className={`min-w-0 cursor-pointer whitespace-nowrap rounded-sm bg-transparent p-0 text-[10px] outline-none focus-visible:ring-1 focus-visible:ring-[var(--app-link)] ${contextWarning?.color ?? 'text-[var(--app-hint)]'}`}
+                            >
+                                <span className="sm:hidden">{compactContextUsageLabel}</span>
+                                <span className="hidden sm:inline">{contextUsageLabel}</span>
+                            </button>
+                        </Popover.Trigger>
+                        <Popover.Portal>
+                            <Popover.Content
+                                side="top"
+                                align="start"
+                                sideOffset={6}
+                                collisionPadding={8}
+                                className="z-50 rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-2 shadow-lg"
+                            >
+                                <div className="flex max-w-[min(22rem,calc(100vw-1rem))] flex-col gap-1 text-xs leading-tight text-[var(--app-fg)]">
+                                    {contextUsageDetails?.cacheRead ? (
+                                        <span className="break-words">
+                                            {t('misc.contextCache', { value: contextUsageDetails.cacheRead })}
+                                        </span>
+                                    ) : null}
+                                    <span className="break-words">
+                                        {contextUsageDetails?.usedPercentage === null
+                                            ? t('misc.contextUsedTokens', { value: contextUsageDetails.used })
+                                            : t('misc.contextUsed', {
+                                                value: contextUsageDetails?.used ?? '',
+                                                percent: contextUsageDetails?.usedPercentage ?? 0
+                                            })}
+                                    </span>
+                                    {contextUsageDetails?.remaining && contextUsageDetails.remainingPercentage !== null ? (
+                                        <span className="break-words">
+                                            {t('misc.contextRemaining', {
+                                                value: contextUsageDetails.remaining,
+                                                percent: contextUsageDetails.remainingPercentage
+                                            })}
+                                        </span>
+                                    ) : null}
+                                </div>
+                            </Popover.Content>
+                        </Popover.Portal>
+                    </Popover.Root>
                 ) : null}
             </div>
 

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -879,8 +879,12 @@ export default {
   'misc.typeAMessage': 'Type a message...',
   'misc.offline': 'offline',
   'misc.permissionRequired': 'permission required',
-  'misc.percentLeft': '{percent}% left',
   'misc.online': 'online',
+  'misc.contextDetails': 'Context details',
+  'misc.contextCache': 'Cache: {value}',
+  'misc.contextUsed': 'Used: {value} ({percent}%)',
+  'misc.contextUsedTokens': 'Used: {value}',
+  'misc.contextRemaining': 'Remaining: {value} ({percent}%)',
 
   // Web Share Target picker
   'share.title': 'Share to HAPI',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -883,8 +883,12 @@ export default {
   'misc.typeAMessage': '输入消息...',
   'misc.offline': '离线',
   'misc.permissionRequired': '需要权限',
-  'misc.percentLeft': '剩余 {percent}%',
   'misc.online': '在线',
+  'misc.contextDetails': '上下文详情',
+  'misc.contextCache': '缓存：{value}',
+  'misc.contextUsed': '使用：{value}（{percent}%）',
+  'misc.contextUsedTokens': '使用：{value}',
+  'misc.contextRemaining': '剩余：{value}（{percent}%）',
 
   // Web Share Target 分享面板
   'share.title': '分享到 HAPI',


### PR DESCRIPTION
## Summary

- visualize desktop context usage with a compact progress bar, used percentage, and used/total token counts
- keep the mobile status compact as `ctx max · percent left`
- move cache, used, and remaining metrics into a localized click/tap popover
- keep the external `left` label in English and preserve the existing low-context warning colors
- add formatting, rounding, localization, and popover interaction coverage

## Testing

- [x] `bun run typecheck`
- [x] `bun run --cwd web test --run --maxWorkers=2` — 194 files, 1711 tests
- [x] `bun run test:shared` — 152 tests
- [x] `bun run build:web`
- [x] `bun run --cwd hub generate:embedded-web-assets`
- [x] `bun run build:hub`

## Notes

- No documentation changes are needed for this focused UI refinement.
- Related issue: none.

## AI assistance

- OpenAI Codex, model `gpt-5.6-sol`, assisted with implementation, review, and testing.
