### PR TITLE
fix(web): preserve drafts across inactive session resume

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.expandSelection.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.expandSelection.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/components/AssistantChat/ComposerButtons', () => ({
 
 vi.mock('@/components/AssistantChat/StatusBar', () => ({ StatusBar: () => null }))
 vi.mock('@/hooks/useComposerDraft', () => ({
-    useComposerDraft: () => ({ sessionId: undefined, complete: true, restoredAny: false }),
+    useComposerDraft: () => ({ sessionId: undefined, complete: true, restoredAny: false, hasStoredAttachments: false }),
 }))
 vi.mock('@/hooks/usePlatform', () => ({
     usePlatform: () => ({

--- a/web/src/components/AssistantChat/HappyComposer.expandSelection.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.expandSelection.test.tsx
@@ -18,7 +18,9 @@ vi.mock('@/components/AssistantChat/ComposerButtons', () => ({
 }))
 
 vi.mock('@/components/AssistantChat/StatusBar', () => ({ StatusBar: () => null }))
-vi.mock('@/hooks/useComposerDraft', () => ({ useComposerDraft: () => {} }))
+vi.mock('@/hooks/useComposerDraft', () => ({
+    useComposerDraft: () => ({ sessionId: undefined, complete: true, restoredAny: false }),
+}))
 vi.mock('@/hooks/usePlatform', () => ({
     usePlatform: () => ({
         isTelegram: false,

--- a/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
@@ -97,7 +97,7 @@ vi.mock('@/lib/composerSegments', () => ({
         showContinueHint ? 'misc.typeMessage' : 'misc.typeAMessage',
 }))
 vi.mock('@/hooks/useComposerDraft', () => ({
-    useComposerDraft: (sessionId: string | undefined) => ({ sessionId, complete: true, restoredAny: false }),
+    useComposerDraft: (sessionId: string | undefined) => ({ sessionId, complete: true, restoredAny: false, hasStoredAttachments: false }),
 }))
 vi.mock('@/hooks/useComposerEnterBehavior', () => ({ useComposerEnterBehavior: () => ({ composerEnterBehavior: 'send' }) }))
 vi.mock('@/hooks/usePlatform', () => ({ usePlatform: () => ({ haptic: { impact: () => {}, notification: () => {} }, isTouch: false }) }))

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -40,7 +40,7 @@ import type { PiThinkingLevel } from '@hapi/protocol'
 import { markSkillUsed } from '@/lib/recent-skills'
 import { useComposerDraft } from '@/hooks/useComposerDraft'
 import type { AttachmentDraftInput } from '@/lib/composer-attachment-drafts'
-import { persistInactiveComposerAttachments, setComposerDraftSnapshot } from '@/lib/composer-draft-transfer'
+import { persistInactiveComposerAttachments, setComposerDraftSnapshot, updateComposerDraftTextSnapshot, attachmentDraftRevision } from '@/lib/composer-draft-transfer'
 import { useComposerEnterBehavior } from '@/hooks/useComposerEnterBehavior'
 import { FloatingOverlay } from '@/components/ChatInput/FloatingOverlay'
 import { Autocomplete } from '@/components/ChatInput/Autocomplete'
@@ -623,6 +623,11 @@ export function HappyComposer(props: {
             uploadSessionId: upload.uploadSessionId,
         }]
     })
+    const attachmentRevision = attachmentDraftRevision(attachmentDrafts)
+    const latestComposerTextRef = useRef(composerText)
+    latestComposerTextRef.current = composerText
+    const attachmentDraftsRef = useRef(attachmentDrafts)
+    attachmentDraftsRef.current = attachmentDrafts
     const draftHydration = useComposerDraft(
         sessionId,
         composerText,
@@ -640,12 +645,24 @@ export function HappyComposer(props: {
         // does not drop them.
         const canHydrateAttachments = props.canRestoreAttachments ?? active
         if (canHydrateAttachments) {
-            setComposerDraftSnapshot(sessionId, composerText, attachmentDrafts)
-            props.onUploadDraftSnapshot?.(composerText, attachmentDrafts)
+            setComposerDraftSnapshot(sessionId, composerText, attachmentDraftsRef.current)
+            props.onUploadDraftSnapshot?.(composerText, attachmentDraftsRef.current)
             return
         }
-        void persistInactiveComposerAttachments(sessionId, composerText, attachmentDrafts)
-    }, [active, attachmentDrafts, composerText, draftHydration.complete, draftHydration.sessionId, props.canRestoreAttachments, props.onUploadDraftSnapshot, sessionId])
+        // Text is cheap (sessionStorage); do not queue a blob merge per keystroke.
+        updateComposerDraftTextSnapshot(sessionId, composerText)
+    }, [active, attachmentRevision, composerText, draftHydration.complete, draftHydration.sessionId, props.canRestoreAttachments, props.onUploadDraftSnapshot, sessionId])
+
+    useEffect(() => {
+        if (draftHydration.sessionId !== sessionId || !draftHydration.complete || !sessionId) return
+        const canHydrateAttachments = props.canRestoreAttachments ?? active
+        if (canHydrateAttachments) return
+        void persistInactiveComposerAttachments(
+            sessionId,
+            latestComposerTextRef.current,
+            attachmentDraftsRef.current,
+        )
+    }, [active, attachmentRevision, draftHydration.complete, draftHydration.sessionId, props.canRestoreAttachments, sessionId])
 
     // assistant-ui clears `composer.text` synchronously the moment a send is
     // invoked AND `SessionChat.handleSend` clears `pendingSchedule` after the

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -39,9 +39,8 @@ import { supportsEffort, supportsModelChange, PI_THINKING_LEVEL_LABELS } from '@
 import type { PiThinkingLevel } from '@hapi/protocol'
 import { markSkillUsed } from '@/lib/recent-skills'
 import { useComposerDraft } from '@/hooks/useComposerDraft'
-import { saveDraft } from '@/lib/composer-drafts'
 import type { AttachmentDraftInput } from '@/lib/composer-attachment-drafts'
-import { clearComposerDraftSnapshot, setComposerDraftSnapshot } from '@/lib/composer-draft-transfer'
+import { persistInactiveComposerAttachments, setComposerDraftSnapshot } from '@/lib/composer-draft-transfer'
 import { useComposerEnterBehavior } from '@/hooks/useComposerEnterBehavior'
 import { FloatingOverlay } from '@/components/ChatInput/FloatingOverlay'
 import { Autocomplete } from '@/components/ChatInput/Autocomplete'
@@ -635,16 +634,17 @@ export function HappyComposer(props: {
 
     useEffect(() => {
         if (draftHydration.sessionId !== sessionId || !draftHydration.complete || !sessionId) return
-        // Inactive sessions keep attachments in IndexedDB only. Publishing an
-        // empty live snapshot here would shadow those files on reopen/transfer.
+        // Inactive sessions do not restore stored attachments into the adapter.
+        // Keep IndexedDB intact when nothing new is visible; when the user did
+        // pick files (even if resume failed), merge them into storage so reopen
+        // does not drop them.
         const canHydrateAttachments = props.canRestoreAttachments ?? active
         if (canHydrateAttachments) {
             setComposerDraftSnapshot(sessionId, composerText, attachmentDrafts)
             props.onUploadDraftSnapshot?.(composerText, attachmentDrafts)
-        } else {
-            saveDraft(sessionId, composerText)
-            clearComposerDraftSnapshot(sessionId)
+            return
         }
+        void persistInactiveComposerAttachments(sessionId, composerText, attachmentDrafts)
     }, [active, attachmentDrafts, composerText, draftHydration.complete, draftHydration.sessionId, props.canRestoreAttachments, props.onUploadDraftSnapshot, sessionId])
 
     // assistant-ui clears `composer.text` synchronously the moment a send is

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -41,7 +41,7 @@ import { markSkillUsed } from '@/lib/recent-skills'
 import { useComposerDraft } from '@/hooks/useComposerDraft'
 import { saveDraft } from '@/lib/composer-drafts'
 import type { AttachmentDraftInput } from '@/lib/composer-attachment-drafts'
-import { setComposerDraftSnapshot } from '@/lib/composer-draft-transfer'
+import { clearComposerDraftSnapshot, setComposerDraftSnapshot } from '@/lib/composer-draft-transfer'
 import { useComposerEnterBehavior } from '@/hooks/useComposerEnterBehavior'
 import { FloatingOverlay } from '@/components/ChatInput/FloatingOverlay'
 import { Autocomplete } from '@/components/ChatInput/Autocomplete'
@@ -634,10 +634,18 @@ export function HappyComposer(props: {
     )
 
     useEffect(() => {
-        if (draftHydration.sessionId !== sessionId || !draftHydration.complete) return
-        if (sessionId) setComposerDraftSnapshot(sessionId, composerText, attachmentDrafts)
-        props.onUploadDraftSnapshot?.(composerText, attachmentDrafts)
-    }, [attachmentDrafts, composerText, draftHydration.complete, draftHydration.sessionId, props.onUploadDraftSnapshot, sessionId])
+        if (draftHydration.sessionId !== sessionId || !draftHydration.complete || !sessionId) return
+        // Inactive sessions keep attachments in IndexedDB only. Publishing an
+        // empty live snapshot here would shadow those files on reopen/transfer.
+        const canHydrateAttachments = props.canRestoreAttachments ?? active
+        if (canHydrateAttachments) {
+            setComposerDraftSnapshot(sessionId, composerText, attachmentDrafts)
+            props.onUploadDraftSnapshot?.(composerText, attachmentDrafts)
+        } else {
+            saveDraft(sessionId, composerText)
+            clearComposerDraftSnapshot(sessionId)
+        }
+    }, [active, attachmentDrafts, composerText, draftHydration.complete, draftHydration.sessionId, props.canRestoreAttachments, props.onUploadDraftSnapshot, sessionId])
 
     // assistant-ui clears `composer.text` synchronously the moment a send is
     // invoked AND `SessionChat.handleSend` clears `pendingSchedule` after the

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -634,9 +634,10 @@ export function HappyComposer(props: {
     )
 
     useEffect(() => {
+        if (draftHydration.sessionId !== sessionId || !draftHydration.complete) return
         if (sessionId) setComposerDraftSnapshot(sessionId, composerText, attachmentDrafts)
         props.onUploadDraftSnapshot?.(composerText, attachmentDrafts)
-    }, [attachmentDrafts, composerText, props.onUploadDraftSnapshot, sessionId])
+    }, [attachmentDrafts, composerText, draftHydration.complete, draftHydration.sessionId, props.onUploadDraftSnapshot, sessionId])
 
     // assistant-ui clears `composer.text` synchronously the moment a send is
     // invoked AND `SessionChat.handleSend` clears `pendingSchedule` after the

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -372,6 +372,11 @@ export function HappyComposer(props: {
     /** Terminal result for a chat mutation, including attachment-bearing failures. */
     sendSettlement?: { attemptId: string; status: 'success' | 'error' } | null
     /**
+     * Resume/handoff path for inactive drafts that only exist in IndexedDB
+     * (no visible text/attachments for assistant-ui to append).
+     */
+    onResumeStoredDraft?: () => void | Promise<void>
+    /**
      * One-shot intent bridge consumed by useHappyRuntime's onNew callback.
      * SessionChat owns this ref so the composer never retains an explicit
      * queue request after a scratchlist/scheduled/failed early path.
@@ -635,7 +640,15 @@ export function HappyComposer(props: {
         (text) => api.composer().setText(text),
         (file) => api.composer().addAttachment(file),
     )
-    const hasAnyAttachments = hasAttachments || draftHydration.hasStoredAttachments
+    const canHydrateAttachments = props.canRestoreAttachments ?? active
+    const hiddenAttachmentStatePending =
+        !canHydrateAttachments
+        && (draftHydration.sessionId !== sessionId || !draftHydration.complete)
+    const hasHiddenAttachments =
+        !canHydrateAttachments && draftHydration.hasStoredAttachments
+    const hasAnyAttachments = hasAttachments || hasHiddenAttachments
+    const blocksScheduling =
+        hasAttachments || hasHiddenAttachments || hiddenAttachmentStatePending
     const canSend = (hasText || hasAnyAttachments) && attachmentsReady && !controlsDisabled
 
     useEffect(() => {
@@ -1159,6 +1172,10 @@ export function HappyComposer(props: {
         // explicit queue intent to SessionChat.
         const effectiveIntent = pendingSchedule == null ? restoredIntent : 'default'
         try {
+            if (!hasText && !hasAttachments && draftHydration.hasStoredAttachments) {
+                await props.onResumeStoredDraft?.()
+                return
+            }
             // Must be adjacent to send(): useHappyRuntime consumes and resets
             // this ref synchronously from assistant-ui's onNew callback.
             if (pendingSendIntentRef) pendingSendIntentRef.current = effectiveIntent
@@ -1181,9 +1198,13 @@ export function HappyComposer(props: {
         api,
         attachments,
         canSend,
+        draftHydration.hasStoredAttachments,
+        hasAttachments,
+        hasText,
         onSuppressSendErrorRestore,
         pendingSchedule,
         props.onParkScratchlist,
+        props.onResumeStoredDraft,
         props.scratchlistMode,
         richMentionsEnabled,
         sendError,
@@ -2279,7 +2300,7 @@ export function HappyComposer(props: {
                             pendingSchedule={pendingSchedule}
                             onSchedule={handleUserSchedule}
                             onClearSchedule={onUserClearSchedule}
-                            hasAttachments={hasAnyAttachments}
+                            hasAttachments={blocksScheduling}
                             piModelLabel={piModelLabel}
                             piModelDisabled={controlsDisabled || !piHasModels}
                             piModelOpen={showPiModelPanel}

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -39,6 +39,9 @@ import { supportsEffort, supportsModelChange, PI_THINKING_LEVEL_LABELS } from '@
 import type { PiThinkingLevel } from '@hapi/protocol'
 import { markSkillUsed } from '@/lib/recent-skills'
 import { useComposerDraft } from '@/hooks/useComposerDraft'
+import { saveDraft } from '@/lib/composer-drafts'
+import type { AttachmentDraftInput } from '@/lib/composer-attachment-drafts'
+import { setComposerDraftSnapshot } from '@/lib/composer-draft-transfer'
 import { useComposerEnterBehavior } from '@/hooks/useComposerEnterBehavior'
 import { FloatingOverlay } from '@/components/ChatInput/FloatingOverlay'
 import { Autocomplete } from '@/components/ChatInput/Autocomplete'
@@ -279,6 +282,8 @@ export function ModelEffortSettingsSection(props: {
 
 export function HappyComposer(props: {
     sessionId?: string
+    onUploadDraftSnapshot?: (text: string, attachments: AttachmentDraftInput[]) => void
+    canRestoreAttachments?: boolean
     disabled?: boolean
     permissionMode?: PermissionMode
     collaborationMode?: CodexCollaborationMode
@@ -610,22 +615,28 @@ export function HappyComposer(props: {
 
     const attachmentDrafts = attachments.flatMap((attachment) => {
         if (!attachment.file) return []
-        const upload = attachment as typeof attachment & { path?: string; previewUrl?: string }
+        const upload = attachment as typeof attachment & { path?: string; previewUrl?: string; uploadSessionId?: string }
         return [{
             id: attachment.id,
             file: attachment.file,
             path: upload.path,
             previewUrl: upload.previewUrl,
+            uploadSessionId: upload.uploadSessionId,
         }]
     })
     const draftHydration = useComposerDraft(
         sessionId,
         composerText,
         attachmentDrafts,
-        active,
+        props.canRestoreAttachments ?? active,
         (text) => api.composer().setText(text),
         (file) => api.composer().addAttachment(file),
     )
+
+    useEffect(() => {
+        if (sessionId) setComposerDraftSnapshot(sessionId, composerText, attachmentDrafts)
+        props.onUploadDraftSnapshot?.(composerText, attachmentDrafts)
+    }, [attachmentDrafts, composerText, props.onUploadDraftSnapshot, sessionId])
 
     // assistant-ui clears `composer.text` synchronously the moment a send is
     // invoked AND `SessionChat.handleSend` clears `pendingSchedule` after the

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -670,7 +670,9 @@ export function HappyComposer(props: {
             sessionId,
             latestComposerTextRef.current,
             attachmentDraftsRef.current,
-        )
+        ).catch((error) => {
+            console.warn('[composer-draft] inactive persistence failed', error)
+        })
     }, [active, attachmentRevision, draftHydration.complete, draftHydration.sessionId, props.canRestoreAttachments, sessionId])
 
     // assistant-ui clears `composer.text` synchronously the moment a send is

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -40,7 +40,7 @@ import type { PiThinkingLevel } from '@hapi/protocol'
 import { markSkillUsed } from '@/lib/recent-skills'
 import { useComposerDraft } from '@/hooks/useComposerDraft'
 import type { AttachmentDraftInput } from '@/lib/composer-attachment-drafts'
-import { persistInactiveComposerAttachments, setComposerDraftSnapshot, updateComposerDraftTextSnapshot, attachmentDraftRevision } from '@/lib/composer-draft-transfer'
+import { persistInactiveComposerAttachments, setComposerDraftSnapshot, updateComposerDraftTextSnapshot, attachmentDraftRevision, resetInactiveComposerAttachmentVisibility } from '@/lib/composer-draft-transfer'
 import { useComposerEnterBehavior } from '@/hooks/useComposerEnterBehavior'
 import { FloatingOverlay } from '@/components/ChatInput/FloatingOverlay'
 import { Autocomplete } from '@/components/ChatInput/Autocomplete'
@@ -636,6 +636,15 @@ export function HappyComposer(props: {
         (text) => api.composer().setText(text),
         (file) => api.composer().addAttachment(file),
     )
+
+    useEffect(() => {
+        if (!sessionId) return
+        const canHydrateAttachments = props.canRestoreAttachments ?? active
+        if (canHydrateAttachments) return
+        // A remount starts with an empty visible list by design; do not treat
+        // previously persisted failed-resume picks as operator removals.
+        resetInactiveComposerAttachmentVisibility(sessionId)
+    }, [active, props.canRestoreAttachments, sessionId])
 
     useEffect(() => {
         if (draftHydration.sessionId !== sessionId || !draftHydration.complete || !sessionId) return

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -511,7 +511,6 @@ export function HappyComposer(props: {
         const path = (attachment as { path?: string }).path
         return typeof path === 'string' && path.length > 0
     })
-    const canSend = (hasText || hasAttachments) && attachmentsReady && !controlsDisabled
 
     const [inputState, setInputState] = useState<TextInputState>({
         text: '',
@@ -636,6 +635,8 @@ export function HappyComposer(props: {
         (text) => api.composer().setText(text),
         (file) => api.composer().addAttachment(file),
     )
+    const hasAnyAttachments = hasAttachments || draftHydration.hasStoredAttachments
+    const canSend = (hasText || hasAnyAttachments) && attachmentsReady && !controlsDisabled
 
     useEffect(() => {
         if (!sessionId) return
@@ -2278,7 +2279,7 @@ export function HappyComposer(props: {
                             pendingSchedule={pendingSchedule}
                             onSchedule={handleUserSchedule}
                             onClearSchedule={onUserClearSchedule}
-                            hasAttachments={hasAttachments}
+                            hasAttachments={hasAnyAttachments}
                             piModelLabel={piModelLabel}
                             piModelDisabled={controlsDisabled || !piHasModels}
                             piModelOpen={showPiModelPanel}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -71,9 +71,14 @@ import type { ScratchlistEntry } from '@/lib/scratchlist'
 import { isHubScratchlistAttachmentPath } from '@hapi/protocol'
 import { consumeSharePendingTransfer } from '@/lib/sharePendingState'
 import { deleteShareTransfer, getShareTransfer } from '@/lib/shareTransfer'
-import { getDraft } from '@/lib/composer-drafts'
+import { getDraft, saveDraft } from '@/lib/composer-drafts'
+import {
+    saveDraftAttachments,
+    type AttachmentDraftInput,
+} from '@/lib/composer-attachment-drafts'
 import { useTranslation } from '@/lib/use-translation'
 import type { SendMessageAcceptance, SendMessageSettlement } from '@/hooks/mutations/useSendMessage'
+import { transferComposerDraft } from '@/lib/composer-draft-transfer'
 import { SessionHeader } from '@/components/SessionHeader'
 import { CursorMigrationBanner } from '@/components/CursorMigrationBanner'
 import { TeamPanel } from '@/components/TeamPanel'
@@ -512,6 +517,8 @@ type SessionChatProps = {
         scheduledAt?: number | null,
         deliveryMode?: MessageDeliveryMode,
     ) => Promise<SendMessageAcceptance | false>
+    resolveSessionIdForUpload?: (sessionId: string) => Promise<string>
+    onUploadSessionResolved?: (sessionId: string) => void
     onViewModeChange: (mode: 'tail' | 'history') => void
     onRetryMessage?: (localId: string) => void
     autocompleteSuggestions?: (query: string) => Promise<Suggestion[]>
@@ -594,6 +601,10 @@ function SessionChatInner(props: SessionChatProps) {
     const blocksByIdRef = useRef<Map<string, ChatBlock>>(new Map())
     const visibleGroupsRef = useRef<ToolGroupBlock[]>([])
     const [forceScrollToken, setForceScrollToken] = useState(0)
+    const uploadDraftSnapshotRef = useRef<{ text: string; attachments: AttachmentDraftInput[] }>({
+        text: '',
+        attachments: [],
+    })
     const [outlineOpen, setOutlineOpen] = useState(props.initialOutlineOpen ?? false)
     const [terminalVisible, setTerminalVisible] = useState(false)
     useEffect(() => {
@@ -1596,18 +1607,31 @@ function SessionChatInner(props: SessionChatProps) {
     }, [agentFlavor, onSendForComposer, props.session.thinking, scratchlistMode, updatePendingSchedule])
 
     const attachmentAdapter = useMemo(() => {
-        if (!props.session.active) {
-            scratchlistAdapterRef.current = null
-            return undefined
-        }
-        if (scratchlistMode) {
+        if (props.session.active && scratchlistMode) {
             const adapter = createScratchlistAttachmentAdapter(props.api, props.session.id)
             scratchlistAdapterRef.current = adapter
             return adapter
         }
         scratchlistAdapterRef.current = null
-        return createAttachmentAdapter(props.api, props.session.id)
-    }, [props.api, props.session.id, props.session.active, scratchlistMode])
+        if (props.session.active) {
+            return createAttachmentAdapter(props.api, props.session.id)
+        }
+        if (!props.resolveSessionIdForUpload) {
+            return undefined
+        }
+        return createAttachmentAdapter(
+            props.api,
+            props.session.id,
+            () => props.resolveSessionIdForUpload!(props.session.id),
+            async (resolvedSessionId) => {
+                const snapshot = uploadDraftSnapshotRef.current
+                saveDraft(resolvedSessionId, snapshot.text)
+                saveDraftAttachments(resolvedSessionId, snapshot.attachments)
+                props.onUploadSessionResolved?.(resolvedSessionId)
+            },
+        )
+    }, [props.api, props.session.id, props.session.active, props.resolveSessionIdForUpload, scratchlistMode])
+
 
     const runtime = useHappyRuntime({
         session: props.session,
@@ -1640,7 +1664,8 @@ function SessionChatInner(props: SessionChatProps) {
                 canReopen={inactiveCanResume}
                 reopenDisabledReason={props.reopenDisabledReason}
                 onSessionDeleted={props.onBack}
-                onSessionReopened={(newSessionId) => {
+                onSessionReopened={async (newSessionId) => {
+                    await transferComposerDraft(props.session.id, newSessionId)
                     navigate({
                         to: '/sessions/$sessionId',
                         params: { sessionId: newSessionId },
@@ -1669,7 +1694,7 @@ function SessionChatInner(props: SessionChatProps) {
             <AssistantRuntimeProvider runtime={runtime}>
                 <ShareSeedConsumer sessionId={props.session.id} sessionActive={props.session.active} />
                 <AbortRestoreConsumer messages={normalizedMessages} onAbortRestore={props.onAbortRestore ?? (() => {})} />
-                <DragDropZone disabled={sessionInactive || props.isSending || pendingSchedule != null || isScratchlistParking}>
+                <DragDropZone disabled={props.isSending || pendingSchedule != null || isScratchlistParking}>
                     <div className="relative flex min-h-0 flex-1 flex-col">
                         {canViewAgentTerminal && (
                             // SessionChatInner is keyed by session.id, so switching sessions remounts this subtree.
@@ -1680,6 +1705,7 @@ function SessionChatInner(props: SessionChatProps) {
                             />
                         )}
                         <div className={(terminalVisible && canViewAgentTerminal) ? 'hidden' : 'flex min-h-0 flex-1 flex-col'}>
+
                     <HappyThread
                         // Key with prefix: different components under the same session
                         // (thread, scratchlist, composer) must have distinct keys to avoid
@@ -1774,6 +1800,10 @@ function SessionChatInner(props: SessionChatProps) {
                         <HappyComposer
                         key={`composer-${props.session.id}`}
                         sessionId={props.session.id}
+                        canRestoreAttachments={attachmentAdapter !== undefined}
+                        onUploadDraftSnapshot={(text, attachments) => {
+                            uploadDraftSnapshotRef.current = { text, attachments }
+                        }}
                         resolveSessionMentionTooltip={resolveSessionMentionTooltip}
                         disabled={props.isSending}
                         pendingSchedule={pendingSchedule}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1615,7 +1615,9 @@ function SessionChatInner(props: SessionChatProps) {
         if (props.session.active) {
             return createAttachmentAdapter(props.api, props.session.id)
         }
-        if (!props.resolveSessionIdForUpload) {
+        // Only offer attachments on inactive sessions that can actually resume;
+        // otherwise file picks become stuck error attachments that cannot send.
+        if (!inactiveCanResume || !props.resolveSessionIdForUpload) {
             return undefined
         }
         return createAttachmentAdapter(
@@ -1631,7 +1633,7 @@ function SessionChatInner(props: SessionChatProps) {
                 props.onUploadSessionResolved?.(resolvedSessionId)
             },
         )
-    }, [props.api, props.session.id, props.session.active, props.resolveSessionIdForUpload, scratchlistMode])
+    }, [props.api, props.session.id, props.session.active, props.resolveSessionIdForUpload, scratchlistMode, inactiveCanResume])
 
 
     const runtime = useHappyRuntime({
@@ -1695,7 +1697,7 @@ function SessionChatInner(props: SessionChatProps) {
             <AssistantRuntimeProvider runtime={runtime}>
                 <ShareSeedConsumer sessionId={props.session.id} sessionActive={props.session.active} />
                 <AbortRestoreConsumer messages={normalizedMessages} onAbortRestore={props.onAbortRestore ?? (() => {})} />
-                <DragDropZone disabled={props.isSending || pendingSchedule != null || isScratchlistParking}>
+                <DragDropZone disabled={(!props.session.active && !inactiveCanResume) || props.isSending || pendingSchedule != null || isScratchlistParking}>
                     <div className="relative flex min-h-0 flex-1 flex-col">
                         {canViewAgentTerminal && (
                             // SessionChatInner is keyed by session.id, so switching sessions remounts this subtree.

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -77,7 +77,7 @@ import {
 } from '@/lib/composer-attachment-drafts'
 import { useTranslation } from '@/lib/use-translation'
 import type { SendMessageAcceptance, SendMessageSettlement } from '@/hooks/mutations/useSendMessage'
-import { handoffComposerDraft, transferComposerDraft } from '@/lib/composer-draft-transfer'
+import { handoffComposerDraft, transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
 import { SessionHeader } from '@/components/SessionHeader'
 import { CursorMigrationBanner } from '@/components/CursorMigrationBanner'
 import { TeamPanel } from '@/components/TeamPanel'
@@ -1674,12 +1674,15 @@ function SessionChatInner(props: SessionChatProps) {
                 reopenDisabledReason={props.reopenDisabledReason}
                 onSessionDeleted={props.onBack}
                 onSessionReopened={async (newSessionId) => {
-                    await transferComposerDraft(props.session.id, newSessionId)
-                    navigate({
-                        to: '/sessions/$sessionId',
-                        params: { sessionId: newSessionId },
-                        replace: true
-                    })
+                    await transferComposerDraftThenNavigate(
+                        props.session.id,
+                        newSessionId,
+                        () => navigate({
+                            to: '/sessions/$sessionId',
+                            params: { sessionId: newSessionId },
+                            replace: true
+                        }),
+                    )
                 }}
             />
 

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -76,8 +76,12 @@ import {
     type AttachmentDraftInput,
 } from '@/lib/composer-attachment-drafts'
 import { useTranslation } from '@/lib/use-translation'
+<<<<<<< HEAD
 import type { SendMessageAcceptance, SendMessageSettlement } from '@/hooks/mutations/useSendMessage'
 import { transferComposerDraft } from '@/lib/composer-draft-transfer'
+=======
+import { handoffComposerDraft, transferComposerDraft } from '@/lib/composer-draft-transfer'
+>>>>>>> 82947a07 (fix(web): include in-flight attachments in inactive resume handoff)
 import { SessionHeader } from '@/components/SessionHeader'
 import { CursorMigrationBanner } from '@/components/CursorMigrationBanner'
 import { TeamPanel } from '@/components/TeamPanel'
@@ -1624,13 +1628,17 @@ function SessionChatInner(props: SessionChatProps) {
             props.api,
             props.session.id,
             () => props.resolveSessionIdForUpload!(props.session.id),
-            async (resolvedSessionId) => {
-                // Attachment restoration can resolve the inactive session
-                // before composer hydration has published a live snapshot.
-                // Transfer from persisted storage in that case and strip the
-                // source session's upload metadata before navigation.
-                await transferComposerDraft(props.session.id, resolvedSessionId)
-                props.onUploadSessionResolved?.(resolvedSessionId)
+            async (resolvedSessionId, pending) => {
+                // Include the in-flight file and coalesce multi-file drops into
+                // one transfer + navigation before the source composer unmounts.
+                await handoffComposerDraft(
+                    props.session.id,
+                    resolvedSessionId,
+                    pending,
+                    async (targetSessionId) => {
+                        props.onUploadSessionResolved?.(targetSessionId)
+                    },
+                )
             },
         )
     }, [props.api, props.session.id, props.session.active, props.resolveSessionIdForUpload, scratchlistMode, inactiveCanResume])

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1620,10 +1620,22 @@ function SessionChatInner(props: SessionChatProps) {
         if (!inactiveCanResume || !props.resolveSessionIdForUpload) {
             return undefined
         }
+        // Keep one resume promise for every generator created by this adapter
+        // instance. Preview generation can outlive navigation; a remount clears
+        // the router cache, so a second file must reuse this closure's promise
+        // instead of starting a fresh resume against the retired source id.
+        let uploadResolution: Promise<string> | undefined
+        const resolveUploadSession = () => {
+            uploadResolution ??= props.resolveSessionIdForUpload!(props.session.id).catch((error) => {
+                uploadResolution = undefined
+                throw error
+            })
+            return uploadResolution
+        }
         return createAttachmentAdapter(
             props.api,
             props.session.id,
-            () => props.resolveSessionIdForUpload!(props.session.id),
+            resolveUploadSession,
             async (resolvedSessionId, pending) => {
                 // Include the in-flight file and coalesce multi-file drops into
                 // one transfer + navigation before the source composer unmounts.

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1811,7 +1811,7 @@ function SessionChatInner(props: SessionChatProps) {
                         <HappyComposer
                         key={`composer-${props.session.id}`}
                         sessionId={props.session.id}
-                        canRestoreAttachments={attachmentAdapter !== undefined}
+                        canRestoreAttachments={props.session.active}
                         onUploadDraftSnapshot={(text, attachments) => {
                             uploadDraftSnapshotRef.current = { text, attachments }
                         }}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -76,12 +76,8 @@ import {
     type AttachmentDraftInput,
 } from '@/lib/composer-attachment-drafts'
 import { useTranslation } from '@/lib/use-translation'
-<<<<<<< HEAD
 import type { SendMessageAcceptance, SendMessageSettlement } from '@/hooks/mutations/useSendMessage'
-import { transferComposerDraft } from '@/lib/composer-draft-transfer'
-=======
 import { handoffComposerDraft, transferComposerDraft } from '@/lib/composer-draft-transfer'
->>>>>>> 82947a07 (fix(web): include in-flight attachments in inactive resume handoff)
 import { SessionHeader } from '@/components/SessionHeader'
 import { CursorMigrationBanner } from '@/components/CursorMigrationBanner'
 import { TeamPanel } from '@/components/TeamPanel'

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -71,9 +71,8 @@ import type { ScratchlistEntry } from '@/lib/scratchlist'
 import { isHubScratchlistAttachmentPath } from '@hapi/protocol'
 import { consumeSharePendingTransfer } from '@/lib/sharePendingState'
 import { deleteShareTransfer, getShareTransfer } from '@/lib/shareTransfer'
-import { getDraft, saveDraft } from '@/lib/composer-drafts'
+import { getDraft } from '@/lib/composer-drafts'
 import {
-    saveDraftAttachments,
     type AttachmentDraftInput,
 } from '@/lib/composer-attachment-drafts'
 import { useTranslation } from '@/lib/use-translation'
@@ -1624,9 +1623,11 @@ function SessionChatInner(props: SessionChatProps) {
             props.session.id,
             () => props.resolveSessionIdForUpload!(props.session.id),
             async (resolvedSessionId) => {
-                const snapshot = uploadDraftSnapshotRef.current
-                saveDraft(resolvedSessionId, snapshot.text)
-                saveDraftAttachments(resolvedSessionId, snapshot.attachments)
+                // Attachment restoration can resolve the inactive session
+                // before composer hydration has published a live snapshot.
+                // Transfer from persisted storage in that case and strip the
+                // source session's upload metadata before navigation.
+                await transferComposerDraft(props.session.id, resolvedSessionId)
                 props.onUploadSessionResolved?.(resolvedSessionId)
             },
         )

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1627,13 +1627,8 @@ function SessionChatInner(props: SessionChatProps) {
             async (resolvedSessionId, pending) => {
                 // Include the in-flight file and coalesce multi-file drops into
                 // one transfer + navigation before the source composer unmounts.
-                // If the pick was cancelled after resume, still transfer text /
-                // other drafts and navigate — the hub may have deleted the source.
-                if (!pending) {
-                    await transferComposerDraft(props.session.id, resolvedSessionId)
-                    props.onUploadSessionResolved?.(resolvedSessionId)
-                    return
-                }
+                // isCancelled is sampled at save time so a mid-handoff remove
+                // still drops the file (and any prior inactive persist of it).
                 await handoffComposerDraft(
                     props.session.id,
                     resolvedSessionId,

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1627,6 +1627,13 @@ function SessionChatInner(props: SessionChatProps) {
             async (resolvedSessionId, pending) => {
                 // Include the in-flight file and coalesce multi-file drops into
                 // one transfer + navigation before the source composer unmounts.
+                // If the pick was cancelled after resume, still transfer text /
+                // other drafts and navigate — the hub may have deleted the source.
+                if (!pending) {
+                    await transferComposerDraft(props.session.id, resolvedSessionId)
+                    props.onUploadSessionResolved?.(resolvedSessionId)
+                    return
+                }
                 await handoffComposerDraft(
                     props.session.id,
                     resolvedSessionId,

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1883,6 +1883,7 @@ function SessionChatInner(props: SessionChatProps) {
                         }
                         active={props.session.active}
                         allowSendWhenInactive
+                        onResumeStoredDraft={() => handleSend('', undefined, null)}
                         thinking={props.session.thinking}
                         agentState={props.session.agentState}
                         backgroundTaskCount={props.session.backgroundTaskCount}

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -148,7 +148,7 @@ export function SessionHeader(props: {
     canReopen?: boolean
     reopenDisabledReason?: string
     onSessionDeleted?: () => void
-    onSessionReopened?: (newSessionId: string) => void
+    onSessionReopened?: (newSessionId: string) => void | Promise<void>
 }) {
     const { t, locale } = useTranslation()
     const queryClient = useQueryClient()
@@ -242,7 +242,7 @@ export function SessionHeader(props: {
         try {
             const result = await reopenSession()
             if (result.sessionId && result.sessionId !== session.id) {
-                onSessionReopened?.(result.sessionId)
+                await onSessionReopened?.(result.sessionId)
             }
         } catch (error) {
             setReopenError(formatReopenError(error))

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -29,6 +29,7 @@ import { useSessionListMachineFilter } from '@/hooks/useSessionListMachineFilter
 import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStatus'
 import { SessionRowSummary } from '@/components/SessionRowSummary'
 import { Spinner } from '@/components/Spinner'
+import { transferComposerDraft } from '@/lib/composer-draft-transfer'
 
 export { getWorktreeSessionLabel } from '@/lib/sessionWorktreeLabel'
 
@@ -885,6 +886,7 @@ function SessionItem(props: {
             // resumeSession may merge the row into a freshly-spawned sessionId.
             // Follow it so the operator lands on the live session.
             if (result.sessionId && result.sessionId !== s.id) {
+                await transferComposerDraft(s.id, result.sessionId)
                 onSelect(result.sessionId)
             }
         } catch (error) {

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -29,7 +29,7 @@ import { useSessionListMachineFilter } from '@/hooks/useSessionListMachineFilter
 import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStatus'
 import { SessionRowSummary } from '@/components/SessionRowSummary'
 import { Spinner } from '@/components/Spinner'
-import { transferComposerDraft } from '@/lib/composer-draft-transfer'
+import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
 
 export { getWorktreeSessionLabel } from '@/lib/sessionWorktreeLabel'
 
@@ -886,8 +886,11 @@ function SessionItem(props: {
             // resumeSession may merge the row into a freshly-spawned sessionId.
             // Follow it so the operator lands on the live session.
             if (result.sessionId && result.sessionId !== s.id) {
-                await transferComposerDraft(s.id, result.sessionId)
-                onSelect(result.sessionId)
+                await transferComposerDraftThenNavigate(
+                    s.id,
+                    result.sessionId,
+                    () => onSelect(result.sessionId),
+                )
             }
         } catch (error) {
             setReopenError(formatReopenError(error))

--- a/web/src/hooks/mutations/useSendMessage.test.tsx
+++ b/web/src/hooks/mutations/useSendMessage.test.tsx
@@ -636,6 +636,44 @@ describe('useSendMessage', () => {
         await expect(acceptedPromise!).resolves.toEqual({ attemptId: 'local-id-1' })
     })
 
+    it('awaits onSessionResolved before starting the send mutation', async () => {
+        const order: string[] = []
+        const gate = deferred<void>()
+        const sendMessage = vi.fn(async () => {
+            order.push('mutate')
+        })
+        const api = createMockApi(sendMessage)
+        const { result } = renderHook(
+            () => useSendMessage(api, 'session-original', {
+                resolveSessionId: async () => 'session-resolved',
+                onSessionResolved: async () => {
+                    order.push('resolved')
+                    await gate.promise
+                    order.push('resolved-done')
+                },
+            }),
+            { wrapper: createWrapper() },
+        )
+
+        act(() => {
+            void result.current.sendMessage('hello with draft')
+        })
+
+        await waitFor(() => {
+            expect(order).toEqual(['resolved'])
+        })
+        expect(sendMessage).not.toHaveBeenCalled()
+
+        await act(async () => {
+            gate.resolve()
+        })
+
+        await waitFor(() => {
+            expect(order).toEqual(['resolved', 'resolved-done', 'mutate'])
+        })
+        expect(sendMessage).toHaveBeenCalled()
+    })
+
     // #918: the inactive-session 409 path
     describe('inactive-session 409 (issue #918)', () => {
         it('fires onError with the ApiError so the consumer can render a session_inactive affordance', async () => {

--- a/web/src/hooks/mutations/useSendMessage.test.tsx
+++ b/web/src/hooks/mutations/useSendMessage.test.tsx
@@ -646,7 +646,8 @@ describe('useSendMessage', () => {
         const { result } = renderHook(
             () => useSendMessage(api, 'session-original', {
                 resolveSessionId: async () => 'session-resolved',
-                onSessionResolved: async () => {
+                onSessionResolved: async (_id, context) => {
+                    expect(context).toEqual({ text: 'hello with draft', attachments: undefined })
                     order.push('resolved')
                     await gate.promise
                     order.push('resolved-done')
@@ -672,6 +673,26 @@ describe('useSendMessage', () => {
             expect(order).toEqual(['resolved', 'resolved-done', 'mutate'])
         })
         expect(sendMessage).toHaveBeenCalled()
+    })
+
+    it('does not mutate when onSessionResolved defers for draft hydration', async () => {
+        const sendMessage = vi.fn(async () => {})
+        const api = createMockApi(sendMessage)
+        const { result } = renderHook(
+            () => useSendMessage(api, 'session-original', {
+                resolveSessionId: async () => 'session-resolved',
+                onSessionResolved: async () => ({ deferUntilDraftHydrated: true }),
+            }),
+            { wrapper: createWrapper() },
+        )
+
+        let accepted: Awaited<ReturnType<typeof result.current.sendMessage>> | undefined
+        await act(async () => {
+            accepted = await result.current.sendMessage('hello with hidden file')
+        })
+
+        expect(accepted).toBe(false)
+        expect(sendMessage).not.toHaveBeenCalled()
     })
 
     // #918: the inactive-session 409 path

--- a/web/src/hooks/mutations/useSendMessage.test.tsx
+++ b/web/src/hooks/mutations/useSendMessage.test.tsx
@@ -148,7 +148,7 @@ describe('useSendMessage', () => {
         const { result } = renderHook(
             () => useSendMessage(api, 'session-original', {
                 onSuccess,
-                resolveSessionId: async () => 'session-resolved',
+                resolveSessionId: async () => ({ sessionId: 'session-resolved', resumed: true }),
                 onSessionResolved: vi.fn(),
             }),
             { wrapper: createWrapper() },
@@ -436,7 +436,7 @@ describe('useSendMessage', () => {
             const { result } = renderHook(
                 () => useSendMessage(api, 'session-original', {
                     onError,
-                    resolveSessionId: async () => 'session-resolved',
+                    resolveSessionId: async () => ({ sessionId: 'session-resolved', resumed: true }),
                     onSessionResolved: vi.fn(),
                 }),
                 { wrapper: createWrapper() },
@@ -624,7 +624,7 @@ describe('useSendMessage', () => {
         const api = createMockApi()
         const { result } = renderHook(
             () => useSendMessage(api, 'session-original', {
-                resolveSessionId: async () => 'session-resolved',
+                resolveSessionId: async () => ({ sessionId: 'session-resolved', resumed: true }),
                 onSessionResolved: vi.fn(),
             }),
             { wrapper: createWrapper() },
@@ -645,7 +645,7 @@ describe('useSendMessage', () => {
         const api = createMockApi(sendMessage)
         const { result } = renderHook(
             () => useSendMessage(api, 'session-original', {
-                resolveSessionId: async () => 'session-resolved',
+                resolveSessionId: async () => ({ sessionId: 'session-resolved', resumed: true }),
                 onSessionResolved: async (_id, context) => {
                     expect(context).toEqual({ text: 'hello with draft', attachments: undefined })
                     order.push('resolved')
@@ -680,7 +680,7 @@ describe('useSendMessage', () => {
         const api = createMockApi(sendMessage)
         const { result } = renderHook(
             () => useSendMessage(api, 'session-original', {
-                resolveSessionId: async () => 'session-resolved',
+                resolveSessionId: async () => ({ sessionId: 'session-resolved', resumed: true }),
                 onSessionResolved: async () => ({ deferUntilDraftHydrated: true }),
             }),
             { wrapper: createWrapper() },
@@ -693,6 +693,51 @@ describe('useSendMessage', () => {
 
         expect(accepted).toBe(false)
         expect(sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('defers after a same-id resume when onSessionResolved asks to wait', async () => {
+        const sendMessage = vi.fn(async () => {})
+        const api = createMockApi(sendMessage)
+        const onSessionResolved = vi.fn(async () => ({ deferUntilDraftHydrated: true as const }))
+        const { result } = renderHook(
+            () => useSendMessage(api, 'session-same', {
+                resolveSessionId: async () => ({ sessionId: 'session-same', resumed: true }),
+                onSessionResolved,
+            }),
+            { wrapper: createWrapper() },
+        )
+
+        let accepted: Awaited<ReturnType<typeof result.current.sendMessage>> | undefined
+        await act(async () => {
+            accepted = await result.current.sendMessage('same-id with hidden file')
+        })
+
+        expect(onSessionResolved).toHaveBeenCalledWith('session-same', {
+            text: 'same-id with hidden file',
+            attachments: undefined,
+        })
+        expect(accepted).toBe(false)
+        expect(sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('does not call onSessionResolved when the session was already active', async () => {
+        const sendMessage = vi.fn(async () => {})
+        const api = createMockApi(sendMessage)
+        const onSessionResolved = vi.fn()
+        const { result } = renderHook(
+            () => useSendMessage(api, 'session-active', {
+                resolveSessionId: async () => ({ sessionId: 'session-active', resumed: false }),
+                onSessionResolved,
+            }),
+            { wrapper: createWrapper() },
+        )
+
+        await act(async () => {
+            await result.current.sendMessage('already active')
+        })
+
+        expect(onSessionResolved).not.toHaveBeenCalled()
+        expect(sendMessage).toHaveBeenCalled()
     })
 
     // #918: the inactive-session 409 path

--- a/web/src/hooks/mutations/useSendMessage.ts
+++ b/web/src/hooks/mutations/useSendMessage.ts
@@ -79,7 +79,7 @@ export type SendErrorInfo = {
 
 type UseSendMessageOptions = {
     resolveSessionId?: (sessionId: string) => Promise<string>
-    onSessionResolved?: (sessionId: string) => void
+    onSessionResolved?: (sessionId: string) => void | Promise<void>
     onBlocked?: (reason: BlockedReason) => void
     onSuccess?: (sessionId: string) => void
     onError?: (info: SendErrorInfo) => void
@@ -283,7 +283,9 @@ export function useSendMessage(
             try {
                 const resolved = await options.resolveSessionId(sessionId)
                 if (resolved && resolved !== sessionId) {
-                    options.onSessionResolved?.(resolved)
+                    // Await draft transfer / navigation before the mutation so
+                    // hidden inactive attachments move with the resumed id.
+                    await options.onSessionResolved?.(resolved)
                     targetSessionId = resolved
                 }
             } catch (error) {

--- a/web/src/hooks/mutations/useSendMessage.ts
+++ b/web/src/hooks/mutations/useSendMessage.ts
@@ -77,6 +77,12 @@ export type SendErrorInfo = {
     mutationStarted: boolean
 }
 
+export type ResolvedSession = {
+    sessionId: string
+    /** True after an inactive-session resume, even when the hub returns the same id. */
+    resumed: boolean
+}
+
 export type SessionResolution = {
     attachments?: AttachmentMetadata[]
     /** Transfer moved hidden drafts; wait for the active composer to hydrate/re-upload. */
@@ -89,7 +95,7 @@ export type SessionResolvedContext = {
 }
 
 type UseSendMessageOptions = {
-    resolveSessionId?: (sessionId: string) => Promise<string>
+    resolveSessionId?: (sessionId: string) => Promise<ResolvedSession>
     onSessionResolved?: (
         sessionId: string,
         context: SessionResolvedContext,
@@ -297,14 +303,15 @@ export function useSendMessage(
             setIsResolving(true)
             try {
                 const resolved = await options.resolveSessionId(sessionId)
-                if (resolved && resolved !== sessionId) {
+                targetSessionId = resolved.sessionId
+                if (resolved.resumed) {
                     // Await draft transfer / navigation before the mutation so
-                    // hidden inactive attachments move with the resumed id.
-                    const resolution = await options.onSessionResolved?.(resolved, {
-                        text,
-                        attachments,
-                    })
-                    targetSessionId = resolved
+                    // hidden inactive attachments move with the resumed id
+                    // (including same-id PTY/Pi/Cursor resumes).
+                    const resolution = await options.onSessionResolved?.(
+                        targetSessionId,
+                        { text, attachments },
+                    )
                     if (resolution?.deferUntilDraftHydrated) {
                         // Target composer still needs to hydrate/re-upload files.
                         return false

--- a/web/src/hooks/mutations/useSendMessage.ts
+++ b/web/src/hooks/mutations/useSendMessage.ts
@@ -77,9 +77,23 @@ export type SendErrorInfo = {
     mutationStarted: boolean
 }
 
+export type SessionResolution = {
+    attachments?: AttachmentMetadata[]
+    /** Transfer moved hidden drafts; wait for the active composer to hydrate/re-upload. */
+    deferUntilDraftHydrated?: boolean
+}
+
+export type SessionResolvedContext = {
+    text: string
+    attachments?: AttachmentMetadata[]
+}
+
 type UseSendMessageOptions = {
     resolveSessionId?: (sessionId: string) => Promise<string>
-    onSessionResolved?: (sessionId: string) => void | Promise<void>
+    onSessionResolved?: (
+        sessionId: string,
+        context: SessionResolvedContext,
+    ) => void | Promise<void | SessionResolution>
     onBlocked?: (reason: BlockedReason) => void
     onSuccess?: (sessionId: string) => void
     onError?: (info: SendErrorInfo) => void
@@ -277,6 +291,7 @@ export function useSendMessage(
         const localId = makeClientSideId('local')
         const createdAt = Date.now()
         let targetSessionId = sessionId
+        let sendAttachments = attachments
         if (options?.resolveSessionId) {
             resolveGuardRef.current = true
             setIsResolving(true)
@@ -285,8 +300,18 @@ export function useSendMessage(
                 if (resolved && resolved !== sessionId) {
                     // Await draft transfer / navigation before the mutation so
                     // hidden inactive attachments move with the resumed id.
-                    await options.onSessionResolved?.(resolved)
+                    const resolution = await options.onSessionResolved?.(resolved, {
+                        text,
+                        attachments,
+                    })
                     targetSessionId = resolved
+                    if (resolution?.deferUntilDraftHydrated) {
+                        // Target composer still needs to hydrate/re-upload files.
+                        return false
+                    }
+                    if (resolution?.attachments) {
+                        sendAttachments = resolution.attachments
+                    }
                 }
             } catch (error) {
                 haptic.notification('error')
@@ -320,7 +345,7 @@ export function useSendMessage(
             text,
             localId,
             createdAt,
-            attachments,
+            attachments: sendAttachments,
             scheduledAt,
             deliveryMode,
         })

--- a/web/src/hooks/mutations/useSessionActions.test.tsx
+++ b/web/src/hooks/mutations/useSessionActions.test.tsx
@@ -95,6 +95,64 @@ describe('useSessionActions - reopenSession', () => {
             expect(result.current.isPending).toBe(false)
         })
     })
+
+    it('does not invalidate the source session detail when reopen returns a different id', async () => {
+        const reopen = vi.fn(async () => ({
+            ok: true as const,
+            sessionId: 'session-B',
+            resumed: true,
+        }))
+        const queryClient = new QueryClient({
+            defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+        })
+        const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+        const api = createMockApi(reopen)
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        )
+        const { result } = renderHook(
+            () => useSessionActions(api, 'session-A', 'cursor'),
+            { wrapper },
+        )
+
+        await act(async () => {
+            await result.current.reopenSession()
+        })
+
+        await waitFor(() => {
+            expect(invalidate).toHaveBeenCalledWith({ queryKey: ['sessions'] })
+        })
+        expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ['session', 'session-A'] })
+    })
+
+    it('invalidates the source session detail when reopen returns the same id', async () => {
+        const reopen = vi.fn(async () => ({
+            ok: true as const,
+            sessionId: 'session-A',
+            resumed: true,
+        }))
+        const queryClient = new QueryClient({
+            defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+        })
+        const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+        const api = createMockApi(reopen)
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        )
+        const { result } = renderHook(
+            () => useSessionActions(api, 'session-A', 'cursor'),
+            { wrapper },
+        )
+
+        await act(async () => {
+            await result.current.reopenSession()
+        })
+
+        await waitFor(() => {
+            expect(invalidate).toHaveBeenCalledWith({ queryKey: ['session', 'session-A'] })
+        })
+        expect(invalidate).toHaveBeenCalledWith({ queryKey: ['sessions'] })
+    })
 })
 
 describe('useSessionActions - setModel', () => {

--- a/web/src/hooks/mutations/useSessionActions.ts
+++ b/web/src/hooks/mutations/useSessionActions.ts
@@ -103,7 +103,14 @@ export function useSessionActions(
         },
         onSuccess: (result) => {
             void (async () => {
-                await invalidateSession()
+                // When reopen merges into a different id, the source detail may
+                // already be gone. Invalidating it while still on the source
+                // route races with draft handoff and flashes "Session unavailable".
+                if (result.sessionId === sessionId) {
+                    await invalidateSession()
+                } else {
+                    await queryClient.invalidateQueries({ queryKey: queryKeys.sessions })
+                }
                 markSessionActiveInCache(result.sessionId)
             })()
         },

--- a/web/src/hooks/useComposerDraft.test.ts
+++ b/web/src/hooks/useComposerDraft.test.ts
@@ -9,6 +9,7 @@ vi.mock('@/lib/composer-drafts', () => ({
 }))
 vi.mock('@/lib/composer-attachment-drafts', () => ({
     getDraftAttachments: vi.fn(async () => []),
+    getRestoredUploadMetadata: vi.fn(() => undefined),
     saveDraftAttachments: vi.fn(),
 }))
 
@@ -177,8 +178,10 @@ describe('useComposerDraft', () => {
         expect(mockSaveDraftAttachments).not.toHaveBeenCalled()
     })
 
-    it('does not overwrite stored attachments with a partial inactive selection on unmount', async () => {
-        const partial = new File(['too-big'], 'huge.bin', { type: 'application/octet-stream' })
+    it('merges a visible inactive selection into stored attachments on unmount', async () => {
+        const stored = new File(['kept'], 'kept.txt', { type: 'text/plain' })
+        const partial = new File(['picked'], 'picked.txt', { type: 'text/plain' })
+        mockGetDraftAttachments.mockResolvedValue([stored])
         const { unmount } = renderHook(() => (
             useComposerDraft(
                 'session-1',
@@ -191,10 +194,19 @@ describe('useComposerDraft', () => {
         ))
         await act(async () => flushRAF())
         unmount()
+        await act(async () => {
+            await Promise.resolve()
+            await Promise.resolve()
+        })
 
-        // Text can still persist; attachments must stay owned by IndexedDB.
         expect(mockSaveDraft).toHaveBeenCalledWith('session-1', 'typed')
-        expect(mockSaveDraftAttachments).not.toHaveBeenCalled()
+        expect(mockSaveDraftAttachments).toHaveBeenCalledWith(
+            'session-1',
+            expect.arrayContaining([
+                expect.objectContaining({ file: stored }),
+                expect.objectContaining({ id: 'partial', file: partial }),
+            ]),
+        )
     })
     it('reports immediate complete hydration when no session exists', () => {
         const { result } = renderHook(() => useComposerDraft(undefined, '', [], true, vi.fn(), vi.fn()))

--- a/web/src/hooks/useComposerDraft.test.ts
+++ b/web/src/hooks/useComposerDraft.test.ts
@@ -14,12 +14,13 @@ vi.mock('@/lib/composer-attachment-drafts', () => ({
 }))
 
 import { getDraft, saveDraft } from '@/lib/composer-drafts'
-import { getDraftAttachments, saveDraftAttachments } from '@/lib/composer-attachment-drafts'
+import { getDraftAttachments, getRestoredUploadMetadata, saveDraftAttachments } from '@/lib/composer-attachment-drafts'
 import { useComposerDraft } from './useComposerDraft'
 
 const mockGetDraft = vi.mocked(getDraft)
 const mockSaveDraft = vi.mocked(saveDraft)
 const mockGetDraftAttachments = vi.mocked(getDraftAttachments)
+const mockGetRestoredUploadMetadata = vi.mocked(getRestoredUploadMetadata)
 const mockSaveDraftAttachments = vi.mocked(saveDraftAttachments)
 
 describe('useComposerDraft', () => {
@@ -29,6 +30,7 @@ describe('useComposerDraft', () => {
         vi.clearAllMocks()
         mockGetDraft.mockReturnValue('')
         mockGetDraftAttachments.mockResolvedValue([])
+        mockGetRestoredUploadMetadata.mockReturnValue(undefined)
         rAFCallbacks = []
         vi.stubGlobal('requestAnimationFrame', vi.fn((cb: () => void) => {
             rAFCallbacks.push(cb)
@@ -65,6 +67,47 @@ describe('useComposerDraft', () => {
         expect(mockGetDraft).toHaveBeenCalledWith('session-1')
         expect(setText).toHaveBeenCalledWith('saved text')
         expect(result.current).toEqual({ sessionId: 'session-1', complete: true, restoredAny: true })
+    })
+
+    it('restores only missing stored attachments when a visible pick already exists', async () => {
+        const storedA = new File(['a'], 'a.txt')
+        const visibleB = new File(['b'], 'b.txt')
+        mockGetDraftAttachments.mockResolvedValue([storedA, visibleB])
+        mockGetRestoredUploadMetadata.mockImplementation((file: File) => {
+            if (file === storedA) return { id: 'stored-a' }
+            if (file === visibleB) return { id: 'visible-b' }
+            return undefined
+        })
+        const addAttachment = vi.fn().mockResolvedValue(undefined)
+        const visible = [{ id: 'visible-b', file: visibleB }]
+
+        const { result, rerender } = renderHook(
+            ({ canRestore, attachments }) => useComposerDraft(
+                'session-1',
+                '',
+                attachments,
+                canRestore,
+                vi.fn(),
+                addAttachment,
+            ),
+            { initialProps: { canRestore: false, attachments: visible } },
+        )
+
+        await act(async () => flushRAF())
+        expect(result.current.complete).toBe(true)
+        expect(addAttachment).not.toHaveBeenCalled()
+
+        // Same-id resume flips inactive → active with B already visible.
+        rerender({ canRestore: true, attachments: visible })
+        await act(async () => flushRAF())
+        await act(async () => {
+            await Promise.resolve()
+            await Promise.resolve()
+        })
+
+        expect(addAttachment).toHaveBeenCalledTimes(1)
+        expect(addAttachment).toHaveBeenCalledWith(storedA)
+        expect(result.current.complete).toBe(true)
     })
 
     it('does not restore draft if composer already has text', async () => {
@@ -150,16 +193,31 @@ describe('useComposerDraft', () => {
         expect(result.current).toEqual({ sessionId: 'session-1', complete: true, restoredAny: true })
     })
 
-    it('does not duplicate saved attachments when the composer already has files', async () => {
+    it('does not duplicate a stored attachment that is already visible by id', async () => {
         const current = new File(['current'], 'current.png', { type: 'image/png' })
-        const saved = new File(['saved'], 'saved.png', { type: 'image/png' })
-        mockGetDraftAttachments.mockResolvedValue([saved])
+        mockGetDraftAttachments.mockResolvedValue([current])
+        mockGetRestoredUploadMetadata.mockReturnValue({ id: 'current' })
         const addAttachment = vi.fn(async () => {})
 
         renderHook(() => useComposerDraft('session-1', '', [{ id: 'current', file: current }], true, vi.fn(), addAttachment))
         await act(async () => flushRAF())
 
         expect(addAttachment).not.toHaveBeenCalled()
+    })
+
+    it('restores a stored sibling when a different attachment is already visible', async () => {
+        const current = new File(['current'], 'current.png', { type: 'image/png' })
+        const saved = new File(['saved'], 'saved.png', { type: 'image/png' })
+        mockGetDraftAttachments.mockResolvedValue([saved])
+        mockGetRestoredUploadMetadata.mockImplementation((file: File) => (
+            file === saved ? { id: 'saved' } : undefined
+        ))
+        const addAttachment = vi.fn(async () => {})
+
+        renderHook(() => useComposerDraft('session-1', '', [{ id: 'current', file: current }], true, vi.fn(), addAttachment))
+        await act(async () => flushRAF())
+
+        expect(addAttachment).toHaveBeenCalledWith(saved)
     })
 
     it('preserves saved attachments while the attachment adapter is unavailable', async () => {

--- a/web/src/hooks/useComposerDraft.test.ts
+++ b/web/src/hooks/useComposerDraft.test.ts
@@ -60,13 +60,13 @@ describe('useComposerDraft', () => {
         // Before rAF fires, setText should not have been called and hydration
         // must prevent failed-send recovery from racing ahead of persistence.
         expect(setText).not.toHaveBeenCalled()
-        expect(result.current).toEqual({ sessionId: 'session-1', complete: false, restoredAny: false })
+        expect(result.current).toEqual({ sessionId: 'session-1', complete: false, restoredAny: false , hasStoredAttachments: false })
 
         // Flush rAF + attachment hydration.
         await act(async () => flushRAF())
         expect(mockGetDraft).toHaveBeenCalledWith('session-1')
         expect(setText).toHaveBeenCalledWith('saved text')
-        expect(result.current).toEqual({ sessionId: 'session-1', complete: true, restoredAny: true })
+        expect(result.current).toEqual({ sessionId: 'session-1', complete: true, restoredAny: true , hasStoredAttachments: false })
     })
 
     it('restores only missing stored attachments when a visible pick already exists', async () => {
@@ -190,7 +190,12 @@ describe('useComposerDraft', () => {
         await act(async () => flushRAF())
 
         expect(addAttachment).toHaveBeenCalledWith(file)
-        expect(result.current).toEqual({ sessionId: 'session-1', complete: true, restoredAny: true })
+        expect(result.current).toEqual({
+            sessionId: 'session-1',
+            complete: true,
+            restoredAny: true,
+            hasStoredAttachments: true,
+        })
     })
 
     it('does not duplicate a stored attachment that is already visible by id', async () => {
@@ -225,14 +230,20 @@ describe('useComposerDraft', () => {
         mockGetDraftAttachments.mockResolvedValue([saved])
         const addAttachment = vi.fn(async () => {})
 
-        const { unmount } = renderHook(() => (
+        const { result, unmount } = renderHook(() => (
             useComposerDraft('session-1', '', [], false, vi.fn(), addAttachment)
         ))
         await act(async () => flushRAF())
-        unmount()
 
-        expect(mockGetDraftAttachments).not.toHaveBeenCalled()
+        expect(mockGetDraftAttachments).toHaveBeenCalledWith('session-1')
         expect(addAttachment).not.toHaveBeenCalled()
+        expect(result.current).toEqual({
+            sessionId: 'session-1',
+            complete: true,
+            restoredAny: false,
+            hasStoredAttachments: true,
+        })
+        unmount()
         expect(mockSaveDraftAttachments).not.toHaveBeenCalled()
     })
 
@@ -268,7 +279,7 @@ describe('useComposerDraft', () => {
     })
     it('reports immediate complete hydration when no session exists', () => {
         const { result } = renderHook(() => useComposerDraft(undefined, '', [], true, vi.fn(), vi.fn()))
-        expect(result.current).toEqual({ sessionId: undefined, complete: true, restoredAny: false })
+        expect(result.current).toEqual({ sessionId: undefined, complete: true, restoredAny: false , hasStoredAttachments: false })
     })
 
     it('returns to pending hydration when the session changes', async () => {
@@ -277,12 +288,12 @@ describe('useComposerDraft', () => {
             { initialProps: { sessionId: 'session-1' as string | undefined } },
         )
         await act(async () => flushRAF())
-        expect(result.current).toEqual({ sessionId: 'session-1', complete: true, restoredAny: false })
+        expect(result.current).toEqual({ sessionId: 'session-1', complete: true, restoredAny: false , hasStoredAttachments: false })
 
         rerender({ sessionId: 'session-2' })
-        expect(result.current).toEqual({ sessionId: 'session-2', complete: false, restoredAny: false })
+        expect(result.current).toEqual({ sessionId: 'session-2', complete: false, restoredAny: false , hasStoredAttachments: false })
         await act(async () => flushRAF())
-        expect(result.current).toEqual({ sessionId: 'session-2', complete: true, restoredAny: false })
+        expect(result.current).toEqual({ sessionId: 'session-2', complete: true, restoredAny: false , hasStoredAttachments: false })
     })
 
     it('lets persisted replacement hydration win over an implicit failed-send restore', async () => {
@@ -330,21 +341,21 @@ describe('useComposerDraft', () => {
         )
 
         await act(async () => flushRAF())
-        expect(result.current).toEqual({ sessionId: 'session-1', complete: false, restoredAny: false })
+        expect(result.current).toEqual({ sessionId: 'session-1', complete: false, restoredAny: false , hasStoredAttachments: false })
 
         rerender({ sessionId: 'session-2' })
-        expect(result.current).toEqual({ sessionId: 'session-2', complete: false, restoredAny: false })
+        expect(result.current).toEqual({ sessionId: 'session-2', complete: false, restoredAny: false , hasStoredAttachments: false })
 
         await act(async () => {
             resolveOldFiles!([oldAttachment])
             await Promise.resolve()
             await Promise.resolve()
         })
-        expect(result.current).toEqual({ sessionId: 'session-2', complete: false, restoredAny: false })
+        expect(result.current).toEqual({ sessionId: 'session-2', complete: false, restoredAny: false , hasStoredAttachments: false })
         expect(addAttachment).not.toHaveBeenCalled()
 
         await act(async () => flushRAF())
-        expect(result.current).toEqual({ sessionId: 'session-2', complete: true, restoredAny: false })
+        expect(result.current).toEqual({ sessionId: 'session-2', complete: true, restoredAny: false , hasStoredAttachments: false })
     })
 
     it('does not mark hydration restored when every saved attachment rejects', async () => {
@@ -356,7 +367,12 @@ describe('useComposerDraft', () => {
         await act(async () => flushRAF())
 
         expect(addAttachment).toHaveBeenCalledWith(file)
-        expect(result.current).toEqual({ sessionId: 'session-1', complete: true, restoredAny: false })
+        expect(result.current).toEqual({
+            sessionId: 'session-1',
+            complete: true,
+            restoredAny: false,
+            hasStoredAttachments: true,
+        })
     })
 
     it('marks hydration restored when at least one saved attachment succeeds', async () => {
@@ -371,7 +387,12 @@ describe('useComposerDraft', () => {
         await act(async () => flushRAF())
 
         expect(addAttachment).toHaveBeenCalledTimes(2)
-        expect(result.current).toEqual({ sessionId: 'session-1', complete: true, restoredAny: true })
+        expect(result.current).toEqual({
+            sessionId: 'session-1',
+            complete: true,
+            restoredAny: true,
+            hasStoredAttachments: true,
+        })
     })
 
     it('allows implicit failed-send restoration when every persisted attachment fails', async () => {

--- a/web/src/hooks/useComposerDraft.test.ts
+++ b/web/src/hooks/useComposerDraft.test.ts
@@ -176,6 +176,26 @@ describe('useComposerDraft', () => {
         expect(addAttachment).not.toHaveBeenCalled()
         expect(mockSaveDraftAttachments).not.toHaveBeenCalled()
     })
+
+    it('does not overwrite stored attachments with a partial inactive selection on unmount', async () => {
+        const partial = new File(['too-big'], 'huge.bin', { type: 'application/octet-stream' })
+        const { unmount } = renderHook(() => (
+            useComposerDraft(
+                'session-1',
+                'typed',
+                [{ id: 'partial', file: partial }],
+                false,
+                vi.fn(),
+                vi.fn(),
+            )
+        ))
+        await act(async () => flushRAF())
+        unmount()
+
+        // Text can still persist; attachments must stay owned by IndexedDB.
+        expect(mockSaveDraft).toHaveBeenCalledWith('session-1', 'typed')
+        expect(mockSaveDraftAttachments).not.toHaveBeenCalled()
+    })
     it('reports immediate complete hydration when no session exists', () => {
         const { result } = renderHook(() => useComposerDraft(undefined, '', [], true, vi.fn(), vi.fn()))
         expect(result.current).toEqual({ sessionId: undefined, complete: true, restoredAny: false })

--- a/web/src/hooks/useComposerDraft.ts
+++ b/web/src/hooks/useComposerDraft.ts
@@ -128,7 +128,9 @@ export function useComposerDraft(
             if (draftReadyRef.current) {
                 saveDraft(sessionId, composerTextRef.current)
             }
-            if (attachmentsRef.current.length > 0 || (canRestoreAttachments && attachmentsReadyRef.current)) {
+            // Inactive composers deliberately skip restoring stored attachments, so
+            // the visible list is incomplete. Never overwrite IndexedDB from it.
+            if (canRestoreAttachments && (attachmentsRef.current.length > 0 || attachmentsReadyRef.current)) {
                 saveDraftAttachments(sessionId, [...attachmentsRef.current])
             }
             draftReadyRef.current = false

--- a/web/src/hooks/useComposerDraft.ts
+++ b/web/src/hooks/useComposerDraft.ts
@@ -5,7 +5,7 @@ import {
     saveDraftAttachments,
     type AttachmentDraftInput,
 } from '@/lib/composer-attachment-drafts'
-import { persistInactiveComposerAttachments } from '@/lib/composer-draft-transfer'
+import { persistInactiveComposerAttachments, composerDraftWasHandedOff } from '@/lib/composer-draft-transfer'
 
 export type ComposerDraftHydration = {
     /** Session represented by this status; prevents a previous session's ready state leaking across a key change. */
@@ -126,6 +126,13 @@ export function useComposerDraft(
         return () => {
             disposed = true
             cancelAnimationFrame(frame)
+            // Cross-session resume already moved this draft; do not recreate the
+            // obsolete source id after the route change unmounts the composer.
+            if (composerDraftWasHandedOff(sessionId)) {
+                draftReadyRef.current = false
+                attachmentsReadyRef.current = false
+                return
+            }
             if (draftReadyRef.current) {
                 saveDraft(sessionId, composerTextRef.current)
             }

--- a/web/src/hooks/useComposerDraft.ts
+++ b/web/src/hooks/useComposerDraft.ts
@@ -153,7 +153,9 @@ export function useComposerDraft(
                     sessionId,
                     composerTextRef.current,
                     attachmentsRef.current,
-                )
+                ).catch((error) => {
+                    console.warn('[composer-draft] inactive persistence failed', error)
+                })
             }
             draftReadyRef.current = false
             attachmentsReadyRef.current = false

--- a/web/src/hooks/useComposerDraft.ts
+++ b/web/src/hooks/useComposerDraft.ts
@@ -14,6 +14,8 @@ export type ComposerDraftHydration = {
     complete: boolean
     /** True when this hydration found and applied a persisted text or attachment draft. */
     restoredAny: boolean
+    /** True when IndexedDB still holds attachment blobs (even if not restored into the adapter). */
+    hasStoredAttachments: boolean
 }
 
 /**
@@ -48,17 +50,28 @@ export function useComposerDraft(
         sessionId,
         complete: sessionId === undefined,
         restoredAny: false,
+        hasStoredAttachments: false,
     }))
 
     useEffect(() => {
         if (!sessionId) {
-            setHydration({ sessionId: undefined, complete: true, restoredAny: false })
+            setHydration({
+                sessionId: undefined,
+                complete: true,
+                restoredAny: false,
+                hasStoredAttachments: false,
+            })
             return
         }
 
         draftReadyRef.current = false
         attachmentsReadyRef.current = false
-        setHydration({ sessionId, complete: false, restoredAny: false })
+        setHydration({
+            sessionId,
+            complete: false,
+            restoredAny: false,
+            hasStoredAttachments: false,
+        })
 
         let disposed = false
         const frame = requestAnimationFrame(() => {
@@ -67,13 +80,36 @@ export function useComposerDraft(
             if (restoreText) {
                 // Mark before the external composer store gets its render so a
                 // consumer never mistakes this persisted replacement for empty.
-                setHydration({ sessionId, complete: !canRestoreAttachments, restoredAny: true })
+                setHydration({
+                    sessionId,
+                    complete: false,
+                    restoredAny: true,
+                    hasStoredAttachments: false,
+                })
                 setText(draft!)
             }
             draftReadyRef.current = true
 
             if (!canRestoreAttachments) {
-                if (!restoreText) setHydration({ sessionId, complete: true, restoredAny: false })
+                // Peek at stored blobs without restoring them into the inactive
+                // adapter so schedule/exclusion UI still knows they exist.
+                void getDraftAttachments(sessionId).then((files) => {
+                    if (disposed) return
+                    setHydration({
+                        sessionId,
+                        complete: true,
+                        restoredAny: restoreText,
+                        hasStoredAttachments: files.length > 0,
+                    })
+                }).catch(() => {
+                    if (disposed) return
+                    setHydration({
+                        sessionId,
+                        complete: true,
+                        restoredAny: restoreText,
+                        hasStoredAttachments: false,
+                    })
+                })
                 return
             }
 
@@ -98,6 +134,7 @@ export function useComposerDraft(
                         sessionId,
                         complete: false,
                         restoredAny: restoreText || current.restoredAny,
+                        hasStoredAttachments: files.length > 0,
                     }
                     : current)
                 let restoredAttachment = false
@@ -113,18 +150,19 @@ export function useComposerDraft(
                         }
                     }
                 }
-                return restoredAttachment
+                return { restoredAttachment, hasStoredAttachments: files.length > 0 }
             }).catch(() => {
                 // Attachment draft read is best effort.
-                return false
-            }).then((restoredAttachment) => {
+                return { restoredAttachment: false, hasStoredAttachments: false }
+            }).then((result) => {
                 if (!disposed) {
                     attachmentsReadyRef.current = true
                     setHydration((current) => current.sessionId === sessionId
                         ? {
                             ...current,
                             complete: true,
-                            restoredAny: current.restoredAny || Boolean(restoredAttachment),
+                            restoredAny: current.restoredAny || Boolean(result?.restoredAttachment),
+                            hasStoredAttachments: Boolean(result?.hasStoredAttachments),
                         }
                         : current)
                 }

--- a/web/src/hooks/useComposerDraft.ts
+++ b/web/src/hooks/useComposerDraft.ts
@@ -5,6 +5,7 @@ import {
     saveDraftAttachments,
     type AttachmentDraftInput,
 } from '@/lib/composer-attachment-drafts'
+import { persistInactiveComposerAttachments } from '@/lib/composer-draft-transfer'
 
 export type ComposerDraftHydration = {
     /** Session represented by this status; prevents a previous session's ready state leaking across a key change. */
@@ -128,10 +129,16 @@ export function useComposerDraft(
             if (draftReadyRef.current) {
                 saveDraft(sessionId, composerTextRef.current)
             }
-            // Inactive composers deliberately skip restoring stored attachments, so
-            // the visible list is incomplete. Never overwrite IndexedDB from it.
             if (canRestoreAttachments && (attachmentsRef.current.length > 0 || attachmentsReadyRef.current)) {
                 saveDraftAttachments(sessionId, [...attachmentsRef.current])
+            } else if (!canRestoreAttachments && attachmentsRef.current.length > 0) {
+                // Merge visible pending picks into IndexedDB; do not replace the
+                // hidden stored list with only the incomplete visible set.
+                void persistInactiveComposerAttachments(
+                    sessionId,
+                    composerTextRef.current,
+                    attachmentsRef.current,
+                )
             }
             draftReadyRef.current = false
             attachmentsReadyRef.current = false

--- a/web/src/hooks/useComposerDraft.ts
+++ b/web/src/hooks/useComposerDraft.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { getDraft, saveDraft } from '@/lib/composer-drafts'
 import {
     getDraftAttachments,
+    getRestoredUploadMetadata,
     saveDraftAttachments,
     type AttachmentDraftInput,
 } from '@/lib/composer-attachment-drafts'
@@ -81,7 +82,14 @@ export function useComposerDraft(
                 // session can already be hydrating when it settles, so never
                 // publish old status or rehydrate old files after disposal.
                 if (disposed) return
-                const restoreAttachments = attachmentsRef.current.length === 0 && files.length > 0
+                // Same-id resume can flip inactive→active with a newly visible
+                // pick already in the adapter. Restore only missing stored ids
+                // instead of skipping the whole draft when anything is visible.
+                const visibleIds = new Set(attachmentsRef.current.map((item) => item.id))
+                const filesToRestore = files.filter((file) => {
+                    const id = getRestoredUploadMetadata(file)?.id
+                    return !id || !visibleIds.has(id)
+                })
                 // Text is already known to be restored; attachment presence by
                 // itself is not. An upload can fail, so only successful adds
                 // contribute to restoredAny in the final completion update.
@@ -93,8 +101,8 @@ export function useComposerDraft(
                     }
                     : current)
                 let restoredAttachment = false
-                if (restoreAttachments) {
-                    for (const file of files) {
+                if (filesToRestore.length > 0) {
+                    for (const file of filesToRestore) {
                         if (disposed) break
                         try {
                             await addAttachment(file)

--- a/web/src/lib/attachmentAdapter.test.ts
+++ b/web/src/lib/attachmentAdapter.test.ts
@@ -151,4 +151,44 @@ describe('attachmentAdapter image previews', () => {
         expect(uploadFile).not.toHaveBeenCalled()
 
     })
+
+    it('skips handoff when the attachment is removed during resume', async () => {
+        const { createAttachmentAdapter } = await import('./attachmentAdapter')
+        const file = new File(['image'], 'ready.png', { type: 'image/png' })
+        const uploadFile = vi.fn().mockResolvedValue({ success: true, path: '/uploads/ready.png' })
+        let releaseResolve!: (sessionId: string) => void
+        let markResolveStarted!: () => void
+        const resolveSessionReady = new Promise<void>((resolve) => {
+            markResolveStarted = resolve
+        })
+        const resolveSessionId = vi.fn().mockImplementation(() => {
+            markResolveStarted()
+            return new Promise<string>((resolve) => {
+                releaseResolve = resolve
+            })
+        })
+        const onSessionResolved = vi.fn().mockResolvedValue(undefined)
+        const adapter = createAttachmentAdapter(
+            { uploadFile } as never,
+            'session-inactive',
+            resolveSessionId,
+            onSessionResolved,
+        )
+
+        const additions = adapter.add({ file }) as AsyncIterable<Record<string, unknown>>
+        const iterator = additions[Symbol.asyncIterator]()
+        const first = await iterator.next()
+        const pendingId = first.value?.id as string
+        expect(pendingId).toBeTruthy()
+
+        const remainder = iterator.next()
+        await resolveSessionReady
+        await adapter.remove({ id: pendingId } as never)
+        releaseResolve('session-resumed')
+        await remainder
+
+        expect(resolveSessionId).toHaveBeenCalledOnce()
+        expect(onSessionResolved).not.toHaveBeenCalled()
+        expect(uploadFile).not.toHaveBeenCalled()
+    })
 })

--- a/web/src/lib/attachmentAdapter.test.ts
+++ b/web/src/lib/attachmentAdapter.test.ts
@@ -200,4 +200,54 @@ describe('attachmentAdapter image previews', () => {
         expect(handoff.isCancelled()).toBe(true)
         expect(uploadFile).not.toHaveBeenCalled()
     })
+
+    it('shares one resume promise across staggered inactive attachment generators', async () => {
+        const { createAttachmentAdapter } = await import('./attachmentAdapter')
+        const file1 = new File(['one'], 'one.txt', { type: 'text/plain' })
+        const file2 = new File(['two'], 'two.txt', { type: 'text/plain' })
+        const uploadFile = vi.fn()
+        let resolveResume!: (sessionId: string) => void
+        let resumeCalls = 0
+        let uploadResolution: Promise<string> | undefined
+        const resolveSessionId = vi.fn(() => {
+            resumeCalls += 1
+            return new Promise<string>((resolve) => {
+                resolveResume = resolve
+            })
+        })
+        const resolveUploadSession = () => {
+            uploadResolution ??= resolveSessionId().catch((error) => {
+                uploadResolution = undefined
+                throw error
+            })
+            return uploadResolution
+        }
+        const onSessionResolved = vi.fn().mockResolvedValue(undefined)
+        const adapter = createAttachmentAdapter(
+            { uploadFile } as never,
+            'session-inactive',
+            resolveUploadSession,
+            onSessionResolved,
+        )
+
+        const first = (async () => {
+            for await (const _ of adapter.add({ file: file1 }) as AsyncIterable<unknown>) {
+                // consume
+            }
+        })()
+        const second = (async () => {
+            for await (const _ of adapter.add({ file: file2 }) as AsyncIterable<unknown>) {
+                // consume
+            }
+        })()
+
+        await vi.waitFor(() => {
+            expect(resumeCalls).toBe(1)
+        })
+        resolveResume('session-resumed')
+        await Promise.all([first, second])
+        expect(resumeCalls).toBe(1)
+        expect(onSessionResolved).toHaveBeenCalled()
+        expect(uploadFile).not.toHaveBeenCalled()
+    })
 })

--- a/web/src/lib/attachmentAdapter.test.ts
+++ b/web/src/lib/attachmentAdapter.test.ts
@@ -144,7 +144,10 @@ describe('attachmentAdapter image previews', () => {
         }
 
         expect(resolveSessionId).toHaveBeenCalledOnce()
-        expect(onSessionResolved).toHaveBeenCalledWith('session-resumed')
+        expect(onSessionResolved).toHaveBeenCalledWith('session-resumed', expect.objectContaining({
+            id: expect.any(String),
+            file,
+        }))
         expect(uploadFile).not.toHaveBeenCalled()
 
     })

--- a/web/src/lib/attachmentAdapter.test.ts
+++ b/web/src/lib/attachmentAdapter.test.ts
@@ -124,4 +124,28 @@ describe('attachmentAdapter image previews', () => {
         expect(emitted).toHaveLength(3)
         expect(emitted.every((attachment) => attachment.previewUrl === undefined)).toBe(true)
     })
+
+    it('hands an inactive attachment to the resumed session before uploading', async () => {
+        const { createAttachmentAdapter } = await import('./attachmentAdapter')
+        const file = new File(['image'], 'ready.png', { type: 'image/png' })
+        const uploadFile = vi.fn().mockResolvedValue({ success: true, path: '/uploads/ready.png' })
+        const resolveSessionId = vi.fn().mockResolvedValue('session-resumed')
+        const onSessionResolved = vi.fn().mockResolvedValue(undefined)
+        const adapter = createAttachmentAdapter(
+            { uploadFile } as never,
+            'session-inactive',
+            resolveSessionId,
+            onSessionResolved,
+        )
+
+        const additions = adapter.add({ file }) as AsyncIterable<unknown>
+        for await (const _attachment of additions) {
+            // Consume the upload lifecycle.
+        }
+
+        expect(resolveSessionId).toHaveBeenCalledOnce()
+        expect(onSessionResolved).toHaveBeenCalledWith('session-resumed')
+        expect(uploadFile).not.toHaveBeenCalled()
+
+    })
 })

--- a/web/src/lib/attachmentAdapter.test.ts
+++ b/web/src/lib/attachmentAdapter.test.ts
@@ -152,7 +152,7 @@ describe('attachmentAdapter image previews', () => {
 
     })
 
-    it('skips handoff when the attachment is removed during resume', async () => {
+    it('still hands off after resume when the attachment is cancelled mid-flight', async () => {
         const { createAttachmentAdapter } = await import('./attachmentAdapter')
         const file = new File(['image'], 'ready.png', { type: 'image/png' })
         const uploadFile = vi.fn().mockResolvedValue({ success: true, path: '/uploads/ready.png' })
@@ -188,7 +188,9 @@ describe('attachmentAdapter image previews', () => {
         await remainder
 
         expect(resolveSessionId).toHaveBeenCalledOnce()
-        expect(onSessionResolved).not.toHaveBeenCalled()
+        // Resume already merged the source session away — navigate without
+        // re-adding the cancelled file, and never upload it.
+        expect(onSessionResolved).toHaveBeenCalledWith('session-resumed', undefined)
         expect(uploadFile).not.toHaveBeenCalled()
     })
 })

--- a/web/src/lib/attachmentAdapter.test.ts
+++ b/web/src/lib/attachmentAdapter.test.ts
@@ -147,6 +147,7 @@ describe('attachmentAdapter image previews', () => {
         expect(onSessionResolved).toHaveBeenCalledWith('session-resumed', expect.objectContaining({
             id: expect.any(String),
             file,
+            isCancelled: expect.any(Function),
         }))
         expect(uploadFile).not.toHaveBeenCalled()
 
@@ -188,9 +189,15 @@ describe('attachmentAdapter image previews', () => {
         await remainder
 
         expect(resolveSessionId).toHaveBeenCalledOnce()
-        // Resume already merged the source session away — navigate without
-        // re-adding the cancelled file, and never upload it.
-        expect(onSessionResolved).toHaveBeenCalledWith('session-resumed', undefined)
+        // Resume already merged the source session away — hand off with a live
+        // cancellation predicate (never drop the id), and never upload.
+        expect(onSessionResolved).toHaveBeenCalledWith('session-resumed', expect.objectContaining({
+            id: pendingId,
+            file,
+            isCancelled: expect.any(Function),
+        }))
+        const handoff = onSessionResolved.mock.calls[0]?.[1] as { isCancelled: () => boolean }
+        expect(handoff.isCancelled()).toBe(true)
         expect(uploadFile).not.toHaveBeenCalled()
     })
 })

--- a/web/src/lib/attachmentAdapter.ts
+++ b/web/src/lib/attachmentAdapter.ts
@@ -98,6 +98,9 @@ export function createAttachmentAdapter(
                 }
 
                 const uploadSessionId = resolveSessionId ? await resolveSessionId() : sessionId
+                if (cancelledAttachmentIds.has(id)) {
+                    return
+                }
                 if (uploadSessionId !== sessionId && onSessionResolved) {
                     // Pass the in-flight file so handoff does not depend on a
                     // composer effect that may not have published yet.

--- a/web/src/lib/attachmentAdapter.ts
+++ b/web/src/lib/attachmentAdapter.ts
@@ -18,7 +18,9 @@ export function createAttachmentAdapter(
     api: ApiClient,
     sessionId: string,
     resolveSessionId?: () => Promise<string>,
-    onSessionResolved?: (sessionId: string, pending: AttachmentDraftInput) => Promise<void>,
+    // pending omitted when the operator cancelled after resume already merged
+    // into a new session id — caller must still navigate/transfer drafts.
+    onSessionResolved?: (sessionId: string, pending?: AttachmentDraftInput) => Promise<void>,
 ): AttachmentAdapter {
     const cancelledAttachmentIds = new Set<string>()
 
@@ -100,13 +102,18 @@ export function createAttachmentAdapter(
                 }
 
                 const uploadSessionId = resolveSessionId ? await resolveSessionId() : sessionId
-                if (cancelledAttachmentIds.has(id)) {
+                // Resume may already have merged the source session away. Even
+                // when this file was cancelled mid-resume, still hand off so
+                // the UI can leave the deleted source route (and keep drafts).
+                const cancelled = cancelledAttachmentIds.has(id)
+                if (uploadSessionId !== sessionId && onSessionResolved) {
+                    await onSessionResolved(
+                        uploadSessionId,
+                        cancelled ? undefined : { id, file, previewUrl },
+                    )
                     return
                 }
-                if (uploadSessionId !== sessionId && onSessionResolved) {
-                    // Pass the in-flight file so handoff does not depend on a
-                    // composer effect that may not have published yet.
-                    await onSessionResolved(uploadSessionId, { id, file, previewUrl })
+                if (cancelled) {
                     return
                 }
 

--- a/web/src/lib/attachmentAdapter.ts
+++ b/web/src/lib/attachmentAdapter.ts
@@ -38,7 +38,11 @@ export function createAttachmentAdapter(
         accept: '*',
 
         async *add({ file }): AsyncGenerator<PendingAttachment> {
-            const restored = getRestoredUploadMetadata(file)
+            // Upload paths are scoped to the session that created them. An
+            // inactive composer may resume into a different session id, so its
+            // persisted file must follow the normal resolve/transfer flow and
+            // be uploaded again by the resumed composer.
+            const restored = resolveSessionId ? undefined : getRestoredUploadMetadata(file)
             if (restored) {
                 yield {
                     id: restored.id,

--- a/web/src/lib/attachmentAdapter.ts
+++ b/web/src/lib/attachmentAdapter.ts
@@ -3,7 +3,7 @@ import type { ApiClient } from '@/api/client'
 import type { AttachmentMetadata } from '@/types/api'
 import { isImageMimeType } from '@/lib/fileAttachments'
 import { randomId } from '@/lib/randomId'
-import { getRestoredUploadMetadata } from '@/lib/composer-attachment-drafts'
+import { getRestoredUploadMetadata, type AttachmentDraftInput } from '@/lib/composer-attachment-drafts'
 
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 const MAX_PREVIEW_BYTES = 5 * 1024 * 1024
@@ -18,7 +18,7 @@ export function createAttachmentAdapter(
     api: ApiClient,
     sessionId: string,
     resolveSessionId?: () => Promise<string>,
-    onSessionResolved?: (sessionId: string) => Promise<void>,
+    onSessionResolved?: (sessionId: string, pending: AttachmentDraftInput) => Promise<void>,
 ): AttachmentAdapter {
     const cancelledAttachmentIds = new Set<string>()
 
@@ -99,7 +99,9 @@ export function createAttachmentAdapter(
 
                 const uploadSessionId = resolveSessionId ? await resolveSessionId() : sessionId
                 if (uploadSessionId !== sessionId && onSessionResolved) {
-                    await onSessionResolved(uploadSessionId)
+                    // Pass the in-flight file so handoff does not depend on a
+                    // composer effect that may not have published yet.
+                    await onSessionResolved(uploadSessionId, { id, file, previewUrl })
                     return
                 }
 

--- a/web/src/lib/attachmentAdapter.ts
+++ b/web/src/lib/attachmentAdapter.ts
@@ -41,9 +41,11 @@ export function createAttachmentAdapter(
             // Upload paths are scoped to the session that created them. An
             // inactive composer may resume into a different session id, so its
             // persisted file must follow the normal resolve/transfer flow and
-            // be uploaded again by the resumed composer.
-            const restored = resolveSessionId ? undefined : getRestoredUploadMetadata(file)
-            if (restored) {
+            // be uploaded again by the resumed composer. Pathless restored
+            // metadata still supplies a stable id so draft merge cannot
+            // duplicate the same File across persistence passes.
+            const restored = getRestoredUploadMetadata(file)
+            if (!resolveSessionId && restored?.path) {
                 yield {
                     id: restored.id,
                     type: 'file',
@@ -58,7 +60,7 @@ export function createAttachmentAdapter(
                 return
             }
 
-            const id = randomId()
+            const id = restored?.id ?? randomId()
             const contentType = file.type || 'application/octet-stream'
 
             try {

--- a/web/src/lib/attachmentAdapter.ts
+++ b/web/src/lib/attachmentAdapter.ts
@@ -3,7 +3,8 @@ import type { ApiClient } from '@/api/client'
 import type { AttachmentMetadata } from '@/types/api'
 import { isImageMimeType } from '@/lib/fileAttachments'
 import { randomId } from '@/lib/randomId'
-import { getRestoredUploadMetadata, type AttachmentDraftInput } from '@/lib/composer-attachment-drafts'
+import { getRestoredUploadMetadata } from '@/lib/composer-attachment-drafts'
+import type { AttachmentDraftHandoff } from '@/lib/composer-draft-transfer'
 
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 const MAX_PREVIEW_BYTES = 5 * 1024 * 1024
@@ -18,9 +19,10 @@ export function createAttachmentAdapter(
     api: ApiClient,
     sessionId: string,
     resolveSessionId?: () => Promise<string>,
-    // pending omitted when the operator cancelled after resume already merged
-    // into a new session id — caller must still navigate/transfer drafts.
-    onSessionResolved?: (sessionId: string, pending?: AttachmentDraftInput) => Promise<void>,
+    // Always hand off after resume merges into a new session id — even when
+    // the pick is cancelled — so the caller can navigate off a deleted source.
+    // Cancellation is re-checked at transfer save time via isCancelled().
+    onSessionResolved?: (sessionId: string, pending: AttachmentDraftHandoff) => Promise<void>,
 ): AttachmentAdapter {
     const cancelledAttachmentIds = new Set<string>()
 
@@ -102,18 +104,19 @@ export function createAttachmentAdapter(
                 }
 
                 const uploadSessionId = resolveSessionId ? await resolveSessionId() : sessionId
-                // Resume may already have merged the source session away. Even
-                // when this file was cancelled mid-resume, still hand off so
-                // the UI can leave the deleted source route (and keep drafts).
-                const cancelled = cancelledAttachmentIds.has(id)
+                // Resume may already have merged the source session away. Always
+                // hand off with a live cancellation predicate so transfer can
+                // drop this id (even if already persisted on the source draft).
                 if (uploadSessionId !== sessionId && onSessionResolved) {
-                    await onSessionResolved(
-                        uploadSessionId,
-                        cancelled ? undefined : { id, file, previewUrl },
-                    )
+                    await onSessionResolved(uploadSessionId, {
+                        id,
+                        file,
+                        previewUrl,
+                        isCancelled: () => cancelledAttachmentIds.has(id),
+                    })
                     return
                 }
-                if (cancelled) {
+                if (cancelledAttachmentIds.has(id)) {
                     return
                 }
 

--- a/web/src/lib/attachmentAdapter.ts
+++ b/web/src/lib/attachmentAdapter.ts
@@ -11,15 +11,21 @@ const MAX_PREVIEW_BYTES = 5 * 1024 * 1024
 type PendingUploadAttachment = PendingAttachment & {
     path?: string
     previewUrl?: string
+    uploadSessionId?: string
 }
 
-export function createAttachmentAdapter(api: ApiClient, sessionId: string): AttachmentAdapter {
+export function createAttachmentAdapter(
+    api: ApiClient,
+    sessionId: string,
+    resolveSessionId?: () => Promise<string>,
+    onSessionResolved?: (sessionId: string) => Promise<void>,
+): AttachmentAdapter {
     const cancelledAttachmentIds = new Set<string>()
 
-    const deleteUpload = async (path?: string) => {
+    const deleteUpload = async (path?: string, uploadSessionId = sessionId) => {
         if (!path) return
         try {
-            await api.deleteUploadFile(sessionId, path)
+            await api.deleteUploadFile(uploadSessionId, path)
         } catch {
             // Best effort cleanup
         }
@@ -43,6 +49,7 @@ export function createAttachmentAdapter(api: ApiClient, sessionId: string): Atta
                     status: { type: 'requires-action', reason: 'composer-send' },
                     path: restored.path,
                     previewUrl: restored.previewUrl,
+                    uploadSessionId: restored.uploadSessionId,
                 } as PendingUploadAttachment
                 return
             }
@@ -86,9 +93,16 @@ export function createAttachmentAdapter(api: ApiClient, sessionId: string): Atta
                     return
                 }
 
+                const uploadSessionId = resolveSessionId ? await resolveSessionId() : sessionId
+                if (uploadSessionId !== sessionId && onSessionResolved) {
+                    await onSessionResolved(uploadSessionId)
+                    return
+                }
+
                 const content = previewUrl
                     ? base64FromDataUrl(previewUrl)
                     : await fileToBase64(file)
+
                 if (cancelledAttachmentIds.has(id)) {
                     return
                 }
@@ -103,10 +117,10 @@ export function createAttachmentAdapter(api: ApiClient, sessionId: string): Atta
                     previewUrl
                 } as PendingUploadAttachment
 
-                const result = await api.uploadFile(sessionId, file.name, content, contentType)
+                const result = await api.uploadFile(uploadSessionId, file.name, content, contentType)
                 if (cancelledAttachmentIds.has(id)) {
                     if (result.success && result.path) {
-                        await deleteUpload(result.path)
+                        await deleteUpload(result.path, uploadSessionId)
                     }
                     return
                 }
@@ -131,8 +145,10 @@ export function createAttachmentAdapter(api: ApiClient, sessionId: string): Atta
                     file,
                     status: { type: 'requires-action', reason: 'composer-send' },
                     path: result.path,
-                    previewUrl
+                    previewUrl,
+                    uploadSessionId,
                 } as PendingUploadAttachment
+
             } catch {
                 yield {
                     id,
@@ -148,7 +164,8 @@ export function createAttachmentAdapter(api: ApiClient, sessionId: string): Atta
         async remove(attachment: Attachment): Promise<void> {
             cancelledAttachmentIds.add(attachment.id)
             const path = (attachment as PendingUploadAttachment).path
-            await deleteUpload(path)
+            const uploadSessionId = (attachment as PendingUploadAttachment).uploadSessionId
+            await deleteUpload(path, uploadSessionId)
         },
 
         async send(attachment: PendingAttachment): Promise<CompleteAttachment> {

--- a/web/src/lib/composer-attachment-drafts.test.ts
+++ b/web/src/lib/composer-attachment-drafts.test.ts
@@ -79,4 +79,22 @@ describe('composer-attachment-drafts', () => {
             previewUrl: 'data:image/png;base64,aW1hZ2U=',
         })
     })
+
+    it('retains stable ids for pathless pending files across persist passes', async () => {
+        const mod = await import('./composer-attachment-drafts')
+        const file = new File(['pending'], 'pending.txt')
+        mod.saveDraftAttachments('session-1', [{ id: 'pending-1', file }])
+
+        const [first] = await mod.getDraftAttachments('session-1')
+        expect(first && mod.getRestoredUploadMetadata(first)?.id).toBe('pending-1')
+
+        mod.saveDraftAttachments('session-1', [{
+            id: mod.getRestoredUploadMetadata(first!)!.id,
+            file: first!,
+        }])
+        const secondPass = await mod.getDraftAttachments('session-1')
+
+        expect(secondPass).toHaveLength(1)
+        expect(secondPass[0] && mod.getRestoredUploadMetadata(secondPass[0])?.id).toBe('pending-1')
+    })
 })

--- a/web/src/lib/composer-attachment-drafts.test.ts
+++ b/web/src/lib/composer-attachment-drafts.test.ts
@@ -187,6 +187,97 @@ describe('composer-attachment-drafts', () => {
         expect(await mod.getDraftAttachments('session-source')).toEqual([])
     })
 
+    it('does not prune an unrelated draft when moving at the retention cap', async () => {
+        const store = new Map<string, { sessionId: string; updatedAt: number; files: unknown[] }>()
+        const fakeDb = {
+            transaction(_name: string, _mode: string) {
+                let pendingCallbacks = 0
+                const finishLater = (cb: () => void) => {
+                    pendingCallbacks += 1
+                    queueMicrotask(() => {
+                        cb()
+                        pendingCallbacks -= 1
+                        if (pendingCallbacks === 0) transaction.oncomplete?.({})
+                    })
+                }
+                const objectStore = () => ({
+                    put: (record: { sessionId: string; updatedAt: number; files: unknown[] }) => {
+                        store.set(record.sessionId, record)
+                    },
+                    delete: (sessionId: string) => {
+                        store.delete(sessionId)
+                    },
+                    getAll: () => {
+                        const request: { onsuccess: ((ev: unknown) => void) | null; result?: unknown[] } = {
+                            onsuccess: null,
+                        }
+                        finishLater(() => {
+                            request.result = [...store.values()]
+                            request.onsuccess?.({})
+                        })
+                        return request
+                    },
+                })
+                const transaction = {
+                    objectStore,
+                    oncomplete: null as ((ev: unknown) => void) | null,
+                    onerror: null as ((ev: unknown) => void) | null,
+                    onabort: null as ((ev: unknown) => void) | null,
+                }
+                queueMicrotask(() => {
+                    if (pendingCallbacks === 0) transaction.oncomplete?.({})
+                })
+                return transaction
+            },
+            close() {},
+        }
+        vi.stubGlobal('indexedDB', {
+            open: () => {
+                const request: {
+                    result: typeof fakeDb
+                    onsuccess: ((ev: unknown) => void) | null
+                    onerror: ((ev: unknown) => void) | null
+                    onupgradeneeded: ((ev: unknown) => void) | null
+                } = {
+                    result: fakeDb,
+                    onsuccess: null,
+                    onerror: null,
+                    onupgradeneeded: null,
+                }
+                queueMicrotask(() => request.onsuccess?.({}))
+                return request
+            },
+        })
+        vi.resetModules()
+        const mod = await import('./composer-attachment-drafts')
+
+        // Fill the retention cap with 49 unrelated drafts + the source (50 total).
+        // Source is mid-range by updatedAt so it is not the oldest entry.
+        for (let i = 0; i < 49; i++) {
+            store.set(`keep-${i}`, {
+                sessionId: `keep-${i}`,
+                updatedAt: i + 1,
+                files: [],
+            })
+        }
+        const file = new File(['payload'], 'notes.txt')
+        mod.saveDraftAttachments('session-source', [{ id: 'a1', file }])
+        store.set('session-source', {
+            sessionId: 'session-source',
+            updatedAt: 25,
+            files: [{ id: 'a1', name: 'notes.txt', type: '', lastModified: 0, blob: file }],
+        })
+        expect(store.size).toBe(50)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+
+        await mod.moveDraftAttachments('session-source', 'session-target', () => [{ id: 'a1', file }])
+
+        expect(store.has('session-target')).toBe(true)
+        expect(store.has('session-source')).toBe(false)
+        expect(store.has('keep-0')).toBe(true)
+        expect(store.size).toBe(50)
+    })
+
     it('rolls cache back and throws when the IndexedDB move transaction fails', async () => {
         vi.stubGlobal('indexedDB', {
             open: () => {

--- a/web/src/lib/composer-attachment-drafts.test.ts
+++ b/web/src/lib/composer-attachment-drafts.test.ts
@@ -109,6 +109,33 @@ describe('composer-attachment-drafts', () => {
         expect(await mod.getDraftAttachments('session-source')).toEqual([])
     })
 
+    it('can surface IndexedDB read failures when throwOnError is set', async () => {
+        vi.stubGlobal('indexedDB', {
+            open: () => {
+                const request: {
+                    result: unknown
+                    onsuccess: ((ev: unknown) => void) | null
+                    onerror: ((ev: unknown) => void) | null
+                    onupgradeneeded: ((ev: unknown) => void) | null
+                    error: Error
+                } = {
+                    result: undefined,
+                    onsuccess: null,
+                    onerror: null,
+                    onupgradeneeded: null,
+                    error: new Error('open failed'),
+                }
+                queueMicrotask(() => request.onerror?.({}))
+                return request
+            },
+        })
+        vi.resetModules()
+        const mod = await import('./composer-attachment-drafts')
+
+        await expect(mod.getDraftAttachments('session-1')).resolves.toEqual([])
+        await expect(mod.getDraftAttachments('session-1', { throwOnError: true })).rejects.toThrow()
+    })
+
     it('commits a put+delete move when IndexedDB is available', async () => {
         const store = new Map<string, unknown>()
         const fakeDb = {

--- a/web/src/lib/composer-attachment-drafts.test.ts
+++ b/web/src/lib/composer-attachment-drafts.test.ts
@@ -340,4 +340,72 @@ describe('composer-attachment-drafts', () => {
         expect((await mod.getDraftAttachments('session-source')).map((item) => item.name)).toEqual(['notes.txt'])
         expect(await mod.getDraftAttachments('session-target')).toEqual([])
     })
+
+    it('propagates a rejected same-target queued write instead of treating it as durable', async () => {
+        let failNextWrite = false
+        vi.stubGlobal('indexedDB', {
+            open: () => {
+                const request: {
+                    result: {
+                        transaction: () => {
+                            objectStore: () => {
+                                put: (record: { sessionId: string }) => void
+                                delete: (sessionId: string) => void
+                                getAll: () => { onsuccess: null; result?: unknown[] }
+                            }
+                            oncomplete: ((ev: unknown) => void) | null
+                            onerror: ((ev: unknown) => void) | null
+                            onabort: null
+                            error: Error | null
+                        }
+                        close: () => void
+                    }
+                    onsuccess: ((ev: unknown) => void) | null
+                    onerror: ((ev: unknown) => void) | null
+                    onupgradeneeded: ((ev: unknown) => void) | null
+                } = {
+                    result: {
+                        transaction: () => {
+                            const transaction = {
+                                objectStore: () => ({
+                                    put: () => {},
+                                    delete: () => {},
+                                    getAll: () => ({ onsuccess: null, result: [] as unknown[] }),
+                                }),
+                                oncomplete: null as ((ev: unknown) => void) | null,
+                                onerror: null as ((ev: unknown) => void) | null,
+                                onabort: null,
+                                error: null as Error | null,
+                            }
+                            queueMicrotask(() => {
+                                if (failNextWrite) {
+                                    transaction.error = new Error('quota exceeded')
+                                    transaction.onerror?.({})
+                                    return
+                                }
+                                transaction.oncomplete?.({})
+                            })
+                            return transaction
+                        },
+                        close: () => {},
+                    },
+                    onsuccess: null,
+                    onerror: null,
+                    onupgradeneeded: null,
+                }
+                queueMicrotask(() => request.onsuccess?.({}))
+                return request
+            },
+        })
+        vi.resetModules()
+        const mod = await import('./composer-attachment-drafts')
+        const file = new File(['payload'], 'notes.txt')
+        failNextWrite = true
+
+        await expect(mod.moveDraftAttachments(
+            'session-target',
+            'session-target',
+            () => [{ id: 'a1', file }],
+        )).rejects.toThrow(/quota exceeded|Composer draft/)
+    })
 })

--- a/web/src/lib/composer-attachment-drafts.test.ts
+++ b/web/src/lib/composer-attachment-drafts.test.ts
@@ -97,4 +97,15 @@ describe('composer-attachment-drafts', () => {
         expect(secondPass).toHaveLength(1)
         expect(secondPass[0] && mod.getRestoredUploadMetadata(secondPass[0])?.id).toBe('pending-1')
     })
+
+    it('moves attachments to the target and tombstones the source in cache', async () => {
+        const mod = await import('./composer-attachment-drafts')
+        const file = new File(['payload'], 'notes.txt')
+        mod.saveDraftAttachments('session-source', [{ id: 'a1', file }])
+
+        await mod.moveDraftAttachments('session-source', 'session-target', [{ id: 'a1', file }])
+
+        expect((await mod.getDraftAttachments('session-target')).map((item) => item.name)).toEqual(['notes.txt'])
+        expect(await mod.getDraftAttachments('session-source')).toEqual([])
+    })
 })

--- a/web/src/lib/composer-attachment-drafts.test.ts
+++ b/web/src/lib/composer-attachment-drafts.test.ts
@@ -103,9 +103,150 @@ describe('composer-attachment-drafts', () => {
         const file = new File(['payload'], 'notes.txt')
         mod.saveDraftAttachments('session-source', [{ id: 'a1', file }])
 
-        await mod.moveDraftAttachments('session-source', 'session-target', [{ id: 'a1', file }])
+        await mod.moveDraftAttachments('session-source', 'session-target', () => [{ id: 'a1', file }])
 
         expect((await mod.getDraftAttachments('session-target')).map((item) => item.name)).toEqual(['notes.txt'])
         expect(await mod.getDraftAttachments('session-source')).toEqual([])
+    })
+
+    it('commits a put+delete move when IndexedDB is available', async () => {
+        const store = new Map<string, unknown>()
+        const fakeDb = {
+            transaction(_name: string, _mode: string) {
+                let pendingCallbacks = 0
+                const finishLater = (cb: () => void) => {
+                    pendingCallbacks += 1
+                    queueMicrotask(() => {
+                        cb()
+                        pendingCallbacks -= 1
+                        if (pendingCallbacks === 0) {
+                            transaction.oncomplete?.({})
+                        }
+                    })
+                }
+                const objectStore = () => ({
+                    put: (record: { sessionId: string }) => {
+                        store.set(record.sessionId, record)
+                    },
+                    delete: (sessionId: string) => {
+                        store.delete(sessionId)
+                    },
+                    getAll: () => {
+                        const request: { onsuccess: ((ev: unknown) => void) | null; result?: unknown[] } = {
+                            onsuccess: null,
+                        }
+                        finishLater(() => {
+                            request.result = [...store.values()]
+                            request.onsuccess?.({})
+                        })
+                        return request
+                    },
+                })
+                const transaction = {
+                    objectStore,
+                    oncomplete: null as ((ev: unknown) => void) | null,
+                    onerror: null as ((ev: unknown) => void) | null,
+                    onabort: null as ((ev: unknown) => void) | null,
+                }
+                // If no async requests were scheduled, complete on next tick.
+                queueMicrotask(() => {
+                    if (pendingCallbacks === 0) transaction.oncomplete?.({})
+                })
+                return transaction
+            },
+            close() {},
+        }
+        vi.stubGlobal('indexedDB', {
+            open: () => {
+                const request: {
+                    result: typeof fakeDb
+                    onsuccess: ((ev: unknown) => void) | null
+                    onerror: ((ev: unknown) => void) | null
+                    onupgradeneeded: ((ev: unknown) => void) | null
+                } = {
+                    result: fakeDb,
+                    onsuccess: null,
+                    onerror: null,
+                    onupgradeneeded: null,
+                }
+                queueMicrotask(() => request.onsuccess?.({}))
+                return request
+            },
+        })
+        vi.resetModules()
+        const mod = await import('./composer-attachment-drafts')
+        const file = new File(['payload'], 'notes.txt')
+        mod.saveDraftAttachments('session-source', [{ id: 'a1', file }])
+        await new Promise((resolve) => setTimeout(resolve, 0))
+
+        await mod.moveDraftAttachments('session-source', 'session-target', () => [{ id: 'a1', file }])
+
+        expect(store.has('session-target')).toBe(true)
+        expect(store.has('session-source')).toBe(false)
+        expect((await mod.getDraftAttachments('session-target')).map((item) => item.name)).toEqual(['notes.txt'])
+        expect(await mod.getDraftAttachments('session-source')).toEqual([])
+    })
+
+    it('rolls cache back and throws when the IndexedDB move transaction fails', async () => {
+        vi.stubGlobal('indexedDB', {
+            open: () => {
+                const request: {
+                    result: {
+                        transaction: () => {
+                            objectStore: () => {
+                                put: () => void
+                                delete: () => void
+                                getAll: () => { onsuccess: null }
+                            }
+                            oncomplete: null
+                            onerror: ((ev: unknown) => void) | null
+                            onabort: null
+                            error: Error
+                        }
+                        close: () => void
+                    }
+                    onsuccess: ((ev: unknown) => void) | null
+                    onerror: ((ev: unknown) => void) | null
+                    onupgradeneeded: ((ev: unknown) => void) | null
+                } = {
+                    result: {
+                        transaction: () => {
+                            const transaction = {
+                                objectStore: () => ({
+                                    put: () => {},
+                                    delete: () => {},
+                                    getAll: () => ({ onsuccess: null }),
+                                }),
+                                oncomplete: null,
+                                onerror: null as ((ev: unknown) => void) | null,
+                                onabort: null,
+                                error: new Error('quota exceeded'),
+                            }
+                            queueMicrotask(() => transaction.onerror?.({}))
+                            return transaction
+                        },
+                        close: () => {},
+                    },
+                    onsuccess: null,
+                    onerror: null,
+                    onupgradeneeded: null,
+                }
+                queueMicrotask(() => request.onsuccess?.({}))
+                return request
+            },
+        })
+        vi.resetModules()
+        const mod = await import('./composer-attachment-drafts')
+        const file = new File(['payload'], 'notes.txt')
+        mod.saveDraftAttachments('session-source', [{ id: 'a1', file }])
+
+        await expect(mod.moveDraftAttachments(
+            'session-source',
+            'session-target',
+            () => [{ id: 'a1', file }],
+        )).rejects.toThrow(/quota exceeded|Composer draft move failed/)
+
+        expect((await mod.getDraftAttachments('session-source')).map((item) => item.name)).toEqual(['notes.txt'])
+        expect(await mod.getDraftAttachments('session-target')).toEqual([])
     })
 })

--- a/web/src/lib/composer-attachment-drafts.ts
+++ b/web/src/lib/composer-attachment-drafts.ts
@@ -259,6 +259,9 @@ export async function moveDraftAttachments(
         await new Promise<void>((resolve, reject) => {
             const transaction = db.transaction(STORE, 'readwrite')
             const store = transaction.objectStore(STORE)
+            // Delete the source before put/prune so a full 50-draft store does not
+            // briefly look like 51 rows and evict an unrelated session.
+            store.delete(sourceSessionId)
             if (attachments.length === 0) {
                 store.delete(targetSessionId)
             } else {
@@ -272,11 +275,11 @@ export async function moveDraftAttachments(
                     const drafts = (allRequest.result as StoredAttachmentDraft[])
                         .sort((a, b) => b.updatedAt - a.updatedAt)
                     for (const stale of drafts.slice(MAX_DRAFTS)) {
+                        if (stale.sessionId === targetSessionId) continue
                         store.delete(stale.sessionId)
                     }
                 }
             }
-            store.delete(sourceSessionId)
             transaction.oncomplete = () => {
                 db.close()
                 resolve()

--- a/web/src/lib/composer-attachment-drafts.ts
+++ b/web/src/lib/composer-attachment-drafts.ts
@@ -158,7 +158,10 @@ function setCachedFiles(sessionId: string, files: File[]): void {
     }
 }
 
-export async function getDraftAttachments(sessionId: string): Promise<File[]> {
+export async function getDraftAttachments(
+    sessionId: string,
+    options: { throwOnError?: boolean } = {},
+): Promise<File[]> {
     const cached = cache.get(sessionId)
     if (cached) return cached.map(copyFile)
 
@@ -179,7 +182,8 @@ export async function getDraftAttachments(sessionId: string): Promise<File[]> {
         const files = record?.files.map(toFile) ?? []
         if (files.length > 0) setCachedFiles(sessionId, files)
         return files
-    } catch {
+    } catch (error) {
+        if (options.throwOnError) throw error
         return []
     }
 }

--- a/web/src/lib/composer-attachment-drafts.ts
+++ b/web/src/lib/composer-attachment-drafts.ts
@@ -136,6 +136,14 @@ function queueWrite(record: StoredAttachmentDraft | null, sessionId: string): vo
     })
 }
 
+async function awaitPendingWrites(...sessionIds: string[]): Promise<void> {
+    const unique = [...new Set(sessionIds)]
+    await Promise.all(unique.map(async (sessionId) => {
+        const pending = pendingWrites.get(sessionId)
+        if (pending) await pending.catch(() => {})
+    }))
+}
+
 function setCachedFiles(sessionId: string, files: File[]): void {
     cache.delete(sessionId)
     cache.set(sessionId, files)
@@ -189,6 +197,69 @@ export function saveDraftAttachments(sessionId: string, attachments: AttachmentD
         files: storedFiles,
         updatedAt: Date.now(),
     }, sessionId)
+}
+
+/**
+ * Atomically put the target draft and delete the source in one IndexedDB
+ * transaction (after draining any queued writes). Cache is updated first so
+ * a concurrent read cannot resurrect the source while the commit is in flight.
+ */
+export async function moveDraftAttachments(
+    sourceSessionId: string,
+    targetSessionId: string,
+    attachments: AttachmentDraftInput[],
+): Promise<void> {
+    if (sourceSessionId === targetSessionId) {
+        saveDraftAttachments(targetSessionId, attachments)
+        await awaitPendingWrites(targetSessionId)
+        return
+    }
+
+    await awaitPendingWrites(sourceSessionId, targetSessionId)
+
+    const storedFiles = attachments.map(toStoredFile)
+    const copies = storedFiles.map(toFile)
+    setCachedFiles(targetSessionId, copies)
+    // Tombstone the source immediately so unmount cleanup / remount cannot
+    // re-read and re-persist the obsolete session id.
+    setCachedFiles(sourceSessionId, [])
+
+    try {
+        const db = await openDb()
+        await new Promise<void>((resolve, reject) => {
+            const transaction = db.transaction(STORE, 'readwrite')
+            const store = transaction.objectStore(STORE)
+            if (attachments.length === 0) {
+                store.delete(targetSessionId)
+            } else {
+                store.put({
+                    sessionId: targetSessionId,
+                    files: storedFiles,
+                    updatedAt: Date.now(),
+                })
+                const allRequest = store.getAll()
+                allRequest.onsuccess = () => {
+                    const drafts = (allRequest.result as StoredAttachmentDraft[])
+                        .sort((a, b) => b.updatedAt - a.updatedAt)
+                    for (const stale of drafts.slice(MAX_DRAFTS)) {
+                        store.delete(stale.sessionId)
+                    }
+                }
+            }
+            store.delete(sourceSessionId)
+            transaction.oncomplete = () => {
+                db.close()
+                resolve()
+            }
+            transaction.onerror = () => {
+                db.close()
+                reject(transaction.error ?? new Error('Composer draft move failed'))
+            }
+            transaction.onabort = transaction.onerror
+        })
+    } catch {
+        // IndexedDB unavailable: cache tombstones still prevent source resurrection.
+    }
 }
 
 export function clearDraftAttachments(sessionId: string): void {

--- a/web/src/lib/composer-attachment-drafts.ts
+++ b/web/src/lib/composer-attachment-drafts.ts
@@ -34,7 +34,7 @@ export type AttachmentDraftInput = {
 
 export type RestoredUploadMetadata = {
     id: string
-    path: string
+    path?: string
     previewUrl?: string
     uploadSessionId?: string
 }
@@ -86,14 +86,14 @@ function toFile(file: StoredAttachment): File {
         type: file.type,
         lastModified: file.lastModified,
     })
-    if (file.path) {
-        restoredUploadMetadata.set(restored, {
-            id: file.id,
-            path: file.path,
-            previewUrl: file.previewUrl,
-            uploadSessionId: file.uploadSessionId,
-        })
-    }
+    // Always retain the stored id so pathless pending picks (failed resume)
+    // round-trip without inventing a synthetic id on the next persist pass.
+    restoredUploadMetadata.set(restored, {
+        id: file.id,
+        path: file.path,
+        previewUrl: file.previewUrl,
+        uploadSessionId: file.uploadSessionId,
+    })
     return restored
 }
 

--- a/web/src/lib/composer-attachment-drafts.ts
+++ b/web/src/lib/composer-attachment-drafts.ts
@@ -11,6 +11,7 @@ type StoredAttachment = {
     blob: Blob
     path?: string
     previewUrl?: string
+    uploadSessionId?: string
 }
 
 type StoredAttachmentDraft = {
@@ -28,12 +29,14 @@ export type AttachmentDraftInput = {
     file: File
     path?: string
     previewUrl?: string
+    uploadSessionId?: string
 }
 
 export type RestoredUploadMetadata = {
     id: string
     path: string
     previewUrl?: string
+    uploadSessionId?: string
 }
 
 function openDb(): Promise<IDBDatabase> {
@@ -74,6 +77,7 @@ function toStoredFile(attachment: AttachmentDraftInput): StoredAttachment {
         blob: file,
         path: attachment.path,
         previewUrl: attachment.previewUrl,
+        uploadSessionId: attachment.uploadSessionId,
     }
 }
 
@@ -87,6 +91,7 @@ function toFile(file: StoredAttachment): File {
             id: file.id,
             path: file.path,
             previewUrl: file.previewUrl,
+            uploadSessionId: file.uploadSessionId,
         })
     }
     return restored

--- a/web/src/lib/composer-attachment-drafts.ts
+++ b/web/src/lib/composer-attachment-drafts.ts
@@ -201,28 +201,58 @@ export function saveDraftAttachments(sessionId: string, attachments: AttachmentD
 
 /**
  * Atomically put the target draft and delete the source in one IndexedDB
- * transaction (after draining any queued writes). Cache is updated first so
- * a concurrent read cannot resurrect the source while the commit is in flight.
+ * transaction (after draining any queued writes). `resolveAttachments` runs
+ * only after that drain so a mid-wait remove() is still honored.
  */
 export async function moveDraftAttachments(
     sourceSessionId: string,
     targetSessionId: string,
-    attachments: AttachmentDraftInput[],
-): Promise<void> {
+    resolveAttachments: () => AttachmentDraftInput[],
+): Promise<AttachmentDraftInput[]> {
     if (sourceSessionId === targetSessionId) {
+        const attachments = resolveAttachments()
         saveDraftAttachments(targetSessionId, attachments)
         await awaitPendingWrites(targetSessionId)
-        return
+        return attachments
     }
 
     await awaitPendingWrites(sourceSessionId, targetSessionId)
 
+    // Re-sample after the drain — cancellation during awaitPendingWrites must win.
+    const attachments = resolveAttachments()
     const storedFiles = attachments.map(toStoredFile)
     const copies = storedFiles.map(toFile)
+
+    const previousSource = cache.has(sourceSessionId)
+        ? (cache.get(sourceSessionId) ?? []).map(copyFile)
+        : null
+    const previousTarget = cache.has(targetSessionId)
+        ? (cache.get(targetSessionId) ?? []).map(copyFile)
+        : null
+
     setCachedFiles(targetSessionId, copies)
     // Tombstone the source immediately so unmount cleanup / remount cannot
-    // re-read and re-persist the obsolete session id.
+    // re-read and re-persist the obsolete session id while the commit runs.
     setCachedFiles(sourceSessionId, [])
+
+    // Environments without IndexedDB (tests / SSR) stay memory-only, matching
+    // saveDraftAttachments. Real IDB open/transaction failures must not look durable.
+    if (typeof indexedDB === 'undefined') {
+        return attachments
+    }
+
+    const restoreCaches = () => {
+        if (previousSource === null) {
+            cache.delete(sourceSessionId)
+        } else {
+            setCachedFiles(sourceSessionId, previousSource)
+        }
+        if (previousTarget === null) {
+            cache.delete(targetSessionId)
+        } else {
+            setCachedFiles(targetSessionId, previousTarget)
+        }
+    }
 
     try {
         const db = await openDb()
@@ -257,8 +287,10 @@ export async function moveDraftAttachments(
             }
             transaction.onabort = transaction.onerror
         })
-    } catch {
-        // IndexedDB unavailable: cache tombstones still prevent source resurrection.
+        return attachments
+    } catch (error) {
+        restoreCaches()
+        throw error instanceof Error ? error : new Error('Composer draft move failed')
     }
 }
 

--- a/web/src/lib/composer-attachment-drafts.ts
+++ b/web/src/lib/composer-attachment-drafts.ts
@@ -98,6 +98,8 @@ function toFile(file: StoredAttachment): File {
 }
 
 async function writeDraft(record: StoredAttachmentDraft | null, sessionId: string): Promise<void> {
+    // No IndexedDB (tests / SSR): cache is already updated by the caller.
+    if (typeof indexedDB === 'undefined') return
     const db = await openDb()
     await new Promise<void>((resolve, reject) => {
         const transaction = db.transaction(STORE, 'readwrite')
@@ -140,7 +142,9 @@ async function awaitPendingWrites(...sessionIds: string[]): Promise<void> {
     const unique = [...new Set(sessionIds)]
     await Promise.all(unique.map(async (sessionId) => {
         const pending = pendingWrites.get(sessionId)
-        if (pending) await pending.catch(() => {})
+        // Propagate IndexedDB failures — same-target corrective writes must not
+        // look durable when the queued transaction rejected.
+        if (pending) await pending
     }))
 }
 

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -160,4 +160,17 @@ describe('handoffComposerDraft', () => {
         const savedAttachments = mocks.saveDraftAttachments.mock.calls.at(-1)?.[1] as Array<{ id: string }>
         expect(savedAttachments.map((item) => item.id).sort()).toEqual(['p1', 'p2'])
     })
+
+    it('appends a staggered file onto the target after the first handoff completes', async () => {
+        const file1 = new File(['one'], 'one.txt')
+        const file2 = new File(['two'], 'two.txt')
+        const onNavigable = vi.fn().mockResolvedValue(undefined)
+
+        await handoffComposerDraft('source-a', 'target-a', { id: 'p1', file: file1 }, onNavigable)
+        await handoffComposerDraft('source-a', 'target-a', { id: 'p2', file: file2 }, onNavigable)
+
+        expect(onNavigable).toHaveBeenCalledOnce()
+        const savedAttachments = mocks.saveDraftAttachments.mock.calls.at(-1)?.[1] as Array<{ id: string }>
+        expect(savedAttachments.map((item) => item.id).sort()).toEqual(['p1', 'p2'])
+    })
 })

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -84,6 +84,30 @@ describe('transferComposerDraft', () => {
         expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-empty', [])
     })
 
+    it('falls back to persisted attachments after an inactive empty live snapshot is cleared', async () => {
+        const file = new File(['kept'], 'kept.txt')
+        mocks.getDraft.mockReturnValue('typed while inactive')
+        mocks.getDraftAttachments.mockResolvedValue([file])
+        mocks.getRestoredUploadMetadata.mockReturnValue({
+            id: 'kept-1',
+            path: '/tmp/kept',
+            uploadSessionId: 'old-empty',
+        })
+        setComposerDraftSnapshot('old-empty', 'typed while inactive', [])
+        clearComposerDraftSnapshot('old-empty')
+
+        await transferComposerDraft('old-empty', 'new-empty')
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('new-empty', 'typed while inactive')
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-empty', [{
+            id: 'kept-1',
+            file,
+            path: undefined,
+            previewUrl: undefined,
+            uploadSessionId: undefined,
+        }])
+    })
+
     it('merges an in-flight pending attachment that is not in the live snapshot yet', async () => {
         const existing = new File(['old'], 'old.txt')
         const pending = new File(['new'], 'new.txt')

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -106,6 +106,34 @@ describe('transferComposerDraft', () => {
             },
         ])
     })
+
+    it('does not let a previously visited target snapshot replace the source draft', async () => {
+        const sourceFile = new File(['source'], 'source.txt')
+        const staleTargetFile = new File(['stale'], 'stale.txt')
+        mocks.getDraft.mockImplementation((sessionId: string) => (
+            sessionId === 'old-stored' ? 'source text' : 'stale target text'
+        ))
+        mocks.getDraftAttachments.mockImplementation(async (sessionId: string) => (
+            sessionId === 'old-stored' ? [sourceFile] : [staleTargetFile]
+        ))
+        mocks.getRestoredUploadMetadata.mockImplementation((file: File) => (
+            file === sourceFile
+                ? { id: 'source-1', path: '/tmp/source', uploadSessionId: 'old-stored' }
+                : { id: 'stale-1', path: '/tmp/stale', uploadSessionId: 'new-stored' }
+        ))
+        setComposerDraftSnapshot('new-stored', 'visited earlier', [{ id: 'stale-1', file: staleTargetFile }])
+
+        await transferComposerDraft('old-stored', 'new-stored')
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('new-stored', 'source text')
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-stored', [{
+            id: 'source-1',
+            file: sourceFile,
+            path: undefined,
+            previewUrl: undefined,
+            uploadSessionId: undefined,
+        }])
+    })
 })
 
 describe('handoffComposerDraft', () => {

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -379,6 +379,31 @@ describe('handoffComposerDraft', () => {
         ])
         expect(composerDraftWasHandedOff('source-a')).toBe(true)
     })
+
+    it('re-samples composer text after the awaited attachment move', async () => {
+        const file = new File(['draft'], 'draft.txt')
+        setComposerDraftSnapshot('source-a', 'before wait', [{ id: 'a1', file }])
+        let releaseDrain!: () => void
+        const drainGate = new Promise<void>((resolve) => {
+            releaseDrain = resolve
+        })
+        mocks.moveDraftAttachments.mockImplementation(async (
+            _source: string,
+            _target: string,
+            resolveAttachments: () => Array<{ id: string; file: File }>,
+        ) => {
+            await drainGate
+            return resolveAttachments()
+        })
+
+        const transfer = transferComposerDraft('source-a', 'target-a')
+        updateComposerDraftTextSnapshot('source-a', 'typed during wait')
+        releaseDrain()
+        await transfer
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('target-a', 'typed during wait')
+        expect(composerDraftWasHandedOff('source-a')).toBe(true)
+    })
 })
 
 describe('updateComposerDraftTextSnapshot', () => {

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -445,6 +445,19 @@ describe('handoffComposerDraft', () => {
         expect(composerDraftWasHandedOff('source-a')).toBe(true)
     })
 
+    it('does not move when the source IndexedDB attachment read fails', async () => {
+        clearComposerDraftSnapshot('source-a')
+        forgetComposerDraftHandoff('source-a')
+        mocks.getDraft.mockReturnValue('typed')
+        mocks.getDraftAttachments.mockRejectedValue(new Error('IndexedDB read failed'))
+
+        await expect(transferComposerDraft('source-a', 'target-a')).rejects.toThrow(/IndexedDB read failed/)
+
+        expect(mocks.moveDraftAttachments).not.toHaveBeenCalled()
+        expect(mocks.clearDraft).not.toHaveBeenCalled()
+        expect(composerDraftWasHandedOff('source-a')).toBe(false)
+    })
+
     it('still navigates when the local durable move rejects', async () => {
         const file = new File(['draft'], 'draft.txt')
         setComposerDraftSnapshot('source-a', 'typed', [{ id: 'a1', file }])

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    getDraft: vi.fn(),
+    saveDraft: vi.fn(),
+    getDraftAttachments: vi.fn(),
+    getRestoredUploadMetadata: vi.fn(),
+    saveDraftAttachments: vi.fn(),
+}))
+
+vi.mock('@/lib/composer-drafts', () => ({
+    getDraft: mocks.getDraft,
+    saveDraft: mocks.saveDraft,
+}))
+vi.mock('@/lib/composer-attachment-drafts', () => ({
+    getDraftAttachments: mocks.getDraftAttachments,
+    getRestoredUploadMetadata: mocks.getRestoredUploadMetadata,
+    saveDraftAttachments: mocks.saveDraftAttachments,
+}))
+
+import { setComposerDraftSnapshot, transferComposerDraft } from './composer-draft-transfer'
+
+describe('transferComposerDraft', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('prefers the live composer snapshot when reopening the visible session', async () => {
+        const file = new File(['draft'], 'draft.txt')
+        setComposerDraftSnapshot('old-live', 'latest text', [{ id: 'a1', file }])
+
+        await transferComposerDraft('old-live', 'new-live')
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('new-live', 'latest text')
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-live', [{ id: 'a1', file }])
+        expect(mocks.getDraftAttachments).not.toHaveBeenCalled()
+    })
+
+    it('copies persisted attachment upload metadata for a session-list reopen', async () => {
+        const file = new File(['draft'], 'draft.txt')
+        mocks.getDraft.mockReturnValue('persisted text')
+        mocks.getDraftAttachments.mockResolvedValue([file])
+        mocks.getRestoredUploadMetadata.mockReturnValue({
+            id: 'uploaded-1',
+            path: '/tmp/uploaded-1',
+            previewUrl: 'blob:preview',
+            uploadSessionId: 'old-stored',
+        })
+
+        await transferComposerDraft('old-stored', 'new-stored')
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('new-stored', 'persisted text')
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-stored', [{
+            id: 'uploaded-1',
+            file,
+            path: '/tmp/uploaded-1',
+            previewUrl: 'blob:preview',
+            uploadSessionId: 'old-stored',
+        }])
+    })
+
+    it('does not resurrect persisted text when the live composer is empty', async () => {
+        mocks.getDraft.mockReturnValue('stale persisted text')
+        setComposerDraftSnapshot('old-empty', '', [])
+
+        await transferComposerDraft('old-empty', 'new-empty')
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('new-empty', '')
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-empty', [])
+    })
+})

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -19,11 +19,13 @@ vi.mock('@/lib/composer-attachment-drafts', () => ({
 }))
 
 import {
+    attachmentDraftRevision,
     clearComposerDraftSnapshot,
     handoffComposerDraft,
     persistInactiveComposerAttachments,
     setComposerDraftSnapshot,
     transferComposerDraft,
+    updateComposerDraftTextSnapshot,
 } from './composer-draft-transfer'
 
 describe('transferComposerDraft', () => {
@@ -197,6 +199,121 @@ describe('handoffComposerDraft', () => {
         expect(onNavigable).toHaveBeenCalledOnce()
         const savedAttachments = mocks.saveDraftAttachments.mock.calls.at(-1)?.[1] as Array<{ id: string }>
         expect(savedAttachments.map((item) => item.id).sort()).toEqual(['p1', 'p2'])
+    })
+
+    it('keeps upload metadata when appending onto the same target session', async () => {
+        const uploaded = new File(['one'], 'one.txt')
+        const late = new File(['two'], 'two.txt')
+        const onNavigable = vi.fn().mockResolvedValue(undefined)
+
+        // First handoff establishes source→target mapping.
+        await handoffComposerDraft('source-a', 'target-a', { id: 'p1', file: uploaded }, onNavigable)
+        // Simulate the target composer having finished uploading p1.
+        setComposerDraftSnapshot('target-a', 'hello', [{
+            id: 'p1',
+            file: uploaded,
+            path: '/uploads/one.txt',
+            uploadSessionId: 'target-a',
+        }])
+        await handoffComposerDraft('source-a', 'target-a', { id: 'p2', file: late }, onNavigable)
+
+        const savedAttachments = mocks.saveDraftAttachments.mock.calls.at(-1)?.[1] as Array<{
+            id: string
+            path?: string
+            uploadSessionId?: string
+        }>
+        expect(savedAttachments).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: 'p1',
+                path: '/uploads/one.txt',
+                uploadSessionId: 'target-a',
+            }),
+            expect.objectContaining({ id: 'p2', file: late }),
+        ]))
+    })
+
+    it('drops a cancelled pending id from the source snapshot at save time', async () => {
+        const kept = new File(['kept'], 'kept.txt')
+        const cancelled = new File(['gone'], 'gone.txt')
+        setComposerDraftSnapshot('source-a', 'typed', [
+            { id: 'kept-1', file: kept },
+            { id: 'gone-1', file: cancelled },
+        ])
+        const onNavigable = vi.fn().mockResolvedValue(undefined)
+
+        await handoffComposerDraft(
+            'source-a',
+            'target-a',
+            {
+                id: 'gone-1',
+                file: cancelled,
+                isCancelled: () => true,
+            },
+            onNavigable,
+        )
+
+        expect(onNavigable).toHaveBeenCalledOnce()
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('target-a', [
+            expect.objectContaining({ id: 'kept-1', file: kept }),
+        ])
+    })
+
+    it('re-samples isCancelled after an async gap before writing the transfer', async () => {
+        const kept = new File(['kept'], 'kept.txt')
+        const cancelled = new File(['gone'], 'gone.txt')
+        setComposerDraftSnapshot('source-a', 'typed', [
+            { id: 'kept-1', file: kept },
+            { id: 'gone-1', file: cancelled },
+        ])
+        let cancelledNow = false
+        const onNavigable = vi.fn().mockResolvedValue(undefined)
+
+        const handoff = handoffComposerDraft(
+            'source-a',
+            'target-a',
+            {
+                id: 'gone-1',
+                file: cancelled,
+                isCancelled: () => cancelledNow,
+            },
+            onNavigable,
+        )
+        // Cancel after enqueue, before the handoff's setTimeout(0) transfer samples.
+        cancelledNow = true
+        await handoff
+
+        expect(onNavigable).toHaveBeenCalledOnce()
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('target-a', [
+            expect.objectContaining({ id: 'kept-1', file: kept }),
+        ])
+    })
+})
+
+describe('updateComposerDraftTextSnapshot', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        clearComposerDraftSnapshot('session-inactive')
+    })
+
+    it('updates text without writing attachment blobs', () => {
+        const file = new File(['blob'], 'big.bin')
+        setComposerDraftSnapshot('session-inactive', 'before', [{ id: 'a1', file }])
+
+        updateComposerDraftTextSnapshot('session-inactive', 'after keystroke')
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('session-inactive', 'after keystroke')
+        expect(mocks.saveDraftAttachments).not.toHaveBeenCalled()
+    })
+
+    it('keeps attachment revision stable across text-only changes', () => {
+        const file = new File(['blob'], 'big.bin')
+        const drafts = [{ id: 'a1', file, path: '/tmp/a', uploadSessionId: 's1' }]
+        expect(attachmentDraftRevision(drafts)).toBe(attachmentDraftRevision([
+            { id: 'a1', file: new File(['other'], 'other.bin'), path: '/tmp/a', uploadSessionId: 's1' },
+        ]))
+        expect(attachmentDraftRevision(drafts)).not.toBe(attachmentDraftRevision([
+            { id: 'a1', file, path: '/tmp/b', uploadSessionId: 's1' },
+        ]))
     })
 })
 

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -7,7 +7,11 @@ const mocks = vi.hoisted(() => ({
     getDraftAttachments: vi.fn(),
     getRestoredUploadMetadata: vi.fn(),
     saveDraftAttachments: vi.fn(),
-    moveDraftAttachments: vi.fn().mockResolvedValue(undefined),
+    moveDraftAttachments: vi.fn(async (
+        _source: string,
+        _target: string,
+        resolveAttachments: () => Array<{ id: string; file: File }>,
+    ) => resolveAttachments()),
 }))
 
 vi.mock('@/lib/composer-drafts', () => ({
@@ -39,10 +43,30 @@ function resetSession(sessionId: string): void {
     forgetComposerDraftHandoff(sessionId)
 }
 
+function expectMovedAttachments(
+    sourceSessionId: string,
+    targetSessionId: string,
+    expected: unknown,
+): void {
+    expect(mocks.moveDraftAttachments).toHaveBeenCalledWith(
+        sourceSessionId,
+        targetSessionId,
+        expect.any(Function),
+    )
+    const resolve = mocks.moveDraftAttachments.mock.calls.find(
+        (call) => call[0] === sourceSessionId && call[1] === targetSessionId,
+    )?.[2] as (() => unknown) | undefined
+    expect(resolve?.()).toEqual(expected)
+}
+
 describe('transferComposerDraft', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        mocks.moveDraftAttachments.mockResolvedValue(undefined)
+        mocks.moveDraftAttachments.mockImplementation(async (
+            _source: string,
+            _target: string,
+            resolveAttachments: () => Array<{ id: string; file: File }>,
+        ) => resolveAttachments())
         resetSession('old-live')
         resetSession('new-live')
         resetSession('old-stored')
@@ -62,7 +86,7 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-live', 'new-live')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-live', 'latest text')
-        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-live', 'new-live', [{ id: 'a1', file }])
+        expectMovedAttachments('old-live', 'new-live', [{ id: 'a1', file }])
         expect(mocks.clearDraft).toHaveBeenCalledWith('old-live')
         expect(mocks.saveDraftAttachments).not.toHaveBeenCalled()
         expect(mocks.getDraftAttachments).not.toHaveBeenCalled()
@@ -83,7 +107,7 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-stored', 'new-stored')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-stored', 'persisted text')
-        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-stored', 'new-stored', [{
+        expectMovedAttachments('old-stored', 'new-stored', [{
             id: 'uploaded-1',
             file,
             path: undefined,
@@ -100,7 +124,7 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-empty', 'new-empty')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-empty', '')
-        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-empty', 'new-empty', [])
+        expectMovedAttachments('old-empty', 'new-empty', [])
     })
 
     it('falls back to persisted attachments after an inactive empty live snapshot is cleared', async () => {
@@ -118,7 +142,7 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-empty', 'new-empty')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-empty', 'typed while inactive')
-        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-empty', 'new-empty', [{
+        expectMovedAttachments('old-empty', 'new-empty', [{
             id: 'kept-1',
             file,
             path: undefined,
@@ -138,7 +162,7 @@ describe('transferComposerDraft', () => {
             previewUrl: 'data:text/plain;base64,bmV3',
         }])
 
-        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-pending', 'new-pending', [
+        expectMovedAttachments('old-pending', 'new-pending', [
             { id: 'a1', file: existing },
             {
                 id: 'a2',
@@ -169,7 +193,7 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-stored', 'new-stored')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-stored', 'source text')
-        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-stored', 'new-stored', [{
+        expectMovedAttachments('old-stored', 'new-stored', [{
             id: 'source-1',
             file: sourceFile,
             path: undefined,
@@ -193,7 +217,11 @@ describe('transferComposerDraft', () => {
 describe('handoffComposerDraft', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        mocks.moveDraftAttachments.mockResolvedValue(undefined)
+        mocks.moveDraftAttachments.mockImplementation(async (
+            _source: string,
+            _target: string,
+            resolveAttachments: () => Array<{ id: string; file: File }>,
+        ) => resolveAttachments())
         resetSession('source-a')
         resetSession('target-a')
         mocks.getDraft.mockReturnValue('hello')
@@ -212,8 +240,8 @@ describe('handoffComposerDraft', () => {
 
         expect(onNavigable).toHaveBeenCalledOnce()
         expect(onNavigable).toHaveBeenCalledWith('target-a')
-        const moved = mocks.moveDraftAttachments.mock.calls.at(-1)?.[2] as Array<{ id: string }>
-        expect(moved.map((item) => item.id).sort()).toEqual(['p1', 'p2'])
+        const resolve = mocks.moveDraftAttachments.mock.calls.at(-1)?.[2] as (() => Array<{ id: string }>)
+        expect(resolve().map((item) => item.id).sort()).toEqual(['p1', 'p2'])
     })
 
     it('appends a staggered file onto the target after the first handoff completes', async () => {
@@ -281,7 +309,7 @@ describe('handoffComposerDraft', () => {
         )
 
         expect(onNavigable).toHaveBeenCalledOnce()
-        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('source-a', 'target-a', [
+        expectMovedAttachments('source-a', 'target-a', [
             expect.objectContaining({ id: 'kept-1', file: kept }),
         ])
     })
@@ -311,9 +339,45 @@ describe('handoffComposerDraft', () => {
         await handoff
 
         expect(onNavigable).toHaveBeenCalledOnce()
-        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('source-a', 'target-a', [
+        expectMovedAttachments('source-a', 'target-a', [
             expect.objectContaining({ id: 'kept-1', file: kept }),
         ])
+    })
+
+    it('re-samples cancellation after the mocked draft-write drain', async () => {
+        const kept = new File(['kept'], 'kept.txt')
+        const cancelled = new File(['gone'], 'gone.txt')
+        setComposerDraftSnapshot('source-a', 'typed', [
+            { id: 'kept-1', file: kept },
+            { id: 'gone-1', file: cancelled },
+        ])
+        let cancelledNow = false
+        let releaseDrain!: () => void
+        const drainGate = new Promise<void>((resolve) => {
+            releaseDrain = resolve
+        })
+        mocks.moveDraftAttachments.mockImplementation(async (
+            _source: string,
+            _target: string,
+            resolveAttachments: () => Array<{ id: string; file: File }>,
+        ) => {
+            await drainGate
+            return resolveAttachments()
+        })
+
+        const transfer = transferComposerDraft('source-a', 'target-a', [{
+            id: 'gone-1',
+            file: cancelled,
+            isCancelled: () => cancelledNow,
+        }])
+        cancelledNow = true
+        releaseDrain()
+        await transfer
+
+        expectMovedAttachments('source-a', 'target-a', [
+            expect.objectContaining({ id: 'kept-1', file: kept }),
+        ])
+        expect(composerDraftWasHandedOff('source-a')).toBe(true)
     })
 })
 
@@ -478,7 +542,7 @@ describe('persistInactiveComposerAttachments', () => {
         releaseRead()
         await Promise.all([persist, transfer])
 
-        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-pending', 'new-pending', expect.arrayContaining([
+        expectMovedAttachments('old-pending', 'new-pending', expect.arrayContaining([
             expect.objectContaining({ id: 'stored-a' }),
             expect.objectContaining({ id: 'picked-b' }),
         ]))

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -3,24 +3,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
     getDraft: vi.fn(),
     saveDraft: vi.fn(),
+    clearDraft: vi.fn(),
     getDraftAttachments: vi.fn(),
     getRestoredUploadMetadata: vi.fn(),
     saveDraftAttachments: vi.fn(),
+    moveDraftAttachments: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@/lib/composer-drafts', () => ({
     getDraft: mocks.getDraft,
     saveDraft: mocks.saveDraft,
+    clearDraft: mocks.clearDraft,
 }))
 vi.mock('@/lib/composer-attachment-drafts', () => ({
     getDraftAttachments: mocks.getDraftAttachments,
     getRestoredUploadMetadata: mocks.getRestoredUploadMetadata,
     saveDraftAttachments: mocks.saveDraftAttachments,
+    moveDraftAttachments: mocks.moveDraftAttachments,
 }))
 
 import {
     attachmentDraftRevision,
     clearComposerDraftSnapshot,
+    composerDraftWasHandedOff,
+    forgetComposerDraftHandoff,
     handoffComposerDraft,
     persistInactiveComposerAttachments,
     setComposerDraftSnapshot,
@@ -28,19 +34,25 @@ import {
     updateComposerDraftTextSnapshot,
 } from './composer-draft-transfer'
 
+function resetSession(sessionId: string): void {
+    clearComposerDraftSnapshot(sessionId)
+    forgetComposerDraftHandoff(sessionId)
+}
+
 describe('transferComposerDraft', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        clearComposerDraftSnapshot('old-live')
-        clearComposerDraftSnapshot('new-live')
-        clearComposerDraftSnapshot('old-stored')
-        clearComposerDraftSnapshot('new-stored')
-        clearComposerDraftSnapshot('old-empty')
-        clearComposerDraftSnapshot('new-empty')
-        clearComposerDraftSnapshot('old-pending')
-        clearComposerDraftSnapshot('new-pending')
-        clearComposerDraftSnapshot('source-a')
-        clearComposerDraftSnapshot('target-a')
+        mocks.moveDraftAttachments.mockResolvedValue(undefined)
+        resetSession('old-live')
+        resetSession('new-live')
+        resetSession('old-stored')
+        resetSession('new-stored')
+        resetSession('old-empty')
+        resetSession('new-empty')
+        resetSession('old-pending')
+        resetSession('new-pending')
+        resetSession('source-a')
+        resetSession('target-a')
     })
 
     it('prefers the live composer snapshot when reopening the visible session', async () => {
@@ -50,8 +62,11 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-live', 'new-live')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-live', 'latest text')
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-live', [{ id: 'a1', file }])
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-live', 'new-live', [{ id: 'a1', file }])
+        expect(mocks.clearDraft).toHaveBeenCalledWith('old-live')
+        expect(mocks.saveDraftAttachments).not.toHaveBeenCalled()
         expect(mocks.getDraftAttachments).not.toHaveBeenCalled()
+        expect(composerDraftWasHandedOff('old-live')).toBe(true)
     })
 
     it('drops session-scoped upload metadata for a session-list reopen', async () => {
@@ -68,13 +83,14 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-stored', 'new-stored')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-stored', 'persisted text')
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-stored', [{
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-stored', 'new-stored', [{
             id: 'uploaded-1',
             file,
             path: undefined,
             previewUrl: undefined,
             uploadSessionId: undefined,
         }])
+        expect(mocks.clearDraft).toHaveBeenCalledWith('old-stored')
     })
 
     it('does not resurrect persisted text when the live composer is empty', async () => {
@@ -84,7 +100,7 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-empty', 'new-empty')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-empty', '')
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-empty', [])
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-empty', 'new-empty', [])
     })
 
     it('falls back to persisted attachments after an inactive empty live snapshot is cleared', async () => {
@@ -102,7 +118,7 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-empty', 'new-empty')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-empty', 'typed while inactive')
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-empty', [{
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-empty', 'new-empty', [{
             id: 'kept-1',
             file,
             path: undefined,
@@ -122,7 +138,7 @@ describe('transferComposerDraft', () => {
             previewUrl: 'data:text/plain;base64,bmV3',
         }])
 
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-pending', [
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-pending', 'new-pending', [
             { id: 'a1', file: existing },
             {
                 id: 'a2',
@@ -153,7 +169,7 @@ describe('transferComposerDraft', () => {
         await transferComposerDraft('old-stored', 'new-stored')
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-stored', 'source text')
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-stored', [{
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-stored', 'new-stored', [{
             id: 'source-1',
             file: sourceFile,
             path: undefined,
@@ -161,13 +177,25 @@ describe('transferComposerDraft', () => {
             uploadSessionId: undefined,
         }])
     })
+
+    it('blocks source re-persist after a durable handoff', async () => {
+        const file = new File(['draft'], 'draft.txt')
+        setComposerDraftSnapshot('old-live', 'latest text', [{ id: 'a1', file }])
+
+        await transferComposerDraft('old-live', 'new-live')
+        await persistInactiveComposerAttachments('old-live', 'resurrect?', [{ id: 'a1', file }])
+
+        expect(composerDraftWasHandedOff('old-live')).toBe(true)
+        expect(mocks.saveDraftAttachments).not.toHaveBeenCalled()
+    })
 })
 
 describe('handoffComposerDraft', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        clearComposerDraftSnapshot('source-a')
-        clearComposerDraftSnapshot('target-a')
+        mocks.moveDraftAttachments.mockResolvedValue(undefined)
+        resetSession('source-a')
+        resetSession('target-a')
         mocks.getDraft.mockReturnValue('hello')
         mocks.getDraftAttachments.mockResolvedValue([])
     })
@@ -184,8 +212,8 @@ describe('handoffComposerDraft', () => {
 
         expect(onNavigable).toHaveBeenCalledOnce()
         expect(onNavigable).toHaveBeenCalledWith('target-a')
-        const savedAttachments = mocks.saveDraftAttachments.mock.calls.at(-1)?.[1] as Array<{ id: string }>
-        expect(savedAttachments.map((item) => item.id).sort()).toEqual(['p1', 'p2'])
+        const moved = mocks.moveDraftAttachments.mock.calls.at(-1)?.[2] as Array<{ id: string }>
+        expect(moved.map((item) => item.id).sort()).toEqual(['p1', 'p2'])
     })
 
     it('appends a staggered file onto the target after the first handoff completes', async () => {
@@ -253,7 +281,7 @@ describe('handoffComposerDraft', () => {
         )
 
         expect(onNavigable).toHaveBeenCalledOnce()
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('target-a', [
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('source-a', 'target-a', [
             expect.objectContaining({ id: 'kept-1', file: kept }),
         ])
     })
@@ -283,7 +311,7 @@ describe('handoffComposerDraft', () => {
         await handoff
 
         expect(onNavigable).toHaveBeenCalledOnce()
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('target-a', [
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('source-a', 'target-a', [
             expect.objectContaining({ id: 'kept-1', file: kept }),
         ])
     })
@@ -292,7 +320,7 @@ describe('handoffComposerDraft', () => {
 describe('updateComposerDraftTextSnapshot', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        clearComposerDraftSnapshot('session-inactive')
+        resetSession('session-inactive')
     })
 
     it('updates text without writing attachment blobs', () => {
@@ -320,7 +348,9 @@ describe('updateComposerDraftTextSnapshot', () => {
 describe('persistInactiveComposerAttachments', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        clearComposerDraftSnapshot('session-inactive')
+        resetSession('session-inactive')
+        resetSession('old-pending')
+        resetSession('new-pending')
     })
 
     it('clears the live snapshot without touching stored files when nothing is visible', async () => {
@@ -448,7 +478,7 @@ describe('persistInactiveComposerAttachments', () => {
         releaseRead()
         await Promise.all([persist, transfer])
 
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-pending', expect.arrayContaining([
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith('old-pending', 'new-pending', expect.arrayContaining([
             expect.objectContaining({ id: 'stored-a' }),
             expect.objectContaining({ id: 'picked-b' }),
         ]))

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -644,6 +644,38 @@ describe('persistInactiveComposerAttachments', () => {
         expect(mocks.clearDraft).toHaveBeenCalledWith('old-pending')
     })
 
+    it('does not mark a durable handoff when the corrective target write rejects', async () => {
+        const kept = new File(['kept'], 'kept.txt')
+        const removed = new File(['gone'], 'gone.txt')
+        setComposerDraftSnapshot('old-pending', 'typed', [
+            { id: 'kept-1', file: kept },
+            { id: 'gone-1', file: removed },
+        ])
+        let releaseMove!: () => void
+        const moveGate = new Promise<void>((resolve) => {
+            releaseMove = resolve
+        })
+        let correctiveCalls = 0
+        mocks.moveDraftAttachments.mockImplementation(async (source, target, resolveAttachments) => {
+            if (source === target) {
+                correctiveCalls += 1
+                throw new Error('quota exceeded')
+            }
+            await moveGate
+            return resolveAttachments()
+        })
+
+        const transfer = transferComposerDraft('old-pending', 'new-pending')
+        await Promise.resolve()
+        await persistInactiveComposerAttachments('old-pending', 'typed', [{ id: 'kept-1', file: kept }])
+        releaseMove()
+        await expect(transfer).rejects.toThrow(/quota exceeded/)
+
+        expect(correctiveCalls).toBe(1)
+        expect(composerDraftWasHandedOff('old-pending')).toBe(false)
+        expect(mocks.clearDraft).not.toHaveBeenCalledWith('old-pending')
+    })
+
     it('buffers a persist that races the first transfer await onto the target', async () => {
         const kept = new File(['kept'], 'kept.txt')
         const removed = new File(['gone'], 'gone.txt')

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -236,4 +236,104 @@ describe('persistInactiveComposerAttachments', () => {
             expect.objectContaining({ id: 'picked-b', file: picked }),
         ])
     })
+
+    it('removes a previously visible failed pick from storage when the operator clears it', async () => {
+        const storedA = new File(['a'], 'a.txt')
+        const pickedB = new File(['b'], 'b.txt')
+        mocks.getDraftAttachments
+            .mockResolvedValueOnce([storedA])
+            .mockResolvedValueOnce([storedA, pickedB])
+        mocks.getRestoredUploadMetadata.mockImplementation((file: File) => {
+            if (file === storedA) {
+                return { id: 'stored-a', path: '/tmp/a', uploadSessionId: 'session-inactive' }
+            }
+            if (file === pickedB) {
+                return { id: 'picked-b' }
+            }
+            return undefined
+        })
+
+        await persistInactiveComposerAttachments('session-inactive', 'typed', [{
+            id: 'picked-b',
+            file: pickedB,
+        }])
+        await persistInactiveComposerAttachments('session-inactive', 'typed', [])
+
+        expect(mocks.saveDraftAttachments).toHaveBeenLastCalledWith('session-inactive', [
+            expect.objectContaining({ id: 'stored-a', file: storedA }),
+        ])
+    })
+
+    it('serializes concurrent persist calls so an older read cannot overwrite a newer merge', async () => {
+        const storedA = new File(['a'], 'a.txt')
+        const pickedB = new File(['b'], 'b.txt')
+        const pickedC = new File(['c'], 'c.txt')
+        let releaseFirstRead!: () => void
+        const firstReadGate = new Promise<void>((resolve) => {
+            releaseFirstRead = resolve
+        })
+        let readCount = 0
+        mocks.getDraftAttachments.mockImplementation(async () => {
+            readCount += 1
+            if (readCount === 1) {
+                await firstReadGate
+                return [storedA]
+            }
+            return [storedA]
+        })
+        mocks.getRestoredUploadMetadata.mockReturnValue({
+            id: 'stored-a',
+            path: '/tmp/a',
+            uploadSessionId: 'session-inactive',
+        })
+
+        const first = persistInactiveComposerAttachments('session-inactive', 'first', [{
+            id: 'picked-b',
+            file: pickedB,
+        }])
+        const second = persistInactiveComposerAttachments('session-inactive', 'second', [{
+            id: 'picked-c',
+            file: pickedC,
+        }])
+        releaseFirstRead()
+        await Promise.all([first, second])
+
+        expect(mocks.saveDraftAttachments.mock.calls.at(-1)?.[1]).toEqual([
+            expect.objectContaining({ id: 'stored-a', file: storedA }),
+            expect.objectContaining({ id: 'picked-c', file: pickedC }),
+        ])
+    })
+
+    it('awaits a pending inactive persist before transferComposerDraft reads storage', async () => {
+        const storedA = new File(['a'], 'a.txt')
+        const pickedB = new File(['b'], 'b.txt')
+        let releaseRead!: () => void
+        const readGate = new Promise<void>((resolve) => {
+            releaseRead = resolve
+        })
+        mocks.getDraft.mockReturnValue('typed')
+        mocks.getDraftAttachments.mockImplementation(async () => {
+            await readGate
+            return [storedA]
+        })
+        mocks.getRestoredUploadMetadata.mockImplementation((file: File) => {
+            if (file === storedA) {
+                return { id: 'stored-a', path: '/tmp/a' }
+            }
+            return { id: 'picked-b' }
+        })
+
+        const persist = persistInactiveComposerAttachments('old-pending', 'typed', [{
+            id: 'picked-b',
+            file: pickedB,
+        }])
+        const transfer = transferComposerDraft('old-pending', 'new-pending')
+        releaseRead()
+        await Promise.all([persist, transfer])
+
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-pending', expect.arrayContaining([
+            expect.objectContaining({ id: 'stored-a' }),
+            expect.objectContaining({ id: 'picked-b' }),
+        ]))
+    })
 })

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -34,7 +34,7 @@ describe('transferComposerDraft', () => {
         expect(mocks.getDraftAttachments).not.toHaveBeenCalled()
     })
 
-    it('copies persisted attachment upload metadata for a session-list reopen', async () => {
+    it('drops session-scoped upload metadata for a session-list reopen', async () => {
         const file = new File(['draft'], 'draft.txt')
         mocks.getDraft.mockReturnValue('persisted text')
         mocks.getDraftAttachments.mockResolvedValue([file])
@@ -51,9 +51,9 @@ describe('transferComposerDraft', () => {
         expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-stored', [{
             id: 'uploaded-1',
             file,
-            path: '/tmp/uploaded-1',
-            previewUrl: 'blob:preview',
-            uploadSessionId: 'old-stored',
+            path: undefined,
+            previewUrl: undefined,
+            uploadSessionId: undefined,
         }])
     })
 

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -484,6 +484,53 @@ describe('handoffComposerDraft', () => {
         expect(composerDraftWasHandedOff('source-a')).toBe(true)
     })
 
+    it('stabilizes multi-file cancellation across the corrective write', async () => {
+        const fileA = new File(['a'], 'a.txt')
+        const fileB = new File(['b'], 'b.txt')
+        setComposerDraftSnapshot('source-a', 'typed', [])
+        let cancelA = false
+        let cancelB = false
+        let correctiveCalls = 0
+        let releaseCorrective!: () => void
+        const correctiveGate = new Promise<void>((resolve) => {
+            releaseCorrective = resolve
+        })
+        mocks.moveDraftAttachments.mockImplementation(async (
+            source: string,
+            target: string,
+            resolveAttachments: () => Array<{ id: string; file: File }>,
+        ) => {
+            if (source === target) {
+                correctiveCalls += 1
+                if (correctiveCalls === 1) {
+                    await correctiveGate
+                }
+                return resolveAttachments()
+            }
+            const resolved = resolveAttachments()
+            cancelA = true
+            return resolved
+        })
+
+        const transfer = transferComposerDraft('source-a', 'target-a', [
+            { id: 'a1', file: fileA, isCancelled: () => cancelA },
+            { id: 'b1', file: fileB, isCancelled: () => cancelB },
+        ])
+        await Promise.resolve()
+        await Promise.resolve()
+        // First corrective is blocked; cancel the sibling mid-write.
+        cancelB = true
+        releaseCorrective()
+        await transfer
+
+        expect(correctiveCalls).toBeGreaterThanOrEqual(2)
+        const lastCorrective = mocks.moveDraftAttachments.mock.calls
+            .filter((call) => call[0] === call[1])
+            .at(-1)?.[2] as (() => Array<{ id: string }>) | undefined
+        expect(lastCorrective?.().map((item) => item.id)).toEqual([])
+        expect(composerDraftWasHandedOff('source-a')).toBe(true)
+    })
+
     it('does not move when the source IndexedDB attachment read fails', async () => {
         clearComposerDraftSnapshot('source-a')
         forgetComposerDraftHandoff('source-a')

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -18,10 +18,27 @@ vi.mock('@/lib/composer-attachment-drafts', () => ({
     saveDraftAttachments: mocks.saveDraftAttachments,
 }))
 
-import { setComposerDraftSnapshot, transferComposerDraft } from './composer-draft-transfer'
+import {
+    clearComposerDraftSnapshot,
+    handoffComposerDraft,
+    setComposerDraftSnapshot,
+    transferComposerDraft,
+} from './composer-draft-transfer'
 
 describe('transferComposerDraft', () => {
-    beforeEach(() => vi.clearAllMocks())
+    beforeEach(() => {
+        vi.clearAllMocks()
+        clearComposerDraftSnapshot('old-live')
+        clearComposerDraftSnapshot('new-live')
+        clearComposerDraftSnapshot('old-stored')
+        clearComposerDraftSnapshot('new-stored')
+        clearComposerDraftSnapshot('old-empty')
+        clearComposerDraftSnapshot('new-empty')
+        clearComposerDraftSnapshot('old-pending')
+        clearComposerDraftSnapshot('new-pending')
+        clearComposerDraftSnapshot('source-a')
+        clearComposerDraftSnapshot('target-a')
+    })
 
     it('prefers the live composer snapshot when reopening the visible session', async () => {
         const file = new File(['draft'], 'draft.txt')
@@ -65,5 +82,54 @@ describe('transferComposerDraft', () => {
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('new-empty', '')
         expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-empty', [])
+    })
+
+    it('merges an in-flight pending attachment that is not in the live snapshot yet', async () => {
+        const existing = new File(['old'], 'old.txt')
+        const pending = new File(['new'], 'new.txt')
+        setComposerDraftSnapshot('old-pending', 'typed', [{ id: 'a1', file: existing }])
+
+        await transferComposerDraft('old-pending', 'new-pending', [{
+            id: 'a2',
+            file: pending,
+            previewUrl: 'data:text/plain;base64,bmV3',
+        }])
+
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-pending', [
+            { id: 'a1', file: existing },
+            {
+                id: 'a2',
+                file: pending,
+                previewUrl: 'data:text/plain;base64,bmV3',
+                path: undefined,
+                uploadSessionId: undefined,
+            },
+        ])
+    })
+})
+
+describe('handoffComposerDraft', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        clearComposerDraftSnapshot('source-a')
+        clearComposerDraftSnapshot('target-a')
+        mocks.getDraft.mockReturnValue('hello')
+        mocks.getDraftAttachments.mockResolvedValue([])
+    })
+
+    it('passes every concurrent in-flight file into one navigable handoff', async () => {
+        const file1 = new File(['one'], 'one.txt')
+        const file2 = new File(['two'], 'two.txt')
+        const onNavigable = vi.fn().mockResolvedValue(undefined)
+
+        const first = handoffComposerDraft('source-a', 'target-a', { id: 'p1', file: file1 }, onNavigable)
+        const second = handoffComposerDraft('source-a', 'target-a', { id: 'p2', file: file2 }, onNavigable)
+
+        await Promise.all([first, second])
+
+        expect(onNavigable).toHaveBeenCalledOnce()
+        expect(onNavigable).toHaveBeenCalledWith('target-a')
+        const savedAttachments = mocks.saveDraftAttachments.mock.calls.at(-1)?.[1] as Array<{ id: string }>
+        expect(savedAttachments.map((item) => item.id).sort()).toEqual(['p1', 'p2'])
     })
 })

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -407,6 +407,44 @@ describe('handoffComposerDraft', () => {
         expect(composerDraftWasHandedOff('source-a')).toBe(true)
     })
 
+    it('keeps IndexedDB-only attachments when typing during a blocked move', async () => {
+        const stored = new File(['kept'], 'kept.txt')
+        mocks.getDraft.mockReturnValue('before')
+        mocks.getDraftAttachments.mockResolvedValue([stored])
+        mocks.getRestoredUploadMetadata.mockReturnValue({ id: 'stored-1' })
+        let releaseDrain!: () => void
+        const drainGate = new Promise<void>((resolve) => {
+            releaseDrain = resolve
+        })
+        let movedDuringDrain: Array<{ id: string; file: File }> | undefined
+        mocks.moveDraftAttachments.mockImplementation(async (
+            source: string,
+            target: string,
+            resolveAttachments: () => Array<{ id: string; file: File }>,
+        ) => {
+            if (source === target) {
+                return resolveAttachments()
+            }
+            await drainGate
+            movedDuringDrain = resolveAttachments()
+            return movedDuringDrain
+        })
+
+        const transfer = transferComposerDraft('source-a', 'target-a')
+        // Let transfer install the barrier and enter the blocked move.
+        await Promise.resolve()
+        await Promise.resolve()
+        updateComposerDraftTextSnapshot('source-a', 'typed during wait')
+        releaseDrain()
+        await transfer
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('target-a', 'typed during wait')
+        expect(movedDuringDrain).toEqual([
+            expect.objectContaining({ id: 'stored-1', file: stored }),
+        ])
+        expect(composerDraftWasHandedOff('source-a')).toBe(true)
+    })
+
     it('still navigates when the local durable move rejects', async () => {
         const file = new File(['draft'], 'draft.txt')
         setComposerDraftSnapshot('source-a', 'typed', [{ id: 'a1', file }])

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -630,10 +630,76 @@ describe('persistInactiveComposerAttachments', () => {
         await transfer
 
         expect(mocks.saveDraftAttachments.mock.calls.filter((call) => call[0] === 'old-pending')).toEqual([])
-        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-pending', [
-            expect.objectContaining({ id: 'kept-1', file: kept }),
-        ])
+        // Late edit triggers an awaited same-target corrective move, not a fire-and-forget save.
+        expect(mocks.moveDraftAttachments).toHaveBeenCalledWith(
+            'new-pending',
+            'new-pending',
+            expect.any(Function),
+        )
+        const corrective = mocks.moveDraftAttachments.mock.calls.find(
+            (call) => call[0] === 'new-pending' && call[1] === 'new-pending',
+        )?.[2] as (() => Array<{ id: string }>) | undefined
+        expect(corrective?.().map((item) => item.id)).toEqual(['kept-1'])
         expect(composerDraftWasHandedOff('old-pending')).toBe(true)
         expect(mocks.clearDraft).toHaveBeenCalledWith('old-pending')
+    })
+
+    it('buffers a persist that races the first transfer await onto the target', async () => {
+        const kept = new File(['kept'], 'kept.txt')
+        const removed = new File(['gone'], 'gone.txt')
+        setComposerDraftSnapshot('old-pending', 'typed', [
+            { id: 'kept-1', file: kept },
+            { id: 'gone-1', file: removed },
+        ])
+        let releasePersistFlush!: () => void
+        const persistFlushGate = new Promise<void>((resolve) => {
+            releasePersistFlush = resolve
+        })
+        // Make awaitInactivePersist wait so the barrier is installed first.
+        mocks.getDraftAttachments.mockImplementation(async () => {
+            await persistFlushGate
+            return []
+        })
+        // Start a no-op queued persist so awaitInactivePersist has work.
+        const flushPersist = persistInactiveComposerAttachments('old-pending', 'typed', [
+            { id: 'kept-1', file: kept },
+            { id: 'gone-1', file: removed },
+        ])
+
+        const transfer = transferComposerDraft('old-pending', 'new-pending')
+        await Promise.resolve()
+        // Barrier is up; this edit must land on pending.latest, not IndexedDB source.
+        await persistInactiveComposerAttachments('old-pending', 'typed', [{ id: 'kept-1', file: kept }])
+        releasePersistFlush()
+        await flushPersist
+        await transfer
+
+        expect(mocks.saveDraftAttachments.mock.calls.filter((call) => call[0] === 'old-pending')).toEqual([])
+        expectMovedAttachments('old-pending', 'new-pending', [
+            expect.objectContaining({ id: 'kept-1', file: kept }),
+        ])
+    })
+
+    it('does not treat remounted empty visible state as removal of stored failed picks', async () => {
+        const { resetInactiveComposerAttachmentVisibility } = await import('./composer-draft-transfer')
+        const storedA = new File(['a'], 'a.txt')
+        const pickedB = new File(['b'], 'b.txt')
+        mocks.getDraftAttachments.mockResolvedValue([storedA, pickedB])
+        mocks.getRestoredUploadMetadata.mockImplementation((file: File) => {
+            if (file === storedA) return { id: 'stored-a' }
+            if (file === pickedB) return { id: 'picked-b' }
+            return undefined
+        })
+
+        await persistInactiveComposerAttachments('session-inactive', 'typed', [{
+            id: 'picked-b',
+            file: pickedB,
+        }])
+        // Remount inactive: visibility tracking resets before the empty hydrate persist.
+        resetInactiveComposerAttachmentVisibility('session-inactive')
+        mocks.saveDraftAttachments.mockClear()
+        await persistInactiveComposerAttachments('session-inactive', 'typed', [])
+
+        expect(mocks.saveDraftAttachments).not.toHaveBeenCalled()
     })
 })

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/lib/composer-attachment-drafts', () => ({
 import {
     clearComposerDraftSnapshot,
     handoffComposerDraft,
+    persistInactiveComposerAttachments,
     setComposerDraftSnapshot,
     transferComposerDraft,
 } from './composer-draft-transfer'
@@ -196,5 +197,43 @@ describe('handoffComposerDraft', () => {
         expect(onNavigable).toHaveBeenCalledOnce()
         const savedAttachments = mocks.saveDraftAttachments.mock.calls.at(-1)?.[1] as Array<{ id: string }>
         expect(savedAttachments.map((item) => item.id).sort()).toEqual(['p1', 'p2'])
+    })
+})
+
+describe('persistInactiveComposerAttachments', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        clearComposerDraftSnapshot('session-inactive')
+    })
+
+    it('clears the live snapshot without touching stored files when nothing is visible', async () => {
+        setComposerDraftSnapshot('session-inactive', 'stale', [])
+        mocks.getDraftAttachments.mockResolvedValue([new File(['kept'], 'kept.txt')])
+
+        await persistInactiveComposerAttachments('session-inactive', 'typed', [])
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('session-inactive', 'typed')
+        expect(mocks.saveDraftAttachments).not.toHaveBeenCalled()
+    })
+
+    it('merges a newly selected file into the hidden stored draft', async () => {
+        const stored = new File(['a'], 'a.txt')
+        const picked = new File(['b'], 'b.txt')
+        mocks.getDraftAttachments.mockResolvedValue([stored])
+        mocks.getRestoredUploadMetadata.mockReturnValue({
+            id: 'stored-a',
+            path: '/tmp/a',
+            uploadSessionId: 'session-inactive',
+        })
+
+        await persistInactiveComposerAttachments('session-inactive', 'typed', [{
+            id: 'picked-b',
+            file: picked,
+        }])
+
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('session-inactive', [
+            expect.objectContaining({ id: 'stored-a', file: stored }),
+            expect.objectContaining({ id: 'picked-b', file: picked }),
+        ])
     })
 })

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -407,6 +407,49 @@ describe('handoffComposerDraft', () => {
         expect(composerDraftWasHandedOff('source-a')).toBe(true)
     })
 
+    it('prefers the send-time textOverride over a cleared inactive draft', async () => {
+        const file = new File(['draft'], 'draft.txt')
+        setComposerDraftSnapshot('source-a', 'submitted hello', [{ id: 'a1', file }])
+        let releaseDrain!: () => void
+        const drainGate = new Promise<void>((resolve) => {
+            releaseDrain = resolve
+        })
+        mocks.moveDraftAttachments.mockImplementation(async (
+            _source: string,
+            _target: string,
+            resolveAttachments: () => Array<{ id: string; file: File }>,
+        ) => {
+            await drainGate
+            return resolveAttachments()
+        })
+
+        const transfer = transferComposerDraft(
+            'source-a',
+            'target-a',
+            [],
+            { textOverride: 'submitted hello' },
+        )
+        // assistant-ui cleared the composer while resumeSession awaited.
+        updateComposerDraftTextSnapshot('source-a', '')
+        releaseDrain()
+        await transfer
+
+        expect(mocks.saveDraft).toHaveBeenCalledWith('target-a', 'submitted hello')
+        expect(composerDraftWasHandedOff('source-a')).toBe(true)
+    })
+
+    it('applies textOverride on same-id resume when attachments stay put', async () => {
+        mocks.getDraft.mockReturnValue('')
+        await transferComposerDraft(
+            'session-same',
+            'session-same',
+            [],
+            { textOverride: 'submitted hello' },
+        )
+        expect(mocks.saveDraft).toHaveBeenCalledWith('session-same', 'submitted hello')
+        expect(mocks.moveDraftAttachments).not.toHaveBeenCalled()
+    })
+
     it('keeps IndexedDB-only attachments when typing during a blocked move', async () => {
         const stored = new File(['kept'], 'kept.txt')
         mocks.getDraft.mockReturnValue('before')

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -456,6 +456,23 @@ describe('handoffComposerDraft', () => {
         expect(mocks.moveDraftAttachments).not.toHaveBeenCalled()
         expect(mocks.clearDraft).not.toHaveBeenCalled()
         expect(composerDraftWasHandedOff('source-a')).toBe(false)
+        // Text is independently recoverable under the resumed id even when
+        // attachment storage fails closed.
+        expect(mocks.saveDraft).toHaveBeenCalledWith('target-a', 'typed')
+    })
+
+    it('still leaves target text after navigate when attachment read fails', async () => {
+        clearComposerDraftSnapshot('source-a')
+        forgetComposerDraftHandoff('source-a')
+        mocks.getDraft.mockReturnValue('typed')
+        mocks.getDraftAttachments.mockRejectedValue(new Error('IndexedDB read failed'))
+        const navigate = vi.fn().mockResolvedValue(undefined)
+
+        await transferComposerDraftThenNavigate('source-a', 'target-a', navigate)
+
+        expect(navigate).toHaveBeenCalledOnce()
+        expect(mocks.saveDraft).toHaveBeenCalledWith('target-a', 'typed')
+        expect(mocks.moveDraftAttachments).not.toHaveBeenCalled()
     })
 
     it('still navigates when the local durable move rejects', async () => {
@@ -535,6 +552,30 @@ describe('persistInactiveComposerAttachments', () => {
 
         expect(mocks.saveDraft).toHaveBeenCalledWith('session-inactive', 'typed')
         expect(mocks.saveDraftAttachments).not.toHaveBeenCalled()
+    })
+
+    it('does not publish a partial snapshot when the merge read fails', async () => {
+        const picked = new File(['b'], 'b.txt')
+        mocks.getDraftAttachments.mockImplementation(async (
+            _sessionId: string,
+            options?: { throwOnError?: boolean },
+        ) => {
+            if (options?.throwOnError) throw new Error('idb merge read failed')
+            return []
+        })
+
+        await expect(persistInactiveComposerAttachments('old-pending', 'typed', [
+            { id: 'b1', file: picked },
+        ])).rejects.toThrow(/idb merge read failed/)
+
+        expect(mocks.saveDraftAttachments).not.toHaveBeenCalled()
+        expect(mocks.getDraftAttachments).toHaveBeenCalledWith('old-pending', { throwOnError: true })
+
+        // Transfer must not see a live-only-B snapshot and skip the strict read.
+        mocks.getDraft.mockReturnValue('typed')
+        await expect(transferComposerDraft('old-pending', 'new-pending')).rejects.toThrow()
+        expect(mocks.moveDraftAttachments).not.toHaveBeenCalled()
+        expect(composerDraftWasHandedOff('old-pending')).toBe(false)
     })
 
     it('merges a newly selected file into the hidden stored draft', async () => {

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -445,6 +445,45 @@ describe('handoffComposerDraft', () => {
         expect(composerDraftWasHandedOff('source-a')).toBe(true)
     })
 
+    it('drops attachments cancelled while the durable move is in flight', async () => {
+        const kept = new File(['kept'], 'kept.txt')
+        const doomed = new File(['doomed'], 'doomed.txt')
+        setComposerDraftSnapshot('source-a', 'typed', [{ id: 'kept-1', file: kept }])
+        let cancelled = false
+        let releaseMove!: () => void
+        const moveGate = new Promise<void>((resolve) => {
+            releaseMove = resolve
+        })
+        mocks.moveDraftAttachments.mockImplementation(async (
+            source: string,
+            target: string,
+            resolveAttachments: () => Array<{ id: string; file: File }>,
+        ) => {
+            if (source === target) {
+                return resolveAttachments()
+            }
+            const resolved = resolveAttachments()
+            await moveGate
+            return resolved
+        })
+
+        const transfer = transferComposerDraft('source-a', 'target-a', [
+            { id: 'doomed-1', file: doomed, isCancelled: () => cancelled },
+        ])
+        await Promise.resolve()
+        await Promise.resolve()
+        cancelled = true
+        releaseMove()
+        await transfer
+
+        const correctiveResolvers = mocks.moveDraftAttachments.mock.calls
+            .filter((call) => call[0] === call[1])
+            .map((call) => call[2] as () => Array<{ id: string }>)
+        expect(correctiveResolvers.length).toBeGreaterThanOrEqual(1)
+        expect(correctiveResolvers.at(-1)?.().map((item) => item.id)).toEqual(['kept-1'])
+        expect(composerDraftWasHandedOff('source-a')).toBe(true)
+    })
+
     it('does not move when the source IndexedDB attachment read fails', async () => {
         clearComposerDraftSnapshot('source-a')
         forgetComposerDraftHandoff('source-a')

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -35,12 +35,22 @@ import {
     persistInactiveComposerAttachments,
     setComposerDraftSnapshot,
     transferComposerDraft,
+    transferComposerDraftThenNavigate,
     updateComposerDraftTextSnapshot,
 } from './composer-draft-transfer'
 
 function resetSession(sessionId: string): void {
     clearComposerDraftSnapshot(sessionId)
     forgetComposerDraftHandoff(sessionId)
+}
+
+function resetMoveDraftMock(): void {
+    mocks.moveDraftAttachments.mockReset()
+    mocks.moveDraftAttachments.mockImplementation(async (
+        _source: string,
+        _target: string,
+        resolveAttachments: () => Array<{ id: string; file: File }>,
+    ) => resolveAttachments())
 }
 
 function expectMovedAttachments(
@@ -62,11 +72,7 @@ function expectMovedAttachments(
 describe('transferComposerDraft', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        mocks.moveDraftAttachments.mockImplementation(async (
-            _source: string,
-            _target: string,
-            resolveAttachments: () => Array<{ id: string; file: File }>,
-        ) => resolveAttachments())
+        resetMoveDraftMock()
         resetSession('old-live')
         resetSession('new-live')
         resetSession('old-stored')
@@ -217,11 +223,7 @@ describe('transferComposerDraft', () => {
 describe('handoffComposerDraft', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        mocks.moveDraftAttachments.mockImplementation(async (
-            _source: string,
-            _target: string,
-            resolveAttachments: () => Array<{ id: string; file: File }>,
-        ) => resolveAttachments())
+        resetMoveDraftMock()
         resetSession('source-a')
         resetSession('target-a')
         mocks.getDraft.mockReturnValue('hello')
@@ -404,11 +406,42 @@ describe('handoffComposerDraft', () => {
         expect(mocks.saveDraft).toHaveBeenCalledWith('target-a', 'typed during wait')
         expect(composerDraftWasHandedOff('source-a')).toBe(true)
     })
+
+    it('still navigates when the local durable move rejects', async () => {
+        const file = new File(['draft'], 'draft.txt')
+        setComposerDraftSnapshot('source-a', 'typed', [{ id: 'a1', file }])
+        mocks.moveDraftAttachments.mockRejectedValue(new Error('quota exceeded'))
+        const onNavigable = vi.fn().mockResolvedValue(undefined)
+
+        await handoffComposerDraft(
+            'source-a',
+            'target-a',
+            { id: 'p1', file },
+            onNavigable,
+        )
+
+        expect(onNavigable).toHaveBeenCalledWith('target-a')
+        expect(composerDraftWasHandedOff('source-a')).toBe(false)
+        expect(mocks.saveDraft).toHaveBeenCalledWith('target-a', 'typed')
+    })
+
+    it('navigates after resume even when transferComposerDraftThenNavigate hits a move failure', async () => {
+        const file = new File(['draft'], 'draft.txt')
+        setComposerDraftSnapshot('source-a', 'typed', [{ id: 'a1', file }])
+        mocks.moveDraftAttachments.mockRejectedValue(new Error('quota exceeded'))
+        const navigate = vi.fn().mockResolvedValue(undefined)
+
+        await transferComposerDraftThenNavigate('source-a', 'target-a', navigate)
+
+        expect(navigate).toHaveBeenCalledOnce()
+        expect(composerDraftWasHandedOff('source-a')).toBe(false)
+    })
 })
 
 describe('updateComposerDraftTextSnapshot', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        resetMoveDraftMock()
         resetSession('session-inactive')
     })
 
@@ -437,6 +470,7 @@ describe('updateComposerDraftTextSnapshot', () => {
 describe('persistInactiveComposerAttachments', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        resetMoveDraftMock()
         resetSession('session-inactive')
         resetSession('old-pending')
         resetSession('new-pending')

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -606,4 +606,34 @@ describe('persistInactiveComposerAttachments', () => {
             expect.objectContaining({ id: 'picked-b' }),
         ]))
     })
+
+    it('routes attachment edits during an in-flight move to the target without recreating the source', async () => {
+        const kept = new File(['kept'], 'kept.txt')
+        const removed = new File(['gone'], 'gone.txt')
+        setComposerDraftSnapshot('old-pending', 'typed', [
+            { id: 'kept-1', file: kept },
+            { id: 'gone-1', file: removed },
+        ])
+        let releaseMove!: () => void
+        const moveGate = new Promise<void>((resolve) => {
+            releaseMove = resolve
+        })
+        mocks.moveDraftAttachments.mockImplementation(async (_source, _target, resolveAttachments) => {
+            await moveGate
+            return resolveAttachments()
+        })
+
+        const transfer = transferComposerDraft('old-pending', 'new-pending')
+        await Promise.resolve()
+        await persistInactiveComposerAttachments('old-pending', 'typed', [{ id: 'kept-1', file: kept }])
+        releaseMove()
+        await transfer
+
+        expect(mocks.saveDraftAttachments.mock.calls.filter((call) => call[0] === 'old-pending')).toEqual([])
+        expect(mocks.saveDraftAttachments).toHaveBeenCalledWith('new-pending', [
+            expect.objectContaining({ id: 'kept-1', file: kept }),
+        ])
+        expect(composerDraftWasHandedOff('old-pending')).toBe(true)
+        expect(mocks.clearDraft).toHaveBeenCalledWith('old-pending')
+    })
 })

--- a/web/src/lib/composer-draft-transfer.test.ts
+++ b/web/src/lib/composer-draft-transfer.test.ts
@@ -676,6 +676,38 @@ describe('persistInactiveComposerAttachments', () => {
         expect(mocks.clearDraft).not.toHaveBeenCalledWith('old-pending')
     })
 
+    it('repeats the corrective target write until late edits stabilize', async () => {
+        const kept = new File(['kept'], 'kept.txt')
+        setComposerDraftSnapshot('old-pending', 'before', [{ id: 'kept-1', file: kept }])
+        let releaseCorrective!: () => void
+        const correctiveGate = new Promise<void>((resolve) => {
+            releaseCorrective = resolve
+        })
+        let correctiveCalls = 0
+        mocks.moveDraftAttachments.mockImplementation(async (source, target, resolveAttachments) => {
+            if (source === target) {
+                correctiveCalls += 1
+                if (correctiveCalls === 1) {
+                    await correctiveGate
+                }
+                return resolveAttachments()
+            }
+            return resolveAttachments()
+        })
+
+        const transfer = transferComposerDraft('old-pending', 'new-pending')
+        await Promise.resolve()
+        await persistInactiveComposerAttachments('old-pending', 'mid', [{ id: 'kept-1', file: kept }])
+        // First corrective is blocked; a later text edit must force another pass.
+        updateComposerDraftTextSnapshot('old-pending', 'final typed')
+        releaseCorrective()
+        await transfer
+
+        expect(correctiveCalls).toBeGreaterThanOrEqual(2)
+        expect(mocks.saveDraft).toHaveBeenCalledWith('new-pending', 'final typed')
+        expect(composerDraftWasHandedOff('old-pending')).toBe(true)
+    })
+
     it('buffers a persist that races the first transfer await onto the target', async () => {
         const kept = new File(['kept'], 'kept.txt')
         const removed = new File(['gone'], 'gone.txt')

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -37,9 +37,20 @@ const inactivePersistQueue = new Map<string, Promise<AttachmentDraftInput[]>>()
 /** In-flight cross-session transfers: inactive persist must not recreate the source row. */
 type PendingTransfer = {
     targetSessionId: string
+    /** Attachment-aware revision recorded during the move (never invent empty from keystrokes). */
     latest?: { text: string; attachments: AttachmentDraftInput[] }
+    /** Text-only keystrokes while inactive (no live attachment snapshot). */
+    latestText?: string
 }
 const pendingTransfers = new Map<string, PendingTransfer>()
+
+function samplePendingTransferText(sessionId: string, fallback: string): string {
+    const pending = pendingTransfers.get(sessionId)
+    return pending?.latest?.text
+        ?? pending?.latestText
+        ?? liveSnapshots.get(sessionId)?.text
+        ?? fallback
+}
 
 export function setComposerDraftSnapshot(
     sessionId: string,
@@ -66,15 +77,13 @@ export function updateComposerDraftTextSnapshot(sessionId: string, text: string)
     if (existing) {
         liveSnapshots.set(sessionId, { ...existing, text })
     }
-    // Keep in-flight transfer latest text in sync with keystrokes during a move.
+    // Keep in-flight transfer text in sync without inventing attachments: [] —
+    // inactive composers withhold hidden stored files from liveSnapshots.
     const pending = pendingTransfers.get(sessionId)
-    if (pending?.latest) {
+    if (!pending) return
+    pending.latestText = text
+    if (pending.latest) {
         pending.latest = { ...pending.latest, text }
-    } else if (pending) {
-        pending.latest = {
-            text,
-            attachments: existing ? [...existing.attachments] : [],
-        }
     }
 }
 
@@ -230,13 +239,25 @@ export async function persistInactiveComposerAttachments(
     // never write IndexedDB under the retiring source id.
     const pending = pendingTransfers.get(sessionId)
     if (pending) {
+        pending.latestText = text
+        saveDraft(sessionId, text)
+        // Empty visible during transfer is common (hidden stored files). Do not
+        // invent pending.latest with attachments: [] — that would erase IDB.
+        if (visibleAttachments.length === 0) {
+            if (pending.latest) {
+                pending.latest = { ...pending.latest, text }
+                return [...pending.latest.attachments]
+            }
+            const existing = liveSnapshots.get(sessionId)
+            if (existing) {
+                liveSnapshots.set(sessionId, { ...existing, text })
+                return [...existing.attachments]
+            }
+            return []
+        }
         const attachments = [...visibleAttachments]
         pending.latest = { text, attachments }
-        saveDraft(sessionId, text)
-        const existing = liveSnapshots.get(sessionId)
-        if (existing || attachments.length > 0) {
-            liveSnapshots.set(sessionId, { text, attachments })
-        }
+        liveSnapshots.set(sessionId, { text, attachments })
         inactiveVisibleIds.set(sessionId, new Set(attachments.map((item) => item.id)))
         return attachments
     }
@@ -344,10 +365,13 @@ export async function transferComposerDraft(
                 // across the await — text/attachment edits during the write must
                 // not be retired with a stale revision.
                 for (;;) {
-                    const latest = pendingTransfers.get(sourceSessionId)?.latest
-                    transferredText = latest?.text
-                        ?? liveSnapshots.get(sourceSessionId)?.text
-                        ?? getDraft(sourceSessionId)
+                    const pendingState = pendingTransfers.get(sourceSessionId)
+                    const latest = pendingState?.latest
+                    const textMarker = pendingState?.latestText
+                    transferredText = samplePendingTransferText(
+                        sourceSessionId,
+                        getDraft(sourceSessionId),
+                    )
                     if (!latest) break
                     attachments = buildTransferredAttachments()
                     await moveDraftAttachments(
@@ -355,8 +379,13 @@ export async function transferComposerDraft(
                         targetSessionId,
                         () => attachments,
                     )
-                    if (pendingTransfers.get(sourceSessionId)?.latest === latest) break
+                    const after = pendingTransfers.get(sourceSessionId)
+                    if (after?.latest === latest && after?.latestText === textMarker) break
                 }
+                transferredText = samplePendingTransferText(
+                    sourceSessionId,
+                    getDraft(sourceSessionId),
+                )
                 saveDraft(targetSessionId, transferredText)
                 clearDraft(sourceSessionId)
                 completedHandoffs.set(sourceSessionId, targetSessionId)
@@ -366,10 +395,10 @@ export async function transferComposerDraft(
                 // Hub resume already succeeded; keep navigating. Copy text + in-memory
                 // attachments to the target without claiming a durable handoff so the
                 // source IndexedDB row remains if the operator reloads the old id.
-                const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
-                transferredText = pendingLatest?.text
-                    ?? liveSnapshots.get(sourceSessionId)?.text
-                    ?? getDraft(sourceSessionId)
+                transferredText = samplePendingTransferText(
+                    sourceSessionId,
+                    getDraft(sourceSessionId),
+                )
                 attachments = buildTransferredAttachments()
                 saveDraft(targetSessionId, transferredText)
                 saveDraftAttachments(targetSessionId, attachments)

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -381,11 +381,18 @@ export async function transferComposerDraft(
                 )
                 // Always rewrite the target at least once after the durable move so
                 // isCancelled flips during the IDB commit window still prune the file.
-                // Then repeat until pending.latest / latestText are stable across the await.
+                // Repeat until pending edits and the cancellation set are stable.
+                const cancellationRevision = () => JSON.stringify(
+                    pendingAttachments
+                        .filter((item) => item.isCancelled?.())
+                        .map((item) => item.id)
+                        .sort(),
+                )
                 for (;;) {
                     const pendingState = pendingTransfers.get(sourceSessionId)
                     const latest = pendingState?.latest
                     const textMarker = pendingState?.latestText
+                    const cancelMarker = cancellationRevision()
                     transferredText = samplePendingTransferText(
                         sourceSessionId,
                         getDraft(sourceSessionId),
@@ -397,7 +404,13 @@ export async function transferComposerDraft(
                         () => attachments,
                     )
                     const after = pendingTransfers.get(sourceSessionId)
-                    if (after?.latest === latest && after?.latestText === textMarker) break
+                    if (
+                        after?.latest === latest
+                        && after?.latestText === textMarker
+                        && cancellationRevision() === cancelMarker
+                    ) {
+                        break
+                    }
                 }
                 transferredText = samplePendingTransferText(
                     sourceSessionId,
@@ -513,15 +526,20 @@ export async function handoffComposerDraft(
         const batch = [...state.pending]
         try {
             await transferComposerDraft(sourceSessionId, targetSessionId, batch)
-            // Belt-and-suspenders: if remove() won during the move commit window,
-            // prune those ids from the target before navigation restores them.
-            const cancelledAfterMove = batch.filter((item) => item.isCancelled?.())
-            if (cancelledAfterMove.length > 0) {
-                await transferComposerDraft(
-                    targetSessionId,
-                    targetSessionId,
-                    cancelledAfterMove,
-                )
+            // Re-sample the full batch until cancellation is stable across the
+            // same-target rewrite (multi-file removes can land mid-await).
+            const cancellationRevision = () => JSON.stringify(
+                batch
+                    .filter((item) => item.isCancelled?.())
+                    .map((item) => item.id)
+                    .sort(),
+            )
+            let observedCancellationRevision = '[]'
+            for (;;) {
+                const nextCancellationRevision = cancellationRevision()
+                if (nextCancellationRevision === observedCancellationRevision) break
+                observedCancellationRevision = nextCancellationRevision
+                await transferComposerDraft(targetSessionId, targetSessionId, batch)
             }
         } catch (error) {
             console.warn('[composer-draft] handoff transfer failed; still navigating', error)

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -81,6 +81,29 @@ async function loadPersistedAttachments(sessionId: string): Promise<AttachmentDr
     })
 }
 
+/**
+ * Persist text for an inactive composer. When the user has visible pending
+ * attachments (e.g. resume failed after pick), merge them into IndexedDB
+ * instead of replacing the hidden stored list or discarding the new picks.
+ */
+export async function persistInactiveComposerAttachments(
+    sessionId: string,
+    text: string,
+    visibleAttachments: readonly AttachmentDraftInput[],
+): Promise<AttachmentDraftInput[]> {
+    saveDraft(sessionId, text)
+    if (visibleAttachments.length === 0) {
+        clearComposerDraftSnapshot(sessionId)
+        return []
+    }
+
+    const stored = await loadPersistedAttachments(sessionId)
+    const merged = mergeAttachmentsById(stored, visibleAttachments)
+    saveDraftAttachments(sessionId, merged)
+    setComposerDraftSnapshot(sessionId, text, merged)
+    return merged
+}
+
 /** Copy a draft to the new id returned by resume/reopen before navigating. */
 export async function transferComposerDraft(
     sourceSessionId: string,

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -173,7 +173,9 @@ async function persistInactiveComposerAttachmentsNow(
         }
         saveDraft(sessionId, text)
         const previousVisibleIds = inactiveVisibleIds.get(sessionId) ?? new Set<string>()
-        const stored = await loadPersistedAttachments(sessionId)
+        // Fail closed: never publish pending.latest / liveSnapshots from a
+        // best-effort empty read that would erase hidden stored files on move.
+        const stored = await loadPersistedAttachments(sessionId, { throwOnError: true })
         const latestAfterRead = pendingTransfers.get(sessionId)?.latest
         if (latestAfterRead) {
             return latestAfterRead.attachments
@@ -200,7 +202,7 @@ async function persistInactiveComposerAttachmentsNow(
     }
     saveDraft(sessionId, text)
     const previousVisibleIds = inactiveVisibleIds.get(sessionId) ?? new Set<string>()
-    const stored = await loadPersistedAttachments(sessionId)
+    const stored = await loadPersistedAttachments(sessionId, { throwOnError: true })
     // Drop ids that were previously visible but are gone now (operator removed
     // a failed-resume pick). Hidden stored files outside that set are retained.
     const retained = stored.filter((item) => !previousVisibleIds.has(item.id))
@@ -314,9 +316,20 @@ export async function transferComposerDraft(
             baseAttachments = sourceLive.attachments
         } else {
             text = getDraft(sourceSessionId)
-            // Fail closed: a transient IndexedDB read must not look like an
-            // empty draft and then delete the source during the durable move.
-            baseAttachments = await loadPersistedAttachments(sourceSessionId, { throwOnError: true })
+            try {
+                // Fail closed: a transient IndexedDB read must not look like an
+                // empty draft and then delete the source during the durable move.
+                baseAttachments = await loadPersistedAttachments(sourceSessionId, {
+                    throwOnError: true,
+                })
+            } catch (error) {
+                // Resume already resolved a new id; keep the independently readable
+                // text under the target even when attachment storage aborts.
+                if (crossSession) {
+                    saveDraft(targetSessionId, text)
+                }
+                throw error
+            }
         }
 
         const buildTransferredAttachments = (): AttachmentDraftInput[] => {

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -1,0 +1,45 @@
+import { getDraft, saveDraft } from '@/lib/composer-drafts'
+import {
+    getDraftAttachments,
+    getRestoredUploadMetadata,
+    saveDraftAttachments,
+    type AttachmentDraftInput,
+} from '@/lib/composer-attachment-drafts'
+
+type ComposerDraftSnapshot = {
+    text: string
+    attachments: AttachmentDraftInput[]
+}
+
+const liveSnapshots = new Map<string, ComposerDraftSnapshot>()
+
+export function setComposerDraftSnapshot(
+    sessionId: string,
+    text: string,
+    attachments: readonly AttachmentDraftInput[],
+): void {
+    liveSnapshots.set(sessionId, { text, attachments: [...attachments] })
+}
+
+/** Copy a draft to the new id returned by resume/reopen before navigating. */
+export async function transferComposerDraft(sourceSessionId: string, targetSessionId: string): Promise<void> {
+    if (sourceSessionId === targetSessionId) return
+
+    const live = liveSnapshots.get(sourceSessionId)
+    const text = live ? live.text : getDraft(sourceSessionId)
+    const attachments = live
+        ? live.attachments
+        : (await getDraftAttachments(sourceSessionId)).map((file, index) => {
+            const metadata = getRestoredUploadMetadata(file)
+            return {
+                id: metadata?.id ?? `transferred-${index}-${file.name}`,
+                file,
+                path: metadata?.path,
+                previewUrl: metadata?.previewUrl,
+                uploadSessionId: metadata?.uploadSessionId,
+            }
+        })
+
+    saveDraft(targetSessionId, text)
+    saveDraftAttachments(targetSessionId, attachments)
+}

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -211,44 +211,52 @@ export async function transferComposerDraft(
         baseAttachments = await loadPersistedAttachments(sourceSessionId)
     }
 
-    // Sample cancellation immediately before writing so a remove() during an
-    // awaited handoff still drops the file (including one already in the
-    // source snapshot from an earlier inactive persist).
-    const cancelledIds = new Set<string>()
-    for (const item of pendingAttachments) {
-        if (item.isCancelled?.()) cancelledIds.add(item.id)
+    const buildTransferredAttachments = (): AttachmentDraftInput[] => {
+        // Sample cancellation at write time (after any awaited IDB drain inside
+        // moveDraftAttachments) so a remove() during the wait still drops the file.
+        const cancelledIds = new Set<string>()
+        for (const item of pendingAttachments) {
+            if (item.isCancelled?.()) cancelledIds.add(item.id)
+        }
+
+        // Cross-session reopen cannot reuse source-authorized upload paths.
+        // Same-target staggered appends must keep path/uploadSessionId already
+        // written by earlier uploads on that resumed composer.
+        const normalizedBase = (
+            sourceSessionId === targetSessionId
+                ? baseAttachments
+                : baseAttachments.map(stripSessionScopedUploadFields)
+        ).filter((item) => !cancelledIds.has(item.id))
+        const normalizedPending = pendingAttachments
+            .filter((item) => !cancelledIds.has(item.id))
+            .map((attachment) => ({
+                id: attachment.id,
+                file: attachment.file,
+                previewUrl: attachment.previewUrl,
+                path: undefined,
+                uploadSessionId: undefined,
+            }))
+        return mergeAttachmentsById(normalizedBase, normalizedPending)
     }
 
-    // Cross-session reopen cannot reuse source-authorized upload paths.
-    // Same-target staggered appends must keep path/uploadSessionId already
-    // written by earlier uploads on that resumed composer.
-    const normalizedBase = (
-        sourceSessionId === targetSessionId
-            ? baseAttachments
-            : baseAttachments.map(stripSessionScopedUploadFields)
-    ).filter((item) => !cancelledIds.has(item.id))
-    const normalizedPending = pendingAttachments
-        .filter((item) => !cancelledIds.has(item.id))
-        .map((attachment) => ({
-            id: attachment.id,
-            file: attachment.file,
-            previewUrl: attachment.previewUrl,
-            path: undefined,
-            uploadSessionId: undefined,
-        }))
-    const attachments = mergeAttachmentsById(normalizedBase, normalizedPending)
-
     saveDraft(targetSessionId, text)
+    let attachments: AttachmentDraftInput[]
     if (sourceSessionId !== targetSessionId) {
         // Durable move: await target put + source delete before navigation so a
         // reload cannot lose the draft, and tombstone the source so unmount
-        // cleanup cannot recreate it under the obsolete id.
-        await moveDraftAttachments(sourceSessionId, targetSessionId, attachments)
+        // cleanup cannot recreate it under the obsolete id. Failed moves throw
+        // without clearing the source or recording a handoff.
+        attachments = await moveDraftAttachments(
+            sourceSessionId,
+            targetSessionId,
+            buildTransferredAttachments,
+        )
         clearDraft(sourceSessionId)
         completedHandoffs.set(sourceSessionId, targetSessionId)
         liveSnapshots.delete(sourceSessionId)
         inactiveVisibleIds.delete(sourceSessionId)
     } else {
+        attachments = buildTransferredAttachments()
         saveDraftAttachments(targetSessionId, attachments)
     }
     setComposerDraftSnapshot(targetSessionId, text, attachments)

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -88,6 +88,11 @@ export function composerDraftWasHandedOff(sessionId: string): boolean {
     return completedHandoffs.has(sessionId)
 }
 
+/** Drop per-mount visibility tracking so a remount does not treat hidden stored files as user-removed. */
+export function resetInactiveComposerAttachmentVisibility(sessionId: string): void {
+    inactiveVisibleIds.delete(sessionId)
+}
+
 /** Test/helper: drop the handoff tombstone so a session id can be reused. */
 export function forgetComposerDraftHandoff(sessionId: string): void {
     completedHandoffs.delete(sessionId)
@@ -134,8 +139,29 @@ async function persistInactiveComposerAttachmentsNow(
     text: string,
     visibleAttachments: readonly AttachmentDraftInput[],
 ): Promise<AttachmentDraftInput[]> {
-    // A queued persist may settle after the source was already moved.
-    if (composerDraftWasHandedOff(sessionId) || pendingTransfers.has(sessionId)) {
+    // A queued persist may settle during/after the source move — buffer onto
+    // the in-flight transfer instead of recreating the retiring source row.
+    const pending = pendingTransfers.get(sessionId)
+    if (pending) {
+        // A newer synchronous barrier edit already recorded latest; keep it.
+        if (pending.latest) {
+            return pending.latest.attachments
+        }
+        saveDraft(sessionId, text)
+        const previousVisibleIds = inactiveVisibleIds.get(sessionId) ?? new Set<string>()
+        const stored = await loadPersistedAttachments(sessionId)
+        // Re-check: a concurrent barrier edit may have landed while we read.
+        if (pending.latest) {
+            return pending.latest.attachments
+        }
+        const retained = stored.filter((item) => !previousVisibleIds.has(item.id))
+        const merged = mergeAttachmentsById(retained, visibleAttachments)
+        pending.latest = { text, attachments: merged }
+        liveSnapshots.set(sessionId, { text, attachments: merged })
+        inactiveVisibleIds.set(sessionId, new Set(visibleAttachments.map((item) => item.id)))
+        return merged
+    }
+    if (composerDraftWasHandedOff(sessionId)) {
         return [...visibleAttachments]
     }
     saveDraft(sessionId, text)
@@ -219,112 +245,126 @@ export async function transferComposerDraft(
 ): Promise<void> {
     if (sourceSessionId === targetSessionId && pendingAttachments.length === 0) return
 
-    // Flush any in-flight inactive merge so reopen cannot race a pending read.
-    await awaitInactivePersist(sourceSessionId)
-
-    const sourceLive = liveSnapshots.get(sourceSessionId)
-
-    let text: string
-    let baseAttachments: AttachmentDraftInput[]
-
-    // Always read the source draft. A previously visited target may still sit
-    // in liveSnapshots; using it would shadow the reopened session's draft.
-    if (sourceLive) {
-        text = sourceLive.text
-        baseAttachments = sourceLive.attachments
-    } else {
-        text = getDraft(sourceSessionId)
-        baseAttachments = await loadPersistedAttachments(sourceSessionId)
+    const crossSession = sourceSessionId !== targetSessionId
+    // Install the barrier before any await so a concurrent inactive persist
+    // cannot recreate the source or miss recording latest onto the transfer.
+    if (crossSession) {
+        pendingTransfers.set(sourceSessionId, { targetSessionId })
     }
 
-    const buildTransferredAttachments = (): AttachmentDraftInput[] => {
-        // Sample cancellation at write time (after any awaited IDB drain inside
-        // moveDraftAttachments) so a remove() during the wait still drops the file.
-        const cancelledIds = new Set<string>()
-        for (const item of pendingAttachments) {
-            if (item.isCancelled?.()) cancelledIds.add(item.id)
+    try {
+        // Flush any in-flight inactive merge so reopen cannot race a pending read.
+        await awaitInactivePersist(sourceSessionId)
+
+        const sourceLive = liveSnapshots.get(sourceSessionId)
+
+        let text: string
+        let baseAttachments: AttachmentDraftInput[]
+
+        // Always read the source draft. A previously visited target may still sit
+        // in liveSnapshots; using it would shadow the reopened session's draft.
+        if (sourceLive) {
+            text = sourceLive.text
+            baseAttachments = sourceLive.attachments
+        } else {
+            text = getDraft(sourceSessionId)
+            baseAttachments = await loadPersistedAttachments(sourceSessionId)
         }
 
-        // Prefer edits recorded while the move was in flight over the snapshot
-        // captured at transfer start.
-        const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
-        const currentBase = pendingLatest?.attachments
-            ?? liveSnapshots.get(sourceSessionId)?.attachments
-            ?? baseAttachments
-
-        // Cross-session reopen cannot reuse source-authorized upload paths.
-        // Same-target staggered appends must keep path/uploadSessionId already
-        // written by earlier uploads on that resumed composer.
-        const normalizedBase = (
-            sourceSessionId === targetSessionId
-                ? currentBase
-                : currentBase.map(stripSessionScopedUploadFields)
-        ).filter((item) => !cancelledIds.has(item.id))
-        const normalizedPending = pendingAttachments
-            .filter((item) => !cancelledIds.has(item.id))
-            .map((attachment) => ({
-                id: attachment.id,
-                file: attachment.file,
-                previewUrl: attachment.previewUrl,
-                path: undefined,
-                uploadSessionId: undefined,
-            }))
-        return mergeAttachmentsById(normalizedBase, normalizedPending)
-    }
-
-    let attachments: AttachmentDraftInput[]
-    let transferredText = text
-    if (sourceSessionId !== targetSessionId) {
-        pendingTransfers.set(sourceSessionId, { targetSessionId })
-        // Durable move: await target put + source delete before navigation so a
-        // reload cannot lose the draft, and tombstone the source so unmount
-        // cleanup cannot recreate it under the obsolete id.
-        try {
-            attachments = await moveDraftAttachments(
-                sourceSessionId,
-                targetSessionId,
-                buildTransferredAttachments,
-            )
-            // Keystrokes / attachment edits during the IDB drain keep updating
-            // the source live snapshot or pendingTransfers.latest; re-read
-            // before retiring it so the target does not get a stale snapshot.
-            const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
-            transferredText = pendingLatest?.text
-                ?? liveSnapshots.get(sourceSessionId)?.text
-                ?? getDraft(sourceSessionId)
-            // Re-resolve after the move so a late persist.latest wins even when
-            // resolveAttachments already ran inside moveDraftAttachments.
-            if (pendingLatest) {
-                attachments = buildTransferredAttachments()
-                saveDraftAttachments(targetSessionId, attachments)
+        const buildTransferredAttachments = (): AttachmentDraftInput[] => {
+            // Sample cancellation at write time (after any awaited IDB drain inside
+            // moveDraftAttachments) so a remove() during the wait still drops the file.
+            const cancelledIds = new Set<string>()
+            for (const item of pendingAttachments) {
+                if (item.isCancelled?.()) cancelledIds.add(item.id)
             }
-            saveDraft(targetSessionId, transferredText)
-            clearDraft(sourceSessionId)
-            completedHandoffs.set(sourceSessionId, targetSessionId)
-            liveSnapshots.delete(sourceSessionId)
-            inactiveVisibleIds.delete(sourceSessionId)
-        } catch (error) {
-            // Hub resume already succeeded; keep navigating. Copy text + in-memory
-            // attachments to the target without claiming a durable handoff so the
-            // source IndexedDB row remains if the operator reloads the old id.
+
+            // Prefer edits recorded while the move was in flight over the snapshot
+            // captured at transfer start.
             const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
-            transferredText = pendingLatest?.text
-                ?? liveSnapshots.get(sourceSessionId)?.text
-                ?? getDraft(sourceSessionId)
+            const currentBase = pendingLatest?.attachments
+                ?? liveSnapshots.get(sourceSessionId)?.attachments
+                ?? baseAttachments
+
+            // Cross-session reopen cannot reuse source-authorized upload paths.
+            // Same-target staggered appends must keep path/uploadSessionId already
+            // written by earlier uploads on that resumed composer.
+            const normalizedBase = (
+                sourceSessionId === targetSessionId
+                    ? currentBase
+                    : currentBase.map(stripSessionScopedUploadFields)
+            ).filter((item) => !cancelledIds.has(item.id))
+            const normalizedPending = pendingAttachments
+                .filter((item) => !cancelledIds.has(item.id))
+                .map((attachment) => ({
+                    id: attachment.id,
+                    file: attachment.file,
+                    previewUrl: attachment.previewUrl,
+                    path: undefined,
+                    uploadSessionId: undefined,
+                }))
+            return mergeAttachmentsById(normalizedBase, normalizedPending)
+        }
+
+        let attachments: AttachmentDraftInput[]
+        let transferredText = text
+        if (crossSession) {
+            // Durable move: await target put + source delete before navigation so a
+            // reload cannot lose the draft, and tombstone the source so unmount
+            // cleanup cannot recreate it under the obsolete id.
+            try {
+                attachments = await moveDraftAttachments(
+                    sourceSessionId,
+                    targetSessionId,
+                    buildTransferredAttachments,
+                )
+                // Keystrokes / attachment edits during the IDB drain keep updating
+                // the source live snapshot or pendingTransfers.latest; re-read
+                // before retiring it so the target does not get a stale snapshot.
+                const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
+                transferredText = pendingLatest?.text
+                    ?? liveSnapshots.get(sourceSessionId)?.text
+                    ?? getDraft(sourceSessionId)
+                // Re-resolve and await a durable target write so a late edit is
+                // committed before the source row is retired.
+                if (pendingLatest) {
+                    attachments = buildTransferredAttachments()
+                    await moveDraftAttachments(
+                        targetSessionId,
+                        targetSessionId,
+                        () => attachments,
+                    )
+                }
+                saveDraft(targetSessionId, transferredText)
+                clearDraft(sourceSessionId)
+                completedHandoffs.set(sourceSessionId, targetSessionId)
+                liveSnapshots.delete(sourceSessionId)
+                inactiveVisibleIds.delete(sourceSessionId)
+            } catch (error) {
+                // Hub resume already succeeded; keep navigating. Copy text + in-memory
+                // attachments to the target without claiming a durable handoff so the
+                // source IndexedDB row remains if the operator reloads the old id.
+                const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
+                transferredText = pendingLatest?.text
+                    ?? liveSnapshots.get(sourceSessionId)?.text
+                    ?? getDraft(sourceSessionId)
+                attachments = buildTransferredAttachments()
+                saveDraft(targetSessionId, transferredText)
+                saveDraftAttachments(targetSessionId, attachments)
+                setComposerDraftSnapshot(targetSessionId, transferredText, attachments)
+                throw error
+            }
+        } else {
             attachments = buildTransferredAttachments()
             saveDraft(targetSessionId, transferredText)
             saveDraftAttachments(targetSessionId, attachments)
-            setComposerDraftSnapshot(targetSessionId, transferredText, attachments)
-            throw error
-        } finally {
+        }
+        setComposerDraftSnapshot(targetSessionId, transferredText, attachments)
+    } finally {
+        if (crossSession) {
             pendingTransfers.delete(sourceSessionId)
         }
-    } else {
-        attachments = buildTransferredAttachments()
-        saveDraft(targetSessionId, transferredText)
-        saveDraftAttachments(targetSessionId, attachments)
     }
-    setComposerDraftSnapshot(targetSessionId, transferredText, attachments)
 }
 
 /**

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -379,9 +379,9 @@ export async function transferComposerDraft(
                     targetSessionId,
                     buildTransferredAttachments,
                 )
-                // Repeat corrective target writes until pending.latest is stable
-                // across the await — text/attachment edits during the write must
-                // not be retired with a stale revision.
+                // Always rewrite the target at least once after the durable move so
+                // isCancelled flips during the IDB commit window still prune the file.
+                // Then repeat until pending.latest / latestText are stable across the await.
                 for (;;) {
                     const pendingState = pendingTransfers.get(sourceSessionId)
                     const latest = pendingState?.latest
@@ -390,7 +390,6 @@ export async function transferComposerDraft(
                         sourceSessionId,
                         getDraft(sourceSessionId),
                     )
-                    if (!latest) break
                     attachments = buildTransferredAttachments()
                     await moveDraftAttachments(
                         targetSessionId,
@@ -514,6 +513,16 @@ export async function handoffComposerDraft(
         const batch = [...state.pending]
         try {
             await transferComposerDraft(sourceSessionId, targetSessionId, batch)
+            // Belt-and-suspenders: if remove() won during the move commit window,
+            // prune those ids from the target before navigation restores them.
+            const cancelledAfterMove = batch.filter((item) => item.isCancelled?.())
+            if (cancelledAfterMove.length > 0) {
+                await transferComposerDraft(
+                    targetSessionId,
+                    targetSessionId,
+                    cancelledAfterMove,
+                )
+            }
         } catch (error) {
             console.warn('[composer-draft] handoff transfer failed; still navigating', error)
         }

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -14,6 +14,15 @@ type ComposerDraftSnapshot = {
 const liveSnapshots = new Map<string, ComposerDraftSnapshot>()
 const MAX_LIVE_SNAPSHOTS = 50
 
+type HandoffState = {
+    targetSessionId: string
+    pending: AttachmentDraftInput[]
+    done: Promise<void>
+    resolveDone: () => void
+}
+
+const activeHandoffs = new Map<string, HandoffState>()
+
 export function setComposerDraftSnapshot(
     sessionId: string,
     text: string,
@@ -27,34 +36,151 @@ export function setComposerDraftSnapshot(
     liveSnapshots.set(sessionId, { text, attachments: [...attachments] })
 }
 
-/** Copy a draft to the new id returned by resume/reopen before navigating. */
-export async function transferComposerDraft(sourceSessionId: string, targetSessionId: string): Promise<void> {
-    if (sourceSessionId === targetSessionId) return
+export function clearComposerDraftSnapshot(sessionId: string): void {
+    liveSnapshots.delete(sessionId)
+}
 
-    const live = liveSnapshots.get(sourceSessionId)
-    const text = live ? live.text : getDraft(sourceSessionId)
-    const sourceAttachments = live
-        ? live.attachments
-        : (await getDraftAttachments(sourceSessionId)).map((file, index) => {
-            const metadata = getRestoredUploadMetadata(file)
-            return {
-                id: metadata?.id ?? `transferred-${index}-${file.name}`,
-                file,
-                path: metadata?.path,
-                previewUrl: metadata?.previewUrl,
-                uploadSessionId: metadata?.uploadSessionId,
-            }
-        })
-    // Reopened sessions can receive a new id and cannot safely reuse upload
-    // paths authorized for (and potentially deleted with) the source session.
-    const attachments = sourceAttachments.map((attachment) => ({
+function stripSessionScopedUploadFields(attachment: AttachmentDraftInput): AttachmentDraftInput {
+    return {
         ...attachment,
         path: undefined,
         previewUrl: undefined,
         uploadSessionId: undefined,
+    }
+}
+
+function mergeAttachmentsById(
+    base: readonly AttachmentDraftInput[],
+    pending: readonly AttachmentDraftInput[],
+): AttachmentDraftInput[] {
+    const byId = new Map<string, AttachmentDraftInput>()
+    for (const attachment of base) {
+        byId.set(attachment.id, attachment)
+    }
+    for (const attachment of pending) {
+        byId.set(attachment.id, attachment)
+    }
+    return [...byId.values()]
+}
+
+async function loadPersistedAttachments(sessionId: string): Promise<AttachmentDraftInput[]> {
+    return (await getDraftAttachments(sessionId)).map((file, index) => {
+        const metadata = getRestoredUploadMetadata(file)
+        return {
+            id: metadata?.id ?? `transferred-${index}-${file.name}`,
+            file,
+            path: metadata?.path,
+            previewUrl: metadata?.previewUrl,
+            uploadSessionId: metadata?.uploadSessionId,
+        }
+    })
+}
+
+/** Copy a draft to the new id returned by resume/reopen before navigating. */
+export async function transferComposerDraft(
+    sourceSessionId: string,
+    targetSessionId: string,
+    pendingAttachments: readonly AttachmentDraftInput[] = [],
+): Promise<void> {
+    if (sourceSessionId === targetSessionId && pendingAttachments.length === 0) return
+
+    const sourceLive = liveSnapshots.get(sourceSessionId)
+    const targetLive = liveSnapshots.get(targetSessionId)
+
+    let text: string
+    let baseAttachments: AttachmentDraftInput[]
+
+    if (sourceLive) {
+        text = sourceLive.text
+        baseAttachments = sourceLive.attachments
+    } else if (targetLive) {
+        // Source live was cleared by an earlier handoff; merge late files into the target.
+        text = targetLive.text
+        baseAttachments = targetLive.attachments
+    } else {
+        text = getDraft(sourceSessionId)
+        baseAttachments = await loadPersistedAttachments(sourceSessionId)
+    }
+
+    // Reopened sessions can receive a new id and cannot safely reuse upload
+    // paths authorized for (and potentially deleted with) the source session.
+    // In-flight picks keep their local preview data URL.
+    const strippedBase = baseAttachments.map(stripSessionScopedUploadFields)
+    const normalizedPending = pendingAttachments.map((attachment) => ({
+        id: attachment.id,
+        file: attachment.file,
+        previewUrl: attachment.previewUrl,
+        path: undefined,
+        uploadSessionId: undefined,
     }))
+    const attachments = mergeAttachmentsById(strippedBase, normalizedPending)
 
     saveDraft(targetSessionId, text)
     saveDraftAttachments(targetSessionId, attachments)
-    liveSnapshots.delete(sourceSessionId)
+    setComposerDraftSnapshot(targetSessionId, text, attachments)
+    if (sourceSessionId !== targetSessionId) {
+        liveSnapshots.delete(sourceSessionId)
+    }
+}
+
+/**
+ * Resume/upload handoff for a newly selected inactive-session attachment.
+ * Concurrent multi-file drops share one transfer + navigation; late files merge into the target.
+ */
+export async function handoffComposerDraft(
+    sourceSessionId: string,
+    targetSessionId: string,
+    pending: AttachmentDraftInput,
+    onNavigable: (targetSessionId: string) => void | Promise<void>,
+): Promise<void> {
+    const pendingItem: AttachmentDraftInput = {
+        id: pending.id,
+        file: pending.file,
+        previewUrl: pending.previewUrl,
+    }
+
+    if (sourceSessionId === targetSessionId) {
+        await transferComposerDraft(sourceSessionId, targetSessionId, [pendingItem])
+        return
+    }
+
+    const existing = activeHandoffs.get(sourceSessionId)
+    if (existing) {
+        if (!existing.pending.some((item) => item.id === pendingItem.id)) {
+            existing.pending.push(pendingItem)
+        }
+        await existing.done
+        // Ensure this file is on the target even if it missed the batched snapshot.
+        await transferComposerDraft(sourceSessionId, targetSessionId, [pendingItem])
+        return
+    }
+
+    let resolveDone!: () => void
+    const done = new Promise<void>((resolve) => {
+        resolveDone = resolve
+    })
+    const state: HandoffState = {
+        targetSessionId,
+        pending: [pendingItem],
+        done,
+        resolveDone,
+    }
+    activeHandoffs.set(sourceSessionId, state)
+
+    try {
+        // Let concurrent add() callbacks enqueue into state.pending before transferring.
+        await new Promise<void>((resolve) => {
+            setTimeout(resolve, 0)
+        })
+        const batch = [...state.pending]
+        await transferComposerDraft(sourceSessionId, targetSessionId, batch)
+        await onNavigable(targetSessionId)
+        const late = state.pending.filter((item) => !batch.some((early) => early.id === item.id))
+        if (late.length > 0) {
+            await transferComposerDraft(sourceSessionId, targetSessionId, late)
+        }
+    } finally {
+        resolveDone()
+        activeHandoffs.delete(sourceSessionId)
+    }
 }

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -66,6 +66,16 @@ export function updateComposerDraftTextSnapshot(sessionId: string, text: string)
     if (existing) {
         liveSnapshots.set(sessionId, { ...existing, text })
     }
+    // Keep in-flight transfer latest text in sync with keystrokes during a move.
+    const pending = pendingTransfers.get(sessionId)
+    if (pending?.latest) {
+        pending.latest = { ...pending.latest, text }
+    } else if (pending) {
+        pending.latest = {
+            text,
+            attachments: existing ? [...existing.attachments] : [],
+        }
+    }
 }
 
 /** Stable membership/metadata key for attachment-only persist effects. */
@@ -330,22 +340,22 @@ export async function transferComposerDraft(
                     targetSessionId,
                     buildTransferredAttachments,
                 )
-                // Keystrokes / attachment edits during the IDB drain keep updating
-                // the source live snapshot or pendingTransfers.latest; re-read
-                // before retiring it so the target does not get a stale snapshot.
-                const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
-                transferredText = pendingLatest?.text
-                    ?? liveSnapshots.get(sourceSessionId)?.text
-                    ?? getDraft(sourceSessionId)
-                // Re-resolve and await a durable target write so a late edit is
-                // committed before the source row is retired.
-                if (pendingLatest) {
+                // Repeat corrective target writes until pending.latest is stable
+                // across the await — text/attachment edits during the write must
+                // not be retired with a stale revision.
+                for (;;) {
+                    const latest = pendingTransfers.get(sourceSessionId)?.latest
+                    transferredText = latest?.text
+                        ?? liveSnapshots.get(sourceSessionId)?.text
+                        ?? getDraft(sourceSessionId)
+                    if (!latest) break
                     attachments = buildTransferredAttachments()
                     await moveDraftAttachments(
                         targetSessionId,
                         targetSessionId,
                         () => attachments,
                     )
+                    if (pendingTransfers.get(sourceSessionId)?.latest === latest) break
                 }
                 saveDraft(targetSessionId, transferredText)
                 clearDraft(sourceSessionId)

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -140,8 +140,11 @@ function mergeAttachmentsById(
     return [...byId.values()]
 }
 
-async function loadPersistedAttachments(sessionId: string): Promise<AttachmentDraftInput[]> {
-    return (await getDraftAttachments(sessionId)).map((file, index) => {
+async function loadPersistedAttachments(
+    sessionId: string,
+    options: { throwOnError?: boolean } = {},
+): Promise<AttachmentDraftInput[]> {
+    return (await getDraftAttachments(sessionId, options)).map((file, index) => {
         const metadata = getRestoredUploadMetadata(file)
         return {
             id: metadata?.id ?? `transferred-${index}-${file.name}`,
@@ -311,7 +314,9 @@ export async function transferComposerDraft(
             baseAttachments = sourceLive.attachments
         } else {
             text = getDraft(sourceSessionId)
-            baseAttachments = await loadPersistedAttachments(sourceSessionId)
+            // Fail closed: a transient IndexedDB read must not look like an
+            // empty draft and then delete the source during the durable move.
+            baseAttachments = await loadPersistedAttachments(sourceSessionId, { throwOnError: true })
         }
 
         const buildTransferredAttachments = (): AttachmentDraftInput[] => {

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -11,12 +11,17 @@ type ComposerDraftSnapshot = {
     attachments: AttachmentDraftInput[]
 }
 
+/** In-flight handoff may carry a live cancellation check sampled at save time. */
+export type AttachmentDraftHandoff = AttachmentDraftInput & {
+    isCancelled?: () => boolean
+}
+
 const liveSnapshots = new Map<string, ComposerDraftSnapshot>()
 const MAX_LIVE_SNAPSHOTS = 50
 
 type HandoffState = {
     targetSessionId: string
-    pending: AttachmentDraftInput[]
+    pending: AttachmentDraftHandoff[]
     done: Promise<void>
     resolveDone: () => void
 }
@@ -42,6 +47,25 @@ export function setComposerDraftSnapshot(
         if (oldestSessionId) liveSnapshots.delete(oldestSessionId)
     }
     liveSnapshots.set(sessionId, { text, attachments: [...attachments] })
+}
+
+/**
+ * Cheap text-only update for inactive composers. Avoids queuing another
+ * IndexedDB blob merge on every keystroke when attachments are unchanged.
+ */
+export function updateComposerDraftTextSnapshot(sessionId: string, text: string): void {
+    saveDraft(sessionId, text)
+    const existing = liveSnapshots.get(sessionId)
+    if (existing) {
+        liveSnapshots.set(sessionId, { ...existing, text })
+    }
+}
+
+/** Stable membership/metadata key for attachment-only persist effects. */
+export function attachmentDraftRevision(attachments: readonly AttachmentDraftInput[]): string {
+    return attachments
+        .map(({ id, path, uploadSessionId }) => `${id}:${path ?? ''}:${uploadSessionId ?? ''}`)
+        .join('\0')
 }
 
 export function clearComposerDraftSnapshot(sessionId: string): void {
@@ -149,7 +173,7 @@ async function awaitInactivePersist(sessionId: string): Promise<void> {
 export async function transferComposerDraft(
     sourceSessionId: string,
     targetSessionId: string,
-    pendingAttachments: readonly AttachmentDraftInput[] = [],
+    pendingAttachments: readonly AttachmentDraftHandoff[] = [],
 ): Promise<void> {
     if (sourceSessionId === targetSessionId && pendingAttachments.length === 0) return
 
@@ -171,18 +195,32 @@ export async function transferComposerDraft(
         baseAttachments = await loadPersistedAttachments(sourceSessionId)
     }
 
-    // Reopened sessions can receive a new id and cannot safely reuse upload
-    // paths authorized for (and potentially deleted with) the source session.
-    // In-flight picks keep their local preview data URL.
-    const strippedBase = baseAttachments.map(stripSessionScopedUploadFields)
-    const normalizedPending = pendingAttachments.map((attachment) => ({
-        id: attachment.id,
-        file: attachment.file,
-        previewUrl: attachment.previewUrl,
-        path: undefined,
-        uploadSessionId: undefined,
-    }))
-    const attachments = mergeAttachmentsById(strippedBase, normalizedPending)
+    // Sample cancellation immediately before writing so a remove() during an
+    // awaited handoff still drops the file (including one already in the
+    // source snapshot from an earlier inactive persist).
+    const cancelledIds = new Set<string>()
+    for (const item of pendingAttachments) {
+        if (item.isCancelled?.()) cancelledIds.add(item.id)
+    }
+
+    // Cross-session reopen cannot reuse source-authorized upload paths.
+    // Same-target staggered appends must keep path/uploadSessionId already
+    // written by earlier uploads on that resumed composer.
+    const normalizedBase = (
+        sourceSessionId === targetSessionId
+            ? baseAttachments
+            : baseAttachments.map(stripSessionScopedUploadFields)
+    ).filter((item) => !cancelledIds.has(item.id))
+    const normalizedPending = pendingAttachments
+        .filter((item) => !cancelledIds.has(item.id))
+        .map((attachment) => ({
+            id: attachment.id,
+            file: attachment.file,
+            previewUrl: attachment.previewUrl,
+            path: undefined,
+            uploadSessionId: undefined,
+        }))
+    const attachments = mergeAttachmentsById(normalizedBase, normalizedPending)
 
     saveDraft(targetSessionId, text)
     saveDraftAttachments(targetSessionId, attachments)
@@ -199,13 +237,14 @@ export async function transferComposerDraft(
 export async function handoffComposerDraft(
     sourceSessionId: string,
     targetSessionId: string,
-    pending: AttachmentDraftInput,
+    pending: AttachmentDraftHandoff,
     onNavigable: (targetSessionId: string) => void | Promise<void>,
 ): Promise<void> {
-    const pendingItem: AttachmentDraftInput = {
+    const pendingItem: AttachmentDraftHandoff = {
         id: pending.id,
         file: pending.file,
         previewUrl: pending.previewUrl,
+        isCancelled: pending.isCancelled,
     }
 
     if (sourceSessionId === targetSessionId) {
@@ -251,6 +290,8 @@ export async function handoffComposerDraft(
         const batch = [...state.pending]
         await transferComposerDraft(sourceSessionId, targetSessionId, batch)
         completedHandoffs.set(sourceSessionId, targetSessionId)
+        // Navigate even when every pending file was cancelled mid-handoff —
+        // resume may already have deleted the source session row.
         await onNavigable(targetSessionId)
         const late = state.pending.filter((item) => !batch.some((early) => early.id === item.id))
         if (late.length > 0) {

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -239,8 +239,8 @@ export async function transferComposerDraft(
         return mergeAttachmentsById(normalizedBase, normalizedPending)
     }
 
-    saveDraft(targetSessionId, text)
     let attachments: AttachmentDraftInput[]
+    let transferredText = text
     if (sourceSessionId !== targetSessionId) {
         // Durable move: await target put + source delete before navigation so a
         // reload cannot lose the draft, and tombstone the source so unmount
@@ -251,15 +251,20 @@ export async function transferComposerDraft(
             targetSessionId,
             buildTransferredAttachments,
         )
+        // Keystrokes during the IDB drain keep updating the source; re-read
+        // before retiring it so the target does not get a stale snapshot.
+        transferredText = liveSnapshots.get(sourceSessionId)?.text ?? getDraft(sourceSessionId)
+        saveDraft(targetSessionId, transferredText)
         clearDraft(sourceSessionId)
         completedHandoffs.set(sourceSessionId, targetSessionId)
         liveSnapshots.delete(sourceSessionId)
         inactiveVisibleIds.delete(sourceSessionId)
     } else {
         attachments = buildTransferredAttachments()
+        saveDraft(targetSessionId, transferredText)
         saveDraftAttachments(targetSessionId, attachments)
     }
-    setComposerDraftSnapshot(targetSessionId, text, attachments)
+    setComposerDraftSnapshot(targetSessionId, transferredText, attachments)
 }
 
 /**

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -141,25 +141,37 @@ async function persistInactiveComposerAttachmentsNow(
 ): Promise<AttachmentDraftInput[]> {
     // A queued persist may settle during/after the source move — buffer onto
     // the in-flight transfer instead of recreating the retiring source row.
-    const pending = pendingTransfers.get(sessionId)
-    if (pending) {
+    if (pendingTransfers.has(sessionId)) {
         // A newer synchronous barrier edit already recorded latest; keep it.
-        if (pending.latest) {
-            return pending.latest.attachments
+        // Re-read the map after awaits — TS would otherwise keep a stale
+        // `pending.latest` narrowing across the async gap.
+        const latestBeforeRead = pendingTransfers.get(sessionId)?.latest
+        if (latestBeforeRead) {
+            return latestBeforeRead.attachments
         }
         saveDraft(sessionId, text)
         const previousVisibleIds = inactiveVisibleIds.get(sessionId) ?? new Set<string>()
         const stored = await loadPersistedAttachments(sessionId)
-        // Re-check: a concurrent barrier edit may have landed while we read.
-        if (pending.latest) {
-            return pending.latest.attachments
+        const latestAfterRead = pendingTransfers.get(sessionId)?.latest
+        if (latestAfterRead) {
+            return latestAfterRead.attachments
         }
-        const retained = stored.filter((item) => !previousVisibleIds.has(item.id))
-        const merged = mergeAttachmentsById(retained, visibleAttachments)
-        pending.latest = { text, attachments: merged }
-        liveSnapshots.set(sessionId, { text, attachments: merged })
-        inactiveVisibleIds.set(sessionId, new Set(visibleAttachments.map((item) => item.id)))
-        return merged
+        // Transfer may have finished while we read storage.
+        if (!pendingTransfers.has(sessionId)) {
+            if (composerDraftWasHandedOff(sessionId)) {
+                return [...visibleAttachments]
+            }
+        } else {
+            const retained = stored.filter((item) => !previousVisibleIds.has(item.id))
+            const merged = mergeAttachmentsById(retained, visibleAttachments)
+            const pending = pendingTransfers.get(sessionId)
+            if (pending) {
+                pending.latest = { text, attachments: merged }
+            }
+            liveSnapshots.set(sessionId, { text, attachments: merged })
+            inactiveVisibleIds.set(sessionId, new Set(visibleAttachments.map((item) => item.id)))
+            return merged
+        }
     }
     if (composerDraftWasHandedOff(sessionId)) {
         return [...visibleAttachments]

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -244,27 +244,56 @@ export async function transferComposerDraft(
     if (sourceSessionId !== targetSessionId) {
         // Durable move: await target put + source delete before navigation so a
         // reload cannot lose the draft, and tombstone the source so unmount
-        // cleanup cannot recreate it under the obsolete id. Failed moves throw
-        // without clearing the source or recording a handoff.
-        attachments = await moveDraftAttachments(
-            sourceSessionId,
-            targetSessionId,
-            buildTransferredAttachments,
-        )
-        // Keystrokes during the IDB drain keep updating the source; re-read
-        // before retiring it so the target does not get a stale snapshot.
-        transferredText = liveSnapshots.get(sourceSessionId)?.text ?? getDraft(sourceSessionId)
-        saveDraft(targetSessionId, transferredText)
-        clearDraft(sourceSessionId)
-        completedHandoffs.set(sourceSessionId, targetSessionId)
-        liveSnapshots.delete(sourceSessionId)
-        inactiveVisibleIds.delete(sourceSessionId)
+        // cleanup cannot recreate it under the obsolete id.
+        try {
+            attachments = await moveDraftAttachments(
+                sourceSessionId,
+                targetSessionId,
+                buildTransferredAttachments,
+            )
+            // Keystrokes during the IDB drain keep updating the source; re-read
+            // before retiring it so the target does not get a stale snapshot.
+            transferredText = liveSnapshots.get(sourceSessionId)?.text ?? getDraft(sourceSessionId)
+            saveDraft(targetSessionId, transferredText)
+            clearDraft(sourceSessionId)
+            completedHandoffs.set(sourceSessionId, targetSessionId)
+            liveSnapshots.delete(sourceSessionId)
+            inactiveVisibleIds.delete(sourceSessionId)
+        } catch (error) {
+            // Hub resume already succeeded; keep navigating. Copy text + in-memory
+            // attachments to the target without claiming a durable handoff so the
+            // source IndexedDB row remains if the operator reloads the old id.
+            transferredText = liveSnapshots.get(sourceSessionId)?.text ?? getDraft(sourceSessionId)
+            attachments = buildTransferredAttachments()
+            saveDraft(targetSessionId, transferredText)
+            saveDraftAttachments(targetSessionId, attachments)
+            setComposerDraftSnapshot(targetSessionId, transferredText, attachments)
+            throw error
+        }
     } else {
         attachments = buildTransferredAttachments()
         saveDraft(targetSessionId, transferredText)
         saveDraftAttachments(targetSessionId, attachments)
     }
     setComposerDraftSnapshot(targetSessionId, transferredText, attachments)
+}
+
+/**
+ * Move drafts after a successful hub resume/reopen, then always run `navigate`.
+ * Local IndexedDB failures must not strand the UI on a deleted source route.
+ */
+export async function transferComposerDraftThenNavigate(
+    sourceSessionId: string,
+    targetSessionId: string,
+    navigate: () => void | Promise<void>,
+    pendingAttachments: readonly AttachmentDraftHandoff[] = [],
+): Promise<void> {
+    try {
+        await transferComposerDraft(sourceSessionId, targetSessionId, pendingAttachments)
+    } catch (error) {
+        console.warn('[composer-draft] transfer failed after resume; continuing navigation', error)
+    }
+    await navigate()
 }
 
 /**
@@ -325,12 +354,21 @@ export async function handoffComposerDraft(
             setTimeout(resolve, 0)
         })
         const batch = [...state.pending]
-        await transferComposerDraft(sourceSessionId, targetSessionId, batch)
-        // completedHandoffs already set inside transfer for cross-session moves
+        try {
+            await transferComposerDraft(sourceSessionId, targetSessionId, batch)
+        } catch (error) {
+            console.warn('[composer-draft] handoff transfer failed; still navigating', error)
+        }
+        // Navigate even when the local durable move failed — resume may already
+        // have deleted the source session row.
         await onNavigable(targetSessionId)
         const late = state.pending.filter((item) => !batch.some((early) => early.id === item.id))
         if (late.length > 0) {
-            await transferComposerDraft(targetSessionId, targetSessionId, late)
+            try {
+                await transferComposerDraft(targetSessionId, targetSessionId, late)
+            } catch (error) {
+                console.warn('[composer-draft] late handoff append failed', error)
+            }
         }
     } finally {
         resolveDone()

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -1,7 +1,8 @@
-import { getDraft, saveDraft } from '@/lib/composer-drafts'
+import { clearDraft, getDraft, saveDraft } from '@/lib/composer-drafts'
 import {
     getDraftAttachments,
     getRestoredUploadMetadata,
+    moveDraftAttachments,
     saveDraftAttachments,
     type AttachmentDraftInput,
 } from '@/lib/composer-attachment-drafts'
@@ -70,8 +71,19 @@ export function attachmentDraftRevision(attachments: readonly AttachmentDraftInp
 
 export function clearComposerDraftSnapshot(sessionId: string): void {
     liveSnapshots.delete(sessionId)
-    completedHandoffs.delete(sessionId)
+    // Keep completedHandoffs: a handed-off source must stay tombstoned so
+    // unmount cleanup cannot recreate the obsolete draft.
     inactiveVisibleIds.delete(sessionId)
+}
+
+/** True after a cross-session transfer retired this source id. */
+export function composerDraftWasHandedOff(sessionId: string): boolean {
+    return completedHandoffs.has(sessionId)
+}
+
+/** Test/helper: drop the handoff tombstone so a session id can be reused. */
+export function forgetComposerDraftHandoff(sessionId: string): void {
+    completedHandoffs.delete(sessionId)
 }
 
 function stripSessionScopedUploadFields(attachment: AttachmentDraftInput): AttachmentDraftInput {
@@ -150,6 +162,10 @@ export async function persistInactiveComposerAttachments(
     text: string,
     visibleAttachments: readonly AttachmentDraftInput[],
 ): Promise<AttachmentDraftInput[]> {
+    // Source session was already moved to a resumed id — do not recreate it.
+    if (composerDraftWasHandedOff(sessionId)) {
+        return []
+    }
     const previous = inactivePersistQueue.get(sessionId) ?? Promise.resolve([] as AttachmentDraftInput[])
     const next = previous
         .catch(() => [] as AttachmentDraftInput[])
@@ -223,11 +239,19 @@ export async function transferComposerDraft(
     const attachments = mergeAttachmentsById(normalizedBase, normalizedPending)
 
     saveDraft(targetSessionId, text)
-    saveDraftAttachments(targetSessionId, attachments)
-    setComposerDraftSnapshot(targetSessionId, text, attachments)
     if (sourceSessionId !== targetSessionId) {
+        // Durable move: await target put + source delete before navigation so a
+        // reload cannot lose the draft, and tombstone the source so unmount
+        // cleanup cannot recreate it under the obsolete id.
+        await moveDraftAttachments(sourceSessionId, targetSessionId, attachments)
+        clearDraft(sourceSessionId)
+        completedHandoffs.set(sourceSessionId, targetSessionId)
         liveSnapshots.delete(sourceSessionId)
+        inactiveVisibleIds.delete(sourceSessionId)
+    } else {
+        saveDraftAttachments(targetSessionId, attachments)
     }
+    setComposerDraftSnapshot(targetSessionId, text, attachments)
 }
 
 /**
@@ -289,9 +313,7 @@ export async function handoffComposerDraft(
         })
         const batch = [...state.pending]
         await transferComposerDraft(sourceSessionId, targetSessionId, batch)
-        completedHandoffs.set(sourceSessionId, targetSessionId)
-        // Navigate even when every pending file was cancelled mid-handoff —
-        // resume may already have deleted the source session row.
+        // completedHandoffs already set inside transfer for cross-session moves
         await onNavigable(targetSessionId)
         const late = state.pending.filter((item) => !batch.some((early) => early.id === item.id))
         if (late.length > 0) {

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -85,18 +85,15 @@ export async function transferComposerDraft(
     if (sourceSessionId === targetSessionId && pendingAttachments.length === 0) return
 
     const sourceLive = liveSnapshots.get(sourceSessionId)
-    const targetLive = liveSnapshots.get(targetSessionId)
 
     let text: string
     let baseAttachments: AttachmentDraftInput[]
 
+    // Always read the source draft. A previously visited target may still sit
+    // in liveSnapshots; using it would shadow the reopened session's draft.
     if (sourceLive) {
         text = sourceLive.text
         baseAttachments = sourceLive.attachments
-    } else if (targetLive) {
-        // Source live was cleared by an earlier handoff; merge late files into the target.
-        text = targetLive.text
-        baseAttachments = targetLive.attachments
     } else {
         text = getDraft(sourceSessionId)
         baseAttachments = await loadPersistedAttachments(sourceSessionId)
@@ -150,8 +147,9 @@ export async function handoffComposerDraft(
             existing.pending.push(pendingItem)
         }
         await existing.done
-        // Ensure this file is on the target even if it missed the batched snapshot.
-        await transferComposerDraft(sourceSessionId, targetSessionId, [pendingItem])
+        // Append onto the target draft itself so an unrelated prior target
+        // snapshot cannot replace the transferred source content.
+        await transferComposerDraft(targetSessionId, targetSessionId, [pendingItem])
         return
     }
 
@@ -177,7 +175,7 @@ export async function handoffComposerDraft(
         await onNavigable(targetSessionId)
         const late = state.pending.filter((item) => !batch.some((early) => early.id === item.id))
         if (late.length > 0) {
-            await transferComposerDraft(sourceSessionId, targetSessionId, late)
+            await transferComposerDraft(targetSessionId, targetSessionId, late)
         }
     } finally {
         resolveDone()

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -285,13 +285,43 @@ async function awaitInactivePersist(sessionId: string): Promise<void> {
     if (pending) await pending.catch(() => {})
 }
 
+export type TransferComposerDraftOptions = {
+    /**
+     * Immutable text captured at send/resume time. Prefer this over drafts that
+     * may already have been cleared by assistant-ui while resume was in flight.
+     */
+    textOverride?: string
+}
+
+function resolveTransferredText(
+    sampled: string,
+    options?: TransferComposerDraftOptions,
+): string {
+    return options?.textOverride !== undefined ? options.textOverride : sampled
+}
+
 /** Copy a draft to the new id returned by resume/reopen before navigating. */
 export async function transferComposerDraft(
     sourceSessionId: string,
     targetSessionId: string,
     pendingAttachments: readonly AttachmentDraftHandoff[] = [],
+    options?: TransferComposerDraftOptions,
 ): Promise<void> {
-    if (sourceSessionId === targetSessionId && pendingAttachments.length === 0) return
+    if (sourceSessionId === targetSessionId && pendingAttachments.length === 0) {
+        // Same-id resume often no-ops attachments, but Send still needs the
+        // submitted text restored after assistant-ui cleared the composer.
+        if (options?.textOverride !== undefined) {
+            saveDraft(targetSessionId, options.textOverride)
+            const existing = liveSnapshots.get(targetSessionId)
+            if (existing) {
+                liveSnapshots.set(targetSessionId, {
+                    ...existing,
+                    text: options.textOverride,
+                })
+            }
+        }
+        return
+    }
 
     const crossSession = sourceSessionId !== targetSessionId
     // Install the barrier before any await so a concurrent inactive persist
@@ -326,7 +356,7 @@ export async function transferComposerDraft(
                 // Resume already resolved a new id; keep the independently readable
                 // text under the target even when attachment storage aborts.
                 if (crossSession) {
-                    saveDraft(targetSessionId, text)
+                    saveDraft(targetSessionId, resolveTransferredText(text, options))
                 }
                 throw error
             }
@@ -412,9 +442,12 @@ export async function transferComposerDraft(
                         break
                     }
                 }
-                transferredText = samplePendingTransferText(
-                    sourceSessionId,
-                    getDraft(sourceSessionId),
+                transferredText = resolveTransferredText(
+                    samplePendingTransferText(
+                        sourceSessionId,
+                        getDraft(sourceSessionId),
+                    ),
+                    options,
                 )
                 saveDraft(targetSessionId, transferredText)
                 clearDraft(sourceSessionId)
@@ -425,9 +458,12 @@ export async function transferComposerDraft(
                 // Hub resume already succeeded; keep navigating. Copy text + in-memory
                 // attachments to the target without claiming a durable handoff so the
                 // source IndexedDB row remains if the operator reloads the old id.
-                transferredText = samplePendingTransferText(
-                    sourceSessionId,
-                    getDraft(sourceSessionId),
+                transferredText = resolveTransferredText(
+                    samplePendingTransferText(
+                        sourceSessionId,
+                        getDraft(sourceSessionId),
+                    ),
+                    options,
                 )
                 attachments = buildTransferredAttachments()
                 saveDraft(targetSessionId, transferredText)
@@ -437,6 +473,7 @@ export async function transferComposerDraft(
             }
         } else {
             attachments = buildTransferredAttachments()
+            transferredText = resolveTransferredText(transferredText, options)
             saveDraft(targetSessionId, transferredText)
             saveDraftAttachments(targetSessionId, attachments)
         }
@@ -457,9 +494,15 @@ export async function transferComposerDraftThenNavigate(
     targetSessionId: string,
     navigate: () => void | Promise<void>,
     pendingAttachments: readonly AttachmentDraftHandoff[] = [],
+    options?: TransferComposerDraftOptions,
 ): Promise<void> {
     try {
-        await transferComposerDraft(sourceSessionId, targetSessionId, pendingAttachments)
+        await transferComposerDraft(
+            sourceSessionId,
+            targetSessionId,
+            pendingAttachments,
+            options,
+        )
     } catch (error) {
         console.warn('[composer-draft] transfer failed after resume; continuing navigation', error)
     }

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -22,12 +22,16 @@ type HandoffState = {
 }
 
 const activeHandoffs = new Map<string, HandoffState>()
+/** Source → target after a handoff completes, so staggered adds append instead of reloading the source. */
+const completedHandoffs = new Map<string, string>()
 
 export function setComposerDraftSnapshot(
     sessionId: string,
     text: string,
     attachments: readonly AttachmentDraftInput[],
 ): void {
+    // A fresh live snapshot means this session is active in a composer again.
+    completedHandoffs.delete(sessionId)
     // Keep the in-memory fast path bounded because snapshots retain File blobs.
     if (!liveSnapshots.has(sessionId) && liveSnapshots.size >= MAX_LIVE_SNAPSHOTS) {
         const oldestSessionId = liveSnapshots.keys().next().value
@@ -38,6 +42,7 @@ export function setComposerDraftSnapshot(
 
 export function clearComposerDraftSnapshot(sessionId: string): void {
     liveSnapshots.delete(sessionId)
+    completedHandoffs.delete(sessionId)
 }
 
 function stripSessionScopedUploadFields(attachment: AttachmentDraftInput): AttachmentDraftInput {
@@ -141,6 +146,12 @@ export async function handoffComposerDraft(
         return
     }
 
+    const completedTarget = completedHandoffs.get(sourceSessionId)
+    if (completedTarget === targetSessionId) {
+        await transferComposerDraft(targetSessionId, targetSessionId, [pendingItem])
+        return
+    }
+
     const existing = activeHandoffs.get(sourceSessionId)
     if (existing) {
         if (!existing.pending.some((item) => item.id === pendingItem.id)) {
@@ -172,6 +183,7 @@ export async function handoffComposerDraft(
         })
         const batch = [...state.pending]
         await transferComposerDraft(sourceSessionId, targetSessionId, batch)
+        completedHandoffs.set(sourceSessionId, targetSessionId)
         await onNavigable(targetSessionId)
         const late = state.pending.filter((item) => !batch.some((early) => early.id === item.id))
         if (late.length > 0) {

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -24,6 +24,10 @@ type HandoffState = {
 const activeHandoffs = new Map<string, HandoffState>()
 /** Source → target after a handoff completes, so staggered adds append instead of reloading the source. */
 const completedHandoffs = new Map<string, string>()
+/** Last visible inactive attachment ids, so a later empty composer can drop them from IndexedDB. */
+const inactiveVisibleIds = new Map<string, Set<string>>()
+/** Serialize read/merge/write so unmount + effect cannot race, and reopen can await the latest. */
+const inactivePersistQueue = new Map<string, Promise<AttachmentDraftInput[]>>()
 
 export function setComposerDraftSnapshot(
     sessionId: string,
@@ -43,6 +47,7 @@ export function setComposerDraftSnapshot(
 export function clearComposerDraftSnapshot(sessionId: string): void {
     liveSnapshots.delete(sessionId)
     completedHandoffs.delete(sessionId)
+    inactiveVisibleIds.delete(sessionId)
 }
 
 function stripSessionScopedUploadFields(attachment: AttachmentDraftInput): AttachmentDraftInput {
@@ -81,27 +86,63 @@ async function loadPersistedAttachments(sessionId: string): Promise<AttachmentDr
     })
 }
 
+async function persistInactiveComposerAttachmentsNow(
+    sessionId: string,
+    text: string,
+    visibleAttachments: readonly AttachmentDraftInput[],
+): Promise<AttachmentDraftInput[]> {
+    saveDraft(sessionId, text)
+    const previousVisibleIds = inactiveVisibleIds.get(sessionId) ?? new Set<string>()
+    const stored = await loadPersistedAttachments(sessionId)
+    // Drop ids that were previously visible but are gone now (operator removed
+    // a failed-resume pick). Hidden stored files outside that set are retained.
+    const retained = stored.filter((item) => !previousVisibleIds.has(item.id))
+    const merged = mergeAttachmentsById(retained, visibleAttachments)
+    inactiveVisibleIds.set(sessionId, new Set(visibleAttachments.map((item) => item.id)))
+
+    if (visibleAttachments.length === 0) {
+        // Inactive composers must not publish a live snapshot of hidden files.
+        liveSnapshots.delete(sessionId)
+        completedHandoffs.delete(sessionId)
+        if (previousVisibleIds.size > 0) {
+            saveDraftAttachments(sessionId, retained)
+        }
+        return retained
+    }
+
+    saveDraftAttachments(sessionId, merged)
+    setComposerDraftSnapshot(sessionId, text, merged)
+    return merged
+}
+
 /**
  * Persist text for an inactive composer. When the user has visible pending
  * attachments (e.g. resume failed after pick), merge them into IndexedDB
  * instead of replacing the hidden stored list or discarding the new picks.
+ * Concurrent calls for one session are serialized.
  */
 export async function persistInactiveComposerAttachments(
     sessionId: string,
     text: string,
     visibleAttachments: readonly AttachmentDraftInput[],
 ): Promise<AttachmentDraftInput[]> {
-    saveDraft(sessionId, text)
-    if (visibleAttachments.length === 0) {
-        clearComposerDraftSnapshot(sessionId)
-        return []
+    const previous = inactivePersistQueue.get(sessionId) ?? Promise.resolve([] as AttachmentDraftInput[])
+    const next = previous
+        .catch(() => [] as AttachmentDraftInput[])
+        .then(() => persistInactiveComposerAttachmentsNow(sessionId, text, visibleAttachments))
+    inactivePersistQueue.set(sessionId, next)
+    try {
+        return await next
+    } finally {
+        if (inactivePersistQueue.get(sessionId) === next) {
+            inactivePersistQueue.delete(sessionId)
+        }
     }
+}
 
-    const stored = await loadPersistedAttachments(sessionId)
-    const merged = mergeAttachmentsById(stored, visibleAttachments)
-    saveDraftAttachments(sessionId, merged)
-    setComposerDraftSnapshot(sessionId, text, merged)
-    return merged
+async function awaitInactivePersist(sessionId: string): Promise<void> {
+    const pending = inactivePersistQueue.get(sessionId)
+    if (pending) await pending.catch(() => {})
 }
 
 /** Copy a draft to the new id returned by resume/reopen before navigating. */
@@ -111,6 +152,9 @@ export async function transferComposerDraft(
     pendingAttachments: readonly AttachmentDraftInput[] = [],
 ): Promise<void> {
     if (sourceSessionId === targetSessionId && pendingAttachments.length === 0) return
+
+    // Flush any in-flight inactive merge so reopen cannot race a pending read.
+    await awaitInactivePersist(sourceSessionId)
 
     const sourceLive = liveSnapshots.get(sourceSessionId)
 

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -34,6 +34,12 @@ const completedHandoffs = new Map<string, string>()
 const inactiveVisibleIds = new Map<string, Set<string>>()
 /** Serialize read/merge/write so unmount + effect cannot race, and reopen can await the latest. */
 const inactivePersistQueue = new Map<string, Promise<AttachmentDraftInput[]>>()
+/** In-flight cross-session transfers: inactive persist must not recreate the source row. */
+type PendingTransfer = {
+    targetSessionId: string
+    latest?: { text: string; attachments: AttachmentDraftInput[] }
+}
+const pendingTransfers = new Map<string, PendingTransfer>()
 
 export function setComposerDraftSnapshot(
     sessionId: string,
@@ -74,6 +80,7 @@ export function clearComposerDraftSnapshot(sessionId: string): void {
     // Keep completedHandoffs: a handed-off source must stay tombstoned so
     // unmount cleanup cannot recreate the obsolete draft.
     inactiveVisibleIds.delete(sessionId)
+    pendingTransfers.delete(sessionId)
 }
 
 /** True after a cross-session transfer retired this source id. */
@@ -127,6 +134,10 @@ async function persistInactiveComposerAttachmentsNow(
     text: string,
     visibleAttachments: readonly AttachmentDraftInput[],
 ): Promise<AttachmentDraftInput[]> {
+    // A queued persist may settle after the source was already moved.
+    if (composerDraftWasHandedOff(sessionId) || pendingTransfers.has(sessionId)) {
+        return [...visibleAttachments]
+    }
     saveDraft(sessionId, text)
     const previousVisibleIds = inactiveVisibleIds.get(sessionId) ?? new Set<string>()
     const stored = await loadPersistedAttachments(sessionId)
@@ -139,7 +150,8 @@ async function persistInactiveComposerAttachmentsNow(
     if (visibleAttachments.length === 0) {
         // Inactive composers must not publish a live snapshot of hidden files.
         liveSnapshots.delete(sessionId)
-        completedHandoffs.delete(sessionId)
+        // Do not clear completedHandoffs here — that tombstone must survive
+        // empty inactive remounts after a cross-session move.
         if (previousVisibleIds.size > 0) {
             saveDraftAttachments(sessionId, retained)
         }
@@ -165,6 +177,20 @@ export async function persistInactiveComposerAttachments(
     // Source session was already moved to a resumed id — do not recreate it.
     if (composerDraftWasHandedOff(sessionId)) {
         return []
+    }
+    // Transfer in flight: record the latest visible state for the target, and
+    // never write IndexedDB under the retiring source id.
+    const pending = pendingTransfers.get(sessionId)
+    if (pending) {
+        const attachments = [...visibleAttachments]
+        pending.latest = { text, attachments }
+        saveDraft(sessionId, text)
+        const existing = liveSnapshots.get(sessionId)
+        if (existing || attachments.length > 0) {
+            liveSnapshots.set(sessionId, { text, attachments })
+        }
+        inactiveVisibleIds.set(sessionId, new Set(attachments.map((item) => item.id)))
+        return attachments
     }
     const previous = inactivePersistQueue.get(sessionId) ?? Promise.resolve([] as AttachmentDraftInput[])
     const next = previous
@@ -219,13 +245,20 @@ export async function transferComposerDraft(
             if (item.isCancelled?.()) cancelledIds.add(item.id)
         }
 
+        // Prefer edits recorded while the move was in flight over the snapshot
+        // captured at transfer start.
+        const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
+        const currentBase = pendingLatest?.attachments
+            ?? liveSnapshots.get(sourceSessionId)?.attachments
+            ?? baseAttachments
+
         // Cross-session reopen cannot reuse source-authorized upload paths.
         // Same-target staggered appends must keep path/uploadSessionId already
         // written by earlier uploads on that resumed composer.
         const normalizedBase = (
             sourceSessionId === targetSessionId
-                ? baseAttachments
-                : baseAttachments.map(stripSessionScopedUploadFields)
+                ? currentBase
+                : currentBase.map(stripSessionScopedUploadFields)
         ).filter((item) => !cancelledIds.has(item.id))
         const normalizedPending = pendingAttachments
             .filter((item) => !cancelledIds.has(item.id))
@@ -242,6 +275,7 @@ export async function transferComposerDraft(
     let attachments: AttachmentDraftInput[]
     let transferredText = text
     if (sourceSessionId !== targetSessionId) {
+        pendingTransfers.set(sourceSessionId, { targetSessionId })
         // Durable move: await target put + source delete before navigation so a
         // reload cannot lose the draft, and tombstone the source so unmount
         // cleanup cannot recreate it under the obsolete id.
@@ -251,9 +285,19 @@ export async function transferComposerDraft(
                 targetSessionId,
                 buildTransferredAttachments,
             )
-            // Keystrokes during the IDB drain keep updating the source; re-read
+            // Keystrokes / attachment edits during the IDB drain keep updating
+            // the source live snapshot or pendingTransfers.latest; re-read
             // before retiring it so the target does not get a stale snapshot.
-            transferredText = liveSnapshots.get(sourceSessionId)?.text ?? getDraft(sourceSessionId)
+            const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
+            transferredText = pendingLatest?.text
+                ?? liveSnapshots.get(sourceSessionId)?.text
+                ?? getDraft(sourceSessionId)
+            // Re-resolve after the move so a late persist.latest wins even when
+            // resolveAttachments already ran inside moveDraftAttachments.
+            if (pendingLatest) {
+                attachments = buildTransferredAttachments()
+                saveDraftAttachments(targetSessionId, attachments)
+            }
             saveDraft(targetSessionId, transferredText)
             clearDraft(sourceSessionId)
             completedHandoffs.set(sourceSessionId, targetSessionId)
@@ -263,12 +307,17 @@ export async function transferComposerDraft(
             // Hub resume already succeeded; keep navigating. Copy text + in-memory
             // attachments to the target without claiming a durable handoff so the
             // source IndexedDB row remains if the operator reloads the old id.
-            transferredText = liveSnapshots.get(sourceSessionId)?.text ?? getDraft(sourceSessionId)
+            const pendingLatest = pendingTransfers.get(sourceSessionId)?.latest
+            transferredText = pendingLatest?.text
+                ?? liveSnapshots.get(sourceSessionId)?.text
+                ?? getDraft(sourceSessionId)
             attachments = buildTransferredAttachments()
             saveDraft(targetSessionId, transferredText)
             saveDraftAttachments(targetSessionId, attachments)
             setComposerDraftSnapshot(targetSessionId, transferredText, attachments)
             throw error
+        } finally {
+            pendingTransfers.delete(sourceSessionId)
         }
     } else {
         attachments = buildTransferredAttachments()

--- a/web/src/lib/composer-draft-transfer.ts
+++ b/web/src/lib/composer-draft-transfer.ts
@@ -12,12 +12,18 @@ type ComposerDraftSnapshot = {
 }
 
 const liveSnapshots = new Map<string, ComposerDraftSnapshot>()
+const MAX_LIVE_SNAPSHOTS = 50
 
 export function setComposerDraftSnapshot(
     sessionId: string,
     text: string,
     attachments: readonly AttachmentDraftInput[],
 ): void {
+    // Keep the in-memory fast path bounded because snapshots retain File blobs.
+    if (!liveSnapshots.has(sessionId) && liveSnapshots.size >= MAX_LIVE_SNAPSHOTS) {
+        const oldestSessionId = liveSnapshots.keys().next().value
+        if (oldestSessionId) liveSnapshots.delete(oldestSessionId)
+    }
     liveSnapshots.set(sessionId, { text, attachments: [...attachments] })
 }
 
@@ -27,7 +33,7 @@ export async function transferComposerDraft(sourceSessionId: string, targetSessi
 
     const live = liveSnapshots.get(sourceSessionId)
     const text = live ? live.text : getDraft(sourceSessionId)
-    const attachments = live
+    const sourceAttachments = live
         ? live.attachments
         : (await getDraftAttachments(sourceSessionId)).map((file, index) => {
             const metadata = getRestoredUploadMetadata(file)
@@ -39,7 +45,16 @@ export async function transferComposerDraft(sourceSessionId: string, targetSessi
                 uploadSessionId: metadata?.uploadSessionId,
             }
         })
+    // Reopened sessions can receive a new id and cannot safely reuse upload
+    // paths authorized for (and potentially deleted with) the source session.
+    const attachments = sourceAttachments.map((attachment) => ({
+        ...attachment,
+        path: undefined,
+        previewUrl: undefined,
+        uploadSessionId: undefined,
+    }))
 
     saveDraft(targetSessionId, text)
     saveDraftAttachments(targetSessionId, attachments)
+    liveSnapshots.delete(sourceSessionId)
 }

--- a/web/src/lib/inactive-composer-draft-lifecycle.test.tsx
+++ b/web/src/lib/inactive-composer-draft-lifecycle.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, render, waitFor } from '@testing-library/react'
-import { useEffect, useState, type ReactElement } from 'react'
+import { useEffect, useRef, useState, type ReactElement } from 'react'
 import { clearDraft, getDraft, saveDraft } from '@/lib/composer-drafts'
 import {
     clearDraftAttachments,
@@ -10,14 +10,16 @@ import {
 } from '@/lib/composer-attachment-drafts'
 import { useComposerDraft } from '@/hooks/useComposerDraft'
 import {
+    attachmentDraftRevision,
     clearComposerDraftSnapshot,
     persistInactiveComposerAttachments,
     setComposerDraftSnapshot,
     transferComposerDraft,
+    updateComposerDraftTextSnapshot,
 } from '@/lib/composer-draft-transfer'
 
 /**
- * Mirrors HappyComposer's post-hydration snapshot effect for the inactive
+ * Mirrors HappyComposer's post-hydration snapshot effects for the inactive
  * archive → switch → reopen lifecycle without mounting the full chat tree.
  */
 function DraftLifecycleComposer(props: {
@@ -31,6 +33,11 @@ function DraftLifecycleComposer(props: {
         props.initialAttachments ?? [],
     )
     const canRestoreAttachments = props.active
+    const attachmentRevision = attachmentDraftRevision(attachmentDrafts)
+    const latestTextRef = useRef(composerText)
+    latestTextRef.current = composerText
+    const attachmentDraftsRef = useRef(attachmentDrafts)
+    attachmentDraftsRef.current = attachmentDrafts
     const draftHydration = useComposerDraft(
         props.sessionId,
         composerText,
@@ -50,14 +57,30 @@ function DraftLifecycleComposer(props: {
     useEffect(() => {
         if (draftHydration.sessionId !== props.sessionId || !draftHydration.complete) return
         if (canRestoreAttachments) {
-            setComposerDraftSnapshot(props.sessionId, composerText, attachmentDrafts)
-        } else {
-            void persistInactiveComposerAttachments(props.sessionId, composerText, attachmentDrafts)
+            setComposerDraftSnapshot(props.sessionId, composerText, attachmentDraftsRef.current)
+            return
         }
+        updateComposerDraftTextSnapshot(props.sessionId, composerText)
     }, [
-        attachmentDrafts,
+        attachmentRevision,
         canRestoreAttachments,
         composerText,
+        draftHydration.complete,
+        draftHydration.sessionId,
+        props.sessionId,
+    ])
+
+    useEffect(() => {
+        if (draftHydration.sessionId !== props.sessionId || !draftHydration.complete) return
+        if (canRestoreAttachments) return
+        void persistInactiveComposerAttachments(
+            props.sessionId,
+            latestTextRef.current,
+            attachmentDraftsRef.current,
+        )
+    }, [
+        attachmentRevision,
+        canRestoreAttachments,
         draftHydration.complete,
         draftHydration.sessionId,
         props.sessionId,

--- a/web/src/lib/inactive-composer-draft-lifecycle.test.tsx
+++ b/web/src/lib/inactive-composer-draft-lifecycle.test.tsx
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, waitFor } from '@testing-library/react'
+import { useEffect, useState, type ReactElement } from 'react'
+import { clearDraft, getDraft, saveDraft } from '@/lib/composer-drafts'
+import {
+    clearDraftAttachments,
+    getDraftAttachments,
+    saveDraftAttachments,
+    type AttachmentDraftInput,
+} from '@/lib/composer-attachment-drafts'
+import { useComposerDraft } from '@/hooks/useComposerDraft'
+import {
+    clearComposerDraftSnapshot,
+    setComposerDraftSnapshot,
+    transferComposerDraft,
+} from '@/lib/composer-draft-transfer'
+
+/**
+ * Mirrors HappyComposer's post-hydration snapshot effect for the inactive
+ * archive → switch → reopen lifecycle without mounting the full chat tree.
+ */
+function DraftLifecycleComposer(props: {
+    sessionId: string
+    active: boolean
+    initialText?: string
+    initialAttachments?: AttachmentDraftInput[]
+}): ReactElement {
+    const [composerText, setComposerText] = useState(props.initialText ?? '')
+    const [attachmentDrafts, setAttachmentDrafts] = useState<AttachmentDraftInput[]>(
+        props.initialAttachments ?? [],
+    )
+    const canRestoreAttachments = props.active
+    const draftHydration = useComposerDraft(
+        props.sessionId,
+        composerText,
+        attachmentDrafts,
+        canRestoreAttachments,
+        setComposerText,
+        async (file) => {
+            setAttachmentDrafts((current) => {
+                if (current.some((item) => item.file.name === file.name && item.file.size === file.size)) {
+                    return current
+                }
+                return [...current, { id: `restored-${file.name}`, file }]
+            })
+        },
+    )
+
+    useEffect(() => {
+        if (draftHydration.sessionId !== props.sessionId || !draftHydration.complete) return
+        if (canRestoreAttachments) {
+            setComposerDraftSnapshot(props.sessionId, composerText, attachmentDrafts)
+        } else {
+            saveDraft(props.sessionId, composerText)
+            clearComposerDraftSnapshot(props.sessionId)
+        }
+    }, [
+        attachmentDrafts,
+        canRestoreAttachments,
+        composerText,
+        draftHydration.complete,
+        draftHydration.sessionId,
+        props.sessionId,
+    ])
+
+    return (
+        <div
+            data-testid="lifecycle-composer"
+            data-session={props.sessionId}
+            data-active={String(props.active)}
+            data-text={composerText}
+            data-attachments={attachmentDrafts.map((item) => item.file.name).join(',')}
+            data-hydration={draftHydration.complete ? 'complete' : 'pending'}
+        />
+    )
+}
+
+describe('inactive composer draft lifecycle', () => {
+    let rAFCallbacks: Array<() => void>
+
+    beforeEach(() => {
+        vi.stubGlobal('indexedDB', undefined)
+        sessionStorage.clear()
+        rAFCallbacks = []
+        vi.stubGlobal('requestAnimationFrame', vi.fn((cb: () => void) => {
+            rAFCallbacks.push(cb)
+            return rAFCallbacks.length
+        }))
+        vi.stubGlobal('cancelAnimationFrame', vi.fn())
+        for (const sessionId of ['session-source', 'session-other', 'session-reopened']) {
+            clearDraft(sessionId)
+            clearDraftAttachments(sessionId)
+            clearComposerDraftSnapshot(sessionId)
+        }
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        for (const sessionId of ['session-source', 'session-other', 'session-reopened']) {
+            clearDraft(sessionId)
+            clearDraftAttachments(sessionId)
+            clearComposerDraftSnapshot(sessionId)
+        }
+        sessionStorage.clear()
+    })
+
+    async function flushRAF() {
+        const cbs = [...rAFCallbacks]
+        rAFCallbacks = []
+        await act(async () => {
+            cbs.forEach((cb) => cb())
+            await Promise.resolve()
+            await Promise.resolve()
+        })
+    }
+
+    it('keeps persisted attachments across archive, session switch, and reopen to a new id', async () => {
+        const file = new File(['payload'], 'notes.txt', { type: 'text/plain' })
+
+        // 1) Active session: user typed text and attached a file.
+        const active = render(
+            <DraftLifecycleComposer
+                sessionId="session-source"
+                active
+                initialText="draft before archive"
+                initialAttachments={[{ id: 'a1', file }]}
+            />,
+        )
+        await flushRAF()
+        await waitFor(() => {
+            expect(active.getByTestId('lifecycle-composer').dataset.hydration).toBe('complete')
+        })
+        // useComposerDraft persists text/attachments on unmount (archive / leave session).
+        active.unmount()
+        expect(getDraft('session-source')).toBe('draft before archive')
+        expect((await getDraftAttachments('session-source')).map((item) => item.name)).toEqual(['notes.txt'])
+
+        // 2) Archive / remount inactive: attachments stay in storage, not restored into the adapter.
+        const inactive = render(
+            <DraftLifecycleComposer
+                sessionId="session-source"
+                active={false}
+            />,
+        )
+        await flushRAF()
+        await waitFor(() => {
+            expect(inactive.getByTestId('lifecycle-composer').dataset.hydration).toBe('complete')
+        })
+        // Text restores; attachments do not (avoids passive resume).
+        expect(inactive.getByTestId('lifecycle-composer').dataset.text).toBe('draft before archive')
+        expect(inactive.getByTestId('lifecycle-composer').dataset.attachments).toBe('')
+        expect((await getDraftAttachments('session-source')).map((item) => item.name)).toEqual(['notes.txt'])
+
+        // 3) Switch away to another session and return to the archived source.
+        inactive.unmount()
+        const other = render(
+            <DraftLifecycleComposer
+                sessionId="session-other"
+                active
+                initialText="other session"
+            />,
+        )
+        await flushRAF()
+        await waitFor(() => {
+            expect(other.getByTestId('lifecycle-composer').dataset.hydration).toBe('complete')
+        })
+        other.unmount()
+
+        const inactiveAgain = render(
+            <DraftLifecycleComposer
+                sessionId="session-source"
+                active={false}
+            />,
+        )
+        await flushRAF()
+        await waitFor(() => {
+            expect(inactiveAgain.getByTestId('lifecycle-composer').dataset.hydration).toBe('complete')
+        })
+        expect(inactiveAgain.getByTestId('lifecycle-composer').dataset.attachments).toBe('')
+        expect((await getDraftAttachments('session-source')).map((item) => item.name)).toEqual(['notes.txt'])
+
+        // 4) Reopen merges into a new session id and must carry text + attachments.
+        await transferComposerDraft('session-source', 'session-reopened')
+        inactiveAgain.unmount()
+
+        expect(getDraft('session-reopened')).toBe('draft before archive')
+        const transferred = await getDraftAttachments('session-reopened')
+        expect(transferred).toHaveLength(1)
+        expect(transferred[0]?.name).toBe('notes.txt')
+        expect(transferred[0]?.size).toBe(file.size)
+        expect(transferred[0]?.type).toBe('text/plain')
+    })
+
+    it('would lose attachments if an empty inactive live snapshot were published', async () => {
+        const file = new File(['payload'], 'notes.txt', { type: 'text/plain' })
+        saveDraft('session-source', 'draft before archive')
+        saveDraftAttachments('session-source', [{ id: 'a1', file }])
+
+        // Regression guard for the prior bug: empty live snapshot shadows IndexedDB.
+        setComposerDraftSnapshot('session-source', 'draft before archive', [])
+        await transferComposerDraft('session-source', 'session-reopened')
+        expect(await getDraftAttachments('session-reopened')).toEqual([])
+
+        // Clearing the empty snapshot restores the persisted-file path used after archive.
+        saveDraft('session-source', 'draft before archive')
+        saveDraftAttachments('session-source', [{ id: 'a1', file }])
+        clearComposerDraftSnapshot('session-source')
+        await transferComposerDraft('session-source', 'session-reopened')
+        expect((await getDraftAttachments('session-reopened')).map((item) => item.name)).toEqual(['notes.txt'])
+    })
+})

--- a/web/src/lib/inactive-composer-draft-lifecycle.test.tsx
+++ b/web/src/lib/inactive-composer-draft-lifecycle.test.tsx
@@ -13,6 +13,7 @@ import {
     attachmentDraftRevision,
     clearComposerDraftSnapshot,
     persistInactiveComposerAttachments,
+    resetInactiveComposerAttachmentVisibility,
     setComposerDraftSnapshot,
     transferComposerDraft,
     updateComposerDraftTextSnapshot,
@@ -38,6 +39,12 @@ function DraftLifecycleComposer(props: {
     latestTextRef.current = composerText
     const attachmentDraftsRef = useRef(attachmentDrafts)
     attachmentDraftsRef.current = attachmentDrafts
+
+    useEffect(() => {
+        if (canRestoreAttachments) return
+        resetInactiveComposerAttachmentVisibility(props.sessionId)
+    }, [canRestoreAttachments, props.sessionId])
+
     const draftHydration = useComposerDraft(
         props.sessionId,
         composerText,

--- a/web/src/lib/inactive-composer-draft-lifecycle.test.tsx
+++ b/web/src/lib/inactive-composer-draft-lifecycle.test.tsx
@@ -11,6 +11,7 @@ import {
 import { useComposerDraft } from '@/hooks/useComposerDraft'
 import {
     clearComposerDraftSnapshot,
+    persistInactiveComposerAttachments,
     setComposerDraftSnapshot,
     transferComposerDraft,
 } from '@/lib/composer-draft-transfer'
@@ -51,8 +52,7 @@ function DraftLifecycleComposer(props: {
         if (canRestoreAttachments) {
             setComposerDraftSnapshot(props.sessionId, composerText, attachmentDrafts)
         } else {
-            saveDraft(props.sessionId, composerText)
-            clearComposerDraftSnapshot(props.sessionId)
+            void persistInactiveComposerAttachments(props.sessionId, composerText, attachmentDrafts)
         }
     }, [
         attachmentDrafts,

--- a/web/src/lib/scratchlistAttachmentAdapter.ts
+++ b/web/src/lib/scratchlistAttachmentAdapter.ts
@@ -74,7 +74,7 @@ export function createScratchlistAttachmentAdapter(
         async *add({ file }): AsyncGenerator<PendingAttachment> {
             const contentType = file.type || 'application/octet-stream'
             const restored = getRestoredUploadMetadata(file)
-            if (restored) {
+            if (restored?.path) {
                 const hubAttachment = hubAttachmentFromRestoredDraft(restored.path, file, contentType)
                 if (hubAttachment) {
                     yield {

--- a/web/src/lib/session-detail-optimistic.test.ts
+++ b/web/src/lib/session-detail-optimistic.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/query-keys'
+import { reapplyOptimisticSessionActive } from './session-detail-optimistic'
+
+describe('reapplyOptimisticSessionActive', () => {
+    it('keeps the cache active after a stale inactive detail fetch', async () => {
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        })
+        const resolvedSessionId = 'session-reopened'
+        queryClient.setQueryData(queryKeys.session(resolvedSessionId), {
+            session: { id: resolvedSessionId, active: true, title: 'seeded' },
+        })
+
+        await queryClient.fetchQuery({
+            queryKey: queryKeys.session(resolvedSessionId),
+            queryFn: async () => ({
+                session: { id: resolvedSessionId, active: false, title: 'stale' },
+            }),
+            staleTime: 0,
+        }).catch(() => undefined).finally(() => {
+            reapplyOptimisticSessionActive(queryClient, resolvedSessionId)
+        })
+
+        expect(queryClient.getQueryData(queryKeys.session(resolvedSessionId))).toEqual({
+            session: { id: resolvedSessionId, active: true, title: 'stale' },
+        })
+    })
+
+    it('is a no-op when the detail cache is empty', () => {
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } },
+        })
+        const spy = vi.spyOn(queryClient, 'setQueryData')
+        reapplyOptimisticSessionActive(queryClient, 'missing')
+        const updater = spy.mock.calls[0]?.[1] as ((previous: unknown) => unknown) | undefined
+        expect(updater?.(undefined)).toBeUndefined()
+    })
+})

--- a/web/src/lib/session-detail-optimistic.test.ts
+++ b/web/src/lib/session-detail-optimistic.test.ts
@@ -1,10 +1,35 @@
 import { describe, expect, it, vi } from 'vitest'
 import { QueryClient } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query-keys'
-import { reapplyOptimisticSessionActive } from './session-detail-optimistic'
+import {
+    mergeSessionDetailIfActiveUnchanged,
+    refreshSessionDetailPreservingActive,
+} from './session-detail-optimistic'
 
-describe('reapplyOptimisticSessionActive', () => {
-    it('keeps the cache active after a stale inactive detail fetch', async () => {
+describe('mergeSessionDetailIfActiveUnchanged', () => {
+    it('keeps a newer inactive SSE transition over a late active response', () => {
+        const current = {
+            session: { id: 'session-reopened', active: false, title: 'sse-inactive' },
+        }
+        const response = {
+            session: { id: 'session-reopened', active: true, title: 'stale-active' },
+        }
+        expect(mergeSessionDetailIfActiveUnchanged(current, response)).toBe(current)
+    })
+
+    it('applies the response when active still matches', () => {
+        const current = {
+            session: { id: 'session-reopened', active: true, title: 'seeded' },
+        }
+        const response = {
+            session: { id: 'session-reopened', active: true, title: 'fresh' },
+        }
+        expect(mergeSessionDetailIfActiveUnchanged(current, response)).toEqual(response)
+    })
+})
+
+describe('refreshSessionDetailPreservingActive', () => {
+    it('does not resurrect active after the cache went inactive mid-flight', async () => {
         const queryClient = new QueryClient({
             defaultOptions: { queries: { retry: false } },
         })
@@ -13,28 +38,30 @@ describe('reapplyOptimisticSessionActive', () => {
             session: { id: resolvedSessionId, active: true, title: 'seeded' },
         })
 
-        await queryClient.fetchQuery({
-            queryKey: queryKeys.session(resolvedSessionId),
-            queryFn: async () => ({
-                session: { id: resolvedSessionId, active: false, title: 'stale' },
-            }),
-            staleTime: 0,
-        }).catch(() => undefined).finally(() => {
-            reapplyOptimisticSessionActive(queryClient, resolvedSessionId)
+        let release!: () => void
+        const gate = new Promise<void>((resolve) => {
+            release = resolve
         })
+        const fetchDetail = vi.fn(async () => {
+            await gate
+            return {
+                session: { id: resolvedSessionId, active: true, title: 'late' },
+            }
+        })
+
+        const refresh = refreshSessionDetailPreservingActive(
+            queryClient,
+            resolvedSessionId,
+            fetchDetail,
+        )
+        queryClient.setQueryData(queryKeys.session(resolvedSessionId), {
+            session: { id: resolvedSessionId, active: false, title: 'sse-inactive' },
+        })
+        release()
+        await refresh
 
         expect(queryClient.getQueryData(queryKeys.session(resolvedSessionId))).toEqual({
-            session: { id: resolvedSessionId, active: true, title: 'stale' },
+            session: { id: resolvedSessionId, active: false, title: 'sse-inactive' },
         })
-    })
-
-    it('is a no-op when the detail cache is empty', () => {
-        const queryClient = new QueryClient({
-            defaultOptions: { queries: { retry: false } },
-        })
-        const spy = vi.spyOn(queryClient, 'setQueryData')
-        reapplyOptimisticSessionActive(queryClient, 'missing')
-        const updater = spy.mock.calls[0]?.[1] as ((previous: unknown) => unknown) | undefined
-        expect(updater?.(undefined)).toBeUndefined()
     })
 })

--- a/web/src/lib/session-detail-optimistic.ts
+++ b/web/src/lib/session-detail-optimistic.ts
@@ -11,27 +11,31 @@ type SessionDetailCache = {
 }
 
 /**
- * Force the session detail cache back to active after a background getSession
- * may have overwritten an optimistic resume/reopen seed with a stale inactive
- * REST/SSE snapshot.
+ * Apply a background getSession response only when the cache still agrees on
+ * `active`. If SSE already flipped active/inactive while the request was in
+ * flight, keep the newer local transition instead of resurrecting a stale REST
+ * snapshot.
  */
-export function reapplyOptimisticSessionActive(
+export function mergeSessionDetailIfActiveUnchanged(
+    current: SessionDetailCache | undefined,
+    response: SessionDetailCache,
+): SessionDetailCache | undefined {
+    if (current?.session.active !== response.session.active) return current
+    return response
+}
+
+/** Background-refresh session detail without clobbering a newer active flag. */
+export function refreshSessionDetailPreservingActive(
     queryClient: QueryClient,
     resolvedSessionId: string,
-): void {
-    queryClient.setQueryData(
-        queryKeys.session(resolvedSessionId),
-        (previous: SessionDetailCache | undefined) => (
-            previous?.session
-                ? {
-                    ...previous,
-                    session: {
-                        ...previous.session,
-                        id: resolvedSessionId,
-                        active: true,
-                    },
-                }
-                : previous
-        ),
-    )
+    fetchDetail: () => Promise<SessionDetailCache>,
+): Promise<void> {
+    return fetchDetail().then((response) => {
+        queryClient.setQueryData(
+            queryKeys.session(resolvedSessionId),
+            (current: SessionDetailCache | undefined) => (
+                mergeSessionDetailIfActiveUnchanged(current, response)
+            ),
+        )
+    }).catch(() => undefined)
 }

--- a/web/src/lib/session-detail-optimistic.ts
+++ b/web/src/lib/session-detail-optimistic.ts
@@ -1,0 +1,37 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/query-keys'
+
+type SessionDetailCache = {
+    session: {
+        id: string
+        active: boolean
+        [key: string]: unknown
+    }
+    [key: string]: unknown
+}
+
+/**
+ * Force the session detail cache back to active after a background getSession
+ * may have overwritten an optimistic resume/reopen seed with a stale inactive
+ * REST/SSE snapshot.
+ */
+export function reapplyOptimisticSessionActive(
+    queryClient: QueryClient,
+    resolvedSessionId: string,
+): void {
+    queryClient.setQueryData(
+        queryKeys.session(resolvedSessionId),
+        (previous: SessionDetailCache | undefined) => (
+            previous?.session
+                ? {
+                    ...previous,
+                    session: {
+                        ...previous.session,
+                        id: resolvedSessionId,
+                        active: true,
+                    },
+                }
+                : previous
+        ),
+    )
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -498,11 +498,11 @@ function SessionPage() {
     }, [session?.id, session?.active])
     const resolveSessionId = useCallback(async (currentSessionId: string) => {
         if (!api || !session || session.active) {
-            return currentSessionId
+            return { sessionId: currentSessionId, resumed: false }
         }
         const cached = resolvedSessionRef.current
         if (cached?.source === currentSessionId) {
-            return await cached.target
+            return { sessionId: await cached.target, resumed: true }
         }
         if (!inactiveSessionCanResume(session, messages.length, cursorChatStoreStatus?.onDisk)) {
             throw new ApiError(
@@ -514,7 +514,7 @@ function SessionPage() {
         try {
             const target = api.resumeSession(currentSessionId, { permissionMode: session.permissionMode ?? undefined })
             resolvedSessionRef.current = { source: currentSessionId, target }
-            return await target
+            return { sessionId: await target, resumed: true }
         } catch (error) {
             if (resolvedSessionRef.current?.source === currentSessionId) {
                 resolvedSessionRef.current = null
@@ -779,7 +779,7 @@ function SessionPage() {
             onLoadMore={loadMoreMessages}
             onCancelLoadMore={cancelLoadMoreMessages}
             onSend={sendMessage}
-            resolveSessionIdForUpload={resolveSessionId}
+            resolveSessionIdForUpload={async (id) => (await resolveSessionId(id)).sessionId}
             onUploadSessionResolved={handleSessionResolved}
             onViewModeChange={setViewMode}
             onRetryMessage={retryMessage}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -43,6 +43,7 @@ import { useToast } from '@/lib/toast-context'
 import { useTranslation } from '@/lib/use-translation'
 import { seedMessageWindowFromSession, syncTailMessages } from '@/lib/message-window-store'
 import { clearDraftsAfterSend } from '@/lib/clearDraftsAfterSend'
+import { transferComposerDraft } from '@/lib/composer-draft-transfer'
 import { inactiveSessionCanResume } from '@/lib/sessionResume'
 import { initializeSessionLastSeen, markSessionSeen } from '@/lib/sessionLastSeen'
 import { useSessionBrowserTitle } from '@/hooks/useSessionBrowserTitle'
@@ -433,6 +434,7 @@ function SessionPage() {
                 await queryClient.invalidateQueries({ queryKey: queryKeys.session(result.sessionId) })
                 await queryClient.invalidateQueries({ queryKey: queryKeys.sessions })
                 if (result.sessionId && result.sessionId !== errorSessionId) {
+                    await transferComposerDraft(errorSessionId, result.sessionId)
                     navigate({
                         to: '/sessions/$sessionId',
                         params: { sessionId: result.sessionId },
@@ -483,6 +485,69 @@ function SessionPage() {
         }
         : null
 
+    const resolvedSessionRef = useRef<{ source: string; target: Promise<string> } | null>(null)
+    const resolveSessionId = useCallback(async (currentSessionId: string) => {
+        if (!api || !session || session.active) {
+            return currentSessionId
+        }
+        const cached = resolvedSessionRef.current
+        if (cached?.source === currentSessionId) {
+            return await cached.target
+        }
+        if (!inactiveSessionCanResume(session, messages.length, cursorChatStoreStatus?.onDisk)) {
+            throw new ApiError(
+                t('chat.sendError.sessionInactive'),
+                409,
+                'session_inactive',
+            )
+        }
+        try {
+            const target = api.resumeSession(currentSessionId, { permissionMode: session.permissionMode ?? undefined })
+            resolvedSessionRef.current = { source: currentSessionId, target }
+            return await target
+        } catch (error) {
+            if (resolvedSessionRef.current?.source === currentSessionId) {
+                resolvedSessionRef.current = null
+            }
+            const message = error instanceof Error ? error.message : t('dialog.error.default')
+            addToast({
+                title: t('resume.failed.title'),
+                body: message,
+                sessionId: currentSessionId,
+                url: ''
+            })
+            throw new ApiError(
+                t('chat.sendError.sessionInactive'),
+                409,
+                'session_inactive',
+            )
+        }
+    }, [api, session, messages.length, cursorChatStoreStatus?.onDisk, t, addToast])
+
+    const handleSessionResolved = useCallback((resolvedSessionId: string) => {
+        if (session) {
+            if (resolvedSessionId !== session.id) {
+                seedMessageWindowFromSession(session.id, resolvedSessionId)
+            }
+            queryClient.setQueryData(queryKeys.session(resolvedSessionId), (previous: { session?: typeof session } | undefined) => ({
+                session: { ...(previous?.session ?? session), id: resolvedSessionId, active: true }
+            }))
+            void queryClient.invalidateQueries({ queryKey: queryKeys.sessions })
+        }
+        navigate({
+            to: '/sessions/$sessionId',
+            params: { sessionId: resolvedSessionId },
+            replace: true
+        })
+        if (api) {
+            void queryClient.prefetchQuery({
+                queryKey: queryKeys.session(resolvedSessionId),
+                queryFn: () => api.getSession(resolvedSessionId),
+            }).catch(() => {})
+            void syncTailMessages(api, resolvedSessionId).catch(() => {})
+        }
+    }, [api, navigate, queryClient, session])
+
     const {
         sendMessage,
         retryMessage,
@@ -520,83 +585,9 @@ function SessionPage() {
                 }
             }))
         },
-        resolveSessionId: async (currentSessionId) => {
-            if (!api || !session || session.active) {
-                return currentSessionId
-            }
-            if (!inactiveSessionCanResume(session, messages.length, cursorChatStoreStatus?.onDisk)) {
-                // #918: surface as a session_inactive ApiError so the
-                // onError consumer's classifier renders the Reopen
-                // affordance.  `status: 409` mirrors the hub guard for
-                // structural parity; no HTTP call was made.
-                throw new ApiError(
-                    t('chat.sendError.sessionInactive'),
-                    409,
-                    'session_inactive',
-                )
-            }
-            try {
-                return await api.resumeSession(currentSessionId, { permissionMode: session.permissionMode ?? undefined })
-            } catch (error) {
-                const message = error instanceof Error ? error.message : t('dialog.error.default')
-                addToast({
-                    title: t('resume.failed.title'),
-                    body: message,
-                    sessionId: currentSessionId,
-                    url: ''
-                })
-                // Rebrand as a session_inactive ApiError so the inline
-                // affordance offers Reopen (a separate code path from the
-                // failed Resume) and the operator has a recovery click.
-                throw new ApiError(
-                    t('chat.sendError.sessionInactive'),
-                    409,
-                    'session_inactive',
-                )
-            }
-        },
-        onSessionResolved: (resolvedSessionId) => {
-            // A direct retry retains its old alert with restoreSuppressed=true.
-            // Move it to the target session before navigation so the mutation's
-            // onSuccess/onError can clear or replace the same record.
-            setSendErrors((previous) => migrateSuppressedSendError(
-                previous,
-                sessionId,
-                resolvedSessionId,
-            ))
-            void (async () => {
-                if (api) {
-                    if (session) {
-                        if (resolvedSessionId !== session.id) {
-                            seedMessageWindowFromSession(session.id, resolvedSessionId)
-                        }
-                        void queryClient.invalidateQueries({ queryKey: queryKeys.sessions })
-                    }
-                    try {
-                        await Promise.all([
-                            queryClient.prefetchQuery({
-                                queryKey: queryKeys.session(resolvedSessionId),
-                                queryFn: () => api.getSession(resolvedSessionId),
-                            }),
-                            syncTailMessages(api, resolvedSessionId),
-                        ])
-                    } catch {
-                    }
-                    if (session) {
-                        // 中文注释：恢复接口成功后，REST/SSE 可能仍有短暂竞态；最后再乐观置为在线，
-                        // 避免刚 prefetch 到旧 inactive 快照导致状态栏继续显示离线。
-                        queryClient.setQueryData(queryKeys.session(resolvedSessionId), (previous: { session?: typeof session } | undefined) => ({
-                            session: { ...(previous?.session ?? session), id: resolvedSessionId, active: true }
-                        }))
-                    }
-                }
-                navigate({
-                    to: '/sessions/$sessionId',
-                    params: { sessionId: resolvedSessionId },
-                    replace: true
-                })
-            })()
-        },
+        resolveSessionId,
+        onSessionResolved: handleSessionResolved,
+
         onBlocked: (reason) => {
             if (reason === 'no-api') {
                 addToast({
@@ -761,6 +752,8 @@ function SessionPage() {
             onLoadMore={loadMoreMessages}
             onCancelLoadMore={cancelLoadMoreMessages}
             onSend={sendMessage}
+            resolveSessionIdForUpload={resolveSessionId}
+            onUploadSessionResolved={handleSessionResolved}
             onViewModeChange={setViewMode}
             onRetryMessage={retryMessage}
             autocompleteSuggestions={getAutocompleteSuggestions}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -44,6 +44,7 @@ import { useTranslation } from '@/lib/use-translation'
 import { seedMessageWindowFromSession, syncTailMessages } from '@/lib/message-window-store'
 import { clearDraftsAfterSend } from '@/lib/clearDraftsAfterSend'
 import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
+import { reapplyOptimisticSessionActive } from '@/lib/session-detail-optimistic'
 import { inactiveSessionCanResume } from '@/lib/sessionResume'
 import { initializeSessionLastSeen, markSessionSeen } from '@/lib/sessionLastSeen'
 import { useSessionBrowserTitle } from '@/hooks/useSessionBrowserTitle'
@@ -552,7 +553,11 @@ function SessionPage() {
                 queryKey: queryKeys.session(resolvedSessionId),
                 queryFn: () => api.getSession(resolvedSessionId),
                 staleTime: 0,
-            }).catch(() => {})
+            }).catch(() => undefined).finally(() => {
+                // Resume can return before REST reflects active; keep the
+                // optimistic seed so the target composer stays on the active adapter.
+                reapplyOptimisticSessionActive(queryClient, resolvedSessionId)
+            })
             void syncTailMessages(api, resolvedSessionId).catch(() => {})
         }
     }, [api, navigate, queryClient, session])

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -44,6 +44,7 @@ import { useTranslation } from '@/lib/use-translation'
 import { seedMessageWindowFromSession, syncTailMessages } from '@/lib/message-window-store'
 import { clearDraftsAfterSend } from '@/lib/clearDraftsAfterSend'
 import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
+import { getDraftAttachments } from '@/lib/composer-attachment-drafts'
 import { refreshSessionDetailPreservingActive } from '@/lib/session-detail-optimistic'
 import { inactiveSessionCanResume } from '@/lib/sessionResume'
 import { initializeSessionLastSeen, markSessionSeen } from '@/lib/sessionLastSeen'
@@ -596,14 +597,24 @@ function SessionPage() {
             }))
         },
         resolveSessionId,
-        onSessionResolved: async (resolvedSessionId) => {
-            if (!sessionId) return
+        onSessionResolved: async (resolvedSessionId, context) => {
+            if (!sessionId) return undefined
             setSendErrors((prev) => migrateSuppressedSendError(prev, sessionId, resolvedSessionId))
             await transferComposerDraftThenNavigate(
                 sessionId,
                 resolvedSessionId,
                 () => handleSessionResolved(resolvedSessionId),
             )
+            // Inactive composers withhold stored files from the visible adapter.
+            // After transfer, defer the mutation so the active target can hydrate
+            // and re-upload before Send; otherwise clearDraftsAfterSend would
+            // wipe the moved draft after a text-only POST.
+            if ((context.attachments?.length ?? 0) > 0) return undefined
+            const stored = await getDraftAttachments(resolvedSessionId)
+            if (stored.length > 0) {
+                return { deferUntilDraftHydrated: true }
+            }
+            return undefined
         },
 
         onBlocked: (reason) => {

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -600,11 +600,14 @@ function SessionPage() {
             }))
         },
         resolveSessionId,
-        onSessionResolved: (resolvedSessionId) => {
-            if (sessionId) {
-                setSendErrors((prev) => migrateSuppressedSendError(prev, sessionId, resolvedSessionId))
-            }
-            handleSessionResolved(resolvedSessionId)
+        onSessionResolved: async (resolvedSessionId) => {
+            if (!sessionId) return
+            setSendErrors((prev) => migrateSuppressedSendError(prev, sessionId, resolvedSessionId))
+            await transferComposerDraftThenNavigate(
+                sessionId,
+                resolvedSessionId,
+                () => handleSessionResolved(resolvedSessionId),
+            )
         },
 
         onBlocked: (reason) => {

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -586,7 +586,12 @@ function SessionPage() {
             }))
         },
         resolveSessionId,
-        onSessionResolved: handleSessionResolved,
+        onSessionResolved: (resolvedSessionId) => {
+            if (sessionId) {
+                setSendErrors((prev) => migrateSuppressedSendError(prev, sessionId, resolvedSessionId))
+            }
+            handleSessionResolved(resolvedSessionId)
+        },
 
         onBlocked: (reason) => {
             if (reason === 'no-api') {

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -605,13 +605,11 @@ function SessionPage() {
                 resolvedSessionId,
                 () => handleSessionResolved(resolvedSessionId),
             )
-            // Inactive composers withhold stored files from the visible adapter.
-            // After transfer, defer the mutation so the active target can hydrate
-            // and re-upload before Send; otherwise clearDraftsAfterSend would
-            // wipe the moved draft after a text-only POST.
-            if ((context.attachments?.length ?? 0) > 0) return undefined
+            // Cross-session resume: visible metadata may still carry source-scoped
+            // upload paths, and inactive remounts hide stored files entirely.
+            // Always defer so the active target can hydrate/re-upload before POST.
             const stored = await getDraftAttachments(resolvedSessionId)
-            if (stored.length > 0) {
+            if ((context.attachments?.length ?? 0) > 0 || stored.length > 0) {
                 return { deferUntilDraftHydrated: true }
             }
             return undefined

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -43,7 +43,7 @@ import { useToast } from '@/lib/toast-context'
 import { useTranslation } from '@/lib/use-translation'
 import { seedMessageWindowFromSession, syncTailMessages } from '@/lib/message-window-store'
 import { clearDraftsAfterSend } from '@/lib/clearDraftsAfterSend'
-import { transferComposerDraft } from '@/lib/composer-draft-transfer'
+import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
 import { inactiveSessionCanResume } from '@/lib/sessionResume'
 import { initializeSessionLastSeen, markSessionSeen } from '@/lib/sessionLastSeen'
 import { useSessionBrowserTitle } from '@/hooks/useSessionBrowserTitle'
@@ -434,12 +434,15 @@ function SessionPage() {
                 await queryClient.invalidateQueries({ queryKey: queryKeys.session(result.sessionId) })
                 await queryClient.invalidateQueries({ queryKey: queryKeys.sessions })
                 if (result.sessionId && result.sessionId !== errorSessionId) {
-                    await transferComposerDraft(errorSessionId, result.sessionId)
-                    navigate({
-                        to: '/sessions/$sessionId',
-                        params: { sessionId: result.sessionId },
-                        replace: true
-                    })
+                    await transferComposerDraftThenNavigate(
+                        errorSessionId,
+                        result.sessionId,
+                        () => navigate({
+                            to: '/sessions/$sessionId',
+                            params: { sessionId: result.sessionId },
+                            replace: true
+                        }),
+                    )
                 }
             } catch (err) {
                 const message = err instanceof Error ? err.message : t('dialog.error.default')

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -604,6 +604,10 @@ function SessionPage() {
                 sessionId,
                 resolvedSessionId,
                 () => handleSessionResolved(resolvedSessionId),
+                [],
+                // assistant-ui clears composer text without awaiting this path;
+                // keep the submitted snapshot so deferred hydration still has it.
+                { textOverride: context.text },
             )
             // Cross-session resume: visible metadata may still carry source-scoped
             // upload paths, and inactive remounts hide stored files entirely.

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -486,6 +486,11 @@ function SessionPage() {
         : null
 
     const resolvedSessionRef = useRef<{ source: string; target: Promise<string> } | null>(null)
+    // Clear when the session id or active flag changes so a same-id resume
+    // that later archives again cannot reuse a stale in-flight/cached resume.
+    useEffect(() => {
+        resolvedSessionRef.current = null
+    }, [session?.id, session?.active])
     const resolveSessionId = useCallback(async (currentSessionId: string) => {
         if (!api || !session || session.active) {
             return currentSessionId

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -545,9 +545,10 @@ function SessionPage() {
             replace: true
         })
         if (api) {
-            void queryClient.prefetchQuery({
+            void queryClient.fetchQuery({
                 queryKey: queryKeys.session(resolvedSessionId),
                 queryFn: () => api.getSession(resolvedSessionId),
+                staleTime: 0,
             }).catch(() => {})
             void syncTailMessages(api, resolvedSessionId).catch(() => {})
         }

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -44,7 +44,7 @@ import { useTranslation } from '@/lib/use-translation'
 import { seedMessageWindowFromSession, syncTailMessages } from '@/lib/message-window-store'
 import { clearDraftsAfterSend } from '@/lib/clearDraftsAfterSend'
 import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
-import { reapplyOptimisticSessionActive } from '@/lib/session-detail-optimistic'
+import { refreshSessionDetailPreservingActive } from '@/lib/session-detail-optimistic'
 import { inactiveSessionCanResume } from '@/lib/sessionResume'
 import { initializeSessionLastSeen, markSessionSeen } from '@/lib/sessionLastSeen'
 import { useSessionBrowserTitle } from '@/hooks/useSessionBrowserTitle'
@@ -549,15 +549,11 @@ function SessionPage() {
             replace: true
         })
         if (api) {
-            void queryClient.fetchQuery({
-                queryKey: queryKeys.session(resolvedSessionId),
-                queryFn: () => api.getSession(resolvedSessionId),
-                staleTime: 0,
-            }).catch(() => undefined).finally(() => {
-                // Resume can return before REST reflects active; keep the
-                // optimistic seed so the target composer stays on the active adapter.
-                reapplyOptimisticSessionActive(queryClient, resolvedSessionId)
-            })
+            void refreshSessionDetailPreservingActive(
+                queryClient,
+                resolvedSessionId,
+                () => api.getSession(resolvedSessionId),
+            )
             void syncTailMessages(api, resolvedSessionId).catch(() => {})
         }
     }, [api, navigate, queryClient, session])

--- a/web/src/routes/sessions/files.test.tsx
+++ b/web/src/routes/sessions/files.test.tsx
@@ -8,6 +8,16 @@ import FilesPage from './files'
 const mocks = vi.hoisted(() => ({
     navigate: vi.fn(),
     fileSearch: vi.fn(),
+    transferComposerDraftThenNavigate: vi.fn(async (
+        _source: string,
+        _target: string,
+        navigate: () => void | Promise<void>,
+    ) => {
+        await navigate()
+    }),
+    sessionHeaderProps: null as null | {
+        onSessionReopened?: (newSessionId: string) => void | Promise<void>
+    },
     search: {
         tab: 'directories' as const,
         query: '感',
@@ -18,6 +28,10 @@ vi.mock('@tanstack/react-router', () => ({
     useNavigate: () => mocks.navigate,
     useParams: () => ({ sessionId: 'session-1' }),
     useSearch: () => mocks.search,
+}))
+
+vi.mock('@/lib/composer-draft-transfer', () => ({
+    transferComposerDraftThenNavigate: mocks.transferComposerDraftThenNavigate,
 }))
 
 vi.mock('@/lib/app-context', () => ({
@@ -64,7 +78,10 @@ vi.mock('@/hooks/queries/useSessionFileSearch', () => ({
 }))
 
 vi.mock('@/components/SessionHeader', () => ({
-    SessionHeader: () => null,
+    SessionHeader: (props: { onSessionReopened?: (newSessionId: string) => void | Promise<void> }) => {
+        mocks.sessionHeaderProps = props
+        return null
+    },
 }))
 
 vi.mock('@/components/SessionFiles/DirectoryTree', () => ({
@@ -139,6 +156,33 @@ describe('FilesPage search navigation', () => {
             to: '/sessions/$sessionId/files',
             params: { sessionId: 'session-1' },
             search: { tab: 'directories' },
+            replace: true,
+        })
+    })
+})
+
+describe('FilesPage reopen draft transfer', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.sessionHeaderProps = null
+        window.localStorage.clear()
+        window.sessionStorage.clear()
+    })
+
+    it('transfers the composer draft before navigating to a reopened files route', async () => {
+        renderFilesPage()
+        expect(mocks.sessionHeaderProps?.onSessionReopened).toEqual(expect.any(Function))
+
+        await mocks.sessionHeaderProps!.onSessionReopened!('session-reopened')
+
+        expect(mocks.transferComposerDraftThenNavigate).toHaveBeenCalledWith(
+            'session-1',
+            'session-reopened',
+            expect.any(Function),
+        )
+        expect(mocks.navigate).toHaveBeenCalledWith({
+            to: '/sessions/$sessionId/files',
+            params: { sessionId: 'session-reopened' },
             replace: true,
         })
     })

--- a/web/src/routes/sessions/files.tsx
+++ b/web/src/routes/sessions/files.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/files-i18n'
 import { encodeBase64 } from '@/lib/utils'
 import { queryKeys } from '@/lib/query-keys'
+import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
 import { formatFileMetadata } from '@/lib/file-metadata'
 import { useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from '@/lib/use-translation'
@@ -473,12 +474,16 @@ export default function FilesPage() {
                 outlineActive={false}
                 api={api}
                 onSessionDeleted={goBack}
-                onSessionReopened={(newSessionId) => {
-                    navigate({
-                        to: '/sessions/$sessionId/files',
-                        params: { sessionId: newSessionId },
-                        replace: true,
-                    })
+                onSessionReopened={async (newSessionId) => {
+                    await transferComposerDraftThenNavigate(
+                        session.id,
+                        newSessionId,
+                        () => navigate({
+                            to: '/sessions/$sessionId/files',
+                            params: { sessionId: newSessionId },
+                            replace: true,
+                        }),
+                    )
                 }}
             />
 


### PR DESCRIPTION
## Summary

- allow attachments to be selected while a resumable session is inactive
- resume the session before uploading, then hand the pending composer draft to the resolved session
- preserve text and attachment drafts across archive, session switches, and every reopen entry point
- navigate to the resolved session without waiting on stale-session refetches, preventing transient `Session unavailable` 404 pages

## Problem

Composer text was already persisted per session after #231/#438, but attachment drafts and inactive-session transitions were incomplete:

- inactive sessions could not accept attachments
- archiving a session and switching away dropped pending attachments
- reopening could return a different session ID without transferring its text and attachment draft
- the old session route could refetch after a successful resume and render `HTTP 404: Session not found`

## Implementation

- extend the attachment adapter with an optional session resolver and resolved-session handoff
- persist attachment upload metadata so restored drafts do not upload the same file twice
- add a shared composer-draft transfer helper backed by live snapshots with IndexedDB/session-storage fallback
- use the transfer helper from the header, session-list, and inline reopen flows
- optimistically seed and navigate to the resolved session before background query synchronization
- keep attachment restore enabled for resumable inactive sessions

## Testing

- `bun run typecheck` — passed
- `bun run test:web` — passed
- `bun run test:shared` — passed
- targeted web tests — 12 passed
- live Playwright test against an isolated Hub and Runner on port 3016:
  - attach a real file and enter text
  - archive the real Codex session
  - switch sessions and return
  - reopen the session
  - verify text and attachment drafts survive
  - verify no session API 404 occurs

## AI disclosure

Code and test preparation used OpenAI Codex (GPT-5.6). The changes were reviewed and exercised with unit, type, build, and live browser tests.

Related: #231