### PR TITLE
fix(web): re-subscribe push subscriptions when VAPID keys change

### DIFF
--- a/web/src/hooks/usePushNotifications.test.ts
+++ b/web/src/hooks/usePushNotifications.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '@/api/client'
+import { usePushNotifications } from '@/hooks/usePushNotifications'
+
+const VAPID_STORAGE_KEY = 'hapi.push.vapidKey'
+const CURRENT_VAPID_KEY = 'AQIDBA'
+
+type PushSubscriptionMock = {
+    endpoint: string
+    unsubscribe: ReturnType<typeof vi.fn>
+    toJSON: ReturnType<typeof vi.fn>
+}
+
+function createSubscription(endpoint: string, unsubscribeResult: boolean | Error): PushSubscriptionMock {
+    return {
+        endpoint,
+        unsubscribe: unsubscribeResult instanceof Error
+            ? vi.fn().mockRejectedValue(unsubscribeResult)
+            : vi.fn().mockResolvedValue(unsubscribeResult),
+        toJSON: vi.fn().mockReturnValue({
+            endpoint,
+            keys: { p256dh: 'p256dh', auth: 'auth' }
+        })
+    }
+}
+
+function setupPushEnvironment(existing: PushSubscriptionMock, replacement: PushSubscriptionMock) {
+    const pushManager = {
+        getSubscription: vi.fn().mockResolvedValue(existing),
+        subscribe: vi.fn().mockResolvedValue(replacement)
+    }
+    Object.defineProperty(navigator, 'serviceWorker', {
+        configurable: true,
+        value: { ready: Promise.resolve({ pushManager }) }
+    })
+    Object.defineProperty(window, 'PushManager', { configurable: true, value: class {} })
+    Object.defineProperty(window, 'Notification', {
+        configurable: true,
+        value: { permission: 'granted', requestPermission: vi.fn().mockResolvedValue('granted') }
+    })
+    return pushManager
+}
+
+function createApi() {
+    return {
+        getPushVapidPublicKey: vi.fn().mockResolvedValue({ publicKey: CURRENT_VAPID_KEY }),
+        subscribePushNotifications: vi.fn().mockResolvedValue(undefined),
+        unsubscribePushNotifications: vi.fn().mockResolvedValue(undefined)
+    }
+}
+
+describe('usePushNotifications VAPID rotation', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        localStorage.setItem(VAPID_STORAGE_KEY, 'stale-key')
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('preserves the existing registration when browser unsubscribe returns false', async () => {
+        const existing = createSubscription('https://push.test/stale', false)
+        const replacement = createSubscription('https://push.test/current', true)
+        const pushManager = setupPushEnvironment(existing, replacement)
+        const api = createApi()
+        const { result } = renderHook(() => usePushNotifications(api as unknown as ApiClient))
+
+        await waitFor(() => expect(result.current.isSupported).toBe(true))
+
+        let success = true
+        await act(async () => {
+            success = await result.current.subscribe()
+        })
+
+        expect(success).toBe(false)
+        expect(api.unsubscribePushNotifications).not.toHaveBeenCalled()
+        expect(pushManager.subscribe).not.toHaveBeenCalled()
+        expect(api.subscribePushNotifications).not.toHaveBeenCalled()
+        expect(localStorage.getItem(VAPID_STORAGE_KEY)).toBe('stale-key')
+    })
+
+    it('preserves the existing registration when browser unsubscribe rejects', async () => {
+        const existing = createSubscription('https://push.test/stale', new Error('unsubscribe failed'))
+        const replacement = createSubscription('https://push.test/current', true)
+        const pushManager = setupPushEnvironment(existing, replacement)
+        const api = createApi()
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const { result } = renderHook(() => usePushNotifications(api as unknown as ApiClient))
+
+        await waitFor(() => expect(result.current.isSupported).toBe(true))
+
+        let success = true
+        await act(async () => {
+            success = await result.current.subscribe()
+        })
+
+        expect(success).toBe(false)
+        expect(consoleError).toHaveBeenCalled()
+        expect(api.unsubscribePushNotifications).not.toHaveBeenCalled()
+        expect(pushManager.subscribe).not.toHaveBeenCalled()
+        expect(api.subscribePushNotifications).not.toHaveBeenCalled()
+        expect(localStorage.getItem(VAPID_STORAGE_KEY)).toBe('stale-key')
+    })
+
+    it('replaces and registers the subscription after browser unsubscribe succeeds', async () => {
+        const existing = createSubscription('https://push.test/stale', true)
+        const replacement = createSubscription('https://push.test/current', true)
+        const pushManager = setupPushEnvironment(existing, replacement)
+        const api = createApi()
+        const { result } = renderHook(() => usePushNotifications(api as unknown as ApiClient))
+
+        await waitFor(() => expect(result.current.isSupported).toBe(true))
+
+        let success = false
+        await act(async () => {
+            success = await result.current.subscribe()
+        })
+
+        expect(success).toBe(true)
+        expect(api.unsubscribePushNotifications).toHaveBeenCalledWith({ endpoint: existing.endpoint })
+        expect(pushManager.subscribe).toHaveBeenCalledTimes(1)
+        expect(api.subscribePushNotifications).toHaveBeenCalledWith({
+            endpoint: replacement.endpoint,
+            keys: { p256dh: 'p256dh', auth: 'auth' }
+        })
+        expect(localStorage.getItem(VAPID_STORAGE_KEY)).toBe(CURRENT_VAPID_KEY)
+    })
+})

--- a/web/src/hooks/usePushNotifications.ts
+++ b/web/src/hooks/usePushNotifications.ts
@@ -21,6 +21,30 @@ function base64UrlToUint8Array(base64Url: string): Uint8Array {
     return output
 }
 
+/**
+ * VAPID public key that the currently stored push subscription was created
+ * with. When the hub changes (or its keys rotate), existing browser
+ * subscriptions become undeliverable (push services reject them with
+ * VapidPkHashMismatch), so we compare and re-create them on the next load.
+ */
+const PUSH_VAPID_KEY_STORAGE = 'hapi.push.vapidKey'
+
+function readStoredVapidKey(): string | null {
+    try {
+        return localStorage.getItem(PUSH_VAPID_KEY_STORAGE)
+    } catch {
+        return null
+    }
+}
+
+function writeStoredVapidKey(publicKey: string): void {
+    try {
+        localStorage.setItem(PUSH_VAPID_KEY_STORAGE, publicKey)
+    } catch {
+        // Ignore storage errors — the key check degrades to a re-subscribe.
+    }
+}
+
 export function usePushNotifications(api: ApiClient | null) {
     const [isSupported, setIsSupported] = useState(false)
     const [permission, setPermission] = useState<NotificationPermission>('default')
@@ -43,8 +67,18 @@ export function usePushNotifications(api: ApiClient | null) {
 
         const registration = await navigator.serviceWorker.ready
         const subscription = await registration.pushManager.getSubscription()
-        setIsSubscribed(Boolean(subscription))
-    }, [])
+        let keyMatches = true
+        if (subscription && api) {
+            try {
+                const { publicKey } = await api.getPushVapidPublicKey()
+                keyMatches = readStoredVapidKey() === publicKey
+            } catch {
+                // Key lookup failed — keep the existing subscription benefit of
+                // the doubt rather than showing a false "off" state.
+            }
+        }
+        setIsSubscribed(Boolean(subscription) && keyMatches)
+    }, [api])
 
     useEffect(() => {
         void refreshSubscription()
@@ -78,10 +112,26 @@ export function usePushNotifications(api: ApiClient | null) {
             const existing = await registration.pushManager.getSubscription()
             const { publicKey } = await api.getPushVapidPublicKey()
             const applicationServerKey = base64UrlToUint8Array(publicKey).buffer as ArrayBuffer
-            const subscription = existing ?? await registration.pushManager.subscribe({
-                userVisibleOnly: true,
-                applicationServerKey
-            })
+            // A subscription created against a previous hub or VAPID key can
+            // never receive notifications from the current hub. Detect the
+            // mismatch via the key recorded at subscribe time and recreate it.
+            let subscription = existing
+            if (existing && readStoredVapidKey() !== publicKey) {
+                try {
+                    await existing.unsubscribe()
+                } catch {
+                    // Ignore unsubscribe failures — subscribe() below still
+                    // issues a fresh subscription with the current key.
+                }
+                subscription = null
+            }
+            if (!subscription) {
+                subscription = await registration.pushManager.subscribe({
+                    userVisibleOnly: true,
+                    applicationServerKey
+                })
+            }
+            writeStoredVapidKey(publicKey)
 
             const json = subscription.toJSON()
             const keys = json.keys

--- a/web/src/hooks/usePushNotifications.ts
+++ b/web/src/hooks/usePushNotifications.ts
@@ -118,12 +118,8 @@ export function usePushNotifications(api: ApiClient | null) {
             let subscription = existing
             if (existing && readStoredVapidKey() !== publicKey) {
                 const staleEndpoint = existing.endpoint
-                try {
-                    await existing.unsubscribe()
-                } catch {
-                    // Ignore unsubscribe failures — subscribe() below still
-                    // issues a fresh subscription with the current key.
-                }
+                const unsubscribed = await existing.unsubscribe()
+                if (!unsubscribed) return false
                 // Prune the obsolete endpoint from the hub so it stops
                 // receiving failed sends (VapidPkHashMismatch) for a
                 // subscription that can no longer be reached.
@@ -185,9 +181,10 @@ export function usePushNotifications(api: ApiClient | null) {
 
             const endpoint = subscription.endpoint
             const success = await subscription.unsubscribe()
+            if (!success) return false
             await api.unsubscribePushNotifications({ endpoint })
             setIsSubscribed(false)
-            return success
+            return true
         } catch (error) {
             console.error('[PushNotifications] Failed to unsubscribe:', error)
             return false

--- a/web/src/hooks/usePushNotifications.ts
+++ b/web/src/hooks/usePushNotifications.ts
@@ -117,11 +117,23 @@ export function usePushNotifications(api: ApiClient | null) {
             // mismatch via the key recorded at subscribe time and recreate it.
             let subscription = existing
             if (existing && readStoredVapidKey() !== publicKey) {
+                const staleEndpoint = existing.endpoint
                 try {
                     await existing.unsubscribe()
                 } catch {
                     // Ignore unsubscribe failures — subscribe() below still
                     // issues a fresh subscription with the current key.
+                }
+                // Prune the obsolete endpoint from the hub so it stops
+                // receiving failed sends (VapidPkHashMismatch) for a
+                // subscription that can no longer be reached.
+                if (staleEndpoint) {
+                    try {
+                        await api.unsubscribePushNotifications({ endpoint: staleEndpoint })
+                    } catch {
+                        // Best-effort cleanup — a stale hub registration is
+                        // harmless beyond repeated failed sends until pruned.
+                    }
                 }
                 subscription = null
             }

--- a/web/src/hooks/usePushNotifications.ts
+++ b/web/src/hooks/usePushNotifications.ts
@@ -143,7 +143,6 @@ export function usePushNotifications(api: ApiClient | null) {
                     applicationServerKey
                 })
             }
-            writeStoredVapidKey(publicKey)
 
             const json = subscription.toJSON()
             const keys = json.keys
@@ -158,6 +157,11 @@ export function usePushNotifications(api: ApiClient | null) {
                     auth: keys.auth
                 }
             })
+            // Only record the key after the hub registration succeeded. A
+            // failed registration must leave the previous key in place so the
+            // next load retries the replacement instead of reusing a
+            // subscription the hub never learned about.
+            writeStoredVapidKey(publicKey)
             setIsSubscribed(true)
             return true
         } catch (error) {


### PR DESCRIPTION
Web Push subscriptions become undeliverable after a hub migration or VAPID key rotation — push services reject sends with `VapidPkHashMismatch`, and the hub keeps retrying the stale endpoint.

- The web client records the VAPID public key used at subscribe time and, on mismatch, unsubscribes the stale subscription and re-subscribes with the current key.
- The obsolete endpoint is pruned from the hub (`unsubscribePushNotifications`) so it stops receiving failed sends.
- The new key is recorded only after the hub registration succeeds, so a failed registration is retried on the next load instead of silently reusing a subscription the hub never learned about.