### PR TITLE
fix(web): make inactive session notices flush with headers

### DIFF
--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1312,12 +1312,10 @@ function SessionChatInner(props: SessionChatProps) {
             )}
 
             {sessionInactive ? (
-                <div className="px-3 pt-3">
-                    <div className="mx-auto w-full max-w-content rounded-md bg-[var(--app-subtle-bg)] p-3 text-sm text-[var(--app-hint)]">
-                        {inactiveCanResume
-                            ? t('session.inactive.autoResume')
-                            : t('session.inactive.cannotResume')}
-                    </div>
+                <div className="mx-auto w-full max-w-content bg-[var(--app-subtle-bg)] p-3 text-sm text-[var(--app-hint)]">
+                    {inactiveCanResume
+                        ? t('session.inactive.autoResume')
+                        : t('session.inactive.cannotResume')}
                 </div>
             ) : null}
 

--- a/web/src/routes/sessions/terminal.tsx
+++ b/web/src/routes/sessions/terminal.tsx
@@ -447,10 +447,8 @@ export default function TerminalPage() {
             </div>
 
             {session.active ? null : (
-                <div className="px-3 pt-3">
-                    <div className="mx-auto w-full max-w-content rounded-md bg-[var(--app-subtle-bg)] p-3 text-sm text-[var(--app-hint)]">
-                        Session is inactive. Terminal is unavailable.
-                    </div>
+                <div className="mx-auto w-full max-w-content bg-[var(--app-subtle-bg)] p-3 text-sm text-[var(--app-hint)]">
+                    Session is inactive. Terminal is unavailable.
                 </div>
             )}
 


### PR DESCRIPTION
## Summary

- remove the outer spacing around inactive-session notices
- align inactive notices directly below the session header
- apply the same full-width treatment to both chat and terminal views

## Motivation

Inactive-session notices represent a persistent page-level state rather than a temporary alert. The previous inset card layout added unnecessary horizontal and vertical gaps, making the spacing below the session header appear unbalanced, especially on mobile.

## Testing

- `bun run typecheck:web`
- `bun run --cwd web test -- src/components/SessionChat.test.ts src/components/SessionChat.exit-mode.test.tsx src/routes/sessions/terminal.test.tsx`
- `bun run build:web`
