### PR TITLE
fix(web): restore composer attachment uploads

### DIFF
--- a/web/src/lib/attachmentAdapter.test.ts
+++ b/web/src/lib/attachmentAdapter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-describe('attachmentAdapter restored uploads', () => {
+describe('attachmentAdapter', () => {
     beforeEach(() => {
         vi.stubGlobal('indexedDB', undefined)
         vi.resetModules()
@@ -8,6 +8,13 @@ describe('attachmentAdapter restored uploads', () => {
 
     afterEach(() => {
         vi.unstubAllGlobals()
+    })
+
+    it('uses the assistant-ui wildcard sentinel so all files reach the adapter', async () => {
+        const { createAttachmentAdapter } = await import('./attachmentAdapter')
+        const adapter = createAttachmentAdapter({} as never, 'session-1')
+
+        expect(adapter.accept).toBe('*')
     })
 
     it('restores an uploaded draft without uploading it again', async () => {

--- a/web/src/lib/attachmentAdapter.ts
+++ b/web/src/lib/attachmentAdapter.ts
@@ -26,7 +26,10 @@ export function createAttachmentAdapter(api: ApiClient, sessionId: string): Atta
     }
 
     return {
-        accept: '*/*',
+        // assistant-ui uses the exact "*" sentinel for an allow-all adapter.
+        // "*/*" is forwarded to MIME matching and rejects every file before
+        // this adapter's add() method can run.
+        accept: '*',
 
         async *add({ file }): AsyncGenerator<PendingAttachment> {
             const restored = getRestoredUploadMetadata(file)

--- a/web/src/lib/scratchlistAttachmentAdapter.test.ts
+++ b/web/src/lib/scratchlistAttachmentAdapter.test.ts
@@ -24,6 +24,12 @@ describe('hubAttachmentFromRestoredDraft', () => {
 })
 
 describe('createScratchlistAttachmentAdapter', () => {
+    it('uses the assistant-ui wildcard sentinel so all files reach the adapter', () => {
+        const adapter = createScratchlistAttachmentAdapter({} as never, 'session-1')
+
+        expect(adapter.accept).toBe('*')
+    })
+
     it('reuses restored hub path without re-uploading', async () => {
         const drafts = await import('./composer-attachment-drafts')
         const hubId = 'a1b2c3d4-e5f6-4789-a012-3456789abcde'

--- a/web/src/lib/scratchlistAttachmentAdapter.ts
+++ b/web/src/lib/scratchlistAttachmentAdapter.ts
@@ -44,7 +44,10 @@ export function createScratchlistAttachmentAdapter(api: ApiClient, sessionId: st
     const cancelledAttachmentIds = new Set<string>()
 
     return {
-        accept: '*/*',
+        // assistant-ui uses the exact "*" sentinel for an allow-all adapter.
+        // "*/*" is forwarded to MIME matching and rejects every file before
+        // this adapter's add() method can run.
+        accept: '*',
 
         async *add({ file }): AsyncGenerator<PendingAttachment> {
             const contentType = file.type || 'application/octet-stream'


### PR DESCRIPTION
## Summary

- restore session-composer file attachments after the assistant-ui 0.14 migration
- use assistant-ui's exact `*` allow-all sentinel in both the normal chat and Scratchlist attachment adapters
- add regression tests that pin the attachment adapter accept contract

## Root cause

Both attachment adapters advertised `*/*`. In assistant-ui 0.14, `fileMatchesAccept` only treats the exact value `*` as the universal wildcard. `*/*` falls through to MIME matching and rejects normal files before either adapter's `add()` method runs.

`ComposerPrimitive.AddAttachment` catches that rejection, so the UI showed no attachment chip and Hapi sent no upload request.

## Testing

- `bun run --cwd web test -- attachmentAdapter.test.ts scratchlistAttachmentAdapter.test.ts`
- `bun typecheck`
- `bun run build:web`
- manually verified attachment selection and upload on the port 3016 test deployment

## AI assistance

OpenAI Codex (`gpt-5.6-sol`) was used to investigate, implement, and test this change.
