### PR TITLE
fix(web): stabilize fork action during streaming

### DIFF
--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -20,7 +20,7 @@ import { normalizeDecryptedMessage } from '@/chat/normalize'
 import { reduceChatBlocks } from '@/chat/reducer'
 import { reconcileChatBlocks } from '@/chat/reconcile'
 import { buildConversationOutline } from '@/chat/outline'
-import { buildVisibleChatBlocks, isToolGroupBlock, visibleBlockRole, type ToolGroupBlock } from '@/chat/toolGroups'
+import { buildVisibleChatBlocks, isToolGroupBlock, type ToolGroupBlock } from '@/chat/toolGroups'
 import { useUnseenBlockCount } from '@/hooks/useUnseenBlockCount'
 import { useCodexExplorationCollapse } from '@/hooks/useCodexExplorationCollapse'
 import { isQueuedForInvocation } from '@/lib/messages'
@@ -45,7 +45,7 @@ import { classifySessionAttention, getSessionAttentionLabelKey } from '@/lib/ses
 import { getSessionLastSeenAt } from '@/lib/sessionLastSeen'
 import { formatRelativeTime } from '@/lib/relativeTime'
 import { ScratchlistMigrationBanner } from '@/components/AssistantChat/ScratchlistMigrationBanner'
-import { assignThreadMessageIds, useHappyRuntime } from '@/lib/assistant-runtime'
+import { findLatestCompletedBoundaryId, useHappyRuntime } from '@/lib/assistant-runtime'
 import {
     getRestoredComposerSendIntent,
     resolveMessageDeliveryMode,
@@ -1294,20 +1294,12 @@ function SessionChatInner(props: SessionChatProps) {
     // and adjacent assistant blocks join under the first block's id.
     const latestCompletedBoundaryId = useMemo(() => {
         if (props.viewMode !== 'tail') return null
-        let candidate: string | null = null
-        let previousRole: ReturnType<typeof visibleBlockRole> | null = null
-        for (const { block, threadMessageId } of assignThreadMessageIds(visibleBlocks)) {
-            const role = visibleBlockRole(block)
-            if (
-                (role === 'user' && block.invokedAt != null)
-                || (role === 'assistant' && previousRole !== 'assistant')
-            ) {
-                candidate = threadMessageId
-            }
-            previousRole = role
-        }
-        return candidate
-    }, [props.viewMode, visibleBlocks])
+        return findLatestCompletedBoundaryId(
+            visibleBlocks,
+            props.session.thinking,
+            props.session.activeTurnStartedAt ?? null
+        )
+    }, [props.viewMode, props.session.activeTurnStartedAt, props.session.thinking, visibleBlocks])
 
     const isLatestCompletedBoundary = useCallback((messageId: string) => {
         return latestCompletedBoundaryId === messageId

--- a/web/src/lib/assistant-runtime.test.ts
+++ b/web/src/lib/assistant-runtime.test.ts
@@ -4,6 +4,7 @@ import {
     aggregateResponseGroups,
     assignThreadMessageIds,
     assignThreadMessageIdsWithStableWrappers,
+    findLatestCompletedBoundaryId,
     getBlockPresentationTimestamp,
     getResponseGroupTimestamps
 } from './assistant-runtime'
@@ -132,6 +133,85 @@ describe('assignThreadMessageIds', () => {
         expect(second[0]).toBe(first[0])
         expect(second[0].threadMessageId).toBe('agent-text:a')
         expect(second[1].threadMessageId).toBe('user-text:u')
+    })
+})
+
+describe('findLatestCompletedBoundaryId', () => {
+    it('keeps the fork boundary before the active turn while streaming blocks change', () => {
+        const completedUser = userText('u1', { invokedAt: 10 })
+        const completedAssistant = agentText('a1')
+        const activeUser = userText('u2', { invokedAt: 20 })
+
+        const firstStreamingShape: VisibleChatBlock[] = [
+            completedUser,
+            completedAssistant,
+            activeUser,
+            agentText('thinking')
+        ]
+        const laterStreamingShape: VisibleChatBlock[] = [
+            completedUser,
+            completedAssistant,
+            activeUser,
+            agentText('thinking'),
+            agentEvent('progress', { type: 'message', message: 'Working' }),
+            agentText('answer')
+        ]
+
+        expect(findLatestCompletedBoundaryId(firstStreamingShape, true, 20)).toBe('agent-text:a1')
+        expect(findLatestCompletedBoundaryId(laterStreamingShape, true, 20)).toBe('agent-text:a1')
+    })
+
+    it('keeps the completed boundary while the active prompt is still queued', () => {
+        const blocks: VisibleChatBlock[] = [
+            userText('u1', { createdAt: 10, invokedAt: 10 }),
+            agentText('a1', { createdAt: 11 })
+        ]
+
+        expect(findLatestCompletedBoundaryId(blocks, true, 20)).toBe('agent-text:a1')
+    })
+
+    it('keeps the boundary before the first user message when a running Pi turn is steered', () => {
+        const blocks: VisibleChatBlock[] = [
+            userText('u1', { invokedAt: 10 }),
+            agentText('a1'),
+            userText('u2', { invokedAt: 20 }),
+            agentText('streaming'),
+            userText('steer', { invokedAt: 30 }),
+            agentText('after-steer')
+        ]
+
+        expect(findLatestCompletedBoundaryId(blocks, true, 20)).toBe('agent-text:a1')
+    })
+
+    it('cuts off active output when the active user row is outside the tail window', () => {
+        const withCompletedHistory: VisibleChatBlock[] = [
+            userText('u1', { invokedAt: 10 }),
+            agentText('a1', { createdAt: 11 }),
+            agentText('streaming', { createdAt: 30 })
+        ]
+        const activeOnly: VisibleChatBlock[] = [
+            agentText('streaming', { createdAt: 30 })
+        ]
+
+        expect(findLatestCompletedBoundaryId(withCompletedHistory, true, 20)).toBe('agent-text:a1')
+        expect(findLatestCompletedBoundaryId(activeOnly, true, 20)).toBeNull()
+    })
+
+    it('promotes the final assistant boundary after the active turn completes', () => {
+        const blocks: VisibleChatBlock[] = [
+            userText('u1', { invokedAt: 10 }),
+            agentText('a1'),
+            userText('u2', { invokedAt: 20 }),
+            agentText('thinking'),
+            agentEvent('progress', { type: 'message', message: 'Working' }),
+            agentText('answer')
+        ]
+
+        expect(findLatestCompletedBoundaryId(blocks, false, null)).toBe('agent-text:answer')
+    })
+
+    it('does not expose a transient boundary when a running tail has no invoked user marker', () => {
+        expect(findLatestCompletedBoundaryId([agentText('streaming')], true, null)).toBeNull()
     })
 })
 

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -367,6 +367,59 @@ export function assignThreadMessageIds(
     return assignThreadMessageIdsWithStableWrappers(blocks, new WeakMap())
 }
 
+/**
+ * Finds the latest conversation-history boundary that is safe to fork.
+ * While the main agent is running, every block from the latest invoked user
+ * message onward belongs to the active turn and must not become a transient
+ * "completed" boundary as streaming events reshape the visible block list.
+ */
+export function findLatestCompletedBoundaryId(
+    blocks: readonly VisibleChatBlock[],
+    isRunning: boolean,
+    activeTurnStartedAt: number | null
+): string | null {
+    const assigned = assignThreadMessageIds(blocks)
+    let limit = assigned.length
+
+    if (isRunning) {
+        const activeTurnStart = activeTurnStartedAt === null
+            ? assigned.findLastIndex(({ block }) => (
+                visibleBlockRole(block) === 'user' && block.invokedAt != null
+            ))
+            : assigned.findIndex(({ block }) => (
+                visibleBlockRole(block) === 'user'
+                && (block.invokedAt ?? block.createdAt) >= activeTurnStartedAt
+            ))
+        if (activeTurnStart >= 0) {
+            limit = activeTurnStart
+        } else if (activeTurnStartedAt === null) {
+            return null
+        } else {
+            const firstActiveBlock = assigned.findIndex(({ block }) => (
+                (block.invokedAt ?? block.createdAt) >= activeTurnStartedAt
+            ))
+            if (firstActiveBlock >= 0) {
+                limit = firstActiveBlock
+            }
+        }
+    }
+
+    let candidate: string | null = null
+    let previousRole: ReturnType<typeof visibleBlockRole> | null = null
+    for (let index = 0; index < limit; index += 1) {
+        const { block, threadMessageId } = assigned[index]
+        const role = visibleBlockRole(block)
+        if (
+            (role === 'user' && block.invokedAt != null)
+            || (role === 'assistant' && previousRole !== 'assistant')
+        ) {
+            candidate = threadMessageId
+        }
+        previousRole = role
+    }
+    return candidate
+}
+
 function toThreadMessageLike(
     block: VisibleChatBlock,
     threadMessageId: string,


### PR DESCRIPTION
## Summary

- keep the Fork action attached to the latest completed conversation boundary while the main agent is streaming
- exclude the active turn, starting at the latest invoked user message, from completed-boundary selection
- cover Pi-like streaming shapes where agent events split assistant output into transient visible groups

## Root cause

`latestCompletedBoundaryId` was derived from every current `visibleBlocks` snapshot. During Pi streaming, agent events can split assistant output into multiple temporary groups, so the candidate moved between message cards. The Fork button was mounted and unmounted as a result, shifting the timestamp beside it.

## Validation

- `bun run typecheck`
- `bun run test:web` (241 files, 2157 tests)
- focused `assistant-runtime.test.ts` regression coverage

Closes #1396
