### PR TITLE
fix(web): fit composer placeholder to available width

### DIFF
--- a/web/src/components/AssistantChat/RichComposerInput.test.tsx
+++ b/web/src/components/AssistantChat/RichComposerInput.test.tsx
@@ -3,6 +3,7 @@ import { flushSync } from 'react-dom'
 import { useRef, useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+    fitSingleLineFontSize,
     mirrorOffsetFromPoint,
     RichComposerInput,
     type RichComposerInputHandle,
@@ -87,6 +88,69 @@ function LineBreakDeletionHarness() {
         </>
     )
 }
+
+describe('RichComposerInput responsive placeholder', () => {
+    it('calculates a smaller font that fits overflowing text', () => {
+        expect(fitSingleLineFontSize(160, 320)).toBeCloseTo(7.95)
+        expect(fitSingleLineFontSize(320, 320)).toBe(16)
+        expect(fitSingleLineFontSize(640, 320)).toBe(16)
+        expect(fitSingleLineFontSize(0, 320)).toBe(16)
+        expect(fitSingleLineFontSize(Number.NaN, 320)).toBe(16)
+        expect(fitSingleLineFontSize(384, 320, 19.2)).toBe(19.2)
+        expect(fitSingleLineFontSize(160, 320, 19.2)).toBeCloseTo(9.54)
+    })
+
+    it('refits the complete single-line placeholder when its container width changes', () => {
+        let resizeCallback: ResizeObserverCallback | undefined
+        class TestResizeObserver {
+            constructor(callback: ResizeObserverCallback) {
+                resizeCallback = callback
+            }
+            observe() {}
+            unobserve() {}
+            disconnect() {}
+        }
+        vi.stubGlobal('ResizeObserver', TestResizeObserver)
+        vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+            fontSize: '19.2px',
+        } as CSSStyleDeclaration)
+
+        try {
+            render(
+                <RichComposerInput
+                    value=""
+                    placeholder="Type what you want the agent to do, without truncation"
+                    onValueChange={() => {}}
+                    onMirrorChange={() => {}}
+                />
+            )
+
+            const placeholder = screen.getByTestId('rich-composer-placeholder')
+            let availableWidth = 160
+            Object.defineProperty(placeholder, 'clientWidth', {
+                configurable: true,
+                get: () => availableWidth,
+            })
+            Object.defineProperty(placeholder, 'scrollWidth', {
+                configurable: true,
+                get: () => 320,
+            })
+
+            resizeCallback?.([], {} as ResizeObserver)
+            expect(placeholder).toHaveTextContent('Type what you want the agent to do, without truncation')
+            expect(placeholder).not.toHaveClass('text-ellipsis')
+            expect(placeholder).toHaveClass('text-base')
+            expect(placeholder.style.fontSize).toBe('9.54px')
+
+            availableWidth = 640
+            resizeCallback?.([], {} as ResizeObserver)
+            expect(placeholder.style.fontSize).toBe('19.2px')
+        } finally {
+            vi.restoreAllMocks()
+            vi.unstubAllGlobals()
+        }
+    })
+})
 
 describe('RichComposerInput controlled synchronization', () => {
     afterEach(() => {

--- a/web/src/components/AssistantChat/RichComposerInput.tsx
+++ b/web/src/components/AssistantChat/RichComposerInput.tsx
@@ -108,6 +108,33 @@ function createMentionSpan(
 const BLOCK_TAGS = new Set(['DIV', 'P', 'LI', 'TR', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'PRE'])
 /** Zero-width pad so a trailing linebreak keeps a caret line-box (pre-wrap / br). */
 const CARET_PAD = '\u200B'
+const PLACEHOLDER_MAX_FONT_SIZE_PX = 16
+const PLACEHOLDER_FIT_GUTTER_PX = 1
+
+export function fitSingleLineFontSize(
+    availableWidth: number,
+    contentWidth: number,
+    maxFontSize = PLACEHOLDER_MAX_FONT_SIZE_PX
+): number {
+    const resolvedMaxFontSize = Number.isFinite(maxFontSize) && maxFontSize > 0
+        ? maxFontSize
+        : PLACEHOLDER_MAX_FONT_SIZE_PX
+    if (
+        !Number.isFinite(availableWidth)
+        || !Number.isFinite(contentWidth)
+        || availableWidth <= 0
+        || contentWidth <= 0
+        || contentWidth <= availableWidth
+    ) {
+        return resolvedMaxFontSize
+    }
+
+    // Keep a tiny buffer for fractional glyph metrics: scrollWidth is rounded
+    // to an integer, while the browser can paint glyphs on sub-pixels.
+    return resolvedMaxFontSize
+        * Math.max(0, availableWidth - PLACEHOLDER_FIT_GUTTER_PX)
+        / contentWidth
+}
 
 function stripCaretPad(text: string): string {
     return text.replaceAll(CARET_PAD, '')
@@ -995,6 +1022,48 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, Props>(func
     // No onDrop: intercepting without caretRangeFromPoint appends at EOF / no-ops
     // in-editor moves. Native CE drop + plaintext-only / paste path is enough for #1215.
 
+    const placeholderRef = useRef<HTMLDivElement>(null)
+
+    useLayoutEffect(() => {
+        const element = placeholderRef.current
+        if (!element || !domIsEmpty || !placeholder) return
+
+        let cancelled = false
+        const fitPlaceholder = () => {
+            if (cancelled) return
+
+            // Restore the configured text-base size before measuring. Measuring
+            // the already-shrunk text would make successive resizes compound.
+            element.style.removeProperty('font-size')
+            const baseFontSize = Number.parseFloat(getComputedStyle(element).fontSize)
+            const fontSize = fitSingleLineFontSize(
+                element.clientWidth,
+                element.scrollWidth,
+                baseFontSize
+            )
+            element.style.fontSize = `${fontSize}px`
+        }
+
+        fitPlaceholder()
+
+        const resizeObserver = typeof ResizeObserver === 'undefined'
+            ? null
+            : new ResizeObserver(fitPlaceholder)
+        resizeObserver?.observe(element)
+        window.addEventListener('resize', fitPlaceholder)
+
+        const fonts = document.fonts
+        void fonts?.ready.then(fitPlaceholder)
+        fonts?.addEventListener?.('loadingdone', fitPlaceholder)
+
+        return () => {
+            cancelled = true
+            resizeObserver?.disconnect()
+            window.removeEventListener('resize', fitPlaceholder)
+            fonts?.removeEventListener?.('loadingdone', fitPlaceholder)
+        }
+    }, [domIsEmpty, placeholder])
+
     const handleKeyDown = useCallback((e: ReactKeyboardEvent<HTMLDivElement>) => {
         if (e.nativeEvent.isComposing || composingRef.current) {
             return
@@ -1043,8 +1112,10 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, Props>(func
         <div className="relative min-w-0 flex-1">
             {domIsEmpty && placeholder ? (
                 <div
+                    ref={placeholderRef}
                     aria-hidden
-                    className="pointer-events-none absolute inset-0 overflow-hidden text-ellipsis whitespace-nowrap text-base leading-snug text-[var(--app-hint)]"
+                    data-testid="rich-composer-placeholder"
+                    className="pointer-events-none absolute inset-0 overflow-hidden whitespace-nowrap text-base leading-[1.375rem] text-[var(--app-hint)]"
                 >
                     {placeholder}
                 </div>


### PR DESCRIPTION
## Summary

- replace the rich composer placeholder's fixed-size ellipsis behavior with single-line font fitting
- recalculate the placeholder size when its container, localized copy, or loaded fonts change
- preserve the normal 16 px size when space is available and retain the full accessible label
- add focused unit and component coverage for narrow and widened container widths

Fixes #1387

## Testing

- `cd web && bun run test -- src/components/AssistantChat/RichComposerInput.test.tsx src/components/AssistantChat/RichComposerInput.segments.test.ts src/lib/composerSegments.test.ts`
- `cd web && bun run typecheck`
- `cd web && bun run build`

## AI-assisted development disclosure

This change was developed with assistance from OpenAI GPT-5.6. The implementation and tests were reviewed and validated locally.
