### PR TITLE
fix(web): preserve rich composer caret

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,7 @@
       "dependencies": {
         "@assistant-ui/react": "^0.14.29",
         "@assistant-ui/react-markdown": "^0.14.7",
+        "@assistant-ui/tap": "^0.9.8",
         "@elevenlabs/react": "^0.13.0",
         "@hapi/protocol": "workspace:*",
         "@lobehub/icons": "^5.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@assistant-ui/react": "^0.14.29",
         "@assistant-ui/react-markdown": "^0.14.7",
+        "@assistant-ui/tap": "^0.9.8",
         "@elevenlabs/react": "^0.13.0",
         "@hapi/protocol": "workspace:*",
         "@lobehub/icons": "^5.4.0",

--- a/web/src/components/AssistantChat/HappyComposer.richBridge.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.richBridge.test.tsx
@@ -1,0 +1,80 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { useEffect, useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { type TextInputState, useRichComposerBridge } from './HappyComposer'
+
+const events = vi.hoisted(() => [] as string[])
+
+vi.mock('@assistant-ui/tap', () => ({
+    flushTapSync: (callback: () => void) => {
+        events.push('flush:start')
+        callback()
+        events.push('flush:end')
+    },
+}))
+
+type Bridge = ReturnType<typeof useRichComposerBridge>
+
+function BridgeHarness(props: {
+    callbacksRef: { current: Bridge | null }
+    api: {
+        composer: () => {
+            setText: (text: string) => void
+        }
+    }
+}) {
+    const [inputState, setInputState] = useState<TextInputState>({
+        text: '',
+        selection: { start: 0, end: 0 },
+    })
+    const [, setUnrelatedVersion] = useState(0)
+    const bridge = useRichComposerBridge(props.api, setInputState, null)
+    props.callbacksRef.current = bridge
+
+    useEffect(() => {
+        if (inputState.text) events.push(`mirror-render:${inputState.text}`)
+    }, [inputState])
+
+    return (
+        <button type="button" onClick={() => setUnrelatedVersion((version) => version + 1)}>
+            Unrelated rerender
+        </button>
+    )
+}
+
+describe('useRichComposerBridge', () => {
+    it('flushes the composer write before mirror render and keeps callbacks stable across unrelated renders', () => {
+        const callbacksRef: { current: Bridge | null } = { current: null }
+        const api = {
+            composer: () => ({
+                setText: (text: string) => events.push(`setText:${text}`),
+            }),
+        }
+
+        render(<BridgeHarness callbacksRef={callbacksRef} api={api} />)
+        const initial = callbacksRef.current
+        expect(initial).not.toBeNull()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Unrelated rerender' }))
+
+        expect(callbacksRef.current?.onValueChange).toBe(initial?.onValueChange)
+        expect(callbacksRef.current?.onMirrorChange).toBe(initial?.onMirrorChange)
+        expect(callbacksRef.current?.onEdit).toBe(initial?.onEdit)
+
+        events.length = 0
+        act(() => {
+            callbacksRef.current!.onValueChange('new composer text')
+            callbacksRef.current!.onMirrorChange({
+                text: 'mirror text',
+                selection: { start: 11, end: 11 },
+            })
+        })
+
+        expect(events).toEqual([
+            'flush:start',
+            'setText:new composer text',
+            'flush:end',
+            'mirror-render:mirror text',
+        ])
+    })
+})

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -1,5 +1,6 @@
 import { getCodexCollaborationModeOptions, getPermissionModeOptionsForFlavor } from '@hapi/protocol'
 import { ComposerPrimitive, useAui, useAuiState } from '@assistant-ui/react'
+import { flushTapSync } from '@assistant-ui/tap'
 import {
     type ChangeEvent as ReactChangeEvent,
     type ClipboardEvent as ReactClipboardEvent,
@@ -84,6 +85,40 @@ export type ComposerSendError = {
         onClick: () => void
         pending?: boolean
     } | null
+}
+
+type RichComposerBridgeApi = {
+    composer: () => {
+        setText: (text: string) => void
+    }
+}
+
+/**
+ * The custom rich contenteditable must follow ComposerPrimitive.Input's
+ * synchronous composer-write contract. Kept separate so its callback identity
+ * is stable across unrelated HappyComposer renders and directly testable.
+ */
+export function useRichComposerBridge(
+    api: RichComposerBridgeApi,
+    setInputState: (state: TextInputState) => void,
+    sendError: ComposerSendError | null,
+    onClearSendError?: () => void,
+) {
+    const onValueChange = useCallback((text: string) => {
+        flushTapSync(() => {
+            api.composer().setText(text)
+        })
+    }, [api])
+
+    const onMirrorChange = useCallback((state: TextInputState) => {
+        setInputState(state)
+    }, [setInputState])
+
+    const onEdit = useCallback(() => {
+        if (sendError && onClearSendError) onClearSendError()
+    }, [sendError, onClearSendError])
+
+    return { onValueChange, onMirrorChange, onEdit }
 }
 
 const defaultSuggestionHandler = async (): Promise<Suggestion[]> => []
@@ -321,6 +356,12 @@ export function HappyComposer(props: {
     // read — hard reload required, so no per-keystroke localStorage/URL parse.
     const [richMentionsEnabled] = useState(() => isRichComposerMentionsEnabled())
     const prevControlledByUser = useRef(controlledByUser)
+
+    const {
+        onValueChange: handleRichValueChange,
+        onMirrorChange: handleRichMirrorChange,
+        onEdit: handleRichEdit,
+    } = useRichComposerBridge(api, setInputState, sendError, onClearSendError)
 
     const attachmentDrafts = attachments.flatMap((attachment) => {
         if (!attachment.file) return []
@@ -1384,14 +1425,12 @@ export function HappyComposer(props: {
                                     autoFocus={!controlsDisabled && !isTouch}
                                     placeholder={showContinueHint ? t('misc.typeMessage') : t('misc.typeAMessage')}
                                     disabled={controlsDisabled}
-                                    onValueChange={(text) => api.composer().setText(text)}
-                                    onMirrorChange={(state) => setInputState(state)}
+                                    onValueChange={handleRichValueChange}
+                                    onMirrorChange={handleRichMirrorChange}
                                     onKeyDown={handleKeyDown}
                                     onPaste={handlePaste}
                                     resolveSessionMentionTooltip={resolveSessionMentionTooltip}
-                                    onEdit={() => {
-                                        if (sendError && onClearSendError) onClearSendError()
-                                    }}
+                                    onEdit={handleRichEdit}
                                     className="max-h-[7.5rem] min-h-[1.5rem] flex-1 overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-base leading-snug text-[var(--app-fg)] focus:outline-none"
                                 />
                             ) : (

--- a/web/src/components/AssistantChat/RichComposerInput.test.tsx
+++ b/web/src/components/AssistantChat/RichComposerInput.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { flushSync } from 'react-dom'
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+    mirrorOffsetFromPoint,
+    RichComposerInput,
+    segmentsFromEditor,
+} from './RichComposerInput'
+import { serializeComposerSegments } from '@/lib/composerSegments'
+
+function selectionOffset(root: HTMLElement): number {
+    const selection = window.getSelection()
+    expect(selection?.rangeCount).toBe(1)
+    const range = selection!.getRangeAt(0)
+    return mirrorOffsetFromPoint(root, range.startContainer, range.startOffset)
+}
+
+function placeCaret(textNode: Text, offset: number): void {
+    const range = document.createRange()
+    range.setStart(textNode, offset)
+    range.collapse(true)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+}
+
+function SynchronousControlledHarness() {
+    const [value, setValue] = useState('alpha')
+    const [, setMirrorVersion] = useState(0)
+
+    return (
+        <>
+            <button type="button" onClick={() => setValue('external draft')}>
+                Replace draft
+            </button>
+            <output data-testid="controlled-value">{value}</output>
+            <RichComposerInput
+                value={value}
+                // Mirrors ComposerPrimitive.Input's required same-tick controlled
+                // acknowledgement. onMirrorChange intentionally re-renders too.
+                onValueChange={(next) => {
+                    flushSync(() => setValue(next))
+                }}
+                onMirrorChange={() => {
+                    setMirrorVersion((version) => version + 1)
+                }}
+            />
+        </>
+    )
+}
+
+describe('RichComposerInput controlled synchronization', () => {
+    afterEach(() => {
+        window.getSelection()?.removeAllRanges()
+    })
+
+    it('preserves a middle-caret DOM input through its synchronous controlled echo and accepts later external replacement', () => {
+        render(<SynchronousControlledHarness />)
+
+        const editor = screen.getByTestId('rich-composer-input')
+        const originalText = editor.firstChild
+        expect(originalText).toBeInstanceOf(Text)
+
+        const textNode = originalText as Text
+        placeCaret(textNode, 2)
+        textNode.textContent = 'alXpha'
+        placeCaret(textNode, 3)
+        fireEvent.input(editor)
+
+        // The same-tick controlled acknowledgement and mirror-triggered parent
+        // render must retain the browser-mutated DOM and logical caret.
+        expect(screen.getByTestId('controlled-value')).toHaveTextContent('alXpha')
+        expect(editor.firstChild).toBe(originalText)
+        expect(serializeComposerSegments(segmentsFromEditor(editor))).toBe('alXpha')
+        expect(selectionOffset(editor)).toBe(3)
+
+        editor.focus()
+        expect(document.activeElement).toBe(editor)
+        fireEvent.click(screen.getByRole('button', { name: 'Replace draft' }))
+
+        expect(serializeComposerSegments(segmentsFromEditor(editor))).toBe('external draft')
+        expect(selectionOffset(editor)).toBe('external draft'.length)
+    })
+})


### PR DESCRIPTION
Fixes #1304.

## Summary

- preserve the logical caret when editing existing text in the default rich composer;
- apply assistant-ui's required synchronous tap-store write contract to HAPI's custom contenteditable;
- stabilize the rich composer callbacks across unrelated parent renders;
- keep `RichComposerInput`'s existing external controlled-value behavior unchanged;
- add focused bridge-ordering and mounted contenteditable caret regressions.

## User-visible behavior

Before this change, typing one character at the beginning or in the middle of existing composer text produced the correct serialized text but moved the caret to the end:

```text
before:  ab|cdef
type X
actual:  abXcdef|
```

After this change:

```text
before:   ab|cdef
type X
expected: abX|cdef
```

A genuine later external value, such as a restored or promoted draft, still replaces the editor content and applies the existing external-selection behavior.

## Regression boundary

The custom rich composer was already present in `v0.25.2`. The issue became reproducible in `v0.25.3` after `9b299eaa` upgraded:

```text
@assistant-ui/react  0.11.53 -> 0.14.29
@assistant-ui/tap    0.3.5  -> 0.9.8
```

## Root cause

HAPI's default composer is a custom controlled `contenteditable`, not assistant-ui's `ComposerPrimitive.Input`.

On a native input event, `RichComposerInput`:

1. serializes the browser-mutated DOM;
2. stores that text in `lastEmittedRef`;
3. calls the parent `onValueChange`;
4. immediately calls `onMirrorChange`, which updates local React state.

The parent previously handled that with inline callbacks:

```tsx
onValueChange={(text) => api.composer().setText(text)}
onMirrorChange={(state) => setInputState(state)}
```

With the newer Tap scheduler, an unflushed composer write can publish after the mirror-state render. That render can still provide the previous controlled value. The new inline callback identities also change `syncFromValue`, causing the layout effect to run against the stale prop.

The effect then calls `syncFromValue(previousValue)`, which rebuilds the entire contenteditable through:

```ts
root.replaceChildren()
```

The browser Selection references a text node that no longer exists. Because no explicit selection accompanies the stale controlled write, `syncFromValue` restores the caret to `mirror.length`, the end of the input.

assistant-ui's own `ComposerPrimitive.Input` avoids this ordering by wrapping composer writes in:

```ts
flushTapSync(() => {
    aui.composer().setText(nextValue)
})
```

HAPI's custom contenteditable bypassed that primitive and therefore bypassed its required synchronization boundary.

## Changes

### Synchronous rich-composer bridge

`HappyComposer` now uses a small `useRichComposerBridge` hook:

- `onValueChange` calls `api.composer().setText(text)` inside `flushTapSync`;
- `onMirrorChange` is a stable `useCallback` around `setInputState`;
- `onEdit` is stable until the send-error semantics actually change.

The resulting order is:

```text
browser DOM mutation
  -> lastEmittedRef updated
  -> flushTapSync(setText)
  -> controlled composer text published
  -> mirror state render
  -> value matches lastEmittedRef
  -> no DOM rebuild, caret remains valid
```

### Direct Tap dependency

The Web package now declares `@assistant-ui/tap` directly because production code imports its public `flushTapSync` API. The lockfile resolves the same existing `0.9.8` version; no duplicate Tap version is introduced.

### No delayed-ack heuristics

`RichComposerInput.tsx` itself is unchanged. The fix intentionally does not infer acknowledgement provenance from equal strings or add pending queues. External `value` remains the source of truth under the same-tick contract documented and used by assistant-ui.

## Regression coverage

### Production bridge test

The bridge test mocks `flushTapSync` and verifies this exact ordering:

```text
flush:start
setText:new composer text
flush:end
mirror-render:mirror text
```

It also verifies that all three callbacks retain their identities across an unrelated parent render.

### Mounted contenteditable test

The component test mounts `RichComposerInput` with a synchronous controlled echo and verifies:

- input at a middle caret position;
- mirror-triggered parent rerender;
- the original text node is not replaced;
- serialized text remains correct;
- the logical caret remains immediately after the inserted character;
- a later real external replacement still synchronizes and moves selection according to the existing external-write rule.

## Validation

Validation was rerun after rebasing onto current `main` (`05ba050e`):

- `mise exec -- bun run --cwd web test -- RichComposerInput.test.tsx RichComposerInput.segments.test.ts HappyComposer.richBridge.test.tsx`
  - 3 files / 15 tests passed
- `mise exec -- bun run --cwd web test`
  - 206 files / 1770 tests passed
- `mise exec -- bun run --cwd web typecheck`
- `git diff --check origin/main...HEAD`

A separate pre-commit reviewer audit challenged two earlier delayed-ack implementations for rapid-input, repeated-value, and external-write ambiguity. Those implementations were removed. The final reviewer pass reported no remaining Blocker, Major, or Minor findings.

## AI disclosure

Root-cause analysis, implementation, tests, adversarial review iterations, and PR drafting were assisted by OpenAI Codex (GPT-5.6).
