### PR TITLE
fix(pi): keep archived sessions visible

### DIFF
--- a/hub/src/store/sessions.test.ts
+++ b/hub/src/store/sessions.test.ts
@@ -174,7 +174,8 @@ describe('updateSessionMetadata: protocol resume token preservation', () => {
         ['opencodeSessionId', 'opencode-thread-x'],
         ['grokSessionId', 'grok-thread-x'],
         ['cursorSessionId', 'cursor-thread-x'],
-        ['kimiSessionId', 'kimi-thread-x']
+        ['kimiSessionId', 'kimi-thread-x'],
+        ['piSessionId', 'pi-thread-x']
     ])('preserves %s across an archive metadata replacement', (field, value) => {
         const store = makeStore()
         const session = store.sessions.getOrCreateSession(

--- a/hub/src/store/sessions.ts
+++ b/hub/src/store/sessions.ts
@@ -60,7 +60,8 @@ const SIMPLE_RESUME_TOKENS = [
     'opencodeSessionId',
     'grokSessionId',
     'cursorSessionId',
-    'kimiSessionId'
+    'kimiSessionId',
+    'piSessionId'
 ] as const
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/shared/src/sessionSummary.test.ts
+++ b/shared/src/sessionSummary.test.ts
@@ -77,6 +77,63 @@ describe('toSessionSummary', () => {
         expect(summary.metadata?.agentSessionId).toBe('grok-session-1')
     })
 
+    it('uses the native id matching the current flavor instead of a stale id', () => {
+        const summary = toSessionSummary(makeSession({
+            metadata: {
+                path: '/proj',
+                host: 'local',
+                flavor: 'cursor',
+                codexSessionId: 'stale-codex-id',
+                cursorSessionId: 'cursor-session-1'
+            }
+        }))
+
+        expect(summary.metadata?.agentSessionId).toBe('cursor-session-1')
+    })
+
+    it('does not fall back to a stale cross-agent id for a known flavor', () => {
+        const summary = toSessionSummary(makeSession({
+            metadata: {
+                path: '/proj',
+                host: 'local',
+                flavor: 'pi',
+                codexSessionId: 'stale-codex-id'
+            }
+        }))
+
+        expect(summary.metadata?.agentSessionId).toBeUndefined()
+    })
+
+    it('includes piSessionId as the native resume token', () => {
+        const summary = toSessionSummary(makeSession({
+            metadata: {
+                path: '/proj',
+                host: 'local',
+                flavor: 'pi',
+                piSessionId: 'pi-session-1'
+            }
+        }))
+
+        expect(summary.metadata?.agentSessionId).toBe('pi-session-1')
+    })
+
+    it.each([
+        undefined,
+        'custom',
+        ' PI '
+    ])('does not infer a Pi identity for an unknown flavor: %s', (flavor) => {
+        const summary = toSessionSummary(makeSession({
+            metadata: {
+                path: '/proj',
+                host: 'local',
+                flavor,
+                piSessionId: 'pi-session-1'
+            }
+        }))
+
+        expect(summary.metadata?.agentSessionId).toBeUndefined()
+    })
+
     it('includes pending request kinds and background task count', () => {
         const summary = toSessionSummary(makeSession({
             backgroundTaskCount: 2,

--- a/shared/src/sessionSummary.ts
+++ b/shared/src/sessionSummary.ts
@@ -1,4 +1,6 @@
-import type { Session, WorktreeMetadata } from './schemas'
+import type { Metadata, Session, WorktreeMetadata } from './schemas'
+import { isKnownFlavor } from './flavors'
+import type { AgentFlavor } from './modes'
 
 export type PendingRequestKind = 'permission' | 'input'
 
@@ -106,6 +108,38 @@ export function getPendingRequestKinds(session: Session): PendingRequestKind[] {
         : Array.from(kinds)
 }
 
+const AGENT_SESSION_ID_FIELD_BY_FLAVOR = {
+    claude: 'claudeSessionId',
+    codex: 'codexSessionId',
+    gemini: 'geminiSessionId',
+    opencode: 'opencodeSessionId',
+    grok: 'grokSessionId',
+    cursor: 'cursorSessionId',
+    kimi: 'kimiSessionId',
+    pi: 'piSessionId'
+} as const satisfies Record<AgentFlavor, keyof Metadata>
+
+function getSummaryAgentSessionId(metadata: Metadata): string | undefined {
+    const flavor = metadata.flavor
+    if (isKnownFlavor(flavor)) {
+        const flavorField = AGENT_SESSION_ID_FIELD_BY_FLAVOR[flavor]
+        const flavorSessionId = metadata[flavorField]
+        return typeof flavorSessionId === 'string' && flavorSessionId.trim()
+            ? flavorSessionId.trim()
+            : undefined
+    }
+
+    // Legacy fallback only applies when the stored flavor is missing or unknown.
+    return metadata.codexSessionId
+        ?? metadata.claudeSessionId
+        ?? metadata.geminiSessionId
+        ?? metadata.opencodeSessionId
+        ?? metadata.grokSessionId
+        ?? metadata.cursorSessionId
+        ?? metadata.kimiSessionId
+        ?? undefined
+}
+
 export function toSessionSummary(session: Session): SessionSummary {
     const pendingRequestsCount = session.agentState?.requests ? Object.keys(session.agentState.requests).length : 0
 
@@ -116,14 +150,7 @@ export function toSessionSummary(session: Session): SessionSummary {
         summary: session.metadata.summary ? { text: session.metadata.summary.text } : undefined,
         flavor: session.metadata.flavor ?? null,
         worktree: session.metadata.worktree,
-        agentSessionId: session.metadata.codexSessionId
-            ?? session.metadata.claudeSessionId
-            ?? session.metadata.geminiSessionId
-            ?? session.metadata.opencodeSessionId
-            ?? session.metadata.grokSessionId
-            ?? session.metadata.cursorSessionId
-            ?? session.metadata.kimiSessionId
-            ?? undefined,
+        agentSessionId: getSummaryAgentSessionId(session.metadata),
         lifecycleState: session.metadata.lifecycleState
     } : null
 

--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { toSessionSummary, type Session } from '@hapi/protocol'
 import type { SessionSummary } from '@/types/api'
 import {
     deduplicateSessionsByAgentId,
@@ -231,6 +232,39 @@ describe('prepareSidebarSessions', () => {
 
         const result = prepareSidebarSessions(sessions)
         expect(result.map(session => session.id)).toEqual(['real'])
+    })
+
+    it('keeps an archived Pi session with a native session id and no title', () => {
+        const piSession: Session = {
+            id: 'archived-pi',
+            namespace: 'default',
+            seq: 1,
+            createdAt: 50,
+            active: false,
+            activeAt: 0,
+            updatedAt: 100,
+            metadata: {
+                path: '/work/hapi',
+                host: 'local',
+                flavor: 'pi',
+                piSessionId: 'pi-session-1',
+                lifecycleState: 'archived'
+            },
+            metadataVersion: 1,
+            agentState: null,
+            agentStateVersion: 0,
+            thinking: false,
+            thinkingAt: 0,
+            model: null,
+            modelReasoningEffort: null,
+            effort: null,
+            serviceTier: null
+        }
+
+        const summary = toSessionSummary(piSession)
+
+        expect(summary.metadata?.agentSessionId).toBe('pi-session-1')
+        expect(prepareSidebarSessions([summary]).map(session => session.id)).toEqual(['archived-pi'])
     })
 
     it('keeps the selected inactive stub visible', () => {


### PR DESCRIPTION
Fixes #1296.

## Summary

- keep archived, untitled Pi sessions visible in the Web sidebar;
- project the native session ID that matches the session's exact flavor, including `piSessionId`;
- preserve `piSessionId` across sparse archive metadata replacements;
- add Shared, Hub, and Web regressions for the full failure chain.

## User-visible behavior

Before this change, a Pi session could be visible while active and disappear immediately after archival. The Hub row, messages, and `piSessionId` were still present, but the sidebar no longer exposed the session or its Reopen action.

After this change, an archived Pi session with a valid native ID remains in the sidebar with the same inactive presentation and actions used by archived Codex and Claude sessions.

## Root cause

The failure required two existing behaviors to interact:

1. `toSessionSummary()` flattened agent-specific native IDs into `metadata.agentSessionId`, but omitted `piSessionId`.
2. PR #836 intentionally hides inactive rows that have no flattened agent ID and no name or summary, because those rows are normally abandoned empty stubs.

The resulting chain was:

```text
Hub row contains piSessionId
  -> SessionSummary drops piSessionId
  -> Web receives agentSessionId = undefined
  -> archive makes the row inactive
  -> no name/summary means "empty stub"
  -> sidebar filters the real Pi session
```

Codex and Claude did not reproduce the issue because their native IDs were already included in the summary projection.

There was also a second Pi-specific gap in `SIMPLE_RESUME_TOKENS`. The store protects native resume identifiers when a stale or null CLI metadata cache produces a sparse archive payload, but `piSessionId` was absent from that carry-forward list. In that failure mode the token could be erased, turning a visibility bug into an actual Reopen failure.

## Changes

### Flavor-aware summary identity

`shared/src/sessionSummary.ts` now uses an exhaustive `AgentFlavor -> Metadata field` mapping and the same exact `isKnownFlavor` semantics used by the resume paths.

For known flavors, only the matching native ID is accepted. This avoids representing a Pi or Cursor session with a stale ID left by another agent integration.

The legacy fixed-order fallback remains limited to missing or unknown flavors. It deliberately does not infer Pi identity in that branch because Hub resume routing treats missing/unknown flavor as Claude.

### Pi resume-token preservation

`piSessionId` is now included in `SIMPLE_RESUME_TOKENS`, retaining the existing semantics:

- omitted field: carry the prior token forward;
- explicit `null`: clear the token;
- explicit new value: replace the token.

### Regression coverage

- canonical `flavor: 'pi'` projects `piSessionId` into summary `agentSessionId`;
- known flavors prefer their own native ID over stale cross-agent metadata;
- missing, unknown, and malformed flavors do not infer Pi identity;
- an archived, untitled Pi summary survives `prepareSidebarSessions()`;
- sparse archive metadata replacement preserves `piSessionId`.

## Related history

- #833 / #836 introduced the empty-stub filter for Cursor archive/resume ghost rows. This change keeps that filter intact and fixes the Pi summary input that caused a real row to be misclassified.
- #1060 previously contained a reviewed flavor-aware Pi summary mapping, but it was closed unmerged after its main copy-resume-command feature was superseded. This PR isolates the identity correctness fix and adds the missing Hub persistence change.

## Validation

- `mise exec -- bun typecheck`
- `mise exec -- bun test shared/src/sessionSummary.test.ts hub/src/store/sessions.test.ts`
- `mise exec -- bun run --cwd web test src/components/SessionList.test.ts`
- `mise exec -- bun run test`
- `git diff --check`

Full-suite result before the final rebase:

```text
CLI:    167 files / 1654 tests passed
Hub:    693 passed / 3 existing real-agent integration tests skipped
Web:    204 files / 1765 tests passed
Shared: 158 passed
```

After rebasing onto the latest `main`, all affected tests and the full CLI/Web/Hub typecheck passed again.

## AI disclosure

Root-cause analysis, implementation, tests, and PR drafting were assisted by OpenAI Codex (GPT-5.6).
