### PR TITLE
feat(web): add setting to keep reasoning collapsed by default

### DIFF
--- a/web/src/components/assistant-ui/reasoning.test.tsx
+++ b/web/src/components/assistant-ui/reasoning.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, fireEvent, act, cleanup } from '@testing-library/react'
+import React from 'react'
+
+// ReasoningGroup consumes `useMessage` from assistant-ui. Mock it so the
+// message status/content can be controlled per test.
+const { mockMessage } = vi.hoisted(() => ({
+    mockMessage: {
+        status: null as { type: string } | null,
+        content: [] as { type: string }[],
+    },
+}))
+
+vi.mock('@assistant-ui/react', () => ({
+    useMessage: () => mockMessage,
+}))
+
+import { ReasoningGroup } from './reasoning'
+
+const STORAGE_KEY = 'hapi-reasoning-collapsed'
+
+function renderGroup() {
+    return render(
+        <ReasoningGroup>
+            <div data-testid="reasoning-content">thinking text</div>
+        </ReasoningGroup>
+    )
+}
+
+// The collapsible region is the direct div child of .aui-reasoning-group
+// (the header is a button). Collapsed state is signalled by the max-h-0 class.
+function isCollapsed(container: HTMLElement): boolean {
+    const region = container.querySelector('.aui-reasoning-group > div') as HTMLElement
+    return region.className.includes('max-h-0')
+}
+
+function setStreaming() {
+    mockMessage.status = { type: 'running' }
+    mockMessage.content = [{ type: 'reasoning' }]
+}
+
+describe('ReasoningGroup', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+        cleanup()
+        mockMessage.status = null
+        mockMessage.content = []
+    })
+
+    it('is collapsed by default', () => {
+        const { container } = renderGroup()
+        expect(isCollapsed(container)).toBe(true)
+    })
+
+    it('expands on click', () => {
+        const { container } = renderGroup()
+        fireEvent.click(container.querySelector('button')!)
+        expect(isCollapsed(container)).toBe(false)
+    })
+
+    it('auto-expands while streaming', () => {
+        const { container, rerender } = renderGroup()
+        setStreaming()
+        rerender(
+            <ReasoningGroup>
+                <div data-testid="reasoning-content">thinking text</div>
+            </ReasoningGroup>
+        )
+        expect(isCollapsed(container)).toBe(false)
+    })
+
+    it('stays collapsed while streaming when the preference is enabled', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'true')
+        const { container, rerender } = renderGroup()
+        setStreaming()
+        rerender(
+            <ReasoningGroup>
+                <div data-testid="reasoning-content">thinking text</div>
+            </ReasoningGroup>
+        )
+        expect(isCollapsed(container)).toBe(true)
+    })
+
+    it('collapses an auto-expanded streaming block when the preference is enabled from another tab', () => {
+        const { container, rerender } = renderGroup()
+        setStreaming()
+        rerender(
+            <ReasoningGroup>
+                <div data-testid="reasoning-content">thinking text</div>
+            </ReasoningGroup>
+        )
+        expect(isCollapsed(container)).toBe(false)
+
+        act(() => {
+            window.localStorage.setItem(STORAGE_KEY, 'true')
+            window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY }))
+        })
+
+        expect(isCollapsed(container)).toBe(true)
+    })
+})

--- a/web/src/components/assistant-ui/reasoning.tsx
+++ b/web/src/components/assistant-ui/reasoning.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, type FC, type PropsWithChildren } from 'react'
 import { useMessage } from '@assistant-ui/react'
 import { MarkdownTextPrimitive } from '@assistant-ui/react-markdown'
 import { cn } from '@/lib/utils'
+import { useReasoningCollapse } from '@/hooks/useReasoningCollapse'
 import {
     MARKDOWN_CLASSNAME,
     MARKDOWN_COMPONENTS_BY_LANGUAGE,
@@ -63,12 +64,12 @@ export const ReasoningGroup: FC<PropsWithChildren> = ({ children }) => {
     const isStreaming = message.status?.type === 'running'
         && message.content.length > 0
         && message.content[message.content.length - 1]?.type === 'reasoning'
+    const { reasoningCollapsed } = useReasoningCollapse()
 
     useEffect(() => {
-        if (isStreaming) {
-            setIsOpen(true)
-        }
-    }, [isStreaming])
+        if (!isStreaming) return
+        setIsOpen(!reasoningCollapsed)
+    }, [isStreaming, reasoningCollapsed])
 
     return (
         <div data-hapi-share-exclude="true" className="aui-reasoning-group my-3 overflow-hidden rounded-2xl bg-[var(--app-reasoning-bg)]">

--- a/web/src/hooks/useReasoningCollapse.test.ts
+++ b/web/src/hooks/useReasoningCollapse.test.ts
@@ -1,0 +1,146 @@
+import { act, renderHook, cleanup } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    DEFAULT_REASONING_COLLAPSED,
+    getInitialReasoningCollapsed,
+    useReasoningCollapse,
+} from './useReasoningCollapse'
+
+const STORAGE_KEY = 'hapi-reasoning-collapsed'
+
+describe('useReasoningCollapse helpers', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('defaults to expanded', () => {
+        expect(getInitialReasoningCollapsed()).toBe(DEFAULT_REASONING_COLLAPSED)
+    })
+
+    it('reads valid stored values and ignores invalid values', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'true')
+        expect(getInitialReasoningCollapsed()).toBe(true)
+
+        window.localStorage.setItem(STORAGE_KEY, 'invalid')
+        expect(getInitialReasoningCollapsed()).toBe(DEFAULT_REASONING_COLLAPSED)
+    })
+})
+
+describe('useReasoningCollapse', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('persists the collapsed preference', () => {
+        const { result } = renderHook(() => useReasoningCollapse())
+
+        act(() => {
+            result.current.setReasoningCollapsed(true)
+        })
+
+        expect(result.current.reasoningCollapsed).toBe(true)
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true')
+    })
+
+    it('removes the stored preference when restored to the default', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'true')
+        const { result } = renderHook(() => useReasoningCollapse())
+
+        act(() => {
+            result.current.setReasoningCollapsed(false)
+        })
+
+        expect(result.current.reasoningCollapsed).toBe(false)
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('keeps the preference in memory when persistence fails', () => {
+        const setItemSpy = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+            throw new Error('quota exceeded')
+        })
+        const { result } = renderHook(() => useReasoningCollapse())
+
+        act(() => {
+            result.current.setReasoningCollapsed(true)
+        })
+
+        expect(result.current.reasoningCollapsed).toBe(true)
+        setItemSpy.mockRestore()
+    })
+
+    it('keeps the preference in memory when removal fails', () => {
+        const removeItemSpy = vi.spyOn(window.localStorage, 'removeItem').mockImplementation(() => {
+            throw new Error('denied')
+        })
+        const { result } = renderHook(() => useReasoningCollapse())
+
+        act(() => {
+            result.current.setReasoningCollapsed(false)
+        })
+
+        expect(result.current.reasoningCollapsed).toBe(false)
+        removeItemSpy.mockRestore()
+    })
+
+    it('retains the in-memory fallback across later subscriptions when persistence fails', () => {
+        const setItemSpy = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+            throw new Error('quota exceeded')
+        })
+        const first = renderHook(() => useReasoningCollapse())
+
+        act(() => {
+            first.result.current.setReasoningCollapsed(true)
+        })
+        expect(first.result.current.reasoningCollapsed).toBe(true)
+
+        // A later-mounted instance must not resync over the in-memory value
+        // that storage does not reflect.
+        const second = renderHook(() => useReasoningCollapse())
+        expect(second.result.current.reasoningCollapsed).toBe(true)
+        expect(first.result.current.reasoningCollapsed).toBe(true)
+
+        setItemSpy.mockRestore()
+    })
+
+    it('applies cross-tab changes from storage events', () => {
+        const { result } = renderHook(() => useReasoningCollapse())
+
+        act(() => {
+            window.localStorage.setItem(STORAGE_KEY, 'true')
+            window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY }))
+        })
+
+        expect(result.current.reasoningCollapsed).toBe(true)
+
+        act(() => {
+            window.localStorage.removeItem(STORAGE_KEY)
+            window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY }))
+        })
+
+        expect(result.current.reasoningCollapsed).toBe(false)
+    })
+
+    it('shares a single storage listener across all hook instances', () => {
+        cleanup()
+        const addSpy = vi.spyOn(window, 'addEventListener')
+        const removeSpy = vi.spyOn(window, 'removeEventListener')
+        const countStorageListeners = () => {
+            const calls = addSpy.mock.calls.filter(([type]) => String(type) === 'storage').length
+                - removeSpy.mock.calls.filter(([type]) => String(type) === 'storage').length
+            return calls
+        }
+
+        const first = renderHook(() => useReasoningCollapse())
+        const second = renderHook(() => useReasoningCollapse())
+        expect(countStorageListeners()).toBe(1)
+
+        first.unmount()
+        expect(countStorageListeners()).toBe(1)
+
+        second.unmount()
+        expect(countStorageListeners()).toBe(0)
+
+        addSpy.mockRestore()
+        removeSpy.mockRestore()
+    })
+})

--- a/web/src/hooks/useReasoningCollapse.ts
+++ b/web/src/hooks/useReasoningCollapse.ts
@@ -1,0 +1,121 @@
+import { useCallback, useSyncExternalStore } from 'react'
+
+export const DEFAULT_REASONING_COLLAPSED = false
+
+const REASONING_COLLAPSED_STORAGE_KEY = 'hapi-reasoning-collapsed'
+
+function isBrowser(): boolean {
+    return typeof window !== 'undefined' && typeof document !== 'undefined'
+}
+
+function safeGetItem(): string | null {
+    if (!isBrowser()) return null
+    try {
+        return localStorage.getItem(REASONING_COLLAPSED_STORAGE_KEY)
+    } catch {
+        return null
+    }
+}
+
+// Persist best-effort. Returns whether the write succeeded so callers can
+// keep the in-memory override when storage is unavailable or quota-limited.
+function persistPreference(value: boolean): boolean {
+    if (!isBrowser()) return false
+    try {
+        if (value === DEFAULT_REASONING_COLLAPSED) {
+            localStorage.removeItem(REASONING_COLLAPSED_STORAGE_KEY)
+        } else {
+            localStorage.setItem(REASONING_COLLAPSED_STORAGE_KEY, String(value))
+        }
+        return true
+    } catch {
+        return false
+    }
+}
+
+function parseReasoningCollapsed(raw: string | null): boolean {
+    if (raw === 'true') return true
+    if (raw === 'false') return false
+    return DEFAULT_REASONING_COLLAPSED
+}
+
+export function getInitialReasoningCollapsed(): boolean {
+    return parseReasoningCollapsed(safeGetItem())
+}
+
+// ── Module-level singleton store ────────────────────────────────────────────
+// ReasoningGroup mounts once per reasoning card, and the chat window keeps
+// hundreds of cards (message-window-store.ts). Mounting a window `storage`
+// listener per card would fan out to hundreds of listeners, so the
+// subscription lives here at module scope: one listener total, and every hook
+// instance reads the same shared snapshot.
+
+let currentCollapsed = DEFAULT_REASONING_COLLAPSED
+// True while a persistence failure left the in-memory value diverging from
+// storage. New subscriptions must not resync over it until a real cross-tab
+// storage event arrives.
+let hasUnpersistedOverride = false
+const listeners = new Set<() => void>()
+
+function syncFromStorage(): void {
+    const next = parseReasoningCollapsed(safeGetItem())
+    if (next === currentCollapsed) return
+    currentCollapsed = next
+    for (const listener of listeners) listener()
+}
+
+// Update the shared snapshot and notify subscribers. Used by the setter so
+// the preference stays functional in memory even when persistence fails
+// (e.g. storage unavailable or quota exceeded).
+function setCurrentCollapsed(value: boolean): void {
+    if (value === currentCollapsed) return
+    currentCollapsed = value
+    for (const listener of listeners) listener()
+}
+
+function handleStorage(event: StorageEvent): void {
+    if (event.key !== REASONING_COLLAPSED_STORAGE_KEY) return
+    hasUnpersistedOverride = false
+    syncFromStorage()
+}
+
+function subscribe(listener: () => void): () => void {
+    // Re-read on every subscribe so fresh hook mounts (and tests) observe the
+    // latest value — unless a persistence failure left an in-memory override
+    // that storage does not reflect yet.
+    if (!hasUnpersistedOverride) {
+        syncFromStorage()
+    }
+    if (listeners.size === 0 && isBrowser()) {
+        window.addEventListener('storage', handleStorage)
+    }
+    listeners.add(listener)
+    return () => {
+        listeners.delete(listener)
+        if (listeners.size === 0 && isBrowser()) {
+            window.removeEventListener('storage', handleStorage)
+        }
+    }
+}
+
+function getSnapshot(): boolean {
+    return currentCollapsed
+}
+
+export function useReasoningCollapse(): {
+    reasoningCollapsed: boolean
+    setReasoningCollapsed: (value: boolean) => void
+} {
+    const reasoningCollapsed = useSyncExternalStore(
+        subscribe,
+        getSnapshot,
+        () => DEFAULT_REASONING_COLLAPSED,
+    )
+
+    const setReasoningCollapsed = useCallback((value: boolean) => {
+        hasUnpersistedOverride = !persistPreference(value)
+        setCurrentCollapsed(value)
+    }, [])
+
+    return { reasoningCollapsed, setReasoningCollapsed }
+}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -797,6 +797,8 @@ export default {
   'settings.chat.terminalToolDisplay.detailed': 'Detailed (show output preview)',
   'settings.chat.codexExplorationCollapsed': 'Collapse explored tool groups by default',
   'settings.chat.codexExplorationCollapsed.desc': 'Keep Codex read and search activity collapsed until you open it.',
+  'settings.chat.reasoningCollapsed': 'Collapse reasoning by default',
+  'settings.chat.reasoningCollapsed.desc': 'Keep AI reasoning messages collapsed, including while streaming.',
   'settings.chat.groupedToolBackground': 'Grouped Tool Use Background',
   'settings.chat.userMessageBackground': 'User Message Background',
   'settings.chat.surfaceColor.default': 'Default color',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -796,6 +796,8 @@ export default {
   'settings.chat.terminalToolDisplay.detailed': '详细（显示输出预览）',
   'settings.chat.codexExplorationCollapsed': '已探索工具组默认收起',
   'settings.chat.codexExplorationCollapsed.desc': 'Codex 的读取和搜索活动默认收起，点击后查看详情。',
+  'settings.chat.reasoningCollapsed': '思考默认折叠',
+  'settings.chat.reasoningCollapsed.desc': 'AI 思考内容默认保持折叠，流式输出期间也不会自动展开。',
   'settings.chat.groupedToolBackground': '聚合 Tool Use 背景',
   'settings.chat.userMessageBackground': '用户消息背景',
   'settings.chat.surfaceColor.default': '默认颜色',

--- a/web/src/routes/settings/chat.tsx
+++ b/web/src/routes/settings/chat.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from '@/lib/use-translation'
 import { getComposerEnterBehaviorOptions, useComposerEnterBehavior } from '@/hooks/useComposerEnterBehavior'
 import { getTerminalToolDisplayModeOptions, useTerminalToolDisplayMode } from '@/hooks/useTerminalToolDisplayMode'
 import { useCodexExplorationCollapse } from '@/hooks/useCodexExplorationCollapse'
+import { useReasoningCollapse } from '@/hooks/useReasoningCollapse'
 import {
     getChatSurfaceColorPickerValue,
     getChatSurfaceColorPresetOptions,
@@ -50,6 +51,7 @@ export default function SettingsChatPage() {
     const { composerEnterBehavior, setComposerEnterBehavior } = useComposerEnterBehavior()
     const { terminalToolDisplayMode, setTerminalToolDisplayMode } = useTerminalToolDisplayMode()
     const { codexExplorationCollapsed, setCodexExplorationCollapsed } = useCodexExplorationCollapse()
+    const { reasoningCollapsed, setReasoningCollapsed } = useReasoningCollapse()
     const { toolGroupBackground, userMessageBackground, setToolGroupBackground, setUserMessageBackground } = useChatSurfaceColors()
     return (
         <SettingsPageContent description={t('settings.chat.description')}>
@@ -74,6 +76,12 @@ export default function SettingsChatPage() {
                     description={t('settings.chat.codexExplorationCollapsed.desc')}
                     checked={codexExplorationCollapsed}
                     onChange={setCodexExplorationCollapsed}
+                />
+                <SettingsSwitch
+                    label={t('settings.chat.reasoningCollapsed')}
+                    description={t('settings.chat.reasoningCollapsed.desc')}
+                    checked={reasoningCollapsed}
+                    onChange={setReasoningCollapsed}
                 />
             </SettingsSection>
             <SettingsSection title={t('settings.chat.colors')}>


### PR DESCRIPTION
## Summary

Reasoning messages are currently auto-expanded while streaming and stay expanded afterwards. For chat-heavy usage this pushes the answer off-screen on every turn, especially on mobile.

This PR adds a **"Collapse reasoning by default"** setting (Settings → Chat → Tool cards) that keeps reasoning blocks collapsed at all times — including during streaming. The existing auto-expand behavior remains the default for everyone else; the setting is opt-in.

## Changes

- `web/src/hooks/useReasoningCollapse.ts` — new localStorage-backed preference hook, modeled after the existing `useCodexExplorationCollapse`
- `web/src/components/assistant-ui/reasoning.tsx` — `ReasoningGroup` only auto-expands while streaming when the preference is off
- `web/src/routes/settings/chat.tsx` — new toggle in the Tool cards section
- `web/src/lib/locales/{en,zh-CN}.ts` — labels for the new setting
- `web/src/hooks/useReasoningCollapse.test.ts` — tests for default, persistence, and cross-tab sync

## Verification

- `vitest run`: 240 files / 2139 tests passed
- `tsc --noEmit` clean