### PR TITLE
fix(web): refresh skill and slash inventories

### DIFF
--- a/web/src/hooks/queries/useSkills.ts
+++ b/web/src/hooks/queries/useSkills.ts
@@ -42,7 +42,9 @@ export function useSkills(
             return await api.getSkills(sessionId)
         },
         enabled: Boolean(api && sessionId),
-        staleTime: Infinity,
+        staleTime: 30_000,
+        refetchInterval: 30_000,
+        refetchOnWindowFocus: 'always',
         gcTime: 30 * 60 * 1000,
         retry: false,
     })

--- a/web/src/hooks/queries/useSlashCommands.ts
+++ b/web/src/hooks/queries/useSlashCommands.ts
@@ -44,7 +44,9 @@ export function useSlashCommands(
             return await api.getSlashCommands(sessionId)
         },
         enabled: Boolean(api && sessionId),
-        staleTime: Infinity,
+        staleTime: 30_000,
+        refetchInterval: 30_000,
+        refetchOnWindowFocus: 'always',
         gcTime: 30 * 60 * 1000,
         retry: false, // Don't retry RPC failures
     })


### PR DESCRIPTION
## Summary
- refresh skill and slash-command inventories every 30 seconds while a session is selected
- refresh immediately when the web app regains focus
- replace the permanent first-result cache so early fallback/empty inventories and filesystem changes become visible

## Tests
- `bun typecheck`
- `bun run test:web` (204 files, 1760 tests)

Closes #1294
Part of #1284
