### PR TITLE
fix(web): stabilize chat scrolling and mobile alignment

### DIFF
--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -1414,10 +1414,10 @@ export function HappyThread(props: {
                 >
                     <div
                         ref={viewportRef}
-                        className="app-scroll-y min-h-0 flex-1 overflow-x-hidden"
+                        className="app-scroll-y chat-scroll-y min-h-0 flex-1 overflow-x-hidden"
                         tabIndex={0}
                     >
-                        <div ref={contentRef} className="mx-auto w-full max-w-content min-w-0 p-3">
+                        <div ref={contentRef} className="chat-scroll-content mx-auto w-full max-w-content min-w-0 p-3">
                             <div ref={topSentinelRef} className="h-px w-full" aria-hidden="true" />
                             {showSkeleton ? (
                                 <MessageSkeleton />

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -461,6 +461,28 @@ export function HappyThread(props: {
         failureCount: 0,
         autoPaused: false
     })
+
+    useLayoutEffect(() => {
+        const viewport = viewportRef.current
+        if (!viewport) return
+
+        const updateScrollbarGutter = () => {
+            const supportsStableBothEdges = typeof CSS !== 'undefined'
+                && typeof CSS.supports === 'function'
+                && CSS.supports('scrollbar-gutter: stable both-edges')
+            const gutter = supportsStableBothEdges
+                ? Math.max(0, (viewport.offsetWidth - viewport.clientWidth) / 2)
+                : 0
+            viewport.style.setProperty('--chat-scroll-gutter-inline', `${gutter}px`)
+        }
+
+        updateScrollbarGutter()
+        if (typeof ResizeObserver === 'undefined') return
+
+        const observer = new ResizeObserver(updateScrollbarGutter)
+        observer.observe(viewport)
+        return () => observer.disconnect()
+    }, [])
     const requestOlderRef = useRef<(source: HistoryLoadSource) => Promise<OlderHistoryLoadResult>>(
         () => Promise.resolve('transient-stop')
     )

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -287,13 +287,17 @@ body {
     touch-action: pan-x pan-y;
     overscroll-behavior: none;
     -webkit-text-size-adjust: 100%;
-    /*
-     * The application owns scrolling through `.app-scroll-y` viewports. Keep
-     * the document itself fixed so a temporarily oversized chat child (for
-     * example while an attachment image is being measured) cannot create a
-     * second, stale page scrollbar.
-     */
+}
+
+html[data-telegram-app="true"],
+html[data-telegram-app="true"] body {
     overflow: hidden;
+}
+
+html:not([data-telegram-app="true"]),
+html:not([data-telegram-app="true"]) body {
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 body {
@@ -304,7 +308,13 @@ body {
 
 #root {
     height: 100%;
-    min-height: 0;
+}
+
+/* Chat viewports own vertical scrolling; keep transiently oversized messages
+ * from creating a second document scrollbar without locking non-chat routes. */
+html:has(.chat-scroll-y),
+html:has(.chat-scroll-y) body,
+html:has(.chat-scroll-y) #root {
     overflow: hidden;
 }
 
@@ -322,7 +332,10 @@ body {
     }
 
     .chat-scroll-content {
-        padding-inline: 0.125rem;
+        padding-inline: max(
+            0.125rem,
+            calc(0.75rem - var(--chat-scroll-gutter-inline, 0px))
+        );
     }
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -287,17 +287,13 @@ body {
     touch-action: pan-x pan-y;
     overscroll-behavior: none;
     -webkit-text-size-adjust: 100%;
-}
-
-html[data-telegram-app="true"],
-html[data-telegram-app="true"] body {
+    /*
+     * The application owns scrolling through `.app-scroll-y` viewports. Keep
+     * the document itself fixed so a temporarily oversized chat child (for
+     * example while an attachment image is being measured) cannot create a
+     * second, stale page scrollbar.
+     */
     overflow: hidden;
-}
-
-html:not([data-telegram-app="true"]),
-html:not([data-telegram-app="true"]) body {
-    overflow-x: hidden;
-    overflow-y: auto;
 }
 
 body {
@@ -308,6 +304,8 @@ body {
 
 #root {
     height: 100%;
+    min-height: 0;
+    overflow: hidden;
 }
 
 .app-scroll-y {
@@ -315,6 +313,17 @@ body {
     overscroll-behavior-y: contain;
     -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
+}
+
+/* On touch-first devices, keep the chat scrollbar from shifting centered content. */
+@media (hover: none) and (pointer: coarse) {
+    .chat-scroll-y {
+        scrollbar-gutter: stable both-edges;
+    }
+
+    .chat-scroll-content {
+        padding-inline: 0.125rem;
+    }
 }
 
 @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
## Summary

- keep document-level overflow from creating a second scrollbar and stale blank space around long chat sessions
- scope document/root containment to chat views while preserving normal document scrolling on login and other non-chat routes
- reserve symmetric chat scrollbar gutters only on touch-first devices, then compensate for the measured physical gutter so the original mobile inset remains unchanged
- leave pointer/hover desktop chat spacing and scrollbar layout unchanged

## Problem

Some chat sessions could intermittently gain two vertical scrollbars, especially after an image attachment changed size during rendering. The outer document scrollbar could retain a stale scroll range and expose a large blank area below the app until the page was refreshed.

On mobile, the remaining chat scrollbar also consumed width on the right side of the scroll viewport. Centered chat content was therefore shifted left and had visibly asymmetric side spacing.

## Changes

- scope `html`, `body`, and `#root` overflow containment to pages containing the chat viewport so temporary chat child measurements cannot expand the document scroll range
- add chat-specific viewport/content classes instead of changing every `.app-scroll-y` surface
- under `(hover: none) and (pointer: coarse)`:
  - use `scrollbar-gutter: stable both-edges`
  - measure the actual reserved gutter and subtract it from the chat content padding
  - retain the original padding on browsers/devices that use overlay scrollbars and reserve no physical gutter
- retain the original `p-3` content spacing on desktop pointer devices

## Testing

- `bun typecheck`
- `bun run test:web` — 193 files, 1705 tests passed
- production build and manual testing through the embedded Hub web app on Windows/Chromium at desktop and mobile viewport sizes
- verified image-attachment sessions no longer create a second document scrollbar or blank page tail
- verified touch-first layouts retain the original left inset and use the same effective inset on the right

## AI disclosure

Code and PR text were prepared with OpenAI GPT-5.6-Sol and manually tested/reviewed.
