### PR TITLE
feat(web): interactive storage usage pie in Settings

### DIFF
--- a/web/src/components/settings/StorageUsagePie.test.tsx
+++ b/web/src/components/settings/StorageUsagePie.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { StorageUsagePie } from './StorageUsagePie'
+
+const labels = {
+    title: 'Relative share',
+    empty: 'No storage to chart yet.',
+    database: 'Database',
+    wal: 'Write-ahead log',
+    shm: 'Shared memory',
+}
+
+describe('StorageUsagePie', () => {
+    it('shows empty state when all sizes are zero', () => {
+        render(<StorageUsagePie usage={{ databaseBytes: 0, walBytes: 0, shmBytes: 0 }} labels={labels} />)
+        expect(screen.getByText(labels.empty)).toBeInTheDocument()
+    })
+
+    it('updates the center readout when a legend option is selected', () => {
+        render(
+            <StorageUsagePie
+                usage={{ databaseBytes: 700, walBytes: 200, shmBytes: 100 }}
+                labels={labels}
+            />,
+        )
+
+        expect(screen.getByTestId('storage-pie-center')).toHaveTextContent('Database')
+        expect(screen.getByRole('img', { name: /Relative share/i })).toBeInTheDocument()
+
+        fireEvent.click(screen.getByTestId('storage-pie-legend-wal'))
+        expect(screen.getByTestId('storage-pie-center')).toHaveTextContent('Write-ahead log')
+        expect(screen.getByTestId('storage-pie-center')).toHaveTextContent('20%')
+    })
+})

--- a/web/src/components/settings/StorageUsagePie.test.tsx
+++ b/web/src/components/settings/StorageUsagePie.test.tsx
@@ -8,11 +8,20 @@ const labels = {
     database: 'Database',
     wal: 'Write-ahead log',
     shm: 'Shared memory',
+    total: 'Total',
+    path: 'Path',
 }
 
 describe('StorageUsagePie', () => {
     it('shows empty state when all sizes are zero', () => {
-        render(<StorageUsagePie usage={{ databaseBytes: 0, walBytes: 0, shmBytes: 0 }} labels={labels} />)
+        render(
+            <StorageUsagePie
+                usage={{ databaseBytes: 0, walBytes: 0, shmBytes: 0 }}
+                totalBytes={0}
+                path="/tmp/hapi.db"
+                labels={labels}
+            />,
+        )
         expect(screen.getByText(labels.empty)).toBeInTheDocument()
     })
 
@@ -20,12 +29,17 @@ describe('StorageUsagePie', () => {
         render(
             <StorageUsagePie
                 usage={{ databaseBytes: 700, walBytes: 200, shmBytes: 100 }}
+                totalBytes={1000}
+                path="/tmp/hapi.db"
                 labels={labels}
             />,
         )
 
         expect(screen.getByTestId('storage-pie-center')).toHaveTextContent('Database')
         expect(screen.getByRole('img', { name: /Relative share/i })).toBeInTheDocument()
+        expect(screen.getByTestId('storage-pie-total')).toHaveTextContent('Total')
+        expect(screen.getByTestId('storage-pie-total')).toHaveTextContent('1000 B')
+        expect(screen.getByTestId('storage-pie-path')).toHaveTextContent('/tmp/hapi.db')
 
         fireEvent.click(screen.getByTestId('storage-pie-legend-wal'))
         expect(screen.getByTestId('storage-pie-center')).toHaveTextContent('Write-ahead log')

--- a/web/src/components/settings/StorageUsagePie.test.tsx
+++ b/web/src/components/settings/StorageUsagePie.test.tsx
@@ -13,7 +13,7 @@ const labels = {
 }
 
 describe('StorageUsagePie', () => {
-    it('shows empty state when all sizes are zero', () => {
+    it('keeps total and path in the empty state', () => {
         render(
             <StorageUsagePie
                 usage={{ databaseBytes: 0, walBytes: 0, shmBytes: 0 }}
@@ -23,9 +23,12 @@ describe('StorageUsagePie', () => {
             />,
         )
         expect(screen.getByText(labels.empty)).toBeInTheDocument()
+        expect(screen.getByTestId('storage-pie-total')).toHaveTextContent('Total')
+        expect(screen.getByTestId('storage-pie-total')).toHaveTextContent('0 B')
+        expect(screen.getByTestId('storage-pie-path')).toHaveTextContent('/tmp/hapi.db')
     })
 
-    it('updates the center readout when a legend option is selected', () => {
+    it('uses roving tabindex and updates the center readout on legend select', () => {
         render(
             <StorageUsagePie
                 usage={{ databaseBytes: 700, walBytes: 200, shmBytes: 100 }}
@@ -37,12 +40,17 @@ describe('StorageUsagePie', () => {
 
         expect(screen.getByTestId('storage-pie-center')).toHaveTextContent('Database')
         expect(screen.getByRole('img', { name: /Relative share/i })).toBeInTheDocument()
-        expect(screen.getByTestId('storage-pie-total')).toHaveTextContent('Total')
+        expect(screen.getByTestId('storage-pie-legend-database')).toHaveAttribute('tabIndex', '0')
+        expect(screen.getByTestId('storage-pie-legend-wal')).toHaveAttribute('tabIndex', '-1')
+        expect(screen.getByTestId('storage-pie-legend-shm')).toHaveAttribute('tabIndex', '-1')
+        expect(screen.getByRole('listbox')).not.toHaveAttribute('aria-activedescendant')
         expect(screen.getByTestId('storage-pie-total')).toHaveTextContent('1000 B')
         expect(screen.getByTestId('storage-pie-path')).toHaveTextContent('/tmp/hapi.db')
 
         fireEvent.click(screen.getByTestId('storage-pie-legend-wal'))
         expect(screen.getByTestId('storage-pie-center')).toHaveTextContent('Write-ahead log')
         expect(screen.getByTestId('storage-pie-center')).toHaveTextContent('20%')
+        expect(screen.getByTestId('storage-pie-legend-wal')).toHaveAttribute('tabIndex', '0')
+        expect(screen.getByTestId('storage-pie-legend-database')).toHaveAttribute('tabIndex', '-1')
     })
 })

--- a/web/src/components/settings/StorageUsagePie.tsx
+++ b/web/src/components/settings/StorageUsagePie.tsx
@@ -21,10 +21,14 @@ type Labels = {
     database: string
     wal: string
     shm: string
+    total: string
+    path: string
 }
 
 type StorageUsagePieProps = {
     usage: StorageUsageBytes
+    totalBytes: number
+    path: string
     labels: Labels
 }
 
@@ -33,7 +37,7 @@ function labelFor(key: StorageUsageSliceKey, labels: Labels): string {
 }
 
 export function StorageUsagePie(props: StorageUsagePieProps) {
-    const { usage, labels } = props
+    const { usage, totalBytes, path, labels } = props
     const chartId = useId()
     const slices = useMemo(() => buildStorageUsageSlices(usage), [usage])
     const [activeKey, setActiveKey] = useState<StorageUsageSliceKey | null>(null)
@@ -57,6 +61,7 @@ export function StorageUsagePie(props: StorageUsagePieProps) {
     const innerRadius = 58
     const outerRadius = 88
     const activeOuterRadius = 96
+    const totalLabel = formatFileSize(totalBytes) ?? '0 B'
 
     const onLegendKeyDown = (event: KeyboardEvent<HTMLButtonElement>, key: StorageUsageSliceKey) => {
         if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
@@ -76,7 +81,7 @@ export function StorageUsagePie(props: StorageUsagePieProps) {
     return (
         <div className="rounded-xl border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-4 shadow-sm">
             <h3 className="mb-3 text-sm font-medium text-[var(--app-fg)]">{labels.title}</h3>
-            <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-center sm:gap-6">
+            <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-start sm:justify-center sm:gap-6">
                 <div className="relative shrink-0" style={{ width: size, height: size }}>
                     <svg
                         viewBox={`0 0 ${size} ${size}`}
@@ -94,7 +99,7 @@ export function StorageUsagePie(props: StorageUsagePieProps) {
                         </desc>
                         {slices.map((slice) => {
                             const isActive = active?.key === slice.key
-                            const path = describeDonutArc(
+                            const pathD = describeDonutArc(
                                 cx,
                                 cy,
                                 innerRadius,
@@ -105,7 +110,7 @@ export function StorageUsagePie(props: StorageUsagePieProps) {
                             return (
                                 <path
                                     key={slice.key}
-                                    d={path}
+                                    d={pathD}
                                     fill={SLICE_FILL[slice.key]}
                                     opacity={isActive ? 1 : 0.82}
                                     className="cursor-pointer transition-[opacity] duration-150"
@@ -155,7 +160,20 @@ export function StorageUsagePie(props: StorageUsagePieProps) {
                             </button>
                         )
                     })}
+                    <div
+                        className="mt-1 flex items-center justify-between gap-2 border-t border-[var(--app-divider)] px-2 pt-2 text-sm"
+                        data-testid="storage-pie-total"
+                    >
+                        <span className="font-medium text-[var(--app-fg)]">{labels.total}</span>
+                        <span className="tabular-nums font-medium text-[var(--app-fg)]">{totalLabel}</span>
+                    </div>
                 </div>
+            </div>
+            <div className="mt-3 border-t border-[var(--app-divider)] pt-3" data-testid="storage-pie-path">
+                <div className="text-xs font-medium text-[var(--app-hint)]">{labels.path}</div>
+                <code className="mt-0.5 block truncate text-xs text-[var(--app-hint)]" title={path}>
+                    {path}
+                </code>
             </div>
         </div>
     )

--- a/web/src/components/settings/StorageUsagePie.tsx
+++ b/web/src/components/settings/StorageUsagePie.tsx
@@ -1,0 +1,176 @@
+import { useId, useMemo, useState, type KeyboardEvent } from 'react'
+import { formatFileSize } from '@/lib/file-metadata'
+import {
+    buildStorageUsageSlices,
+    describeDonutArc,
+    formatStoragePercent,
+    type StorageUsageBytes,
+    type StorageUsageSlice,
+    type StorageUsageSliceKey,
+} from '@/components/settings/storageUsagePie'
+
+const SLICE_FILL: Record<StorageUsageSliceKey, string> = {
+    database: 'var(--app-link)',
+    wal: 'color-mix(in srgb, var(--app-link) 55%, var(--app-hint))',
+    shm: 'var(--app-hint)',
+}
+
+type Labels = {
+    title: string
+    empty: string
+    database: string
+    wal: string
+    shm: string
+}
+
+type StorageUsagePieProps = {
+    usage: StorageUsageBytes
+    labels: Labels
+}
+
+function labelFor(key: StorageUsageSliceKey, labels: Labels): string {
+    return labels[key]
+}
+
+export function StorageUsagePie(props: StorageUsagePieProps) {
+    const { usage, labels } = props
+    const chartId = useId()
+    const slices = useMemo(() => buildStorageUsageSlices(usage), [usage])
+    const [activeKey, setActiveKey] = useState<StorageUsageSliceKey | null>(null)
+
+    const active = useMemo(() => {
+        if (slices.length === 0) return null
+        return slices.find((slice) => slice.key === activeKey) ?? slices[0] ?? null
+    }, [activeKey, slices])
+
+    if (slices.length === 0) {
+        return (
+            <div className="rounded-xl border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-4 text-sm text-[var(--app-hint)]">
+                {labels.empty}
+            </div>
+        )
+    }
+
+    const size = 220
+    const cx = size / 2
+    const cy = size / 2
+    const innerRadius = 58
+    const outerRadius = 88
+    const activeOuterRadius = 96
+
+    const onLegendKeyDown = (event: KeyboardEvent<HTMLButtonElement>, key: StorageUsageSliceKey) => {
+        if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+            return
+        }
+        event.preventDefault()
+        const index = slices.findIndex((slice) => slice.key === key)
+        if (index < 0) return
+        const delta = event.key === 'ArrowDown' || event.key === 'ArrowRight' ? 1 : -1
+        const next = slices[(index + delta + slices.length) % slices.length]
+        if (!next) return
+        setActiveKey(next.key)
+        const nextButton = event.currentTarget.parentElement?.querySelector<HTMLButtonElement>(`[data-slice-key="${next.key}"]`)
+        nextButton?.focus()
+    }
+
+    return (
+        <div className="rounded-xl border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-4 shadow-sm">
+            <h3 className="mb-3 text-sm font-medium text-[var(--app-fg)]">{labels.title}</h3>
+            <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-center sm:gap-6">
+                <div className="relative shrink-0" style={{ width: size, height: size }}>
+                    <svg
+                        viewBox={`0 0 ${size} ${size}`}
+                        width={size}
+                        height={size}
+                        role="img"
+                        aria-labelledby={`${chartId}-title ${chartId}-desc`}
+                        className="select-none"
+                    >
+                        <title id={`${chartId}-title`}>{labels.title}</title>
+                        <desc id={`${chartId}-desc`}>
+                            {slices
+                                .map((slice) => `${labelFor(slice.key, labels)} ${formatStoragePercent(slice.percent)}`)
+                                .join(', ')}
+                        </desc>
+                        {slices.map((slice) => {
+                            const isActive = active?.key === slice.key
+                            const path = describeDonutArc(
+                                cx,
+                                cy,
+                                innerRadius,
+                                isActive ? activeOuterRadius : outerRadius,
+                                slice.startAngle,
+                                slice.endAngle,
+                            )
+                            return (
+                                <path
+                                    key={slice.key}
+                                    d={path}
+                                    fill={SLICE_FILL[slice.key]}
+                                    opacity={isActive ? 1 : 0.82}
+                                    className="cursor-pointer transition-[opacity] duration-150"
+                                    onPointerEnter={() => setActiveKey(slice.key)}
+                                    onFocus={() => setActiveKey(slice.key)}
+                                    onClick={() => setActiveKey(slice.key)}
+                                    tabIndex={-1}
+                                    aria-hidden="true"
+                                />
+                            )
+                        })}
+                    </svg>
+                    {active ? <CenterReadout slice={active} labels={labels} /> : null}
+                </div>
+
+                <div className="flex w-full max-w-xs flex-col gap-1" role="listbox" aria-label={labels.title} aria-activedescendant={active ? `${chartId}-${active.key}` : undefined}>
+                    {slices.map((slice) => {
+                        const isActive = active?.key === slice.key
+                        const sizeLabel = formatFileSize(slice.bytes) ?? '0 B'
+                        return (
+                            <button
+                                key={slice.key}
+                                id={`${chartId}-${slice.key}`}
+                                type="button"
+                                role="option"
+                                aria-selected={isActive}
+                                data-slice-key={slice.key}
+                                data-testid={`storage-pie-legend-${slice.key}`}
+                                onClick={() => setActiveKey(slice.key)}
+                                onPointerEnter={() => setActiveKey(slice.key)}
+                                onFocus={() => setActiveKey(slice.key)}
+                                onKeyDown={(event) => onLegendKeyDown(event, slice.key)}
+                                className={`flex items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors ${
+                                    isActive
+                                        ? 'bg-[var(--app-secondary-bg)] text-[var(--app-fg)]'
+                                        : 'text-[var(--app-hint)] hover:bg-[var(--app-secondary-bg)]/60 hover:text-[var(--app-fg)]'
+                                }`}
+                            >
+                                <span
+                                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                                    style={{ background: SLICE_FILL[slice.key] }}
+                                    aria-hidden="true"
+                                />
+                                <span className="min-w-0 flex-1 truncate font-medium">{labelFor(slice.key, labels)}</span>
+                                <span className="shrink-0 tabular-nums">{sizeLabel}</span>
+                                <span className="w-12 shrink-0 text-right tabular-nums">{formatStoragePercent(slice.percent)}</span>
+                            </button>
+                        )
+                    })}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function CenterReadout(props: { slice: StorageUsageSlice; labels: Labels }) {
+    const sizeLabel = formatFileSize(props.slice.bytes) ?? '0 B'
+    return (
+        <div
+            className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center px-6 text-center"
+            data-testid="storage-pie-center"
+        >
+            <div className="text-xs font-medium text-[var(--app-hint)]">{labelFor(props.slice.key, props.labels)}</div>
+            <div className="mt-0.5 text-base font-semibold text-[var(--app-fg)]">{sizeLabel}</div>
+            <div className="text-xs tabular-nums text-[var(--app-hint)]">{formatStoragePercent(props.slice.percent)}</div>
+        </div>
+    )
+}

--- a/web/src/components/settings/StorageUsagePie.tsx
+++ b/web/src/components/settings/StorageUsagePie.tsx
@@ -47,10 +47,15 @@ export function StorageUsagePie(props: StorageUsagePieProps) {
         return slices.find((slice) => slice.key === activeKey) ?? slices[0] ?? null
     }, [activeKey, slices])
 
+    const totalLabel = formatFileSize(totalBytes) ?? '0 B'
+
     if (slices.length === 0) {
         return (
-            <div className="rounded-xl border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-4 text-sm text-[var(--app-hint)]">
-                {labels.empty}
+            <div className="rounded-xl border border-[var(--app-border)] bg-[var(--app-bg)] px-3 py-4 shadow-sm">
+                <h3 className="mb-3 text-sm font-medium text-[var(--app-fg)]">{labels.title}</h3>
+                <div className="text-sm text-[var(--app-hint)]">{labels.empty}</div>
+                <TotalFooter label={labels.total} value={totalLabel} className="mt-3" />
+                <PathFooter label={labels.path} path={path} />
             </div>
         )
     }
@@ -61,7 +66,6 @@ export function StorageUsagePie(props: StorageUsagePieProps) {
     const innerRadius = 58
     const outerRadius = 88
     const activeOuterRadius = 96
-    const totalLabel = formatFileSize(totalBytes) ?? '0 B'
 
     const onLegendKeyDown = (event: KeyboardEvent<HTMLButtonElement>, key: StorageUsageSliceKey) => {
         if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp' && event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
@@ -126,55 +130,70 @@ export function StorageUsagePie(props: StorageUsagePieProps) {
                     {active ? <CenterReadout slice={active} labels={labels} /> : null}
                 </div>
 
-                <div className="flex w-full max-w-xs flex-col gap-1" role="listbox" aria-label={labels.title} aria-activedescendant={active ? `${chartId}-${active.key}` : undefined}>
-                    {slices.map((slice) => {
-                        const isActive = active?.key === slice.key
-                        const sizeLabel = formatFileSize(slice.bytes) ?? '0 B'
-                        return (
-                            <button
-                                key={slice.key}
-                                id={`${chartId}-${slice.key}`}
-                                type="button"
-                                role="option"
-                                aria-selected={isActive}
-                                data-slice-key={slice.key}
-                                data-testid={`storage-pie-legend-${slice.key}`}
-                                onClick={() => setActiveKey(slice.key)}
-                                onPointerEnter={() => setActiveKey(slice.key)}
-                                onFocus={() => setActiveKey(slice.key)}
-                                onKeyDown={(event) => onLegendKeyDown(event, slice.key)}
-                                className={`flex items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors ${
-                                    isActive
-                                        ? 'bg-[var(--app-secondary-bg)] text-[var(--app-fg)]'
-                                        : 'text-[var(--app-hint)] hover:bg-[var(--app-secondary-bg)]/60 hover:text-[var(--app-fg)]'
-                                }`}
-                            >
-                                <span
-                                    className="h-2.5 w-2.5 shrink-0 rounded-full"
-                                    style={{ background: SLICE_FILL[slice.key] }}
-                                    aria-hidden="true"
-                                />
-                                <span className="min-w-0 flex-1 truncate font-medium">{labelFor(slice.key, labels)}</span>
-                                <span className="shrink-0 tabular-nums">{sizeLabel}</span>
-                                <span className="w-12 shrink-0 text-right tabular-nums">{formatStoragePercent(slice.percent)}</span>
-                            </button>
-                        )
-                    })}
-                    <div
-                        className="mt-1 flex items-center justify-between gap-2 border-t border-[var(--app-divider)] px-2 pt-2 text-sm"
-                        data-testid="storage-pie-total"
-                    >
-                        <span className="font-medium text-[var(--app-fg)]">{labels.total}</span>
-                        <span className="tabular-nums font-medium text-[var(--app-fg)]">{totalLabel}</span>
+                <div className="flex w-full max-w-xs flex-col gap-1">
+                    <div className="flex flex-col gap-1" role="listbox" aria-label={labels.title}>
+                        {slices.map((slice) => {
+                            const isActive = active?.key === slice.key
+                            const sizeLabel = formatFileSize(slice.bytes) ?? '0 B'
+                            return (
+                                <button
+                                    key={slice.key}
+                                    id={`${chartId}-${slice.key}`}
+                                    type="button"
+                                    role="option"
+                                    aria-selected={isActive}
+                                    tabIndex={isActive ? 0 : -1}
+                                    data-slice-key={slice.key}
+                                    data-testid={`storage-pie-legend-${slice.key}`}
+                                    onClick={() => setActiveKey(slice.key)}
+                                    onPointerEnter={() => setActiveKey(slice.key)}
+                                    onFocus={() => setActiveKey(slice.key)}
+                                    onKeyDown={(event) => onLegendKeyDown(event, slice.key)}
+                                    className={`flex items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors ${
+                                        isActive
+                                            ? 'bg-[var(--app-secondary-bg)] text-[var(--app-fg)]'
+                                            : 'text-[var(--app-hint)] hover:bg-[var(--app-secondary-bg)]/60 hover:text-[var(--app-fg)]'
+                                    }`}
+                                >
+                                    <span
+                                        className="h-2.5 w-2.5 shrink-0 rounded-full"
+                                        style={{ background: SLICE_FILL[slice.key] }}
+                                        aria-hidden="true"
+                                    />
+                                    <span className="min-w-0 flex-1 truncate font-medium">{labelFor(slice.key, labels)}</span>
+                                    <span className="shrink-0 tabular-nums">{sizeLabel}</span>
+                                    <span className="w-12 shrink-0 text-right tabular-nums">{formatStoragePercent(slice.percent)}</span>
+                                </button>
+                            )
+                        })}
                     </div>
+                    <TotalFooter label={labels.total} value={totalLabel} className="mt-1 border-t border-[var(--app-divider)] pt-2" />
                 </div>
             </div>
-            <div className="mt-3 border-t border-[var(--app-divider)] pt-3" data-testid="storage-pie-path">
-                <div className="text-xs font-medium text-[var(--app-hint)]">{labels.path}</div>
-                <code className="mt-0.5 block truncate text-xs text-[var(--app-hint)]" title={path}>
-                    {path}
-                </code>
-            </div>
+            <PathFooter label={labels.path} path={path} />
+        </div>
+    )
+}
+
+function TotalFooter(props: { label: string; value: string; className?: string }) {
+    return (
+        <div
+            className={`flex items-center justify-between gap-2 px-2 text-sm ${props.className ?? ''}`}
+            data-testid="storage-pie-total"
+        >
+            <span className="font-medium text-[var(--app-fg)]">{props.label}</span>
+            <span className="tabular-nums font-medium text-[var(--app-fg)]">{props.value}</span>
+        </div>
+    )
+}
+
+function PathFooter(props: { label: string; path: string }) {
+    return (
+        <div className="mt-3 border-t border-[var(--app-divider)] pt-3" data-testid="storage-pie-path">
+            <div className="text-xs font-medium text-[var(--app-hint)]">{props.label}</div>
+            <code className="mt-0.5 block truncate text-xs text-[var(--app-hint)]" title={props.path}>
+                {props.path}
+            </code>
         </div>
     )
 }

--- a/web/src/components/settings/storageUsagePie.test.ts
+++ b/web/src/components/settings/storageUsagePie.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+    buildStorageUsageSlices,
+    describeDonutArc,
+    formatStoragePercent,
+    polarToCartesian,
+} from './storageUsagePie'
+
+describe('buildStorageUsageSlices', () => {
+    it('drops zero-byte sidecars and returns empty when nothing has size', () => {
+        expect(buildStorageUsageSlices({ databaseBytes: 0, walBytes: 0, shmBytes: 0 })).toEqual([])
+        expect(buildStorageUsageSlices({ databaseBytes: 10, walBytes: 0, shmBytes: 0 })).toHaveLength(1)
+    })
+
+    it('assigns equal thirds for equal byte counts', () => {
+        const slices = buildStorageUsageSlices({ databaseBytes: 100, walBytes: 100, shmBytes: 100 })
+        expect(slices.map((s) => s.key)).toEqual(['database', 'wal', 'shm'])
+        expect(slices.every((s) => s.percent === 33.3)).toBe(true)
+        expect(slices[0]?.startAngle).toBe(-90)
+        expect(slices[2]?.endAngle).toBe(270)
+        expect(slices[1]!.endAngle - slices[1]!.startAngle).toBeCloseTo(120, 5)
+    })
+
+    it('gives a single full-circle slice when only one component has bytes', () => {
+        const [only] = buildStorageUsageSlices({ databaseBytes: 42, walBytes: 0, shmBytes: 0 })
+        expect(only).toMatchObject({ key: 'database', bytes: 42, percent: 100, startAngle: -90, endAngle: 270 })
+    })
+})
+
+describe('donut geometry', () => {
+    it('maps 0deg to the right of center', () => {
+        expect(polarToCartesian(0, 0, 10, 0)).toEqual({ x: 10, y: 0 })
+    })
+
+    it('returns a closed path for a quarter arc', () => {
+        const path = describeDonutArc(50, 50, 20, 40, -90, 0)
+        expect(path.startsWith('M ')).toBe(true)
+        expect(path.endsWith('Z')).toBe(true)
+        expect(path).toContain('A 40 40')
+        expect(path).toContain('A 20 20')
+    })
+
+    it('returns a two-half path for a full circle', () => {
+        const path = describeDonutArc(50, 50, 20, 40, -90, 270)
+        expect(path.split('A 40 40').length - 1).toBe(2)
+    })
+})
+
+describe('formatStoragePercent', () => {
+    it('formats whole and fractional percents', () => {
+        expect(formatStoragePercent(50)).toBe('50%')
+        expect(formatStoragePercent(33.3)).toBe('33.3%')
+        expect(formatStoragePercent(Number.NaN)).toBe('0%')
+    })
+})

--- a/web/src/components/settings/storageUsagePie.ts
+++ b/web/src/components/settings/storageUsagePie.ts
@@ -1,0 +1,116 @@
+export type StorageUsageSliceKey = 'database' | 'wal' | 'shm'
+
+export type StorageUsageBytes = {
+    databaseBytes: number
+    walBytes: number
+    shmBytes: number
+}
+
+export type StorageUsageSlice = {
+    key: StorageUsageSliceKey
+    bytes: number
+    percent: number
+    startAngle: number
+    endAngle: number
+}
+
+const SLICE_ORDER: StorageUsageSliceKey[] = ['database', 'wal', 'shm']
+const FULL_CIRCLE = 360
+/** Start at 12 o'clock so the first slice reads top-heavy on mobile. */
+const START_ANGLE = -90
+
+function bytesForKey(usage: StorageUsageBytes, key: StorageUsageSliceKey): number {
+    if (key === 'database') return usage.databaseBytes
+    if (key === 'wal') return usage.walBytes
+    return usage.shmBytes
+}
+
+export function buildStorageUsageSlices(usage: StorageUsageBytes): StorageUsageSlice[] {
+    const entries = SLICE_ORDER
+        .map((key) => {
+            const raw = bytesForKey(usage, key)
+            return { key, bytes: Number.isFinite(raw) && raw > 0 ? raw : 0 }
+        })
+        .filter((entry) => entry.bytes > 0)
+
+    const total = entries.reduce((sum, entry) => sum + entry.bytes, 0)
+    if (total <= 0) return []
+
+    let cursor = START_ANGLE
+    return entries.map((entry, index) => {
+        const isLast = index === entries.length - 1
+        const endAngle = isLast
+            ? START_ANGLE + FULL_CIRCLE
+            : cursor + (entry.bytes / total) * FULL_CIRCLE
+        const slice: StorageUsageSlice = {
+            key: entry.key,
+            bytes: entry.bytes,
+            percent: Math.round((entry.bytes / total) * 1000) / 10,
+            startAngle: cursor,
+            endAngle,
+        }
+        cursor = endAngle
+        return slice
+    })
+}
+
+export function polarToCartesian(cx: number, cy: number, radius: number, angleDeg: number): { x: number; y: number } {
+    const radians = (angleDeg * Math.PI) / 180
+    return {
+        x: cx + radius * Math.cos(radians),
+        y: cy + radius * Math.sin(radians),
+    }
+}
+
+export function describeDonutArc(
+    cx: number,
+    cy: number,
+    innerRadius: number,
+    outerRadius: number,
+    startAngle: number,
+    endAngle: number,
+): string {
+    // Prefer raw delta: (end - start) % 360 collapses a full 360° sweep to 0.
+    const sweep = endAngle - startAngle
+    if (sweep < 0.001) return ''
+
+    // Full circle: SVG arc with identical start/end is ambiguous; use two half arcs.
+    if (sweep >= FULL_CIRCLE - 0.001) {
+        const mid = startAngle + 180
+        const outerStart = polarToCartesian(cx, cy, outerRadius, startAngle)
+        const outerMid = polarToCartesian(cx, cy, outerRadius, mid)
+        const outerEnd = polarToCartesian(cx, cy, outerRadius, endAngle)
+        const innerEnd = polarToCartesian(cx, cy, innerRadius, endAngle)
+        const innerMid = polarToCartesian(cx, cy, innerRadius, mid)
+        const innerStart = polarToCartesian(cx, cy, innerRadius, startAngle)
+        return [
+            `M ${outerStart.x} ${outerStart.y}`,
+            `A ${outerRadius} ${outerRadius} 0 1 1 ${outerMid.x} ${outerMid.y}`,
+            `A ${outerRadius} ${outerRadius} 0 1 1 ${outerEnd.x} ${outerEnd.y}`,
+            `L ${innerEnd.x} ${innerEnd.y}`,
+            `A ${innerRadius} ${innerRadius} 0 1 0 ${innerMid.x} ${innerMid.y}`,
+            `A ${innerRadius} ${innerRadius} 0 1 0 ${innerStart.x} ${innerStart.y}`,
+            'Z',
+        ].join(' ')
+    }
+
+    const largeArc = sweep > 180 ? 1 : 0
+    const outerStart = polarToCartesian(cx, cy, outerRadius, startAngle)
+    const outerEnd = polarToCartesian(cx, cy, outerRadius, endAngle)
+    const innerEnd = polarToCartesian(cx, cy, innerRadius, endAngle)
+    const innerStart = polarToCartesian(cx, cy, innerRadius, startAngle)
+
+    return [
+        `M ${outerStart.x} ${outerStart.y}`,
+        `A ${outerRadius} ${outerRadius} 0 ${largeArc} 1 ${outerEnd.x} ${outerEnd.y}`,
+        `L ${innerEnd.x} ${innerEnd.y}`,
+        `A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${innerStart.x} ${innerStart.y}`,
+        'Z',
+    ].join(' ')
+}
+
+export function formatStoragePercent(percent: number): string {
+    if (!Number.isFinite(percent)) return '0%'
+    const rounded = Math.round(percent * 10) / 10
+    return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`
+}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -693,7 +693,6 @@ export default {
   'settings.storage.refreshing': 'Refreshing…',
   'settings.storage.chartTitle': 'Relative share',
   'settings.storage.chartEmpty': 'No on-disk size to chart yet.',
-  'settings.storage.detailsTitle': 'Exact sizes',
   'settings.usage.title': 'Token usage',
   'settings.usage.summary': 'Token-only usage dashboard',
   'settings.usage.description': 'Tokens processed while agents are managed by HAPI. Imported earlier transcript usage is excluded; costs are not included.',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -691,6 +691,8 @@ export default {
   'settings.storage.path': 'Path',
   'settings.storage.refresh': 'Refresh',
   'settings.storage.refreshing': 'Refreshing…',
+  'settings.storage.chartTitle': 'Relative share',
+  'settings.storage.chartEmpty': 'No on-disk size to chart yet.',
   'settings.usage.title': 'Token usage',
   'settings.usage.summary': 'Token-only usage dashboard',
   'settings.usage.description': 'Tokens processed while agents are managed by HAPI. Imported earlier transcript usage is excluded; costs are not included.',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -693,6 +693,7 @@ export default {
   'settings.storage.refreshing': 'Refreshing…',
   'settings.storage.chartTitle': 'Relative share',
   'settings.storage.chartEmpty': 'No on-disk size to chart yet.',
+  'settings.storage.detailsTitle': 'Exact sizes',
   'settings.usage.title': 'Token usage',
   'settings.usage.summary': 'Token-only usage dashboard',
   'settings.usage.description': 'Tokens processed while agents are managed by HAPI. Imported earlier transcript usage is excluded; costs are not included.',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -692,7 +692,6 @@ export default {
   'settings.storage.refreshing': '正在刷新…',
   'settings.storage.chartTitle': '相对占比',
   'settings.storage.chartEmpty': '暂无可绘制的磁盘占用。',
-  'settings.storage.detailsTitle': '精确大小',
   'settings.usage.title': 'Token 用量',
   'settings.usage.summary': 'Token 用量看板',
   'settings.usage.description': '统计 Agent 由 HAPI 管理期间处理的 Token；不含导入前的历史会话用量和费用估算。',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -692,6 +692,7 @@ export default {
   'settings.storage.refreshing': '正在刷新…',
   'settings.storage.chartTitle': '相对占比',
   'settings.storage.chartEmpty': '暂无可绘制的磁盘占用。',
+  'settings.storage.detailsTitle': '精确大小',
   'settings.usage.title': 'Token 用量',
   'settings.usage.summary': 'Token 用量看板',
   'settings.usage.description': '统计 Agent 由 HAPI 管理期间处理的 Token；不含导入前的历史会话用量和费用估算。',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -690,6 +690,8 @@ export default {
   'settings.storage.path': '路径',
   'settings.storage.refresh': '刷新',
   'settings.storage.refreshing': '正在刷新…',
+  'settings.storage.chartTitle': '相对占比',
+  'settings.storage.chartEmpty': '暂无可绘制的磁盘占用。',
   'settings.usage.title': 'Token 用量',
   'settings.usage.summary': 'Token 用量看板',
   'settings.usage.description': '统计 Agent 由 HAPI 管理期间处理的 Token；不含导入前的历史会话用量和费用估算。',

--- a/web/src/routes/settings/storage.test.tsx
+++ b/web/src/routes/settings/storage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { describe, expect, it, vi } from 'vitest'
 import { I18nProvider } from '@/lib/i18n-context'
@@ -17,7 +17,7 @@ vi.mock('@/lib/app-context', () => ({
 }))
 
 describe('SettingsStoragePage', () => {
-    it('uses paired button theme colors for the refresh action', () => {
+    it('uses paired button theme colors for the refresh action and renders the pie chart', async () => {
         const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
         render(
             <QueryClientProvider client={queryClient}>
@@ -27,9 +27,13 @@ describe('SettingsStoragePage', () => {
             </QueryClientProvider>,
         )
 
-        const refreshButton = screen.getByRole('button')
+        const refreshButton = screen.getByRole('button', { name: /refresh/i })
         expect(refreshButton).toHaveClass('bg-[var(--app-button)]')
         expect(refreshButton).toHaveClass('text-[var(--app-button-text)]')
         expect(refreshButton).not.toHaveClass('text-white')
+
+        await waitFor(() => {
+            expect(screen.getByRole('img', { name: /Relative share/i })).toBeInTheDocument()
+        })
     })
 })

--- a/web/src/routes/settings/storage.test.tsx
+++ b/web/src/routes/settings/storage.test.tsx
@@ -17,7 +17,7 @@ vi.mock('@/lib/app-context', () => ({
 }))
 
 describe('SettingsStoragePage', () => {
-    it('uses paired button theme colors for the refresh action and renders the pie chart', async () => {
+    it('uses paired button theme colors and shows a single chart card without a duplicate exact-sizes table', async () => {
         const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
         render(
             <QueryClientProvider client={queryClient}>
@@ -36,8 +36,9 @@ describe('SettingsStoragePage', () => {
             expect(screen.getByRole('img', { name: /Relative share/i })).toBeInTheDocument()
         })
 
-        const chart = screen.getByRole('img', { name: /Relative share/i })
-        const details = screen.getByRole('heading', { name: /Exact sizes/i })
-        expect(chart.compareDocumentPosition(details) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+        expect(screen.queryByRole('heading', { name: /Exact sizes/i })).not.toBeInTheDocument()
+        expect(screen.getByTestId('storage-pie-legend-database')).toBeInTheDocument()
+        expect(screen.getByTestId('storage-pie-total')).toBeInTheDocument()
+        expect(screen.getByTestId('storage-pie-path')).toHaveTextContent('C:\\hapi\\hapi.db')
     })
 })

--- a/web/src/routes/settings/storage.test.tsx
+++ b/web/src/routes/settings/storage.test.tsx
@@ -35,5 +35,9 @@ describe('SettingsStoragePage', () => {
         await waitFor(() => {
             expect(screen.getByRole('img', { name: /Relative share/i })).toBeInTheDocument()
         })
+
+        const chart = screen.getByRole('img', { name: /Relative share/i })
+        const details = screen.getByRole('heading', { name: /Exact sizes/i })
+        expect(chart.compareDocumentPosition(details) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     })
 })

--- a/web/src/routes/settings/storage.tsx
+++ b/web/src/routes/settings/storage.tsx
@@ -24,11 +24,34 @@ export default function SettingsStoragePage() {
 
     return (
         <SettingsPageContent description={t('settings.storage.description')}>
-            <SettingsSection>
-                {query.isLoading ? <SettingsRow label={t('settings.storage.loading')} /> : null}
-                {query.error ? <SettingsRow label={t('settings.storage.error')} description={query.error instanceof Error ? query.error.message : undefined} /> : null}
-                {query.data ? (
-                    <>
+            {query.isLoading || query.error ? (
+                <SettingsSection>
+                    {query.isLoading ? <SettingsRow label={t('settings.storage.loading')} /> : null}
+                    {query.error ? (
+                        <SettingsRow
+                            label={t('settings.storage.error')}
+                            description={query.error instanceof Error ? query.error.message : undefined}
+                        />
+                    ) : null}
+                </SettingsSection>
+            ) : null}
+            {query.data ? (
+                <>
+                    <StorageUsagePie
+                        usage={{
+                            databaseBytes: query.data.databaseBytes,
+                            walBytes: query.data.walBytes,
+                            shmBytes: query.data.shmBytes,
+                        }}
+                        labels={{
+                            title: t('settings.storage.chartTitle'),
+                            empty: t('settings.storage.chartEmpty'),
+                            database: t('settings.storage.database'),
+                            wal: t('settings.storage.wal'),
+                            shm: t('settings.storage.shm'),
+                        }}
+                    />
+                    <SettingsSection title={t('settings.storage.detailsTitle')}>
                         <SettingsRow label={t('settings.storage.total')} trailing={<span className="font-medium text-[var(--app-fg)]">{formatFileSize(query.data.totalBytes)}</span>} />
                         <SettingsRow label={t('settings.storage.database')} trailing={<span className="text-[var(--app-hint)]">{formatFileSize(query.data.databaseBytes)}</span>} />
                         <SettingsRow label={t('settings.storage.wal')} trailing={<span className="text-[var(--app-hint)]">{formatFileSize(query.data.walBytes)}</span>} />
@@ -38,24 +61,8 @@ export default function SettingsStoragePage() {
                                 {query.data.path}
                             </code>
                         } />
-                    </>
-                ) : null}
-            </SettingsSection>
-            {query.data ? (
-                <StorageUsagePie
-                    usage={{
-                        databaseBytes: query.data.databaseBytes,
-                        walBytes: query.data.walBytes,
-                        shmBytes: query.data.shmBytes,
-                    }}
-                    labels={{
-                        title: t('settings.storage.chartTitle'),
-                        empty: t('settings.storage.chartEmpty'),
-                        database: t('settings.storage.database'),
-                        wal: t('settings.storage.wal'),
-                        shm: t('settings.storage.shm'),
-                    }}
-                />
+                    </SettingsSection>
+                </>
             ) : null}
             <button
                 type="button"

--- a/web/src/routes/settings/storage.tsx
+++ b/web/src/routes/settings/storage.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { StorageUsagePie } from '@/components/settings/StorageUsagePie'
 import { SettingsPageContent, SettingsRow, SettingsSection } from '@/components/settings/SettingsPrimitives'
 import { useAppContext } from '@/lib/app-context'
 import { formatFileSize } from '@/lib/file-metadata'
@@ -40,6 +41,22 @@ export default function SettingsStoragePage() {
                     </>
                 ) : null}
             </SettingsSection>
+            {query.data ? (
+                <StorageUsagePie
+                    usage={{
+                        databaseBytes: query.data.databaseBytes,
+                        walBytes: query.data.walBytes,
+                        shmBytes: query.data.shmBytes,
+                    }}
+                    labels={{
+                        title: t('settings.storage.chartTitle'),
+                        empty: t('settings.storage.chartEmpty'),
+                        database: t('settings.storage.database'),
+                        wal: t('settings.storage.wal'),
+                        shm: t('settings.storage.shm'),
+                    }}
+                />
+            ) : null}
             <button
                 type="button"
                 onClick={() => void query.refetch()}

--- a/web/src/routes/settings/storage.tsx
+++ b/web/src/routes/settings/storage.tsx
@@ -36,33 +36,24 @@ export default function SettingsStoragePage() {
                 </SettingsSection>
             ) : null}
             {query.data ? (
-                <>
-                    <StorageUsagePie
-                        usage={{
-                            databaseBytes: query.data.databaseBytes,
-                            walBytes: query.data.walBytes,
-                            shmBytes: query.data.shmBytes,
-                        }}
-                        labels={{
-                            title: t('settings.storage.chartTitle'),
-                            empty: t('settings.storage.chartEmpty'),
-                            database: t('settings.storage.database'),
-                            wal: t('settings.storage.wal'),
-                            shm: t('settings.storage.shm'),
-                        }}
-                    />
-                    <SettingsSection title={t('settings.storage.detailsTitle')}>
-                        <SettingsRow label={t('settings.storage.total')} trailing={<span className="font-medium text-[var(--app-fg)]">{formatFileSize(query.data.totalBytes)}</span>} />
-                        <SettingsRow label={t('settings.storage.database')} trailing={<span className="text-[var(--app-hint)]">{formatFileSize(query.data.databaseBytes)}</span>} />
-                        <SettingsRow label={t('settings.storage.wal')} trailing={<span className="text-[var(--app-hint)]">{formatFileSize(query.data.walBytes)}</span>} />
-                        <SettingsRow label={t('settings.storage.shm')} trailing={<span className="text-[var(--app-hint)]">{formatFileSize(query.data.shmBytes)}</span>} />
-                        <SettingsRow label={t('settings.storage.path')} trailing={
-                            <code className="block max-w-[min(20rem,55vw)] truncate text-xs text-[var(--app-hint)]" title={query.data.path}>
-                                {query.data.path}
-                            </code>
-                        } />
-                    </SettingsSection>
-                </>
+                <StorageUsagePie
+                    usage={{
+                        databaseBytes: query.data.databaseBytes,
+                        walBytes: query.data.walBytes,
+                        shmBytes: query.data.shmBytes,
+                    }}
+                    totalBytes={query.data.totalBytes}
+                    path={query.data.path}
+                    labels={{
+                        title: t('settings.storage.chartTitle'),
+                        empty: t('settings.storage.chartEmpty'),
+                        database: t('settings.storage.database'),
+                        wal: t('settings.storage.wal'),
+                        shm: t('settings.storage.shm'),
+                        total: t('settings.storage.total'),
+                        path: t('settings.storage.path'),
+                    }}
+                />
             ) : null}
             <button
                 type="button"


### PR DESCRIPTION
## Summary

- Settings → Storage shows a single interactive Relative share donut with legend lines (label, bytes, %) beside the chart on wider viewports / below on mobile.
- No second Exact sizes table - that duplicated the legend. Total + database path stay as footer lines only.
- No new chart library; zero-byte sidecars omitted from wedges.

## Test plan

- [x] `bun typecheck`
- [x] Web unit tests for pie math, legend select, page no longer renders Exact sizes heading
- [ ] Manual: Settings → Storage on phone - donut + legend + total/path; Refresh still works
- [ ] Soup promote when remat is clear

## Issues

Fixes #1382