### PR TITLE
fix(web): preserve manual scroll during initial settling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1104,8 +1104,6 @@
 
     "@twsxtd/hapi-win32-x64": ["@twsxtd/hapi-win32-x64@0.26.0", "", { "os": "win32", "cpu": "x64", "bin": { "hapi": "bin/hapi.exe" } }, "sha512-+LQAPkyT/ioEnQ4TJpVMMZs7MY7BeomhvuEETyBqsovDOSPqRfXUHrDT4K3zF3CAA0ushA5PFTJultVKcfHivA=="],
 
-    "@twsxtd/hapi-win32-x64": ["@twsxtd/hapi-win32-x64@0.25.3", "", { "os": "win32", "cpu": "x64", "bin": { "hapi": "bin/hapi.exe" } }, "sha512-K1zhYTj8eAPt5W7q92U4ywdUs0122faulU2kywHOuzmwO95nI4zQ0CXlCNkJlGpTv6AYj7GiQdU21sR1NJSYFg=="],
-
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],

--- a/web/src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx
@@ -123,7 +123,7 @@ describe('mobile initial scroll settling', () => {
         expect(onViewModeChange).toHaveBeenLastCalledWith('history')
     })
 
-    it('does not snap back after a native scrollbar drag without pointer events', () => {
+    it('keeps settling for non-explicit non-zero layout movement', () => {
         const { viewport, onViewModeChange } = renderThread()
 
         viewport.scrollTop = 520
@@ -132,8 +132,50 @@ describe('mobile initial scroll settling', () => {
             vi.advanceTimersByTime(1_800)
         })
 
+        expect(viewport.scrollTop).toBe(702)
+        expect(onViewModeChange).not.toHaveBeenCalledWith('history')
+    })
+
+    it('does not snap back after a window-captured native scrollbar drag', () => {
+        const { viewport, onViewModeChange } = renderThread()
+        vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue({
+            left: 0,
+            top: 0,
+            right: 320,
+            bottom: 600
+        } as DOMRect)
+
+        fireEvent.mouseDown(window, { button: 0, clientX: 319, clientY: 200 })
+        viewport.scrollTop = 520
+        fireEvent.scroll(viewport)
+        fireEvent.mouseUp(window)
+        act(() => {
+            vi.advanceTimersByTime(1_800)
+        })
+
         expect(viewport.scrollTop).toBe(520)
         expect(onViewModeChange).toHaveBeenLastCalledWith('history')
+    })
+
+    it('ignores captured mouse input outside the chat viewport', () => {
+        const { viewport, onViewModeChange } = renderThread()
+        vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue({
+            left: 0,
+            top: 0,
+            right: 320,
+            bottom: 600
+        } as DOMRect)
+
+        fireEvent.mouseDown(window, { button: 0, clientX: 400, clientY: 200 })
+        viewport.scrollTop = 520
+        fireEvent.scroll(viewport)
+        fireEvent.mouseUp(window)
+        act(() => {
+            vi.advanceTimersByTime(1_800)
+        })
+
+        expect(viewport.scrollTop).toBe(702)
+        expect(onViewModeChange).not.toHaveBeenCalledWith('history')
     })
 
     it('keeps settling after the runtime resets the viewport to the exact top', () => {

--- a/web/src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx
@@ -123,13 +123,23 @@ describe('mobile initial scroll settling', () => {
         expect(onViewModeChange).toHaveBeenLastCalledWith('history')
     })
 
-    it('ignores pointer cancellation that did not start in the chat viewport', () => {
+    it('does not snap back after a native scrollbar drag without pointer events', () => {
         const { viewport, onViewModeChange } = renderThread()
-        const pointerCancel = new Event('pointercancel', { bubbles: true })
-        Object.defineProperty(pointerCancel, 'pointerType', { value: 'touch' })
-        fireEvent(window, pointerCancel)
 
         viewport.scrollTop = 520
+        fireEvent.scroll(viewport)
+        act(() => {
+            vi.advanceTimersByTime(1_800)
+        })
+
+        expect(viewport.scrollTop).toBe(520)
+        expect(onViewModeChange).toHaveBeenLastCalledWith('history')
+    })
+
+    it('keeps settling after the runtime resets the viewport to the exact top', () => {
+        const { viewport, onViewModeChange } = renderThread()
+
+        viewport.scrollTop = 0
         fireEvent.scroll(viewport)
         act(() => {
             vi.advanceTimersByTime(1_800)

--- a/web/src/components/AssistantChat/HappyThread.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.test.tsx
@@ -200,18 +200,7 @@ describe('scroll anchor helpers', () => {
             distanceFromBottom: 182,
             isScrollingUp: true
         })
-        expect(shouldCancelInitialScrollSettling(intent, true, 520)).toBe(true)
-    })
-
-    it('cancels initial scroll settling for a native scrollbar drag without pointer events', () => {
-        const intent = getScrollIntent({
-            scrollTop: 520,
-            previousScrollTop: 700,
-            scrollHeight: 1232,
-            clientHeight: 530
-        })
-
-        expect(shouldCancelInitialScrollSettling(intent, false, 520)).toBe(true)
+        expect(shouldCancelInitialScrollSettling(intent, true)).toBe(true)
     })
 
     it('keeps initial scroll settling for programmatic upward movement', () => {
@@ -222,7 +211,7 @@ describe('scroll anchor helpers', () => {
             clientHeight: 530
         })
 
-        expect(shouldCancelInitialScrollSettling(intent, false, 0)).toBe(false)
+        expect(shouldCancelInitialScrollSettling(intent, false)).toBe(false)
     })
 
     it('keeps initial scroll settling for negligible movement at the bottom', () => {
@@ -237,7 +226,7 @@ describe('scroll anchor helpers', () => {
             distanceFromBottom: 0,
             isScrollingUp: false
         })
-        expect(shouldCancelInitialScrollSettling(intent, false, 702)).toBe(false)
+        expect(shouldCancelInitialScrollSettling(intent, false)).toBe(false)
     })
 
     it('restores the captured message to the same viewport offset', () => {

--- a/web/src/components/AssistantChat/HappyThread.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.test.tsx
@@ -200,7 +200,18 @@ describe('scroll anchor helpers', () => {
             distanceFromBottom: 182,
             isScrollingUp: true
         })
-        expect(shouldCancelInitialScrollSettling(intent, true)).toBe(true)
+        expect(shouldCancelInitialScrollSettling(intent, true, 520)).toBe(true)
+    })
+
+    it('cancels initial scroll settling for a native scrollbar drag without pointer events', () => {
+        const intent = getScrollIntent({
+            scrollTop: 520,
+            previousScrollTop: 700,
+            scrollHeight: 1232,
+            clientHeight: 530
+        })
+
+        expect(shouldCancelInitialScrollSettling(intent, false, 520)).toBe(true)
     })
 
     it('keeps initial scroll settling for programmatic upward movement', () => {
@@ -211,7 +222,7 @@ describe('scroll anchor helpers', () => {
             clientHeight: 530
         })
 
-        expect(shouldCancelInitialScrollSettling(intent, false)).toBe(false)
+        expect(shouldCancelInitialScrollSettling(intent, false, 0)).toBe(false)
     })
 
     it('keeps initial scroll settling for negligible movement at the bottom', () => {
@@ -226,7 +237,7 @@ describe('scroll anchor helpers', () => {
             distanceFromBottom: 0,
             isScrollingUp: false
         })
-        expect(shouldCancelInitialScrollSettling(intent, false)).toBe(false)
+        expect(shouldCancelInitialScrollSettling(intent, false, 702)).toBe(false)
     })
 
     it('restores the captured message to the same viewport offset', () => {

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -168,9 +168,14 @@ export function getScrollIntent(params: {
 
 export function shouldCancelInitialScrollSettling(
     intent: ScrollIntent,
-    hasExplicitUpwardIntent: boolean
+    hasExplicitUpwardIntent: boolean,
+    scrollTop: number
 ): boolean {
-    return hasExplicitUpwardIntent
+    // Native scrollbar drags do not consistently emit pointer or wheel events
+    // to the scroll container. A non-zero upward position is still sufficient
+    // evidence of manual navigation. Preserve the exact-top exception because
+    // the runtime may reset the viewport to zero while the initial DOM settles.
+    return (hasExplicitUpwardIntent || scrollTop > MANUAL_SCROLL_EPSILON_PX)
         && intent.isScrollingUp
         && intent.distanceFromBottom > MANUAL_SCROLL_EPSILON_PX
 }
@@ -737,7 +742,7 @@ export function HappyThread(props: {
             const explicitUpwardIntent = needsCoverage && consumeExplicitUpwardIntent(intent)
 
             if (isInitialScrollSettling()) {
-                if (shouldCancelInitialScrollSettling(intent, hadExplicitUpwardIntent)) {
+                if (shouldCancelInitialScrollSettling(intent, hadExplicitUpwardIntent, viewport.scrollTop)) {
                     initialScrollDeadlineRef.current = 0
                     clearInitialScrollTimers()
                     setAutoScrollMode(false)

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -168,14 +168,9 @@ export function getScrollIntent(params: {
 
 export function shouldCancelInitialScrollSettling(
     intent: ScrollIntent,
-    hasExplicitUpwardIntent: boolean,
-    scrollTop: number
+    hasExplicitUpwardIntent: boolean
 ): boolean {
-    // Native scrollbar drags do not consistently emit pointer or wheel events
-    // to the scroll container. A non-zero upward position is still sufficient
-    // evidence of manual navigation. Preserve the exact-top exception because
-    // the runtime may reset the viewport to zero while the initial DOM settles.
-    return (hasExplicitUpwardIntent || scrollTop > MANUAL_SCROLL_EPSILON_PX)
+    return hasExplicitUpwardIntent
         && intent.isScrollingUp
         && intent.distanceFromBottom > MANUAL_SCROLL_EPSILON_PX
 }
@@ -742,7 +737,7 @@ export function HappyThread(props: {
             const explicitUpwardIntent = needsCoverage && consumeExplicitUpwardIntent(intent)
 
             if (isInitialScrollSettling()) {
-                if (shouldCancelInitialScrollSettling(intent, hadExplicitUpwardIntent, viewport.scrollTop)) {
+                if (shouldCancelInitialScrollSettling(intent, hadExplicitUpwardIntent)) {
                     initialScrollDeadlineRef.current = 0
                     clearInitialScrollTimers()
                     setAutoScrollMode(false)
@@ -812,13 +807,40 @@ export function HappyThread(props: {
             }
         }
 
+        const armPointerIntent = () => {
+            pointerResumeActive = true
+            pointerResumeUntil = 0
+            pointerResumeLatched = false
+        }
+
         const handlePointerDown = (event: PointerEvent) => {
             if (event.button !== 0) {
                 return
             }
-            pointerResumeActive = true
-            pointerResumeUntil = 0
-            pointerResumeLatched = false
+            armPointerIntent()
+        }
+
+        const isInsideViewport = (clientX: number, clientY: number) => {
+            const rect = viewport.getBoundingClientRect()
+            return clientX >= rect.left
+                && clientX <= rect.right
+                && clientY >= rect.top
+                && clientY <= rect.bottom
+        }
+
+        // Native scrollbar interaction may bypass the viewport's own event
+        // listeners. Capture pointer and mouse input at the window boundary,
+        // then scope it back to the chat viewport by coordinates.
+        const handleWindowPointerDown = (event: PointerEvent) => {
+            if (event.button === 0 && isInsideViewport(event.clientX, event.clientY)) {
+                armPointerIntent()
+            }
+        }
+
+        const handleWindowMouseDown = (event: MouseEvent) => {
+            if (event.button === 0 && isInsideViewport(event.clientX, event.clientY)) {
+                armPointerIntent()
+            }
         }
 
         const clearPointerIntent = () => {
@@ -915,7 +937,10 @@ export function HappyThread(props: {
         viewport.addEventListener('touchmove', handleTouchMove, { passive: true })
         viewport.addEventListener('touchend', handleTouchEnd, { passive: true })
         viewport.addEventListener('touchcancel', handleTouchCancel, { passive: true })
+        window.addEventListener('pointerdown', handleWindowPointerDown, { capture: true, passive: true })
+        window.addEventListener('mousedown', handleWindowMouseDown, { capture: true, passive: true })
         window.addEventListener('pointerup', clearPointerIntent, { passive: true })
+        window.addEventListener('mouseup', clearPointerIntent, { passive: true })
         window.addEventListener('pointercancel', handlePointerCancel, { passive: true })
         window.addEventListener('blur', clearPointerIntent)
         return () => {
@@ -927,7 +952,10 @@ export function HappyThread(props: {
             viewport.removeEventListener('touchmove', handleTouchMove)
             viewport.removeEventListener('touchend', handleTouchEnd)
             viewport.removeEventListener('touchcancel', handleTouchCancel)
+            window.removeEventListener('pointerdown', handleWindowPointerDown, true)
+            window.removeEventListener('mousedown', handleWindowMouseDown, true)
             window.removeEventListener('pointerup', clearPointerIntent)
+            window.removeEventListener('mouseup', clearPointerIntent)
             window.removeEventListener('pointercancel', handlePointerCancel)
             window.removeEventListener('blur', clearPointerIntent)
         }


### PR DESCRIPTION
## Summary

- keep initial settling gated on explicit upward input
- capture native scrollbar pointer/mouse input at the window boundary and scope it to the chat viewport
- preserve runtime-driven non-explicit layout movement and exact-top resets
- add helper and component regression coverage for each path

## Root cause

Initial scroll settling only treated upward movement as manual navigation when it could be correlated with an explicit pointer, wheel, or keyboard event. Native scrollbar drags do not consistently deliver those events to the scroll container, so the scroll handler kept auto-follow enabled and a later settling timer snapped the viewport back to the bottom.

The fix captures pointer and mouse input at the window boundary, verifies that its coordinates are inside the chat viewport, and feeds that into the existing explicit-intent guard. Scroll position alone is not used to infer user intent.

## User impact

Users can drag the scrollbar upward to read the beginning of the current assistant response without being pulled back to the latest content during the initial settling window.

## CI baseline

The first CI run also exposed a duplicate `@twsxtd/hapi-win32-x64` entry on `main` that made Bun 1.3.14 reject `bun.lock`. The one-line cleanup remains isolated in its own commit. A separate `RawSendError` type failure was fixed upstream and was dropped when this branch was rebased onto the latest `main`.

## Validation

- `vitest run src/components/AssistantChat/HappyThread.test.tsx src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx` — 27 tests passed
- `tsc --noEmit -p web/tsconfig.json` — passed
- GitHub Actions `test` — passed
- Codex PR Review follow-up — no findings
- mergeability — no conflicts with `main`