### PR TITLE
fix(web): show full voice platform rules in settings preview

### DIFF
--- a/shared/src/voicePersonality.test.ts
+++ b/shared/src/voicePersonality.test.ts
@@ -11,7 +11,7 @@ import {
     truncateUtf8ByteLength,
     utf8ByteLength
 } from './voicePersonality'
-import { VOICE_PLATFORM_FIXTURES } from './voicePromptLayers'
+import { VOICE_PLATFORM_FIXTURES, getVoicePlatformFixturesPreview } from './voicePromptLayers'
 
 describe('voicePersonality', () => {
     test('parseVoicePersonalityPreferences returns defaults for invalid input', () => {
@@ -77,5 +77,11 @@ describe('voicePersonality', () => {
         expect(text).toBe('hello 🎙️ world')
         const huge = truncateUtf8ByteLength('a'.repeat(50_000), 100)
         expect(utf8ByteLength(huge)).toBeLessThanOrEqual(100)
+    })
+
+    test('settings fixtures preview returns full platform rules by default', () => {
+        expect(getVoicePlatformFixturesPreview()).toBe(VOICE_PLATFORM_FIXTURES)
+        expect(getVoicePlatformFixturesPreview(40)).toContain('[…]')
+        expect(getVoicePlatformFixturesPreview(40).length).toBeLessThan(VOICE_PLATFORM_FIXTURES.length)
     })
 })

--- a/shared/src/voicePromptLayers.ts
+++ b/shared/src/voicePromptLayers.ts
@@ -205,9 +205,15 @@ export function composeVoiceAgentPrompt(
     return prompt
 }
 
-/** Short preview for Settings (fixtures are read-only). */
-export function getVoicePlatformFixturesPreview(maxChars = 600): string {
+/**
+ * Read-only fixtures text for Settings.
+ * Pass a finite maxChars only when deliberately truncating (e.g. tests);
+ * Settings shows the full document in a scrollable panel.
+ */
+export function getVoicePlatformFixturesPreview(maxChars?: number): string {
     const text = VOICE_PLATFORM_FIXTURES
-    if (text.length <= maxChars) return text
+    if (maxChars == null || !Number.isFinite(maxChars) || maxChars <= 0 || text.length <= maxChars) {
+        return text
+    }
     return `${text.slice(0, maxChars)}\n\n[…]`
 }

--- a/web/src/components/settings/VoiceAdvancedControls.tsx
+++ b/web/src/components/settings/VoiceAdvancedControls.tsx
@@ -307,7 +307,7 @@ export function VoiceDiagnosticsControls(props: {
 
     const backend = props.voiceBackend ?? 'elevenlabs'
     const wireHint = getVoiceWireBudgetHint(backend)
-    const fixturesPreview = useMemo(() => getVoicePlatformFixturesPreview(800), [])
+    const fixturesPreview = useMemo(() => getVoicePlatformFixturesPreview(), [])
     const composed = useMemo(
         () => resolveComposedVoiceSystemPrompt(prefs, { backend }),
         [prefs, backend]


### PR DESCRIPTION
## Summary
- Settings → Voice → Advanced → Platform rules (read-only) now shows the **full** fixtures text in the scrollable panel.
- Truncation remains available for explicit caps (tests); default is no slice.

Closes #1341

## Test plan
- [x] `bun test shared/src/voicePersonality.test.ts` (10 pass)
- [x] Open Settings → Voice → Advanced → Platform rules (peer-stack :3101 dogfood)
- [x] Scroll through full fixtures (tools, proactive updates, first interaction, etc.) — no early `[…]` (assert len=4549, has `# First Interaction`, no trailing `[…]`)

## Proof
Peer-stack PNG attached on this PR (release asset). Soup remat for `:3006` blocked on unrelated heal `20-verify-tests-grok-acp.patch` — escalated to Meta remat owner `05d9f0f2`; layer already in manifest + WIP tip.