### PR TITLE
fix(agy): make conversation discovery deterministic at session start

### DIFF
--- a/cli/src/agy/agyPtyLauncher.test.ts
+++ b/cli/src/agy/agyPtyLauncher.test.ts
@@ -1,15 +1,18 @@
 /**
  * Tests for the brain-UUID discovery wiring in AgyPtyLauncher.
  *
- * Bug context (2026-07-03 diagnosis): the PreToolUse hook discovers the agy
- * brain UUID and calls `session.onSessionFound(uuid)` to persist it to
- * session metadata, but nothing ever told the scanner about it — the scanner
- * only started tailing once its OWN content-match found the brain. For a
- * first message with attachments, content-match fails (see
- * agySessionScanner.test.ts), so the chat stayed empty even though the hook
- * had already discovered the UUID. Root-cause fix: register a
- * sessionFoundCallback on the shared AgentSessionBase registry so any
- * discovery path (hook OR scanner content-match) notifies the scanner.
+ * Bug context (2026-07-03 diagnosis, since generalized): the PreToolUse hook
+ * discovers the agy brain UUID and calls `session.onSessionFound(uuid)` to
+ * persist it to session metadata, but nothing ever told the scanner about
+ * it — the scanner only started tailing once its OWN transcript content-match
+ * found the brain, which failed outright for a first message with
+ * attachments. Root-cause fix: register a sessionFoundCallback on the shared
+ * AgentSessionBase registry so hook discovery notifies the scanner.
+ *
+ * The content-match fallback itself was removed once the PreToolUse and
+ * PreInvocation hooks became the sole, authoritative discovery path (see
+ * agySessionScanner.ts and the 2026-08-04 agy-preinvocation-discovery plan);
+ * this file now only exercises the hook -> scanner bridge.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -19,7 +22,6 @@ import { userRequestMatches } from './agyPtyLauncher'
 
 const harness = vi.hoisted(() => ({
     scannerOnNewSession: vi.fn(),
-    scannerSetSessionMessageText: vi.fn(),
     scannerCleanupCalls: 0,
     scannerOpts: null as Record<string, unknown> | null,
     scannerBrainUuid: null as string | null,
@@ -32,6 +34,11 @@ const harness = vi.hoisted(() => ({
     switchHandler: null as (() => void | Promise<void>) | null,
     liveModelHandler: null as ((model: string | null) => Promise<void>) | null,
     afterNextMessage: null as null | ((opts: any, next: unknown) => void | Promise<void>),
+    // Number of launchOnce rounds the mocked respawn loop runs before
+    // stopping (see the RemoteLauncherBase mock below). Defaults to 1 to
+    // match every existing test's single-spawn assumption; a respawn test
+    // bumps this to exercise a second launchOnce call.
+    respawnRounds: 1,
 }))
 
 let ptyOptsCaptured: any = null
@@ -55,7 +62,6 @@ vi.mock('./utils/agySessionScanner', async (importOriginal) => {
             harness.scannerOpts = opts
             return {
                 cleanup: async () => { harness.scannerCleanupCalls += 1 },
-                setSessionMessageText: harness.scannerSetSessionMessageText,
                 getBrainUuid: () => harness.scannerBrainUuid,
                 onNewSession: harness.scannerOnNewSession,
             }
@@ -125,12 +131,26 @@ vi.mock('@/modules/common/remote/RemoteLauncherBase', () => ({
             harness.exitReason = reason
             await handler()
         }
-        // Simplified respawn loop: runs launchOnce exactly once (no retry/backoff)
-        // so the wiring test resolves deterministically.
+        // Simplified respawn loop: runs launchOnce for harness.respawnRounds
+        // rounds (default 1, no retry/backoff) so most wiring tests resolve
+        // deterministically after a single spawn. A respawn-path test bumps
+        // harness.respawnRounds to observe a second launchOnce call (each
+        // round re-reads whatever `this.agySessionId` currently is, exactly
+        // like the real loop's launchOnce -> agyPty(resumeSessionId) wiring).
         protected async runRespawnLoop(opts: { launchOnce: (signal: AbortSignal) => Promise<unknown> }): Promise<void> {
-            const controller = new AbortController()
-            this.ptyAbortController = controller
-            await opts.launchOnce(controller.signal)
+            for (let round = 0; round < harness.respawnRounds; round += 1) {
+                // Round 0 always runs regardless of harness.exitReason — several
+                // describe blocks' afterEach hooks leave a leftover 'exit' value
+                // set as a defensive default between tests, and this mock must
+                // match the original single-shot behavior (which never checked
+                // exitReason at all) for every test that never opts into a
+                // respawn. Only rounds AFTER the first are gated on it, so a
+                // respawn test naturally stops once the session actually ends.
+                if (round > 0 && harness.exitReason) break
+                const controller = new AbortController()
+                this.ptyAbortController = controller
+                await opts.launchOnce(controller.signal)
+            }
             this.ptyAbortController = null
         }
         async start(): Promise<string> {
@@ -199,7 +219,6 @@ function createSessionStub(opts?: { agyPermissionHandler?: Record<string, unknow
 describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
     afterEach(() => {
         harness.scannerOnNewSession.mockClear()
-        harness.scannerSetSessionMessageText.mockClear()
         harness.scannerCleanupCalls = 0
         harness.scannerOpts = null
         harness.scannerBrainUuid = null
@@ -211,6 +230,7 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
         harness.switchHandler = null
         harness.liveModelHandler = null
         harness.afterNextMessage = null
+        harness.respawnRounds = 1
         ptyOptsCaptured = null
     })
 
@@ -221,19 +241,6 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
 
         expect(session.client.emitSessionReady).toHaveBeenCalledTimes(1)
         expect(session.client.sendSessionEvent).toHaveBeenCalledWith({ type: 'ready' })
-    })
-
-    it('surfaces ambiguous brain discovery without exposing conversation identities', async () => {
-        const { session } = createSessionStub()
-
-        await agyPtyLauncher(session as never)
-        const onDiscoveryAmbiguous = harness.scannerOpts!.onDiscoveryAmbiguous as (count: number) => void
-        onDiscoveryAmbiguous(2)
-
-        expect(session.client.sendSessionEvent).toHaveBeenCalledWith({
-            type: 'error',
-            message: 'Antigravity session could not be identified because 2 conversations matched the first message. Continue in the terminal or start a new session with a more specific prompt.',
-        })
     })
 
     it('changes the live AGY model only after the picker and completion markers are observed', async () => {
@@ -378,15 +385,19 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
         await launcherPromise
     })
 
-    it('persists the discovered UUID so a later PTY onMessage does not re-fire session.onSessionFound (hostile-review finding: crash-recovery resume gap)', async () => {
-        // Root-cause regression guard for a gap the initial fix missed: the hook
-        // callback must persist the uuid through the shared launcher contract
-        // handleSessionFound does (this.claudeSessionId = sessionId), otherwise a
-        // respawn between hook discovery and the next PTY output chunk would read
-        // a stale null resumeSessionId and silently start a fresh brain instead of
-        // resuming. onMessage's `if (!this.agySessionId)` fallback guard doubles as
-        // an oracle here: if the hook path failed to persist agySessionId, this
-        // guard would incorrectly re-fire session.onSessionFound on the next chunk.
+    it('persists the discovered UUID through a respawn, so the next agy spawn resumes via --conversation instead of silently starting a fresh brain (hostile-review finding: crash-recovery resume gap)', async () => {
+        // Root-cause regression guard (Fix 7 deleted the previous version of this
+        // guard along with the onMessage getBrainUuid() fallback it used as an
+        // oracle — that oracle was itself dead code, but the invariant it
+        // protected is not: handleSessionFound must persist the uuid to
+        // this.agySessionId synchronously, otherwise a PTY crash/respawn between
+        // hook discovery and the next spawn reads a stale null resumeSessionId
+        // and silently starts a fresh brain instead of resuming the one the user
+        // was already talking to. This version drives an actual second
+        // launchOnce round (via harness.respawnRounds) and inspects the args the
+        // NEXT spawn would actually be launched with — the real symptom of the
+        // original defect — instead of a proxy assertion on the first spawn.
+        harness.respawnRounds = 2
         const { session } = createSessionStub()
         const msgPromise = deferred<{ message: string } | null>()
         vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
@@ -394,18 +405,31 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
         const launcherPromise = agyPtyLauncher(session as never)
         await tick(20)
 
+        expect(harness.foundCallbacks).toHaveLength(1)
+        // First spawn has no brain yet: resumeSessionId is unset.
+        expect(ptyOptsCaptured.resumeSessionId).toBeUndefined()
+
+        // The hook fires mid-round-1 (agy's PreToolUse/PreInvocation hook ->
+        // session.onSessionFound -> this handleSessionFound), then round 1 ends
+        // (e.g. the PTY crashes) and the mocked respawn loop starts round 2.
         harness.foundCallbacks[0]('hook-discovered-uuid')
-        // The real scanner's onNewSession() synchronously updates foundBrainUuid,
-        // so getBrainUuid() reflects it immediately — mirror that here.
-        harness.scannerBrainUuid = 'hook-discovered-uuid'
+        msgPromise.resolve(null)
+        await tick(20)
 
-        expect(ptyOptsCaptured).toBeTruthy()
-        ptyOptsCaptured.onMessage('some pty output chunk')
-
-        expect(session.onSessionFound).not.toHaveBeenCalled()
+        // ptyOptsCaptured now reflects the SECOND agyPty(...) call (round 2's
+        // spawn args) — this is the assertion that fails if handleSessionFound
+        // stops persisting agySessionId synchronously: resumeSessionId would
+        // read back undefined and buildAgyPtyArgs would omit --conversation.
+        expect(ptyOptsCaptured.resumeSessionId).toBe('hook-discovered-uuid')
+        // Real (non-mocked) buildAgyPtyArgs, fetched via importActual so the
+        // shared `./agyPty` mock (used by every other test in this file for
+        // agyPty itself) stays untouched — this is the pure arg-builder that
+        // turns resumeSessionId into the actual `--conversation <uuid>` CLI
+        // flag agy would be launched with.
+        const { buildAgyPtyArgs } = await vi.importActual<typeof import('./agyPty')>('./agyPty')
+        expect(buildAgyPtyArgs(ptyOptsCaptured).join(' ')).toContain('--conversation hook-discovered-uuid')
 
         harness.exitReason = 'exit'
-        msgPromise.resolve(null)
         await launcherPromise
     })
 
@@ -422,18 +446,6 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
         await agyPtyLauncher(session as never)
 
         expect(harness.scannerCleanupCalls).toBe(1)
-    })
-
-    it('forwards a queued user message with the current scanner interface', async () => {
-        const { session } = createSessionStub()
-        vi.mocked(session.queue.waitForMessagesAndGetAsString)
-            .mockResolvedValueOnce({ message: 'hello agy', mode: 'default' } as never)
-        harness.afterNextMessage = async (opts) => {
-            await opts.onBeforeMessageSubmit?.('hello agy')
-        }
-
-        await expect(agyPtyLauncher(session as never)).resolves.toBe('exit')
-        expect(harness.scannerSetSessionMessageText).toHaveBeenCalledWith('hello agy')
     })
 
     it('acknowledges a dequeued web message only after a matching USER_INPUT is observed', async () => {
@@ -603,8 +615,6 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
         await agyPtyLauncher(session as never)
 
         expect(session.client.emitMessagesConsumed).toHaveBeenCalledWith(['local-clear'])
-        expect(harness.scannerSetSessionMessageText).toHaveBeenCalledOnce()
-        expect(harness.scannerSetSessionMessageText).toHaveBeenCalledWith('following prompt')
     })
 
     it('ends the launcher instead of respawning when PTY exits with an unconfirmed web delivery', async () => {
@@ -875,6 +885,140 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
         harness.exitReason = 'exit'
         msgPromise.resolve(null)
         await launcherPromise
+    })
+})
+
+// Fix 6 (hostile-review round 1): dropping the scanner's content-match
+// discovery also dropped onDiscoveryAmbiguous, which used to be the ONLY
+// path that ever told the user discovery had failed. Without a replacement,
+// a hook that never fires (misconfigured bridge, hooks.json didn't load, a
+// future agy version drops the field, ...) leaves the web chat silently
+// empty forever with no explanation. These tests pin the one-shot timeout
+// warning that replaces it.
+describe('agyPtyLauncher discovery-timeout warning (Fix 6)', () => {
+    afterEach(() => {
+        vi.useRealTimers()
+        harness.scannerOnNewSession.mockClear()
+        harness.scannerCleanupCalls = 0
+        harness.scannerOpts = null
+        harness.scannerBrainUuid = null
+        harness.foundCallbacks = []
+        harness.removedCallbacks = []
+        harness.exitReason = null
+        harness.sendKeys.mockClear()
+        harness.abortHandler = null
+        harness.switchHandler = null
+        harness.liveModelHandler = null
+        harness.afterNextMessage = null
+        harness.respawnRounds = 1
+        ptyOptsCaptured = null
+    })
+
+    const errorEvents = (session: ReturnType<typeof createSessionStub>['session']) =>
+        vi.mocked(session.client.sendSessionEvent).mock.calls
+            .map(([event]) => event as { type: string; message?: string })
+            .filter((event) => event.type === 'error')
+
+    it('does not warn when the PTY is ready but idle — no message ever submitted, no model call started (Fix 9 N1 regression guard)', async () => {
+        // onReady only means the TUI prompt can accept keystrokes; a user who
+        // spawns agy and reads the prompt for a minute (or switches away) before
+        // typing anything is a completely normal, common flow — not a discovery
+        // failure. Before Fix 9 (which armed on onReady instead of the first
+        // evidence of an actual model call), this was a false positive that
+        // fired for every idle new session and burned the one-shot latch before
+        // a real failure could ever be reported.
+        vi.useFakeTimers()
+        const { session } = createSessionStub()
+        const msgPromise = deferred<{ message: string } | null>()
+        vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
+
+        const launcherPromise = agyPtyLauncher(session as never)
+        await vi.advanceTimersByTimeAsync(0)
+
+        // Idle: never call onThinkingChange(true), never fire the discovery
+        // hook — just let well over the timeout window pass.
+        await vi.advanceTimersByTimeAsync(120_000)
+
+        expect(errorEvents(session)).toHaveLength(0)
+
+        harness.exitReason = 'exit'
+        msgPromise.resolve(null)
+        await launcherPromise
+    })
+
+    it('does not warn when the brain UUID is discovered before the timeout elapses', async () => {
+        vi.useFakeTimers()
+        const { session } = createSessionStub()
+        const msgPromise = deferred<{ message: string } | null>()
+        vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
+
+        const launcherPromise = agyPtyLauncher(session as never)
+        await vi.advanceTimersByTimeAsync(0)
+
+        // A model call actually starts — this is what arms the timer now.
+        ptyOptsCaptured.onThinkingChange(true)
+        harness.foundCallbacks[0]('hook-discovered-uuid')
+        await vi.advanceTimersByTimeAsync(60_000)
+
+        expect(errorEvents(session)).toHaveLength(0)
+
+        harness.exitReason = 'exit'
+        msgPromise.resolve(null)
+        await launcherPromise
+    })
+
+    it('warns exactly once when a model call starts but the brain UUID is never discovered within the timeout (no duplicate notifications)', async () => {
+        vi.useFakeTimers()
+        const { session } = createSessionStub()
+        const msgPromise = deferred<{ message: string } | null>()
+        vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
+
+        const launcherPromise = agyPtyLauncher(session as never)
+        await vi.advanceTimersByTimeAsync(0)
+
+        // The model call starting (thinking=true) is what arms the timer —
+        // covers both a web-queued submission and text typed directly into the
+        // terminal, since both eventually flip agy's busy marker.
+        ptyOptsCaptured.onThinkingChange(true)
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        expect(errorEvents(session)).toHaveLength(1)
+        expect(errorEvents(session)[0]!.message).toMatch(/continue in the terminal/i)
+
+        // Time continuing to pass (e.g. a respawn cycle) must not re-fire it.
+        await vi.advanceTimersByTimeAsync(120_000)
+        expect(errorEvents(session)).toHaveLength(1)
+
+        harness.exitReason = 'exit'
+        msgPromise.resolve(null)
+        await launcherPromise
+    })
+
+    it('clears the pending timer on session teardown — no leak, no late fire after exit', async () => {
+        vi.useFakeTimers()
+        const { session } = createSessionStub()
+        const msgPromise = deferred<{ message: string } | null>()
+        vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
+
+        const launcherPromise = agyPtyLauncher(session as never)
+        await vi.advanceTimersByTimeAsync(0)
+
+        // Arm the timer first (a model call started) so teardown actually has
+        // something pending to clear — without this the assertions below would
+        // pass vacuously regardless of whether clearDiscoveryTimeoutWarning()
+        // does anything, since an unarmed timer trivially leaves 0 pending.
+        ptyOptsCaptured.onThinkingChange(true)
+        expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+        harness.exitReason = 'exit'
+        msgPromise.resolve(null)
+        await launcherPromise
+
+        expect(vi.getTimerCount()).toBe(0)
+
+        vi.mocked(session.client.sendSessionEvent).mockClear()
+        await vi.advanceTimersByTimeAsync(60_000)
+        expect(errorEvents(session)).toHaveLength(0)
     })
 })
 

--- a/cli/src/agy/agyPtyLauncher.test.ts
+++ b/cli/src/agy/agyPtyLauncher.test.ts
@@ -1150,6 +1150,40 @@ describe('agyPtyLauncher PreInvocation self-detach/respawn-reattach (Phase 2.7)'
         await launcherPromise
     })
 
+    it('6) aborts before agy ever spawns when the carrier cannot be recreated (Fix 1: fail-closed)', async () => {
+        harness.carrierIntact = false
+        // harness.carrierRecreateResult stays undefined (afterEach's reset
+        // default) — simulates prepareAgyHookCarrier() failing (ENOSPC, an
+        // unwritable HAPI_HOME, ...).
+        const { session } = createSessionStub({
+            hookCarrierDir: '/tmp/carrier-fail',
+            hooksJsonWithPreInvocation: HOOKS_JSON_WITH,
+            hooksJsonWithoutPreInvocation: HOOKS_JSON_WITHOUT,
+        })
+
+        const launcherPromise = agyPtyLauncher(session as never)
+
+        // Fails (mutation check: revert syncPreInvocationHookForLaunch's
+        // `if (!recreated)` branch back to log-and-return) if the launcher
+        // resolves/exits cleanly instead of propagating the fail-closed abort.
+        await expect(launcherPromise).rejects.toThrow(/hook carrier/i)
+
+        // The explicit ask this test guards: agyPty (and therefore
+        // --dangerously-skip-permissions) must never be spawned when the
+        // permission bridge cannot be rebuilt. ptyOptsCaptured is only ever
+        // set from inside the mocked agyPty() body (see the top-of-file
+        // vi.mock('./agyPty', ...)), so it staying null proves agyPty was
+        // never invoked for this launch.
+        expect(ptyOptsCaptured).toBeNull()
+
+        // The web chat must show WHY the session ended, not just that it
+        // did — mirrors the discovery-timeout warning's
+        // sendSessionEvent({type:'error'}) (Fix 6, above).
+        expect(session.client.sendSessionEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'error' })
+        )
+    })
+
     it('5) detach/reattach do not disturb the existing discovery or resume wiring', async () => {
         harness.respawnRounds = 2
         const { session } = createSessionStub({

--- a/cli/src/agy/agyPtyLauncher.test.ts
+++ b/cli/src/agy/agyPtyLauncher.test.ts
@@ -39,6 +39,26 @@ const harness = vi.hoisted(() => ({
     // match every existing test's single-spawn assumption; a respawn test
     // bumps this to exercise a second launchOnce call.
     respawnRounds: 1,
+    // Phase 2.7 (PreInvocation self-detach/respawn-reattach): every
+    // writeAgyHooksJsonAtomic call the launcher makes, in order, so tests can
+    // assert both WHICH content was written and WHEN (detach on discovery vs.
+    // reattach before a respawn).
+    hooksJsonWrites: [] as Array<{ carrierDir: string; content: string }>,
+    // Whether agyHookCarrierIsIntact() should report the carrier as present.
+    // Flipping this to false simulates the carrier vanishing (e.g. /tmp's
+    // 30-day tmpfiles.d sweep) between the initial spawn and a respawn.
+    carrierIntact: true,
+    // prepareAgyHookCarrier() call count/result for the carrier-recreation path.
+    carrierRecreateCalls: 0,
+    carrierRecreateResult: undefined as { carrierDir: string } | undefined,
+    // hooks.json content prepareAgyHookCarrier() was actually invoked with,
+    // one entry per call — R5-2: the carrier-recreation path has its own
+    // WITH/WITHOUT variant selection (syncPreInvocationHookForLaunch's
+    // `desired`, independent of the in-place writeAgyHooksJsonAtomic path
+    // that hooksJsonWrites already tracks) and nothing was asserting it, so
+    // a regression there (e.g. reverting to always pass `withDiscovery`)
+    // could pass the full suite silently.
+    carrierRecreateContents: [] as string[],
 }))
 
 let ptyOptsCaptured: any = null
@@ -68,6 +88,18 @@ vi.mock('./utils/agySessionScanner', async (importOriginal) => {
         }),
     }
 })
+
+vi.mock('./utils/agyHookCarrier', () => ({
+    writeAgyHooksJsonAtomic: vi.fn((carrierDir: string, content: string) => {
+        harness.hooksJsonWrites.push({ carrierDir, content })
+    }),
+    agyHookCarrierIsIntact: vi.fn(() => harness.carrierIntact),
+    prepareAgyHookCarrier: vi.fn((content: string) => {
+        harness.carrierRecreateCalls += 1
+        harness.carrierRecreateContents.push(content)
+        return harness.carrierRecreateResult
+    }),
+}))
 
 vi.mock('@/ui/ink/RemoteModeDisplay', () => ({
     RemoteModeDisplay: () => null,
@@ -137,7 +169,10 @@ vi.mock('@/modules/common/remote/RemoteLauncherBase', () => ({
         // harness.respawnRounds to observe a second launchOnce call (each
         // round re-reads whatever `this.agySessionId` currently is, exactly
         // like the real loop's launchOnce -> agyPty(resumeSessionId) wiring).
-        protected async runRespawnLoop(opts: { launchOnce: (signal: AbortSignal) => Promise<unknown> }): Promise<void> {
+        protected async runRespawnLoop(opts: {
+            launchOnce: (signal: AbortSignal) => Promise<unknown>
+            onLaunchStart?: (isNewSession: boolean) => void
+        }): Promise<void> {
             for (let round = 0; round < harness.respawnRounds; round += 1) {
                 // Round 0 always runs regardless of harness.exitReason — several
                 // describe blocks' afterEach hooks leave a leftover 'exit' value
@@ -147,6 +182,10 @@ vi.mock('@/modules/common/remote/RemoteLauncherBase', () => ({
                 // respawn. Only rounds AFTER the first are gated on it, so a
                 // respawn test naturally stops once the session actually ends.
                 if (round > 0 && harness.exitReason) break
+                // Mirrors RemoteLauncherBase's real runRespawnLoop: onLaunchStart
+                // runs synchronously before every launchOnce, including the
+                // first — see runAgy.ts's Phase 2.7 syncPreInvocationHookForLaunch call.
+                opts.onLaunchStart?.(round === 0)
                 const controller = new AbortController()
                 this.ptyAbortController = controller
                 await opts.launchOnce(controller.signal)
@@ -169,7 +208,17 @@ function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
 
 const tick = (ms = 0) => new Promise((r) => setTimeout(r, ms))
 
-function createSessionStub(opts?: { agyPermissionHandler?: Record<string, unknown> | null }) {
+function createSessionStub(opts?: {
+    agyPermissionHandler?: Record<string, unknown> | null
+    // Phase 2.7: the PreInvocation self-detach/respawn-reattach cycle only
+    // engages when these are set (mirrors runAgy.ts leaving them undefined
+    // outside PTY mode) — omitted by default so every pre-existing test in
+    // this file exercises the same no-op path it always has.
+    hookCarrierDir?: string
+    hooksJsonWithPreInvocation?: string
+    hooksJsonWithoutPreInvocation?: string
+    hookMcpServer?: { command: string; args?: string[] }
+}) {
     const passedHandler = opts?.agyPermissionHandler
     // Merge a default registerQuestionRequest/cancelPendingQuestions into
     // whatever the test passes, so tests that only care about one method
@@ -184,36 +233,39 @@ function createSessionStub(opts?: { agyPermissionHandler?: Record<string, unknow
             cancelAll: vi.fn(),
             ...(passedHandler ?? {}),
         }
-    return {
-        session: {
-            sessionId: null,
-            path: '/tmp/agy-pty-test',
-            hookCarrierDir: undefined,
-            hookPort: undefined,
-            hookToken: undefined,
-            agyPermissionHandler,
-            getModel: () => null,
-            setLiveModelHandler: (handler: ((model: string | null) => Promise<void>) | null) => { harness.liveModelHandler = handler },
-            onThinkingChange: vi.fn(),
-            setKillHandler: (_h: () => void) => {},
-            onSessionFound: vi.fn(),
-            addSessionFoundCallback: (cb: (sessionId: string) => void) => { harness.foundCallbacks.push(cb) },
-            removeSessionFoundCallback: (cb: (sessionId: string) => void) => { harness.removedCallbacks.push(cb) },
-            queue: {
-                waitForMessagesAndGetAsString: vi.fn().mockResolvedValue(null),
-            },
-            client: {
-                sendAgySessionMessage: vi.fn(),
-                sendSessionEvent: vi.fn(),
-                emitSessionReady: vi.fn(),
-                emitMessagesConsumed: vi.fn(),
-                resetAgentTerminal: vi.fn(),
-                setAgentTerminalControls: vi.fn(),
-                emitAgentTerminalOutput: vi.fn(),
-                rpcHandlerManager: { registerHandler: () => {} },
-            },
+    const session = {
+        sessionId: null as string | null,
+        path: '/tmp/agy-pty-test',
+        hookCarrierDir: opts?.hookCarrierDir,
+        hookPort: undefined,
+        hookToken: undefined,
+        hooksJsonWithPreInvocation: opts?.hooksJsonWithPreInvocation,
+        hooksJsonWithoutPreInvocation: opts?.hooksJsonWithoutPreInvocation,
+        hookMcpServer: opts?.hookMcpServer,
+        setHookCarrierDir: (dir: string) => { session.hookCarrierDir = dir },
+        agyPermissionHandler,
+        getModel: () => null,
+        setLiveModelHandler: (handler: ((model: string | null) => Promise<void>) | null) => { harness.liveModelHandler = handler },
+        onThinkingChange: vi.fn(),
+        setKillHandler: (_h: () => void) => {},
+        onSessionFound: vi.fn(),
+        addSessionFoundCallback: (cb: (sessionId: string) => void) => { harness.foundCallbacks.push(cb) },
+        removeSessionFoundCallback: (cb: (sessionId: string) => void) => { harness.removedCallbacks.push(cb) },
+        queue: {
+            waitForMessagesAndGetAsString: vi.fn().mockResolvedValue(null),
+        },
+        client: {
+            sendAgySessionMessage: vi.fn(),
+            sendSessionEvent: vi.fn(),
+            emitSessionReady: vi.fn(),
+            emitMessagesConsumed: vi.fn(),
+            resetAgentTerminal: vi.fn(),
+            setAgentTerminalControls: vi.fn(),
+            emitAgentTerminalOutput: vi.fn(),
+            rpcHandlerManager: { registerHandler: () => {} },
         },
     }
+    return { session }
 }
 
 describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
@@ -231,6 +283,11 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
         harness.liveModelHandler = null
         harness.afterNextMessage = null
         harness.respawnRounds = 1
+        harness.hooksJsonWrites = []
+        harness.carrierIntact = true
+        harness.carrierRecreateCalls = 0
+        harness.carrierRecreateResult = undefined
+        harness.carrierRecreateContents = []
         ptyOptsCaptured = null
     })
 
@@ -888,6 +945,246 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
     })
 })
 
+// Phase 2.7 (agy-preinvocation-discovery plan §6.6/§8): PreInvocation fires
+// on EVERY model call (measured ~424ms round trip) but is only useful until
+// the brain UUID is confirmed — after that it's pure waste. agy re-reads
+// hooks.json before every model call, so the carrier's hooks.json can be
+// rewritten in place to drop PreInvocation once discovery succeeds, and
+// restored before every respawn (a resume that silently fails would
+// otherwise leave no way to discover the replacement conversation's UUID).
+describe('agyPtyLauncher PreInvocation self-detach/respawn-reattach (Phase 2.7)', () => {
+    afterEach(() => {
+        harness.scannerOnNewSession.mockClear()
+        harness.scannerCleanupCalls = 0
+        harness.scannerOpts = null
+        harness.scannerBrainUuid = null
+        harness.foundCallbacks = []
+        harness.removedCallbacks = []
+        harness.exitReason = null
+        harness.sendKeys.mockClear()
+        harness.abortHandler = null
+        harness.switchHandler = null
+        harness.liveModelHandler = null
+        harness.afterNextMessage = null
+        harness.respawnRounds = 1
+        harness.hooksJsonWrites = []
+        harness.carrierIntact = true
+        harness.carrierRecreateCalls = 0
+        harness.carrierRecreateResult = undefined
+        harness.carrierRecreateContents = []
+        ptyOptsCaptured = null
+    })
+
+    const HOOKS_JSON_WITH = '{"hapi-bridge":{"PreToolUse":[{"matcher":"*","hooks":[{"command":"pre-tool-use-cmd","timeout":3600}]}],"PreInvocation":[{"type":"command","command":"pre-invocation-cmd","timeout":5}]}}'
+    const HOOKS_JSON_WITHOUT = '{"hapi-bridge":{"PreToolUse":[{"matcher":"*","hooks":[{"command":"pre-tool-use-cmd","timeout":3600}]}]}}'
+
+    it('1) drops the PreInvocation block once the brain UUID is confirmed, leaving PreToolUse untouched', async () => {
+        const { session } = createSessionStub({
+            hookCarrierDir: '/tmp/carrier-a',
+            hooksJsonWithPreInvocation: HOOKS_JSON_WITH,
+            hooksJsonWithoutPreInvocation: HOOKS_JSON_WITHOUT,
+        })
+        const msgPromise = deferred<{ message: string } | null>()
+        vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
+
+        const launcherPromise = agyPtyLauncher(session as never)
+        await tick(20)
+        // Round 1's onLaunchStart already reattached once (idempotent restore
+        // of the same with-discovery content the carrier was born with) —
+        // clear it so this test only inspects the discovery-triggered write.
+        harness.hooksJsonWrites = []
+
+        harness.foundCallbacks[0]('hook-discovered-uuid')
+
+        // Fails if handleSessionFound stops calling detachPreInvocationHook,
+        // or if it writes the wrong (with-discovery) content, or writes to
+        // the wrong carrier directory.
+        expect(harness.hooksJsonWrites).toHaveLength(1)
+        expect(harness.hooksJsonWrites[0].carrierDir).toBe('/tmp/carrier-a')
+        const parsed = JSON.parse(harness.hooksJsonWrites[0].content)
+        const group = Object.values(parsed)[0] as { PreToolUse: Array<{ matcher: string }>; PreInvocation?: unknown }
+        expect(group.PreInvocation).toBeUndefined()
+        expect(group.PreToolUse[0].matcher).toBe('*')
+
+        harness.exitReason = 'exit'
+        msgPromise.resolve(null)
+        await launcherPromise
+    })
+
+    it('2) keeps PreInvocation detached across a respawn once the brain UUID is already known (Fix N1)', async () => {
+        harness.respawnRounds = 2
+        const { session } = createSessionStub({
+            hookCarrierDir: '/tmp/carrier-b',
+            hooksJsonWithPreInvocation: HOOKS_JSON_WITH,
+            hooksJsonWithoutPreInvocation: HOOKS_JSON_WITHOUT,
+        })
+        const msgPromise = deferred<{ message: string } | null>()
+        vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
+
+        const launcherPromise = agyPtyLauncher(session as never)
+        await tick(20)
+        harness.hooksJsonWrites = []
+
+        // Discovery detaches PreInvocation mid-round-1 (e.g. the PTY then crashes).
+        harness.foundCallbacks[0]('hook-discovered-uuid')
+        expect(harness.hooksJsonWrites).toHaveLength(1)
+        expect(harness.hooksJsonWrites[0].content).toBe(HOOKS_JSON_WITHOUT)
+
+        // Round 1 ends and the mocked respawn loop starts round 2 — its
+        // onLaunchStart must NOT re-arm PreInvocation: this.agySessionId is
+        // already set from the discovery above, so syncPreInvocationHookForLaunch
+        // writes WITHOUT again (a no-op re-assertion of the current state),
+        // not WITH. Before Fix N1 this wrote WITH unconditionally, silently
+        // undoing detachPreInvocationHook's work on every single respawn —
+        // the exact bug this test now guards against (see
+        // agyPtyLauncher.ts:syncPreInvocationHookForLaunch's docstring for why
+        // resuming the SAME brain via --conversation makes re-arming
+        // pointless: a resume failure is out of scope, per Fix N2).
+        msgPromise.resolve(null)
+        await tick(20)
+
+        // Fails (mutation check: revert syncPreInvocationHookForLaunch to always
+        // write `withDiscovery`) if PreInvocation gets re-armed on a respawn
+        // after discovery already succeeded.
+        expect(harness.hooksJsonWrites).toHaveLength(2)
+        expect(harness.hooksJsonWrites[1].content).toBe(HOOKS_JSON_WITHOUT)
+        expect(harness.hooksJsonWrites[1].carrierDir).toBe('/tmp/carrier-b')
+
+        harness.exitReason = 'exit'
+        await launcherPromise
+    })
+
+    it('3) detaches PreInvocation on the very first launch when the session is resume-seeded, and it stays detached across a respawn (Fix N1)', async () => {
+        harness.respawnRounds = 2
+        const { session } = createSessionStub({
+            hookCarrierDir: '/tmp/carrier-resume',
+            hooksJsonWithPreInvocation: HOOKS_JSON_WITH,
+            hooksJsonWithoutPreInvocation: HOOKS_JSON_WITHOUT,
+        })
+        // Mirrors loop.ts calling session.onSessionFound(resumeSessionId)
+        // BEFORE the launcher is constructed — by the time AgyPtyLauncher's
+        // constructor runs, session.sessionId is already the resumed UUID,
+        // so this.agySessionId is seeded, and no PreToolUse/PreInvocation
+        // hook will ever fire addSessionFoundCallback's handleSessionFound
+        // for it (first-wins guard: wrapper.sessionId is already set).
+        session.sessionId = 'resumed-uuid'
+
+        const msgPromise = deferred<{ message: string } | null>()
+        vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
+
+        const launcherPromise = agyPtyLauncher(session as never)
+        await tick(20)
+
+        // Fails (mutation check: revert syncPreInvocationHookForLaunch to always
+        // write `withDiscovery`) if a resume-seeded session's first launch
+        // still writes WITH — before Fix N1 this never wrote WITHOUT at all
+        // for a resume, since handleSessionFound (the only other writer of
+        // WITHOUT) never fires for it.
+        expect(harness.hooksJsonWrites).toHaveLength(1)
+        expect(harness.hooksJsonWrites[0].content).toBe(HOOKS_JSON_WITHOUT)
+        expect(harness.hooksJsonWrites[0].carrierDir).toBe('/tmp/carrier-resume')
+
+        // No PreToolUse/PreInvocation hook fires in this test (harness.foundCallbacks
+        // is never invoked) — the resumed conversation is assumed to keep
+        // resuming successfully, which is the common case (resume-failure
+        // detection is explicitly out of scope, per Fix N2).
+        msgPromise.resolve(null)
+        await tick(20)
+
+        expect(harness.hooksJsonWrites).toHaveLength(2)
+        expect(harness.hooksJsonWrites[1].content).toBe(HOOKS_JSON_WITHOUT)
+
+        harness.exitReason = 'exit'
+        await launcherPromise
+    })
+
+    it('4) recreates a vanished carrier before a respawn and repoints hookCarrierDir for the next agy spawn', async () => {
+        harness.respawnRounds = 2
+        harness.carrierIntact = false
+        harness.carrierRecreateResult = { carrierDir: '/tmp/carrier-c-recreated' }
+        const { session } = createSessionStub({
+            hookCarrierDir: '/tmp/carrier-c-original',
+            hooksJsonWithPreInvocation: HOOKS_JSON_WITH,
+            hooksJsonWithoutPreInvocation: HOOKS_JSON_WITHOUT,
+        })
+        const msgPromise = deferred<{ message: string } | null>()
+        vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
+
+        const launcherPromise = agyPtyLauncher(session as never)
+        await tick(20)
+        harness.carrierRecreateCalls = 0
+        // Round 1's onLaunchStart already recreated the carrier once (the
+        // brain UUID isn't known yet at that point, so it recreated with
+        // `withDiscovery`) — reset alongside carrierRecreateCalls so what's
+        // left below is only round 2's call, the one this test actually
+        // targets (recreation happening AFTER discovery, before a respawn).
+        harness.carrierRecreateContents = []
+
+        harness.foundCallbacks[0]('hook-discovered-uuid')
+        msgPromise.resolve(null)
+        await tick(20)
+
+        // Fails if the launcher writes to the (now-nonexistent) old carrier
+        // path instead of checking agyHookCarrierIsIntact() and rebuilding,
+        // or if it forgets to repoint session.hookCarrierDir afterward.
+        expect(harness.carrierRecreateCalls).toBe(1)
+        expect(session.hookCarrierDir).toBe('/tmp/carrier-c-recreated')
+        // R5-2: the recreation path picks its own WITH/WITHOUT variant
+        // independently of the in-place writeAgyHooksJsonAtomic path — by
+        // this point in the test, discovery already happened
+        // (this.agySessionId is set), so the carrier must be recreated with
+        // WITHOUT, never WITH. Mutation check: reverting
+        // agyPtyLauncher.ts's prepareAgyHookCarrier(desired, ...) call back
+        // to prepareAgyHookCarrier(withDiscovery, ...) keeps every assertion
+        // above green (carrierRecreateCalls, hookCarrierDir, --add-dir all
+        // still pass) while this one alone catches PreInvocation getting
+        // silently re-armed on the recreated carrier.
+        expect(harness.carrierRecreateContents).toEqual([HOOKS_JSON_WITHOUT])
+        // The recreated carrier is what the SECOND agy spawn must actually
+        // use for --add-dir — this is the real symptom a stale hookCarrierDir
+        // would produce (agy launched pointed at a directory that no longer
+        // carries any hooks at all).
+        expect(ptyOptsCaptured.hookCarrierDir).toBe('/tmp/carrier-c-recreated')
+
+        harness.exitReason = 'exit'
+        await launcherPromise
+    })
+
+    it('5) detach/reattach do not disturb the existing discovery or resume wiring', async () => {
+        harness.respawnRounds = 2
+        const { session } = createSessionStub({
+            hookCarrierDir: '/tmp/carrier-d',
+            hooksJsonWithPreInvocation: HOOKS_JSON_WITH,
+            hooksJsonWithoutPreInvocation: HOOKS_JSON_WITHOUT,
+        })
+        const msgPromise = deferred<{ message: string } | null>()
+        vi.mocked(session.queue.waitForMessagesAndGetAsString).mockImplementation(() => msgPromise.promise)
+
+        const launcherPromise = agyPtyLauncher(session as never)
+        await tick(20)
+
+        harness.foundCallbacks[0]('hook-discovered-uuid')
+        // The scanner bridge (pre-existing discovery wiring) must still fire
+        // despite the hooks.json rewrite alongside it.
+        expect(harness.scannerOnNewSession).toHaveBeenCalledWith('hook-discovered-uuid')
+
+        msgPromise.resolve(null)
+        await tick(20)
+
+        // Fails if detachPreInvocationHook/syncPreInvocationHookForLaunch throw
+        // (breaking the launcher's promise chain) or otherwise corrupt
+        // this.agySessionId — the pre-existing crash-recovery guard (round 2
+        // must resume the SAME conversation via --conversation) is the oracle.
+        expect(ptyOptsCaptured.resumeSessionId).toBe('hook-discovered-uuid')
+        expect(ptyOptsCaptured.hookCarrierDir).toBe(session.hookCarrierDir)
+        const { buildAgyPtyArgs } = await vi.importActual<typeof import('./agyPty')>('./agyPty')
+        expect(buildAgyPtyArgs(ptyOptsCaptured).join(' ')).toContain('--conversation hook-discovered-uuid')
+
+        harness.exitReason = 'exit'
+        await launcherPromise
+    })
+})
+
 // Fix 6 (hostile-review round 1): dropping the scanner's content-match
 // discovery also dropped onDiscoveryAmbiguous, which used to be the ONLY
 // path that ever told the user discovery had failed. Without a replacement,
@@ -911,6 +1208,11 @@ describe('agyPtyLauncher discovery-timeout warning (Fix 6)', () => {
         harness.liveModelHandler = null
         harness.afterNextMessage = null
         harness.respawnRounds = 1
+        harness.hooksJsonWrites = []
+        harness.carrierIntact = true
+        harness.carrierRecreateCalls = 0
+        harness.carrierRecreateResult = undefined
+        harness.carrierRecreateContents = []
         ptyOptsCaptured = null
     })
 

--- a/cli/src/agy/agyPtyLauncher.ts
+++ b/cli/src/agy/agyPtyLauncher.ts
@@ -23,6 +23,20 @@ const QUOTA_DETECTOR_RAW_TAIL_SIZE = 8 * 1024
 const QUOTA_ANCHOR = 'Individual quota reached. Please upgrade your subscription to increase your limits.'
 const QUOTA_SCREEN_CONTEXT = "How's the CLI experience so far? Help us improve:"
 
+// Brain-UUID discovery (see runAgy.ts's PreToolUse/PreInvocation hooks) is
+// the only way this launcher learns the agy conversation ID; there is no
+// content-matching fallback anymore. If a model call has actually started
+// (see the onThinkingChange wiring below — NOT just "the PTY is ready",
+// which fires the moment the prompt is usable and says nothing about a
+// model having been invoked yet) and neither hook has fired within this
+// window (bridge misconfigured, hooks.json didn't load, future agy version
+// drops the field, ...), the web chat would otherwise sit silently empty
+// forever with no explanation other than the terminal mirror. 60s
+// comfortably covers the latency to a model's first response (and thus the
+// first PreInvocation/PreToolUse hook firing) without leaving the user in
+// the dark for an excessive stretch if discovery is genuinely broken.
+const DISCOVERY_TIMEOUT_MS = 60_000
+
 function stripTerminalControlSequences(raw: string): string {
     let clean = ''
     for (let index = 0; index < raw.length; index += 1) {
@@ -109,7 +123,6 @@ export function userRequestMatches(message: string, content: string): boolean {
 class AgyPtyLauncher extends RemoteLauncherBase {
     private readonly session: AgySession
     private scanner: any = null
-    private firstMessageSent = false
     // The agy brain UUID for the current conversation. Set from the pre-known
     // resume ID (if this is a resume) or adopted via handleSessionFound, which
     // is fed by agy's PreToolUse/PreInvocation hook (see
@@ -138,6 +151,36 @@ class AgyPtyLauncher extends RemoteLauncherBase {
     private pendingWebDelivery: PendingWebDelivery | null = null
     private pendingWebDeliveryResolved: (() => void) | null = null
     private activeWebPrompt: string | null = null
+    // One-shot "discovery never happened" warning. Armed on the first real
+    // evidence a model call is in flight (onThinkingChange(true) — NOT PTY
+    // ready, which only means the prompt can accept keystrokes and can sit
+    // idle for as long as the user likes with no discovery failure at all)
+    // and disarmed the moment a brain UUID is adopted or the session tears
+    // down — never rearmed, so a respawn cannot re-trigger it and a stale
+    // timer cannot fire (or leak) after the launcher is done.
+    private discoveryTimeoutTimer: ReturnType<typeof setTimeout> | null = null
+    private discoveryTimeoutFired = false
+
+    private armDiscoveryTimeoutWarning(): void {
+        if (this.agySessionId || this.discoveryTimeoutFired || this.discoveryTimeoutTimer) return
+        this.discoveryTimeoutTimer = setTimeout(() => {
+            this.discoveryTimeoutTimer = null
+            if (this.agySessionId || this.discoveryTimeoutFired) return
+            this.discoveryTimeoutFired = true
+            logger.warn(`[agy-pty]: brain UUID not discovered within ${DISCOVERY_TIMEOUT_MS}ms of the first model call; notifying the web chat`)
+            this.session.client.sendSessionEvent({
+                type: 'error',
+                message: 'Antigravity conversation could not be identified — continue in the terminal.',
+            })
+        }, DISCOVERY_TIMEOUT_MS)
+    }
+
+    private clearDiscoveryTimeoutWarning(): void {
+        if (this.discoveryTimeoutTimer) {
+            clearTimeout(this.discoveryTimeoutTimer)
+            this.discoveryTimeoutTimer = null
+        }
+    }
 
     private waitForPendingWebDelivery(signal: AbortSignal): Promise<void> {
         if (!this.pendingWebDelivery) return Promise.resolve()
@@ -493,17 +536,23 @@ class AgyPtyLauncher extends RemoteLauncherBase {
                     }
                     this.session.client.emitAgentTerminalOutput(data)
                     this.detectQuotaOutput(data)
-                    if (!this.agySessionId) {
-                        const discovered = this.scanner.getBrainUuid()
-                        if (discovered) {
-                            logger.debug(`[agy-pty]: brain UUID discovered: ${discovered}`)
-                            this.agySessionId = discovered
-                            this.session.onSessionFound(discovered)
-                        }
-                    }
                 },
                 onThinkingChange: (thinking: boolean) => {
                     this.session.onThinkingChange(thinking)
+                    // Fix 9 (hostile-review round 2): onReady only means the TUI
+                    // prompt is usable, not that a model call happened — a user
+                    // who spawns agy and reads the prompt for a minute before
+                    // typing anything is completely normal, not a discovery
+                    // failure. thinking=true is driven by agy's busy marker
+                    // ("Generating") in the raw PTY output (see AGY_BUSY_MARKERS,
+                    // agyPty.ts) as well as HAPI's own optimistic post-submit
+                    // signal, so it fires for BOTH a web-queued message and text
+                    // typed directly into the terminal — the first real evidence
+                    // a model call is actually in flight, which is what
+                    // PreInvocation/PreToolUse hooks fire alongside.
+                    if (thinking) {
+                        this.armDiscoveryTimeoutWarning()
+                    }
                 },
                 onMessageSubmitted: () => {
                     this.markWebDeliverySubmitted()
@@ -526,12 +575,6 @@ class AgyPtyLauncher extends RemoteLauncherBase {
                 },
                 onBeforeMessageSubmit: (message) => {
                     this.activeWebPrompt = message
-                    if (!this.firstMessageSent) {
-                        this.firstMessageSent = true
-                        if (!this.agySessionId) {
-                            this.scanner.setSessionMessageText(message)
-                        }
-                    }
                     // The driver's text echo has completed but its CR has not
                     // yet been written, so user-input echo cannot trigger this
                     // output-only detector.
@@ -595,19 +638,6 @@ class AgyPtyLauncher extends RemoteLauncherBase {
         const resumeBrainUuid = this.agySessionId ?? undefined
         this.scanner = await createAgySessionScanner({
             resumeBrainUuid,
-            onDiscoveryAmbiguous: (count) => {
-                session.client.sendSessionEvent({
-                    type: 'error',
-                    message: `Antigravity session could not be identified because ${count} conversations matched the first message. Continue in the terminal or start a new session with a more specific prompt.`,
-                })
-            },
-            onBrainFound: (uuid) => {
-                if (!this.agySessionId) {
-                    logger.debug(`[agy-pty]: brain UUID discovered via onBrainFound: ${uuid}`)
-                    this.agySessionId = uuid
-                    session.onSessionFound(uuid)
-                }
-            },
             onEntry: (entry) => {
                 if (entry.type === 'USER_INPUT') {
                     if (!this.observeUserInput(entry.content ?? '')) {
@@ -660,31 +690,26 @@ class AgyPtyLauncher extends RemoteLauncherBase {
             }
         })
 
-        // Bridge the OTHER brain-UUID discovery path (the PreToolUse hook, via
-        // runAgy.ts:onPreToolUse -> wrapper.onSessionFound) into the scanner.
-        // Previously that path only updated session metadata (see the comment
-        // there) and never notified the scanner, so a session whose scanner
-        // content-match failed (e.g. a first message with attachments — see
-        // agySessionScanner.test.ts) never started tailing even though the hook
-        // had already discovered the UUID: the chat stayed empty. Both discovery
-        // paths funnel through AgentSessionBase.onSessionFound, so registering
-        // here covers hook discovery AND is idempotent with the onBrainFound
-        // self-loop above (scanner.onNewSession no-ops on an unchanged UUID).
-        // Also persist agySessionId here (mirroring the shared launcher contract
-        // handleSessionFound) so a crash/respawn in the narrow window between
-        // the hook firing and the next PTY output chunk (which is the only other
-        // writer, via onMessage's getBrainUuid() fallback) still resumes the same
-        // brain conversation via --conversation instead of silently starting a
-        // fresh one.
+        // Bridge brain-UUID discovery (the agy PreToolUse/PreInvocation hooks,
+        // via runAgy.ts:onPreToolUse/onAgyPreInvocation -> wrapper.onSessionFound)
+        // into the scanner — this is the scanner's ONLY discovery signal (see
+        // agySessionScanner.ts: it no longer discovers brains by transcript
+        // content-matching). handleSessionFound is the ONLY writer of
+        // this.agySessionId (besides the constructor's resume seed) — there
+        // is no onMessage-side fallback anymore. Setting it synchronously
+        // here (not just forwarding to the scanner) matters for a
+        // crash/respawn: launchOnce reads this.agySessionId to pass
+        // --conversation to the next spawn, so it must already be current by
+        // the time a respawn happens, however soon after this hook fired.
         const handleSessionFound = (uuid: string) => {
             this.agySessionId = uuid
             this.scanner?.onNewSession(uuid)
+            this.clearDiscoveryTimeoutWarning()
         }
         session.addSessionFoundCallback(handleSessionFound)
         session.setLiveModelHandler((model) => this.applyLiveModel(model))
 
         try {
-            this.firstMessageSent = false
             await this.runRespawnLoop({
                 maxAuthRetries: 8,
                 authRetryDelayMs: 1500,
@@ -709,6 +734,7 @@ class AgyPtyLauncher extends RemoteLauncherBase {
                 }
             })
         } finally {
+            this.clearDiscoveryTimeoutWarning()
             session.setLiveModelHandler(null)
             if (this.outputWaiter) {
                 clearTimeout(this.outputWaiter.timer)

--- a/cli/src/agy/agyPtyLauncher.ts
+++ b/cli/src/agy/agyPtyLauncher.ts
@@ -111,8 +111,9 @@ class AgyPtyLauncher extends RemoteLauncherBase {
     private scanner: any = null
     private firstMessageSent = false
     // The agy brain UUID for the current conversation. Set from the pre-known
-    // resume ID (if this is a resume) or discovered via the scanner's content-
-    // match once the first user message appears in the brain transcript.
+    // resume ID (if this is a resume) or adopted via handleSessionFound, which
+    // is fed by agy's PreToolUse/PreInvocation hook (see
+    // runAgy.ts:onPreToolUse/onAgyPreInvocation -> wrapper.onSessionFound).
     // Persisted here so re-spawns (crash recovery) resume the same conversation.
     private agySessionId: string | null = null
     // Live PTY controls (raw keystroke injection) for turn-interrupt

--- a/cli/src/agy/agyPtyLauncher.ts
+++ b/cli/src/agy/agyPtyLauncher.ts
@@ -235,6 +235,16 @@ class AgyPtyLauncher extends RemoteLauncherBase {
     // a long-lived session, §9), it is rebuilt from scratch via
     // prepareAgyHookCarrier and hookCarrierDir is repointed so the next agy
     // spawn's --add-dir uses it.
+    // Fail-closed contract note: launchOnce always spawns agy with
+    // --dangerously-skip-permissions (see its agyArgs above) — the carrier's
+    // PreToolUse hook is the ONLY thing standing between that and agy
+    // auto-approving every tool call with no user in the loop. runAgy.ts's
+    // initial prepareAgyHookCarrier() failure already honors this by
+    // aborting the session outright ("agy PTY session aborted: could not
+    // prepare the hook carrier...") rather than starting unprotected. This
+    // function is the respawn-time counterpart of that same carrier, so a
+    // recreation failure here must carry the identical consequence: abort,
+    // never spawn.
     private syncPreInvocationHookForLaunch(): void {
         const withDiscovery = this.session.hooksJsonWithPreInvocation
         const withoutDiscovery = this.session.hooksJsonWithoutPreInvocation
@@ -244,8 +254,30 @@ class AgyPtyLauncher extends RemoteLauncherBase {
         if (!carrierDir || !agyHookCarrierIsIntact(carrierDir)) {
             const recreated = prepareAgyHookCarrier(desired, this.session.hookMcpServer)
             if (!recreated) {
-                logger.debug('[agy-pty]: failed to recreate the hook carrier before respawn; the next agy spawn will run without it')
-                return
+                // Fix 1 (fail-closed): previously this just logged and
+                // returned, letting onLaunchStart finish normally and
+                // launchOnce spawn agy anyway — with no carrier at all, i.e.
+                // no PreToolUse hook, i.e. every tool call auto-approved
+                // with --dangerously-skip-permissions and nobody in the
+                // loop. Throwing here instead propagates out of
+                // onLaunchStart (called synchronously, before launchOnce,
+                // by RemoteLauncherBase.runRespawnLoop — see its call site)
+                // and aborts the respawn loop before agy is ever spawned.
+                // sendSessionEvent first: the throw alone would otherwise
+                // surface to the user only as an abrupt, unexplained session
+                // end (runAgy.ts's catch -> markCrash logs to the debug log,
+                // not the web chat) — mirrors the discovery-timeout warning
+                // above (armDiscoveryTimeoutWarning), the existing mechanism
+                // for "something silent broke, tell the web chat why."
+                logger.debug('[agy-pty]: failed to recreate the hook carrier before respawn; aborting rather than spawning agy without a permission bridge (fail-closed)')
+                this.session.client.sendSessionEvent({
+                    type: 'error',
+                    message: 'agy session aborted: could not recreate the permission bridge (hook carrier). Check that the temporary directory is writable and has sufficient space.',
+                })
+                throw new Error(
+                    'agy PTY session aborted: could not recreate the hook carrier needed for the permission bridge. ' +
+                    'Check that the temporary directory is writable and has sufficient space.'
+                )
             }
             this.session.setHookCarrierDir(recreated.carrierDir)
             logger.debug(`[agy-pty]: hook carrier was missing before a respawn; recreated at ${recreated.carrierDir}`)
@@ -254,6 +286,18 @@ class AgyPtyLauncher extends RemoteLauncherBase {
         try {
             writeAgyHooksJsonAtomic(carrierDir, desired)
         } catch (error) {
+            // Unlike the recreation branch above, this stays fail-open
+            // (log-and-continue) on purpose: agyHookCarrierIsIntact() just
+            // confirmed carrierDir/.agents/hooks.json exists on disk with
+            // SOME prior content (either prepareAgyHookCarrier's original
+            // write or an earlier successful call to this same function) —
+            // the permission bridge (PreToolUse) that content registers is
+            // still in force either way. A failed overwrite here (ENOSPC, a
+            // permission change mid-session, ...) only risks the
+            // PreInvocation discovery block being stale (armed when it
+            // should have been dropped, or vice versa) — a discovery
+            // latency/overhead problem, never an unprotected-tool-call one.
+            // That is not worth aborting a session over.
             logger.debug('[agy-pty]: failed to sync the PreInvocation hook state before respawn', error)
         }
     }

--- a/cli/src/agy/agyPtyLauncher.ts
+++ b/cli/src/agy/agyPtyLauncher.ts
@@ -272,11 +272,11 @@ class AgyPtyLauncher extends RemoteLauncherBase {
                 logger.debug('[agy-pty]: failed to recreate the hook carrier before respawn; aborting rather than spawning agy without a permission bridge (fail-closed)')
                 this.session.client.sendSessionEvent({
                     type: 'error',
-                    message: 'agy session aborted: could not recreate the permission bridge (hook carrier). Check that the temporary directory is writable and has sufficient space.',
+                    message: 'agy session aborted: could not recreate the permission bridge (hook carrier). Check that HAPI_HOME (default: ~/.hapi) is writable and has sufficient space.',
                 })
                 throw new Error(
                     'agy PTY session aborted: could not recreate the hook carrier needed for the permission bridge. ' +
-                    'Check that the temporary directory is writable and has sufficient space.'
+                    'Check that HAPI_HOME (default: ~/.hapi) is writable and has sufficient space.'
                 )
             }
             this.session.setHookCarrierDir(recreated.carrierDir)

--- a/cli/src/agy/agyPtyLauncher.ts
+++ b/cli/src/agy/agyPtyLauncher.ts
@@ -7,6 +7,7 @@ import type { AgyToolCall } from "./utils/agyTranscriptTypes"
 import { isAgyAskQuestionToolCall, buildCanonicalAskUserQuestionInput, type AgyAskQuestionQuestion } from "./utils/agyAskQuestion"
 import { buildAgyQuestionKeys } from "./utils/agyQuestionKeys"
 import { buildAgyModelNavigationKeys, buildAgyModelPickerTarget, findAgyCurrentModelRow } from './utils/agyModelKeys'
+import { agyHookCarrierIsIntact, prepareAgyHookCarrier, writeAgyHooksJsonAtomic } from './utils/agyHookCarrier'
 import { logger } from "@/ui/logger"
 import {
     RemoteLauncherBase,
@@ -179,6 +180,81 @@ class AgyPtyLauncher extends RemoteLauncherBase {
         if (this.discoveryTimeoutTimer) {
             clearTimeout(this.discoveryTimeoutTimer)
             this.discoveryTimeoutTimer = null
+        }
+    }
+
+    // PreInvocation fires on EVERY model call (measured ~424ms round trip,
+    // see the agy-preinvocation-discovery plan §6.5 Gate 3) but is only
+    // useful until the brain UUID is confirmed — after that every firing is
+    // pure waste. agy re-reads hooks.json before every model call (§6.6), so
+    // dropping the PreInvocation block from the SAME running carrier makes
+    // that waste disappear immediately, without restarting agy. PreToolUse
+    // is left untouched — the permission bridge is needed for the rest of
+    // the session. Fail-open: if the write fails, PreInvocation just keeps
+    // firing (harmless overhead), which is why this is a best-effort
+    // try/catch rather than something that can abort the session.
+    private detachPreInvocationHook(): void {
+        const carrierDir = this.session.hookCarrierDir
+        const withoutDiscovery = this.session.hooksJsonWithoutPreInvocation
+        if (!carrierDir || !withoutDiscovery) return
+        try {
+            writeAgyHooksJsonAtomic(carrierDir, withoutDiscovery)
+            logger.debug('[agy-pty]: brain UUID confirmed; dropped the now-redundant PreInvocation discovery hook')
+        } catch (error) {
+            logger.debug('[agy-pty]: failed to drop the PreInvocation hook after discovery (harmless — it will keep firing)', error)
+        }
+    }
+
+    // Restores (or keeps dropped) the PreInvocation block right before every
+    // launch — called from onLaunchStart, which — per
+    // RemoteLauncherBase.runRespawnLoop — runs synchronously before each
+    // launchOnce, including the very first one.
+    //
+    // Fix N1: which variant gets written depends on whether the brain UUID
+    // is ALREADY known (this.agySessionId set — either seeded by a resume,
+    // per the constructor, or adopted earlier via handleSessionFound). If it
+    // is, PreInvocation is redundant and WITHOUT is written (or kept) —
+    // there is no discovery left to do, so there is nothing to arm. This is
+    // what makes a resumed session detach on its very first launch (previously
+    // it never detached at all: handleSessionFound only runs off
+    // addSessionFoundCallback, which is registered by run() AFTER
+    // loop.ts's session.onSessionFound(resumeSessionId) has already fired
+    // and already set this.agySessionId, so the callback that would have
+    // triggered detachPreInvocationHook never sees that resume) and what
+    // keeps a respawn from re-arming PreInvocation once discovery already
+    // succeeded (previously onLaunchStart wrote WITH unconditionally on
+    // every round, undoing detachPreInvocationHook's work the moment a
+    // respawn happened — see agyPtyLauncher.test.ts's Phase 2.7 suite).
+    //
+    // If the UUID is NOT yet known, WITH is written (or kept) so discovery
+    // can still happen on this launch. Resume-failure detection (a resume
+    // silently starting a brand-new, unknown-UUID conversation) is out of
+    // scope here — see Fix N2's docstring on why.
+    //
+    // If the carrier itself is gone (e.g. /tmp's 30-day tmpfiles.d sweep on
+    // a long-lived session, §9), it is rebuilt from scratch via
+    // prepareAgyHookCarrier and hookCarrierDir is repointed so the next agy
+    // spawn's --add-dir uses it.
+    private syncPreInvocationHookForLaunch(): void {
+        const withDiscovery = this.session.hooksJsonWithPreInvocation
+        const withoutDiscovery = this.session.hooksJsonWithoutPreInvocation
+        if (!withDiscovery || !withoutDiscovery) return
+        const desired = this.agySessionId ? withoutDiscovery : withDiscovery
+        const carrierDir = this.session.hookCarrierDir
+        if (!carrierDir || !agyHookCarrierIsIntact(carrierDir)) {
+            const recreated = prepareAgyHookCarrier(desired, this.session.hookMcpServer)
+            if (!recreated) {
+                logger.debug('[agy-pty]: failed to recreate the hook carrier before respawn; the next agy spawn will run without it')
+                return
+            }
+            this.session.setHookCarrierDir(recreated.carrierDir)
+            logger.debug(`[agy-pty]: hook carrier was missing before a respawn; recreated at ${recreated.carrierDir}`)
+            return
+        }
+        try {
+            writeAgyHooksJsonAtomic(carrierDir, desired)
+        } catch (error) {
+            logger.debug('[agy-pty]: failed to sync the PreInvocation hook state before respawn', error)
         }
     }
 
@@ -705,6 +781,7 @@ class AgyPtyLauncher extends RemoteLauncherBase {
             this.agySessionId = uuid
             this.scanner?.onNewSession(uuid)
             this.clearDiscoveryTimeoutWarning()
+            this.detachPreInvocationHook()
         }
         session.addSessionFoundCallback(handleSessionFound)
         session.setLiveModelHandler((model) => this.applyLiveModel(model))
@@ -714,6 +791,10 @@ class AgyPtyLauncher extends RemoteLauncherBase {
                 maxAuthRetries: 8,
                 authRetryDelayMs: 1500,
                 onLaunchStart: (isNewSession) => {
+                    // Runs synchronously before every launchOnce, including
+                    // the first — restores PreInvocation if a prior round
+                    // detached it (see syncPreInvocationHookForLaunch's docstring).
+                    this.syncPreInvocationHookForLaunch()
                     messageBuffer.addMessage('═'.repeat(40), 'status')
                     if (this.agySessionId) {
                         messageBuffer.addMessage('Resuming agy PTY session...', 'status')

--- a/cli/src/agy/loop.ts
+++ b/cli/src/agy/loop.ts
@@ -7,6 +7,7 @@ import { ApiClient, ApiSessionClient } from '@/lib';
 import type { AgyMode, PermissionMode } from './types';
 import type { SessionEffort, SessionModel } from '@/api/types';
 import type { AgyPermissionHandler } from './utils/agyPermissionHandler';
+import type { AgyMcpServerEntry } from './utils/agyHookCarrier';
 
 interface AgyLoopOptions {
     path: string;
@@ -25,6 +26,11 @@ interface AgyLoopOptions {
     hookCarrierDir?: string;
     hookPort?: number;
     hookToken?: string;
+    /** hooks.json contents for the with/without-PreInvocation carrier states (see AgySession's docstring). */
+    hooksJsonWithPreInvocation?: string;
+    hooksJsonWithoutPreInvocation?: string;
+    /** MCP server entry needed to rebuild the carrier if it has to be recreated mid-session. */
+    hookMcpServer?: AgyMcpServerEntry;
     /** PTY-mode permission bridge. */
     agyPermissionHandler?: AgyPermissionHandler | null;
 }
@@ -52,6 +58,9 @@ export async function agyLoop(opts: AgyLoopOptions): Promise<void> {
         hookCarrierDir: opts.hookCarrierDir,
         hookPort: opts.hookPort,
         hookToken: opts.hookToken,
+        hooksJsonWithPreInvocation: opts.hooksJsonWithPreInvocation,
+        hooksJsonWithoutPreInvocation: opts.hooksJsonWithoutPreInvocation,
+        hookMcpServer: opts.hookMcpServer,
         agyPermissionHandler: opts.agyPermissionHandler,
     });
 

--- a/cli/src/agy/runAgy.lifecycle.test.ts
+++ b/cli/src/agy/runAgy.lifecycle.test.ts
@@ -84,6 +84,7 @@ vi.mock('@/codex/utils/buildHapiMcpBridge', () => ({
 vi.mock('./utils/agyHookCarrier', () => ({
     prepareAgyHookCarrier: vi.fn(() => h.failAt === 'carrier' ? null : { carrierDir: '/tmp/carrier' }),
     cleanupAgyHookCarrier: h.carrierCleanup,
+    sweepAgyHookCarriers: vi.fn(),
 }))
 vi.mock('./utils/agyPermissionHandler', () => ({
     AgyPermissionHandler: class {

--- a/cli/src/agy/runAgy.lifecycle.test.ts
+++ b/cli/src/agy/runAgy.lifecycle.test.ts
@@ -8,6 +8,26 @@ const h = vi.hoisted(() => ({
     sessionClose: vi.fn(),
     sendSessionDeath: vi.fn(),
     lifecycle: null as null | { cleanup: () => Promise<void> },
+    // Captures the options passed to startHookServer so tests can invoke
+    // onPreToolUse/onAgyPreInvocation directly, as agy would.
+    hookServerOpts: null as null | {
+        onPreToolUse?: (data: Record<string, unknown>) => Promise<unknown>
+        onAgyPreInvocation?: (data: Record<string, unknown>) => void
+    },
+    // When set, the mocked agyLoop invokes onSessionReady with this fake
+    // wrapper (mirroring how the real AgySession is handed to onSessionReady
+    // once the PTY session is up) so tests can control wrapper.sessionId.
+    sessionReadyWrapper: null as null | {
+        sessionId: string | null
+        onSessionFound: (id: string) => void
+        setPermissionMode: () => void
+        setModel: () => void
+        setEffort: () => void
+        pushKeepAlive: () => void
+    },
+    // Captures the options buildAgyHooksJson was called with, so tests can
+    // assert the PreToolUse/PreInvocation commands were not swapped.
+    buildAgyHooksJsonOptions: null as null | { preToolUseCommand: string; preInvocationCommand: string; hookName?: string },
 }))
 
 vi.mock('@/agent/sessionFactory', () => ({
@@ -44,7 +64,8 @@ vi.mock('@/claude/registerKillSessionHandler', () => ({ registerKillSessionHandl
 vi.mock('@/agent/localHandoff', () => ({ registerLocalHandoffHandler: vi.fn() }))
 vi.mock('@/agent/sessionConfigRpc', () => ({ registerSessionConfigRpc: vi.fn() }))
 vi.mock('@/claude/utils/startHookServer', () => ({
-    startHookServer: vi.fn(async () => {
+    startHookServer: vi.fn(async (opts: unknown) => {
+        h.hookServerOpts = opts as typeof h.hookServerOpts
         if (h.failAt === 'hook') throw new Error('hook failed')
         return { port: 1234, token: 'token', stop: h.hookStop }
     }),
@@ -64,12 +85,26 @@ vi.mock('./utils/agyPermissionHandler', () => ({
     AgyPermissionHandler: class {
         constructor() { if (h.failAt === 'permission') throw new Error('permission failed') }
         cancelAll() {}
+        requestDecision = vi.fn(async () => ({ permissionDecision: 'allow' as const }))
     },
 }))
-vi.mock('./loop', () => ({ agyLoop: vi.fn(async () => {}) }))
-vi.mock('@/utils/spawnHappyCLI', () => ({ getHappyCliCommand: vi.fn(() => ({ command: 'hapi', args: [] })) }))
-vi.mock('@/modules/common/shellQuote', () => ({ shellJoin: vi.fn(() => 'hapi hook-forwarder') }))
-vi.mock('@/modules/common/hooks/generateHookSettings', () => ({ buildAgyHooksJson: vi.fn(() => ({})) }))
+vi.mock('./loop', () => ({
+    agyLoop: vi.fn(async (opts: { onSessionReady?: (wrapper: unknown) => void }) => {
+        if (h.sessionReadyWrapper) opts.onSessionReady?.(h.sessionReadyWrapper)
+    }),
+}))
+// Reflect the real args back out (rather than a fixed constant) so the
+// PreToolUse and PreInvocation forwarder commands built in runAgy.ts come out
+// distinguishable — a fixed-constant mock can't catch the two commands being
+// passed to buildAgyHooksJson in the wrong slots.
+vi.mock('@/utils/spawnHappyCLI', () => ({ getHappyCliCommand: vi.fn((args: string[]) => ({ command: 'hapi', args })) }))
+vi.mock('@/modules/common/shellQuote', () => ({ shellJoin: vi.fn((parts: string[]) => parts.join(' ')) }))
+vi.mock('@/modules/common/hooks/generateHookSettings', () => ({
+    buildAgyHooksJson: vi.fn((opts: { preToolUseCommand: string; preInvocationCommand: string; hookName?: string }) => {
+        h.buildAgyHooksJsonOptions = opts
+        return '{}'
+    }),
+}))
 vi.mock('@/ui/logger', () => ({ logger: { debug: vi.fn() } }))
 
 import { runAgy } from './runAgy'
@@ -79,6 +114,9 @@ describe('runAgy post-bootstrap setup lifecycle', () => {
         vi.clearAllMocks()
         h.failAt = ''
         h.lifecycle = null
+        h.hookServerOpts = null
+        h.sessionReadyWrapper = null
+        h.buildAgyHooksJsonOptions = null
         vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
         vi.spyOn(process, 'on').mockImplementation((() => process) as never)
     })
@@ -108,4 +146,80 @@ describe('runAgy post-bootstrap setup lifecycle', () => {
             expect(h.carrierCleanup).toHaveBeenCalledTimes(scenario.carrier)
         })
     }
+
+    it('never swaps the fail-closed PreToolUse command with the fail-open PreInvocation command', async () => {
+        await runAgy({ startingMode: 'pty', workingDirectory: '/tmp/project' })
+
+        const opts = h.buildAgyHooksJsonOptions
+        expect(opts).not.toBeNull()
+        // Only the PreInvocation command is built with --event pre-invocation;
+        // a positional-arg swap would put this string in preToolUseCommand
+        // instead, silently turning the permission bridge fail-open.
+        expect(opts!.preInvocationCommand).toContain('--event pre-invocation')
+        expect(opts!.preToolUseCommand).not.toContain('--event')
+    })
+})
+
+function fakeSessionWrapper(sessionId: string | null, onSessionFound: (id: string) => void) {
+    return {
+        sessionId,
+        onSessionFound,
+        setPermissionMode: vi.fn(),
+        setModel: vi.fn(),
+        setEffort: vi.fn(),
+        pushKeepAlive: vi.fn(),
+    }
+}
+
+describe('runAgy brain UUID adoption via agy hooks', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        h.failAt = ''
+        h.lifecycle = null
+        h.hookServerOpts = null
+        h.sessionReadyWrapper = null
+        h.buildAgyHooksJsonOptions = null
+        vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+        vi.spyOn(process, 'on').mockImplementation((() => process) as never)
+    })
+
+    it('adopts the brain UUID from a PreInvocation hook when no sessionId is set yet', async () => {
+        const onSessionFound = vi.fn()
+        h.sessionReadyWrapper = fakeSessionWrapper(null, onSessionFound)
+
+        await runAgy({ startingMode: 'pty', workingDirectory: '/tmp/project' })
+
+        h.hookServerOpts!.onAgyPreInvocation!({ conversationId: 'new-uuid' })
+        expect(onSessionFound).toHaveBeenCalledWith('new-uuid')
+    })
+
+    it('does not let a PreInvocation hook overwrite a resume-seeded sessionId (hostile-review risk card: resume/reconnect regression)', async () => {
+        const onSessionFound = vi.fn()
+        h.sessionReadyWrapper = fakeSessionWrapper('resumed-uuid', onSessionFound)
+
+        await runAgy({ startingMode: 'pty', workingDirectory: '/tmp/project', resumeSessionId: 'resumed-uuid' })
+
+        h.hookServerOpts!.onAgyPreInvocation!({ conversationId: 'different-uuid' })
+        expect(onSessionFound).not.toHaveBeenCalled()
+    })
+
+    it('does not let a PreToolUse hook overwrite a resume-seeded sessionId (same first-wins guard, PreToolUse side)', async () => {
+        const onSessionFound = vi.fn()
+        h.sessionReadyWrapper = fakeSessionWrapper('resumed-uuid', onSessionFound)
+
+        await runAgy({ startingMode: 'pty', workingDirectory: '/tmp/project', resumeSessionId: 'resumed-uuid' })
+
+        await h.hookServerOpts!.onPreToolUse!({ conversationId: 'different-uuid', toolCall: { name: 'run_command' } })
+        expect(onSessionFound).not.toHaveBeenCalled()
+    })
+
+    it('a PreInvocation hook with no conversationId is a no-op (agy always sends one, but stay defensive)', async () => {
+        const onSessionFound = vi.fn()
+        h.sessionReadyWrapper = fakeSessionWrapper(null, onSessionFound)
+
+        await runAgy({ startingMode: 'pty', workingDirectory: '/tmp/project' })
+
+        h.hookServerOpts!.onAgyPreInvocation!({})
+        expect(onSessionFound).not.toHaveBeenCalled()
+    })
 })

--- a/cli/src/agy/runAgy.lifecycle.test.ts
+++ b/cli/src/agy/runAgy.lifecycle.test.ts
@@ -25,9 +25,13 @@ const h = vi.hoisted(() => ({
         setEffort: () => void
         pushKeepAlive: () => void
     },
-    // Captures the options buildAgyHooksJson was called with, so tests can
-    // assert the PreToolUse/PreInvocation commands were not swapped.
-    buildAgyHooksJsonOptions: null as null | { preToolUseCommand: string; preInvocationCommand: string; hookName?: string },
+    // Captures every call buildAgyHooksJson receives, so tests can assert the
+    // PreToolUse/PreInvocation commands were not swapped. runAgy.ts now calls
+    // it twice per PTY session (Phase 2.7): once with preInvocationCommand
+    // (the carrier's initial/reattached state) and once without (the
+    // self-detached state) — see hooksJsonWithPreInvocation/
+    // hooksJsonWithoutPreInvocation in runAgy.ts.
+    buildAgyHooksJsonCalls: [] as Array<{ preToolUseCommand: string; preInvocationCommand?: string; hookName?: string }>,
 }))
 
 vi.mock('@/agent/sessionFactory', () => ({
@@ -100,8 +104,8 @@ vi.mock('./loop', () => ({
 vi.mock('@/utils/spawnHappyCLI', () => ({ getHappyCliCommand: vi.fn((args: string[]) => ({ command: 'hapi', args })) }))
 vi.mock('@/modules/common/shellQuote', () => ({ shellJoin: vi.fn((parts: string[]) => parts.join(' ')) }))
 vi.mock('@/modules/common/hooks/generateHookSettings', () => ({
-    buildAgyHooksJson: vi.fn((opts: { preToolUseCommand: string; preInvocationCommand: string; hookName?: string }) => {
-        h.buildAgyHooksJsonOptions = opts
+    buildAgyHooksJson: vi.fn((opts: { preToolUseCommand: string; preInvocationCommand?: string; hookName?: string }) => {
+        h.buildAgyHooksJsonCalls.push(opts)
         return '{}'
     }),
 }))
@@ -116,7 +120,7 @@ describe('runAgy post-bootstrap setup lifecycle', () => {
         h.lifecycle = null
         h.hookServerOpts = null
         h.sessionReadyWrapper = null
-        h.buildAgyHooksJsonOptions = null
+        h.buildAgyHooksJsonCalls = []
         vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
         vi.spyOn(process, 'on').mockImplementation((() => process) as never)
     })
@@ -150,13 +154,24 @@ describe('runAgy post-bootstrap setup lifecycle', () => {
     it('never swaps the fail-closed PreToolUse command with the fail-open PreInvocation command', async () => {
         await runAgy({ startingMode: 'pty', workingDirectory: '/tmp/project' })
 
-        const opts = h.buildAgyHooksJsonOptions
-        expect(opts).not.toBeNull()
-        // Only the PreInvocation command is built with --event pre-invocation;
-        // a positional-arg swap would put this string in preToolUseCommand
-        // instead, silently turning the permission bridge fail-open.
-        expect(opts!.preInvocationCommand).toContain('--event pre-invocation')
-        expect(opts!.preToolUseCommand).not.toContain('--event')
+        // Two calls: the with-PreInvocation carrier state (used to build the
+        // initial/reattached hooks.json) and the without-PreInvocation state
+        // (used after self-detach). Every call's preToolUseCommand must stay
+        // the fail-closed command, and any call carrying a preInvocationCommand
+        // must carry the fail-open one — a positional-arg swap would put the
+        // --event pre-invocation string in preToolUseCommand instead, silently
+        // turning the permission bridge fail-open.
+        expect(h.buildAgyHooksJsonCalls.length).toBeGreaterThanOrEqual(2)
+        for (const call of h.buildAgyHooksJsonCalls) {
+            expect(call.preToolUseCommand).not.toContain('--event')
+        }
+        const withInvocation = h.buildAgyHooksJsonCalls.filter((call) => call.preInvocationCommand !== undefined)
+        expect(withInvocation.length).toBeGreaterThanOrEqual(1)
+        for (const call of withInvocation) {
+            expect(call.preInvocationCommand).toContain('--event pre-invocation')
+        }
+        const withoutInvocation = h.buildAgyHooksJsonCalls.filter((call) => call.preInvocationCommand === undefined)
+        expect(withoutInvocation.length).toBeGreaterThanOrEqual(1)
     })
 })
 
@@ -178,7 +193,7 @@ describe('runAgy brain UUID adoption via agy hooks', () => {
         h.lifecycle = null
         h.hookServerOpts = null
         h.sessionReadyWrapper = null
-        h.buildAgyHooksJsonOptions = null
+        h.buildAgyHooksJsonCalls = []
         vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
         vi.spyOn(process, 'on').mockImplementation((() => process) as never)
     })

--- a/cli/src/agy/runAgy.ts
+++ b/cli/src/agy/runAgy.ts
@@ -143,23 +143,42 @@ export async function runAgy(opts: {
                 const toolInput = extractToolInput(data);
                 const toolUseId = extractToolUseId(data) ?? `${toolName}-${Date.now()}`;
                 return agyPermissionHandler.requestDecision(toolUseId, toolName, toolInput);
+            },
+            onAgyPreInvocation: (data) => {
+                // PreInvocation fires before every model call, tool use or
+                // not — unlike PreToolUse, which only fires once a tool
+                // actually runs. Registering both means a brain UUID is
+                // discovered even on tool-free turns (e.g. a plain "hi").
+                // Same first-wins guard, same fail-open discovery contract —
+                // this hook carries no permission decision to adjudicate.
+                adoptBrainUuidIfUnset(data.conversationId, 'PreInvocation');
             }
         });
         logger.debug(`[agy] Hook server started on port ${hookServer.port}`);
 
         // Keep endpoint secrets out of the carrier; the hook reads them from
-        // the AGY child environment via --from-env.
-        const { command, args } = getHappyCliCommand([
-            'hook-forwarder', '--flavor', 'agy', '--from-env'
-        ]);
-        let hookCommand: string;
-        try {
-            hookCommand = shellJoin([command, ...args]);
-        } catch (error) {
-            throw new Error('agy PTY session aborted: could not safely encode the hook command.', { cause: error });
-        }
+        // the AGY child environment via --from-env. Two distinct forwarder
+        // commands are needed: PreToolUse and PreInvocation have different
+        // stdin/stdout contracts (see sessionHookForwarder.ts), and agy has
+        // no way to tell them apart from the payload shape alone — only the
+        // explicit --event flag distinguishes them.
+        const buildForwarderCommand = (extraArgs: string[], label: string): string => {
+            const { command, args } = getHappyCliCommand([
+                'hook-forwarder', '--flavor', 'agy', '--from-env', ...extraArgs
+            ]);
+            try {
+                return shellJoin([command, ...args]);
+            } catch (error) {
+                throw new Error(`agy PTY session aborted: could not safely encode the ${label} hook command.`, { cause: error });
+            }
+        };
+        const hookCommand = buildForwarderCommand([], 'PreToolUse');
+        const preInvocationHookCommand = buildForwarderCommand(['--event', 'pre-invocation'], 'PreInvocation');
 
-        const hooksJson = buildAgyHooksJson(hookCommand);
+        const hooksJson = buildAgyHooksJson({
+            preToolUseCommand: hookCommand,
+            preInvocationCommand: preInvocationHookCommand
+        });
         let carrierResult: ReturnType<typeof prepareAgyHookCarrier>;
         try {
             hapiMcpBridge = await buildHapiMcpBridge(session, {

--- a/cli/src/agy/runAgy.ts
+++ b/cli/src/agy/runAgy.ts
@@ -16,7 +16,7 @@ import type { SessionEffort, SessionModel } from '@/api/types';
 import { startHookServer } from '@/claude/utils/startHookServer';
 import { AgyPermissionHandler } from './utils/agyPermissionHandler';
 import { buildAgyHooksJson } from '@/modules/common/hooks/generateHookSettings';
-import { prepareAgyHookCarrier, cleanupAgyHookCarrier } from './utils/agyHookCarrier';
+import { prepareAgyHookCarrier, cleanupAgyHookCarrier, sweepAgyHookCarriers } from './utils/agyHookCarrier';
 import type { AgyMcpServerEntry } from './utils/agyHookCarrier';
 import { shellJoin } from '@/modules/common/shellQuote';
 import { getHappyCliCommand } from '@/utils/spawnHappyCLI';
@@ -140,6 +140,13 @@ export async function runAgy(opts: {
 
     try {
         if (isPtyMode) {
+        // Best-effort: reclaim carriers left behind by sessions whose
+        // owning process has since died (crash, kill -9 — anything that
+        // skips onAfterClose's cleanupAgyHookCarrier). Never throws; see
+        // sweepAgyHookCarriers's docstring for why over-preservation is the
+        // only safe failure mode here.
+        sweepAgyHookCarriers();
+
         hookServer = await startHookServer({
             onSessionHook: () => {
                 // agy does not fire a SessionStart hook; this callback is a

--- a/cli/src/agy/runAgy.ts
+++ b/cli/src/agy/runAgy.ts
@@ -88,6 +88,20 @@ export async function runAgy(opts: {
     let hapiMcpBridge: Awaited<ReturnType<typeof buildHapiMcpBridge>> | null = null;
     let hookCarrierDir: string | undefined;
 
+    // Adopts a brain UUID discovered via an agy hook into session metadata,
+    // first-wins: never overwrites an already-set sessionId (set by a resume
+    // seed or an earlier hook firing), so a resumed session's seeded UUID is
+    // never clobbered by a later hook, and a UUID discovered by one hook is
+    // never re-adopted (as a no-op) by another.
+    const adoptBrainUuidIfUnset = (conversationId: string | undefined, source: string): void => {
+        if (!conversationId) return;
+        const wrapper = sessionWrapperRef.current as { sessionId?: string | null; onSessionFound?: (id: string) => void } | null;
+        if (wrapper && !wrapper.sessionId && typeof wrapper.onSessionFound === 'function') {
+            logger.debug(`[agy] brain UUID from ${source} hook: ${conversationId}`);
+            wrapper.onSessionFound(conversationId);
+        }
+    };
+
     const lifecycle = createRunnerLifecycle({
         session,
         logTag: 'agy',
@@ -121,16 +135,10 @@ export async function runAgy(opts: {
                 }
                 // Reliable path: every PreToolUse hook carries the brain's
                 // conversationId. Persist it to session metadata on first sight
-                // so resume works even if the scanner's content-match hasn't
-                // fired yet. No-op if the session already has a UUID (set by
-                // the scanner's onBrainFound or a resume seed).
-                if (data.conversationId) {
-                    const wrapper = sessionWrapperRef.current as { sessionId?: string | null; onSessionFound?: (id: string) => void } | null;
-                    if (wrapper && !wrapper.sessionId && typeof wrapper.onSessionFound === 'function') {
-                        logger.debug(`[agy] brain UUID from PreToolUse hook: ${data.conversationId}`);
-                        wrapper.onSessionFound(data.conversationId);
-                    }
-                }
+                // so resume works even if no other hook has fired yet. No-op
+                // if the session already has a UUID (set by an earlier hook
+                // or a resume seed).
+                adoptBrainUuidIfUnset(data.conversationId, 'PreToolUse');
                 const toolName = extractToolName(data) ?? '';
                 const toolInput = extractToolInput(data);
                 const toolUseId = extractToolUseId(data) ?? `${toolName}-${Date.now()}`;

--- a/cli/src/agy/runAgy.ts
+++ b/cli/src/agy/runAgy.ts
@@ -226,7 +226,7 @@ export async function runAgy(opts: {
             logger.debug('[agy] Failed to prepare hook carrier; aborting PTY session (fail-closed)');
             throw new Error(
                 'agy PTY session aborted: could not prepare the hook carrier needed for the permission bridge. ' +
-                'Check that the temporary directory is writable and has sufficient space.'
+                'Check that HAPI_HOME (default: ~/.hapi) is writable and has sufficient space.'
             );
         }
         hookCarrierDir = carrierResult.carrierDir;

--- a/cli/src/agy/runAgy.ts
+++ b/cli/src/agy/runAgy.ts
@@ -17,6 +17,7 @@ import { startHookServer } from '@/claude/utils/startHookServer';
 import { AgyPermissionHandler } from './utils/agyPermissionHandler';
 import { buildAgyHooksJson } from '@/modules/common/hooks/generateHookSettings';
 import { prepareAgyHookCarrier, cleanupAgyHookCarrier } from './utils/agyHookCarrier';
+import type { AgyMcpServerEntry } from './utils/agyHookCarrier';
 import { shellJoin } from '@/modules/common/shellQuote';
 import { getHappyCliCommand } from '@/utils/spawnHappyCLI';
 import { extractToolName, extractToolInput, extractToolUseId } from '@/claude/utils/startHookServer';
@@ -87,6 +88,16 @@ export async function runAgy(opts: {
     let hookServer: Awaited<ReturnType<typeof startHookServer>> | null = null;
     let hapiMcpBridge: Awaited<ReturnType<typeof buildHapiMcpBridge>> | null = null;
     let hookCarrierDir: string | undefined;
+    // hooks.json contents for the carrier's two PreInvocation states, and the
+    // MCP server entry needed to rebuild the carrier from scratch — handed to
+    // the session so agyPtyLauncher can self-detach the PreInvocation hook
+    // once the brain UUID is confirmed (it fires on every model call and is
+    // redundant after that) and reattach it before every respawn (see
+    // AgySession's docstring and Phase 2.7 of the agy-preinvocation-discovery
+    // plan). Undefined outside PTY mode, where no carrier is built.
+    let hooksJsonWithPreInvocation: string | undefined;
+    let hooksJsonWithoutPreInvocation: string | undefined;
+    let hookMcpServer: AgyMcpServerEntry | undefined;
 
     // Adopts a brain UUID discovered via an agy hook into session metadata,
     // first-wins: never overwrites an already-set sessionId (set by a resume
@@ -111,7 +122,13 @@ export async function runAgy(opts: {
             agyPermissionHandler?.cancelAll('Session ended');
             hookServer?.stop();
             hapiMcpBridge?.server.stop();
-            cleanupAgyHookCarrier(hookCarrierDir);
+            // Prefer the session's live hookCarrierDir: agyPtyLauncher's
+            // respawn-reattach cycle can rebuild the carrier at a NEW path
+            // (prepareAgyHookCarrier always mkdtemps a fresh directory) if
+            // the original one vanished mid-session. Falling back to the
+            // local variable covers every path where the session wrapper
+            // never got assigned (e.g. setup failed before onSessionReady).
+            cleanupAgyHookCarrier(sessionWrapperRef.current?.hookCarrierDir ?? hookCarrierDir);
         }
     });
 
@@ -175,9 +192,17 @@ export async function runAgy(opts: {
         const hookCommand = buildForwarderCommand([], 'PreToolUse');
         const preInvocationHookCommand = buildForwarderCommand(['--event', 'pre-invocation'], 'PreInvocation');
 
-        const hooksJson = buildAgyHooksJson({
+        // Two variants: the carrier is always built with PreInvocation (a
+        // resume-failure right after a respawn needs it to discover the
+        // replacement conversation's UUID), but agyPtyLauncher swaps to the
+        // PreToolUse-only variant once discovery is confirmed, and back
+        // before every respawn. See AgySession's docstring.
+        hooksJsonWithPreInvocation = buildAgyHooksJson({
             preToolUseCommand: hookCommand,
             preInvocationCommand: preInvocationHookCommand
+        });
+        hooksJsonWithoutPreInvocation = buildAgyHooksJson({
+            preToolUseCommand: hookCommand
         });
         let carrierResult: ReturnType<typeof prepareAgyHookCarrier>;
         try {
@@ -185,7 +210,8 @@ export async function runAgy(opts: {
                 skillLookup: { workingDirectory, flavor: 'agy' }
             });
             const { command: mcpCommand, args: mcpArgs } = hapiMcpBridge.mcpServers.hapi;
-            carrierResult = prepareAgyHookCarrier(hooksJson, { command: mcpCommand, args: mcpArgs });
+            hookMcpServer = { command: mcpCommand, args: mcpArgs };
+            carrierResult = prepareAgyHookCarrier(hooksJsonWithPreInvocation, hookMcpServer);
         } catch (error) {
             throw new Error('agy PTY session aborted: could not prepare the session-local HAPI MCP bridge.', { cause: error });
         }
@@ -271,6 +297,9 @@ export async function runAgy(opts: {
             hookCarrierDir,
             hookPort: hookServer?.port,
             hookToken: hookServer?.token,
+            hooksJsonWithPreInvocation,
+            hooksJsonWithoutPreInvocation,
+            hookMcpServer,
             agyPermissionHandler,
             onModeChange: createModeChangeHandler(session),
             onSessionReady: (instance) => {

--- a/cli/src/agy/session.ts
+++ b/cli/src/agy/session.ts
@@ -5,6 +5,7 @@ import type { AgyMode, PermissionMode } from './types';
 import type { LocalLaunchExitReason } from '@/agent/localLaunchPolicy';
 import type { SessionEffort, SessionModel } from '@/api/types';
 import type { AgyPermissionHandler } from './utils/agyPermissionHandler';
+import type { AgyMcpServerEntry } from './utils/agyHookCarrier';
 
 type LocalLaunchFailure = {
     message: string;
@@ -14,10 +15,32 @@ type LocalLaunchFailure = {
 export class AgySession extends AgentSessionBase<AgyMode> {
     private liveModelHandler: ((model: SessionModel) => Promise<void>) | null = null;
     readonly startedBy: 'runner' | 'terminal';
-    /** Additional workspace carrying HAPI hooks without modifying HOME or the project. */
-    readonly hookCarrierDir: string | undefined;
+    /**
+     * Additional workspace carrying HAPI hooks without modifying HOME or the
+     * project. Mutable (not readonly): agyPtyLauncher's respawn-reattach
+     * cycle can rebuild the carrier at a NEW path (prepareAgyHookCarrier
+     * always mkdtemps a fresh directory — it cannot reuse the old one) if the
+     * original carrier vanished (e.g. /tmp's 30-day tmpfiles.d sweep on a
+     * long-lived session), and must repoint this field so the next agy spawn
+     * picks it up via --add-dir. See setHookCarrierDir.
+     */
+    hookCarrierDir: string | undefined;
     readonly hookPort: number | undefined;
     readonly hookToken: string | undefined;
+    /**
+     * hooks.json contents for the carrier's two PreInvocation states — with
+     * the discovery hook registered, and without it. agyPtyLauncher swaps
+     * between them via agyHookCarrier.ts's writeAgyHooksJsonAtomic, choosing
+     * WITHOUT once the brain UUID is confirmed (agySessionId set — it fires
+     * on every model call and is redundant once discovery has nothing left
+     * to do) and WITH otherwise (still-undiscovered sessions, on every
+     * launch including the first). Undefined outside PTY mode, where no
+     * carrier exists.
+     */
+    readonly hooksJsonWithPreInvocation: string | undefined;
+    readonly hooksJsonWithoutPreInvocation: string | undefined;
+    /** MCP server entry needed to rebuild the carrier's HAPI plugin files if the carrier has to be recreated (see hookCarrierDir's docstring). */
+    readonly hookMcpServer: AgyMcpServerEntry | undefined;
     /**
      * The PTY-mode permission bridge (null outside PTY mode). agyPtyLauncher
      * uses this to register agy's native `ask_question` as a pending request
@@ -44,6 +67,9 @@ export class AgySession extends AgentSessionBase<AgyMode> {
         hookCarrierDir?: string;
         hookPort?: number;
         hookToken?: string;
+        hooksJsonWithPreInvocation?: string;
+        hooksJsonWithoutPreInvocation?: string;
+        hookMcpServer?: AgyMcpServerEntry;
         agyPermissionHandler?: AgyPermissionHandler | null;
     }) {
         super({
@@ -72,6 +98,9 @@ export class AgySession extends AgentSessionBase<AgyMode> {
         this.hookCarrierDir = opts.hookCarrierDir;
         this.hookPort = opts.hookPort;
         this.hookToken = opts.hookToken;
+        this.hooksJsonWithPreInvocation = opts.hooksJsonWithPreInvocation;
+        this.hooksJsonWithoutPreInvocation = opts.hooksJsonWithoutPreInvocation;
+        this.hookMcpServer = opts.hookMcpServer;
         this.agyPermissionHandler = opts.agyPermissionHandler ?? null;
         this.permissionMode = opts.permissionMode;
         this.model = opts.model;
@@ -80,6 +109,11 @@ export class AgySession extends AgentSessionBase<AgyMode> {
 
     setPermissionMode = (mode: PermissionMode): void => {
         this.permissionMode = mode;
+    };
+
+    /** Repoint hookCarrierDir after agyPtyLauncher rebuilds the carrier at a new path (see the field's docstring). */
+    setHookCarrierDir = (carrierDir: string): void => {
+        this.hookCarrierDir = carrierDir;
     };
 
     setModel = (model: SessionModel): void => {

--- a/cli/src/agy/utils/agyHookCarrier.test.ts
+++ b/cli/src/agy/utils/agyHookCarrier.test.ts
@@ -1,12 +1,34 @@
-import { describe, expect, it } from 'vitest';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
+import { hostname, tmpdir } from 'node:os';
+import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import {
     agyHookCarrierIsIntact,
     cleanupAgyHookCarrier,
     prepareAgyHookCarrier,
+    sweepAgyHookCarriers,
     writeAgyHooksJsonAtomic
 } from './agyHookCarrier';
+
+/**
+ * Spawns a real child process, waits for it to exit, and returns its PID.
+ * By the time this resolves the PID is guaranteed dead — a stronger,
+ * non-vacuous stand-in for "some unrelated orphaned carrier's owner" than a
+ * made-up large integer, which could in theory collide with a live PID.
+ */
+function spawnAndReapDeadPid(): Promise<number> {
+    return new Promise((resolvePid, reject) => {
+        const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
+        const pid = child.pid;
+        if (!pid) {
+            reject(new Error('failed to obtain a PID for the throwaway child process'));
+            return;
+        }
+        child.once('exit', () => resolvePid(pid));
+        child.once('error', reject);
+    });
+}
 
 describe('agy hook carrier', () => {
     it('creates workspace-local hooks and a session-scoped HAPI MCP plugin', () => {
@@ -63,6 +85,32 @@ describe('writeAgyHooksJsonAtomic', () => {
     it('throws when the carrier does not exist — callers must check agyHookCarrierIsIntact() first', () => {
         expect(() => writeAgyHooksJsonAtomic('/tmp/hapi-agy-carrier-does-not-exist', '{}')).toThrow();
     });
+
+    it('cleans up the temp file when the atomic rename fails (Fix N5)', () => {
+        const result = prepareAgyHookCarrier('{"hapi-bridge":{"PreToolUse":[]}}');
+        expect(result).toBeDefined();
+        if (!result) return;
+
+        try {
+            const agentsDir = join(result.carrierDir, '.agents');
+            // Force renameSync to fail without mocking fs: renaming a
+            // regular file onto an existing (non-empty-capable) directory
+            // fails with EISDIR — a real, OS-enforced failure mode, not a
+            // simulated one.
+            rmSync(join(agentsDir, 'hooks.json'), { force: true });
+            mkdirSync(join(agentsDir, 'hooks.json'));
+
+            expect(() => writeAgyHooksJsonAtomic(result.carrierDir, '{"hapi-bridge":{"PreInvocation":[]}}')).toThrow();
+
+            // Fails (mutation check: drop the try/finally around renameSync)
+            // if a leftover .hooks.json.<pid>.<uuid>.tmp file is left behind
+            // in .agents/ after the failed rename.
+            const leftoverTmpFiles = readdirSync(agentsDir).filter((name) => name.startsWith('.hooks.json.') && name.endsWith('.tmp'));
+            expect(leftoverTmpFiles).toEqual([]);
+        } finally {
+            cleanupAgyHookCarrier(result.carrierDir);
+        }
+    });
 });
 
 describe('agyHookCarrierIsIntact', () => {
@@ -85,5 +133,293 @@ describe('agyHookCarrierIsIntact', () => {
 
         cleanupAgyHookCarrier(result.carrierDir);
         expect(agyHookCarrierIsIntact(result.carrierDir)).toBe(false);
+    });
+});
+
+// Phase 2.8: carriers used to live under the OS tmp dir (mkdtempSync(join(
+// tmpdir(), ...))), where a machine's periodic tmpfiles.d sweep can delete a
+// still-in-use carrier out from under a long-lived session (agy re-reads
+// hooks.json on every model call — see the plan's §6.6 — so a carrier isn't
+// a one-shot file, it must survive for the session's entire lifetime).
+// Moving it under HAPI_HOME gets it out of that blast radius and gives HAPI
+// its own directory to run a liveness-based sweep over at session start.
+describe('agy hook carrier location (Phase 2.8)', () => {
+    let previousHapiHome: string | undefined;
+    let customHapiHome: string;
+
+    beforeEach(() => {
+        previousHapiHome = process.env.HAPI_HOME;
+        customHapiHome = mkdtempSync(join(tmpdir(), 'hapi-phase28-home-'));
+        process.env.HAPI_HOME = customHapiHome;
+    });
+
+    afterEach(() => {
+        if (previousHapiHome === undefined) delete process.env.HAPI_HOME;
+        else process.env.HAPI_HOME = previousHapiHome;
+        rmSync(customHapiHome, { recursive: true, force: true });
+    });
+
+    it('creates a new carrier under HAPI_HOME/agy-carriers, not the OS tmp dir', () => {
+        const result = prepareAgyHookCarrier('{}');
+        expect(result).toBeDefined();
+        if (!result) return;
+
+        try {
+            const expectedRoot = join(customHapiHome, 'agy-carriers');
+            expect(result.carrierDir.startsWith(expectedRoot + '/')).toBe(true);
+            // A stale (unmodified) implementation would place it directly
+            // under the OS tmp dir instead — assert it did not.
+            expect(result.carrierDir.startsWith(join(tmpdir(), 'hapi-agy-carrier-'))).toBe(false);
+        } finally {
+            cleanupAgyHookCarrier(result.carrierDir);
+        }
+    });
+
+    it('writes owner metadata (pid, hostname) at the carrier root, outside .agents/', () => {
+        const result = prepareAgyHookCarrier('{}');
+        expect(result).toBeDefined();
+        if (!result) return;
+
+        try {
+            const ownerPath = join(result.carrierDir, 'owner.json');
+            expect(existsSync(ownerPath)).toBe(true);
+            const owner = JSON.parse(readFileSync(ownerPath, 'utf8'));
+            expect(owner.pid).toBe(process.pid);
+            // Fix N6: hostname is the over-delete guard for a shared
+            // HAPI_HOME (devcontainer bind-mount, NFS home) — a pid
+            // recorded by a different host's PID namespace must never be
+            // probed by this host's sweep.
+            expect(owner.hostname).toBe(hostname());
+            // Must not land inside .agents/ — that's the directory agy itself
+            // reads (hooks.json, plugins/), and owner metadata is HAPI-only
+            // bookkeeping that must not pollute it.
+            expect(existsSync(join(result.carrierDir, '.agents', 'owner.json'))).toBe(false);
+        } finally {
+            cleanupAgyHookCarrier(result.carrierDir);
+        }
+    });
+});
+
+describe('sweepAgyHookCarriers', () => {
+    let previousHapiHome: string | undefined;
+    let customHapiHome: string;
+
+    beforeEach(() => {
+        previousHapiHome = process.env.HAPI_HOME;
+        customHapiHome = mkdtempSync(join(tmpdir(), 'hapi-phase28-sweep-home-'));
+        process.env.HAPI_HOME = customHapiHome;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (previousHapiHome === undefined) delete process.env.HAPI_HOME;
+        else process.env.HAPI_HOME = previousHapiHome;
+        rmSync(customHapiHome, { recursive: true, force: true });
+    });
+
+    // Every real carrier is mkdtemp'd under this prefix (see
+    // prepareAgyHookCarrier / CARRIER_DIR_PREFIX in agyHookCarrier.ts) — the
+    // hand-built carriers below must match it so Fix N3's prefix filter
+    // doesn't skip them for reasons unrelated to what each test wants to
+    // exercise.
+    const CARRIER_PREFIX = 'hapi-agy-carrier-';
+
+    /** Builds a carrier directory by hand (not via prepareAgyHookCarrier) so
+     * the test can control the owner.json contents independently of this
+     * test process's own PID. */
+    function makeCarrierDir(name: string): string {
+        const root = join(customHapiHome, 'agy-carriers');
+        mkdirSync(root, { recursive: true });
+        const carrierDir = join(root, `${CARRIER_PREFIX}${name}`);
+        mkdirSync(join(carrierDir, '.agents'), { recursive: true });
+        writeFileSync(join(carrierDir, '.agents', 'hooks.json'), '{}');
+        return carrierDir;
+    }
+
+    it('sweeps a carrier whose owner process has died', async () => {
+        const deadPid = await spawnAndReapDeadPid();
+        const carrierDir = makeCarrierDir('dead-owner');
+        writeFileSync(
+            join(carrierDir, 'owner.json'),
+            JSON.stringify({ pid: deadPid, hostname: hostname() })
+        );
+
+        sweepAgyHookCarriers();
+
+        expect(existsSync(carrierDir)).toBe(false);
+    });
+
+    it('preserves a carrier whose owner process is alive — the costliest mistake is deleting a live session\'s carrier', () => {
+        const carrierDir = makeCarrierDir('alive-owner');
+        // This test process's own PID is guaranteed alive for the duration
+        // of the test.
+        writeFileSync(
+            join(carrierDir, 'owner.json'),
+            JSON.stringify({ pid: process.pid, hostname: hostname() })
+        );
+
+        sweepAgyHookCarriers();
+
+        expect(existsSync(carrierDir)).toBe(true);
+    });
+
+    it('treats EPERM (process exists but is owned by someone else) as alive, not dead', () => {
+        const carrierDir = makeCarrierDir('eperm-owner');
+        writeFileSync(
+            join(carrierDir, 'owner.json'),
+            JSON.stringify({ pid: 1, hostname: hostname() })
+        );
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+            if (pid === 1) {
+                const error = new Error('EPERM') as NodeJS.ErrnoException;
+                error.code = 'EPERM';
+                throw error;
+            }
+            return true;
+        }) as typeof process.kill);
+
+        sweepAgyHookCarriers();
+
+        expect(existsSync(carrierDir)).toBe(true);
+    });
+
+    it('preserves a carrier with unreadable/missing owner metadata unless it is old enough to be a stale leftover', () => {
+        const carrierDir = makeCarrierDir('no-owner-metadata');
+
+        // Fresh, no owner.json at all — simulates a carrier from before this
+        // feature shipped, or a partial write. Must be preserved: deleting
+        // it on sight would be exactly the mtime/name-based guessing this
+        // Phase was written to avoid.
+        sweepAgyHookCarriers();
+        expect(existsSync(carrierDir)).toBe(true);
+
+        // Age it well past the staleness threshold and sweep again — now it
+        // is old enough to be treated as a genuine leftover.
+        const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
+        utimesSync(carrierDir, staleTime, staleTime);
+        sweepAgyHookCarriers();
+        expect(existsSync(carrierDir)).toBe(false);
+    });
+
+    it('treats a legacy owner.json (pid only, no hostname field) as unreadable metadata, not as a same-host dead pid, and sweeps it on the age-based ownerless path instead', async () => {
+        // Sanity companion to the Fix N6 test below: a same-host dead pid
+        // (no hostname field at all, i.e. legacy owner.json) still falls
+        // back to the age-based ownerless path rather than being probed —
+        // readOwnerMetadata requires `hostname` now, so a pre-Fix-N6
+        // owner.json (pid only) is treated as unreadable, not as "same
+        // host, dead pid".
+        const carrierDir = makeCarrierDir('legacy-owner-no-hostname');
+        writeFileSync(join(carrierDir, 'owner.json'), JSON.stringify({ pid: 999999 }));
+
+        sweepAgyHookCarriers();
+        expect(existsSync(carrierDir)).toBe(true);
+
+        const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
+        utimesSync(carrierDir, staleTime, staleTime);
+        sweepAgyHookCarriers();
+        expect(existsSync(carrierDir)).toBe(false);
+    });
+
+    it('preserves a carrier owned by a different host even when its recorded pid is dead (Fix N6)', async () => {
+        const deadPid = await spawnAndReapDeadPid();
+        const carrierDir = makeCarrierDir('other-host-dead-pid');
+        writeFileSync(
+            join(carrierDir, 'owner.json'),
+            // A pid namespace from a different host — this deadPid is only
+            // meaningfully "dead" in THIS process's PID namespace; recorded
+            // under another host it must never be probed at all.
+            JSON.stringify({ pid: deadPid, hostname: 'some-other-host-4a1c9e' })
+        );
+
+        sweepAgyHookCarriers();
+
+        // Fails (mutation check: drop the `owner.hostname !== hostname()`
+        // guard in sweepAgyHookCarriers) if the carrier gets deleted because
+        // its pid happens to be dead in THIS host's namespace too.
+        expect(existsSync(carrierDir)).toBe(true);
+    });
+
+    it('never inspects (or deletes) an entry that does not carry the carrier prefix, no matter how old (Fix N3)', () => {
+        const root = join(customHapiHome, 'agy-carriers');
+        mkdirSync(root, { recursive: true });
+        // Deliberately NOT prefixed with hapi-agy-carrier- — simulates
+        // unrelated content sharing the agy-carriers/ root (HAPI_HOME
+        // misconfiguration/reuse).
+        const strangerDir = join(root, 'not-a-hapi-carrier');
+        mkdirSync(strangerDir, { recursive: true });
+        writeFileSync(join(strangerDir, 'important-unrelated-file.txt'), 'do not delete me');
+
+        // Age it well past the ownerless staleness threshold — the ONLY
+        // other reason sweepAgyHookCarriers would ever delete an
+        // owner-metadata-less entry.
+        const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
+        utimesSync(strangerDir, staleTime, staleTime);
+
+        sweepAgyHookCarriers();
+
+        // Fails (mutation check: drop the `entry.startsWith(CARRIER_DIR_PREFIX)`
+        // guard) if the stale-ownerless branch deletes this non-carrier
+        // directory purely because it is old.
+        expect(existsSync(strangerDir)).toBe(true);
+        expect(existsSync(join(strangerDir, 'important-unrelated-file.txt'))).toBe(true);
+    });
+
+    it('judges a carrier-prefixed entry by the entry itself, not a symlink target (Fix N4)', () => {
+        const root = join(customHapiHome, 'agy-carriers');
+        mkdirSync(root, { recursive: true });
+
+        // A real, live-owned, otherwise-untouchable directory elsewhere —
+        // the "attack surface" a naive statSync-based sweep would
+        // dereference into.
+        const targetDir = mkdtempSync(join(tmpdir(), 'hapi-n4-symlink-target-'));
+        try {
+            const linkPath = join(root, `${CARRIER_PREFIX}symlinked`);
+            symlinkSync(targetDir, linkPath, 'dir');
+
+            sweepAgyHookCarriers();
+
+            // Fails (mutation check: revert lstatSync back to statSync) if
+            // the sweep dereferences the symlink and evaluates the TARGET
+            // directory's contents/owner as if it were the carrier entry
+            // itself — lstatSync().isDirectory() on a symlink is false, so
+            // the loop must skip it outright (preserve both the link and
+            // whatever it points at) rather than treat it as a carrier.
+            expect(existsSync(linkPath)).toBe(true);
+            expect(existsSync(targetDir)).toBe(true);
+        } finally {
+            rmSync(targetDir, { recursive: true, force: true });
+        }
+    });
+
+    it('does not let two different HAPI_HOME roots interfere with each other', () => {
+        const hapiHomeA = customHapiHome;
+        const carrierA = prepareAgyHookCarrier('{"a":true}');
+        expect(carrierA).toBeDefined();
+        if (!carrierA) return;
+
+        const hapiHomeB = mkdtempSync(join(tmpdir(), 'hapi-phase28-home-b-'));
+        try {
+            process.env.HAPI_HOME = hapiHomeB;
+
+            // Sweeping under HAPI_HOME B must never touch A's carrier, even
+            // though A's carrier has no owner.json reachable from B's root.
+            sweepAgyHookCarriers();
+            expect(existsSync(carrierA.carrierDir)).toBe(true);
+
+            const carrierB = prepareAgyHookCarrier('{"b":true}');
+            expect(carrierB).toBeDefined();
+            if (!carrierB) return;
+            expect(carrierB.carrierDir.startsWith(join(hapiHomeB, 'agy-carriers') + '/')).toBe(true);
+
+            // B's root must contain exactly B's own carrier, not A's.
+            const bEntries = readdirSync(join(hapiHomeB, 'agy-carriers'));
+            expect(bEntries).toEqual([carrierB.carrierDir.split('/').pop()]);
+
+            cleanupAgyHookCarrier(carrierB.carrierDir);
+        } finally {
+            process.env.HAPI_HOME = hapiHomeA;
+            cleanupAgyHookCarrier(carrierA.carrierDir);
+            rmSync(hapiHomeB, { recursive: true, force: true });
+        }
     });
 });

--- a/cli/src/agy/utils/agyHookCarrier.test.ts
+++ b/cli/src/agy/utils/agyHookCarrier.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
-import { hostname, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import {
     agyHookCarrierIsIntact,
     cleanupAgyHookCarrier,
+    computeLocalCarrierScope,
     prepareAgyHookCarrier,
     sweepAgyHookCarriers,
-    writeAgyHooksJsonAtomic
+    writeAgyHooksJsonAtomic,
+    type ScopeProbe
 } from './agyHookCarrier';
 
 /**
@@ -175,7 +177,7 @@ describe('agy hook carrier location (Phase 2.8)', () => {
         }
     });
 
-    it('writes owner metadata (pid, hostname) at the carrier root, outside .agents/', () => {
+    it('writes owner metadata (pid, scope) at the carrier root, outside .agents/', () => {
         const result = prepareAgyHookCarrier('{}');
         expect(result).toBeDefined();
         if (!result) return;
@@ -185,11 +187,13 @@ describe('agy hook carrier location (Phase 2.8)', () => {
             expect(existsSync(ownerPath)).toBe(true);
             const owner = JSON.parse(readFileSync(ownerPath, 'utf8'));
             expect(owner.pid).toBe(process.pid);
-            // Fix N6: hostname is the over-delete guard for a shared
-            // HAPI_HOME (devcontainer bind-mount, NFS home) — a pid
-            // recorded by a different host's PID namespace must never be
-            // probed by this host's sweep.
-            expect(owner.hostname).toBe(hostname());
+            // Fix 2: `scope` (boot-id + PID-namespace on Linux, a tagged
+            // hostname fallback elsewhere) is the over-delete guard for a
+            // shared HAPI_HOME (devcontainer bind-mount, NFS home) — a pid
+            // recorded under a different scope must never be probed by this
+            // host's sweep. See computeLocalCarrierScope's docstring for why
+            // hostname alone (the original Fix N6) wasn't enough.
+            expect(owner.scope).toBe(computeLocalCarrierScope());
             // Must not land inside .agents/ — that's the directory agy itself
             // reads (hooks.json, plugins/), and owner metadata is HAPI-only
             // bookkeeping that must not pollute it.
@@ -197,6 +201,36 @@ describe('agy hook carrier location (Phase 2.8)', () => {
         } finally {
             cleanupAgyHookCarrier(result.carrierDir);
         }
+    });
+});
+
+describe('computeLocalCarrierScope', () => {
+    it('computes a linux:<bootId>:<nsId> scope from real /proc reads on this (Linux) test host', () => {
+        // Non-vacuous: this sandbox's /proc is genuinely readable (verified
+        // manually before writing this test), so this pins the real Linux
+        // success path, not just the fallback.
+        const scope = computeLocalCarrierScope();
+        expect(scope).toMatch(/^linux:[0-9a-f-]{36}:\d+$/);
+    });
+
+    it('falls back to a distinctly-tagged hostname when the Linux probe fails', () => {
+        const probe: ScopeProbe = {
+            readBootId: () => { throw new Error('ENOENT: no /proc on this platform'); },
+            readPidNamespaceId: () => { throw new Error('should not be reached'); },
+            hostname: () => 'macbook.local',
+        };
+        // Fails (mutation check: drop the hostname-fallback prefix) if this
+        // ever collides with a real linux:... scope string.
+        expect(computeLocalCarrierScope(probe)).toBe('hostname-fallback:macbook.local');
+    });
+
+    it('returns undefined when both the Linux probe and the hostname fallback fail', () => {
+        const probe: ScopeProbe = {
+            readBootId: () => { throw new Error('no /proc'); },
+            readPidNamespaceId: () => { throw new Error('no /proc'); },
+            hostname: () => { throw new Error('gethostname() failed'); },
+        };
+        expect(computeLocalCarrierScope(probe)).toBeUndefined();
     });
 });
 
@@ -236,16 +270,19 @@ describe('sweepAgyHookCarriers', () => {
         return carrierDir;
     }
 
-    it('sweeps a carrier whose owner process has died', async () => {
+    it('③ sweeps a carrier whose owner scope matches AND whose process has died', async () => {
         const deadPid = await spawnAndReapDeadPid();
-        const carrierDir = makeCarrierDir('dead-owner');
+        const carrierDir = makeCarrierDir('dead-owner-matching-scope');
         writeFileSync(
             join(carrierDir, 'owner.json'),
-            JSON.stringify({ pid: deadPid, hostname: hostname() })
+            JSON.stringify({ pid: deadPid, scope: computeLocalCarrierScope() })
         );
 
         sweepAgyHookCarriers();
 
+        // Fails if the scope-match requirement (Fix 2b) or the liveness
+        // check regresses to always-preserve — this is the one combination
+        // that must actually delete.
         expect(existsSync(carrierDir)).toBe(false);
     });
 
@@ -255,7 +292,7 @@ describe('sweepAgyHookCarriers', () => {
         // of the test.
         writeFileSync(
             join(carrierDir, 'owner.json'),
-            JSON.stringify({ pid: process.pid, hostname: hostname() })
+            JSON.stringify({ pid: process.pid, scope: computeLocalCarrierScope() })
         );
 
         sweepAgyHookCarriers();
@@ -267,7 +304,7 @@ describe('sweepAgyHookCarriers', () => {
         const carrierDir = makeCarrierDir('eperm-owner');
         writeFileSync(
             join(carrierDir, 'owner.json'),
-            JSON.stringify({ pid: 1, hostname: hostname() })
+            JSON.stringify({ pid: 1, scope: computeLocalCarrierScope() })
         );
         vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
             if (pid === 1) {
@@ -283,32 +320,32 @@ describe('sweepAgyHookCarriers', () => {
         expect(existsSync(carrierDir)).toBe(true);
     });
 
-    it('preserves a carrier with unreadable/missing owner metadata unless it is old enough to be a stale leftover', () => {
-        const carrierDir = makeCarrierDir('no-owner-metadata');
-
+    it('① preserves a carrier with unreadable/missing owner metadata no matter how old (Fix 2a)', () => {
         // Fresh, no owner.json at all — simulates a carrier from before this
-        // feature shipped, or a partial write. Must be preserved: deleting
-        // it on sight would be exactly the mtime/name-based guessing this
-        // Phase was written to avoid.
+        // feature shipped, a partial write, or a read that raced a
+        // concurrent write against a still-live, multi-day session.
+        const carrierDir = makeCarrierDir('no-owner-metadata');
         sweepAgyHookCarriers();
         expect(existsSync(carrierDir)).toBe(true);
 
-        // Age it well past the staleness threshold and sweep again — now it
-        // is old enough to be treated as a genuine leftover.
+        // Fix 2a: age no longer matters at all — a carrier this old used to
+        // be swept purely on age once the owner-metadata read failed. That
+        // is exactly what would delete a live, multi-day agy session's
+        // carrier if its owner.json read merely raced a write. Aging it
+        // past the OLD 24h threshold must change nothing now.
         const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
         utimesSync(carrierDir, staleTime, staleTime);
         sweepAgyHookCarriers();
-        expect(existsSync(carrierDir)).toBe(false);
+        // Fails (mutation check: reintroduce the mtime-based ownerless
+        // fallback branch) if this carrier gets swept purely for being old.
+        expect(existsSync(carrierDir)).toBe(true);
     });
 
-    it('treats a legacy owner.json (pid only, no hostname field) as unreadable metadata, not as a same-host dead pid, and sweeps it on the age-based ownerless path instead', async () => {
-        // Sanity companion to the Fix N6 test below: a same-host dead pid
-        // (no hostname field at all, i.e. legacy owner.json) still falls
-        // back to the age-based ownerless path rather than being probed —
-        // readOwnerMetadata requires `hostname` now, so a pre-Fix-N6
-        // owner.json (pid only) is treated as unreadable, not as "same
-        // host, dead pid".
-        const carrierDir = makeCarrierDir('legacy-owner-no-hostname');
+    it('treats a legacy owner.json (pid only, no scope field) as unreadable metadata and preserves it regardless of age', () => {
+        // A pre-this-fix owner.json (hostname field, not scope) or a
+        // pre-Fix-N6 one (pid only) both fail the new schema check the same
+        // way: readOwnerMetadata requires a non-empty `scope` string.
+        const carrierDir = makeCarrierDir('legacy-owner-no-scope');
         writeFileSync(join(carrierDir, 'owner.json'), JSON.stringify({ pid: 999999 }));
 
         sweepAgyHookCarriers();
@@ -317,29 +354,59 @@ describe('sweepAgyHookCarriers', () => {
         const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
         utimesSync(carrierDir, staleTime, staleTime);
         sweepAgyHookCarriers();
-        expect(existsSync(carrierDir)).toBe(false);
+        expect(existsSync(carrierDir)).toBe(true);
     });
 
-    it('preserves a carrier owned by a different host even when its recorded pid is dead (Fix N6)', async () => {
+    it('② preserves a carrier owned by a different scope even when its recorded pid is dead (Fix 2b)', async () => {
         const deadPid = await spawnAndReapDeadPid();
-        const carrierDir = makeCarrierDir('other-host-dead-pid');
+        const carrierDir = makeCarrierDir('other-scope-dead-pid');
         writeFileSync(
             join(carrierDir, 'owner.json'),
-            // A pid namespace from a different host — this deadPid is only
-            // meaningfully "dead" in THIS process's PID namespace; recorded
-            // under another host it must never be probed at all.
-            JSON.stringify({ pid: deadPid, hostname: 'some-other-host-4a1c9e' })
+            // A scope that can never equal this process's real
+            // computeLocalCarrierScope() (real scopes are always prefixed
+            // `linux:` or `hostname-fallback:`) — this deadPid is only
+            // meaningfully "dead" in THIS process's own boot/PID-namespace;
+            // recorded under a different scope it must never be probed at
+            // all.
+            JSON.stringify({ pid: deadPid, scope: 'some-other-container-scope-4a1c9e' })
         );
 
         sweepAgyHookCarriers();
 
-        // Fails (mutation check: drop the `owner.hostname !== hostname()`
+        // Fails (mutation check: drop the `owner.scope !== localScope`
         // guard in sweepAgyHookCarriers) if the carrier gets deleted because
-        // its pid happens to be dead in THIS host's namespace too.
+        // its pid happens to be dead in THIS process's namespace too.
         expect(existsSync(carrierDir)).toBe(true);
     });
 
-    it('never inspects (or deletes) an entry that does not carry the carrier prefix, no matter how old (Fix N3)', () => {
+    it('④ preserves everything, without even scanning, when the local scope cannot be determined', async () => {
+        const deadPid = await spawnAndReapDeadPid();
+        const carrierDir = makeCarrierDir('would-be-swept-if-scope-resolved');
+        // This owner.json carries the REAL local scope and a genuinely dead
+        // pid — under a working scope probe this is exactly the carrier
+        // that test ③ proves gets swept. The only variable here is that
+        // sweepAgyHookCarriers itself is called with a probe that fails to
+        // resolve ANY scope (Linux probe and hostname fallback both throw).
+        writeFileSync(
+            join(carrierDir, 'owner.json'),
+            JSON.stringify({ pid: deadPid, scope: computeLocalCarrierScope() })
+        );
+
+        const failingProbe: ScopeProbe = {
+            readBootId: () => { throw new Error('no /proc'); },
+            readPidNamespaceId: () => { throw new Error('no /proc'); },
+            hostname: () => { throw new Error('gethostname() failed'); },
+        };
+        sweepAgyHookCarriers(failingProbe);
+
+        // Fails (mutation check: drop the `if (!localScope) return` early
+        // bailout in sweepAgyHookCarriers) if this ever gets deleted despite
+        // the sweep being unable to identify itself.
+        expect(existsSync(carrierDir)).toBe(true);
+    });
+
+    it('never inspects (or deletes) an entry that does not carry the carrier prefix, even when its owner.json would otherwise qualify for deletion (Fix N3)', async () => {
+        const deadPid = await spawnAndReapDeadPid();
         const root = join(customHapiHome, 'agy-carriers');
         mkdirSync(root, { recursive: true });
         // Deliberately NOT prefixed with hapi-agy-carrier- — simulates
@@ -348,18 +415,18 @@ describe('sweepAgyHookCarriers', () => {
         const strangerDir = join(root, 'not-a-hapi-carrier');
         mkdirSync(strangerDir, { recursive: true });
         writeFileSync(join(strangerDir, 'important-unrelated-file.txt'), 'do not delete me');
-
-        // Age it well past the ownerless staleness threshold — the ONLY
-        // other reason sweepAgyHookCarriers would ever delete an
-        // owner-metadata-less entry.
-        const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
-        utimesSync(strangerDir, staleTime, staleTime);
+        // A matching scope + confirmed-dead pid — exactly the combination
+        // test ③ proves gets deleted for a properly-prefixed carrier.
+        writeFileSync(
+            join(strangerDir, 'owner.json'),
+            JSON.stringify({ pid: deadPid, scope: computeLocalCarrierScope() })
+        );
 
         sweepAgyHookCarriers();
 
         // Fails (mutation check: drop the `entry.startsWith(CARRIER_DIR_PREFIX)`
-        // guard) if the stale-ownerless branch deletes this non-carrier
-        // directory purely because it is old.
+        // guard) if the sweep deletes this non-carrier directory despite its
+        // owner.json otherwise qualifying.
         expect(existsSync(strangerDir)).toBe(true);
         expect(existsSync(join(strangerDir, 'important-unrelated-file.txt'))).toBe(true);
     });

--- a/cli/src/agy/utils/agyHookCarrier.test.ts
+++ b/cli/src/agy/utils/agyHookCarrier.test.ts
@@ -213,25 +213,19 @@ describe('computeLocalCarrierScope', () => {
         expect(scope).toMatch(/^linux:[0-9a-f-]{36}:\d+$/);
     });
 
-    it('falls back to a distinctly-tagged hostname when the Linux probe fails', () => {
+    it('refuses to fall back to hostname when the Linux probe fails — hostname is not an identity', () => {
         const probe: ScopeProbe = {
             readBootId: () => { throw new Error('ENOENT: no /proc on this platform'); },
             readPidNamespaceId: () => { throw new Error('should not be reached'); },
             hostname: () => 'macbook.local',
         };
-        // Fails (mutation check: drop the hostname-fallback prefix) if this
-        // ever collides with a real linux:... scope string.
-        expect(computeLocalCarrierScope(probe)).toBe('hostname-fallback:macbook.local');
-    });
-
-    it('returns undefined when both the Linux probe and the hostname fallback fail', () => {
-        const probe: ScopeProbe = {
-            readBootId: () => { throw new Error('no /proc'); },
-            readPidNamespaceId: () => { throw new Error('no /proc'); },
-            hostname: () => { throw new Error('gethostname() failed'); },
-        };
+        // Two machines sharing a HAPI_HOME can share a hostname while their
+        // pids live in unrelated spaces, so a hostname-derived scope would let
+        // one sweep the other's live carrier. Undefined makes the sweep
+        // preserve everything instead. Fails if a fallback is reintroduced.
         expect(computeLocalCarrierScope(probe)).toBeUndefined();
     });
+
 });
 
 describe('sweepAgyHookCarriers', () => {
@@ -364,7 +358,7 @@ describe('sweepAgyHookCarriers', () => {
             join(carrierDir, 'owner.json'),
             // A scope that can never equal this process's real
             // computeLocalCarrierScope() (real scopes are always prefixed
-            // `linux:` or `hostname-fallback:`) — this deadPid is only
+            // `linux:`) — this deadPid is only
             // meaningfully "dead" in THIS process's own boot/PID-namespace;
             // recorded under a different scope it must never be probed at
             // all.

--- a/cli/src/agy/utils/agyHookCarrier.test.ts
+++ b/cli/src/agy/utils/agyHookCarrier.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
-import { cleanupAgyHookCarrier, prepareAgyHookCarrier } from './agyHookCarrier';
+import {
+    agyHookCarrierIsIntact,
+    cleanupAgyHookCarrier,
+    prepareAgyHookCarrier,
+    writeAgyHooksJsonAtomic
+} from './agyHookCarrier';
 
 describe('agy hook carrier', () => {
     it('creates workspace-local hooks and a session-scoped HAPI MCP plugin', () => {
@@ -31,5 +36,54 @@ describe('agy hook carrier', () => {
 
         cleanupAgyHookCarrier(result.carrierDir);
         expect(existsSync(result.carrierDir)).toBe(false);
+    });
+});
+
+describe('writeAgyHooksJsonAtomic', () => {
+    it('overwrites an existing carrier\'s hooks.json in place, leaving no stray temp file behind', () => {
+        const result = prepareAgyHookCarrier('{"hapi-bridge":{"PreToolUse":[]}}');
+        expect(result).toBeDefined();
+        if (!result) return;
+
+        try {
+            const replacement = '{"hapi-bridge":{"PreToolUse":[],"PreInvocation":[]}}';
+            writeAgyHooksJsonAtomic(result.carrierDir, replacement);
+
+            const agentsDir = join(result.carrierDir, '.agents');
+            expect(readFileSync(join(agentsDir, 'hooks.json'), 'utf8')).toBe(replacement);
+            // The atomic-write temp file must be renamed away, not merely
+            // written alongside the target — a leftover .tmp file would mean
+            // the rename step silently failed or was skipped.
+            expect(readdirSync(agentsDir).sort()).toEqual(['hooks.json']);
+        } finally {
+            cleanupAgyHookCarrier(result.carrierDir);
+        }
+    });
+
+    it('throws when the carrier does not exist — callers must check agyHookCarrierIsIntact() first', () => {
+        expect(() => writeAgyHooksJsonAtomic('/tmp/hapi-agy-carrier-does-not-exist', '{}')).toThrow();
+    });
+});
+
+describe('agyHookCarrierIsIntact', () => {
+    it('is true when hooks.json is present', () => {
+        const result = prepareAgyHookCarrier('{}');
+        expect(result).toBeDefined();
+        if (!result) return;
+
+        try {
+            expect(agyHookCarrierIsIntact(result.carrierDir)).toBe(true);
+        } finally {
+            cleanupAgyHookCarrier(result.carrierDir);
+        }
+    });
+
+    it('is false once the carrier has been cleaned up (directory gone entirely)', () => {
+        const result = prepareAgyHookCarrier('{}');
+        expect(result).toBeDefined();
+        if (!result) return;
+
+        cleanupAgyHookCarrier(result.carrierDir);
+        expect(agyHookCarrierIsIntact(result.carrierDir)).toBe(false);
     });
 });

--- a/cli/src/agy/utils/agyHookCarrier.ts
+++ b/cli/src/agy/utils/agyHookCarrier.ts
@@ -46,9 +46,9 @@ export type AgyMcpServerEntry = {
 // /proc — differs only across an actual host reboot, which is the one case
 // where every previously-recorded pid is unconditionally dead; this fix
 // does not attempt to special-case that, see sweepAgyHookCarriers's
-// docstring). Platforms without a working /proc (macOS, ...) fall back to
-// hostname, tagged so a fallback-computed scope can never collide with a
-// real Linux one.
+// docstring). Platforms without a working /proc (macOS, ...) get no scope at
+// all and are therefore never swept — hostname is not an identity, so there
+// is deliberately no fallback (see computeLocalCarrierScope).
 type AgyHookCarrierOwner = {
     pid: number;
     scope: string;
@@ -62,10 +62,6 @@ const OWNER_FILE_NAME = 'owner.json';
 // at a directory with other content) must never turn into a recursive
 // delete of whatever else happens to live there (Fix N3).
 const CARRIER_DIR_PREFIX = 'hapi-agy-carrier-';
-
-// Tags a hostname-derived scope so it can never equal a Linux
-// boot-id+namespace scope, even by coincidence — see computeLocalCarrierScope.
-const HOSTNAME_FALLBACK_SCOPE_PREFIX = 'hostname-fallback:';
 
 /**
  * Reads the boot-id + PID-namespace pair that identifies "this exact kernel
@@ -124,21 +120,24 @@ const defaultScopeProbe: ScopeProbe = {
 /**
  * Computes this process's carrier scope: an opaque string identifying
  * "carriers this process could plausibly own", used to gate sweepAgyHookCarriers.
- * Prefers the Linux boot-id+PID-namespace pair (readLinuxBootAndNamespaceScope);
- * falls back to a tagged hostname when that is unavailable (non-Linux, or a
- * /proc that exists but is restricted). Returns undefined only when BOTH the
- * Linux probe and the hostname fallback fail — callers must treat that as
- * "cannot self-identify" and preserve everything rather than guess.
+ *
+ * Only the Linux boot-id+PID-namespace pair qualifies. There is deliberately
+ * no hostname fallback: hostname is not an identity. Two machines or
+ * containers that share a HAPI_HOME and happen to share a hostname would
+ * compute the same scope, and a pid that is live on the owning system reads
+ * as ESRCH here — deleting a carrier out from under a running agy, which is
+ * spawned with --dangerously-skip-permissions and depends on that carrier's
+ * hooks.json for its PreToolUse approval bridge.
+ *
+ * Returning undefined makes sweepAgyHookCarriers preserve everything. That
+ * costs orphaned carriers on platforms without a strong identity (macOS, a
+ * restricted /proc), which is the cheaper failure: normal teardown still
+ * removes carriers via cleanupAgyHookCarrier, so only crash leftovers
+ * accumulate. Add a platform-specific boot/namespace identity here before
+ * re-enabling sweeping there.
  */
 export function computeLocalCarrierScope(probe: ScopeProbe = defaultScopeProbe): string | undefined {
-    const linuxScope = readLinuxBootAndNamespaceScope(probe);
-    if (linuxScope) return linuxScope;
-    try {
-        const host = probe.hostname();
-        return host ? `${HOSTNAME_FALLBACK_SCOPE_PREFIX}${host}` : undefined;
-    } catch {
-        return undefined;
-    }
+    return readLinuxBootAndNamespaceScope(probe);
 }
 
 /**
@@ -340,7 +339,6 @@ export function sweepAgyHookCarriers(scopeProbe: ScopeProbe = defaultScopeProbe)
             }
             if (owner.scope !== localScope) {
                 // Fix 2b: a pid recorded under a different boot/PID-namespace
-                // (or, on a hostname-fallback platform, a different host)
                 // means nothing in this process's PID space — never probe
                 // it, never delete it.
                 continue;

--- a/cli/src/agy/utils/agyHookCarrier.ts
+++ b/cli/src/agy/utils/agyHookCarrier.ts
@@ -1,8 +1,20 @@
-import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import {
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    renameSync,
+    rmSync,
+    unlinkSync,
+    writeFileSync
+} from 'node:fs';
 import { randomUUID } from 'node:crypto';
-import { tmpdir } from 'node:os';
+import { hostname } from 'node:os';
 import { join } from 'node:path';
 import { logger } from '@/ui/logger';
+import { resolveHapiHomeDir } from '@/configuration';
 
 export type AgyHookCarrier = {
     carrierDir: string;
@@ -14,6 +26,49 @@ export type AgyMcpServerEntry = {
     env?: Record<string, string>;
 };
 
+// hostname is the over-delete guard for a shared HAPI_HOME (Fix N6): a
+// devcontainer bind-mounting ~/.hapi, or an NFS-shared home, puts carriers
+// written by different PID namespaces in the same agy-carriers/ directory.
+// A pid recorded by namespace A means nothing in namespace B — probing it
+// there can hit ESRCH for a process that is very much alive in A. hostname
+// does not fully solve cross-host PID collisions (two hosts using the same
+// hostname, or two containers sharing a hostname, remain unresolved — no
+// occurrence of this so far, and not what this fix targets), but it closes
+// the concrete case the reviewer raised. Sweep only ever probes liveness
+// for a carrier this host itself could plausibly own.
+type AgyHookCarrierOwner = {
+    pid: number;
+    hostname: string;
+};
+
+const AGY_CARRIERS_DIRNAME = 'agy-carriers';
+const OWNER_FILE_NAME = 'owner.json';
+// Every carrier prepareAgyHookCarrier() creates is mkdtemp'd under this
+// prefix (see below). Sweep must never touch a directory that doesn't carry
+// it — HAPI_HOME misconfiguration or reuse (pointing an unrelated HAPI_HOME
+// at a directory with other content) must never turn into a recursive
+// delete of whatever else happens to live there (Fix N3).
+const CARRIER_DIR_PREFIX = 'hapi-agy-carrier-';
+
+// Carriers whose owner.json is missing or unreadable (pre-Phase-2.8 builds,
+// or a write that got interrupted) are legacy/ambiguous, not confirmed dead.
+// Give them a full day before sweeping them on age alone — long enough that
+// a carrier still mid-creation or briefly unreadable is never caught by it,
+// short enough that real leftovers don't linger for the OS's own 30-day
+// tmpfiles.d window (see the agy-preinvocation-discovery plan §8/§9).
+const STALE_OWNERLESS_CARRIER_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Root directory HAPI creates all agy hook carriers under: `<HAPI_HOME>/
+ * agy-carriers/`. Resolved fresh on every call (via resolveHapiHomeDir(),
+ * not the cached `configuration.happyHomeDir` singleton) so an isolated E2E
+ * stack that overrides HAPI_HOME per-process gets carriers that are
+ * automatically isolated too, with no extra wiring.
+ */
+function agyCarriersRootDir(): string {
+    return join(resolveHapiHomeDir(), AGY_CARRIERS_DIRNAME);
+}
+
 /**
  * Create an extra AGY workspace containing HAPI's session-local hook and MCP plugin.
  * The user's HOME, global hooks, and target project remain untouched.
@@ -24,7 +79,10 @@ export function prepareAgyHookCarrier(
 ): AgyHookCarrier | undefined {
     let carrierDir: string | undefined;
     try {
-        carrierDir = mkdtempSync(join(tmpdir(), 'hapi-agy-carrier-'));
+        const carriersRoot = agyCarriersRootDir();
+        mkdirSync(carriersRoot, { recursive: true, mode: 0o700 });
+        carrierDir = mkdtempSync(join(carriersRoot, CARRIER_DIR_PREFIX));
+        writeOwnerMetadata(carrierDir);
         const agentsDir = join(carrierDir, '.agents');
         mkdirSync(agentsDir, { recursive: true, mode: 0o700 });
         writeFileSync(join(agentsDir, 'hooks.json'), hooksJsonContent, { mode: 0o600 });
@@ -46,6 +104,149 @@ export function prepareAgyHookCarrier(
         }
         logger.debug('[agyHookCarrier] preparation failed', error);
         return undefined;
+    }
+}
+
+/**
+ * Records which process owns a carrier, at the carrier root — deliberately
+ * outside .agents/, which is the directory agy itself reads (hooks.json,
+ * plugins/); owner metadata is HAPI-only bookkeeping and must never show up
+ * there.
+ */
+function writeOwnerMetadata(carrierDir: string): void {
+    const owner: AgyHookCarrierOwner = { pid: process.pid, hostname: hostname() };
+    writeFileSync(join(carrierDir, OWNER_FILE_NAME), JSON.stringify(owner), { mode: 0o600 });
+}
+
+function readOwnerMetadata(carrierDir: string): AgyHookCarrierOwner | undefined {
+    try {
+        const parsed = JSON.parse(readFileSync(join(carrierDir, OWNER_FILE_NAME), 'utf8')) as Partial<AgyHookCarrierOwner>;
+        if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid) && parsed.pid > 0 && typeof parsed.hostname === 'string' && parsed.hostname.length > 0) {
+            return { pid: parsed.pid, hostname: parsed.hostname };
+        }
+        return undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Distinguishes "definitely dead" from "definitely alive" from "can't tell"
+ * for a PID, using process.kill(pid, 0) (sends no signal, just probes).
+ *
+ * This deliberately does NOT reuse @/utils/process's isProcessAlive(): that
+ * helper treats every kill() failure — ESRCH (no such process) AND EPERM
+ * (process exists, we just don't own it) — as "not alive", which is correct
+ * for its callers but wrong here. A carrier owned by a live process we don't
+ * have permission to signal is exactly the case sweeping must NOT delete
+ * (see the agy-preinvocation-discovery plan §8) — collapsing it into "dead"
+ * would make the sweep as unsafe as the mtime/name heuristics it replaces.
+ */
+function checkProcessLiveness(pid: number): 'alive' | 'dead' | 'unknown' {
+    try {
+        process.kill(pid, 0);
+        return 'alive';
+    } catch (error) {
+        const code = (error as NodeJS.ErrnoException)?.code;
+        if (code === 'ESRCH') return 'dead';
+        if (code === 'EPERM') return 'alive';
+        // Anything else (unexpected errno, platform quirk) is unknown, not
+        // dead — preservation is the safe default when liveness can't be
+        // determined with confidence.
+        return 'unknown';
+    }
+}
+
+/**
+ * Removes agy hook carriers under HAPI_HOME whose owning process has
+ * confirmed-died (process.kill(pid, 0) raises ESRCH), and carriers old
+ * enough with unreadable/missing owner metadata to be considered stale
+ * leftovers. Meant to be called once per session start — see runAgy.ts.
+ *
+ * Deliberately conservative in every ambiguous direction: a carrier whose
+ * owner is alive (including EPERM — alive, just not ours), whose owner is
+ * on a different host (Fix N6 — a shared HAPI_HOME, e.g. a devcontainer
+ * bind-mounting ~/.hapi or an NFS home, means a pid recorded by another
+ * host's PID namespace is meaningless here and must never be probed), or
+ * whose liveness can't be determined is preserved, never removed.
+ * Over-deleting a carrier still in use silently kills that session's
+ * permission bridge and discovery hook; over-preserving a truly dead
+ * carrier just leaves inert bytes on disk. The two mistakes are not
+ * symmetric, so this only ever errs toward preservation.
+ *
+ * Best-effort and side-effect-free on failure: an unreadable carriers root,
+ * or a single entry this process can't stat/read, is skipped rather than
+ * thrown — a broken sweep must never abort session startup.
+ */
+export function sweepAgyHookCarriers(): void {
+    const carriersRoot = agyCarriersRootDir();
+    let entries: string[];
+    try {
+        entries = readdirSync(carriersRoot);
+    } catch {
+        // Root doesn't exist yet (first-ever session under this HAPI_HOME)
+        // or isn't readable — nothing to sweep either way.
+        return;
+    }
+
+    for (const entry of entries) {
+        // Fix N3: only ever consider entries this module itself could have
+        // created. A misconfigured/reused HAPI_HOME can put anything under
+        // agy-carriers/ (another app's state dir, a stray checkout, ...) —
+        // without this check, the age-based owner-less fallback below would
+        // happily recursive-delete it once it turned 24h old.
+        if (!entry.startsWith(CARRIER_DIR_PREFIX)) continue;
+        const carrierDir = join(carriersRoot, entry);
+        try {
+            // Fix N4: lstat, not stat — judge the directory entry itself,
+            // never whatever a symlink might point at. rmSync only ever
+            // unlinks a symlink (never recurses through it), so there is no
+            // data-loss path either way, but liveness/age decisions must
+            // still be about this entry, not its target.
+            const stats = lstatSync(carrierDir);
+            if (!stats.isDirectory()) continue;
+
+            const owner = readOwnerMetadata(carrierDir);
+            if (owner) {
+                if (owner.hostname !== hostname()) {
+                    // Fix N6: a pid recorded on another host means nothing
+                    // in this PID namespace — never probe it, never delete.
+                    //
+                    // Known trade-off (R5-3, won't-fix): if the hostname
+                    // itself changes underneath a carrier (DHCP-assigned
+                    // name, container restart, VPN interface renaming...),
+                    // this guard permanently mismatches and the carrier is
+                    // never swept — owner.json is present and readable, so
+                    // the age-based owner-less fallback below never triggers
+                    // either. This is deliberately left as-is: erring toward
+                    // over-retention is the safe direction (the alternative
+                    // is deleting a live carrier out from under a process
+                    // that renamed its host), the affected population is
+                    // narrow (only sessions that crashed — a clean exit is
+                    // swept by cleanupAgyHookCarrier regardless of hostname
+                    // — *and* whose host was then renamed before the process
+                    // died of natural causes), and what's left behind is a
+                    // few inert bytes under HAPI_HOME, not a leak with
+                    // externally visible effects. Do not add a time-based
+                    // fallback for this case without revisiting why the
+                    // pid-liveness check above was deemed unsafe to trust
+                    // across a hostname change in the first place.
+                    continue;
+                }
+                if (checkProcessLiveness(owner.pid) === 'dead') {
+                    rmSync(carrierDir, { recursive: true, force: true });
+                    logger.debug(`[agyHookCarrier] swept orphaned carrier ${carrierDir} (owner pid ${owner.pid} is dead)`);
+                }
+                continue;
+            }
+
+            if (Date.now() - stats.mtimeMs > STALE_OWNERLESS_CARRIER_AGE_MS) {
+                rmSync(carrierDir, { recursive: true, force: true });
+                logger.debug(`[agyHookCarrier] swept carrier with unreadable/missing owner metadata ${carrierDir} (older than ${STALE_OWNERLESS_CARRIER_AGE_MS}ms)`);
+            }
+        } catch (error) {
+            logger.debug(`[agyHookCarrier] sweep skipped ${carrierDir}`, error);
+        }
     }
 }
 
@@ -79,13 +280,40 @@ export function agyHookCarrierIsIntact(carrierDir: string): boolean {
  * Throws if the carrier's .agents directory does not exist; callers must
  * check agyHookCarrierIsIntact() first and fall back to
  * prepareAgyHookCarrier() (a fresh carrier) if it does not.
+ *
+ * Fix N5: the temp file must be a same-directory sibling of the target for
+ * renameSync's atomicity to hold (see above) — it cannot simply be moved
+ * outside .agents/ to satisfy writeOwnerMetadata's "no HAPI bookkeeping
+ * inside .agents/" rule (that rule is about files agy's own directory scan
+ * could stumble on; a same-fs rename target is a different constraint
+ * entirely). So instead, a failed renameSync (or a throw from the caller's
+ * own error handling further up the stack — this function is best-effort
+ * per detachPreInvocationHook/syncPreInvocationHookForLaunch's fail-open
+ * contract) must not leave the temp file behind: without cleanup, every
+ * failed detach/re-attach cycle leaves one more `.hooks.json.<pid>.<uuid>.tmp`
+ * sitting in .agents/ forever.
  */
 export function writeAgyHooksJsonAtomic(carrierDir: string, hooksJsonContent: string): void {
     const agentsDir = join(carrierDir, '.agents');
     const target = join(agentsDir, 'hooks.json');
     const tmpPath = join(agentsDir, `.hooks.json.${process.pid}.${randomUUID()}.tmp`);
-    writeFileSync(tmpPath, hooksJsonContent, { mode: 0o600 });
-    renameSync(tmpPath, target);
+    let renamed = false;
+    try {
+        writeFileSync(tmpPath, hooksJsonContent, { mode: 0o600 });
+        renameSync(tmpPath, target);
+        renamed = true;
+    } finally {
+        // renameSync already moved the file away on success — unlink would
+        // just throw ENOENT for no reason, so only clean up on the failure
+        // path (finally still runs there too; the original error propagates
+        // after this block regardless). This also covers writeFileSync itself
+        // throwing (ENOSPC, EDQUOT, ...) before the file was fully written —
+        // without the write inside this try, a failed write would leave a
+        // partial temp file behind with nothing to clean it up.
+        if (!renamed) {
+            try { unlinkSync(tmpPath); } catch { /* best-effort */ }
+        }
+    }
 }
 
 export function cleanupAgyHookCarrier(carrierDir: string | undefined): void {

--- a/cli/src/agy/utils/agyHookCarrier.ts
+++ b/cli/src/agy/utils/agyHookCarrier.ts
@@ -5,6 +5,7 @@ import {
     mkdtempSync,
     readdirSync,
     readFileSync,
+    readlinkSync,
     renameSync,
     rmSync,
     unlinkSync,
@@ -26,19 +27,31 @@ export type AgyMcpServerEntry = {
     env?: Record<string, string>;
 };
 
-// hostname is the over-delete guard for a shared HAPI_HOME (Fix N6): a
-// devcontainer bind-mounting ~/.hapi, or an NFS-shared home, puts carriers
-// written by different PID namespaces in the same agy-carriers/ directory.
-// A pid recorded by namespace A means nothing in namespace B — probing it
-// there can hit ESRCH for a process that is very much alive in A. hostname
-// does not fully solve cross-host PID collisions (two hosts using the same
-// hostname, or two containers sharing a hostname, remain unresolved — no
-// occurrence of this so far, and not what this fix targets), but it closes
-// the concrete case the reviewer raised. Sweep only ever probes liveness
-// for a carrier this host itself could plausibly own.
+// `scope` is the over-delete guard for a shared HAPI_HOME (Fix N6, hardened
+// further below): a devcontainer bind-mounting ~/.hapi, or an NFS-shared
+// home, puts carriers written by different PID namespaces in the same
+// agy-carriers/ directory. A pid recorded by namespace A means nothing in
+// namespace B — probing it there can hit ESRCH for a process that is very
+// much alive in A.
+//
+// hostname alone (the original Fix N6) does not close this: two containers
+// sharing a HAPI_HOME typically also share a hostname (or both default to
+// the same short container-id-derived one), which is exactly the collision
+// this guard exists to prevent. `scope` instead identifies the boot +
+// PID-namespace pair a carrier's pid was recorded in — see
+// computeLocalCarrierScope() below — which distinguishes exactly the cases
+// hostname could not: two containers on the same host (different PID
+// namespaces, same boot_id) and the same container across a restart
+// (same PID namespace file, but the boot_id — read from the host's
+// /proc — differs only across an actual host reboot, which is the one case
+// where every previously-recorded pid is unconditionally dead; this fix
+// does not attempt to special-case that, see sweepAgyHookCarriers's
+// docstring). Platforms without a working /proc (macOS, ...) fall back to
+// hostname, tagged so a fallback-computed scope can never collide with a
+// real Linux one.
 type AgyHookCarrierOwner = {
     pid: number;
-    hostname: string;
+    scope: string;
 };
 
 const AGY_CARRIERS_DIRNAME = 'agy-carriers';
@@ -50,13 +63,83 @@ const OWNER_FILE_NAME = 'owner.json';
 // delete of whatever else happens to live there (Fix N3).
 const CARRIER_DIR_PREFIX = 'hapi-agy-carrier-';
 
-// Carriers whose owner.json is missing or unreadable (pre-Phase-2.8 builds,
-// or a write that got interrupted) are legacy/ambiguous, not confirmed dead.
-// Give them a full day before sweeping them on age alone — long enough that
-// a carrier still mid-creation or briefly unreadable is never caught by it,
-// short enough that real leftovers don't linger for the OS's own 30-day
-// tmpfiles.d window (see the agy-preinvocation-discovery plan §8/§9).
-const STALE_OWNERLESS_CARRIER_AGE_MS = 24 * 60 * 60 * 1000;
+// Tags a hostname-derived scope so it can never equal a Linux
+// boot-id+namespace scope, even by coincidence — see computeLocalCarrierScope.
+const HOSTNAME_FALLBACK_SCOPE_PREFIX = 'hostname-fallback:';
+
+/**
+ * Reads the boot-id + PID-namespace pair that identifies "this exact kernel
+ * boot, this exact PID namespace" on Linux. /proc/sys/kernel/random/boot_id
+ * is a fresh random UUID generated once per boot (host or container, shared
+ * with any container sharing the host's kernel); /proc/self/ns/pid resolves
+ * (via its inode number) to a namespace identifier that differs between
+ * containers even when they share a boot_id. Together they're a strictly
+ * stronger identity than hostname for deciding whether a recorded pid could
+ * plausibly mean anything in the CURRENT process's PID space.
+ *
+ * Returns undefined on any read failure — not just "file missing" (a
+ * non-Linux OS) but also a restricted/virtualized /proc that exists but
+ * denies these specific reads (some sandboxes) — so the caller has one
+ * signal ("could not determine") to fall back on, rather than needing to
+ * distinguish failure modes.
+ */
+function readLinuxBootAndNamespaceScope(probe: Pick<ScopeProbe, 'readBootId' | 'readPidNamespaceId'>): string | undefined {
+    try {
+        const bootId = probe.readBootId();
+        const nsId = probe.readPidNamespaceId();
+        if (!bootId || !nsId) return undefined;
+        return `linux:${bootId}:${nsId}`;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Dependency seams for computeLocalCarrierScope, real implementations by
+ * default. Exists so tests can force each branch (Linux success, Linux
+ * failure -> hostname fallback, total failure) without mocking node:fs/
+ * node:os module-wide — which would also affect every other real-filesystem
+ * test in this file's suite.
+ */
+export type ScopeProbe = {
+    readBootId: () => string;
+    readPidNamespaceId: () => string;
+    hostname: () => string;
+};
+
+const defaultScopeProbe: ScopeProbe = {
+    readBootId: () => readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim(),
+    readPidNamespaceId: () => {
+        // Linux exposes the PID namespace as a magic symlink whose target
+        // encodes its inode number, e.g. "pid:[4026531836]" — that number
+        // is the namespace identifier.
+        const link = readlinkSync('/proc/self/ns/pid');
+        const match = /pid:\[(\d+)\]/.exec(link);
+        if (!match) throw new Error(`unexpected /proc/self/ns/pid format: ${link}`);
+        return match[1];
+    },
+    hostname: () => hostname(),
+};
+
+/**
+ * Computes this process's carrier scope: an opaque string identifying
+ * "carriers this process could plausibly own", used to gate sweepAgyHookCarriers.
+ * Prefers the Linux boot-id+PID-namespace pair (readLinuxBootAndNamespaceScope);
+ * falls back to a tagged hostname when that is unavailable (non-Linux, or a
+ * /proc that exists but is restricted). Returns undefined only when BOTH the
+ * Linux probe and the hostname fallback fail — callers must treat that as
+ * "cannot self-identify" and preserve everything rather than guess.
+ */
+export function computeLocalCarrierScope(probe: ScopeProbe = defaultScopeProbe): string | undefined {
+    const linuxScope = readLinuxBootAndNamespaceScope(probe);
+    if (linuxScope) return linuxScope;
+    try {
+        const host = probe.hostname();
+        return host ? `${HOSTNAME_FALLBACK_SCOPE_PREFIX}${host}` : undefined;
+    } catch {
+        return undefined;
+    }
+}
 
 /**
  * Root directory HAPI creates all agy hook carriers under: `<HAPI_HOME>/
@@ -114,15 +197,21 @@ export function prepareAgyHookCarrier(
  * there.
  */
 function writeOwnerMetadata(carrierDir: string): void {
-    const owner: AgyHookCarrierOwner = { pid: process.pid, hostname: hostname() };
+    // A carrier written while the local scope could not be determined
+    // records no scope at all rather than a fabricated one — readOwnerMetadata
+    // requires a non-empty scope, so this carrier falls into the
+    // "unreadable owner" bucket below and is preserved indefinitely rather
+    // than risk being matched against a wrong or guessed scope later.
+    const scope = computeLocalCarrierScope();
+    const owner: AgyHookCarrierOwner = { pid: process.pid, scope: scope ?? '' };
     writeFileSync(join(carrierDir, OWNER_FILE_NAME), JSON.stringify(owner), { mode: 0o600 });
 }
 
 function readOwnerMetadata(carrierDir: string): AgyHookCarrierOwner | undefined {
     try {
         const parsed = JSON.parse(readFileSync(join(carrierDir, OWNER_FILE_NAME), 'utf8')) as Partial<AgyHookCarrierOwner>;
-        if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid) && parsed.pid > 0 && typeof parsed.hostname === 'string' && parsed.hostname.length > 0) {
-            return { pid: parsed.pid, hostname: parsed.hostname };
+        if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid) && parsed.pid > 0 && typeof parsed.scope === 'string' && parsed.scope.length > 0) {
+            return { pid: parsed.pid, scope: parsed.scope };
         }
         return undefined;
     } catch {
@@ -158,27 +247,54 @@ function checkProcessLiveness(pid: number): 'alive' | 'dead' | 'unknown' {
 }
 
 /**
- * Removes agy hook carriers under HAPI_HOME whose owning process has
- * confirmed-died (process.kill(pid, 0) raises ESRCH), and carriers old
- * enough with unreadable/missing owner metadata to be considered stale
- * leftovers. Meant to be called once per session start — see runAgy.ts.
+ * Removes agy hook carriers under HAPI_HOME whose owning process has been
+ * ACTIVELY confirmed dead: owner.json is present and parses (pid + a
+ * non-empty scope), that scope exactly matches this process's own
+ * computeLocalCarrierScope(), AND process.kill(pid, 0) raises ESRCH for that
+ * pid. Meant to be called once per session start — see runAgy.ts.
  *
- * Deliberately conservative in every ambiguous direction: a carrier whose
- * owner is alive (including EPERM — alive, just not ours), whose owner is
- * on a different host (Fix N6 — a shared HAPI_HOME, e.g. a devcontainer
- * bind-mounting ~/.hapi or an NFS home, means a pid recorded by another
- * host's PID namespace is meaningless here and must never be probed), or
- * whose liveness can't be determined is preserved, never removed.
- * Over-deleting a carrier still in use silently kills that session's
- * permission bridge and discovery hook; over-preserving a truly dead
- * carrier just leaves inert bytes on disk. The two mistakes are not
- * symmetric, so this only ever errs toward preservation.
+ * Fix 2 (hardened from the original hostname-only Fix N6): two things used
+ * to let this delete a carrier that was still very much in use.
+ *
+ *  (a) A carrier whose owner.json failed to read — for ANY reason, not just
+ *      "genuinely never written" — used to be swept once it turned 24h old.
+ *      But a transient read failure (a concurrent write racing the read, a
+ *      momentarily-unmounted overlay, ...) against a live, multi-day agy
+ *      session looks IDENTICAL to a genuinely ownerless leftover from this
+ *      function's point of view — there is no way to tell them apart from
+ *      here. Sweeping on age alone in that case can delete a carrier a
+ *      running session still depends on for its permission bridge. There is
+ *      no longer an age-based path at all: an unreadable/missing owner.json
+ *      is now preserved unconditionally. The cost is that legacy
+ *      (pre-this-fix) or truly-orphaned ownerless carriers never get swept
+ *      automatically — every carrier created after this fix always has a
+ *      readable owner.json, so this cost is one-time, not ongoing.
+ *
+ *  (b) hostname alone doesn't identify a PID namespace: two containers
+ *      sharing a HAPI_HOME (bind mount, NFS home) commonly also share a
+ *      hostname, so a pid recorded by one could be misread as belonging to
+ *      the other's PID space and probed there. computeLocalCarrierScope's
+ *      boot-id+PID-namespace scope (falling back to a distinctly-tagged
+ *      hostname only where /proc isn't usable) closes this the same way a
+ *      stronger identity always beats a weaker one: an exact match is
+ *      required, not merely a matching hostname.
+ *
+ * Deliberately conservative in every ambiguous direction, in this priority
+ * order: local scope cannot be determined at all -> preserve everything
+ * (never scan for anything to delete); a carrier's owner cannot be read ->
+ * preserve; a carrier's owner scope doesn't exactly match -> preserve; the
+ * owner is alive (including EPERM — alive, just not ours) or liveness can't
+ * be determined -> preserve. Only "read owner, scope matches, pid confirmed
+ * dead" deletes. Over-deleting a carrier still in use silently kills that
+ * session's permission bridge and discovery hook; over-preserving a truly
+ * dead carrier just leaves inert bytes on disk under HAPI_HOME. The two
+ * mistakes are not symmetric, so this only ever errs toward preservation.
  *
  * Best-effort and side-effect-free on failure: an unreadable carriers root,
  * or a single entry this process can't stat/read, is skipped rather than
  * thrown — a broken sweep must never abort session startup.
  */
-export function sweepAgyHookCarriers(): void {
+export function sweepAgyHookCarriers(scopeProbe: ScopeProbe = defaultScopeProbe): void {
     const carriersRoot = agyCarriersRootDir();
     let entries: string[];
     try {
@@ -189,60 +305,49 @@ export function sweepAgyHookCarriers(): void {
         return;
     }
 
+    const localScope = computeLocalCarrierScope(scopeProbe);
+    if (!localScope) {
+        // Cannot identify which carriers this process could even plausibly
+        // own — comparing anything against an unknown scope is meaningless,
+        // so nothing is examined at all rather than falling back to a
+        // weaker (and potentially wrong) heuristic.
+        logger.debug('[agyHookCarrier] sweep skipped entirely: could not determine local carrier scope');
+        return;
+    }
+
     for (const entry of entries) {
         // Fix N3: only ever consider entries this module itself could have
         // created. A misconfigured/reused HAPI_HOME can put anything under
         // agy-carriers/ (another app's state dir, a stray checkout, ...) —
-        // without this check, the age-based owner-less fallback below would
-        // happily recursive-delete it once it turned 24h old.
+        // without this check, a bad match below could recursive-delete it.
         if (!entry.startsWith(CARRIER_DIR_PREFIX)) continue;
         const carrierDir = join(carriersRoot, entry);
         try {
             // Fix N4: lstat, not stat — judge the directory entry itself,
             // never whatever a symlink might point at. rmSync only ever
             // unlinks a symlink (never recurses through it), so there is no
-            // data-loss path either way, but liveness/age decisions must
+            // data-loss path either way, but liveness/scope decisions must
             // still be about this entry, not its target.
             const stats = lstatSync(carrierDir);
             if (!stats.isDirectory()) continue;
 
             const owner = readOwnerMetadata(carrierDir);
-            if (owner) {
-                if (owner.hostname !== hostname()) {
-                    // Fix N6: a pid recorded on another host means nothing
-                    // in this PID namespace — never probe it, never delete.
-                    //
-                    // Known trade-off (R5-3, won't-fix): if the hostname
-                    // itself changes underneath a carrier (DHCP-assigned
-                    // name, container restart, VPN interface renaming...),
-                    // this guard permanently mismatches and the carrier is
-                    // never swept — owner.json is present and readable, so
-                    // the age-based owner-less fallback below never triggers
-                    // either. This is deliberately left as-is: erring toward
-                    // over-retention is the safe direction (the alternative
-                    // is deleting a live carrier out from under a process
-                    // that renamed its host), the affected population is
-                    // narrow (only sessions that crashed — a clean exit is
-                    // swept by cleanupAgyHookCarrier regardless of hostname
-                    // — *and* whose host was then renamed before the process
-                    // died of natural causes), and what's left behind is a
-                    // few inert bytes under HAPI_HOME, not a leak with
-                    // externally visible effects. Do not add a time-based
-                    // fallback for this case without revisiting why the
-                    // pid-liveness check above was deemed unsafe to trust
-                    // across a hostname change in the first place.
-                    continue;
-                }
-                if (checkProcessLiveness(owner.pid) === 'dead') {
-                    rmSync(carrierDir, { recursive: true, force: true });
-                    logger.debug(`[agyHookCarrier] swept orphaned carrier ${carrierDir} (owner pid ${owner.pid} is dead)`);
-                }
+            if (!owner) {
+                // Fix 2a: no age-based fallback anymore — see the docstring
+                // above for why an unreadable owner is no longer evidence of
+                // staleness.
                 continue;
             }
-
-            if (Date.now() - stats.mtimeMs > STALE_OWNERLESS_CARRIER_AGE_MS) {
+            if (owner.scope !== localScope) {
+                // Fix 2b: a pid recorded under a different boot/PID-namespace
+                // (or, on a hostname-fallback platform, a different host)
+                // means nothing in this process's PID space — never probe
+                // it, never delete it.
+                continue;
+            }
+            if (checkProcessLiveness(owner.pid) === 'dead') {
                 rmSync(carrierDir, { recursive: true, force: true });
-                logger.debug(`[agyHookCarrier] swept carrier with unreadable/missing owner metadata ${carrierDir} (older than ${STALE_OWNERLESS_CARRIER_AGE_MS}ms)`);
+                logger.debug(`[agyHookCarrier] swept orphaned carrier ${carrierDir} (owner pid ${owner.pid}, scope matched, confirmed dead)`);
             }
         } catch (error) {
             logger.debug(`[agyHookCarrier] sweep skipped ${carrierDir}`, error);

--- a/cli/src/agy/utils/agyHookCarrier.ts
+++ b/cli/src/agy/utils/agyHookCarrier.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { logger } from '@/ui/logger';
@@ -46,6 +47,45 @@ export function prepareAgyHookCarrier(
         logger.debug('[agyHookCarrier] preparation failed', error);
         return undefined;
     }
+}
+
+/**
+ * True if the carrier's hooks.json is present and therefore safe to
+ * overwrite in place. False covers both "the whole carrier directory is
+ * gone" (e.g. /tmp's 30-day tmpfiles.d sweep on a long-lived session, see
+ * the agy-preinvocation-discovery plan §9) and "hooks.json specifically was
+ * removed" — either way, the caller must rebuild the carrier from scratch
+ * (prepareAgyHookCarrier) rather than attempt an atomic overwrite, since
+ * writeAgyHooksJsonAtomic requires the .agents directory to already exist.
+ */
+export function agyHookCarrierIsIntact(carrierDir: string): boolean {
+    return existsSync(join(carrierDir, '.agents', 'hooks.json'));
+}
+
+/**
+ * Overwrite an existing carrier's hooks.json in place, atomically.
+ *
+ * agy re-reads hooks.json before every single model call (confirmed live —
+ * see the agy-preinvocation-discovery plan §6.6), not just once at spawn
+ * time. That means a plain writeFileSync has a real window where agy can
+ * observe a partially-written file: JSON.parse throws, agy drops every hook
+ * registered under this carrier for that read (including the PreToolUse
+ * permission bridge, not just the PreInvocation discovery hook this function
+ * is used to add/remove). Writing to a sibling temp file in the same
+ * directory and renaming over the target avoids that window — rename() is
+ * atomic on the same filesystem, so agy only ever observes the old complete
+ * file or the new complete file, never a partial one.
+ *
+ * Throws if the carrier's .agents directory does not exist; callers must
+ * check agyHookCarrierIsIntact() first and fall back to
+ * prepareAgyHookCarrier() (a fresh carrier) if it does not.
+ */
+export function writeAgyHooksJsonAtomic(carrierDir: string, hooksJsonContent: string): void {
+    const agentsDir = join(carrierDir, '.agents');
+    const target = join(agentsDir, 'hooks.json');
+    const tmpPath = join(agentsDir, `.hooks.json.${process.pid}.${randomUUID()}.tmp`);
+    writeFileSync(tmpPath, hooksJsonContent, { mode: 0o600 });
+    renameSync(tmpPath, target);
 }
 
 export function cleanupAgyHookCarrier(carrierDir: string | undefined): void {

--- a/cli/src/agy/utils/agySessionScanner.test.ts
+++ b/cli/src/agy/utils/agySessionScanner.test.ts
@@ -1,20 +1,21 @@
 /**
  * Tests for agy resume support in AgySessionScanner:
- *  1. getBrainUuid() reports the matched brain UUID once content is matched.
+ *  1. getBrainUuid() reports the brain UUID once a hook (onNewSession) or a
+ *     resume seed identifies it — the scanner never discovers a brain on its
+ *     own (that was transcript content-matching, removed once the
+ *     PreToolUse/PreInvocation hooks became the authoritative discovery
+ *     path; see 2026-08-04_agy-preinvocation-discovery plan §7.5).
  *  2. initialize() seeds processed keys from an existing transcript so a
  *     resume does NOT re-emit prior turns (the "old messages re-show" bug).
  *  3. onNewSession() switches to a new brain UUID.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync, utimesSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
 import { createAgySessionScanner, emitAgyEntriesWithModels } from './agySessionScanner'
 import type { AgyTranscriptEntry } from './agyTranscriptTypes'
-import { formatMessageWithAttachments } from '@/utils/attachmentFormatter'
-import type { AttachmentMetadata } from '@/api/types'
-import { logger } from '@/ui/logger'
 
 // Build a minimal transcript line for a given step and type.
 function makeTranscriptLine(step_index: number, type: AgyTranscriptEntry['type'], content: string): string {
@@ -87,22 +88,6 @@ describe('AGY planner model settling', () => {
     })
 })
 
-// Build a USER_INPUT line in the shape agy actually writes: the submitted text
-// wrapped in <USER_REQUEST> with agy's own trailing sections appended.
-function makeAgyUserInputLine(step_index: number, request: string): string {
-    return makeTranscriptLine(step_index, 'USER_INPUT', [
-        '<USER_REQUEST>',
-        request,
-        '</USER_REQUEST>',
-        '<ADDITIONAL_METADATA>',
-        'The current local time is: 2026-08-04T00:00:00+09:00.',
-        '</ADDITIONAL_METADATA>',
-        '<USER_SETTINGS_CHANGE>',
-        'The user changed setting `Model Selection` from None to Gemini 3.6 Flash (Low).',
-        '</USER_SETTINGS_CHANGE>',
-    ].join('\n'))
-}
-
 function makeTempBrain(uuid: string, content: string): { brainDir: string; logPath: string } {
     const brainDir = join(BRAIN_BASE, uuid)
     const logDir = join(brainDir, '.system_generated', 'logs')
@@ -121,30 +106,20 @@ describe('AgySessionScanner — resume support', () => {
         try { rmSync(join(BRAIN_BASE, TEST_UUID), { recursive: true, force: true }) } catch { /* best-effort */ }
     })
 
-    it('getBrainUuid() returns null before content match', async () => {
-        // A fresh scanner with no session message → no brain known yet.
+    it('getBrainUuid() returns null until a hook (onNewSession) identifies the brain — no scan, no attach, even with candidate brains on disk', async () => {
+        // A brain that exists on disk before the hook ever fires must NOT be
+        // attached to. The scanner has no discovery mechanism of its own
+        // anymore (that was content-match, removed once the PreToolUse/
+        // PreInvocation hooks became the authoritative discovery path); it
+        // only ever watches a brain it was explicitly told about.
+        makeTempBrain(TEST_UUID, makeTranscriptLine(0, 'USER_INPUT', 'unrelated-existing-brain') + '\n')
         const emitted: AgyTranscriptEntry[] = []
         const scanner = await createAgySessionScanner({ onEntry: (e) => emitted.push(e) })
+
+        await new Promise((r) => setTimeout(r, 300))
         expect(scanner.getBrainUuid()).toBeNull()
-        await scanner.cleanup()
-    })
+        expect(emitted).toHaveLength(0)
 
-    it('getBrainUuid() returns the UUID once a content match identifies the brain', async () => {
-        const needle = `hapi-test-needle-${Date.now()}`
-        // USER_INPUT, not PLANNER_RESPONSE: content-match only inspects the
-        // decoded content of USER_INPUT entries (our own submitted message
-        // echoed back by agy), not the model's own response text — matching
-        // PLANNER_RESPONSE would be exactly the "tool-result/response false
-        // positive" this scanner deliberately avoids.
-        const line = makeTranscriptLine(0, 'USER_INPUT', needle)
-        const emitted: AgyTranscriptEntry[] = []
-        const scanner = await createAgySessionScanner({ onEntry: (e) => emitted.push(e) })
-        makeTempBrain(TEST_UUID, line + '\n')
-
-        // Arm the scanner with the session message text so it can match.
-        scanner.setSessionMessageText(needle)
-        // Allow a scan cycle to run.
-        await vi.waitFor(() => expect(scanner.getBrainUuid()).toBe(TEST_UUID), { timeout: 1500 })
         await scanner.cleanup()
     })
 
@@ -213,10 +188,11 @@ describe('AgySessionScanner — resume support', () => {
         await scanner.cleanup()
     })
 
-    it('onNewSession() alone (no content-match, no resumeBrainUuid) emits the existing backlog — the mechanism the launcher hook-wiring fix (agyPtyLauncher.test.ts) depends on', async () => {
+    it('onNewSession() alone (no resumeBrainUuid) emits the existing backlog — the mechanism the launcher hook-wiring fix (agyPtyLauncher.test.ts) depends on', async () => {
         // Existing transcript with a PLANNER_RESPONSE, written BEFORE the scanner
         // is even created (simulates: agy already produced output by the time the
-        // PreToolUse hook discovers the brain UUID and notifies the scanner).
+        // PreToolUse/PreInvocation hook discovers the brain UUID and notifies
+        // the scanner).
         const existingLines = [
             makeTranscriptLine(0, 'USER_INPUT', 'hello'),
             makeTranscriptLine(1, 'PLANNER_RESPONSE', 'agent output the hook must surface'),
@@ -224,13 +200,14 @@ describe('AgySessionScanner — resume support', () => {
         makeTempBrain(TEST_UUID, existingLines)
 
         const emitted: AgyTranscriptEntry[] = []
-        // Fresh scanner: no resumeBrainUuid seeded, no sessionMessageText set —
-        // content-match never runs, so this is the ONLY discovery signal.
+        // Fresh scanner: no resumeBrainUuid seeded — onNewSession() (driven by
+        // a hook) is the ONLY discovery signal there is.
         const scanner = await createAgySessionScanner({ onEntry: (e) => emitted.push(e) })
 
         // The scanner does nothing until told about a brain (shouldScan() is
-        // false with neither sessionMessageText nor foundBrainUuid set).
+        // false with foundBrainUuid unset).
         expect(emitted).toHaveLength(0)
+        expect(scanner.getBrainUuid()).toBeNull()
 
         scanner.onNewSession(TEST_UUID)
         await vi.waitFor(() => expect(emitted).toHaveLength(2), { timeout: 1200 })
@@ -243,304 +220,4 @@ describe('AgySessionScanner — resume support', () => {
         await scanner.cleanup()
     })
 
-    it('onBrainFound callback is invoked when content-match identifies the brain', async () => {
-        const needle = `hapi-test-onbrainFound-${Date.now()}`
-        // USER_INPUT — see the "getBrainUuid()...content match" test above for why.
-        const line = makeTranscriptLine(0, 'USER_INPUT', needle)
-        const emitted: AgyTranscriptEntry[] = []
-        const foundUuids: string[] = []
-        const scanner = await createAgySessionScanner({
-            onEntry: (e) => emitted.push(e),
-            onBrainFound: (uuid) => foundUuids.push(uuid),
-        })
-        makeTempBrain(TEST_UUID, line + '\n')
-
-        scanner.setSessionMessageText(needle)
-        await vi.waitFor(() => expect(scanner.getBrainUuid()).toBe(TEST_UUID), { timeout: 1500 })
-        expect(foundUuids).toEqual([TEST_UUID])
-
-        await scanner.cleanup()
-    })
-
-    it('content-match identifies the brain from the wrapper shape agy actually writes', async () => {
-        // A real transcript never stores the bare prompt: agy wraps it in
-        // <USER_REQUEST> and appends its own sections. Matching the whole
-        // content field can therefore never succeed against a live session.
-        const needle = `hapi-test-wrapped-${Date.now()}`
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        // After the scanner starts: a brain that already existed is treated as
-        // pre-existing and skipped during discovery.
-        makeTempBrain(TEST_UUID, makeAgyUserInputLine(0, needle) + '\n')
-
-        scanner.setSessionMessageText(needle)
-        await vi.waitFor(() => expect(scanner.getBrainUuid()).toBe(TEST_UUID), { timeout: 1500 })
-
-        await scanner.cleanup()
-    })
-
-    it('content-match stays fail-closed when the wrapped request is a different message', async () => {
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        makeTempBrain(TEST_UUID, makeAgyUserInputLine(0, 'someone-elses-prompt') + '\n')
-
-        scanner.setSessionMessageText(`hapi-test-nomatch-${Date.now()}`)
-        await new Promise((resolve) => setTimeout(resolve, 800))
-        expect(scanner.getBrainUuid()).toBeNull()
-
-        await scanner.cleanup()
-    })
-
-    it('onBrainFound is NOT called when resumeBrainUuid is pre-seeded (already known)', async () => {
-        makeTempBrain(TEST_UUID, makeTranscriptLine(0, 'PLANNER_RESPONSE', 'existing') + '\n')
-
-        const foundUuids: string[] = []
-        const scanner = await createAgySessionScanner({
-            resumeBrainUuid: TEST_UUID,
-            onEntry: () => {},
-            onBrainFound: (uuid) => foundUuids.push(uuid),
-        })
-
-        // Give scanner time to initialize — callback must NOT fire for pre-seeded UUID.
-        await new Promise((r) => setTimeout(r, 200))
-        expect(foundUuids).toHaveLength(0)
-
-        await scanner.cleanup()
-    })
-
-    // Phase 2 (defense-in-depth): the "attachment first message" bug diagnosed
-    // 2026-07-03. runAgy.ts's onUserMessage pushes
-    // formatMessageWithAttachments(text, attachments) — "@path1 @path2 ...\n\nbody"
-    // — into the queue, and agyPtyLauncher sets that as the scanner's
-    // sessionMessageText needle. agy's own transcript re-packages the attachment
-    // references in a DIFFERENT order/wrapper (observed in production:
-    // "<USER_REQUEST>\n@reordered-paths...\nbody"), so a naive
-    // content.includes(needle) never matches — the raw needle's "\n\n" separator
-    // alone breaks the match (JSON-encodes to a literal two-char "\n" on disk,
-    // never equal to the real newline byte in our in-memory needle), regardless
-    // of attachment order.
-    it('matches content when the transcript re-packages attachments differently than the needle (attachment-first-message regression)', async () => {
-        const attachments: AttachmentMetadata[] = [
-            { id: 'a', filename: 'a.png', mimeType: 'image/png', size: 1, path: '/tmp/a.png' },
-            { id: 'b', filename: 'b.png', mimeType: 'image/png', size: 1, path: '/tmp/b.png' },
-            { id: 'c', filename: 'c.png', mimeType: 'image/png', size: 1, path: '/tmp/c.png' },
-        ]
-        const bodyText = `hapi-test-attachment-reorder-${Date.now()}`
-        const needle = formatMessageWithAttachments(bodyText, attachments)
-        expect(needle).toBe(`@/tmp/a.png @/tmp/b.png @/tmp/c.png\n\n${bodyText}`)
-
-        // Transcript re-packages the SAME attachments in a different order and a
-        // different wrapper/separator — same shape as the real agy <USER_REQUEST> repackaging.
-        const reorderedLine = makeAgyUserInputLine(
-            0,
-            `@/tmp/c.png @/tmp/a.png @/tmp/b.png\n${bodyText}`
-        )
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        makeTempBrain(TEST_UUID, reorderedLine + '\n')
-        scanner.setSessionMessageText(needle)
-        await vi.waitFor(() => expect(scanner.getBrainUuid()).toBe(TEST_UUID), { timeout: 1500 })
-
-        await scanner.cleanup()
-    })
-
-    // 2026-07-10: a resident service (gen-proxy) on this machine spawns
-    // `agy --print` repeatedly, minting a new brain dir per call — 238 in 5h
-    // observed. The old "newest 3 by mtime" cap pushed a real HAPI session's
-    // brain out of the scan window within seconds of it being created, so it
-    // was never content-matched and the chat stayed permanently empty. The
-    // scan window (all brains newer than scannerStartMs - SLACK, no count cap)
-    // replaces that cap.
-    it('finds our brain despite churn from many newer brains (formerly truncated by the newest-3 window)', async () => {
-        const needle = `hapi-churn-needle-${Date.now()}`
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        makeTempBrain(TEST_UUID, makeTranscriptLine(0, 'USER_INPUT', needle) + '\n')
-
-        // Simulate several more-recently-touched foreign brains created after
-        // ours (short-lived agy --print churn). Under the old "newest 3" cap,
-        // 3+ of these alone would push our brain out of the window entirely.
-        const foreignUuids: string[] = []
-        for (let i = 0; i < 6; i++) {
-            const uuid = `10000000-0000-4000-8000-00000000000${i}`
-            foreignUuids.push(uuid)
-            makeTempBrain(uuid, makeTranscriptLine(0, 'USER_INPUT', `unrelated-${i}`) + '\n')
-        }
-
-        try {
-            scanner.setSessionMessageText(needle)
-            await new Promise((r) => setTimeout(r, 300))
-
-            expect(scanner.getBrainUuid()).toBe(TEST_UUID)
-            await scanner.cleanup()
-        } finally {
-            for (const uuid of foreignUuids) {
-                try { rmSync(join(BRAIN_BASE, uuid), { recursive: true, force: true }) } catch { /* best-effort */ }
-            }
-        }
-    })
-
-    it('never matches a brain older than the discovery window, even if its transcript contains the needle', async () => {
-        const needle = `hapi-stale-needle-${Date.now()}`
-        const { brainDir } = makeTempBrain(TEST_UUID, makeTranscriptLine(0, 'USER_INPUT', needle) + '\n')
-
-        // Backdate the brain dir well past the (tens-of-seconds) discovery
-        // slack, simulating a brain that predates this scanner instance.
-        const old = new Date(Date.now() - 5 * 60 * 1000)
-        utimesSync(brainDir, old, old)
-
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        scanner.setSessionMessageText(needle)
-        await new Promise((r) => setTimeout(r, 300))
-
-        // Content matches, but the brain is outside the scan window — must
-        // stay unmatched (never falsely claim a stale/foreign brain).
-        expect(scanner.getBrainUuid()).toBeNull()
-        await scanner.cleanup()
-    })
-
-    it('ignores an exact matching brain that existed before scanner startup even within the same timestamp second', async () => {
-        const prompt = `timestamp-boundary-${Date.now()}`
-        const foreignUuid = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
-        const foreignLine = JSON.stringify({
-            ...JSON.parse(makeTranscriptLine(0, 'USER_INPUT', prompt)),
-            created_at: new Date(Math.ceil(Date.now() / 1000) * 1000).toISOString().replace('.000Z', 'Z'),
-        })
-
-        try {
-            makeTempBrain(foreignUuid, foreignLine + '\n')
-            const scanner = await createAgySessionScanner({ onEntry: () => {} })
-            scanner.setSessionMessageText(prompt)
-            await new Promise((resolve) => setTimeout(resolve, 300))
-
-            expect(scanner.getBrainUuid()).toBeNull()
-            await scanner.cleanup()
-        } finally {
-            try { rmSync(join(BRAIN_BASE, foreignUuid), { recursive: true, force: true }) } catch { /* best-effort */ }
-        }
-    })
-
-    it('fails closed when two in-window brains have the same exact first prompt', async () => {
-        const otherUuid = '00000000-0000-4000-8000-000000000002'
-        const prompt = `hapi-ambiguous-${Date.now()}`
-        try {
-            const foundUuids: string[] = []
-            const ambiguityCounts: number[] = []
-            const scanner = await createAgySessionScanner({
-                onEntry: () => {},
-                onBrainFound: (uuid) => foundUuids.push(uuid),
-                onDiscoveryAmbiguous: (count) => ambiguityCounts.push(count),
-            })
-            makeTempBrain(TEST_UUID, makeTranscriptLine(0, 'USER_INPUT', prompt) + '\n')
-            makeTempBrain(otherUuid, makeTranscriptLine(0, 'USER_INPUT', prompt) + '\n')
-            scanner.setSessionMessageText(prompt)
-            await new Promise((r) => setTimeout(r, 300))
-            scanner.setSessionMessageText(prompt)
-            await new Promise((r) => setTimeout(r, 300))
-
-            expect(scanner.getBrainUuid()).toBeNull()
-            expect(foundUuids).toEqual([])
-            expect(ambiguityCounts).toEqual([2])
-            await scanner.cleanup()
-        } finally {
-            rmSync(join(BRAIN_BASE, otherUuid), { recursive: true, force: true })
-        }
-    })
-
-    it('does not match a USER_INPUT that only contains the first prompt as a substring', async () => {
-        const prompt = `yes-${Date.now()}`
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        makeTempBrain(TEST_UUID, makeTranscriptLine(0, 'USER_INPUT', `please say ${prompt} now`) + '\n')
-        scanner.setSessionMessageText(prompt)
-        await new Promise((r) => setTimeout(r, 300))
-
-        expect(scanner.getBrainUuid()).toBeNull()
-        await scanner.cleanup()
-    })
-
-    it('matches a first message whose USER_INPUT line is longer than the bounded prefix read', async () => {
-        // The first USER_INPUT sits at offset 0, so a very long first message
-        // IS the prefix window: no complete line fits, the prefix parse yields
-        // nothing, and giving up there would blank the chat forever (the old
-        // whole-file read matched this input).
-        const needle = `${'x'.repeat(70 * 1024)} hapi-huge-needle-${Date.now()}`
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        makeTempBrain(TEST_UUID, makeTranscriptLine(0, 'USER_INPUT', needle) + '\n')
-        scanner.setSessionMessageText(needle)
-        await vi.waitFor(() => expect(scanner.getBrainUuid()).toBe(TEST_UUID), { timeout: 1500 })
-        await scanner.cleanup()
-    })
-
-    it('finds our brain even when in-window candidates exceed the sanity bound (our brain is the OLDEST in the window)', async () => {
-        // Our brain is minted right after the scanner starts, so every foreign
-        // brain that churn creates afterwards is NEWER than ours. Any cap that
-        // keeps the newest N therefore drops precisely the one brain we are
-        // looking for — the newest-3 bug, moved to N.
-        const needle = `hapi-cap-needle-${Date.now()}`
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        const { brainDir } = makeTempBrain(TEST_UUID, makeTranscriptLine(0, 'USER_INPUT', needle) + '\n')
-        const older = new Date(Date.now() - 5000) // still inside the window, but oldest
-        utimesSync(brainDir, older, older)
-
-        const foreignUuids: string[] = []
-        for (let i = 0; i < 60; i++) {
-            const uuid = `30000000-0000-4000-8000-${String(i).padStart(12, '0')}`
-            foreignUuids.push(uuid)
-            makeTempBrain(uuid, makeTranscriptLine(0, 'USER_INPUT', `unrelated-${i}`) + '\n')
-        }
-
-        try {
-            scanner.setSessionMessageText(needle)
-            await new Promise((r) => setTimeout(r, 500))
-
-            expect(scanner.getBrainUuid()).toBe(TEST_UUID)
-            await scanner.cleanup()
-        } finally {
-            for (const uuid of foreignUuids) {
-                try { rmSync(join(BRAIN_BASE, uuid), { recursive: true, force: true }) } catch { /* best-effort */ }
-            }
-        }
-    })
-
-    it('logs a warning (not silent truncation) when in-window candidates exceed the sanity bound', async () => {
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        const extraUuids: string[] = []
-        const COUNT = 60 // comfortably above the sanity bound, with margin for ambient brain-dir churn on this machine
-        for (let i = 0; i < COUNT; i++) {
-            const uuid = `20000000-0000-4000-8000-${String(i).padStart(12, '0')}`
-            extraUuids.push(uuid)
-            mkdirSync(join(BRAIN_BASE, uuid), { recursive: true })
-        }
-
-        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined)
-        try {
-            scanner.setSessionMessageText('needle-that-matches-nothing')
-            await new Promise((r) => setTimeout(r, 500))
-
-            expect(warnSpy).toHaveBeenCalled()
-            const [message] = warnSpy.mock.calls[0] ?? []
-            expect(message).toMatch(/scan window|sanity bound|dropping/i)
-
-            // No content matched anything real → still correctly unmatched.
-            expect(scanner.getBrainUuid()).toBeNull()
-            await scanner.cleanup()
-        } finally {
-            warnSpy.mockRestore()
-            for (const uuid of extraUuids) {
-                try { rmSync(join(BRAIN_BASE, uuid), { recursive: true, force: true }) } catch { /* best-effort */ }
-            }
-        }
-    })
-
-    // Transcript content is JSON-encoded, so a real newline in the user's
-    // first message is escaped as the two characters "\n" on disk. Raw-file
-    // `fileText.includes(needle)` compares that raw (still-escaped) text
-    // against the needle (a real newline byte in memory) and never matches —
-    // any multi-line first message permanently blanked the chat. Matching on
-    // the JSON-decoded content field (not raw file text) fixes this.
-    it('matches a multi-line first user message (decoded-content match, not raw-file substring)', async () => {
-        const bodyText = `line one\nline two\nhapi-multiline-${Date.now()}`
-        const line = makeTranscriptLine(0, 'USER_INPUT', bodyText)
-        const scanner = await createAgySessionScanner({ onEntry: () => {} })
-        makeTempBrain(TEST_UUID, line + '\n')
-        scanner.setSessionMessageText(bodyText)
-        await vi.waitFor(() => expect(scanner.getBrainUuid()).toBe(TEST_UUID), { timeout: 1500 })
-        await scanner.cleanup()
-    })
 })

--- a/cli/src/agy/utils/agySessionScanner.ts
+++ b/cli/src/agy/utils/agySessionScanner.ts
@@ -1,4 +1,4 @@
-import { open, readdir, stat } from "node:fs/promises"
+import { open, stat } from "node:fs/promises"
 import { join } from "node:path"
 import { homedir } from "node:os"
 import { BaseSessionScanner } from "@/modules/common/session/BaseSessionScanner"
@@ -9,30 +9,6 @@ import { resolveAgyTurnModels } from "./agyConversationModel"
 const AGY_BRAIN_DIR = join(homedir(), '.gemini', 'antigravity-cli', 'brain')
 const LOG_REL_PATH = join('.system_generated', 'logs', 'transcript_full.jsonl')
 
-// Discovery-phase scan window: every brain dir whose mtime falls within this
-// many ms of "now" (relative to when THIS scanner was constructed) is a
-// candidate. Replaces a stale "newest N by mtime" cap that a background
-// service spawning short-lived `agy --print` calls (238 brain dirs in 5h
-// observed on one machine) could push a real session's brain out of within
-// seconds, permanently blanking the chat. Our own brain cannot predate the
-// scanner (it's minted by the very `agy` process this scanner was created to
-// watch), so "recent enough" is a correct and self-bounding filter, and the
-// window is the only bound: an unusually large candidate set is logged, never
-// truncated (see SCAN_CANDIDATE_WARN_THRESHOLD).
-//
-// 30s covers: (a) clock/mtime granularity across filesystems, (b) the
-// spawn -> first-write-to-brain-dir delay observed for agy startup.
-const DISCOVERY_WINDOW_SLACK_MS = 30_000
-
-// Observability only — never a cap. Our brain is minted right after the
-// scanner starts, so every brain that churn creates afterwards is NEWER than
-// ours: dropping the "oldest" candidates would discard precisely the brain we
-// are looking for (that is the newest-3 bug, relocated). Dropping the newest
-// instead is no safer, because unrelated brains can also be minted inside the
-// slack window before ours. So the window is the only bound; an unusually
-// large candidate set is logged, not truncated. Cost stays bounded by the
-// prefix read below and by the early exit on the first match.
-const SCAN_CANDIDATE_WARN_THRESHOLD = 50
 const MODEL_SETTLING_RETRY_DELAYS_MS = [100, 200, 300] as const
 
 type ResolveModels = typeof resolveAgyTurnModels
@@ -90,93 +66,53 @@ export async function emitAgyEntriesWithModels(
     for (const entry of entries) onEntry(entry)
 }
 
-// Bounded prefix read for discovery-phase content matching: the first user
-// message lives near the top of the transcript, so we never need to read a
-// whole (potentially 1MB+) transcript file on every poll just to check for a
-// match.
-const CONTENT_MATCH_PREFIX_BYTES = 64 * 1024
-
 function brainLogPath(uuid: string): string {
     return join(AGY_BRAIN_DIR, uuid, LOG_REL_PATH)
-}
-
-async function listBrainUuids(): Promise<Set<string>> {
-    try {
-        const entries = await readdir(AGY_BRAIN_DIR, { withFileTypes: true })
-        return new Set(entries
-            .filter((entry) => entry.isDirectory() && /^[0-9a-f-]{36}$/.test(entry.name))
-            .map((entry) => entry.name))
-    } catch {
-        return new Set()
-    }
 }
 
 type CreateAgySessionScannerOpts = {
     onEntry: (entry: AgyTranscriptEntry) => void
     /**
-     * When set, the scanner skips the content-match discovery phase and uses
-     * this brain UUID directly. Used on resume: the launcher knows the brain
-     * UUID from the previous session and passes it here so the scanner seeds
-     * the existing transcript as processed (preventing re-emission of prior
-     * turns) without waiting for a new user message to trigger content-match.
+     * When set, the scanner seeds the existing transcript as processed and
+     * uses this brain UUID directly. Used on resume: the launcher knows the
+     * brain UUID from the previous session and passes it here so prior turns
+     * are not re-emitted.
      */
     resumeBrainUuid?: string
-    /**
-     * Called exactly once when the brain UUID is first identified via content-
-     * match (new-session path only — NOT called when resumeBrainUuid is pre-
-     * seeded, because that UUID is already known to the caller).
-     * Lets the launcher persist the UUID to session metadata immediately upon
-     * discovery rather than relying on the onMessage PTY polling path.
-     */
-    onBrainFound?: (uuid: string) => void
-    /** Called once when discovery cannot safely choose among exact matches. */
-    onDiscoveryAmbiguous?: (matchCount: number) => void
 }
 
 export async function createAgySessionScanner(opts: CreateAgySessionScannerOpts) {
-    const preexistingBrainUuids = await listBrainUuids()
-    const scanner = new AgySessionScanner(opts, preexistingBrainUuids)
+    const scanner = new AgySessionScanner(opts)
     await scanner.start()
     return {
         cleanup: () => scanner.cleanup(),
-        setSessionMessageText: (text: string) => scanner.setSessionMessageText(text),
-        // Returns the matched/known brain UUID, or null if not yet identified.
+        // Returns the known brain UUID, or null if the scanner has not been
+        // told about one yet (via a resume seed or onNewSession()).
         getBrainUuid: () => scanner.getBrainUuid(),
-        // Switches the scanner to a new brain UUID (used after a re-spawn where
-        // agy starts a fresh conversation but we still track the PTY session).
+        // Switches the scanner to a new brain UUID. This is the scanner's
+        // ONLY discovery signal: it is driven by the agy PreToolUse/
+        // PreInvocation hooks (via AgentSessionBase.onSessionFound ->
+        // agyPtyLauncher's sessionFoundCallback), never discovered by the
+        // scanner itself.
         onNewSession: (uuid: string) => scanner.onNewSession(uuid),
     }
 }
 
 class AgySessionScanner extends BaseSessionScanner<AgyTranscriptEntry> {
     private readonly onEntry: (entry: AgyTranscriptEntry) => void
-    private readonly onBrainFoundCallback: ((uuid: string) => void) | undefined
-    private readonly onDiscoveryAmbiguousCallback: ((matchCount: number) => void) | undefined
-    // Recorded at construction time — the scanner is created right as the
-    // launcher is about to start agy, so our real brain dir cannot predate
-    // this. Anchors the discovery scan window (see DISCOVERY_WINDOW_SLACK_MS).
-    private readonly scannerStartMs: number
-    private readonly preexistingBrainUuids: ReadonlySet<string>
-    private sessionMessageText: string | null = null
-    private sessionMessageSubmittedAtMs: number | null = null
     private foundBrainUuid: string | null = null
-    private ambiguityReported = false
     private readonly modelSettlingAbortController = new AbortController()
 
-    constructor(opts: CreateAgySessionScannerOpts, preexistingBrainUuids: ReadonlySet<string>) {
+    constructor(opts: CreateAgySessionScannerOpts) {
         super({ intervalMs: 5000 })
-        this.scannerStartMs = Date.now()
-        this.preexistingBrainUuids = preexistingBrainUuids
         this.onEntry = opts.onEntry
-        this.onBrainFoundCallback = opts.onBrainFound
-        this.onDiscoveryAmbiguousCallback = opts.onDiscoveryAmbiguous
         if (opts.resumeBrainUuid) {
             this.foundBrainUuid = opts.resumeBrainUuid
             logger.debug(`[agy-scanner] resume: pre-seeded brain UUID ${opts.resumeBrainUuid}`)
         }
     }
 
-    /** Returns the matched/known brain UUID, or null if not yet identified. */
+    /** Returns the known brain UUID, or null if not yet identified. */
     getBrainUuid(): string | null {
         return this.foundBrainUuid
     }
@@ -186,32 +122,23 @@ class AgySessionScanner extends BaseSessionScanner<AgyTranscriptEntry> {
         await super.cleanup()
     }
 
-    /** Switch to a new brain UUID (e.g. after a re-spawn). */
+    /** Switch to a new brain UUID (e.g. after a re-spawn, or a hook re-firing with the same UUID). */
     onNewSession(uuid: string): void {
-        // Idempotency guard: the launcher's onBrainFound callback calls
-        // session.onSessionFound(uuid), which (via the sessionFoundCallbacks
-        // registry) calls back into this same scanner's onNewSession(uuid) with
-        // the UUID we just set ourselves — a self-loop. Without this guard that
-        // loop would invalidate() and trigger an unnecessary rescan every time
-        // content-match discovers a brain.
+        // Idempotency guard: the agy PreToolUse/PreInvocation hooks can both
+        // fire (and a hook can fire more than once) with the same
+        // conversationId within a single turn, and each one routes here via
+        // AgentSessionBase.onSessionFound -> the launcher's
+        // sessionFoundCallback. Without this guard a repeat notification for
+        // the UUID we already have would invalidate() and trigger an
+        // unnecessary rescan.
         if (this.foundBrainUuid === uuid) return
         logger.debug(`[agy-scanner] onNewSession: switching brain to ${uuid}`)
         this.foundBrainUuid = uuid
         this.invalidate()
     }
 
-    setSessionMessageText(text: string): void {
-        if (this.sessionMessageSubmittedAtMs === null) {
-            // Called immediately before the PTY writes CR. The matching AGY
-            // USER_INPUT must therefore be created at or after this boundary.
-            this.sessionMessageSubmittedAtMs = Date.now()
-        }
-        this.sessionMessageText = text
-        this.invalidate()
-    }
-
     protected shouldScan(): boolean {
-        return this.sessionMessageText !== null || this.foundBrainUuid !== null
+        return this.foundBrainUuid !== null
     }
 
     /**
@@ -232,85 +159,17 @@ class AgySessionScanner extends BaseSessionScanner<AgyTranscriptEntry> {
         this.setCursor(logPath, nextCursor)
     }
 
+    /**
+     * The scanner has no discovery mechanism of its own: it only ever watches
+     * a brain it has been explicitly told about (resumeBrainUuid at
+     * construction, or onNewSession() later — both ultimately driven by the
+     * agy PreToolUse/PreInvocation hooks). Until then it watches nothing, so
+     * it never risks attaching to the wrong brain.
+     */
     protected async findSessionFiles(): Promise<string[]> {
         if (this.foundBrainUuid) {
             return [brainLogPath(this.foundBrainUuid)]
         }
-
-        let uuids: string[]
-        try {
-            const entries = await readdir(AGY_BRAIN_DIR, { withFileTypes: true })
-            uuids = entries
-                .filter((e) => e.isDirectory() && /^[0-9a-f-]{36}$/.test(e.name))
-                .map((e) => e.name)
-        } catch {
-            return []
-        }
-
-        const withMtime = await Promise.all(
-            uuids.map(async (uuid) => {
-                try {
-                    const s = await stat(join(AGY_BRAIN_DIR, uuid))
-                    return { uuid, mtime: s.mtimeMs }
-                } catch {
-                    return null
-                }
-            })
-        )
-
-        const windowStartMs = this.scannerStartMs - DISCOVERY_WINDOW_SLACK_MS
-        const candidates = withMtime
-            .filter((e): e is NonNullable<typeof e> => e !== null)
-            .filter((e) => e.mtime >= windowStartMs)
-            .filter((e) => !this.preexistingBrainUuids.has(e.uuid))
-            // Newest-first: the likely match (our own, just-written brain) is
-            // tried first. Ordering is a heuristic for speed only — every
-            // candidate in the window is scanned until one matches.
-            .sort((a, b) => b.mtime - a.mtime)
-
-        if (candidates.length > SCAN_CANDIDATE_WARN_THRESHOLD) {
-            logger.warn(
-                `[agy-scanner] scan window has ${candidates.length} candidate brains (above ${SCAN_CANDIDATE_WARN_THRESHOLD}) — scanning all of them; unusual brain-dir churn?`
-            )
-        }
-
-        const text = this.sessionMessageText
-        const bodyNeedle = text ? extractBodyText(text) : null
-        const matches: Array<{ uuid: string; logPath: string }> = []
-        for (const { uuid } of candidates) {
-            const logPath = brainLogPath(uuid)
-            if (text) {
-                try {
-                    if (await brainTranscriptMatches(logPath, text, bodyNeedle, this.sessionMessageSubmittedAtMs)) {
-                        logger.debug(`[agy-scanner] matched brain ${uuid} via content`)
-                        matches.push({ uuid, logPath })
-                    }
-                } catch {
-                    continue
-                }
-            }
-        }
-
-        if (matches.length === 1) {
-            const [{ uuid, logPath }] = matches
-            this.foundBrainUuid = uuid
-            // Notify the caller immediately so it can persist the UUID to
-            // session metadata without waiting for onMessage polling.
-            this.onBrainFoundCallback?.(uuid)
-            logger.debug(`[agy-scanner] found brain ${uuid}, watching 1 file`)
-            return [logPath]
-        }
-        if (matches.length > 1) {
-            logger.warn(`[agy-scanner] ${matches.length} brains matched the first message exactly; refusing ambiguous attachment`)
-            if (!this.ambiguityReported) {
-                this.ambiguityReported = true
-                this.onDiscoveryAmbiguousCallback?.(matches.length)
-            }
-        }
-        // Brain not yet identified — do NOT fall back to watching all candidates.
-        // Emitting from unmatched brains leaks another session's transcript into
-        // this chat (the raw-JSON noise). Watch nothing until the session message
-        // text appears in exactly one brain's transcript on a later scan.
         return []
     }
 
@@ -352,6 +211,14 @@ function generateKey(entry: AgyTranscriptEntry): string {
     return `${entry.step_index}:${entry.type}`
 }
 
+// extractBodyText / extractUserRequest / normalizeUserInput below are NOT
+// discovery helpers (the scanner no longer discovers brains by content —
+// see the class docblock above and the removed content-match code this
+// module used to carry). They are kept because agyPtyLauncher.ts's
+// userRequestMatches() — a DIFFERENT concern, confirming a web-submitted
+// message was echoed back into the PTY — still needs them; agy hook payloads
+// carry no user-input text, so that echo check has no hook-based substitute.
+
 // Strips a leading "@path1 @path2 ...\n\n" attachment-reference prefix (the
 // exact shape formatMessageWithAttachments() produces — see
 // cli/src/utils/attachmentFormatter.ts) from a session-message needle, leaving
@@ -384,141 +251,8 @@ export function extractUserRequest(content: string): string | null {
     return request
 }
 
-// Discovery-phase content match: does this brain's transcript contain our
-// session's first message? Reads only a bounded prefix (the first user
-// message is near the top) and matches against the DECODED content field of
-// USER_INPUT entries — never raw file text. Two reasons:
-//  1. Raw-file substring matching compares JSON-escaped bytes (a real
-//     newline in the needle vs. the literal two-char "\n" escape on disk) and
-//     never matches a multi-line first message.
-//  2. Restricting to USER_INPUT (our own message, echoed back by agy) avoids
-//     false positives from the needle text coincidentally appearing inside a
-//     tool result or the model's own response.
-async function brainTranscriptMatches(
-    logPath: string,
-    text: string,
-    bodyNeedle: string | null,
-    submittedAtMs: number | null,
-): Promise<boolean> {
-    const prefix = await readTranscriptPrefix(logPath, CONTENT_MATCH_PREFIX_BYTES)
-    if (matchesUserInput(prefix.entries, text, bodyNeedle, submittedAtMs)) return true
-
-    // The first USER_INPUT sits at offset 0, so a first message longer than the
-    // prefix window leaves no complete line to parse. Giving up here would
-    // blank the chat permanently (and silently) for that session, so re-read
-    // the whole transcript once. A prefix that DID yield a USER_INPUT needs no
-    // retry: that entry is the first message, and it did not match.
-    const sawUserInput = prefix.entries.some((e) => e.type === 'USER_INPUT')
-    if (!sawUserInput && prefix.truncated) {
-        logger.warn(
-            `[agy-scanner] no complete USER_INPUT entry within the first ${CONTENT_MATCH_PREFIX_BYTES}B of ${logPath} — falling back to a full read`
-        )
-        const full = await readTranscriptPrefix(logPath, Number.POSITIVE_INFINITY)
-        return matchesUserInput(full.entries, text, bodyNeedle, submittedAtMs)
-    }
-    return false
-}
-
-function matchesUserInput(
-    entries: AgyTranscriptEntry[],
-    text: string,
-    bodyNeedle: string | null,
-    submittedAtMs: number | null,
-): boolean {
-    const normalizedText = normalizeUserInput(text)
-    const normalizedBody = bodyNeedle ? normalizeUserInput(bodyNeedle) : null
-    for (const entry of entries) {
-        if (entry.type !== 'USER_INPUT') continue
-        const createdAtMs = Date.parse(entry.created_at)
-        const submittedSecondMs = submittedAtMs === null ? null : Math.floor(submittedAtMs / 1000) * 1000
-        if (submittedSecondMs === null || !Number.isFinite(createdAtMs) || createdAtMs < submittedSecondMs) continue
-        const content = entry.content
-        if (!content) continue
-        // Prefer the attachment-stripped body text too: agy re-packages
-        // attachment references into its own <USER_REQUEST> wrapper
-        // (different order/separator than our @path...\n\n prefix), so a
-        // whole-needle match fails for any first message that has
-        // attachments. The body text alone still appears verbatim in agy's
-        // re-packaged transcript regardless of how it re-orders/re-wraps the
-        // attachment references.
-        // agy stores the submitted text inside a <USER_REQUEST> block and
-        // appends its own sections (<ADDITIONAL_METADATA>, ...), so the raw
-        // content field never equals what we sent. Compare the isolated
-        // request, falling back to the whole field when no wrapper is present.
-        const normalizedContent = normalizeUserInput(extractUserRequest(content) ?? content)
-        if (normalizedContent === normalizedText) {
-            return true
-        }
-        if (normalizedBody && extractRepackagedAttachmentBody(normalizedContent) === normalizedBody) return true
-    }
-    return false
-}
-
 export function normalizeUserInput(value: string): string {
     return value.replace(/\r\n/g, '\n').trim()
-}
-
-function extractRepackagedAttachmentBody(content: string): string {
-    return content
-        .split('\n')
-        .filter((line) => line !== '<USER_REQUEST>' && line !== '</USER_REQUEST>')
-        .filter((line) => !/^@\S+( @\S+)*$/.test(line.trim()))
-        .join('\n')
-        .trim()
-}
-
-// Reads and JSONL-parses at most `maxBytes` from the START of the file (not
-// an incremental cursor read — this is discovery-phase-only, re-run on every
-// poll until a match is found, so it must stay cheap and NOT read whole
-// (potentially 1MB+) transcript files every tick). A trailing partial line
-// (cut off by the byte cap) is dropped rather than guessed at.
-async function readTranscriptPrefix(
-    filePath: string,
-    maxBytes: number,
-): Promise<{ entries: AgyTranscriptEntry[]; truncated: boolean }> {
-    let fd
-    try {
-        fd = await open(filePath, 'r')
-    } catch {
-        return { entries: [], truncated: false }
-    }
-    try {
-        const size = (await fd.stat()).size
-        const length = Math.min(maxBytes, size)
-        if (length <= 0) return { entries: [], truncated: false }
-        // `truncated` means "the file has content we did not look at", which is
-        // the only case where an empty parse warrants a wider re-read.
-        const truncated = size > length
-
-        const chunk = Buffer.allocUnsafe(length)
-        // Honor the actual byte count: a concurrent truncation between stat()
-        // and read() would otherwise leave uninitialized memory in the tail.
-        const { bytesRead } = await fd.read(chunk, 0, length, 0)
-        const read = chunk.subarray(0, bytesRead)
-
-        const lastNewline = read.lastIndexOf(0x0a)
-        // No complete line in the window. Only a wider read can help, and only
-        // if there is more file to read (otherwise the first line is simply
-        // still being written — retry on the next poll).
-        if (lastNewline === -1) return { entries: [], truncated }
-        const text = read.subarray(0, lastNewline).toString('utf-8')
-
-        const entries: AgyTranscriptEntry[] = []
-        for (const raw of text.split('\n')) {
-            const line = raw.trim()
-            if (!line) continue
-            try {
-                const entry = JSON.parse(line) as AgyTranscriptEntry & { type?: string }
-                if (!entry.type) continue
-                entries.push(entry as AgyTranscriptEntry)
-            } catch {
-                continue
-            }
-        }
-        return { entries, truncated }
-    } finally {
-        await fd.close()
-    }
 }
 
 async function readBrainLog(

--- a/cli/src/claude/utils/sessionHookForwarder.test.ts
+++ b/cli/src/claude/utils/sessionHookForwarder.test.ts
@@ -322,3 +322,174 @@ describe('runSessionHookForwarder — agy flavor', () => {
         expect('hookSpecificOutput' in response).toBe(false);
     });
 });
+
+describe('runSessionHookForwarder — agy PreInvocation (discovery, fail-open)', () => {
+    it('POSTs to /hook/agy-pre-invocation and always writes {} + exit 0 on stdout', async () => {
+        let hitPath = '';
+        let hitBody = '';
+        const port = await startStub((path, body) => {
+            hitPath = path;
+            hitBody = body;
+            return { status: 200, body: '{}' };
+        });
+
+        const payload = JSON.stringify({ conversationId: 'brain-1', invocationNum: 0 });
+        const out = captureStdout();
+        const originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+        try {
+            await withStdin(payload, () =>
+                runSessionHookForwarder(['--port', String(port), '--token', 'tok', '--flavor', 'agy', '--event', 'pre-invocation'])
+            );
+            expect(process.exitCode).toBeUndefined();
+        } finally {
+            out.restore();
+            process.exitCode = originalExitCode;
+        }
+
+        expect(hitPath).toBe('/hook/agy-pre-invocation');
+        expect(JSON.parse(hitBody).conversationId).toBe('brain-1');
+        expect(out.get()).toBe('{}');
+    });
+
+    it('fails OPEN (still writes {} + exit 0) when the bridge is unreachable', async () => {
+        // Port 1 is a well-known low port nothing listens on in this test
+        // environment — connecting refuses immediately without needing a
+        // real (and then torn-down) stub server.
+        const out = captureStdout();
+        const originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+        try {
+            await withStdin(
+                JSON.stringify({ conversationId: 'brain-2' }),
+                () => runSessionHookForwarder(['--port', '1', '--token', 'tok', '--flavor', 'agy', '--event', 'pre-invocation'])
+            );
+            expect(process.exitCode).toBeUndefined();
+        } finally {
+            out.restore();
+            process.exitCode = originalExitCode;
+        }
+
+        expect(out.get()).toBe('{}');
+    }, 10_000);
+
+    it('fails OPEN (still writes {} + exit 0) even when the bridge replies with an error status', async () => {
+        const port = await startStub(() => ({ status: 500, body: 'boom' }));
+
+        const out = captureStdout();
+        const originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+        try {
+            await withStdin(
+                JSON.stringify({ conversationId: 'brain-3' }),
+                () => runSessionHookForwarder(['--port', String(port), '--token', 'tok', '--flavor', 'agy', '--event', 'pre-invocation'])
+            );
+            expect(process.exitCode).toBeUndefined();
+        } finally {
+            out.restore();
+            process.exitCode = originalExitCode;
+        }
+
+        expect(out.get()).toBe('{}');
+    });
+
+    it('defaults to pre-tool-use when --event is omitted (existing agy callers keep working)', async () => {
+        let hitPath = '';
+        const port = await startStub((path) => {
+            hitPath = path;
+            return { status: 200, body: JSON.stringify({ permissionDecision: 'allow' }) };
+        });
+
+        const out = captureStdout();
+        try {
+            await withStdin(
+                JSON.stringify({ toolCall: { name: 'run_command', args: {} }, conversationId: 'brain-4' }),
+                () => runSessionHookForwarder(['--port', String(port), '--token', 'tok', '--flavor', 'agy'])
+            );
+        } finally {
+            out.restore();
+        }
+
+        expect(hitPath).toBe('/hook/pre-tool-use');
+        expect(JSON.parse(out.get()).decision).toBe('allow');
+    });
+
+    it('rejects an unrecognized --event value instead of silently degrading to pre-tool-use', async () => {
+        // A discovery payload (no toolCall field) routed down the
+        // permission-gate path would produce a phantom approval card with an
+        // empty tool name and violate the pre-invocation {} stdout contract.
+        // An unknown --event (typo, future value) must fail loudly instead.
+        let serverHit = false;
+        const port = await startStub(() => {
+            serverHit = true;
+            return { status: 200, body: JSON.stringify({ permissionDecision: 'allow' }) };
+        });
+
+        const out = captureStdout();
+        const originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+        try {
+            await withStdin(
+                JSON.stringify({ conversationId: 'brain-5' }),
+                () => runSessionHookForwarder(['--port', String(port), '--token', 'tok', '--flavor', 'agy', '--event', 'pre-invocaiton'])
+            );
+            expect(process.exitCode).toBe(1);
+        } finally {
+            out.restore();
+            process.exitCode = originalExitCode;
+        }
+
+        expect(serverHit).toBe(false);
+        expect(out.get()).toBe('');
+    });
+
+    it('rejects an unrecognized --event=value form the same way', async () => {
+        const port = await startStub(() => ({ status: 200, body: JSON.stringify({ permissionDecision: 'allow' }) }));
+
+        const out = captureStdout();
+        const originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+        try {
+            await withStdin(
+                JSON.stringify({ conversationId: 'brain-6' }),
+                () => runSessionHookForwarder(['--port', String(port), '--token', 'tok', '--flavor', 'agy', '--event=bogus'])
+            );
+            expect(process.exitCode).toBe(1);
+        } finally {
+            out.restore();
+            process.exitCode = originalExitCode;
+        }
+
+        expect(out.get()).toBe('');
+    });
+
+    it('rejects a trailing --event with no value instead of silently defaulting to pre-tool-use', async () => {
+        // args[i+1] is undefined when --event is the last argument — that must
+        // NOT collapse to the same "flag omitted" undefined that legitimately
+        // defaults to pre-tool-use, or a malformed invocation missing only the
+        // value would silently reopen the fail-open degrade this whole guard
+        // exists to close.
+        let serverHit = false;
+        const port = await startStub(() => {
+            serverHit = true;
+            return { status: 200, body: JSON.stringify({ permissionDecision: 'allow' }) };
+        });
+
+        const out = captureStdout();
+        const originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+        try {
+            await withStdin(
+                JSON.stringify({ conversationId: 'brain-7' }),
+                () => runSessionHookForwarder(['--port', String(port), '--token', 'tok', '--flavor', 'agy', '--event'])
+            );
+            expect(process.exitCode).toBe(1);
+        } finally {
+            out.restore();
+            process.exitCode = originalExitCode;
+        }
+
+        expect(serverHit).toBe(false);
+        expect(out.get()).toBe('');
+    });
+});

--- a/cli/src/claude/utils/sessionHookForwarder.ts
+++ b/cli/src/claude/utils/sessionHookForwarder.ts
@@ -135,10 +135,24 @@ function parsePort(value: string | undefined): number | null {
     return port;
 }
 
-function parseArgs(args: string[]): { port: number | null; token: string | null; flavor: 'claude' | 'agy' } {
+function parseArgs(args: string[]): {
+    port: number | null;
+    token: string | null;
+    flavor: 'claude' | 'agy';
+    event: 'pre-tool-use' | 'pre-invocation';
+    /**
+     * The raw --event value as given, or undefined if the flag was omitted
+     * entirely. Lets the caller distinguish "omitted" (defaults to
+     * pre-tool-use) from "provided but unrecognized" (must be rejected, not
+     * silently defaulted to pre-tool-use — that would route a discovery
+     * payload through the permission-gate path).
+     */
+    eventRaw: string | undefined;
+} {
     let port: number | null = null;
     let token: string | null = null;
     let flavor: 'claude' | 'agy' = 'claude';
+    let eventRaw: string | undefined;
     let fromEnv = false;
 
     for (let i = 0; i < args.length; i += 1) {
@@ -187,6 +201,24 @@ function parseArgs(args: string[]): { port: number | null; token: string | null;
             continue;
         }
 
+        if (arg === '--event') {
+            // `?? ''` matters: a trailing `--event` with no following value
+            // must NOT collapse to the same `undefined` that means "the flag
+            // was never given at all" (which legitimately defaults to
+            // pre-tool-use below) — that would silently re-open the exact
+            // fail-open degrade Fix 2/6 closed for every OTHER malformed
+            // --event value. An empty string is neither known event name, so
+            // it falls through to the explicit rejection.
+            eventRaw = args[i + 1] ?? '';
+            i += 1;
+            continue;
+        }
+
+        if (arg.startsWith('--event=')) {
+            eventRaw = arg.slice('--event='.length);
+            continue;
+        }
+
         if (!port) {
             port = parsePort(arg);
             continue;
@@ -202,11 +234,13 @@ function parseArgs(args: string[]): { port: number | null; token: string | null;
         token = process.env.HAPI_AGY_HOOK_TOKEN?.trim() || null;
     }
 
-    return { port, token, flavor };
+    const event: 'pre-tool-use' | 'pre-invocation' = eventRaw === 'pre-invocation' ? 'pre-invocation' : 'pre-tool-use';
+
+    return { port, token, flavor, event, eventRaw };
 }
 
 export async function runSessionHookForwarder(args: string[]): Promise<void> {
-    const { port, token, flavor } = parseArgs(args);
+    const { port, token, flavor, event, eventRaw } = parseArgs(args);
     if (!port) {
         logError('Invalid or missing port argument');
         process.exitCode = 1;
@@ -215,6 +249,17 @@ export async function runSessionHookForwarder(args: string[]): Promise<void> {
 
     if (!token) {
         logError('Missing hook token');
+        process.exitCode = 1;
+        return;
+    }
+
+    // An --event value was given but is neither known event name. Silently
+    // falling back to pre-tool-use here would route a discovery payload
+    // (no toolCall field) down the permission-gate path — a phantom
+    // approval card for an empty tool name — and would also violate the
+    // pre-invocation stdout contract (always {}). Reject explicitly instead.
+    if (eventRaw !== undefined && eventRaw !== 'pre-tool-use' && eventRaw !== 'pre-invocation') {
+        logError(`Unknown --event value: ${eventRaw}`);
         process.exitCode = 1;
         return;
     }
@@ -231,6 +276,22 @@ export async function runSessionHookForwarder(args: string[]): Promise<void> {
         }
 
         const body = Buffer.concat(chunks);
+
+        // agy PreInvocation: discovery-ONLY bridge, fail-OPEN. Unlike
+        // PreToolUse (a permission gate that must fail-closed), a dead or
+        // slow bridge here must never block or degrade the model call — the
+        // only thing riding on this hook is brain-UUID discovery, which has
+        // a fallback (the PreToolUse hook, or the next PreInvocation call).
+        // agy's own hook-side timeout (5s, see generateHookSettings.ts)
+        // bounds the worst case if the POST hangs; we also apply our own
+        // shorter request timeout so a hung connection can't eat that whole
+        // budget. Always emit stdout `{}` (no injectSteps) regardless of the
+        // POST outcome — this is a discovery signal, not a decision.
+        if (flavor === 'agy' && event === 'pre-invocation') {
+            await postHook(port, token, '/hook/agy-pre-invocation', body, SESSION_HOOK_FORWARD_TIMEOUT_MS);
+            process.stdout.write('{}');
+            return;
+        }
 
         // agy flavor: every hook invocation is a PreToolUse (agy has no
         // SessionStart hook). The stdin format is agy's camelCase schema

--- a/cli/src/claude/utils/startHookServer.test.ts
+++ b/cli/src/claude/utils/startHookServer.test.ts
@@ -193,4 +193,68 @@ describe('startHookServer', () => {
             expect(called).toBe(false)
         })
     })
+
+    describe('agy-pre-invocation', () => {
+        const sendAgyInvocation = (port: number, payload: unknown, token?: string) =>
+            sendHookRequest(port, JSON.stringify(payload), token, '/hook/agy-pre-invocation')
+
+        it('forwards conversationId to onAgyPreInvocation and responds 200 immediately', async () => {
+            let received: unknown = null
+            const server = await startHookServer({
+                onSessionHook: () => {},
+                onAgyPreInvocation: (data) => { received = data }
+            })
+
+            try {
+                const response = await sendAgyInvocation(
+                    server.port,
+                    { conversationId: 'brain-1', invocationNum: 0, modelName: 'gemini-3.5-flash' },
+                    server.token
+                )
+                expect(response.statusCode).toBe(200)
+            } finally {
+                server.stop()
+            }
+
+            expect((received as { conversationId?: string }).conversationId).toBe('brain-1')
+        })
+
+        it('responds 200 even when no onAgyPreInvocation handler is wired (discovery is best-effort)', async () => {
+            const server = await startHookServer({ onSessionHook: () => {} })
+            try {
+                const response = await sendAgyInvocation(server.port, { conversationId: 'brain-2' }, server.token)
+                expect(response.statusCode).toBe(200)
+            } finally {
+                server.stop()
+            }
+        })
+
+        it('returns 401 when the token is missing', async () => {
+            let called = false
+            const server = await startHookServer({
+                onSessionHook: () => {},
+                onAgyPreInvocation: () => { called = true }
+            })
+            try {
+                const response = await sendAgyInvocation(server.port, { conversationId: 'brain-3' })
+                expect(response.statusCode).toBe(401)
+            } finally {
+                server.stop()
+            }
+            expect(called).toBe(false)
+        })
+
+        it('responds 200 even when the handler throws (a discovery failure must never surface as an error to agy)', async () => {
+            const server = await startHookServer({
+                onSessionHook: () => {},
+                onAgyPreInvocation: () => { throw new Error('boom') }
+            })
+            try {
+                const response = await sendAgyInvocation(server.port, { conversationId: 'brain-4' }, server.token)
+                expect(response.statusCode).toBe(200)
+            } finally {
+                server.stop()
+            }
+        })
+    })
 })

--- a/cli/src/claude/utils/startHookServer.ts
+++ b/cli/src/claude/utils/startHookServer.ts
@@ -70,6 +70,23 @@ export interface PreToolUseDecision {
     updatedInput?: Record<string, unknown>;
 }
 
+/**
+ * Data received from agy's PreInvocation hook — fires before every model
+ * call, regardless of tool use (unlike PreToolUse, which only fires when a
+ * tool actually runs). HAPI uses this ONLY for brain UUID discovery; there is
+ * no `toolCall` field on this event at all.
+ */
+export interface AgyPreInvocationHookData {
+    conversationId?: string;
+    invocationNum?: number;
+    initialNumSteps?: number;
+    modelName?: string;
+    transcriptPath?: string;
+    artifactDirectoryPath?: string;
+    workspacePaths?: string[];
+    [key: string]: unknown;
+}
+
 export interface HookServerOptions {
     /** Called when a session hook is received with a valid session ID. */
     onSessionHook: (sessionId: string, data: SessionHookData) => void;
@@ -79,6 +96,13 @@ export interface HookServerOptions {
      * omitted, tool calls are allowed (no-op), matching --yolo behavior.
      */
     onPreToolUse?: (data: PreToolUseHookData) => Promise<PreToolUseDecision>;
+    /**
+     * Called for each agy PreInvocation hook (discovery-only, fail-open). No
+     * decision is awaited — the route always responds 200 immediately,
+     * mirroring the forwarder's fail-open contract for this event. When
+     * omitted, the route still responds 200 (discovery is best-effort).
+     */
+    onAgyPreInvocation?: (data: AgyPreInvocationHookData) => void;
     /** Optional token to require for hook requests. */
     token?: string;
 }
@@ -243,6 +267,54 @@ export async function startHookServer(options: HookServerOptions): Promise<HookS
                         res.writeHead(200, { 'Content-Type': 'application/json' }).end(
                             JSON.stringify({ permissionDecision: 'deny', reason: 'Permission bridge error.' })
                         );
+                    }
+                }
+                return;
+            }
+
+            if (req.method === 'POST' && requestPath === '/hook/agy-pre-invocation') {
+                const providedToken = readHookToken(req);
+                if (providedToken !== hookToken) {
+                    logger.debug('[hookServer] Unauthorized agy-pre-invocation request');
+                    res.writeHead(401, { 'Content-Type': 'text/plain' }).end('unauthorized');
+                    req.resume();
+                    return;
+                }
+
+                // Fail-open route: this event carries discovery only, never a
+                // decision the CLI blocks on. Every branch below responds 200
+                // immediately (auth failure is the only exception — that is a
+                // security boundary, not a discovery failure).
+                try {
+                    const chunks: Buffer[] = [];
+                    for await (const chunk of req) {
+                        chunks.push(chunk as Buffer);
+                    }
+                    const body = Buffer.concat(chunks).toString('utf-8');
+
+                    let data: AgyPreInvocationHookData = {};
+                    try {
+                        const parsed = JSON.parse(body);
+                        if (parsed && typeof parsed === 'object') {
+                            data = parsed as AgyPreInvocationHookData;
+                        }
+                    } catch (parseError) {
+                        logger.debug('[hookServer] Failed to parse agy-pre-invocation data (proceeding with empty data):', parseError);
+                    }
+
+                    try {
+                        options.onAgyPreInvocation?.(data);
+                    } catch (error) {
+                        logger.debug('[hookServer] Error dispatching agy-pre-invocation hook:', error);
+                    }
+
+                    if (!res.headersSent && !res.writableEnded) {
+                        res.writeHead(200, { 'Content-Type': 'application/json' }).end('{}');
+                    }
+                } catch (error) {
+                    logger.debug('[hookServer] Error handling agy-pre-invocation hook:', error);
+                    if (!res.headersSent && !res.writableEnded) {
+                        res.writeHead(200, { 'Content-Type': 'application/json' }).end('{}');
                     }
                 }
                 return;

--- a/cli/src/configuration.ts
+++ b/cli/src/configuration.ts
@@ -47,6 +47,21 @@ export function parseExtraHeaders(raw: string | undefined, warn: (message: strin
     }
 }
 
+/**
+ * Resolves HAPI's home directory: the `HAPI_HOME` env override (with a
+ * leading `~` expanded to the current user's home) takes priority, else
+ * `~/.hapi`. Takes an explicit env object (defaulting to `process.env`) so
+ * callers that need a fresh read on every call — rather than the cached
+ * `Configuration.happyHomeDir` singleton value, which is fixed at process
+ * startup — can reuse this instead of re-deriving the same priority logic.
+ */
+export function resolveHapiHomeDir(env: NodeJS.ProcessEnv = process.env): string {
+    if (env.HAPI_HOME) {
+        return env.HAPI_HOME.replace(/^~/, homedir())
+    }
+    return join(homedir(), '.hapi')
+}
+
 class Configuration {
     private _apiUrl: string
     private _cliApiToken: string
@@ -75,13 +90,7 @@ class Configuration {
         this.isRunnerProcess = args.length >= 2 && args[0] === 'runner' && (args[1] === 'start-sync')
 
         // Directory configuration - Priority: HAPI_HOME env > default home dir
-        if (process.env.HAPI_HOME) {
-            // Expand ~ to home directory if present
-            const expandedPath = process.env.HAPI_HOME.replace(/^~/, homedir())
-            this.happyHomeDir = expandedPath
-        } else {
-            this.happyHomeDir = join(homedir(), '.hapi')
-        }
+        this.happyHomeDir = resolveHapiHomeDir()
 
         this.logsDir = join(this.happyHomeDir, 'logs')
         this.settingsFile = join(this.happyHomeDir, 'settings.json')

--- a/cli/src/modules/common/hooks/generateHookSettings.test.ts
+++ b/cli/src/modules/common/hooks/generateHookSettings.test.ts
@@ -31,16 +31,54 @@ describe('buildHookSettings PTY approvals', () => {
 
 describe('buildAgyHooksJson', () => {
     it('produces a valid agy hooks.json with PreToolUse for all tools', () => {
-        const parsed = JSON.parse(buildAgyHooksJson('hapi hook-forwarder --port 12345 --token abc')) as Record<string, { PreToolUse: Array<{ matcher: string; hooks: Array<{ command: string; timeout: number }> }> }>
+        const parsed = JSON.parse(buildAgyHooksJson({
+            preToolUseCommand: 'hapi hook-forwarder --port 12345 --token abc',
+            preInvocationCommand: 'hapi hook-forwarder --port 12345 --token abc --event pre-invocation'
+        })) as Record<string, { PreToolUse: Array<{ matcher: string; hooks: Array<{ command: string; timeout: number }> }> }>
         const group = Object.values(parsed)[0]
         expect(group.PreToolUse[0].matcher).toBe('*')
         expect(group.PreToolUse[0].hooks[0].command).toContain('hook-forwarder')
         expect(group.PreToolUse[0].hooks[0].timeout).toBeGreaterThanOrEqual(600)
     })
 
-    it('accepts a custom hook name and omits Claude-only type', () => {
-        const parsed = JSON.parse(buildAgyHooksJson('cmd', 'my-hook')) as Record<string, { PreToolUse: Array<{ hooks: Array<Record<string, unknown>> }> }>
+    it('accepts a custom hook name and omits Claude-only type on the PreToolUse entry', () => {
+        const parsed = JSON.parse(buildAgyHooksJson({
+            preToolUseCommand: 'cmd',
+            preInvocationCommand: 'cmd --event pre-invocation',
+            hookName: 'my-hook'
+        })) as Record<string, { PreToolUse: Array<{ hooks: Array<Record<string, unknown>> }> }>
         expect(parsed['my-hook']).toBeDefined()
         expect('type' in parsed['my-hook'].PreToolUse[0].hooks[0]).toBe(false)
+    })
+
+    it('registers PreInvocation as a FLAT array — agy silently ignores the {matcher,hooks} wrapper for this event', () => {
+        const parsed = JSON.parse(buildAgyHooksJson({
+            preToolUseCommand: 'cmd-pre-tool-use',
+            preInvocationCommand: 'cmd-pre-invocation'
+        })) as Record<string, {
+            PreInvocation: Array<{ type: string; command: string; timeout?: number; matcher?: string; hooks?: unknown }>
+        }>
+        const group = Object.values(parsed)[0]
+        expect(Array.isArray(group.PreInvocation)).toBe(true)
+        const entry = group.PreInvocation[0]
+        expect(entry).not.toHaveProperty('matcher')
+        expect(entry).not.toHaveProperty('hooks')
+        expect(entry.type).toBe('command')
+        expect(entry.command).toBe('cmd-pre-invocation')
+    })
+
+    it('gives PreInvocation a short timeout — it blocks the agent loop synchronously, unlike the long PreToolUse approval wait', () => {
+        const parsed = JSON.parse(buildAgyHooksJson({
+            preToolUseCommand: 'cmd-pre-tool-use',
+            preInvocationCommand: 'cmd-pre-invocation'
+        })) as Record<string, {
+            PreInvocation: Array<{ timeout?: number }>
+            PreToolUse: Array<{ hooks: Array<{ timeout?: number }> }>
+        }>
+        const group = Object.values(parsed)[0]
+        const preInvocationTimeout = group.PreInvocation[0].timeout ?? Infinity
+        const preToolUseTimeout = group.PreToolUse[0].hooks[0].timeout ?? Infinity
+        expect(preInvocationTimeout).toBeLessThanOrEqual(10)
+        expect(preInvocationTimeout).toBeLessThan(preToolUseTimeout)
     })
 })

--- a/cli/src/modules/common/hooks/generateHookSettings.test.ts
+++ b/cli/src/modules/common/hooks/generateHookSettings.test.ts
@@ -81,4 +81,13 @@ describe('buildAgyHooksJson', () => {
         expect(preInvocationTimeout).toBeLessThanOrEqual(10)
         expect(preInvocationTimeout).toBeLessThan(preToolUseTimeout)
     })
+
+    it('omits the PreInvocation block entirely when preInvocationCommand is not given (self-detach state)', () => {
+        const parsed = JSON.parse(buildAgyHooksJson({
+            preToolUseCommand: 'cmd-pre-tool-use'
+        })) as Record<string, { PreToolUse: unknown; PreInvocation?: unknown }>
+        const group = Object.values(parsed)[0]
+        expect(group.PreToolUse).toBeDefined()
+        expect('PreInvocation' in group).toBe(false)
+    })
 })

--- a/cli/src/modules/common/hooks/generateHookSettings.ts
+++ b/cli/src/modules/common/hooks/generateHookSettings.ts
@@ -182,15 +182,21 @@ type AgyFlatHookEntry = {
 type AgyHooksJson = {
     [hookName: string]: {
         PreToolUse: AgyHookEntry[];
-        PreInvocation: AgyFlatHookEntry[];
+        PreInvocation?: AgyFlatHookEntry[];
     };
 };
 
 export type BuildAgyHooksJsonOptions = {
     /** Command for the fail-closed permission bridge (PreToolUse). */
     preToolUseCommand: string;
-    /** Command for the fail-open discovery hook (PreInvocation). */
-    preInvocationCommand: string;
+    /**
+     * Command for the fail-open discovery hook (PreInvocation). Omit to
+     * build a hooks.json with PreToolUse only — used by agyPtyLauncher's
+     * self-detach/respawn-reattach cycle (see agyHookCarrier.ts's
+     * writeAgyHooksJsonAtomic) to drop the now-redundant discovery hook once
+     * the brain UUID is confirmed, and restore it before every respawn.
+     */
+    preInvocationCommand?: string;
     hookName?: string;
 };
 
@@ -224,9 +230,13 @@ export function buildAgyHooksJson({
                     hooks: [{ command: preToolUseCommand, timeout: PRE_TOOL_USE_TIMEOUT_SECONDS }]
                 }
             ],
-            PreInvocation: [
-                { type: 'command', command: preInvocationCommand, timeout: PRE_INVOCATION_TIMEOUT_SECONDS }
-            ]
+            ...(preInvocationCommand
+                ? {
+                    PreInvocation: [
+                        { type: 'command' as const, command: preInvocationCommand, timeout: PRE_INVOCATION_TIMEOUT_SECONDS }
+                    ]
+                }
+                : {})
         }
     };
     return JSON.stringify(content, null, 4);

--- a/cli/src/modules/common/hooks/generateHookSettings.ts
+++ b/cli/src/modules/common/hooks/generateHookSettings.ts
@@ -140,11 +140,30 @@ export function generateHookSettingsFile(
 // agy hooks.json generation
 //
 // agy's hooks.json schema differs from claude's: it is a flat map of
-// hookName → { PreToolUse: [...] } entries. There is no SessionStart event
-// in agy (session identity comes from the PreToolUse stdin conversationId).
+// hookName → { <event>: [...] } entries. There is no SessionStart event in
+// agy. Two events are registered:
+//   - PreToolUse: GROUPED schema ({ matcher, hooks: [...] }), fires only when
+//     a tool actually runs. Used for the permission bridge (fail-closed) and,
+//     as a side effect, brain UUID discovery.
+//   - PreInvocation: FLAT schema (handler objects directly in the array),
+//     fires before every model call regardless of tool use. Used ONLY for
+//     brain UUID discovery (fail-open) — see the agy hooks vault topic
+//     (2026-06-13_agy-antigravity-cli-hooks.md) for why the grouped shape
+//     silently fails to fire for this event.
 // The format:
-//   { "<hookName>": { "PreToolUse": [{ "matcher": "*", "hooks": [{ "command": "...", "timeout": N }] }] } }
+//   {
+//     "<hookName>": {
+//       "PreToolUse": [{ "matcher": "*", "hooks": [{ "command": "...", "timeout": N }] }],
+//       "PreInvocation": [{ "type": "command", "command": "...", "timeout": N }]
+//     }
+//   }
 // ---------------------------------------------------------------------------
+
+// PreInvocation hook blocks the agent loop synchronously (unlike PreToolUse,
+// which waits on a human approving on their phone), so its timeout must stay
+// short: this is the worst-case added latency on every model call. Discovery
+// is a nice-to-have, not worth a multi-second stall for.
+const PRE_INVOCATION_TIMEOUT_SECONDS = 5;
 
 type AgyHookEntry = {
     matcher: string;
@@ -154,28 +173,59 @@ type AgyHookEntry = {
     }>;
 };
 
+type AgyFlatHookEntry = {
+    type: 'command';
+    command: string;
+    timeout?: number;
+};
+
 type AgyHooksJson = {
     [hookName: string]: {
         PreToolUse: AgyHookEntry[];
+        PreInvocation: AgyFlatHookEntry[];
     };
+};
+
+export type BuildAgyHooksJsonOptions = {
+    /** Command for the fail-closed permission bridge (PreToolUse). */
+    preToolUseCommand: string;
+    /** Command for the fail-open discovery hook (PreInvocation). */
+    preInvocationCommand: string;
+    hookName?: string;
 };
 
 /**
  * Build the JSON string for agy's hooks.json. The returned string is suitable
  * for writing into a workspace-local .agents/hooks.json carrier.
  *
- * agy does not use a `type` field on hook entries (unlike claude which requires
- * `"type": "command"`). The timeout is in seconds; 3600 gives the user an hour
- * to answer a permission prompt on their phone.
+ * agy's PreToolUse hooks do not use a `type` field (unlike claude, which
+ * requires `"type": "command"`); PreInvocation hooks DO require it — the two
+ * events use different schemas (grouped vs flat) entirely, see the module
+ * docblock above. Timeouts are in seconds.
+ *
+ * Takes an options object (rather than positional string args) on purpose:
+ * preToolUseCommand and preInvocationCommand are two adjacent same-typed
+ * strings with opposite safety semantics (fail-closed 3600s permission gate
+ * vs. fail-open 5s discovery hook) — a positional swap would silently turn
+ * the permission bridge into a 5s fail-open hole and discovery into a
+ * 3600s-blocking gate. Naming the args at the call site makes that swap
+ * impossible.
  */
-export function buildAgyHooksJson(command: string, hookName = 'hapi-bridge'): string {
+export function buildAgyHooksJson({
+    preToolUseCommand,
+    preInvocationCommand,
+    hookName = 'hapi-bridge'
+}: BuildAgyHooksJsonOptions): string {
     const content: AgyHooksJson = {
         [hookName]: {
             PreToolUse: [
                 {
                     matcher: '*',
-                    hooks: [{ command, timeout: PRE_TOOL_USE_TIMEOUT_SECONDS }]
+                    hooks: [{ command: preToolUseCommand, timeout: PRE_TOOL_USE_TIMEOUT_SECONDS }]
                 }
+            ],
+            PreInvocation: [
+                { type: 'command', command: preInvocationCommand, timeout: PRE_INVOCATION_TIMEOUT_SECONDS }
             ]
         }
     };


### PR DESCRIPTION
## Problem

Following up on the agy PTY support from #1320.

HAPI learns an agy session's conversation id (the "brain UUID") from the `PreToolUse` hook, which carries it on every firing. That works well for the common case, but the hook only fires once a tool actually executes. On a turn that needs no tools — a greeting, a quick question, anything the model answers directly — the id is not yet known, so the session falls back to matching the submitted prompt against the transcripts of recently written brains on disk.

That fallback is a guess, and it can guess wrong: two agy sessions started from the same first prompt are indistinguishable to it, so a session can end up tailing a conversation that belongs to somewhere else. Attaching to the wrong brain leaks another session's transcript into this one, which is worse than not knowing.

## Solution

agy's `PreInvocation` hook fires immediately before every model call, regardless of whether any tool runs, and it carries the same `conversationId`. Registering it alongside `PreToolUse` makes discovery deterministic from the first model call, which in turn makes the transcript matching unnecessary — so this removes it, along with the scan window, the candidate enumeration, and the ambiguity reporting that existed to contain its guesswork.

Because the guess is gone, a discovery failure would otherwise be silent — the web chat would simply stay empty forever. So the launcher arms a one-shot timer at the first sign of a model call and, if no hook has arrived within 60 seconds, tells the user to continue in the terminal. It arms on the thinking transition rather than on PTY readiness, so an idle prompt never triggers it.

The hook then pays for itself on every model call afterwards, which is wasted once the id is settled — measured at roughly 400 ms per firing, nearly all of it process startup, and agy fires it up to eight times on a sub-agent turn. agy re-reads `hooks.json` on every model call, so the launcher drops the `PreInvocation` entry as soon as the conversation is identified and restores it before any respawn where the id is not yet known. Sessions that resume with a known id never register it at all.

That makes the carrier file something the session depends on for its whole life rather than only at spawn, so it moves from the system temp directory to `<HAPI_HOME>/agy-carriers/`, where a system temp-file reaper cannot remove it mid-session. Carriers left behind by a crashed session are swept at the next session start, and the sweep only deletes when `process.kill(pid, 0)` reports `ESRCH` — a process that exists but cannot be signalled counts as alive, as does anything it cannot determine.

Three details about agy's hook contract are worth calling out, all confirmed against 1.1.10. `PreInvocation` uses the flat handler-array schema rather than the `{matcher, hooks}` wrapper that `PreToolUse` uses; the grouped form is written to `hooks.json` without error and then never fires. The two events also need opposite failure modes — a permission decision must fail closed, discovery must fail open and never block a model call — and their stdout contracts differ, so they get separate routes and the forwarder distinguishes them by an explicit `--event` flag rather than by inspecting the payload, since agy's hook payloads carry no event-name field.

## Tests

Unit tests cover the hook registration shape, the forwarder's event routing and its fail-open behaviour when the bridge is unreachable, the new server route, and rejection of an unrecognised `--event` value. On the launcher: the discovery timeout fires exactly once and only after a model call has started, stays silent while the prompt sits idle, and leaves no timer behind at teardown; a resume-seeded id is never overwritten by a hook; a respawn after hook discovery resumes the same conversation rather than starting a fresh one; and the hook entry is dropped at identification, stays dropped across respawns, and is absent from the start on a resumed session. On the carrier: atomic replacement leaves no temp file even when the rename fails, the sweep removes carriers whose owner is confirmed dead, and preserves them when the owner is alive, when the pid belongs to another user, when the metadata is unreadable and recent, when the entry is not one of ours, and when the owner is recorded on a different host.

Manually verified end to end against agy 1.1.10: a tool-free turn identifies the conversation within a second, a tool-bearing turn routes permissions normally under the same id, an idle prompt sits quietly past the timeout, a carrier with the `PreInvocation` entry removed surfaces the warning once while the terminal keeps working, and the hook entry is gone after identification, still gone after a respawn, and absent from the start on a resumed session.

## Note on size

The diff is larger than the one-line summary suggests, but more than half of it is tests and one file is a net 344-line deletion. The pieces form a single chain — making discovery deterministic is what allows the guessing path to go, which is what makes the failure need to be visible, which exposes the per-call cost of the hook, which requires editing the carrier at runtime, which is what makes the carrier's lifetime matter. Reviewing commit by commit should track that order; each commit builds and tests on its own.

## Follow-up

Out of scope here: registering `PostInvocation`/`Stop`, using `injectSteps` for anything, and detecting the case where a resume silently fails and agy starts a new conversation under a different id.
