### PR TITLE
fix(web): keep session date filter directly accessible

### DIFF
--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -208,6 +208,7 @@ describe('SessionList time filter', () => {
         expect(screen.queryByRole('button', { name: /Old session/ })).toBeNull()
         expect(screen.queryByPlaceholderText('Search sessions…')).toBeNull()
         expect(filterButton).toHaveAttribute('title', '2026-07-17 – 2026-07-18')
+        expect(filterButton).toHaveAccessibleName('Filter sessions by last activity: 2026-07-17 – 2026-07-18')
         expect(filterButton).toHaveFocus()
     })
 

--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -160,7 +160,7 @@ describe('SessionList time filter', () => {
         vi.useRealTimers()
     })
 
-    it('filters after selecting a start and end date', () => {
+    it('keeps the date filter beside collapsed search and filters without expanding it', () => {
         const recent = makeSession({
             id: 'recent',
             updatedAt: Date.now(),
@@ -188,8 +188,14 @@ describe('SessionList time filter', () => {
         expect(screen.getByRole('button', { name: /Recent session/ })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /Old session/ })).toBeInTheDocument()
 
-        fireEvent.click(screen.getByRole('button', { name: 'Search sessions' }))
-        fireEvent.click(screen.getByRole('button', { name: 'Filter sessions by last activity' }))
+        const searchButton = screen.getByRole('button', { name: 'Search sessions' })
+        const filterButton = screen.getByRole('button', { name: 'Filter sessions by last activity' })
+        expect(searchButton.nextElementSibling).toBe(filterButton)
+        expect(searchButton.parentElement).toBe(filterButton.parentElement)
+        expect(searchButton.parentElement).toHaveClass('relative', 'gap-1')
+        expect(screen.queryByPlaceholderText('Search sessions…')).toBeNull()
+
+        fireEvent.click(filterButton)
         const emptyDate = screen.getByRole('button', { name: new Date(2026, 6, 17).toLocaleDateString() })
         const activeDate = screen.getByRole('button', { name: `${new Date(2026, 6, 18).toLocaleDateString()}, has session activity` })
         expect(emptyDate).toHaveClass('text-[var(--app-hint)]')
@@ -200,6 +206,9 @@ describe('SessionList time filter', () => {
 
         expect(screen.getByRole('button', { name: /Recent session/ })).toBeInTheDocument()
         expect(screen.queryByRole('button', { name: /Old session/ })).toBeNull()
+        expect(screen.queryByPlaceholderText('Search sessions…')).toBeNull()
+        expect(filterButton).toHaveAttribute('title', '2026-07-17 – 2026-07-18')
+        expect(filterButton).toHaveFocus()
     })
 
     it('highlights today without requiring hover or session activity', () => {

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -702,7 +702,9 @@ function SessionListSearch(props: {
                         hasDateRange ? 'text-[var(--app-link)]' : 'text-[var(--app-hint)]'
                     )}
                     title={hasDateRange ? `${props.customStart} – ${props.customEnd}` : t('sessions.timeFilter.label')}
-                    aria-label={t('sessions.timeFilter.label')}
+                    aria-label={hasDateRange
+                        ? `${t('sessions.timeFilter.label')}: ${props.customStart} – ${props.customEnd}`
+                        : t('sessions.timeFilter.label')}
                     aria-expanded={datePickerOpen}
                 >
                     <CalendarIcon className="h-5 w-5" />

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -556,6 +556,7 @@ function SessionDateRangePicker(props: {
     onChange: (start: string, end: string) => void
     onClear: () => void
     onClose: () => void
+    align: 'left' | 'right'
 }) {
     const { t } = useTranslation()
     const initialDate = parseLocalDate(props.start) ?? new Date()
@@ -577,7 +578,10 @@ function SessionDateRangePicker(props: {
     }
 
     return (
-        <div className="absolute right-0 top-full z-30 mt-2 w-72 rounded-xl border border-[var(--app-border)] bg-[var(--app-bg)] p-3 shadow-xl">
+        <div className={cn(
+            'absolute top-full z-30 mt-2 w-72 rounded-xl border border-[var(--app-border)] bg-[var(--app-bg)] p-3 shadow-xl',
+            props.align === 'left' ? 'left-0' : 'right-0'
+        )}>
             <div className="mb-2 flex items-center justify-between">
                 <button
                     type="button"
@@ -668,8 +672,8 @@ function SessionListSearch(props: {
     const { t } = useTranslation()
     const [datePickerOpen, setDatePickerOpen] = useState(false)
     const inputRef = useRef<HTMLInputElement>(null)
+    const dateButtonRef = useRef<HTMLButtonElement>(null)
     const hasDateRange = Boolean(props.customStart && props.customEnd)
-    const hasActiveFilters = props.value.length > 0 || hasDateRange
 
     useEffect(() => {
         if (props.expanded) {
@@ -679,18 +683,85 @@ function SessionListSearch(props: {
         }
     }, [props.expanded])
 
+    const renderDateFilter = (variant: 'standalone' | 'embedded') => {
+        const returnFocus = () => {
+            (variant === 'embedded' ? inputRef.current : dateButtonRef.current)?.focus()
+        }
+
+        return (
+            <>
+                <button
+                    ref={dateButtonRef}
+                    type="button"
+                    onClick={() => setDatePickerOpen(open => !open)}
+                    className={cn(
+                        'relative shrink-0 transition-colors hover:bg-[var(--app-subtle-bg)]',
+                        variant === 'standalone'
+                            ? 'rounded-full p-1.5 hover:text-[var(--app-fg)]'
+                            : 'flex items-center rounded-r-lg rounded-l-md px-2',
+                        hasDateRange ? 'text-[var(--app-link)]' : 'text-[var(--app-hint)]'
+                    )}
+                    title={hasDateRange ? `${props.customStart} – ${props.customEnd}` : t('sessions.timeFilter.label')}
+                    aria-label={t('sessions.timeFilter.label')}
+                    aria-expanded={datePickerOpen}
+                >
+                    <CalendarIcon className="h-5 w-5" />
+                    {hasDateRange ? (
+                        <span className={cn(
+                            'absolute h-1.5 w-1.5 rounded-full bg-[var(--app-link)]',
+                            variant === 'standalone' ? 'right-0.5 top-0.5' : 'right-1 top-1'
+                        )} />
+                    ) : null}
+                </button>
+                {datePickerOpen ? (
+                    <>
+                        <button
+                            type="button"
+                            aria-label={t('sessions.timeFilter.close')}
+                            className="fixed inset-0 z-20 cursor-default"
+                            onClick={() => {
+                                setDatePickerOpen(false)
+                                returnFocus()
+                            }}
+                        />
+                        <SessionDateRangePicker
+                            start={props.customStart}
+                            end={props.customEnd}
+                            sessionActivityDates={props.sessionActivityDates}
+                            onChange={props.onDateRangeChange}
+                            onClear={() => {
+                                props.onDateRangeChange('', '')
+                                // The footer Clear button unmounts once the range is
+                                // empty; return focus so it does not drop to <body>.
+                                returnFocus()
+                            }}
+                            onClose={() => {
+                                setDatePickerOpen(false)
+                                returnFocus()
+                            }}
+                            align={variant === 'standalone' ? 'left' : 'right'}
+                        />
+                    </>
+                ) : null}
+            </>
+        )
+    }
+
     if (!props.expanded) {
         return (
-            <button
-                type="button"
-                onClick={() => props.onExpandedChange(true)}
-                className="relative shrink-0 rounded-full p-1.5 text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
-                title={t('sessions.search.open')}
-                aria-label={t('sessions.search.open')}
-            >
-                <SearchIcon className="h-5 w-5" />
-                {hasActiveFilters ? <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[var(--app-link)]" /> : null}
-            </button>
+            <div className="relative flex items-center gap-1">
+                <button
+                    type="button"
+                    onClick={() => props.onExpandedChange(true)}
+                    className="relative shrink-0 rounded-full p-1.5 text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
+                    title={t('sessions.search.open')}
+                    aria-label={t('sessions.search.open')}
+                >
+                    <SearchIcon className="h-5 w-5" />
+                    {props.value.length > 0 ? <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[var(--app-link)]" /> : null}
+                </button>
+                {renderDateFilter('standalone')}
+            </div>
         )
     }
 
@@ -730,44 +801,7 @@ function SessionListSearch(props: {
                 </button>
             ) : null}
             <div className="absolute inset-y-0 right-0 flex items-stretch">
-                <button
-                    type="button"
-                    onClick={() => setDatePickerOpen(open => !open)}
-                    className={cn(
-                        'relative flex items-center rounded-r-lg rounded-l-md px-2 transition-colors hover:bg-[var(--app-subtle-bg)]',
-                        hasDateRange ? 'text-[var(--app-link)]' : 'text-[var(--app-hint)]'
-                    )}
-                    title={hasDateRange ? `${props.customStart} – ${props.customEnd}` : t('sessions.timeFilter.label')}
-                    aria-label={t('sessions.timeFilter.label')}
-                    aria-expanded={datePickerOpen}
-                >
-                    <CalendarIcon className="h-5 w-5" />
-                    {hasDateRange ? <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-[var(--app-link)]" /> : null}
-                </button>
-                {datePickerOpen ? (
-                    <>
-                        <button type="button" aria-label={t('sessions.timeFilter.close')} className="fixed inset-0 z-20 cursor-default" onClick={() => {
-                            setDatePickerOpen(false)
-                            inputRef.current?.focus()
-                        }} />
-                        <SessionDateRangePicker
-                            start={props.customStart}
-                            end={props.customEnd}
-                            sessionActivityDates={props.sessionActivityDates}
-                            onChange={props.onDateRangeChange}
-                            onClear={() => {
-                                props.onDateRangeChange('', '')
-                                // The footer Clear button unmounts once the range is
-                                // empty; return focus so the wrapper blur still works.
-                                inputRef.current?.focus()
-                            }}
-                            onClose={() => {
-                                setDatePickerOpen(false)
-                                inputRef.current?.focus()
-                            }}
-                        />
-                    </>
-                ) : null}
+                {renderDateFilter('embedded')}
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary

- keep the session date filter visible beside the compact search action
- reuse the existing date picker in compact and expanded search modes
- preserve active-range indicators and return focus to the appropriate control
- add regression coverage for filtering by date without expanding text search

## Problem

The date filter works independently of a text query, but it was only reachable after expanding search. This made an independent filter look like part of text search and added an unnecessary interaction before filtering sessions by date.

Following the review feedback on #1309, this PR extracts only the date-filter accessibility fix. It does not add toolbar customization, action ordering or visibility settings, Refresh, a Codex import shortcut, or a persistent-search layout preference.

## Testing

- `bun typecheck`
- `cd web && bun run test -- src/components/SessionList.directory-action.test.tsx src/components/SessionList.machine-filter.test.tsx` (30 tests)
- `bun run test:web`
- `git diff --check origin/main...HEAD`
- manually verified on the port 3016 test deployment

## AI usage

AI-assisted with OpenAI Codex.
