### PR TITLE
fix(web): coordinate streaming reasoning scroll

### DIFF
--- a/web/src/components/AssistantChat/HappyThread.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.test.tsx
@@ -9,6 +9,7 @@ import {
     getPullToLoadState,
     getScrollIntent,
     hasAppliedHistoryVersion,
+    isNestedScrollEvent,
     locateOutlineTargetMessage,
     prependMissingUserSnapshot,
     restoreScrollAnchor,
@@ -33,6 +34,28 @@ const outlineItems: ConversationOutlineItem[] = [
         createdAt: 2000
     }
 ]
+
+describe('nested scroll event ownership', () => {
+    it('recognizes events from a nested scroll viewport and its descendants', () => {
+        const nested = document.createElement('div')
+        nested.dataset.hapiNestedScroll = 'true'
+        const child = document.createElement('span')
+        child.textContent = 'reasoning'
+        nested.append(child)
+        document.body.append(nested)
+
+        const nestedEvent = new Event('wheel')
+        Object.defineProperty(nestedEvent, 'target', { value: nested })
+        const childEvent = new Event('keydown')
+        Object.defineProperty(childEvent, 'target', { value: child })
+
+        expect(isNestedScrollEvent(new WheelEvent('wheel'))).toBe(false)
+        expect(isNestedScrollEvent(nestedEvent)).toBe(true)
+        expect(isNestedScrollEvent(childEvent)).toBe(true)
+
+        nested.remove()
+    })
+})
 
 function rect(values: Pick<DOMRect, 'top' | 'bottom'> & Partial<DOMRect>): DOMRect {
     return {

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -68,6 +68,16 @@ type ShareTurnSnapshot = {
     role?: 'user' | 'assistant'
 }
 
+export function isNestedScrollEvent(event: Event): boolean {
+    const target = event.target
+    const element = typeof Element !== 'undefined' && target instanceof Element
+        ? target
+        : typeof Node !== 'undefined' && target instanceof Node
+            ? target.parentElement
+            : null
+    return element?.closest('[data-hapi-nested-scroll="true"]') != null
+}
+
 function findNearestMessageElement(content: HTMLElement, clientY?: number): HTMLElement | null {
     const messages = Array.from(content.querySelectorAll('.happy-thread-messages > [id]'))
         .filter((element): element is HTMLElement => element instanceof HTMLElement)
@@ -786,6 +796,7 @@ export function HappyThread(props: {
         }
 
         const handleKeyDown = (event: KeyboardEvent) => {
+            if (isNestedScrollEvent(event)) return
             const target = event.target
             if (
                 event.defaultPrevented
@@ -814,7 +825,7 @@ export function HappyThread(props: {
         }
 
         const handlePointerDown = (event: PointerEvent) => {
-            if (event.button !== 0) {
+            if (isNestedScrollEvent(event) || event.button !== 0) {
                 return
             }
             armPointerIntent()
@@ -832,12 +843,14 @@ export function HappyThread(props: {
         // listeners. Capture pointer and mouse input at the window boundary,
         // then scope it back to the chat viewport by coordinates.
         const handleWindowPointerDown = (event: PointerEvent) => {
+            if (isNestedScrollEvent(event)) return
             if (event.button === 0 && isInsideViewport(event.clientX, event.clientY)) {
                 armPointerIntent()
             }
         }
 
         const handleWindowMouseDown = (event: MouseEvent) => {
+            if (isNestedScrollEvent(event)) return
             if (event.button === 0 && isInsideViewport(event.clientX, event.clientY)) {
                 armPointerIntent()
             }
@@ -850,6 +863,7 @@ export function HappyThread(props: {
         }
 
         const handlePointerCancel = (event: PointerEvent) => {
+            if (isNestedScrollEvent(event)) return
             const hadActivePointer = pointerResumeActive
             pointerResumeActive = false
             if (hadActivePointer && (event.pointerType === 'touch' || event.pointerType === 'pen')) {
@@ -864,6 +878,7 @@ export function HappyThread(props: {
         }
 
         const handleWheel = (event: WheelEvent) => {
+            if (isNestedScrollEvent(event)) return
             if (event.deltaY >= 0) {
                 wheelIntentUntil = 0
                 return
@@ -886,6 +901,7 @@ export function HappyThread(props: {
         }
 
         const handleTouchStart = (event: TouchEvent) => {
+            if (isNestedScrollEvent(event)) return
             updatePullToLoadState('idle')
             pullStartY = (
                 viewport.scrollTop <= 0
@@ -899,6 +915,7 @@ export function HappyThread(props: {
         }
 
         const handleTouchMove = (event: TouchEvent) => {
+            if (isNestedScrollEvent(event)) return
             if (pullStartY === null) {
                 return
             }
@@ -913,7 +930,8 @@ export function HappyThread(props: {
             }
         }
 
-        const handleTouchEnd = () => {
+        const handleTouchEnd = (event: TouchEvent) => {
+            if (isNestedScrollEvent(event)) return
             const shouldLoad = pullStartY !== null
                 && pullToLoadStateRef.current === 'ready'
                 && viewport.scrollTop <= 0
@@ -924,7 +942,8 @@ export function HappyThread(props: {
             }
         }
 
-        const handleTouchCancel = () => {
+        const handleTouchCancel = (event: TouchEvent) => {
+            if (isNestedScrollEvent(event)) return
             pullStartY = null
             updatePullToLoadState('idle')
         }
@@ -968,6 +987,13 @@ export function HappyThread(props: {
             lastScrollTopRef.current = viewport.scrollTop
         }
     }, [])
+
+    const handleNestedScrollFollowChange = useCallback((followLatest: boolean) => {
+        if (!followLatest) {
+            clearInitialScrollTimers()
+        }
+        autoScrollEnabledRef.current = followLatest && atBottomRef.current
+    }, [clearInitialScrollTimers])
 
     // Scroll to bottom handler for the indicator button
     const scrollToBottom = useCallback(() => {
@@ -1539,6 +1565,7 @@ export function HappyThread(props: {
             hasMoreMessages: props.hasMoreMessages,
             isSyncingTail: props.isSyncingTail,
             isLoadingMoreMessages: props.isLoadingMoreMessages,
+            onNestedScrollFollowChange: handleNestedScrollFollowChange,
             loadOlderMessagesPreservingScroll: loadOlderFromConsumer
         }}>
             <ThreadPrimitive.Root className="flex min-h-0 flex-1 flex-col relative">

--- a/web/src/components/AssistantChat/context.tsx
+++ b/web/src/components/AssistantChat/context.tsx
@@ -26,6 +26,7 @@ export type HappyChatContextValue = {
     hasMoreMessages: boolean
     isSyncingTail: boolean
     isLoadingMoreMessages: boolean
+    onNestedScrollFollowChange?: (followLatest: boolean) => void
     loadOlderMessagesPreservingScroll: () => Promise<OlderHistoryLoadResult>
 }
 

--- a/web/src/components/assistant-ui/reasoning.test.tsx
+++ b/web/src/components/assistant-ui/reasoning.test.tsx
@@ -4,15 +4,20 @@ import React from 'react'
 
 // ReasoningGroup consumes `useMessage` from assistant-ui. Mock it so the
 // message status/content can be controlled per test.
-const { mockMessage } = vi.hoisted(() => ({
+const { mockMessage, onNestedScrollFollowChange } = vi.hoisted(() => ({
     mockMessage: {
         status: null as { type: string } | null,
         content: [] as { type: string }[],
     },
+    onNestedScrollFollowChange: vi.fn(),
 }))
 
 vi.mock('@assistant-ui/react', () => ({
     useMessage: () => mockMessage,
+}))
+
+vi.mock('@/components/AssistantChat/context', () => ({
+    useOptionalHappyChatContext: () => ({ onNestedScrollFollowChange }),
 }))
 
 import { ReasoningGroup } from './reasoning'
@@ -45,6 +50,12 @@ describe('ReasoningGroup', () => {
         cleanup()
         mockMessage.status = null
         mockMessage.content = []
+        onNestedScrollFollowChange.mockReset()
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+            callback(0)
+            return 1
+        })
+        vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
     })
 
     it('is collapsed by default', () => {
@@ -54,8 +65,11 @@ describe('ReasoningGroup', () => {
 
     it('expands on click', () => {
         const { container } = renderGroup()
+        const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
+        expect(scroll.tabIndex).toBe(-1)
         fireEvent.click(container.querySelector('button')!)
         expect(isCollapsed(container)).toBe(false)
+        expect(scroll.tabIndex).toBe(0)
     })
 
     it('auto-expands while streaming', () => {
@@ -91,11 +105,139 @@ describe('ReasoningGroup', () => {
         )
         expect(isCollapsed(container)).toBe(false)
 
+        const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
+        Object.defineProperties(scroll, {
+            scrollHeight: { configurable: true, value: 500 },
+            clientHeight: { configurable: true, value: 100 },
+        })
+        scroll.scrollTop = 100
+        fireEvent.scroll(scroll)
+        expect(onNestedScrollFollowChange).toHaveBeenLastCalledWith(false)
+
         act(() => {
             window.localStorage.setItem(STORAGE_KEY, 'true')
             window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY }))
         })
 
         expect(isCollapsed(container)).toBe(true)
+        expect(onNestedScrollFollowChange).toHaveBeenLastCalledWith(true)
+    })
+
+    it('opens a streaming reasoning panel at the latest content and follows new output at the bottom', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'true')
+        setStreaming()
+        const { container, rerender } = renderGroup()
+        const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
+        let scrollHeight = 500
+        Object.defineProperties(scroll, {
+            scrollHeight: { configurable: true, get: () => scrollHeight },
+            clientHeight: { configurable: true, get: () => 100 },
+        })
+
+        fireEvent.click(container.querySelector('button')!)
+        expect(scroll.scrollTop).toBe(500)
+
+        scrollHeight = 700
+        rerender(
+            <ReasoningGroup>
+                <div data-testid="reasoning-content">more thinking text</div>
+            </ReasoningGroup>
+        )
+        expect(scroll.scrollTop).toBe(700)
+    })
+
+    it('stops following new output after the user scrolls away from the bottom', () => {
+        setStreaming()
+        const { container, rerender } = renderGroup()
+        const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
+        let scrollHeight = 500
+        Object.defineProperties(scroll, {
+            scrollHeight: { configurable: true, get: () => scrollHeight },
+            clientHeight: { configurable: true, get: () => 100 },
+        })
+        scroll.scrollTop = 100
+        fireEvent.scroll(scroll)
+
+        scrollHeight = 700
+        rerender(
+            <ReasoningGroup>
+                <div data-testid="reasoning-content">more thinking text</div>
+            </ReasoningGroup>
+        )
+        expect(scroll.scrollTop).toBe(100)
+    })
+
+    it('releases nested scroll ownership when a scrolled-away panel is collapsed', () => {
+        setStreaming()
+        const { container } = renderGroup()
+        const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
+        Object.defineProperties(scroll, {
+            scrollHeight: { configurable: true, value: 500 },
+            clientHeight: { configurable: true, value: 100 },
+        })
+        scroll.scrollTop = 100
+        fireEvent.scroll(scroll)
+        expect(onNestedScrollFollowChange).toHaveBeenLastCalledWith(false)
+
+        fireEvent.click(container.querySelector('button')!)
+
+        expect(isCollapsed(container)).toBe(true)
+        expect(scroll.tabIndex).toBe(-1)
+        expect(onNestedScrollFollowChange).toHaveBeenLastCalledWith(true)
+    })
+
+    it('restores follow-tail after a pointer gesture ends without scrolling', () => {
+        const { container } = renderGroup()
+        const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
+        Object.defineProperties(scroll, {
+            scrollHeight: { configurable: true, value: 500 },
+            clientHeight: { configurable: true, value: 100 },
+        })
+        scroll.scrollTop = 400
+
+        fireEvent.pointerDown(scroll)
+        fireEvent.pointerUp(window)
+
+        expect(onNestedScrollFollowChange.mock.calls).toEqual([[false], [true]])
+    })
+
+    it('keeps nested ownership until pointer-up while reasoning continues streaming', () => {
+        setStreaming()
+        const { container, rerender } = renderGroup()
+        const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
+        let scrollHeight = 500
+        Object.defineProperties(scroll, {
+            scrollHeight: { configurable: true, get: () => scrollHeight },
+            clientHeight: { configurable: true, get: () => 100 },
+        })
+        scroll.scrollTop = 400
+
+        fireEvent.pointerDown(scroll)
+        scrollHeight = 700
+        rerender(
+            <ReasoningGroup>
+                <div data-testid="reasoning-content">more thinking text</div>
+            </ReasoningGroup>
+        )
+        fireEvent.scroll(scroll)
+
+        expect(scroll.scrollTop).toBe(400)
+        expect(onNestedScrollFollowChange.mock.calls).toEqual([[false], [false]])
+
+        fireEvent.pointerUp(window)
+        expect(onNestedScrollFollowChange).toHaveBeenLastCalledWith(false)
+    })
+
+    it('restores follow-tail after a boundary wheel gesture cannot scroll', () => {
+        const { container } = renderGroup()
+        const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
+        Object.defineProperties(scroll, {
+            scrollHeight: { configurable: true, value: 100 },
+            clientHeight: { configurable: true, value: 100 },
+        })
+
+        fireEvent.wheel(scroll)
+
+        expect(onNestedScrollFollowChange.mock.calls).toEqual([[false], [true]])
     })
 })

--- a/web/src/components/assistant-ui/reasoning.tsx
+++ b/web/src/components/assistant-ui/reasoning.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, type FC, type PropsWithChildren } from 'react'
+import { useState, useCallback, useEffect, useLayoutEffect, useRef, type FC, type KeyboardEvent, type PropsWithChildren, type UIEvent } from 'react'
 import { useMessage } from '@assistant-ui/react'
 import { MarkdownTextPrimitive } from '@assistant-ui/react-markdown'
 import { cn } from '@/lib/utils'
 import { useReasoningCollapse } from '@/hooks/useReasoningCollapse'
+import { useOptionalHappyChatContext } from '@/components/AssistantChat/context'
 import {
     MARKDOWN_CLASSNAME,
     MARKDOWN_COMPONENTS_BY_LANGUAGE,
@@ -59,23 +60,119 @@ export const Reasoning: FC = () => {
 
 export const ReasoningGroup: FC<PropsWithChildren> = ({ children }) => {
     const [isOpen, setIsOpen] = useState(false)
+    const scrollRef = useRef<HTMLDivElement | null>(null)
+    const followLatestRef = useRef(true)
+    const pointerActiveRef = useRef(false)
+    const pointerCleanupRef = useRef<(() => void) | null>(null)
+    const followSyncFrameRef = useRef<number | null>(null)
 
     const message = useMessage()
     const isStreaming = message.status?.type === 'running'
         && message.content.length > 0
         && message.content[message.content.length - 1]?.type === 'reasoning'
     const { reasoningCollapsed } = useReasoningCollapse()
+    const chatContext = useOptionalHappyChatContext()
 
     useEffect(() => {
         if (!isStreaming) return
-        setIsOpen(!reasoningCollapsed)
+        const nextOpen = !reasoningCollapsed
+        if (nextOpen) {
+            followLatestRef.current = true
+        }
+        setIsOpen(nextOpen)
     }, [isStreaming, reasoningCollapsed])
+
+    useEffect(() => {
+        if (isOpen || followLatestRef.current) return
+        followLatestRef.current = true
+        chatContext?.onNestedScrollFollowChange?.(true)
+    }, [isOpen, chatContext])
+
+    useLayoutEffect(() => {
+        const scroll = scrollRef.current
+        if (!scroll || !isOpen || !isStreaming || !followLatestRef.current) return
+        scroll.scrollTop = scroll.scrollHeight
+    })
+
+    const handleToggle = () => {
+        const nextOpen = !isOpen
+        if (nextOpen && isStreaming) {
+            followLatestRef.current = true
+        }
+        setIsOpen(nextOpen)
+    }
+
+    const syncNestedFollow = useCallback(() => {
+        const scroll = scrollRef.current
+        if (!scroll) return
+        const atBottom = scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight <= 8
+        const followLatest = atBottom && !pointerActiveRef.current
+        followLatestRef.current = followLatest
+        chatContext?.onNestedScrollFollowChange?.(followLatest)
+    }, [chatContext])
+
+    const handleScroll = (_event: UIEvent<HTMLDivElement>) => {
+        syncNestedFollow()
+    }
+
+    const claimNestedScroll = () => {
+        chatContext?.onNestedScrollFollowChange?.(false)
+    }
+
+    const scheduleNestedFollowSync = () => {
+        if (followSyncFrameRef.current !== null) {
+            window.cancelAnimationFrame(followSyncFrameRef.current)
+        }
+        followSyncFrameRef.current = window.requestAnimationFrame(() => {
+            followSyncFrameRef.current = null
+            syncNestedFollow()
+        })
+    }
+
+    const claimNestedPointerScroll = () => {
+        pointerActiveRef.current = true
+        followLatestRef.current = false
+        claimNestedScroll()
+        pointerCleanupRef.current?.()
+
+        const finish = () => {
+            pointerCleanupRef.current?.()
+            pointerActiveRef.current = false
+            syncNestedFollow()
+        }
+        const cleanup = () => {
+            window.removeEventListener('pointerup', finish)
+            window.removeEventListener('pointercancel', finish)
+            pointerCleanupRef.current = null
+        }
+        pointerCleanupRef.current = cleanup
+        window.addEventListener('pointerup', finish, { once: true })
+        window.addEventListener('pointercancel', finish, { once: true })
+    }
+
+    const claimNestedWheelScroll = () => {
+        claimNestedScroll()
+        scheduleNestedFollowSync()
+    }
+
+    const claimNestedKeyboardScroll = (event: KeyboardEvent<HTMLDivElement>) => {
+        if (!['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '].includes(event.key)) return
+        claimNestedScroll()
+        scheduleNestedFollowSync()
+    }
+
+    useEffect(() => () => {
+        pointerCleanupRef.current?.()
+        if (followSyncFrameRef.current !== null) {
+            window.cancelAnimationFrame(followSyncFrameRef.current)
+        }
+    }, [])
 
     return (
         <div data-hapi-share-exclude="true" className="aui-reasoning-group my-3 overflow-hidden rounded-2xl bg-[var(--app-reasoning-bg)]">
             <button
                 type="button"
-                onClick={() => setIsOpen(!isOpen)}
+                onClick={handleToggle}
                 className={cn(
                     'flex w-full items-center gap-1.5 px-3.5 py-2.5 text-left text-xs font-medium',
                     'text-[var(--app-hint)] hover:text-[var(--app-fg)]',
@@ -97,7 +194,16 @@ export const ReasoningGroup: FC<PropsWithChildren> = ({ children }) => {
                     isOpen ? 'max-h-[5000px] opacity-100' : 'max-h-0 opacity-0'
                 )}
             >
-                <div className="max-h-[60vh] overflow-y-auto border-t border-[var(--app-divider)] px-3.5 py-3">
+                <div
+                    ref={scrollRef}
+                    data-hapi-nested-scroll="true"
+                    tabIndex={isOpen ? 0 : -1}
+                    onScroll={handleScroll}
+                    onPointerDown={claimNestedPointerScroll}
+                    onWheel={claimNestedWheelScroll}
+                    onKeyDown={claimNestedKeyboardScroll}
+                    className="aui-reasoning-scroll max-h-[60vh] overflow-y-auto overscroll-y-contain border-t border-[var(--app-divider)] px-3.5 py-3"
+                >
                     {children}
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- open an active reasoning panel at its latest streamed content and keep following while its inner viewport remains at the bottom
- stop following when the user scrolls away, and resume when they return to the bottom
- coordinate nested-scroll ownership with the outer chat viewport and contain overscroll inside the reasoning panel
- add keyboard focus and regression coverage for pointer, wheel, and follow-tail behavior

## Root cause

The reasoning body was an independent scroll container with no follow-tail state. Meanwhile, user interaction inside it did not pause `HappyThread`'s outer follow-tail, so the outer `ResizeObserver` kept moving the chat viewport while the user manipulated the inner scrollbar.

## Validation

- `bun run typecheck`
- `bun run test:web` (241 files, 2157 tests)
- focused reasoning and HappyThread regression coverage

Closes #1397
