### PR TITLE
fix(pi): keep running state through active RPC turns

### DIFF
--- a/cli/src/pi/loop.test.ts
+++ b/cli/src/pi/loop.test.ts
@@ -1000,6 +1000,44 @@ describe('Pi lifecycle timeline', () => {
         expect(stateSession.piIsStreaming).toBe(true);
         emit({ type: 'compaction_end', reason: 'manual', aborted: false, willRetry: false });
     });
+
+    it('does not let a delayed get_state false interrupt an active prompt lifecycle', () => {
+        let listener: ((event: Record<string, unknown>) => void) | null = null;
+        const transport = {
+            onEvent: vi.fn((handler: (event: Record<string, unknown>) => void) => { listener = handler; }),
+            send: vi.fn(),
+        } as unknown as PiTransport;
+        const stateSession = createMockSession();
+        const controller = wireTransportEvents(transport, stateSession, []);
+        const emit = (event: Record<string, unknown>) => listener?.(event);
+
+        controller.beginPromptLifecycle('prompt-1');
+        emit({ type: 'agent_start' });
+        expect(stateSession.piIsStreaming).toBe(true);
+
+        emit({ type: 'response', command: 'get_state', success: true, data: { isStreaming: false } });
+        expect(stateSession.piIsStreaming).toBe(true);
+
+        emit({ type: 'turn_start' });
+        expect(stateSession.piIsStreaming).toBe(true);
+    });
+
+    it('still applies get_state false when no prompt lifecycle is active', () => {
+        let listener: ((event: Record<string, unknown>) => void) | null = null;
+        const transport = {
+            onEvent: vi.fn((handler: (event: Record<string, unknown>) => void) => { listener = handler; }),
+            send: vi.fn(),
+        } as unknown as PiTransport;
+        const stateSession = createMockSession();
+        wireTransportEvents(transport, stateSession, []);
+        const emit = (event: Record<string, unknown>) => listener?.(event);
+
+        emit({ type: 'response', command: 'get_state', success: true, data: { isStreaming: true } });
+        expect(stateSession.piIsStreaming).toBe(true);
+
+        emit({ type: 'response', command: 'get_state', success: true, data: { isStreaming: false } });
+        expect(stateSession.piIsStreaming).toBe(false);
+    });
 });
 
 describe('Pi prompt-settlement boundaries', () => {

--- a/cli/src/pi/loop.test.ts
+++ b/cli/src/pi/loop.test.ts
@@ -1020,6 +1020,10 @@ describe('Pi lifecycle timeline', () => {
 
         emit({ type: 'turn_start' });
         expect(stateSession.piIsStreaming).toBe(true);
+
+        emit({ type: 'agent_end', willRetry: false });
+        emit({ type: 'response', command: 'get_state', success: true, data: { isStreaming: false } });
+        expect(stateSession.piIsStreaming).toBe(true);
     });
 
     it('still applies get_state false when no prompt lifecycle is active', () => {

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -122,6 +122,7 @@ function applyGetState(
         isStreaming?: boolean;
     },
     session: PiSession,
+    applyStreamingState = true,
 ): void {
 
     if (data.model) {
@@ -161,7 +162,7 @@ function applyGetState(
         session.currentSteeringMode = data.steeringMode;
     }
 
-    if (data.isStreaming !== undefined) {
+    if (data.isStreaming !== undefined && applyStreamingState) {
         // get_state is Pi's authoritative current-session snapshot. Synchronize
         // only its explicit boolean, never infer state from unknown event types.
         session.updateThinkingState(data.isStreaming);
@@ -177,6 +178,7 @@ function handleResponse(
     onStartupFailure?: (error: Error) => void,
     conversationHistory?: PiConversationHistory,
     onReady?: () => void,
+    shouldApplyGetStateStreaming?: (isStreaming: boolean) => boolean,
 ): { rejectedPromptLocalId?: string } {
     const { command, success } = response;
     const resolver = session.rpcResolver!;
@@ -241,7 +243,12 @@ function handleResponse(
             // but never publish the temporary identity/model to the source row.
             if (!session.isHistoryTransactionActive) {
                 session.markNativeReady();
-                applyGetState(state, session);
+                const applyStreamingState = state.isStreaming === undefined
+                    || shouldApplyGetStateStreaming?.(state.isStreaming) !== false;
+                if (!applyStreamingState) {
+                    logger.debug('[pi] Ignoring get_state isStreaming=false during an active prompt lifecycle');
+                }
+                applyGetState(state, session, applyStreamingState);
                 onReady?.();
             }
             resolvePendingRpc(resolver, response);
@@ -674,6 +681,13 @@ export function wireTransportEvents(
                     options.onStartupFailure,
                     options.conversationHistory,
                     options.onReady,
+                    (isStreaming) => {
+                        if (isStreaming) return true;
+                        const promptLifecycleActive = !deliveredSettlement
+                            && !promptLifecycleAborted
+                            && (activePromptId !== null || agentLifecycleSeen);
+                        return !promptLifecycleActive;
+                    },
                 );
                 if (isCurrentPrompt && !parsed.data.success) {
                     const rejectedLocalId = responseOutcome.rejectedPromptLocalId ?? activePromptLocalId;


### PR DESCRIPTION
## Summary

- keep Pi sessions in the running state while an RPC prompt lifecycle is active
- ignore a delayed `get_state.isStreaming=false` snapshot when agent or prompt lifecycle events already prove that the turn is still running
- continue applying `get_state` streaming snapshots while the session is idle
- add regression coverage for both active-turn suppression and idle-state synchronization

## Root cause

HAPI starts Pi with `pi --mode rpc` and sends a fire-and-forget `get_state` request during startup. Its response is not ordered against later `agent_start` and `turn_start` events. A delayed snapshot containing `isStreaming=false` could therefore overwrite the running state after `agent_start`, before `turn_start` set it back to true.

The Hub and Web session list correctly consume `thinking` as the canonical running signal, so that transient false value moved the same session repeatedly between the in-progress and idle list sections.

## Fix

`get_state.isStreaming=true` remains authoritative. A false snapshot is ignored only while the current prompt lifecycle is active. Explicit settlement, rejection, abort, and idle snapshots retain their existing behavior.

## Validation

- `vitest run src/pi/loop.test.ts --config vitest.config.ts` — 65 tests passed
- `tsc --noEmit` in `cli/` — passed
