### PR TITLE
fix(web): display Windows file search paths correctly

### DIFF
--- a/hub/src/web/routes/git.test.ts
+++ b/hub/src/web/routes/git.test.ts
@@ -121,4 +121,34 @@ describe('file search route', () => {
             ]
         })
     })
+
+    it('preserves backslashes in file names for non-Windows sessions', async () => {
+        const session = {
+            id: 'session-1',
+            namespace: 'default',
+            active: true,
+            metadata: { path: '/project' }
+        } as unknown as Session
+        const engine = {
+            resolveSessionAccess: () => ({ ok: true as const, sessionId: 'session-1', session }),
+            runRipgrep: async () => ({
+                success: true,
+                stdout: 'src/file\\name.ts\n'
+            }),
+            statFiles: async (_sessionId: string, paths: string[]) => ({
+                success: true,
+                entries: paths.map((path) => ({ path, size: 10, modified: 100 }))
+            })
+        } as unknown as Partial<SyncEngine>
+
+        const response = await buildApp(engine).request('/api/sessions/session-1/files?query=.ts')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+            success: true,
+            files: [
+                { fileName: 'file\\name.ts', filePath: 'src', fullPath: 'src/file\\name.ts', fileType: 'file', size: 10, modified: 100 },
+            ]
+        })
+    })
 })

--- a/hub/src/web/routes/git.test.ts
+++ b/hub/src/web/routes/git.test.ts
@@ -90,4 +90,35 @@ describe('file search route', () => {
             ]
         })
     })
+
+    it('normalizes ripgrep path separators before deriving file names and directories', async () => {
+        const session = {
+            id: 'session-1',
+            namespace: 'default',
+            active: true,
+            metadata: { path: 'C:\\project' }
+        } as unknown as Session
+        const engine = {
+            resolveSessionAccess: () => ({ ok: true as const, sessionId: 'session-1', session }),
+            runRipgrep: async () => ({
+                success: true,
+                stdout: 'src\\nested\\file.ts\nroot.ts\n'
+            }),
+            statFiles: async (_sessionId: string, paths: string[]) => ({
+                success: true,
+                entries: paths.map((path) => ({ path, size: 10, modified: 100 }))
+            })
+        } as unknown as Partial<SyncEngine>
+
+        const response = await buildApp(engine).request('/api/sessions/session-1/files?query=.ts')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+            success: true,
+            files: [
+                { fileName: 'file.ts', filePath: 'src/nested', fullPath: 'src/nested/file.ts', fileType: 'file', size: 10, modified: 100 },
+                { fileName: 'root.ts', filePath: '', fullPath: 'root.ts', fileType: 'file', size: 10, modified: 100 },
+            ]
+        })
+    })
 })

--- a/hub/src/web/routes/git.ts
+++ b/hub/src/web/routes/git.ts
@@ -25,6 +25,10 @@ function normalizeFileSearchPath(path: string): string {
     return path.replaceAll('\\', '/')
 }
 
+function isWindowsSessionPath(path: string): boolean {
+    return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith('\\\\')
+}
+
 function parseBooleanParam(value: string | undefined): boolean | undefined {
     if (value === 'true') return true
     if (value === 'false') return false
@@ -231,11 +235,14 @@ export function createGitRoutes(getSyncEngine: () => SyncEngine | null): Hono<We
         }
 
         const stdout = result.stdout ?? ''
+        const normalizePath = isWindowsSessionPath(sessionPath)
+            ? normalizeFileSearchPath
+            : (path: string) => path
         const paths = stdout
             .split('\n')
             .map((line) => line.trim())
             .filter((line) => line.length > 0)
-            .map(normalizeFileSearchPath)
+            .map(normalizePath)
             .slice(0, limit)
 
         const metadataResult = await runRpc(() => engine.statFiles(sessionResult.sessionId, paths))

--- a/hub/src/web/routes/git.ts
+++ b/hub/src/web/routes/git.ts
@@ -21,6 +21,10 @@ const generatedImageSchema = z.object({
     imageId: z.string().min(1)
 })
 
+function normalizeFileSearchPath(path: string): string {
+    return path.replaceAll('\\', '/')
+}
+
 function parseBooleanParam(value: string | undefined): boolean | undefined {
     if (value === 'true') return true
     if (value === 'false') return false
@@ -231,6 +235,7 @@ export function createGitRoutes(getSyncEngine: () => SyncEngine | null): Hono<We
             .split('\n')
             .map((line) => line.trim())
             .filter((line) => line.length > 0)
+            .map(normalizeFileSearchPath)
             .slice(0, limit)
 
         const metadataResult = await runRpc(() => engine.statFiles(sessionResult.sessionId, paths))

--- a/web/src/routes/sessions/files.tsx
+++ b/web/src/routes/sessions/files.tsx
@@ -260,8 +260,7 @@ function SearchResultRow(props: {
     onOpen: () => void
     showDivider: boolean
 }) {
-    const { t, locale } = useTranslation()
-    const subtitle = getProjectRootLabel(props.file.filePath, t)
+    const { locale } = useTranslation()
     const metadata = formatFileMetadata(props.file.size, props.file.modified, locale)
     const icon = props.file.fileType === 'file'
         ? <FileIcon fileName={props.file.fileName} size={22} />
@@ -275,11 +274,8 @@ function SearchResultRow(props: {
         >
             {icon}
             <div className="min-w-0 flex-1">
-                <div className="truncate font-medium">{props.file.fileName}</div>
-                <div className="flex min-w-0 items-center gap-2 text-xs text-[var(--app-hint)]">
-                    <span className="truncate">{subtitle}</span>
-                    {metadata ? <span className="shrink-0">{metadata}</span> : null}
-                </div>
+                <div className="truncate font-medium">{props.file.fullPath}</div>
+                {metadata ? <div className="text-xs text-[var(--app-hint)]">{metadata}</div> : null}
             </div>
         </button>
     )


### PR DESCRIPTION
## Summary

- normalize ripgrep file-search paths to forward slashes before deriving file names and directories
- show each search result's full project-relative path on the primary line
- reserve the secondary line for modification time and file size instead of repeating the directory or `project root`

## Problem

On Windows, ripgrep returns paths with backslash separators. The file-search route only split paths on `/`, so nested paths were treated as a single file name and their directory was reported as empty. The web UI then labeled every result as `project root`.

Displaying the directory on the metadata line also left little room for longer paths once the modification time and file size were present.

## Changes

- canonicalize ripgrep results before metadata lookup and response construction
- derive `fileName`, `filePath`, and `fullPath` from the canonical path
- render `fullPath` as the search result title
- render only file metadata on the secondary line
- add route coverage for nested Windows paths and project-root files

## Testing

- `bun run typecheck`
- `bun test hub/src/web/routes/git.test.ts`
- `git diff --check`
- manually verified file search with a Windows runner against the 3016 test Hub

## AI assistance

Implementation and PR preparation used OpenAI GPT-5.6-sol.
