### PR TITLE
fix(web): collapse expanded composer after successful send

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
@@ -14,6 +14,7 @@ import { HappyComposer, type ComposerSendError } from './HappyComposer'
  */
 type FakeAttachment = { id: string; status: { type: 'complete' } }
 type MockComposerInputProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+    asChild?: boolean
     maxRows?: number
     submitOnEnter?: boolean
     cancelOnEscape?: boolean
@@ -63,7 +64,14 @@ vi.mock('@assistant-ui/react', async () => {
                 <form onSubmit={onSubmit}>{children}</form>
             ),
             Input: React.forwardRef<HTMLTextAreaElement, MockComposerInputProps>(
-                ({ onChange, maxRows: _maxRows, submitOnEnter: _submitOnEnter, cancelOnEscape: _cancelOnEscape, ...props }, ref) => (
+                ({
+                    asChild: _asChild,
+                    onChange,
+                    maxRows: _maxRows,
+                    submitOnEnter: _submitOnEnter,
+                    cancelOnEscape: _cancelOnEscape,
+                    ...props
+                }, ref) => (
                     <textarea
                         {...props}
                         ref={ref}
@@ -107,9 +115,14 @@ vi.mock('@/components/AssistantChat/ComposerButtons', () => ({
         onSchedule: (pending: PendingSchedule) => void
         onClearSchedule: () => void
         pendingSchedule: PendingSchedule | null
+        expanded: boolean
+        onExpandedToggle: () => void
     }) => (
         <div>
             <button type="button" onClick={props.onSend}>send</button>
+            <button type="button" onClick={props.onExpandedToggle}>
+                {props.expanded ? 'collapse' : 'expand'}
+            </button>
             <button type="button" onClick={() => props.onSchedule({ type: 'absolute', ms: 9000 })}>select schedule</button>
             <button type="button" onClick={props.onClearSchedule}>clear schedule</button>
             <output data-testid="pending-schedule">{JSON.stringify(props.pendingSchedule)}</output>
@@ -124,6 +137,7 @@ type HarnessControls = {
     acceptAndClearSchedule: () => void
     remount: () => void
     programmaticSetText: (text: string) => void
+    acceptSend: () => void
     getClearErrorCalls: () => number
 }
 
@@ -140,6 +154,7 @@ function ComposerHarness(props: {
     const [schedule, setSchedule] = useState<PendingSchedule | null>(props.initialSchedule ?? null)
     const [sendError, setSendError] = useState<ComposerSendError | null>(null)
     const [composerKey, setComposerKey] = useState('composer-a')
+    const [sendAcceptedRevision, setSendAcceptedRevision] = useState(0)
     const clearErrorCallsRef = useRef(0)
     const pendingSendIntentRef = useRef<ComposerSendIntent>('default')
 
@@ -165,6 +180,7 @@ function ComposerHarness(props: {
             ...current,
             composer: { ...current.composer, text },
         })),
+        acceptSend: () => setSendAcceptedRevision((revision) => revision + 1),
         getClearErrorCalls: () => clearErrorCallsRef.current,
     }
 
@@ -174,6 +190,7 @@ function ComposerHarness(props: {
                 key={composerKey}
                 sessionId={composerKey}
                 pendingSchedule={schedule}
+                sendAcceptedRevision={sendAcceptedRevision}
                 onSchedule={setSchedule}
                 onClearSchedule={() => setSchedule(null)}
                 sendError={sendError}
@@ -234,6 +251,18 @@ describe('HappyComposer send-error atomic restore', () => {
     afterEach(() => {
         cleanup()
         runtime.setSnapshot = null
+    })
+
+    it('collapses an expanded composer only after the send is accepted', async () => {
+        const controls = renderComposer('message', null)
+        fireEvent.click(screen.getByRole('button', { name: 'expand' }))
+        expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded', 'true')
+
+        send()
+        expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded', 'true')
+
+        act(() => controls.current!.acceptSend())
+        await waitFor(() => expect(screen.getByTestId('composer-shell')).not.toHaveAttribute('data-expanded'))
     })
 
     it('restores untouched text and its absolute schedule after accepted-send clear', async () => {

--- a/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
@@ -139,6 +139,7 @@ type HarnessControls = {
     programmaticSetText: (text: string) => void
     acceptSend: () => void
     settleSend: (error?: ComposerSendError) => void
+    settleAttachmentSendFailure: () => void
     getClearErrorCalls: () => number
 }
 
@@ -156,7 +157,11 @@ function ComposerHarness(props: {
     const [sendError, setSendError] = useState<ComposerSendError | null>(null)
     const [isSending, setIsSending] = useState(false)
     const [composerKey, setComposerKey] = useState('composer-a')
-    const [sendAcceptedRevision, setSendAcceptedRevision] = useState(0)
+    const [sendAcceptance, setSendAcceptance] = useState<{ attemptId: string | null } | null>(null)
+    const [sendSettlement, setSendSettlement] = useState<{
+        attemptId: string
+        status: 'success' | 'error'
+    } | null>(null)
     const clearErrorCallsRef = useRef(0)
     const pendingSendIntentRef = useRef<ComposerSendIntent>('default')
 
@@ -184,10 +189,16 @@ function ComposerHarness(props: {
         })),
         acceptSend: () => {
             setIsSending(true)
-            setSendAcceptedRevision((revision) => revision + 1)
+            setSendSettlement(null)
+            setSendAcceptance({ attemptId: 'attempt-1' })
         },
         settleSend: (error) => {
             if (error) setSendError(error)
+            setSendSettlement({ attemptId: 'attempt-1', status: error ? 'error' : 'success' })
+            setIsSending(false)
+        },
+        settleAttachmentSendFailure: () => {
+            setSendSettlement({ attemptId: 'attempt-1', status: 'error' })
             setIsSending(false)
         },
         getClearErrorCalls: () => clearErrorCallsRef.current,
@@ -200,7 +211,8 @@ function ComposerHarness(props: {
                 sessionId={composerKey}
                 disabled={isSending}
                 pendingSchedule={schedule}
-                sendAcceptedRevision={sendAcceptedRevision}
+                sendAcceptance={sendAcceptance}
+                sendSettlement={sendSettlement}
                 onSchedule={setSchedule}
                 onClearSchedule={() => setSchedule(null)}
                 sendError={sendError}
@@ -288,6 +300,19 @@ describe('HappyComposer send-error atomic restore', () => {
 
         await waitFor(() => expect(input()).toHaveValue('message'))
         expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded', 'true')
+    })
+
+    it('keeps the composer expanded when an attachment send later fails', () => {
+        const controls = renderComposer('', null)
+        act(() => controls.current!.addAttachment())
+        fireEvent.click(screen.getByRole('button', { name: 'expand' }))
+        send()
+
+        act(() => controls.current!.acceptSend())
+        act(() => controls.current!.settleAttachmentSendFailure())
+
+        expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded', 'true')
+        expect(screen.queryByTestId('composer-send-error')).toBeNull()
     })
 
     it('restores untouched text and its absolute schedule after accepted-send clear', async () => {

--- a/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
@@ -138,6 +138,7 @@ type HarnessControls = {
     remount: () => void
     programmaticSetText: (text: string) => void
     acceptSend: () => void
+    settleSend: (error?: ComposerSendError) => void
     getClearErrorCalls: () => number
 }
 
@@ -153,6 +154,7 @@ function ComposerHarness(props: {
     }))
     const [schedule, setSchedule] = useState<PendingSchedule | null>(props.initialSchedule ?? null)
     const [sendError, setSendError] = useState<ComposerSendError | null>(null)
+    const [isSending, setIsSending] = useState(false)
     const [composerKey, setComposerKey] = useState('composer-a')
     const [sendAcceptedRevision, setSendAcceptedRevision] = useState(0)
     const clearErrorCallsRef = useRef(0)
@@ -180,7 +182,14 @@ function ComposerHarness(props: {
             ...current,
             composer: { ...current.composer, text },
         })),
-        acceptSend: () => setSendAcceptedRevision((revision) => revision + 1),
+        acceptSend: () => {
+            setIsSending(true)
+            setSendAcceptedRevision((revision) => revision + 1)
+        },
+        settleSend: (error) => {
+            if (error) setSendError(error)
+            setIsSending(false)
+        },
         getClearErrorCalls: () => clearErrorCallsRef.current,
     }
 
@@ -189,6 +198,7 @@ function ComposerHarness(props: {
             <HappyComposer
                 key={composerKey}
                 sessionId={composerKey}
+                disabled={isSending}
                 pendingSchedule={schedule}
                 sendAcceptedRevision={sendAcceptedRevision}
                 onSchedule={setSchedule}
@@ -253,7 +263,7 @@ describe('HappyComposer send-error atomic restore', () => {
         runtime.setSnapshot = null
     })
 
-    it('collapses an expanded composer only after the send is accepted', async () => {
+    it('collapses an expanded composer only after an accepted send succeeds', async () => {
         const controls = renderComposer('message', null)
         fireEvent.click(screen.getByRole('button', { name: 'expand' }))
         expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded', 'true')
@@ -262,7 +272,22 @@ describe('HappyComposer send-error atomic restore', () => {
         expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded', 'true')
 
         act(() => controls.current!.acceptSend())
+        expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded', 'true')
+
+        act(() => controls.current!.settleSend())
         await waitFor(() => expect(screen.getByTestId('composer-shell')).not.toHaveAttribute('data-expanded'))
+    })
+
+    it('keeps the composer expanded when an accepted send later fails', async () => {
+        const controls = renderComposer('message', null)
+        fireEvent.click(screen.getByRole('button', { name: 'expand' }))
+        send()
+
+        act(() => controls.current!.acceptSend())
+        act(() => controls.current!.settleSend(fail(1, 'message', null)))
+
+        await waitFor(() => expect(input()).toHaveValue('message'))
+        expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded', 'true')
     })
 
     it('restores untouched text and its absolute schedule after accepted-send clear', async () => {

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -363,8 +363,10 @@ export function HappyComposer(props: {
     sendError?: ComposerSendError | null
     onClearSendError?: () => void
     onSuppressSendErrorRestore?: (id: number) => void
-    /** Incremented by SessionChat after a send starts; collapse waits for its result. */
-    sendAcceptedRevision?: number
+    /** Emitted by SessionChat after a send is accepted. Null attempt ids are settled scratchlist sends. */
+    sendAcceptance?: { attemptId: string | null } | null
+    /** Terminal result for a chat mutation, including attachment-bearing failures. */
+    sendSettlement?: { attemptId: string; status: 'success' | 'error' } | null
     /**
      * One-shot intent bridge consumed by useHappyRuntime's onNew callback.
      * SessionChat owns this ref so the composer never retains an explicit
@@ -512,8 +514,8 @@ export function HappyComposer(props: {
         selection: { start: 0, end: 0 }
     })
     const [isExpanded, setIsExpanded] = useState(false)
-    const lastSendAcceptedRevisionRef = useRef(props.sendAcceptedRevision)
-    const collapseAfterSendRef = useRef(false)
+    const lastSendAcceptanceRef = useRef(props.sendAcceptance)
+    const pendingSendAttemptIdRef = useRef<string | null>(null)
     const [showSettings, setShowSettings] = useState(false)
     const [showPiModelPanel, setShowPiModelPanel] = useState(false)
     const [showPiThinkingPanel, setShowPiThinkingPanel] = useState(false)
@@ -527,20 +529,30 @@ export function HappyComposer(props: {
     const setPendingSchedule = isControlled ? onScheduleProp : setPendingScheduleLocal
 
     useEffect(() => {
-        const revision = props.sendAcceptedRevision
-        if (revision === undefined || revision === lastSendAcceptedRevisionRef.current) return
-        lastSendAcceptedRevisionRef.current = revision
-        collapseAfterSendRef.current = true
-    }, [props.sendAcceptedRevision])
+        const acceptance = props.sendAcceptance
+        if (!acceptance || acceptance === lastSendAcceptanceRef.current) return
+        lastSendAcceptanceRef.current = acceptance
+        if (acceptance.attemptId === null) {
+            pendingSendAttemptIdRef.current = null
+            setIsExpanded(false)
+            return
+        }
+        pendingSendAttemptIdRef.current = acceptance.attemptId
+        const settlement = props.sendSettlement
+        if (!settlement || settlement.attemptId !== acceptance.attemptId) return
+        pendingSendAttemptIdRef.current = null
+        if (settlement.status === 'success') setIsExpanded(false)
+    }, [props.sendAcceptance, props.sendSettlement])
 
-    // A chat mutation being accepted only means it started. Wait until its
-    // disabled/pending state settles so a route-level error can preserve the
-    // expanded retry surface instead of collapsing before the draft returns.
+    // Match the terminal mutation result to the exact accepted attempt. Text
+    // failures also expose sendError for draft restoration, while attachment
+    // failures intentionally do not, so settlement must be the outcome source.
     useEffect(() => {
-        if (!collapseAfterSendRef.current || disabled) return
-        collapseAfterSendRef.current = false
-        if (!sendError) setIsExpanded(false)
-    }, [disabled, sendError])
+        const settlement = props.sendSettlement
+        if (!settlement || settlement.attemptId !== pendingSendAttemptIdRef.current) return
+        pendingSendAttemptIdRef.current = null
+        if (settlement.status === 'success') setIsExpanded(false)
+    }, [props.sendSettlement])
 
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const richInputRef = useRef<RichComposerInputHandle>(null)

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -363,7 +363,7 @@ export function HappyComposer(props: {
     sendError?: ComposerSendError | null
     onClearSendError?: () => void
     onSuppressSendErrorRestore?: (id: number) => void
-    /** Incremented by SessionChat after the send mutation is accepted. */
+    /** Incremented by SessionChat after a send starts; collapse waits for its result. */
     sendAcceptedRevision?: number
     /**
      * One-shot intent bridge consumed by useHappyRuntime's onNew callback.
@@ -513,6 +513,7 @@ export function HappyComposer(props: {
     })
     const [isExpanded, setIsExpanded] = useState(false)
     const lastSendAcceptedRevisionRef = useRef(props.sendAcceptedRevision)
+    const collapseAfterSendRef = useRef(false)
     const [showSettings, setShowSettings] = useState(false)
     const [showPiModelPanel, setShowPiModelPanel] = useState(false)
     const [showPiThinkingPanel, setShowPiThinkingPanel] = useState(false)
@@ -529,8 +530,17 @@ export function HappyComposer(props: {
         const revision = props.sendAcceptedRevision
         if (revision === undefined || revision === lastSendAcceptedRevisionRef.current) return
         lastSendAcceptedRevisionRef.current = revision
-        setIsExpanded(false)
+        collapseAfterSendRef.current = true
     }, [props.sendAcceptedRevision])
+
+    // A chat mutation being accepted only means it started. Wait until its
+    // disabled/pending state settles so a route-level error can preserve the
+    // expanded retry surface instead of collapsing before the draft returns.
+    useEffect(() => {
+        if (!collapseAfterSendRef.current || disabled) return
+        collapseAfterSendRef.current = false
+        if (!sendError) setIsExpanded(false)
+    }, [disabled, sendError])
 
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const richInputRef = useRef<RichComposerInputHandle>(null)

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -363,6 +363,8 @@ export function HappyComposer(props: {
     sendError?: ComposerSendError | null
     onClearSendError?: () => void
     onSuppressSendErrorRestore?: (id: number) => void
+    /** Incremented by SessionChat after the send mutation is accepted. */
+    sendAcceptedRevision?: number
     /**
      * One-shot intent bridge consumed by useHappyRuntime's onNew callback.
      * SessionChat owns this ref so the composer never retains an explicit
@@ -510,6 +512,7 @@ export function HappyComposer(props: {
         selection: { start: 0, end: 0 }
     })
     const [isExpanded, setIsExpanded] = useState(false)
+    const lastSendAcceptedRevisionRef = useRef(props.sendAcceptedRevision)
     const [showSettings, setShowSettings] = useState(false)
     const [showPiModelPanel, setShowPiModelPanel] = useState(false)
     const [showPiThinkingPanel, setShowPiThinkingPanel] = useState(false)
@@ -521,6 +524,13 @@ export function HappyComposer(props: {
     const isControlled = onScheduleProp !== undefined
     const pendingSchedule = isControlled ? (pendingScheduleProp ?? null) : pendingScheduleLocal
     const setPendingSchedule = isControlled ? onScheduleProp : setPendingScheduleLocal
+
+    useEffect(() => {
+        const revision = props.sendAcceptedRevision
+        if (revision === undefined || revision === lastSendAcceptedRevisionRef.current) return
+        lastSendAcceptedRevisionRef.current = revision
+        setIsExpanded(false)
+    }, [props.sendAcceptedRevision])
 
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const richInputRef = useRef<RichComposerInputHandle>(null)
@@ -1055,6 +1065,7 @@ export function HappyComposer(props: {
                 await prepared.beforeClear()
                 api.composer().setText('')
                 await api.composer().clearAttachments()
+                setIsExpanded(false)
             } finally {
                 parkInFlightRef.current = false
                 setIsParkingScratchlist(false)

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1506,6 +1506,7 @@ function SessionChatInner(props: SessionChatProps) {
     // absolute epoch-ms using Date.now() at that moment (send-time base for presets).
     const [pendingSchedule, setPendingSchedule] = useState<PendingSchedule | null>(null)
     const [pendingScheduleRevision, setPendingScheduleRevision] = useState(0)
+    const [sendAcceptedRevision, setSendAcceptedRevision] = useState(0)
     const updatePendingSchedule = useCallback((next: PendingSchedule | null) => {
         setPendingSchedule(next)
         setPendingScheduleRevision((revision) => revision + 1)
@@ -1586,6 +1587,7 @@ function SessionChatInner(props: SessionChatProps) {
         })
         const accepted = await onSendForComposer(text, attachments, scheduledAt, deliveryMode)
         if (!accepted) return
+        setSendAcceptedRevision((revision) => revision + 1)
         if (!routedToScratchlist) {
             // Clear pendingSchedule only after the mutation is actually
             // accepted - covers both pre-mutation guards AND async
@@ -1781,6 +1783,7 @@ function SessionChatInner(props: SessionChatProps) {
                         resolveSessionMentionTooltip={resolveSessionMentionTooltip}
                         disabled={props.isSending}
                         pendingSchedule={pendingSchedule}
+                        sendAcceptedRevision={sendAcceptedRevision}
                         onSchedule={updatePendingSchedule}
                         onClearSchedule={() => updatePendingSchedule(null)}
                         permissionMode={props.session.permissionMode}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -73,6 +73,7 @@ import { consumeSharePendingTransfer } from '@/lib/sharePendingState'
 import { deleteShareTransfer, getShareTransfer } from '@/lib/shareTransfer'
 import { getDraft } from '@/lib/composer-drafts'
 import { useTranslation } from '@/lib/use-translation'
+import type { SendMessageAcceptance, SendMessageSettlement } from '@/hooks/mutations/useSendMessage'
 import { SessionHeader } from '@/components/SessionHeader'
 import { CursorMigrationBanner } from '@/components/CursorMigrationBanner'
 import { TeamPanel } from '@/components/TeamPanel'
@@ -405,7 +406,7 @@ export function ScratchlistDrawerHost(props: {
         attachments?: AttachmentMetadata[],
         scheduledAt?: number | null,
         deliveryMode?: MessageDeliveryMode,
-    ) => Promise<boolean>
+    ) => Promise<boolean | SendMessageAcceptance>
     onExitScratchlistMode: () => void
     disabled?: boolean
 }) {
@@ -443,7 +444,7 @@ export function ScratchlistDrawerHost(props: {
         if (accepted) {
             props.onExitScratchlistMode()
         }
-        return accepted
+        return Boolean(accepted)
     }, [props.api, props.disabled, props.onSend, props.onExitScratchlistMode, props.sessionId])
     return (
         <ScratchlistDrawer
@@ -493,6 +494,7 @@ type SessionChatProps = {
     isSyncingTail: boolean
     isLoadingMoreMessages: boolean
     isSending: boolean
+    sendSettlement: SendMessageSettlement | null
     viewMode: 'tail' | 'history'
     messagesVersion: number
     historyVersion: number
@@ -500,7 +502,7 @@ type SessionChatProps = {
     onRefresh: () => void
     onLoadMore: (onBeforeApply?: (historyVersion: number) => boolean) => Promise<OlderLoadOutcome>
     onCancelLoadMore: () => void
-    // Resolves true when the send was accepted by the underlying mutation, false when
+    // Returns the accepted mutation's attempt id, or false when
     // pre-mutation guards (no-api / no-session / pending) rejected the call OR async
     // inactive-session resume failed. Composer state that should only be cleared on
     // actual send (pendingSchedule) must await this — see handleSend below.
@@ -509,7 +511,7 @@ type SessionChatProps = {
         attachments?: AttachmentMetadata[],
         scheduledAt?: number | null,
         deliveryMode?: MessageDeliveryMode,
-    ) => Promise<boolean>
+    ) => Promise<SendMessageAcceptance | false>
     onViewModeChange: (mode: 'tail' | 'history') => void
     onRetryMessage?: (localId: string) => void
     autocompleteSuggestions?: (query: string) => Promise<Suggestion[]>
@@ -769,7 +771,7 @@ function SessionChatInner(props: SessionChatProps) {
             attachments?: AttachmentMetadata[],
             scheduledAt?: number | null,
             deliveryMode: MessageDeliveryMode = 'queue',
-        ): Promise<boolean> => {
+        ): Promise<{ attemptId: string | null } | false> => {
             if (
                 scratchlistMode
                 && scheduledAt == null
@@ -788,7 +790,7 @@ function SessionChatInner(props: SessionChatProps) {
                     attachments,
                     accepted,
                 )
-                return accepted
+                return accepted ? { attemptId: null } : false
             }
             // If the user uploaded while scratchlist mode was on, then toggled
             // it off before send, pending items still carry hub paths. Stage
@@ -1506,7 +1508,7 @@ function SessionChatInner(props: SessionChatProps) {
     // absolute epoch-ms using Date.now() at that moment (send-time base for presets).
     const [pendingSchedule, setPendingSchedule] = useState<PendingSchedule | null>(null)
     const [pendingScheduleRevision, setPendingScheduleRevision] = useState(0)
-    const [sendAcceptedRevision, setSendAcceptedRevision] = useState(0)
+    const [sendAcceptance, setSendAcceptance] = useState<{ attemptId: string | null } | null>(null)
     const updatePendingSchedule = useCallback((next: PendingSchedule | null) => {
         setPendingSchedule(next)
         setPendingScheduleRevision((revision) => revision + 1)
@@ -1587,7 +1589,7 @@ function SessionChatInner(props: SessionChatProps) {
         })
         const accepted = await onSendForComposer(text, attachments, scheduledAt, deliveryMode)
         if (!accepted) return
-        setSendAcceptedRevision((revision) => revision + 1)
+        setSendAcceptance({ attemptId: accepted.attemptId })
         if (!routedToScratchlist) {
             // Clear pendingSchedule only after the mutation is actually
             // accepted - covers both pre-mutation guards AND async
@@ -1783,7 +1785,8 @@ function SessionChatInner(props: SessionChatProps) {
                         resolveSessionMentionTooltip={resolveSessionMentionTooltip}
                         disabled={props.isSending}
                         pendingSchedule={pendingSchedule}
-                        sendAcceptedRevision={sendAcceptedRevision}
+                        sendAcceptance={sendAcceptance}
+                        sendSettlement={props.sendSettlement}
                         onSchedule={updatePendingSchedule}
                         onClearSchedule={() => updatePendingSchedule(null)}
                         permissionMode={props.session.permissionMode}

--- a/web/src/hooks/mutations/useSendMessage.test.tsx
+++ b/web/src/hooks/mutations/useSendMessage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
-import { useSendMessage } from './useSendMessage'
+import { useSendMessage, type SendMessageAcceptance } from './useSendMessage'
 import { ApiError, type ApiClient } from '@/api/client'
 
 vi.mock('@/lib/message-window-store', () => ({
@@ -63,6 +63,10 @@ describe('useSendMessage', () => {
 
         await waitFor(() => {
             expect(onSuccess).toHaveBeenCalledWith('session-A')
+        })
+        expect(result.current.sendSettlement).toEqual({
+            attemptId: 'local-id-1',
+            status: 'success',
         })
     })
 
@@ -478,6 +482,10 @@ describe('useSendMessage', () => {
             await waitFor(() => {
                 expect(updateMock).toHaveBeenCalledWith('session-A', 'local-id-1', 'failed')
             })
+            expect(result.current.sendSettlement).toEqual({
+                attemptId: 'local-id-1',
+                status: 'error',
+            })
             // No composer-restore: onError is NOT fired and the optimistic
             // row is NOT removed -- both would destroy the attachment UX.
             expect(onError).not.toHaveBeenCalled()
@@ -555,17 +563,17 @@ describe('useSendMessage', () => {
         expect(onSuccess).not.toHaveBeenCalled()
     })
 
-    it('resolves true when the send is accepted', async () => {
+    it('returns the attempt id when the send is accepted', async () => {
         const api = createMockApi()
         const { result } = renderHook(
             () => useSendMessage(api, 'session-A'),
             { wrapper: createWrapper() },
         )
-        let acceptedPromise: Promise<boolean> | undefined
+        let acceptedPromise: Promise<SendMessageAcceptance | false> | undefined
         act(() => {
             acceptedPromise = result.current.sendMessage('hello')
         })
-        await expect(acceptedPromise!).resolves.toBe(true)
+        await expect(acceptedPromise!).resolves.toEqual({ attemptId: 'local-id-1' })
     })
 
     it('resolves false when blocked (no api) so the caller can preserve schedule state', async () => {
@@ -574,7 +582,7 @@ describe('useSendMessage', () => {
             () => useSendMessage(null, 'session-A', { onBlocked }),
             { wrapper: createWrapper() },
         )
-        let acceptedPromise: Promise<boolean> | undefined
+        let acceptedPromise: Promise<SendMessageAcceptance | false> | undefined
         act(() => {
             acceptedPromise = result.current.sendMessage('hello')
         })
@@ -588,7 +596,7 @@ describe('useSendMessage', () => {
             () => useSendMessage(api, null),
             { wrapper: createWrapper() },
         )
-        let acceptedPromise: Promise<boolean> | undefined
+        let acceptedPromise: Promise<SendMessageAcceptance | false> | undefined
         act(() => {
             acceptedPromise = result.current.sendMessage('hello')
         })
@@ -605,14 +613,14 @@ describe('useSendMessage', () => {
             }),
             { wrapper: createWrapper() },
         )
-        let acceptedPromise: Promise<boolean> | undefined
+        let acceptedPromise: Promise<SendMessageAcceptance | false> | undefined
         act(() => {
             acceptedPromise = result.current.sendMessage('hello')
         })
         await expect(acceptedPromise!).resolves.toBe(false)
     })
 
-    it('resolves true after async resolveSessionId succeeds and mutation starts', async () => {
+    it('returns the attempt id after async resolveSessionId succeeds and mutation starts', async () => {
         const api = createMockApi()
         const { result } = renderHook(
             () => useSendMessage(api, 'session-original', {
@@ -621,11 +629,11 @@ describe('useSendMessage', () => {
             }),
             { wrapper: createWrapper() },
         )
-        let acceptedPromise: Promise<boolean> | undefined
+        let acceptedPromise: Promise<SendMessageAcceptance | false> | undefined
         act(() => {
             acceptedPromise = result.current.sendMessage('hello')
         })
-        await expect(acceptedPromise!).resolves.toBe(true)
+        await expect(acceptedPromise!).resolves.toEqual({ attemptId: 'local-id-1' })
     })
 
     // #918: the inactive-session 409 path

--- a/web/src/hooks/mutations/useSendMessage.ts
+++ b/web/src/hooks/mutations/useSendMessage.ts
@@ -23,6 +23,15 @@ type SendMessageInput = {
     deliveryMode: MessageDeliveryMode
 }
 
+export type SendMessageAcceptance = {
+    attemptId: string
+}
+
+export type SendMessageSettlement = {
+    attemptId: string
+    status: 'success' | 'error'
+}
+
 type BlockedReason = 'no-api' | 'no-session' | 'pending'
 
 /**
@@ -159,7 +168,7 @@ export function useSendMessage(
     sessionId: string | null,
     options?: UseSendMessageOptions
 ): {
-    // Resolves true when a mutation was actually started, false when the call was
+    // Returns the started mutation's attempt id, or false when the call was
     // rejected pre-mutation (no-api / no-session / pending) OR the async
     // resolveSessionId step threw. Async is required because inactive-session
     // resume happens before mutation.mutate(), and a sync `true` would let the
@@ -170,12 +179,14 @@ export function useSendMessage(
         attachments?: AttachmentMetadata[],
         scheduledAt?: number | null,
         deliveryMode?: MessageDeliveryMode,
-    ) => Promise<boolean>
+    ) => Promise<SendMessageAcceptance | false>
     retryMessage: (localId: string) => boolean
     isSending: boolean
+    sendSettlement: SendMessageSettlement | null
 } {
     const { haptic } = usePlatform()
     const [isResolving, setIsResolving] = useState(false)
+    const [sendSettlement, setSendSettlement] = useState<SendMessageSettlement | null>(null)
     const resolveGuardRef = useRef(false)
     const isSessionThinkingRef = useRef(options?.isSessionThinking ?? false)
     isSessionThinkingRef.current = options?.isSessionThinking ?? false
@@ -200,6 +211,7 @@ export function useSendMessage(
             return { successStatus }
         },
         onSuccess: (_, input, context) => {
+            setSendSettlement({ attemptId: input.localId, status: 'success' })
             updateMessageStatus(
                 input.sessionId,
                 input.localId,
@@ -209,6 +221,7 @@ export function useSendMessage(
             options?.onSuccess?.(input.sessionId)
         },
         onError: (error, input) => {
+            setSendSettlement({ attemptId: input.localId, status: 'error' })
             // Attachment sends keep the legacy failed-bubble UX: the
             // composer-restore path can only re-seat text + scheduledAt,
             // not the uploaded attachment metadata.  Removing the row
@@ -246,7 +259,7 @@ export function useSendMessage(
         attachments?: AttachmentMetadata[],
         scheduledAt?: number | null,
         deliveryMode: MessageDeliveryMode = 'queue',
-    ): Promise<boolean> => {
+    ): Promise<SendMessageAcceptance | false> => {
         if (!api) {
             options?.onBlocked?.('no-api')
             haptic.notification('error')
@@ -309,7 +322,7 @@ export function useSendMessage(
             scheduledAt,
             deliveryMode,
         })
-        return true
+        return { attemptId: localId }
     }
 
     const retryMessage = (localId: string): boolean => {
@@ -349,5 +362,6 @@ export function useSendMessage(
         sendMessage,
         retryMessage,
         isSending: mutation.isPending || isResolving,
+        sendSettlement,
     }
 }

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -487,6 +487,7 @@ function SessionPage() {
         sendMessage,
         retryMessage,
         isSending,
+        sendSettlement,
     } = useSendMessage(api, sessionId, {
         isSessionThinking: session?.thinking ?? false,
         onSuccess: (sentSessionId) => {
@@ -751,6 +752,7 @@ function SessionPage() {
             isSyncingTail={messagesSyncingTail}
             isLoadingMoreMessages={messagesLoadingMore}
             isSending={isSending}
+            sendSettlement={sendSettlement}
             viewMode={messagesViewMode}
             messagesVersion={messagesVersion}
             historyVersion={historyVersion}


### PR DESCRIPTION
## Summary

- collapse the expanded composer only after the exact accepted chat send settles successfully
- keep the composer expanded for text-only and attachment-bearing mutation failures
- preserve restored draft state for pre-mutation rejections and asynchronous text-send failures
- collapse the composer after a successful scratchlist park
- retain queue delivery provenance for abort-restored prompts

## Context

Follow-up to #1319. After expanding the composer, a successful send cleared the draft but left the empty editor occupying the full conversation area until it was collapsed manually.

`assistant-ui` exposes `composer.send()` as a fire-and-forget API, while `useSendMessage` reports acceptance once the mutation starts. The send hook now returns that mutation's attempt id and emits an explicit terminal settlement for both text and attachment sends. The composer matches the settlement to the accepted attempt, collapsing only on success; failures remain expanded even when attachment UX intentionally uses a failed thread bubble instead of `sendError`.

Pre-mutation guards and inactive-session resume failures never emit an accepted attempt, so they also leave retryable state visible. The abort-restore error record explicitly uses queue delivery, matching retry semantics and satisfying the shared `RawSendError` contract.

## Testing

- `bun run typecheck`
- `bun run test:web` — 238 files passed, 2121 tests passed

## AI disclosure

Implementation and tests were assisted by OpenAI Codex (GPT-5.6).
