### PR TITLE
fix(web): show truncated query on collapsed session search

### DIFF
--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -855,6 +855,8 @@ describe('SessionList search toggle', () => {
         expect(screen.queryByPlaceholderText('Search sessions…')).toBeNull()
         const collapsed = screen.getByRole('button', { name: /Search sessions/ })
         expect(collapsed).toHaveTextContent('jellybot')
+        expect(collapsed.className).toContain('bg-[var(--app-chat-user-chip-bg)]')
+        expect(collapsed.className).toContain('text-[var(--app-chat-user-chip-fg)]')
         expect(screen.getByRole('button', { name: /jellybot task/ })).toBeInTheDocument()
         expect(screen.queryByRole('button', { name: /Other task/ })).toBeNull()
     })

--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -815,8 +815,47 @@ describe('SessionList search toggle', () => {
         // Blur collapses back to the icon; the query stays applied.
         fireEvent.blur(input)
         expect(screen.queryByPlaceholderText('Search sessions…')).toBeNull()
-        expect(screen.getByRole('button', { name: 'Search sessions' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Search sessions/ })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /Matching task/ })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /Other task/ })).toBeNull()
+    })
+
+    it('shows truncated query text on the collapsed search control when a text filter is active', () => {
+        const sessions = [
+            makeSession({
+                id: 'session-jelly',
+                updatedAt: 100,
+                metadata: { path: '/work/hapi', name: 'jellybot task', flavor: 'codex' },
+            }),
+            makeSession({
+                id: 'session-other',
+                updatedAt: 90,
+                metadata: { path: '/work/hapi', name: 'Other task', flavor: 'codex' },
+            }),
+        ]
+
+        renderWithProviders(
+            <SessionList
+                sessions={sessions}
+                selectedSessionId={null}
+                onSelect={vi.fn()}
+                onNewSession={vi.fn()}
+                onRefresh={vi.fn()}
+                isLoading={false}
+                renderHeader={false}
+                api={null}
+            />
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'Search sessions' }))
+        const input = screen.getByPlaceholderText('Search sessions…')
+        fireEvent.change(input, { target: { value: 'jellybot' } })
+        fireEvent.blur(input)
+
+        expect(screen.queryByPlaceholderText('Search sessions…')).toBeNull()
+        const collapsed = screen.getByRole('button', { name: /Search sessions/ })
+        expect(collapsed).toHaveTextContent('jellybot')
+        expect(screen.getByRole('button', { name: /jellybot task/ })).toBeInTheDocument()
         expect(screen.queryByRole('button', { name: /Other task/ })).toBeNull()
     })
 

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -750,17 +750,29 @@ function SessionListSearch(props: {
     }
 
     if (!props.expanded) {
+        const hasTextQuery = props.value.length > 0
+        const openLabel = t('sessions.search.open')
+        const collapsedLabel = hasTextQuery ? `${openLabel}: ${props.value}` : openLabel
         return (
             <div className="relative flex items-center gap-1">
                 <button
                     type="button"
                     onClick={() => props.onExpandedChange(true)}
-                    className="relative shrink-0 rounded-full p-1.5 text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
-                    title={t('sessions.search.open')}
-                    aria-label={t('sessions.search.open')}
+                    className={cn(
+                        'relative flex min-w-0 max-w-[9rem] items-center gap-1 rounded-full transition-colors',
+                        hasTextQuery
+                            // Dedicated chip tokens (blue wash) so the active query stays
+                            // readable when truncated text disappears at small widths.
+                            ? 'bg-[var(--app-chat-user-chip-bg)] px-2 py-1 text-[var(--app-chat-user-chip-fg)] hover:opacity-90'
+                            : 'shrink-0 p-1.5 text-[var(--app-hint)] hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]'
+                    )}
+                    title={collapsedLabel}
+                    aria-label={collapsedLabel}
                 >
-                    <SearchIcon className="h-5 w-5" />
-                    {props.value.length > 0 ? <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[var(--app-link)]" /> : null}
+                    <SearchIcon className="h-5 w-5 shrink-0" />
+                    {hasTextQuery ? (
+                        <span className="min-w-0 truncate text-xs font-medium">{props.value}</span>
+                    ) : null}
                 </button>
                 {renderDateFilter('standalone')}
             </div>


### PR DESCRIPTION
## Summary

After the session search collapsed into the sidebar toolbar ([3f73a5f6e](https://github.com/tiann/hapi/commit/3f73a5f6ef04157166f9875ecbc264d1b625068d)), an active text filter left only the search icon + indicator dot. Operators could see *that* a filter was active, but not *for what*.

This change renders a compact chip when collapsed with a text query:

- Search icon + truncated query (`truncate` / ellipsis, `max-w-[9rem]`)
- Active highlight via `--app-chat-user-chip-bg` / `--app-chat-user-chip-fg` so the chip still reads as active when text truncates away at small widths
- Click still expands to the full input
- Keeps the standalone date-filter control from #1367

## Test plan

- [x] Vitest: collapsed control shows query text + chip token classes
- [x] Vitest: expand / filter / blur still collapses and keeps filtering
- [x] `bun run typecheck` (web)
- [ ] Hard-reload sessions sidebar: type a query (e.g. `jellybot`), blur — blue chip shows truncated text
- [ ] Narrow the sidebar until text ellipsizes — blue wash still visible
- [ ] Date-only filter (no text): standalone calendar control unchanged

## Issues

Fixes #1356