### PR TITLE
fix(web): close composer settings on outside click

### DIFF
--- a/web/src/components/AssistantChat/ComposerButtons.tsx
+++ b/web/src/components/AssistantChat/ComposerButtons.tsx
@@ -6,7 +6,7 @@ import { ScheduleTimePicker } from './ScheduleTimePicker'
 import type { PendingSchedule } from './ScheduleTimePicker'
 import { useFue } from '@/lib/use-fue'
 import { FueCallout, FueDot } from '@/components/Fue'
-import { Children, isValidElement, useRef, useState, type ReactElement, type ReactNode } from 'react'
+import { Children, isValidElement, useRef, useState, type ReactElement, type ReactNode, type Ref } from 'react'
 import { useComposerToolbarLayout, type ComposerToolbarItemId, type ComposerToolbarLayout } from '@/hooks/useComposerToolbarLayout'
 import { useLongPress } from '@/hooks/useLongPress'
 import type { ComposerSendIntent } from '@/lib/messageDelivery'
@@ -623,6 +623,7 @@ export function ComposerButtons(props: {
     canSend: boolean
     controlsDisabled: boolean
     showSettingsButton: boolean
+    settingsButtonRef?: Ref<HTMLButtonElement>
     onSettingsToggle: () => void
     expanded: boolean
     onExpandedToggle: () => void
@@ -704,6 +705,7 @@ export function ComposerButtons(props: {
                 <ToolbarItemSlot item="settings">
                 {props.showSettingsButton ? (
                     <button
+                        ref={props.settingsButtonRef}
                         type="button"
                         aria-label={t('composer.settings')}
                         title={t('composer.settings')}

--- a/web/src/components/AssistantChat/HappyComposer.expandSelection.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.expandSelection.test.tsx
@@ -4,16 +4,33 @@ import {
     useLocalRuntime,
 } from '@assistant-ui/react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { Ref } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { HappyComposer } from './HappyComposer'
 
 vi.mock('@/components/AssistantChat/ComposerButtons', () => ({
-    ComposerButtons: (props: { expanded: boolean; onExpandedToggle: () => void }) => (
-        <button
-            type="button"
-            aria-label={props.expanded ? 'Collapse message editor' : 'Expand message editor'}
-            onClick={props.onExpandedToggle}
-        />
+    ComposerButtons: (props: {
+        expanded: boolean
+        onExpandedToggle: () => void
+        showSettingsButton: boolean
+        settingsButtonRef?: Ref<HTMLButtonElement>
+        onSettingsToggle: () => void
+    }) => (
+        <div>
+            <button
+                type="button"
+                aria-label={props.expanded ? 'Collapse message editor' : 'Expand message editor'}
+                onClick={props.onExpandedToggle}
+            />
+            {props.showSettingsButton ? (
+                <button
+                    ref={props.settingsButtonRef}
+                    type="button"
+                    aria-label="Composer settings"
+                    onClick={props.onSettingsToggle}
+                />
+            ) : null}
+        </div>
     ),
 }))
 
@@ -51,11 +68,14 @@ const adapter: ChatModelAdapter = {
     async *run() {},
 }
 
-function TestRuntime() {
+function TestRuntime(props: { withSettings?: boolean }) {
     const runtime = useLocalRuntime(adapter)
     return (
         <AssistantRuntimeProvider runtime={runtime}>
-            <HappyComposer />
+            <HappyComposer
+                agentFlavor={props.withSettings ? 'claude' : undefined}
+                onPermissionModeChange={props.withSettings ? () => {} : undefined}
+            />
         </AssistantRuntimeProvider>
     )
 }
@@ -101,5 +121,28 @@ describe('HappyComposer plain-text expansion', () => {
             expect(nextCollapsedInput.selectionDirection).toBe('backward')
             expect(document.activeElement).toBe(nextCollapsedInput)
         })
+    })
+
+    it('closes settings when clicking outside while preserving inside and trigger interactions', () => {
+        render(<TestRuntime withSettings />)
+
+        const settingsButton = screen.getByRole('button', { name: 'Composer settings' })
+        fireEvent.click(settingsButton)
+
+        const panelLabel = screen.getByText('misc.permissionMode')
+        fireEvent.pointerDown(panelLabel)
+        expect(screen.getByText('misc.permissionMode')).toBeInTheDocument()
+
+        fireEvent.pointerDown(settingsButton)
+        expect(screen.getByText('misc.permissionMode')).toBeInTheDocument()
+
+        fireEvent.click(settingsButton)
+        expect(screen.queryByText('misc.permissionMode')).not.toBeInTheDocument()
+
+        fireEvent.click(settingsButton)
+        expect(screen.getByText('misc.permissionMode')).toBeInTheDocument()
+
+        fireEvent.pointerDown(screen.getByRole('textbox'))
+        expect(screen.queryByText('misc.permissionMode')).not.toBeInTheDocument()
     })
 })

--- a/web/src/components/AssistantChat/HappyComposer.expandSelection.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.expandSelection.test.tsx
@@ -76,6 +76,13 @@ function TestRuntime(props: { withSettings?: boolean }) {
                 agentFlavor={props.withSettings ? 'claude' : undefined}
                 onPermissionModeChange={props.withSettings ? () => {} : undefined}
             />
+            {props.withSettings ? (
+                <button
+                    type="button"
+                    aria-label="Outside action"
+                    onPointerDown={(event) => event.stopPropagation()}
+                />
+            ) : null}
         </AssistantRuntimeProvider>
     )
 }
@@ -143,6 +150,12 @@ describe('HappyComposer plain-text expansion', () => {
         expect(screen.getByText('misc.permissionMode')).toBeInTheDocument()
 
         fireEvent.pointerDown(screen.getByRole('textbox'))
+        expect(screen.queryByText('misc.permissionMode')).not.toBeInTheDocument()
+
+        fireEvent.click(settingsButton)
+        expect(screen.getByText('misc.permissionMode')).toBeInTheDocument()
+
+        fireEvent.pointerDown(screen.getByRole('button', { name: 'Outside action' }))
         expect(screen.queryByText('misc.permissionMode')).not.toBeInTheDocument()
     })
 })

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -525,6 +525,8 @@ export function HappyComposer(props: {
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const richInputRef = useRef<RichComposerInputHandle>(null)
     const richComposerFueAnchorRef = useRef<HTMLDivElement>(null)
+    const settingsButtonRef = useRef<HTMLButtonElement>(null)
+    const settingsOverlayRef = useRef<HTMLDivElement>(null)
     // `composer.text === ''` alone is not enough to identify the empty state
     // created by a send. A user can type and delete a fresh draft before the
     // failed mutation reports back. Keep monotonic interaction generations so
@@ -1380,6 +1382,21 @@ export function HappyComposer(props: {
         haptic('light')
     }, [onModelEffortChange, onModelChange, controlsDisabled, haptic, dismissSettings])
 
+    useEffect(() => {
+        if (!showSettings) return
+
+        const handlePointerDown = (event: PointerEvent) => {
+            const target = event.target
+            if (!(target instanceof Node)) return
+            if (settingsOverlayRef.current?.contains(target)) return
+            if (settingsButtonRef.current?.contains(target)) return
+            dismissSettings()
+        }
+
+        document.addEventListener('pointerdown', handlePointerDown)
+        return () => document.removeEventListener('pointerdown', handlePointerDown)
+    }, [dismissSettings, showSettings])
+
     const handleSubmit = useCallback((event?: ReactFormEvent<HTMLFormElement>) => {
         event?.preventDefault()
         if (!attachmentsReady) {
@@ -1557,7 +1574,7 @@ export function HappyComposer(props: {
         // Non-Pi flavors: original unified gear menu
         if (showSettings && (showCollaborationSettings || showCopilotAgentModeSettings || showPermissionSettings || showModelSettings || showModelEffortSettings || showModelReasoningEffortSettings || showEffortSettings || showFastModeSettings)) {
             return (
-                <div className={`${overlayPositionClass} w-full`}>
+                <div ref={settingsOverlayRef} className={`${overlayPositionClass} w-full`}>
                     <FloatingOverlay maxHeight={320}>
                         {showCollaborationSettings ? (
                             <div className="py-2">
@@ -2171,6 +2188,7 @@ export function HappyComposer(props: {
                             canSend={canSend}
                             controlsDisabled={controlsDisabled}
                             showSettingsButton={showSettingsButton}
+                            settingsButtonRef={settingsButtonRef}
                             onSettingsToggle={handleSettingsToggle}
                             expanded={isExpanded}
                             onExpandedToggle={handleExpandedToggle}

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -1393,8 +1393,8 @@ export function HappyComposer(props: {
             dismissSettings()
         }
 
-        document.addEventListener('pointerdown', handlePointerDown)
-        return () => document.removeEventListener('pointerdown', handlePointerDown)
+        document.addEventListener('pointerdown', handlePointerDown, true)
+        return () => document.removeEventListener('pointerdown', handlePointerDown, true)
     }, [dismissSettings, showSettings])
 
     const handleSubmit = useCallback((event?: ReactFormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
## Summary

- close the composer settings overlay when the user clicks outside it
- keep clicks inside the overlay and on the settings trigger from being treated as outside clicks
- add regression coverage for inside, trigger, and outside pointer interactions

## Testing

- `bun typecheck`
- `bun run test`
- `git diff --check`