### PR TITLE
fix(web): prevent near-bottom chat scroll jump

### DIFF
--- a/web/src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx
@@ -32,7 +32,7 @@ import type { Session } from '@/types/api'
 const originalScrollTo = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollTo')
 
 function renderThread(onViewModeChange = vi.fn()) {
-    const result = render(
+    const renderHappyThread = (forceScrollToken: number) => (
         <I18nProvider>
             <HappyThread
                 api={{} as ApiClient}
@@ -53,13 +53,14 @@ function renderThread(onViewModeChange = vi.fn()) {
                 normalizedMessagesCount={1}
                 messagesVersion={1}
                 historyVersion={0}
-                forceScrollToken={0}
+                forceScrollToken={forceScrollToken}
                 outlineOpen={false}
                 outlineItems={[]}
                 onOutlineOpenChange={vi.fn()}
             />
         </I18nProvider>
     )
+    const result = render(renderHappyThread(0))
     const viewport = result.container.querySelector<HTMLElement>('.chat-scroll-y')
     if (!viewport) {
         throw new Error('Chat viewport was not rendered')
@@ -71,7 +72,12 @@ function renderThread(onViewModeChange = vi.fn()) {
     act(() => {
         vi.advanceTimersByTime(0)
     })
-    return { ...result, viewport, onViewModeChange }
+    return {
+        ...result,
+        viewport,
+        onViewModeChange,
+        rerenderThread: (forceScrollToken: number) => result.rerender(renderHappyThread(forceScrollToken))
+    }
 }
 
 beforeEach(() => {
@@ -188,6 +194,39 @@ describe('mobile initial scroll settling', () => {
         })
 
         expect(viewport.scrollTop).toBe(702)
+        expect(onViewModeChange).not.toHaveBeenCalledWith('history')
+    })
+})
+
+describe('explicit tail scrolling', () => {
+    it('stays in tail mode through smooth-scroll progress and content growth', () => {
+        const { viewport, onViewModeChange, rerenderThread } = renderThread()
+        act(() => {
+            vi.advanceTimersByTime(1_800)
+        })
+
+        viewport.scrollTop = 400
+        fireEvent.scroll(viewport)
+        expect(onViewModeChange).toHaveBeenLastCalledWith('history')
+
+        Object.defineProperty(viewport, 'scrollTo', {
+            configurable: true,
+            value: vi.fn()
+        })
+        onViewModeChange.mockClear()
+        rerenderThread(1)
+        expect(onViewModeChange).toHaveBeenLastCalledWith('tail')
+
+        viewport.scrollTop = 500
+        fireEvent.scroll(viewport)
+        Object.defineProperty(viewport, 'scrollHeight', { configurable: true, value: 1_400 })
+        viewport.scrollTop = 650
+        fireEvent.scroll(viewport)
+
+        expect(onViewModeChange).not.toHaveBeenCalledWith('history')
+
+        viewport.scrollTop = 870
+        fireEvent.scroll(viewport)
         expect(onViewModeChange).not.toHaveBeenCalledWith('history')
     })
 })

--- a/web/src/components/AssistantChat/HappyThread.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.test.tsx
@@ -170,8 +170,21 @@ describe('scroll anchor helpers', () => {
             clientHeight: 530
         })).toMatchObject({
             distanceFromBottom: 12,
-            isNearBottom: true,
+            isNearBottom: false,
             isScrollingUp: true
+        })
+    })
+
+    it('does not resume tail-following merely because downward reading is close to the bottom', () => {
+        expect(getScrollIntent({
+            scrollTop: 610,
+            previousScrollTop: 590,
+            scrollHeight: 1232,
+            clientHeight: 530
+        })).toMatchObject({
+            distanceFromBottom: 92,
+            isNearBottom: false,
+            isScrollingUp: false
         })
     })
 

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -523,6 +523,7 @@ export function HappyThread(props: {
     const pendingLoadResolveRef = useRef<((value: OlderHistoryLoadResult) => void) | null>(null)
     const coverageCheckTimerRef = useRef<number | null>(null)
     const failureRetryTimerRef = useRef<number | null>(null)
+    const tailScrollInProgressRef = useRef(false)
     const historyLoaderRef = useRef<HistoryLoaderState>({
         runId: 0,
         phase: 'idle',
@@ -760,14 +761,24 @@ export function HappyThread(props: {
             }
 
             if (intent.isScrollingUp && intent.distanceFromBottom > MANUAL_SCROLL_EPSILON_PX) {
+                tailScrollInProgressRef.current = false
                 setAutoScrollMode(false)
                 setAtBottomMode(false)
                 return
             }
 
             if (intent.isNearBottom) {
+                tailScrollInProgressRef.current = false
                 setAutoScrollMode(true)
                 setAtBottomMode(true)
+                return
+            }
+
+            // An explicit jump-to-tail uses native smooth scrolling. Its
+            // intermediate scroll events are still far from the bottom and
+            // must not be mistaken for ordinary history browsing. Keep tail
+            // mode armed until the animation arrives or the user reverses it.
+            if (tailScrollInProgressRef.current) {
                 return
             }
 
@@ -976,6 +987,7 @@ export function HappyThread(props: {
     const scrollToBottom = useCallback(() => {
         const viewport = viewportRef.current
         if (viewport) {
+            tailScrollInProgressRef.current = true
             viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'smooth' })
             lastScrollTopRef.current = viewport.scrollTop
         }
@@ -989,6 +1001,7 @@ export function HappyThread(props: {
     // Reset state when session changes
     useLayoutEffect(() => {
         autoScrollEnabledRef.current = true
+        tailScrollInProgressRef.current = false
         lastScrollTopRef.current = viewportRef.current?.scrollTop ?? 0
         atBottomRef.current = true
         onViewModeChangeRef.current('tail')

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -107,7 +107,10 @@ export function prependMissingUserSnapshot(
 }
 
 const MESSAGE_ANCHOR_SELECTOR = '.happy-thread-messages > [id]'
-const AUTO_SCROLL_RESUME_THRESHOLD_PX = 120
+// Resume tail-following only once the user has actually reached the bottom.
+// A wider proximity threshold makes a downward-reading user enter tail mode
+// early; the next content/layout update then snaps the viewport to the end.
+const AUTO_SCROLL_RESUME_THRESHOLD_PX = 1
 const MANUAL_SCROLL_EPSILON_PX = 1
 const INITIAL_SCROLL_SETTLE_MS = 1800
 const INITIAL_SCROLL_SETTLE_DELAYS_MS = [0, 16, 50, 120, 250, 500, 900, 1400, 1800] as const
@@ -161,7 +164,7 @@ export function getScrollIntent(params: {
     const distanceFromBottom = params.scrollHeight - params.scrollTop - params.clientHeight
     return {
         distanceFromBottom,
-        isNearBottom: distanceFromBottom < thresholdPx,
+        isNearBottom: distanceFromBottom <= thresholdPx,
         isScrollingUp: params.scrollTop < params.previousScrollTop - MANUAL_SCROLL_EPSILON_PX
     }
 }


### PR DESCRIPTION
## Summary
- resume tail-following only after the viewport actually reaches the bottom
- prevent downward readers from being snapped past the final content
- add regression coverage for downward scrolling near the bottom

## Tests
- `cd web && bun run test -- HappyThread.test.tsx`
- `cd web && bun run typecheck`