### PR TITLE
fix(web): show Pi reasoning effort

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -1336,6 +1336,7 @@ export function HappyComposer(props: {
                         contextModel={contextModel}
                         model={model}
                         modelReasoningEffort={modelReasoningEffort}
+                        effort={effort}
                         serviceTier={serviceTier}
                         permissionMode={permissionMode}
                         collaborationMode={collaborationMode}

--- a/web/src/components/AssistantChat/StatusBar.popover.test.tsx
+++ b/web/src/components/AssistantChat/StatusBar.popover.test.tsx
@@ -58,6 +58,7 @@ describe('StatusBar context details popover', () => {
                     agentState={null}
                     agentFlavor="codex"
                     modelReasoningEffort="xhigh"
+                    effort="max"
                 />
             </I18nProvider>
         )
@@ -66,6 +67,105 @@ describe('StatusBar context details popover', () => {
         const desktopLabel = screen.getByText('reasoning xhigh')
         expect(desktopLabel.className.split(' ')).toContain('hidden')
         expect(desktopLabel.className.split(' ')).toContain('sm:inline')
+    })
+
+    it('keeps the Codex default reasoning label when model effort is absent', () => {
+        render(
+            <I18nProvider>
+                <StatusBar
+                    active
+                    thinking={false}
+                    agentState={null}
+                    agentFlavor="codex"
+                    modelReasoningEffort={null}
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.getByText('default').className.split(' ')).toContain('sm:hidden')
+        expect(screen.getByText('reasoning default').className.split(' ')).toContain('sm:inline')
+    })
+
+    it('uses Pi ordinary effort instead of model reasoning effort', () => {
+        render(
+            <I18nProvider>
+                <StatusBar
+                    active
+                    thinking={false}
+                    agentState={null}
+                    agentFlavor="pi"
+                    modelReasoningEffort="xhigh"
+                    effort="max"
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.getByText('max').className.split(' ')).toContain('sm:hidden')
+        expect(screen.getByText('reasoning max').className.split(' ')).toContain('sm:inline')
+        expect(screen.queryByText('reasoning xhigh')).not.toBeInTheDocument()
+    })
+
+    it('hides Pi reasoning when effort is absent or blank', () => {
+        const { rerender } = render(
+            <I18nProvider>
+                <StatusBar
+                    active
+                    thinking={false}
+                    agentState={null}
+                    agentFlavor="pi"
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.queryByText('reasoning default')).not.toBeInTheDocument()
+        expect(screen.queryByText('default')).not.toBeInTheDocument()
+
+        rerender(
+            <I18nProvider>
+                <StatusBar
+                    active
+                    thinking={false}
+                    agentState={null}
+                    agentFlavor="pi"
+                    effort="   "
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.queryByText('reasoning default')).not.toBeInTheDocument()
+        expect(screen.queryByText('default')).not.toBeInTheDocument()
+    })
+
+    it('does not expose ordinary effort for Claude or unknown flavors', () => {
+        const { rerender } = render(
+            <I18nProvider>
+                <StatusBar
+                    active
+                    thinking={false}
+                    agentState={null}
+                    agentFlavor="claude"
+                    effort="max"
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.queryByText('reasoning max')).not.toBeInTheDocument()
+        expect(screen.queryByText('max')).not.toBeInTheDocument()
+
+        rerender(
+            <I18nProvider>
+                <StatusBar
+                    active
+                    thinking={false}
+                    agentState={null}
+                    agentFlavor="unknown"
+                    effort="max"
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.queryByText('reasoning max')).not.toBeInTheDocument()
+        expect(screen.queryByText('max')).not.toBeInTheDocument()
     })
 
     it('opens from the mobile-accessible context trigger and keeps the requested detail order', async () => {

--- a/web/src/components/AssistantChat/StatusBar.tsx
+++ b/web/src/components/AssistantChat/StatusBar.tsx
@@ -12,9 +12,10 @@ import type { ConversationStatus } from '@/realtime/types'
 import type { ThreadGoal } from '@/types/api'
 import { getContextBudgetTokens } from '@/chat/modelConfig'
 import {
-    formatCodexReasoningLabel,
-    formatCompactCodexReasoningLabel,
-    shouldShowCodexReasoningLabel
+    formatReasoningLabel,
+    formatCompactReasoningLabel,
+    getReasoningEffortForFlavor,
+    shouldShowReasoningStatusLabel
 } from '@/lib/codexStatusLabels'
 import { isFastServiceTier } from './codexFastMode'
 import { useTranslation } from '@/lib/use-translation'
@@ -205,6 +206,7 @@ export function StatusBar(props: {
     contextModel?: string | null
     model?: string | null
     modelReasoningEffort?: string | null
+    effort?: string | null
     serviceTier?: string | null
     permissionMode?: PermissionMode
     collaborationMode?: CodexCollaborationMode
@@ -262,12 +264,17 @@ export function StatusBar(props: {
     const collaborationModeLabel = displayCollaborationMode
         ? getCodexCollaborationModeLabel(displayCollaborationMode)
         : null
-    const displaysCodexReasoning = shouldShowCodexReasoningLabel(props.agentFlavor)
-    const codexReasoningLabel = displaysCodexReasoning
-        ? formatCodexReasoningLabel(props.modelReasoningEffort, headerMetadata.showLabels)
+    const reasoningEffort = getReasoningEffortForFlavor(
+        props.agentFlavor,
+        props.modelReasoningEffort,
+        props.effort
+    )
+    const displaysReasoning = shouldShowReasoningStatusLabel(props.agentFlavor, reasoningEffort)
+    const reasoningLabel = displaysReasoning
+        ? formatReasoningLabel(reasoningEffort, headerMetadata.showLabels)
         : null
-    const compactCodexReasoningLabel = displaysCodexReasoning
-        ? formatCompactCodexReasoningLabel(props.modelReasoningEffort)
+    const compactReasoningLabel = displaysReasoning
+        ? formatCompactReasoningLabel(reasoningEffort)
         : null
     const codexFastMode = shouldShowCodexFastBadge(props.agentFlavor, props.serviceTier)
     const goalLabel = props.agentFlavor === 'codex' && props.threadGoal
@@ -350,10 +357,10 @@ export function StatusBar(props: {
             </div>
 
             <div className="flex min-w-0 shrink-0 items-baseline gap-2">
-                {codexReasoningLabel ? (
+                {reasoningLabel ? (
                     <span className="whitespace-nowrap text-xs text-[var(--app-hint)]">
-                        <span className="sm:hidden">{compactCodexReasoningLabel}</span>
-                        <span className="hidden sm:inline">{codexReasoningLabel}</span>
+                        <span className="sm:hidden">{compactReasoningLabel}</span>
+                        <span className="hidden sm:inline">{reasoningLabel}</span>
                     </span>
                 ) : null}
                 {codexFastMode ? (

--- a/web/src/components/SessionHeader.test.tsx
+++ b/web/src/components/SessionHeader.test.tsx
@@ -6,7 +6,10 @@ import { I18nProvider } from '@/lib/i18n-context'
 import { ToastProvider } from '@/lib/toast-context'
 import { resolveSessionHeaderMachineLabel, SessionHeader } from './SessionHeader'
 
-afterEach(() => cleanup())
+afterEach(() => {
+    cleanup()
+    localStorage.clear()
+})
 
 function baseSession(overrides: Partial<Session> = {}): Session {
     return {
@@ -77,6 +80,55 @@ describe('SessionHeader', () => {
         renderHeader(baseSession(), { serviceTier: 'priority' })
         expect(screen.getByText('fast')).toBeInTheDocument()
         expect(screen.queryByText('reasoning default')).not.toBeInTheDocument()
+    })
+
+    it('shows Pi ordinary effort as reasoning metadata', () => {
+        renderHeader(baseSession({
+            metadata: { flavor: 'pi', path: '/repo', host: 'machine' },
+            modelReasoningEffort: null,
+            effort: 'max'
+        }))
+
+        expect(screen.getByTestId('session-header-reasoning')).toHaveTextContent('reasoning max')
+    })
+
+    it('keeps model reasoning effort for Codex and hides ordinary effort for non-Pi flavors', () => {
+        const { rerender } = renderHeader(baseSession({
+            modelReasoningEffort: 'xhigh',
+            effort: 'max'
+        }))
+
+        expect(screen.getByTestId('session-header-reasoning')).toHaveTextContent('reasoning xhigh')
+
+        rerender(
+            <QueryClientProvider client={new QueryClient()}>
+                <ToastProvider>
+                    <I18nProvider>
+                        <SessionHeader
+                            session={baseSession({
+                                metadata: { flavor: 'claude', path: '/repo', host: 'machine' },
+                                modelReasoningEffort: null,
+                                effort: 'max'
+                            })}
+                            onBack={vi.fn()}
+                            api={null}
+                        />
+                    </I18nProvider>
+                </ToastProvider>
+            </QueryClientProvider>
+        )
+
+        expect(screen.queryByTestId('session-header-reasoning')).not.toBeInTheDocument()
+    })
+
+    it('hides Pi reasoning metadata when the header reasoning setting is disabled', () => {
+        localStorage.setItem('hapi-session-header-metadata', JSON.stringify({ reasoning: false }))
+        renderHeader(baseSession({
+            metadata: { flavor: 'pi', path: '/repo', host: 'machine' },
+            effort: 'max'
+        }))
+
+        expect(screen.queryByTestId('session-header-reasoning')).not.toBeInTheDocument()
     })
 
     it('shows machine label and relative last-active age in the meta row', () => {

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -10,7 +10,7 @@ import { RenameSessionDialog } from '@/components/RenameSessionDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { useScratchlistCount } from '@/lib/use-scratchlist-count'
 import { formatReopenError } from '@/lib/reopenError'
-import { formatCodexReasoningLabel, shouldShowCodexReasoningLabel } from '@/lib/codexStatusLabels'
+import { formatReasoningLabel, getReasoningEffortForFlavor } from '@/lib/codexStatusLabels'
 import { getSessionModelLabel } from '@/lib/sessionModelLabel'
 import { useTranslation } from '@/lib/use-translation'
 import { AgentFlavorIcon } from '@/components/AgentFlavorIcon'
@@ -138,9 +138,13 @@ export function SessionHeader(props: {
     const modelLabel = getSessionModelLabel(session)
     const agentFlavor = session.metadata?.flavor ?? null
     const agentLabel = agentFlavor?.trim() || null
-    const reasoningEffort = session.modelReasoningEffort?.trim() || null
-    const reasoningLabel = reasoningEffort && shouldShowCodexReasoningLabel(agentFlavor)
-        ? formatCodexReasoningLabel(reasoningEffort, headerMetadata.showLabels)
+    const reasoningEffort = getReasoningEffortForFlavor(
+        agentFlavor,
+        session.modelReasoningEffort,
+        session.effort
+    )
+    const reasoningLabel = reasoningEffort
+        ? formatReasoningLabel(reasoningEffort, headerMetadata.showLabels)
         : null
     // Match expected Fast badge semantics (#1004): only explicit service tier, no effort/model heuristics.
     const showFastBadge = agentFlavor === 'codex' && isFastServiceTier(props.serviceTier ?? session.serviceTier)

--- a/web/src/lib/codexStatusLabels.test.ts
+++ b/web/src/lib/codexStatusLabels.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
     formatCodexReasoningLabel,
     formatCompactCodexReasoningLabel,
-    shouldShowCodexReasoningLabel
+    formatReasoningLabel,
+    formatCompactReasoningLabel,
+    getReasoningEffortForFlavor,
+    shouldShowCodexReasoningLabel,
+    shouldShowReasoningStatusLabel
 } from './codexStatusLabels'
 
 describe('codexStatusLabels', () => {
@@ -35,5 +39,32 @@ describe('codexStatusLabels', () => {
         expect(shouldShowCodexReasoningLabel('opencode')).toBe(true)
         expect(shouldShowCodexReasoningLabel('claude')).toBe(false)
         expect(shouldShowCodexReasoningLabel(null)).toBe(false)
+    })
+})
+
+describe('reasoning status metadata', () => {
+    it('formats Pi reasoning labels with the shared formatter', () => {
+        expect(formatReasoningLabel('MAX')).toBe('reasoning max')
+        expect(formatCompactReasoningLabel(' MAX ')).toBe('max')
+    })
+
+    it('uses model reasoning effort for Codex/OpenCode and ordinary effort only for Pi', () => {
+        expect(getReasoningEffortForFlavor('codex', 'xhigh', 'max')).toBe('xhigh')
+        expect(getReasoningEffortForFlavor('opencode', 'high', 'max')).toBe('high')
+        expect(getReasoningEffortForFlavor('pi', 'xhigh', 'max')).toBe('max')
+        expect(getReasoningEffortForFlavor('claude', 'xhigh', 'max')).toBeNull()
+        expect(getReasoningEffortForFlavor('grok', 'xhigh', 'max')).toBeNull()
+        expect(getReasoningEffortForFlavor(null, 'xhigh', 'max')).toBeNull()
+    })
+
+    it('keeps unset defaults for Codex/OpenCode and requires a real Pi effort', () => {
+        expect(shouldShowReasoningStatusLabel('codex', null)).toBe(true)
+        expect(shouldShowReasoningStatusLabel('opencode', null)).toBe(true)
+        expect(shouldShowReasoningStatusLabel('pi', 'max')).toBe(true)
+        expect(shouldShowReasoningStatusLabel('pi', null)).toBe(false)
+        expect(shouldShowReasoningStatusLabel('pi', '   ')).toBe(false)
+        expect(shouldShowReasoningStatusLabel('claude', 'max')).toBe(false)
+        expect(shouldShowReasoningStatusLabel('grok', 'max')).toBe(false)
+        expect(shouldShowReasoningStatusLabel(null, 'max')).toBe(false)
     })
 })

--- a/web/src/lib/codexStatusLabels.ts
+++ b/web/src/lib/codexStatusLabels.ts
@@ -1,15 +1,47 @@
-/** Labels shared by SessionHeader and composer StatusBar for Codex/OpenCode. */
+/** Labels shared by SessionHeader and composer StatusBar for supported reasoning providers. */
 
-export function formatCompactCodexReasoningLabel(effort?: string | null): string {
+export function formatCompactReasoningLabel(effort?: string | null): string {
     const normalized = effort?.trim().toLowerCase()
     if (!normalized || normalized === 'default') return 'default'
     return normalized
 }
 
-export function formatCodexReasoningLabel(effort?: string | null, showLabel = true): string {
-    const value = formatCompactCodexReasoningLabel(effort)
+export function formatReasoningLabel(effort?: string | null, showLabel = true): string {
+    const value = formatCompactReasoningLabel(effort)
     return showLabel ? `reasoning ${value}` : value
 }
+
+/**
+ * Status metadata comes from different session fields by agent protocol:
+ * Codex/OpenCode publish model reasoning effort, while Pi publishes effort.
+ */
+export function getReasoningEffortForFlavor(
+    agentFlavor: string | null | undefined,
+    modelReasoningEffort?: string | null,
+    effort?: string | null
+): string | null {
+    if (agentFlavor === 'codex' || agentFlavor === 'opencode') {
+        return modelReasoningEffort?.trim() || null
+    }
+    if (agentFlavor === 'pi') {
+        return effort?.trim() || null
+    }
+    return null
+}
+
+export function shouldShowReasoningStatusLabel(
+    agentFlavor: string | null | undefined,
+    reasoningEffort?: string | null
+): boolean {
+    // Codex/OpenCode retain their existing explicit default label when unset.
+    if (agentFlavor === 'codex' || agentFlavor === 'opencode') return true
+    // Pi has no meaningful default for non-reasoning models; only show a real level.
+    return agentFlavor === 'pi' && Boolean(reasoningEffort?.trim())
+}
+
+/** Codex-only aliases retained for tool-card and thread call sites. */
+export const formatCompactCodexReasoningLabel = formatCompactReasoningLabel
+export const formatCodexReasoningLabel = formatReasoningLabel
 
 export function shouldShowCodexReasoningLabel(agentFlavor: string | null | undefined): boolean {
     return agentFlavor === 'codex' || agentFlavor === 'opencode'


### PR DESCRIPTION
Fixes #1302.

## Summary

- show Pi's native thinking level in the SessionHeader reasoning metadata;
- show the same Pi level in the composer StatusBar;
- resolve the source field by agent flavor instead of treating all reasoning metadata as Codex/OpenCode data;
- preserve existing Codex/OpenCode default-label behavior while hiding missing Pi effort;
- add component and helper regressions for Pi, Codex, Claude, Grok, unknown flavors, and the header visibility preference.

## User-visible behavior

Before this change, Pi could report and persist an explicit level such as `max`, and the composer picker would show `Max`, but the session metadata surfaces remained blank:

```text
metadata.flavor = pi
effort = max
modelReasoningEffort = null
```

After this change, the existing metadata UI displays:

```text
reasoning max
```

The compact/mobile StatusBar label remains:

```text
max
```

When Pi has not reported a level, or a non-reasoning Pi model clears the field, the UI shows no reasoning metadata instead of inventing `reasoning default`.

## Root cause

HAPI has two different effort fields with different protocol ownership:

```text
modelReasoningEffort
  -> Codex / OpenCode model reasoning effort

effort
  -> Pi native thinking level (and other agents' ordinary effort contracts)
```

The Pi CLI and Hub path was already correct:

```text
Pi get_state.thinkingLevel
  -> PiSession.currentThinkingLevel
  -> keepAlive.runtime.effort
  -> Hub session.effort
  -> Web session.effort
```

The gap was limited to Web presentation:

1. `SessionHeader` only read `session.modelReasoningEffort` and used a Codex/OpenCode-only visibility predicate.
2. `HappyComposer` already received ordinary `effort`, but did not pass it to `StatusBar`.
3. `StatusBar` therefore also only read `modelReasoningEffort`.

The missing-value semantics are intentionally not identical. Codex/OpenCode retain their existing unset -> `reasoning default` StatusBar contract. For Pi, missing or null effort means the native level is unknown or explicitly cleared, and can also represent a non-reasoning model; displaying a default would be false metadata.

## Changes

### Shared flavor-aware reasoning resolver

`web/src/lib/codexStatusLabels.ts` now provides a common contract used by both surfaces:

- `codex` / `opencode` read only `modelReasoningEffort`;
- `pi` reads only ordinary `effort`;
- Claude, Grok, and unknown flavors resolve to no reasoning metadata.

The existing compact/full formatting is generalized without changing its output. Codex-only aliases remain available for existing call sites outside these metadata surfaces.

Visibility also preserves provider-specific defaults:

- Codex/OpenCode may display `reasoning default` when unset;
- Pi displays a label only for a real, non-blank level.

### SessionHeader

`SessionHeader` uses the shared resolver before applying the existing reasoning preference and `showLabels` formatting.

The mobile secondary-field priority and Codex Fast badge logic are unchanged.

### Composer StatusBar

`HappyComposer` now passes ordinary `effort` into `StatusBar`. The StatusBar resolves the correct source by flavor and keeps the existing compact/desktop responsive labels.

## Regression coverage

- Pi `effort=max`, `modelReasoningEffort=null` -> Header renders `reasoning max`;
- Pi StatusBar uses ordinary effort and ignores a stale model reasoning field;
- Pi missing or blank effort renders no synthetic default;
- Codex continues using `modelReasoningEffort`, ignores ordinary effort, and retains unset -> default;
- Claude, Grok, and unknown flavors do not expose ordinary effort;
- disabling the Header reasoning preference hides Pi metadata;
- existing compact and desktop label classes remain covered.

## Validation

- `mise exec -- bun run --cwd web test -- src/lib/codexStatusLabels.test.ts src/components/SessionHeader.test.tsx src/components/AssistantChat/StatusBar.popover.test.tsx src/components/AssistantChat/StatusBar.test.ts`
  - 4 files / 28 tests passed
- `mise exec -- bun run --cwd web test`
  - 204 files / 1778 tests passed
- `mise exec -- bun run --cwd web typecheck`
- `git diff --check`

A separate pre-commit reviewer audit initially found the missing-Pi-effort default-label edge case. The implementation and tests were updated, and the reviewer re-audit reported no remaining Blocker, Major, or Minor findings.

## AI disclosure

Root-cause analysis, implementation, tests, review iteration, and PR drafting were assisted by OpenAI Codex (GPT-5.6).
