### PR TITLE
feat(hub,web): support custom Claude models via settings.json

### DIFF
--- a/docs/public/schemas/settings.schema.json
+++ b/docs/public/schemas/settings.schema.json
@@ -46,6 +46,15 @@
       },
       "description": "Allowed CORS origins. ENV: CORS_ORIGINS (comma-separated)"
     },
+    "customClaudeModels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true,
+      "description": "Additional model names offered by the Claude model picker when using a custom ANTHROPIC_BASE_URL."
+    },
     "telegramBotToken": {
       "type": "string",
       "description": "Telegram Bot API token from @BotFather. ENV: TELEGRAM_BOT_TOKEN"

--- a/hub/src/config/settings.ts
+++ b/hub/src/config/settings.ts
@@ -34,6 +34,8 @@ export interface Settings {
      * Env vars still win when set at process start (ops override).
      */
     providerCredentials?: Partial<Record<string, string>>
+    /** Custom model names offered in the Claude model picker (e.g. DeepSeek via ANTHROPIC_BASE_URL). */
+    customClaudeModels?: string[]
 }
 
 export function getSettingsFile(dataDir: string): string {

--- a/hub/src/startHub.ts
+++ b/hub/src/startHub.ts
@@ -259,7 +259,8 @@ export async function startHub(options: StartHubOptions = {}): Promise<HubInstan
         socketEngine: socketServer.engine,
         corsOrigins,
         relayMode: relayFlag.enabled,
-        officialWebUrl
+        officialWebUrl,
+        dataDir: config.dataDir
     })
 
     // Start the bot if configured

--- a/hub/src/web/routes/claudeModels.test.ts
+++ b/hub/src/web/routes/claudeModels.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createClaudeModelsRoutes } from './claudeModels'
+
+describe('Claude custom models route', () => {
+    let dataDir: string | null = null
+
+    afterEach(() => {
+        if (dataDir) {
+            rmSync(dataDir, { recursive: true, force: true })
+            dataDir = null
+        }
+    })
+
+    it('returns trimmed unique model names and drops malformed values', async () => {
+        dataDir = mkdtempSync(join(tmpdir(), 'hapi-claude-models-test-'))
+        writeFileSync(join(dataDir, 'settings.json'), JSON.stringify({
+            customClaudeModels: [
+                ' deepseek-v4-flash[1m] ',
+                'deepseek-v4-flash[1m]',
+                '',
+                42,
+                null
+            ]
+        }))
+        const app = createClaudeModelsRoutes(dataDir)
+
+        const response = await app.request('/claude/custom-models')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({ models: ['deepseek-v4-flash[1m]'] })
+    })
+})

--- a/hub/src/web/routes/claudeModels.ts
+++ b/hub/src/web/routes/claudeModels.ts
@@ -1,0 +1,23 @@
+import { Hono } from 'hono'
+import type { WebAppEnv } from '../middleware/auth'
+import { getSettingsFile, readSettings } from '../../config/settings'
+
+/**
+ * Custom Claude model names configured in settings.json
+ * (`customClaudeModels`). Claude Code has no model catalog API like Codex,
+ * so users routing Claude through a custom ANTHROPIC_BASE_URL list their
+ * endpoint's model names here to surface them in the New Session picker.
+ */
+export function createClaudeModelsRoutes(dataDir: string): Hono<WebAppEnv> {
+    const app = new Hono<WebAppEnv>()
+
+    app.get('/claude/custom-models', async (c) => {
+        const settings = await readSettings(getSettingsFile(dataDir))
+        const models = Array.isArray(settings?.customClaudeModels)
+            ? settings.customClaudeModels
+            : []
+        return c.json({ models })
+    })
+
+    return app
+}

--- a/hub/src/web/routes/claudeModels.ts
+++ b/hub/src/web/routes/claudeModels.ts
@@ -15,8 +15,11 @@ export function createClaudeModelsRoutes(dataDir: string): Hono<WebAppEnv> {
         const settings = await readSettings(getSettingsFile(dataDir))
         const models = Array.isArray(settings?.customClaudeModels)
             ? settings.customClaudeModels
+                .filter((value): value is string => typeof value === 'string')
+                .map((value) => value.trim())
+                .filter(Boolean)
             : []
-        return c.json({ models })
+        return c.json({ models: [...new Set(models)] })
     })
 
     return app

--- a/hub/src/web/server.ts
+++ b/hub/src/web/server.ts
@@ -30,6 +30,7 @@ import { createPushRoutes } from './routes/push'
 import { createDevicesRoutes } from './routes/devices'
 import { createVoiceRoutes } from './routes/voice'
 import { createHubSettingsRoutes } from './routes/hubSettings'
+import { createClaudeModelsRoutes } from './routes/claudeModels'
 import type { SSEManager } from '../sse/sseManager'
 import type { VisibilityTracker } from '../visibility/visibilityTracker'
 import type { Server as BunServer, ServerWebSocket } from 'bun'
@@ -226,6 +227,7 @@ function createWebApp(options: {
     embeddedAssetMap: Map<string, EmbeddedWebAsset> | null
     relayMode?: boolean
     officialWebUrl?: string
+    dataDir: string
 }): Hono<WebAppEnv> {
     const app = new Hono<WebAppEnv>()
 
@@ -293,6 +295,7 @@ function createWebApp(options: {
         getSyncEngine: options.getSyncEngine
     }))
     app.route('/api', createPushRoutes(options.store, options.vapidPublicKey))
+    app.route('/api', createClaudeModelsRoutes(options.dataDir))
     app.route('/api', createDevicesRoutes(options.store))
     app.route('/api', createVoiceRoutes({ dataDir: configuration.dataDir }))
 
@@ -410,6 +413,7 @@ export async function startWebServer(options: {
     corsOrigins?: string[]
     relayMode?: boolean
     officialWebUrl?: string
+    dataDir: string
 }): Promise<BunServer<WebSocketData>> {
     const isCompiled = isBunCompiled()
     const embeddedAssetMap = isCompiled ? await loadEmbeddedAssetMap() : null
@@ -422,6 +426,7 @@ export async function startWebServer(options: {
         vapidPublicKey: options.vapidPublicKey,
         corsOrigins: options.corsOrigins,
         embeddedAssetMap,
+        dataDir: options.dataDir,
         relayMode: options.relayMode,
         officialWebUrl: options.officialWebUrl
     })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -250,6 +250,10 @@ export class ApiClient {
         return await this.request<PushVapidPublicKeyResponse>('/api/push/vapid-public-key')
     }
 
+    async getClaudeCustomModels(): Promise<{ models: string[] }> {
+        return await this.request<{ models: string[] }>('/api/claude/custom-models')
+    }
+
     async subscribePushNotifications(payload: PushSubscriptionPayload): Promise<void> {
         await this.request('/api/push/subscribe', {
             method: 'POST',

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -173,8 +173,19 @@ vi.mock('./AgyModelSelector', () => ({
     )
 }))
 vi.mock('./LaunchEffortSelector', () => ({
-    LaunchEffortSelector: (props: { effort: string }) => (
-        <div data-testid="launch-effort">{props.effort}</div>
+    LaunchEffortSelector: (props: {
+        effort: string
+        isDisabled: boolean
+        onEffortChange: (effort: string) => void
+    }) => (
+        <button
+            type="button"
+            data-testid="launch-effort"
+            disabled={props.isDisabled}
+            onClick={() => props.onEffortChange('low')}
+        >
+            {props.effort}
+        </button>
     )
 }))
 vi.mock('./ModelSelector', () => ({
@@ -372,12 +383,16 @@ describe('NewSession launch preferences', () => {
         )
 
         const model = screen.getByTestId('model')
+        const effort = screen.getByTestId('launch-effort')
         const create = screen.getByTestId('create')
         expect(model).toBeDisabled()
+        expect(effort).toBeDisabled()
         expect(create).toBeDisabled()
         fireEvent.click(model)
+        fireEvent.click(effort)
         fireEvent.click(create)
         expect(model).toHaveTextContent('auto')
+        expect(effort).toHaveTextContent('auto')
         expect(mocks.spawnSession).not.toHaveBeenCalled()
 
         await act(async () => {
@@ -387,6 +402,8 @@ describe('NewSession launch preferences', () => {
         await waitFor(() => {
             expect(model).toHaveTextContent('deepseek-v4-flash[1m]')
             expect(model).toBeEnabled()
+            expect(effort).toHaveTextContent('high')
+            expect(effort).toBeEnabled()
             expect(create).toBeEnabled()
         })
     })

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -181,10 +181,17 @@ vi.mock('./ModelSelector', () => ({
     ModelSelector: (props: {
         model: string
         options?: Array<{ value: string; label: string }>
+        isDisabled: boolean
+        isLoading?: boolean
         onModelChange: (model: string) => void
     }) => (
         <>
-            <button type="button" data-testid="model" onClick={() => props.onModelChange('gpt-5.6-terra')}>
+            <button
+                type="button"
+                data-testid="model"
+                disabled={props.isDisabled || props.isLoading}
+                onClick={() => props.onModelChange('gpt-5.6-terra')}
+            >
                 {props.model}
             </button>
             <div data-testid="model-options">{props.options?.map((option) => option.label).join(',')}</div>
@@ -335,6 +342,52 @@ describe('NewSession launch preferences', () => {
         await waitFor(() => {
             expect(screen.getByTestId('model')).toHaveTextContent('deepseek-v4-flash[1m]')
             expect(screen.getByTestId('launch-effort')).toHaveTextContent('high')
+        })
+    })
+
+    it('blocks model changes and creation until custom Claude models load', async () => {
+        savePreferredAgent('claude')
+        savePreferredLaunchSettings('machine-1', 'claude', {
+            model: 'deepseek-v4-flash[1m]',
+            cursorSelectedBase: 'auto',
+            effort: 'high',
+            modelReasoningEffort: 'default'
+        })
+        let resolveModels!: (value: { models: string[] }) => void
+        const claudeApi = {
+            getClaudeCustomModels: vi.fn().mockReturnValue(new Promise((resolve) => {
+                resolveModels = resolve
+            }))
+        } as unknown as ApiClient
+
+        render(
+            <NewSession
+                api={claudeApi}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        const model = screen.getByTestId('model')
+        const create = screen.getByTestId('create')
+        expect(model).toBeDisabled()
+        expect(create).toBeDisabled()
+        fireEvent.click(model)
+        fireEvent.click(create)
+        expect(model).toHaveTextContent('auto')
+        expect(mocks.spawnSession).not.toHaveBeenCalled()
+
+        await act(async () => {
+            resolveModels({ models: ['deepseek-v4-flash[1m]'] })
+        })
+
+        await waitFor(() => {
+            expect(model).toHaveTextContent('deepseek-v4-flash[1m]')
+            expect(model).toBeEnabled()
+            expect(create).toBeEnabled()
         })
     })
 

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -307,6 +307,37 @@ describe('NewSession launch preferences', () => {
         await waitFor(() => expect(screen.getByTestId('create')).toBeDisabled())
     })
 
+    it('waits for custom Claude models before restoring a saved model', async () => {
+        savePreferredAgent('claude')
+        savePreferredLaunchSettings('machine-1', 'claude', {
+            model: 'deepseek-v4-flash[1m]',
+            cursorSelectedBase: 'auto',
+            effort: 'high',
+            modelReasoningEffort: 'default'
+        })
+        const claudeApi = {
+            getClaudeCustomModels: vi.fn().mockResolvedValue({
+                models: ['deepseek-v4-flash[1m]']
+            })
+        } as unknown as ApiClient
+
+        render(
+            <NewSession
+                api={claudeApi}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('model')).toHaveTextContent('deepseek-v4-flash[1m]')
+            expect(screen.getByTestId('launch-effort')).toHaveTextContent('high')
+        })
+    })
+
     it.each([
         ['model', 'gpt-5.6-sol', 'default'],
         ['reasoning effort', 'auto', 'xhigh']

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -195,19 +195,24 @@ vi.mock('./ModelSelector', () => ({
         isDisabled: boolean
         isLoading?: boolean
         onModelChange: (model: string) => void
-    }) => (
-        <>
-            <button
-                type="button"
-                data-testid="model"
-                disabled={props.isDisabled || props.isLoading}
-                onClick={() => props.onModelChange('gpt-5.6-terra')}
-            >
-                {props.model}
-            </button>
-            <div data-testid="model-options">{props.options?.map((option) => option.label).join(',')}</div>
-        </>
-    )
+    }) => {
+        const displayedModel = props.options && !props.options.some((option) => option.value === props.model)
+            ? props.options[0]?.value ?? props.model
+            : props.model
+        return (
+            <>
+                <button
+                    type="button"
+                    data-testid="model"
+                    disabled={props.isDisabled || props.isLoading}
+                    onClick={() => props.onModelChange('gpt-5.6-terra')}
+                >
+                    {displayedModel}
+                </button>
+                <div data-testid="model-options">{props.options?.map((option) => option.label).join(',')}</div>
+            </>
+        )
+    }
 }))
 vi.mock('./ReasoningEffortSelector', () => ({
     ReasoningEffortSelector: (props: { value: string; onChange: (effort: string) => void }) => (
@@ -829,5 +834,50 @@ describe('NewSession launch preferences', () => {
             expect(screen.getByTestId('model')).toHaveTextContent('gpt-5.6-terra')
             expect(screen.getByTestId('reasoning')).toHaveTextContent('max')
         })
+    })
+
+    it('keeps a browse-return custom Claude model visible when it is no longer configured', async () => {
+        savePreferredAgent('claude')
+        saveNewSessionFormDraft({
+            agent: 'claude',
+            model: 'deepseek-v4-flash[1m]',
+            cursorSelectedBase: 'auto',
+            machineId: 'machine-1',
+            effort: 'high',
+            modelReasoningEffort: 'default',
+            serviceTier: 'standard',
+            collaborationMode: 'default',
+            copilotAgentMode: 'interactive',
+            yoloMode: false,
+            codexFamilyPermissionMode: 'default',
+            grokPermissionMode: 'default',
+            sessionType: 'simple',
+            worktreeName: ''
+        })
+        mocks.spawnSession.mockResolvedValue({ type: 'success', sessionId: 'session-1' })
+        const claudeApi = {
+            getClaudeCustomModels: vi.fn().mockResolvedValue({ models: [] })
+        } as unknown as ApiClient
+
+        render(
+            <NewSession
+                api={claudeApi}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('model')).toHaveTextContent('deepseek-v4-flash[1m]')
+            expect(screen.getByTestId('create')).toBeEnabled()
+        })
+        fireEvent.click(screen.getByTestId('create'))
+
+        await waitFor(() => expect(mocks.spawnSession).toHaveBeenCalledWith(
+            expect.objectContaining({ model: 'deepseek-v4-flash[1m]' })
+        ))
     })
 })

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -37,6 +37,7 @@ import {
     shouldRestoreNewSessionFormDraft
 } from './newSessionFormDraft'
 import type { AgentType, LaunchEffort, CodexReasoningEffort, NewSessionServiceTier, SessionType } from './types'
+import { MODEL_OPTIONS } from './types'
 import { ActionButtons } from './ActionButtons'
 import { AgentSelector } from './AgentSelector'
 import { CollaborationModeSelector } from './CollaborationModeSelector'
@@ -281,6 +282,32 @@ export function NewSession(props: {
         enabled: agent === 'codex' && Boolean(machineId)
     })
     const [agySelectedModel, setAgySelectedModel] = useState<string | null>(null)
+    const [claudeCustomModels, setClaudeCustomModels] = useState<string[]>([])
+    useEffect(() => {
+        let cancelled = false
+        if (!props.api) {
+            return
+        }
+        props.api.getClaudeCustomModels().then((result) => {
+            if (!cancelled) {
+                setClaudeCustomModels(Array.isArray(result.models) ? result.models : [])
+            }
+        }).catch(() => {
+            // Custom models are optional — fall back to the built-in presets.
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [props.api])
+    const claudeModelOptions = useMemo(() => {
+        const options = [...MODEL_OPTIONS.claude]
+        for (const modelName of claudeCustomModels) {
+            if (!options.some((option) => option.value === modelName)) {
+                options.push({ value: modelName, label: modelName })
+            }
+        }
+        return options
+    }, [claudeCustomModels])
     const runnerSpawnError = useMemo(
         () => formatRunnerSpawnError(selectedMachine),
         [selectedMachine]
@@ -1626,7 +1653,9 @@ export function NewSession(props: {
                         agent={agent}
                         model={model}
                         options={
-                            agent === 'codex'
+                            agent === 'claude'
+                                ? claudeModelOptions
+                                : agent === 'codex'
                                 ? codexModelOptions
                                 : agent === 'grok'
                                     ? grokModelOptions

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -327,7 +327,8 @@ export function NewSession(props: {
         () => agent === 'claude' ? claudeModelOptions.map((option) => option.value) : null,
         [agent, claudeModelOptions]
     )
-    const preferredModelCatalogReady = agent !== 'claude' || claudeModelsLoaded
+    const claudeModelsLoading = agent === 'claude' && !claudeModelsLoaded
+    const preferredModelCatalogReady = !claudeModelsLoading
     const runnerSpawnError = useMemo(
         () => formatRunnerSpawnError(selectedMachine),
         [selectedMachine]
@@ -1497,7 +1498,8 @@ export function NewSession(props: {
     }
 
     const isLaunchPreferenceValidationPending =
-        (agent === 'codex'
+        claudeModelsLoading
+        || (agent === 'codex'
             && (model !== 'auto' || modelReasoningEffort !== 'default')
             && codexModelsState.isLoading)
         || (agent === 'agy'
@@ -1690,7 +1692,8 @@ export function NewSession(props: {
                             || (agent === 'grok' && Boolean(grokModelsState.error))
                             || (agent === 'copilot' && Boolean(copilotModelsState.error))
                         }
-                        isLoading={(agent === 'codex' && codexModelsState.isLoading)
+                        isLoading={claudeModelsLoading
+                            || (agent === 'codex' && codexModelsState.isLoading)
                             || (agent === 'grok' && grokModelsState.isLoading)
                             || (agent === 'copilot' && copilotModelsState.isLoading)}
                         error={agent === 'codex' && codexModelsState.error

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -288,13 +288,18 @@ export function NewSession(props: {
         if (!props.api) {
             return
         }
-        props.api.getClaudeCustomModels().then((result) => {
-            if (!cancelled) {
-                setClaudeCustomModels(Array.isArray(result.models) ? result.models : [])
-            }
-        }).catch(() => {
-            // Custom models are optional — fall back to the built-in presets.
-        })
+        try {
+            props.api.getClaudeCustomModels().then((result) => {
+                if (!cancelled) {
+                    setClaudeCustomModels(Array.isArray(result.models) ? result.models : [])
+                }
+            }).catch(() => {
+                // Custom models are optional — fall back to the built-in presets.
+            })
+        } catch {
+            // Partial api clients (tests, older hub versions) without the
+            // method must not break the New Session form.
+        }
         return () => {
             cancelled = true
         }

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -321,11 +321,20 @@ export function NewSession(props: {
                 options.push({ value: modelName, label: modelName })
             }
         }
+        if (
+            agent === 'claude'
+            && model !== 'auto'
+            && !options.some((option) => option.value === model)
+        ) {
+            options.splice(1, 0, { value: model, label: model })
+        }
         return options
-    }, [claudeCustomModels])
+    }, [agent, claudeCustomModels, model])
     const claudePreferredModelValues = useMemo(
-        () => agent === 'claude' ? claudeModelOptions.map((option) => option.value) : null,
-        [agent, claudeModelOptions]
+        () => agent === 'claude'
+            ? [...MODEL_OPTIONS.claude.map((option) => option.value), ...claudeCustomModels]
+            : null,
+        [agent, claudeCustomModels]
     )
     const claudeModelsLoading = agent === 'claude' && !claudeModelsLoaded
     const preferredModelCatalogReady = !claudeModelsLoading

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -283,22 +283,32 @@ export function NewSession(props: {
     })
     const [agySelectedModel, setAgySelectedModel] = useState<string | null>(null)
     const [claudeCustomModels, setClaudeCustomModels] = useState<string[]>([])
+    const [claudeModelsLoaded, setClaudeModelsLoaded] = useState(false)
     useEffect(() => {
         let cancelled = false
+        setClaudeModelsLoaded(false)
         if (!props.api) {
+            setClaudeModelsLoaded(true)
             return
         }
         try {
             props.api.getClaudeCustomModels().then((result) => {
                 if (!cancelled) {
                     setClaudeCustomModels(Array.isArray(result.models) ? result.models : [])
+                    setClaudeModelsLoaded(true)
                 }
             }).catch(() => {
                 // Custom models are optional — fall back to the built-in presets.
+                if (!cancelled) {
+                    setClaudeCustomModels([])
+                    setClaudeModelsLoaded(true)
+                }
             })
         } catch {
             // Partial api clients (tests, older hub versions) without the
             // method must not break the New Session form.
+            setClaudeCustomModels([])
+            setClaudeModelsLoaded(true)
         }
         return () => {
             cancelled = true
@@ -313,6 +323,11 @@ export function NewSession(props: {
         }
         return options
     }, [claudeCustomModels])
+    const claudePreferredModelValues = useMemo(
+        () => agent === 'claude' ? claudeModelOptions.map((option) => option.value) : null,
+        [agent, claudeModelOptions]
+    )
+    const preferredModelCatalogReady = agent !== 'claude' || claudeModelsLoaded
     const runnerSpawnError = useMemo(
         () => formatRunnerSpawnError(selectedMachine),
         [selectedMachine]
@@ -696,13 +711,14 @@ export function NewSession(props: {
     }, [agent, machineId, deferredDirectory])
 
     useEffect(() => {
-        if (!machineId || preserveRestoredDraftRef.current) {
+        if (!machineId || preserveRestoredDraftRef.current || !preferredModelCatalogReady) {
             return
         }
 
         const preferred = resolvePreferredLaunchSettings(
             agent,
-            loadPreferredLaunchSettings(machineId, agent)
+            loadPreferredLaunchSettings(machineId, agent),
+            claudePreferredModelValues ?? undefined
         )
 
         setModel(agent === 'opencode' ? 'auto' : preferred.model)
@@ -715,7 +731,7 @@ export function NewSession(props: {
         setAgySelectedModel(
             agent === 'agy' && preferred.model !== 'auto' ? preferred.model : null
         )
-    }, [agent, machineId])
+    }, [agent, claudePreferredModelValues, machineId, preferredModelCatalogReady])
 
     useEffect(() => {
         if (

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -1710,7 +1710,7 @@ export function NewSession(props: {
             <LaunchEffortSelector
                 agent={agent}
                 effort={effort}
-                isDisabled={isFormDisabled}
+                isDisabled={isFormDisabled || claudeModelsLoading}
                 onEffortChange={setEffort}
                 grokOptions={agent === 'grok' ? grokEffortOptions : undefined}
             />

--- a/web/src/components/NewSession/preferences.test.ts
+++ b/web/src/components/NewSession/preferences.test.ts
@@ -135,6 +135,20 @@ describe('NewSession preferences', () => {
         })
     })
 
+    it('keeps a remembered custom Claude model after its catalog loads', () => {
+        expect(resolvePreferredLaunchSettings('claude', {
+            model: 'deepseek-v4-flash[1m]',
+            cursorSelectedBase: 'auto',
+            effort: 'high',
+            modelReasoningEffort: 'default'
+        }, ['auto', 'sonnet', 'deepseek-v4-flash[1m]'])).toEqual({
+            model: 'deepseek-v4-flash[1m]',
+            cursorSelectedBase: 'auto',
+            effort: 'high',
+            modelReasoningEffort: 'default'
+        })
+    })
+
     it('keeps dynamic model values for catalog validation after restore', () => {
         expect(resolvePreferredLaunchSettings('codex', {
             model: 'gpt-5.6-sol',

--- a/web/src/components/NewSession/preferences.ts
+++ b/web/src/components/NewSession/preferences.ts
@@ -116,10 +116,11 @@ function resolvePreferredOptionValue(
 
 export function resolvePreferredLaunchSettings(
     agent: AgentType,
-    preferred: PreferredLaunchSettings | null
+    preferred: PreferredLaunchSettings | null,
+    availableModelValues?: readonly string[]
 ): PreferredLaunchSettings {
     const preferredModel = preferred?.model ?? 'auto'
-    const staticModelValues = MODEL_OPTIONS[agent].map((option) => option.value)
+    const staticModelValues = availableModelValues ?? MODEL_OPTIONS[agent].map((option) => option.value)
     const model = staticModelValues.length > 0 && agent !== 'codex' && agent !== 'copilot'
         ? resolvePreferredOptionValue(preferredModel, staticModelValues, 'auto')
         : preferredModel


### PR DESCRIPTION
Claude Code has no model catalog API like Codex, so sessions routed through a custom `ANTHROPIC_BASE_URL` (e.g. DeepSeek) could not select their models in the New Session picker.

- `settings.json` gains an optional `customClaudeModels: string[]` field.
- New hub route `GET /api/claude/custom-models` exposes the list.
- The New Session Claude model picker merges the configured names with the built-in presets; the fetch is guarded so partial API clients (older hubs, tests) don't break the form.

Tested against a hub routing Claude to `api.deepseek.com/anthropic` with `deepseek-v4-flash[1m]`.