### PR TITLE
fix(agy): move carrier sweep off the startup path, enable on macOS

### DIFF
--- a/cli/src/agy/runAgy.lifecycle.test.ts
+++ b/cli/src/agy/runAgy.lifecycle.test.ts
@@ -84,7 +84,7 @@ vi.mock('@/codex/utils/buildHapiMcpBridge', () => ({
 vi.mock('./utils/agyHookCarrier', () => ({
     prepareAgyHookCarrier: vi.fn(() => h.failAt === 'carrier' ? null : { carrierDir: '/tmp/carrier' }),
     cleanupAgyHookCarrier: h.carrierCleanup,
-    sweepAgyHookCarriers: vi.fn(),
+    sweepAgyHookCarriers: vi.fn(() => Promise.resolve()),
 }))
 vi.mock('./utils/agyPermissionHandler', () => ({
     AgyPermissionHandler: class {
@@ -113,6 +113,7 @@ vi.mock('@/modules/common/hooks/generateHookSettings', () => ({
 vi.mock('@/ui/logger', () => ({ logger: { debug: vi.fn() } }))
 
 import { runAgy } from './runAgy'
+import { prepareAgyHookCarrier, sweepAgyHookCarriers } from './utils/agyHookCarrier'
 
 describe('runAgy post-bootstrap setup lifecycle', () => {
     beforeEach(() => {
@@ -173,6 +174,20 @@ describe('runAgy post-bootstrap setup lifecycle', () => {
         }
         const withoutInvocation = h.buildAgyHooksJsonCalls.filter((call) => call.preInvocationCommand === undefined)
         expect(withoutInvocation.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('never awaits sweepAgyHookCarriers before continuing session setup (Phase 2-A: fire-and-forget)', async () => {
+        // A promise that intentionally never settles. If runAgy() awaited
+        // sweepAgyHookCarriers() before continuing (the pre-Phase-2-A
+        // behavior), this test would hang until the suite's timeout instead
+        // of completing -- there is no other way for it to finish.
+        const neverResolves = new Promise<void>(() => {})
+        vi.mocked(sweepAgyHookCarriers).mockReturnValueOnce(neverResolves)
+
+        await runAgy({ startingMode: 'pty', workingDirectory: '/tmp/project' })
+
+        expect(sweepAgyHookCarriers).toHaveBeenCalled()
+        expect(prepareAgyHookCarrier).toHaveBeenCalled()
     })
 })
 

--- a/cli/src/agy/runAgy.lifecycle.test.ts
+++ b/cli/src/agy/runAgy.lifecycle.test.ts
@@ -85,6 +85,7 @@ vi.mock('./utils/agyHookCarrier', () => ({
     prepareAgyHookCarrier: vi.fn(() => h.failAt === 'carrier' ? null : { carrierDir: '/tmp/carrier' }),
     cleanupAgyHookCarrier: h.carrierCleanup,
     sweepAgyHookCarriers: vi.fn(() => Promise.resolve()),
+    warmCarrierScope: vi.fn(() => Promise.resolve()),
 }))
 vi.mock('./utils/agyPermissionHandler', () => ({
     AgyPermissionHandler: class {
@@ -113,7 +114,7 @@ vi.mock('@/modules/common/hooks/generateHookSettings', () => ({
 vi.mock('@/ui/logger', () => ({ logger: { debug: vi.fn() } }))
 
 import { runAgy } from './runAgy'
-import { prepareAgyHookCarrier, sweepAgyHookCarriers } from './utils/agyHookCarrier'
+import { prepareAgyHookCarrier, sweepAgyHookCarriers, warmCarrierScope } from './utils/agyHookCarrier'
 
 describe('runAgy post-bootstrap setup lifecycle', () => {
     beforeEach(() => {
@@ -187,6 +188,50 @@ describe('runAgy post-bootstrap setup lifecycle', () => {
         await runAgy({ startingMode: 'pty', workingDirectory: '/tmp/project' })
 
         expect(sweepAgyHookCarriers).toHaveBeenCalled()
+        expect(prepareAgyHookCarrier).toHaveBeenCalled()
+    })
+
+    it('awaits warmCarrierScope before calling prepareAgyHookCarrier (hostile-review round 1 finding ②: mutation-killer for the pre-prepareAgyHookCarrier await)', async () => {
+        // The inverse of the fire-and-forget test above: writeOwnerMetadata's
+        // correctness depends on warmCarrierScope() having resolved BEFORE
+        // prepareAgyHookCarrier() runs. Deleting that `await` in runAgy.ts
+        // previously left every test in this file green (prepareAgyHookCarrier
+        // is itself mocked, so nothing observed the missing wait) -- this
+        // test makes that ordering an explicit, hangs-if-violated assertion.
+        //
+        // warmCarrierScope is called twice per PTY session setup (fired
+        // without awaiting it early, then awaited again right before
+        // prepareAgyHookCarrier) -- both invocations must resolve the SAME
+        // gate for this to correctly stall the awaited one specifically
+        // instead of racing an already-resolved fire-and-forget call.
+        let resolveWarm: () => void = () => {}
+        const warmGate = new Promise<void>((resolve) => { resolveWarm = resolve })
+        vi.mocked(warmCarrierScope)
+            .mockImplementationOnce(() => warmGate)
+            .mockImplementationOnce(() => warmGate)
+
+        const runPromise = runAgy({ startingMode: 'pty', workingDirectory: '/tmp/project' })
+
+        // Flush whatever CAN run without warmCarrierScope's gate resolving
+        // (hook server startup, MCP bridge setup) -- if the `await` before
+        // prepareAgyHookCarrier() were ever removed, this is exactly where
+        // prepareAgyHookCarrier would already have been called.
+        await new Promise((resolve) => setImmediate(resolve))
+        // hostile-review round 2 finding ④: without this, the negative
+        // assertion below is satisfied by two different scenarios --
+        // "reached the await and is correctly blocked on it" (the intent)
+        // and "hasn't reached that point of the function yet" (vacuous,
+        // e.g. if startHookServer/buildHapiMcpBridge/bootstrapSession ever
+        // grow a real timer or macrotask that the setImmediate flush above
+        // doesn't clear). Asserting both warmCarrierScope calls have
+        // already happened confirms execution actually reached the awaited
+        // one and is blocked there, not merely running behind schedule.
+        expect(warmCarrierScope).toHaveBeenCalledTimes(2)
+        expect(prepareAgyHookCarrier).not.toHaveBeenCalled()
+
+        resolveWarm()
+        await runPromise
+
         expect(prepareAgyHookCarrier).toHaveBeenCalled()
     })
 })

--- a/cli/src/agy/runAgy.ts
+++ b/cli/src/agy/runAgy.ts
@@ -16,7 +16,7 @@ import type { SessionEffort, SessionModel } from '@/api/types';
 import { startHookServer } from '@/claude/utils/startHookServer';
 import { AgyPermissionHandler } from './utils/agyPermissionHandler';
 import { buildAgyHooksJson } from '@/modules/common/hooks/generateHookSettings';
-import { prepareAgyHookCarrier, cleanupAgyHookCarrier, sweepAgyHookCarriers } from './utils/agyHookCarrier';
+import { prepareAgyHookCarrier, cleanupAgyHookCarrier, sweepAgyHookCarriers, warmCarrierScope } from './utils/agyHookCarrier';
 import type { AgyMcpServerEntry } from './utils/agyHookCarrier';
 import { shellJoin } from '@/modules/common/shellQuote';
 import { getHappyCliCommand } from '@/utils/spawnHappyCLI';
@@ -157,6 +157,24 @@ export async function runAgy(opts: {
             logger.debug('[agy] sweep failed unexpectedly (fire-and-forget, non-fatal)', error);
         });
 
+        // Fired here (without await) so the macOS probe cost (two child
+        // processes: ioreg, sysctl) overlaps with the hook server startup
+        // and MCP bridge setup below instead of adding to session startup
+        // latency. Awaited just before prepareAgyHookCarrier() so that
+        // call's synchronous writeOwnerMetadata reads a warm cache instead
+        // of falling back to the (Linux-only) synchronous path. See
+        // warmCarrierScope's docstring for the respawn-path (agyPtyLauncher.ts)
+        // rationale -- it needs no equivalent wiring since it always runs in
+        // this same, by-then-already-warm process. Same fire-and-forget
+        // contract as sweepAgyHookCarriers just above (never throws/rejects
+        // on its own -- see warmCarrierScope's docstring); the .catch here
+        // is the same defense-in-depth, kept symmetric with the sweep call
+        // above rather than trusting that contract alone (both feed into
+        // the same runnerLifecycle unhandledRejection -> markCrash path).
+        void warmCarrierScope().catch((error) => {
+            logger.debug('[agy] warmCarrierScope failed unexpectedly (fire-and-forget, non-fatal)', error);
+        });
+
         hookServer = await startHookServer({
             onSessionHook: () => {
                 // agy does not fire a SessionStart hook; this callback is a
@@ -228,6 +246,9 @@ export async function runAgy(opts: {
             });
             const { command: mcpCommand, args: mcpArgs } = hapiMcpBridge.mcpServers.hapi;
             hookMcpServer = { command: mcpCommand, args: mcpArgs };
+            // warmCarrierScope() never rejects (see its docstring), so this
+            // await cannot itself trigger the catch below.
+            await warmCarrierScope();
             carrierResult = prepareAgyHookCarrier(hooksJsonWithPreInvocation, hookMcpServer);
         } catch (error) {
             throw new Error('agy PTY session aborted: could not prepare the session-local HAPI MCP bridge.', { cause: error });

--- a/cli/src/agy/runAgy.ts
+++ b/cli/src/agy/runAgy.ts
@@ -145,7 +145,7 @@ export async function runAgy(opts: {
         // skips onAfterClose's cleanupAgyHookCarrier). Never throws; see
         // sweepAgyHookCarriers's docstring for why over-preservation is the
         // only safe failure mode here.
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
 
         hookServer = await startHookServer({
             onSessionHook: () => {

--- a/cli/src/agy/runAgy.ts
+++ b/cli/src/agy/runAgy.ts
@@ -142,10 +142,20 @@ export async function runAgy(opts: {
         if (isPtyMode) {
         // Best-effort: reclaim carriers left behind by sessions whose
         // owning process has since died (crash, kill -9 — anything that
-        // skips onAfterClose's cleanupAgyHookCarrier). Never throws; see
-        // sweepAgyHookCarriers's docstring for why over-preservation is the
-        // only safe failure mode here.
-        await sweepAgyHookCarriers();
+        // skips onAfterClose's cleanupAgyHookCarrier). Fired without await:
+        // sweep is a backup path for teardown that normally already
+        // happened via cleanupAgyHookCarrier (see that function and this
+        // one's docstring), so it must never delay THIS session's own
+        // startup (hook server, carrier prep, PTY spawn) -- there is no
+        // urgency requirement on it. It runs concurrently with this
+        // session's own prepareAgyHookCarrier() call below; see
+        // agyHookCarrier.test.ts's "racing safety" suite for why that is
+        // safe. Never throws/rejects; the .catch below is defense in depth
+        // only (sweepAgyHookCarriers's own docstring documents why it
+        // should never reach here).
+        void sweepAgyHookCarriers().catch((error) => {
+            logger.debug('[agy] sweep failed unexpectedly (fire-and-forget, non-fatal)', error);
+        });
 
         hookServer = await startHookServer({
             onSessionHook: () => {

--- a/cli/src/agy/utils/agyHookCarrier.test.ts
+++ b/cli/src/agy/utils/agyHookCarrier.test.ts
@@ -567,6 +567,35 @@ describe('sweepAgyHookCarriers', () => {
             expect(existsSync(carrierDir)).toBe(true);
         });
 
+        it('reads the directory listing before resolving the local scope — not just an outcome, the actual call order', async () => {
+            // hostile-review round 1 finding ③: the test above only proves
+            // "a carrier created after the snapshot is invisible", which a
+            // reversed implementation (resolve scope, THEN readdir) could
+            // also satisfy by coincidence in a synchronous mock. This
+            // asserts the call order directly so reversing the two
+            // statements in sweepAgyHookCarriers fails this test even if it
+            // doesn't happen to break the outcome-based one above.
+            makeCarrierDir('baseline-existing');
+            const callOrder: string[] = [];
+
+            vi.mocked(readdir).mockImplementationOnce((async (path: string) => {
+                callOrder.push('readdir');
+                return readdirSync(path);
+            }) as typeof readdir);
+            const probe: ScopeProbe = {
+                readBootId: () => { callOrder.push('scope-probe'); return 'boot-id'; },
+                readPidNamespaceId: () => '1',
+                hostname: () => 'irrelevant',
+            };
+
+            await sweepAgyHookCarriers(probe);
+
+            // Fails (mutation check: swap the readdir()/resolveLocalCarrierScope()
+            // statements in sweepAgyHookCarriers) if the scope probe ever
+            // runs before the directory snapshot is taken.
+            expect(callOrder).toEqual(['readdir', 'scope-probe']);
+        });
+
         it('preserves this session\'s own real carrier if prepareAgyHookCarrier() creates it while an in-flight sweep has already snapshotted the directory', async () => {
             // See the previous test: a carrier must already exist so
             // agy-carriers/ itself exists by the time sweep's readdir() runs.

--- a/cli/src/agy/utils/agyHookCarrier.test.ts
+++ b/cli/src/agy/utils/agyHookCarrier.test.ts
@@ -1,8 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { join } from 'node:path';
+
+// node:fs/promises' namespace object cannot be spied on directly in this
+// ESM environment ("Module namespace is not configurable") -- vi.mock is
+// the supported seam. Every call other than the two racing tests below
+// delegates straight through to the real implementation, so this has no
+// effect on the rest of the file's (many) real-filesystem assertions.
+vi.mock('node:fs/promises', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:fs/promises')>();
+    return { ...actual, readdir: vi.fn(actual.readdir) };
+});
 import {
     agyHookCarrierIsIntact,
     cleanupAgyHookCarrier,
@@ -272,7 +283,7 @@ describe('sweepAgyHookCarriers', () => {
             JSON.stringify({ pid: deadPid, scope: computeLocalCarrierScope() })
         );
 
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
 
         // Fails if the scope-match requirement (Fix 2b) or the liveness
         // check regresses to always-preserve — this is the one combination
@@ -280,7 +291,7 @@ describe('sweepAgyHookCarriers', () => {
         expect(existsSync(carrierDir)).toBe(false);
     });
 
-    it('preserves a carrier whose owner process is alive — the costliest mistake is deleting a live session\'s carrier', () => {
+    it('preserves a carrier whose owner process is alive — the costliest mistake is deleting a live session\'s carrier', async () => {
         const carrierDir = makeCarrierDir('alive-owner');
         // This test process's own PID is guaranteed alive for the duration
         // of the test.
@@ -289,12 +300,12 @@ describe('sweepAgyHookCarriers', () => {
             JSON.stringify({ pid: process.pid, scope: computeLocalCarrierScope() })
         );
 
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
 
         expect(existsSync(carrierDir)).toBe(true);
     });
 
-    it('treats EPERM (process exists but is owned by someone else) as alive, not dead', () => {
+    it('treats EPERM (process exists but is owned by someone else) as alive, not dead', async () => {
         const carrierDir = makeCarrierDir('eperm-owner');
         writeFileSync(
             join(carrierDir, 'owner.json'),
@@ -309,17 +320,17 @@ describe('sweepAgyHookCarriers', () => {
             return true;
         }) as typeof process.kill);
 
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
 
         expect(existsSync(carrierDir)).toBe(true);
     });
 
-    it('① preserves a carrier with unreadable/missing owner metadata no matter how old (Fix 2a)', () => {
+    it('① preserves a carrier with unreadable/missing owner metadata no matter how old (Fix 2a)', async () => {
         // Fresh, no owner.json at all — simulates a carrier from before this
         // feature shipped, a partial write, or a read that raced a
         // concurrent write against a still-live, multi-day session.
         const carrierDir = makeCarrierDir('no-owner-metadata');
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
         expect(existsSync(carrierDir)).toBe(true);
 
         // Fix 2a: age no longer matters at all — a carrier this old used to
@@ -329,25 +340,25 @@ describe('sweepAgyHookCarriers', () => {
         // past the OLD 24h threshold must change nothing now.
         const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
         utimesSync(carrierDir, staleTime, staleTime);
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
         // Fails (mutation check: reintroduce the mtime-based ownerless
         // fallback branch) if this carrier gets swept purely for being old.
         expect(existsSync(carrierDir)).toBe(true);
     });
 
-    it('treats a legacy owner.json (pid only, no scope field) as unreadable metadata and preserves it regardless of age', () => {
+    it('treats a legacy owner.json (pid only, no scope field) as unreadable metadata and preserves it regardless of age', async () => {
         // A pre-this-fix owner.json (hostname field, not scope) or a
         // pre-Fix-N6 one (pid only) both fail the new schema check the same
         // way: readOwnerMetadata requires a non-empty `scope` string.
         const carrierDir = makeCarrierDir('legacy-owner-no-scope');
         writeFileSync(join(carrierDir, 'owner.json'), JSON.stringify({ pid: 999999 }));
 
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
         expect(existsSync(carrierDir)).toBe(true);
 
         const staleTime = new Date(Date.now() - 25 * 60 * 60 * 1000);
         utimesSync(carrierDir, staleTime, staleTime);
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
         expect(existsSync(carrierDir)).toBe(true);
     });
 
@@ -365,7 +376,7 @@ describe('sweepAgyHookCarriers', () => {
             JSON.stringify({ pid: deadPid, scope: 'some-other-container-scope-4a1c9e' })
         );
 
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
 
         // Fails (mutation check: drop the `owner.scope !== localScope`
         // guard in sweepAgyHookCarriers) if the carrier gets deleted because
@@ -391,7 +402,7 @@ describe('sweepAgyHookCarriers', () => {
             readPidNamespaceId: () => { throw new Error('no /proc'); },
             hostname: () => { throw new Error('gethostname() failed'); },
         };
-        sweepAgyHookCarriers(failingProbe);
+        await sweepAgyHookCarriers(failingProbe);
 
         // Fails (mutation check: drop the `if (!localScope) return` early
         // bailout in sweepAgyHookCarriers) if this ever gets deleted despite
@@ -416,7 +427,7 @@ describe('sweepAgyHookCarriers', () => {
             JSON.stringify({ pid: deadPid, scope: computeLocalCarrierScope() })
         );
 
-        sweepAgyHookCarriers();
+        await sweepAgyHookCarriers();
 
         // Fails (mutation check: drop the `entry.startsWith(CARRIER_DIR_PREFIX)`
         // guard) if the sweep deletes this non-carrier directory despite its
@@ -425,7 +436,7 @@ describe('sweepAgyHookCarriers', () => {
         expect(existsSync(join(strangerDir, 'important-unrelated-file.txt'))).toBe(true);
     });
 
-    it('judges a carrier-prefixed entry by the entry itself, not a symlink target (Fix N4)', () => {
+    it('judges a carrier-prefixed entry by the entry itself, not a symlink target (Fix N4)', async () => {
         const root = join(customHapiHome, 'agy-carriers');
         mkdirSync(root, { recursive: true });
 
@@ -437,7 +448,7 @@ describe('sweepAgyHookCarriers', () => {
             const linkPath = join(root, `${CARRIER_PREFIX}symlinked`);
             symlinkSync(targetDir, linkPath, 'dir');
 
-            sweepAgyHookCarriers();
+            await sweepAgyHookCarriers();
 
             // Fails (mutation check: revert lstatSync back to statSync) if
             // the sweep dereferences the symlink and evaluates the TARGET
@@ -452,7 +463,7 @@ describe('sweepAgyHookCarriers', () => {
         }
     });
 
-    it('does not let two different HAPI_HOME roots interfere with each other', () => {
+    it('does not let two different HAPI_HOME roots interfere with each other', async () => {
         const hapiHomeA = customHapiHome;
         const carrierA = prepareAgyHookCarrier('{"a":true}');
         expect(carrierA).toBeDefined();
@@ -464,7 +475,7 @@ describe('sweepAgyHookCarriers', () => {
 
             // Sweeping under HAPI_HOME B must never touch A's carrier, even
             // though A's carrier has no owner.json reachable from B's root.
-            sweepAgyHookCarriers();
+            await sweepAgyHookCarriers();
             expect(existsSync(carrierA.carrierDir)).toBe(true);
 
             const carrierB = prepareAgyHookCarrier('{"b":true}');
@@ -482,5 +493,116 @@ describe('sweepAgyHookCarriers', () => {
             cleanupAgyHookCarrier(carrierA.carrierDir);
             rmSync(hapiHomeB, { recursive: true, force: true });
         }
+    });
+
+    // Phase 2-A: sweepAgyHookCarriers is now async and no longer runs
+    // strictly before every other carrier-creating call in the process (see
+    // runAgy.ts, which now fires it without awaiting it so it cannot delay
+    // session startup). That makes a genuinely new race possible: THIS
+    // session's own prepareAgyHookCarrier() call can now interleave with an
+    // in-flight sweep. Three guarantees together make that safe -- two are
+    // already covered by the tests above under their new async form
+    // (① unreadable/missing owner.json -> preserved; "preserves a carrier
+    // whose owner process is alive" -> preserved); the one below is the
+    // genuinely new guarantee this phase introduces: a directory that
+    // didn't exist yet when readdir() took its snapshot is never examined
+    // at all, matching or not.
+    describe('racing safety (Phase 2-A: sweep decoupled from the session-startup path)', () => {
+        // mockImplementationOnce below is self-consuming (reverts to the
+        // module-level vi.fn(actual.readdir) delegate after exactly one
+        // call), so no explicit mock teardown is needed here -- and
+        // vi.restoreAllMocks() would be actively harmful: readdir is a
+        // plain vi.fn() (module-mock factory, not vi.spyOn), so "restore"
+        // has no original to revert to and would instead wipe its
+        // delegating default for the rest of this file's run.
+        it('never examines a carrier created after the readdir snapshot was already taken, even though it would otherwise qualify for deletion', async () => {
+            let releaseGate: () => void = () => {};
+            const gate = new Promise<void>((resolve) => { releaseGate = resolve; });
+            let markSnapshotTaken: () => void = () => {};
+            const snapshotTaken = new Promise<void>((resolve) => { markSnapshotTaken = resolve; });
+
+            // A carrier must already exist so agy-carriers/ itself exists by
+            // the time sweep's readdir() runs (an ENOENT root is a distinct,
+            // already-covered early-return path, not what this test targets).
+            makeCarrierDir('baseline-existing');
+
+            // node:fs/promises' readdir has an overloaded signature (Dirent[]
+            // with withFileTypes, Buffer[] with an encoding option, ...);
+            // sweepAgyHookCarriers only ever calls the plain string[] form, so
+            // the cast below pins the mock to that one overload rather than
+            // fighting the union.
+            vi.mocked(readdir).mockImplementationOnce((async (path: string) => {
+                // readdirSync (already imported from node:fs for the rest of
+                // this file) captures the real, unmodified directory listing
+                // FIRST -- this is the actual snapshot sweepAgyHookCarriers
+                // will iterate over -- then signals the test it is safe to
+                // create a new (would-otherwise-qualify) carrier, and only
+                // returns the already-captured (now stale) array once
+                // released.
+                const result = readdirSync(path);
+                markSnapshotTaken();
+                await gate;
+                return result;
+            }) as typeof readdir);
+
+            const sweepPromise = sweepAgyHookCarriers();
+            await snapshotTaken;
+
+            const deadPid = await spawnAndReapDeadPid();
+            const carrierDir = makeCarrierDir('created-after-snapshot');
+            writeFileSync(
+                join(carrierDir, 'owner.json'),
+                // Matching scope + confirmed-dead pid: exactly the
+                // combination test ③ proves gets deleted for a carrier that
+                // WAS in the snapshot.
+                JSON.stringify({ pid: deadPid, scope: computeLocalCarrierScope() })
+            );
+
+            releaseGate();
+            await sweepPromise;
+
+            // Fails (mutation check: capture the snapshot lazily / re-read
+            // the directory mid-loop) if a carrier created after the
+            // snapshot was taken ever gets examined, let alone deleted.
+            expect(existsSync(carrierDir)).toBe(true);
+        });
+
+        it('preserves this session\'s own real carrier if prepareAgyHookCarrier() creates it while an in-flight sweep has already snapshotted the directory', async () => {
+            // See the previous test: a carrier must already exist so
+            // agy-carriers/ itself exists by the time sweep's readdir() runs.
+            makeCarrierDir('baseline-existing');
+
+            let releaseGate: () => void = () => {};
+            const gate = new Promise<void>((resolve) => { releaseGate = resolve; });
+            let markSnapshotTaken: () => void = () => {};
+            const snapshotTaken = new Promise<void>((resolve) => { markSnapshotTaken = resolve; });
+
+            vi.mocked(readdir).mockImplementationOnce((async (path: string) => {
+                const result = readdirSync(path);
+                markSnapshotTaken();
+                await gate;
+                return result;
+            }) as typeof readdir);
+
+            const sweepPromise = sweepAgyHookCarriers();
+            await snapshotTaken;
+
+            // The real production entrypoint (runAgy.ts/agyPtyLauncher.ts),
+            // not the hand-built makeCarrierDir helper -- proves the actual
+            // API used in production is safe under this race, not just a
+            // synthetic fixture that resembles it.
+            const ownCarrier = prepareAgyHookCarrier('{}');
+            expect(ownCarrier).toBeDefined();
+            if (!ownCarrier) return;
+
+            try {
+                releaseGate();
+                await sweepPromise;
+
+                expect(existsSync(ownCarrier.carrierDir)).toBe(true);
+            } finally {
+                cleanupAgyHookCarrier(ownCarrier.carrierDir);
+            }
+        });
     });
 });

--- a/cli/src/agy/utils/agyHookCarrier.ts
+++ b/cli/src/agy/utils/agyHookCarrier.ts
@@ -12,6 +12,7 @@ import {
     writeFileSync
 } from 'node:fs';
 import { lstat, readFile, readdir, rm } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { hostname } from 'node:os';
 import { join } from 'node:path';
@@ -39,17 +40,22 @@ export type AgyMcpServerEntry = {
 // sharing a HAPI_HOME typically also share a hostname (or both default to
 // the same short container-id-derived one), which is exactly the collision
 // this guard exists to prevent. `scope` instead identifies the boot +
-// PID-namespace pair a carrier's pid was recorded in — see
-// computeLocalCarrierScope() below — which distinguishes exactly the cases
-// hostname could not: two containers on the same host (different PID
-// namespaces, same boot_id) and the same container across a restart
-// (same PID namespace file, but the boot_id — read from the host's
-// /proc — differs only across an actual host reboot, which is the one case
-// where every previously-recorded pid is unconditionally dead; this fix
-// does not attempt to special-case that, see sweepAgyHookCarriers's
-// docstring). Platforms without a working /proc (macOS, ...) get no scope at
-// all and are therefore never swept — hostname is not an identity, so there
-// is deliberately no fallback (see computeLocalCarrierScope).
+// PID-namespace pair a carrier's pid was recorded in on Linux (see
+// computeLocalCarrierScope()) or the machine + boot-session pair on macOS
+// (see computeLocalCarrierScopeAsync/warmCarrierScope) — which
+// distinguishes exactly the cases hostname could not: two containers on the
+// same host (different PID namespaces, same boot_id) and the same container
+// across a restart (same PID namespace file, but the boot_id — read from
+// the host's /proc — differs only across an actual host reboot, which is
+// the one case where every previously-recorded pid is unconditionally dead;
+// this fix does not attempt to special-case that, see sweepAgyHookCarriers's
+// docstring). A platform/environment this module cannot identify at all (a
+// restricted /proc that exists but denies these specific reads, a
+// failed/timed-out macOS probe, Windows — see computeLocalCarrierScopeAsync's
+// docstring for why it stays unsupported — or any other unrecognized
+// process.platform) gets no scope and is therefore never swept — hostname
+// is not an identity, so there is deliberately no
+// fallback to it (see computeLocalCarrierScope/computeLocalCarrierScopeAsync).
 type AgyHookCarrierOwner = {
     pid: number;
     scope: string;
@@ -91,17 +97,116 @@ function readLinuxBootAndNamespaceScope(probe: Pick<ScopeProbe, 'readBootId' | '
     }
 }
 
+// Shared by every platform-specific identifier below: a value that "looks
+// like an error message" or is truncated must never be woven into a scope
+// string (an over-eager regex match on the wrong line of output is the
+// realistic failure mode, not total absence of output). Every raw id read
+// from an external command is checked against this before use.
+const UUID_PATTERN = /^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/;
+
+// macOS identity probes are child processes (no /proc equivalent), so they
+// get an explicit timeout rather than relying on the caller's own patience —
+// sweepAgyHookCarriers's docstring already establishes there is no latency
+// budget to protect here (it is a backup path off the session boot path as
+// of the previous commit), but an unbounded child process is still a
+// leak/hang risk on a wedged system.
+const PLATFORM_SCOPE_PROBE_TIMEOUT_MS = 2000;
+
 /**
- * Dependency seams for computeLocalCarrierScope, real implementations by
- * default. Exists so tests can force each branch (Linux success, Linux
- * failure -> hostname fallback, total failure) without mocking node:fs/
- * node:os module-wide — which would also affect every other real-filesystem
- * test in this file's suite.
+ * Extracts IOPlatformUUID from `ioreg -rd1 -c IOPlatformExpertDevice` output,
+ * e.g. `"IOPlatformUUID" = "D8F7807A-6B93-57A4-9DF2-E9A54FA2E046"`. Returns
+ * undefined (never throws) on any format this regex/pattern doesn't
+ * recognize, rather than risk feeding a truncated or wrong value into a
+ * scope string. Exported as a pure function so its parsing logic is
+ * unit-testable against a real captured sample without invoking ioreg.
+ */
+export function parseIoregPlatformUUID(stdout: string): string | undefined {
+    const match = /"IOPlatformUUID"\s*=\s*"([0-9A-Za-z-]+)"/.exec(stdout);
+    const uuid = match?.[1];
+    return uuid && UUID_PATTERN.test(uuid) ? uuid : undefined;
+}
+
+/**
+ * Extracts the boot identifier from `sysctl -n kern.bootsessionuuid` output
+ * (a bare UUID, e.g. `76A5605C-FF4D-4B31-80D8-239964198B7D\n`).
+ *
+ * `kern.bootsessionuuid` — not `kern.boottime` — is the macOS analogue of
+ * Linux's /proc/sys/kernel/random/boot_id. `kern.boottime` was the original
+ * choice (see this repo's history) but was disproven: a live re-measurement
+ * 8 days after the first one, on a host that had NOT rebooted in between,
+ * showed the value drift by 1.318 seconds (kern.boottime is recomputed from
+ * NTP-adjusted wall clock time under the hood, per XNU's
+ * clock_get_boottime_microtime() — a short observation window made it look
+ * stable). `kern.bootsessionuuid` does not have this problem: it is a
+ * random UUID XNU generates once per boot (bsd/kern/kern_sysctl.c) and
+ * reuses for the life of that boot session (referenced by
+ * osfmk/arm/model_dep.c's panic-log boot session UUID, and by
+ * bsd/kern/kern_exec.c's per-boot app hash salt) — this "regenerated once
+ * per boot" behavior is inferred from those call sites, not stated in an
+ * Apple document, so it is asserted here with that caveat rather than as a
+ * documented guarantee.
+ */
+export function parseSysctlBootSessionUUID(stdout: string): string | undefined {
+    const value = stdout.trim();
+    return UUID_PATTERN.test(value) ? value : undefined;
+}
+
+/**
+ * Runs an external identifier probe by absolute path, never through a
+ * shell (no quoting concerns, no PATH dependency that could silently
+ * resolve to the wrong binary in a reduced/GUI-launcher environment) and
+ * with a bounded timeout. Resolves to stdout on a clean exit; rejects
+ * (caught by every caller below) on a non-zero exit, a missing binary
+ * (ENOENT), or a timeout. `windowsHide` matches this repo's other child-spawn
+ * call sites (agyModels.ts, grokModels.ts, ripgrep/index.ts, utils/process.ts,
+ * spawnWithAbort.ts, ...) — a no-op on the platforms this function currently
+ * runs probes on, kept for when it is reused elsewhere.
+ */
+function execFileForScopeProbe(command: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+        execFile(command, args, { timeout: PLATFORM_SCOPE_PROBE_TIMEOUT_MS, windowsHide: true }, (error, stdout) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(stdout);
+        });
+    });
+}
+
+async function readDarwinMachineIdReal(): Promise<string> {
+    const stdout = await execFileForScopeProbe('/usr/sbin/ioreg', ['-rd1', '-c', 'IOPlatformExpertDevice']);
+    const uuid = parseIoregPlatformUUID(stdout);
+    if (!uuid) throw new Error('could not parse IOPlatformUUID from ioreg output');
+    return uuid;
+}
+
+async function readDarwinBootSessionIdReal(): Promise<string> {
+    const stdout = await execFileForScopeProbe('/usr/sbin/sysctl', ['-n', 'kern.bootsessionuuid']);
+    const bootSessionId = parseSysctlBootSessionUUID(stdout);
+    if (!bootSessionId) throw new Error('unexpected kern.bootsessionuuid format');
+    return bootSessionId;
+}
+
+/**
+ * Dependency seams for computeLocalCarrierScope/computeLocalCarrierScopeAsync,
+ * real implementations by default. Exists so tests can force each branch
+ * (Linux success, Linux failure, macOS success/partial-failure/total-failure)
+ * without mocking node:fs/node:os/node:child_process module-wide — which
+ * would also affect every other real-filesystem test in this file's suite.
+ *
+ * The macOS fields are optional: a ScopeProbe built only for the Linux
+ * branch (this file has many) remains valid without them, and readDarwinScope
+ * below treats a missing field the same as a failing one -- both fall
+ * through to undefined. There is deliberately no Windows field — see
+ * computeLocalCarrierScopeAsync's docstring for why.
  */
 export type ScopeProbe = {
     readBootId: () => string;
     readPidNamespaceId: () => string;
     hostname: () => string;
+    readDarwinMachineId?: () => Promise<string>;
+    readDarwinBootSessionId?: () => Promise<string>;
 };
 
 const defaultScopeProbe: ScopeProbe = {
@@ -116,7 +221,28 @@ const defaultScopeProbe: ScopeProbe = {
         return match[1];
     },
     hostname: () => hostname(),
+    readDarwinMachineId: readDarwinMachineIdReal,
+    readDarwinBootSessionId: readDarwinBootSessionIdReal,
 };
+
+/**
+ * Combines the two macOS identifiers into this platform's scope string.
+ * Requires BOTH — a machine id without a boot id (or vice versa) is not a
+ * stronger guarantee than nothing, since PID-space collision requires the
+ * pair to distinguish "same machine, different boot" from "same machine,
+ * same boot". A missing probe field is treated identically to a throwing
+ * one: both fall through to undefined (preserve).
+ */
+async function readDarwinScope(probe: Pick<ScopeProbe, 'readDarwinMachineId' | 'readDarwinBootSessionId'>): Promise<string | undefined> {
+    if (!probe.readDarwinMachineId || !probe.readDarwinBootSessionId) return undefined;
+    try {
+        const [machineId, bootSessionId] = await Promise.all([probe.readDarwinMachineId(), probe.readDarwinBootSessionId()]);
+        if (!machineId || !bootSessionId) return undefined;
+        return `darwin:${machineId}:${bootSessionId}`;
+    } catch {
+        return undefined;
+    }
+}
 
 /**
  * Computes this process's carrier scope: an opaque string identifying
@@ -134,10 +260,11 @@ const defaultScopeProbe: ScopeProbe = {
  * this (sync, Linux-only) path that costs orphaned carriers on platforms
  * without a working /proc, which is the cheaper failure: normal teardown
  * still removes carriers via cleanupAgyHookCarrier, so only crash leftovers
- * accumulate. macOS/Windows identity is computed asynchronously instead (see
+ * accumulate. macOS identity is computed asynchronously instead (see
  * warmCarrierScope below) and is not reachable from this function — this one
  * stays the synchronous fallback writeOwnerMetadata uses when nothing has
- * warmed the cache yet.
+ * warmed the cache yet. Windows has no supported identity at all — see
+ * computeLocalCarrierScopeAsync's docstring.
  */
 export function computeLocalCarrierScope(probe: ScopeProbe = defaultScopeProbe): string | undefined {
     return readLinuxBootAndNamespaceScope(probe);
@@ -145,16 +272,50 @@ export function computeLocalCarrierScope(probe: ScopeProbe = defaultScopeProbe):
 
 /**
  * Async counterpart of computeLocalCarrierScope, dispatching on
- * process.platform. Only the 'linux' branch is implemented as of this
- * commit (delegating to the exact same synchronous read as
- * computeLocalCarrierScope, so this changes no OBSERVABLE behavior on any
- * platform yet — macOS/Windows still resolve to undefined here exactly as
- * they did via the old code path's failed /proc reads). Platform-specific
- * probes are added in a follow-up commit; this function's shape exists now
- * so the cache/warm-up plumbing below has something real to sit on top of.
+ * process.platform to the strong-identity computation for that platform.
+ * Any platform this module does not recognize (or a platform whose probe(s)
+ * fail/time out) resolves to undefined, which — same as always — makes
+ * sweepAgyHookCarriers preserve everything rather than fall back to a
+ * weaker heuristic. Windows falls into this "unrecognized" bucket
+ * deliberately — see below.
+ *
+ * Windows is deliberately not enabled here (evaluated and rejected
+ * 2026-08-07, hostile-review round 1). `MachineGuid` (from the registry) is
+ * the obvious candidate for a win32 scope, but it is wrong: `MachineGuid` is
+ * a machine identifier, not a PID-space identifier — it is written once at
+ * OS install time and is NOT regenerated by cloning a disk image (that is
+ * exactly what `sysprep` exists to fix). Two clones of the same image that
+ * share a HAPI_HOME (SMB share, sync folder, shared VM folder) compute the
+ * IDENTICAL `win32:<guid>` scope while having completely independent PID
+ * spaces — a
+ * pid alive in one clone reads as ESRCH in the other, so sweep would delete
+ * a live session's carrier and its --dangerously-skip-permissions approval
+ * bridge with it. Linux (`boot_id`) and macOS (`kern.bootsessionuuid`) both
+ * close this because those identifiers are regenerated every boot; Windows
+ * has no cheap equivalent:
+ *   - `HKLM\SYSTEM\CurrentControlSet\Control\Windows` has no boot-id key
+ *     (only `ShutdownTime`, a REG_BINARY of the last *shutdown* — which a
+ *     clone shares just as much as MachineGuid).
+ *   - `HKLM\SYSTEM\CurrentControlSet\Control\Session Manager` has nothing
+ *     boot-scoped either.
+ *   - `Win32_OperatingSystem.LastBootUpTime` via CIM was measured at
+ *     1.4-2.5s per call on real hardware (2026-08-07) — this is meant to be
+ *     cheap identity plumbing, not a multi-second startup cost.
+ *   - `net statistics workstation` / `systeminfo` output is locale-dependent
+ *     (parsing failed against Korean-locale Windows output in testing) —
+ *     unfit as a machine-parsed identifier source regardless of cost.
+ * So, unlike Linux/macOS, Windows cannot prove "same boot, same PID space"
+ * at any price this module is willing to pay, and per this file's core
+ * policy (identification failure -> preserve, no weak-identity fallback —
+ * see computeLocalCarrierScope's docstring) it stays undefined rather than
+ * risk the over-delete above. Before re-enabling Windows, find a boot-scoped
+ * (not machine-scoped) identifier cheaper than CIM; re-measure whatever the
+ * current Windows version offers rather than trusting this comment's
+ * numbers to still hold.
  */
 async function computeLocalCarrierScopeAsync(probe: ScopeProbe): Promise<string | undefined> {
     if (process.platform === 'linux') return readLinuxBootAndNamespaceScope(probe);
+    if (process.platform === 'darwin') return readDarwinScope(probe);
     return undefined;
 }
 
@@ -168,8 +329,8 @@ async function computeLocalCarrierScopeAsync(probe: ScopeProbe): Promise<string 
 let scopeCache: { value: string | undefined } | undefined;
 // The in-flight computation, so a second warmCarrierScope() call issued
 // before the first has settled awaits the SAME probe run instead of
-// launching a duplicate one (relevant once the macOS/Windows probes spawn
-// child processes — a duplicate run would double that cost for no benefit).
+// launching a duplicate one (relevant once the macOS probes spawn child
+// processes — a duplicate run would double that cost for no benefit).
 let scopeWarmupPromise: Promise<void> | undefined;
 
 /**
@@ -203,7 +364,7 @@ export function warmCarrierScope(probe: ScopeProbe = defaultScopeProbe): Promise
  * several tests deliberately warm the cache with a fabricated probe result.
  * Not for production use.
  */
-export function __resetCarrierScopeCacheForTests(): void {
+export function _resetCarrierScopeCacheForTests(): void {
     scopeCache = undefined;
     scopeWarmupPromise = undefined;
 }
@@ -296,11 +457,33 @@ function writeOwnerMetadata(carrierDir: string): void {
     // prepareAgyHookCarrier() call of a session) if one is available, and
     // otherwise falls back to the synchronous Linux-only computation — the
     // same computation this function used before the cache existed. A cache
-    // miss on macOS/Windows (warmCarrierScope not yet awaited anywhere in
-    // this process) therefore still yields undefined/empty scope, same as
-    // always: this fallback trades nothing away, it only adds a faster path
-    // when a cache is available.
+    // miss on macOS (warmCarrierScope not yet awaited anywhere in this
+    // process) or an unsupported platform (Windows — see
+    // computeLocalCarrierScopeAsync's docstring) therefore still yields
+    // undefined/empty scope, same as always: this fallback trades nothing
+    // away, it only adds a faster path when a cache is available.
+    //
+    // hostile-review round 1 finding ②: this correctness depends on
+    // warmCarrierScope() having actually been awaited by the caller before
+    // this runs (runAgy.ts does; see its "await warmCarrierScope()" call
+    // right before prepareAgyHookCarrier()) -- nothing in this function's
+    // own signature enforces that ordering. The debug log below is the
+    // fallback signal for when it silently doesn't hold (a future call site
+    // that skips the await, a refactor that reorders it): an empty scope
+    // written here permanently preserves this carrier (see the sweep
+    // docstring), so at minimum that should be visible in the debug log
+    // instead of vanishing without a trace.
     const scope = scopeCache !== undefined ? scopeCache.value : computeLocalCarrierScope();
+    // hostile-review round 2 finding ③: gated to linux/darwin, where an
+    // empty scope is always an anomaly worth a trace (a genuine probe
+    // failure, or the ordering bug this log exists to catch). On win32 an
+    // empty scope is the permanent, documented baseline (see
+    // computeLocalCarrierScopeAsync's docstring) -- logging it there would
+    // fire on every single carrier creation and drown out the actual
+    // anomaly this is meant to surface on the platforms where it matters.
+    if (!scope && (process.platform === 'linux' || process.platform === 'darwin')) {
+        logger.debug(`[agyHookCarrier] writing owner metadata with no local scope for ${carrierDir} — this carrier will be preserved indefinitely by sweepAgyHookCarriers`);
+    }
     const owner: AgyHookCarrierOwner = { pid: process.pid, scope: scope ?? '' };
     writeFileSync(join(carrierDir, OWNER_FILE_NAME), JSON.stringify(owner), { mode: 0o600 });
 }
@@ -395,6 +578,20 @@ function checkProcessLiveness(pid: number): 'alive' | 'dead' | 'unknown' {
 export async function sweepAgyHookCarriers(scopeProbe: ScopeProbe = defaultScopeProbe): Promise<void> {
     const carriersRoot = agyCarriersRootDir();
     let entries: string[];
+    // Snapshotting the directory listing BEFORE resolving the local scope is
+    // load-bearing, not incidental ordering — swap these two lines and the
+    // "racing safety" guarantee (agyHookCarrier.test.ts) silently weakens.
+    // resolveLocalCarrierScope() can take real wall-clock time on macOS (two
+    // child processes, ~50ms combined per the Phase 2-B cost measurement),
+    // during which a concurrent prepareAgyHookCarrier() in this same process
+    // (see runAgy.ts, which now fires sweep without awaiting it) can mkdtemp
+    // a brand-new carrier. Taking the readdir() snapshot first means that
+    // carrier is simply never in the list this loop iterates below,
+    // regardless of how long the scope probe takes afterward. Reversing the
+    // order would instead let the scope probe's latency open a window where
+    // a carrier created during it IS included in a still-to-be-taken
+    // snapshot -- collapsing the margin the "created after the snapshot"
+    // test exists to prove.
     try {
         entries = await readdir(carriersRoot);
     } catch {

--- a/cli/src/agy/utils/agyHookCarrier.ts
+++ b/cli/src/agy/utils/agyHookCarrier.ts
@@ -122,23 +122,108 @@ const defaultScopeProbe: ScopeProbe = {
  * Computes this process's carrier scope: an opaque string identifying
  * "carriers this process could plausibly own", used to gate sweepAgyHookCarriers.
  *
- * Only the Linux boot-id+PID-namespace pair qualifies. There is deliberately
- * no hostname fallback: hostname is not an identity. Two machines or
- * containers that share a HAPI_HOME and happen to share a hostname would
- * compute the same scope, and a pid that is live on the owning system reads
- * as ESRCH here — deleting a carrier out from under a running agy, which is
- * spawned with --dangerously-skip-permissions and depends on that carrier's
- * hooks.json for its PreToolUse approval bridge.
+ * Synchronous and Linux-only. There is deliberately no hostname fallback:
+ * hostname is not an identity. Two machines or containers that share a
+ * HAPI_HOME and happen to share a hostname would compute the same scope, and
+ * a pid that is live on the owning system reads as ESRCH here — deleting a
+ * carrier out from under a running agy, which is spawned with
+ * --dangerously-skip-permissions and depends on that carrier's hooks.json
+ * for its PreToolUse approval bridge.
  *
- * Returning undefined makes sweepAgyHookCarriers preserve everything. That
- * costs orphaned carriers on platforms without a strong identity (macOS, a
- * restricted /proc), which is the cheaper failure: normal teardown still
- * removes carriers via cleanupAgyHookCarrier, so only crash leftovers
- * accumulate. Add a platform-specific boot/namespace identity here before
- * re-enabling sweeping there.
+ * Returning undefined makes sweepAgyHookCarriers preserve everything. On
+ * this (sync, Linux-only) path that costs orphaned carriers on platforms
+ * without a working /proc, which is the cheaper failure: normal teardown
+ * still removes carriers via cleanupAgyHookCarrier, so only crash leftovers
+ * accumulate. macOS/Windows identity is computed asynchronously instead (see
+ * warmCarrierScope below) and is not reachable from this function — this one
+ * stays the synchronous fallback writeOwnerMetadata uses when nothing has
+ * warmed the cache yet.
  */
 export function computeLocalCarrierScope(probe: ScopeProbe = defaultScopeProbe): string | undefined {
     return readLinuxBootAndNamespaceScope(probe);
+}
+
+/**
+ * Async counterpart of computeLocalCarrierScope, dispatching on
+ * process.platform. Only the 'linux' branch is implemented as of this
+ * commit (delegating to the exact same synchronous read as
+ * computeLocalCarrierScope, so this changes no OBSERVABLE behavior on any
+ * platform yet — macOS/Windows still resolve to undefined here exactly as
+ * they did via the old code path's failed /proc reads). Platform-specific
+ * probes are added in a follow-up commit; this function's shape exists now
+ * so the cache/warm-up plumbing below has something real to sit on top of.
+ */
+async function computeLocalCarrierScopeAsync(probe: ScopeProbe): Promise<string | undefined> {
+    if (process.platform === 'linux') return readLinuxBootAndNamespaceScope(probe);
+    return undefined;
+}
+
+// Process-lifetime cache for the async scope computation. boot/machine
+// identity is invariant for the life of this process, so computing it once
+// and reusing the result is always correct — there is no staleness window
+// to worry about (contrast with e.g. a TTL cache). `undefined` is a valid,
+// deliberately-cached outcome (see warmCarrierScope's docstring): a failed
+// probe is not retried on a later call, matching computeLocalCarrierScope's
+// existing "no retry, just report the failure" contract.
+let scopeCache: { value: string | undefined } | undefined;
+// The in-flight computation, so a second warmCarrierScope() call issued
+// before the first has settled awaits the SAME probe run instead of
+// launching a duplicate one (relevant once the macOS/Windows probes spawn
+// child processes — a duplicate run would double that cost for no benefit).
+let scopeWarmupPromise: Promise<void> | undefined;
+
+/**
+ * Populates the module-level scope cache by running computeLocalCarrierScopeAsync
+ * once and memoizing the result (success OR failure — both are cached, never
+ * retried). Safe to call from a hot path without awaiting it (fire-and-forget):
+ * it never throws or leaves an unhandled rejection.
+ *
+ * Callers: runAgy.ts fires this without awaiting it early in PTY session
+ * setup (so the (eventually async, cross-process) probe cost overlaps with
+ * hook-server startup instead of adding to it), then awaits it immediately
+ * before prepareAgyHookCarrier() so writeOwnerMetadata (synchronous, see
+ * below) reads a warm cache instead of falling back to the Linux-only sync
+ * path. A respawn (agyPtyLauncher.ts's syncPreInvocationHookForLaunch) is
+ * always in the same process, so its prepareAgyHookCarrier() call always
+ * finds an already-warm cache with no extra wiring needed there.
+ */
+export function warmCarrierScope(probe: ScopeProbe = defaultScopeProbe): Promise<void> {
+    if (!scopeWarmupPromise) {
+        scopeWarmupPromise = computeLocalCarrierScopeAsync(probe)
+            .then((value) => { scopeCache = { value }; })
+            .catch(() => { scopeCache = { value: undefined }; });
+    }
+    return scopeWarmupPromise;
+}
+
+/**
+ * Test-only reset for the module-level scope cache — vitest gives each test
+ * FILE its own module registry (so this never leaks across files), but
+ * multiple `it()`s within the same file share this module's state, and
+ * several tests deliberately warm the cache with a fabricated probe result.
+ * Not for production use.
+ */
+export function __resetCarrierScopeCacheForTests(): void {
+    scopeCache = undefined;
+    scopeWarmupPromise = undefined;
+}
+
+/**
+ * Scope resolution used by sweepAgyHookCarriers. The DEFAULT probe (the real
+ * one, used in production) goes through the warm cache — see warmCarrierScope.
+ * Any OTHER probe object (identity-compared) bypasses the cache and computes
+ * fresh on every call: a custom probe exists specifically so a test can force
+ * a particular scenario for THAT call, and sharing the cache across differing
+ * probes would let an earlier call's cached result leak into a later call
+ * that intended a different, injected outcome (this file's test suites pass
+ * many different custom probes to sweepAgyHookCarriers across many tests).
+ */
+async function resolveLocalCarrierScope(probe: ScopeProbe): Promise<string | undefined> {
+    if (probe !== defaultScopeProbe) {
+        return computeLocalCarrierScopeAsync(probe);
+    }
+    await warmCarrierScope(probe);
+    return scopeCache?.value;
 }
 
 /**
@@ -202,7 +287,20 @@ function writeOwnerMetadata(carrierDir: string): void {
     // requires a non-empty scope, so this carrier falls into the
     // "unreadable owner" bucket below and is preserved indefinitely rather
     // than risk being matched against a wrong or guessed scope later.
-    const scope = computeLocalCarrierScope();
+    //
+    // This function is synchronous (prepareAgyHookCarrier's respawn-time
+    // caller, agyPtyLauncher.ts's syncPreInvocationHookForLaunch, must stay
+    // synchronous — see that function's fail-closed-contract docstring), so
+    // it cannot await an async probe. It reads the warm cache (populated by
+    // warmCarrierScope — see runAgy.ts, which awaits it before the FIRST
+    // prepareAgyHookCarrier() call of a session) if one is available, and
+    // otherwise falls back to the synchronous Linux-only computation — the
+    // same computation this function used before the cache existed. A cache
+    // miss on macOS/Windows (warmCarrierScope not yet awaited anywhere in
+    // this process) therefore still yields undefined/empty scope, same as
+    // always: this fallback trades nothing away, it only adds a faster path
+    // when a cache is available.
+    const scope = scopeCache !== undefined ? scopeCache.value : computeLocalCarrierScope();
     const owner: AgyHookCarrierOwner = { pid: process.pid, scope: scope ?? '' };
     writeFileSync(join(carrierDir, OWNER_FILE_NAME), JSON.stringify(owner), { mode: 0o600 });
 }
@@ -305,7 +403,7 @@ export async function sweepAgyHookCarriers(scopeProbe: ScopeProbe = defaultScope
         return;
     }
 
-    const localScope = computeLocalCarrierScope(scopeProbe);
+    const localScope = await resolveLocalCarrierScope(scopeProbe);
     if (!localScope) {
         // Cannot identify which carriers this process could even plausibly
         // own — comparing anything against an unknown scope is meaningless,

--- a/cli/src/agy/utils/agyHookCarrier.ts
+++ b/cli/src/agy/utils/agyHookCarrier.ts
@@ -11,6 +11,7 @@ import {
     unlinkSync,
     writeFileSync
 } from 'node:fs';
+import { lstat, readFile, readdir, rm } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { hostname } from 'node:os';
 import { join } from 'node:path';
@@ -206,9 +207,9 @@ function writeOwnerMetadata(carrierDir: string): void {
     writeFileSync(join(carrierDir, OWNER_FILE_NAME), JSON.stringify(owner), { mode: 0o600 });
 }
 
-function readOwnerMetadata(carrierDir: string): AgyHookCarrierOwner | undefined {
+async function readOwnerMetadata(carrierDir: string): Promise<AgyHookCarrierOwner | undefined> {
     try {
-        const parsed = JSON.parse(readFileSync(join(carrierDir, OWNER_FILE_NAME), 'utf8')) as Partial<AgyHookCarrierOwner>;
+        const parsed = JSON.parse(await readFile(join(carrierDir, OWNER_FILE_NAME), 'utf8')) as Partial<AgyHookCarrierOwner>;
         if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid) && parsed.pid > 0 && typeof parsed.scope === 'string' && parsed.scope.length > 0) {
             return { pid: parsed.pid, scope: parsed.scope };
         }
@@ -293,11 +294,11 @@ function checkProcessLiveness(pid: number): 'alive' | 'dead' | 'unknown' {
  * or a single entry this process can't stat/read, is skipped rather than
  * thrown — a broken sweep must never abort session startup.
  */
-export function sweepAgyHookCarriers(scopeProbe: ScopeProbe = defaultScopeProbe): void {
+export async function sweepAgyHookCarriers(scopeProbe: ScopeProbe = defaultScopeProbe): Promise<void> {
     const carriersRoot = agyCarriersRootDir();
     let entries: string[];
     try {
-        entries = readdirSync(carriersRoot);
+        entries = await readdir(carriersRoot);
     } catch {
         // Root doesn't exist yet (first-ever session under this HAPI_HOME)
         // or isn't readable — nothing to sweep either way.
@@ -314,6 +315,10 @@ export function sweepAgyHookCarriers(scopeProbe: ScopeProbe = defaultScopeProbe)
         return;
     }
 
+    // Sequential, not Promise.all: this is a backup path with no latency
+    // requirement (see the module docstring), and processing one entry at a
+    // time keeps each entry's error handling isolated without adding
+    // concurrency-ordering complexity to a destructive operation.
     for (const entry of entries) {
         // Fix N3: only ever consider entries this module itself could have
         // created. A misconfigured/reused HAPI_HOME can put anything under
@@ -323,18 +328,25 @@ export function sweepAgyHookCarriers(scopeProbe: ScopeProbe = defaultScopeProbe)
         const carrierDir = join(carriersRoot, entry);
         try {
             // Fix N4: lstat, not stat — judge the directory entry itself,
-            // never whatever a symlink might point at. rmSync only ever
-            // unlinks a symlink (never recurses through it), so there is no
+            // never whatever a symlink might point at. rm only ever unlinks
+            // a symlink (never recurses through it), so there is no
             // data-loss path either way, but liveness/scope decisions must
             // still be about this entry, not its target.
-            const stats = lstatSync(carrierDir);
+            const stats = await lstat(carrierDir);
             if (!stats.isDirectory()) continue;
 
-            const owner = readOwnerMetadata(carrierDir);
+            const owner = await readOwnerMetadata(carrierDir);
             if (!owner) {
                 // Fix 2a: no age-based fallback anymore — see the docstring
                 // above for why an unreadable owner is no longer evidence of
-                // staleness.
+                // staleness. This also covers a carrier whose directory this
+                // readdir() snapshot caught mid-creation (mkdtemp landed,
+                // owner.json has not been written yet by a concurrent
+                // prepareAgyHookCarrier — see this function's own docstring
+                // on why sweeping is no longer on the session-boot critical
+                // path and can race a fresh carrier's creation): an
+                // unreadable owner is preserved unconditionally, the same as
+                // a genuinely-never-written one.
                 continue;
             }
             if (owner.scope !== localScope) {
@@ -344,7 +356,7 @@ export function sweepAgyHookCarriers(scopeProbe: ScopeProbe = defaultScopeProbe)
                 continue;
             }
             if (checkProcessLiveness(owner.pid) === 'dead') {
-                rmSync(carrierDir, { recursive: true, force: true });
+                await rm(carrierDir, { recursive: true, force: true });
                 logger.debug(`[agyHookCarrier] swept orphaned carrier ${carrierDir} (owner pid ${owner.pid}, scope matched, confirmed dead)`);
             }
         } catch (error) {

--- a/cli/src/agy/utils/agyHookCarrierPlatformScope.test.ts
+++ b/cli/src/agy/utils/agyHookCarrierPlatformScope.test.ts
@@ -1,0 +1,447 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    _resetCarrierScopeCacheForTests,
+    cleanupAgyHookCarrier,
+    parseIoregPlatformUUID,
+    parseSysctlBootSessionUUID,
+    prepareAgyHookCarrier,
+    sweepAgyHookCarriers,
+    warmCarrierScope,
+    type ScopeProbe
+} from './agyHookCarrier';
+
+/**
+ * Spawns a real child process, waits for it to exit, and returns its PID --
+ * mirrors agyHookCarrier.test.ts's helper of the same shape (a genuinely
+ * dead pid, not a made-up one that could collide with a live process).
+ */
+function spawnAndReapDeadPid(): Promise<number> {
+    return new Promise((resolvePid, reject) => {
+        const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
+        const pid = child.pid;
+        if (!pid) {
+            reject(new Error('failed to obtain a PID for the throwaway child process'));
+            return;
+        }
+        child.once('exit', () => resolvePid(pid));
+        child.once('error', reject);
+    });
+}
+
+function stubPlatform(value: NodeJS.Platform): () => void {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+    return () => {
+        Object.defineProperty(process, 'platform', { value: original, configurable: true });
+    };
+}
+
+// Throwing stubs for the Linux-only probe fields -- every ScopeProbe object
+// below targets darwin (or an unrecognized platform), so these must never
+// actually be invoked; a throw makes an accidental Linux-path call fail
+// loudly instead of silently returning a bogus scope.
+const unusedLinuxFields = {
+    readBootId: (): string => { throw new Error('not used on this platform'); },
+    readPidNamespaceId: (): string => { throw new Error('not used on this platform'); },
+    hostname: (): string => { throw new Error('not used on this platform'); },
+};
+
+/** Isolates HAPI_HOME under a fresh mkdtemp dir so prepareAgyHookCarrier()
+ * never writes into the worker's shared config.tmpHome (hostile-review round
+ * 1 finding ⑦). Call from beforeEach/afterEach in every describe block that
+ * touches the filesystem via prepareAgyHookCarrier/sweepAgyHookCarriers. */
+function useIsolatedHapiHome(): { customHapiHome(): string } {
+    let previousHapiHome: string | undefined;
+    let customHapiHome: string;
+
+    beforeEach(() => {
+        previousHapiHome = process.env.HAPI_HOME;
+        customHapiHome = mkdtempSync(join(tmpdir(), 'hapi-phase2b-platform-home-'));
+        process.env.HAPI_HOME = customHapiHome;
+    });
+
+    afterEach(() => {
+        if (previousHapiHome === undefined) delete process.env.HAPI_HOME;
+        else process.env.HAPI_HOME = previousHapiHome;
+        rmSync(customHapiHome, { recursive: true, force: true });
+    });
+
+    return { customHapiHome: () => customHapiHome };
+}
+
+describe('parseIoregPlatformUUID (Phase 1 real capture)', () => {
+    it('extracts IOPlatformUUID from a real ioreg -rd1 -c IOPlatformExpertDevice capture', () => {
+        const sample = [
+            '+-o Mac-1234567890ABCDEF  <class IOPlatformExpertDevice, id 0x100000000, registered, matched, active, busy 0 (0 ms), retain 40>',
+            '    {',
+            '      "IOPlatformUUID" = "D8F7807A-6B93-57A4-9DF2-E9A54FA2E046"',
+            '      "IOPlatformSerialNumber" = "FVFXC1234567"',
+            '    }',
+        ].join('\n');
+        expect(parseIoregPlatformUUID(sample)).toBe('D8F7807A-6B93-57A4-9DF2-E9A54FA2E046');
+    });
+
+    it('returns undefined for output with no IOPlatformUUID key (unexpected ioreg version/format)', () => {
+        expect(parseIoregPlatformUUID('some unrelated ioreg output\nwith no matching key\n')).toBeUndefined();
+    });
+
+    it('returns undefined if the captured value is not UUID-shaped (defensive against a malformed/truncated capture)', () => {
+        expect(parseIoregPlatformUUID('"IOPlatformUUID" = "not-a-uuid"')).toBeUndefined();
+    });
+});
+
+describe('parseSysctlBootSessionUUID (Phase 1 real capture, 2026-08-07 correction)', () => {
+    it('accepts a real sysctl -n kern.bootsessionuuid capture (bare UUID, trailing newline)', () => {
+        expect(parseSysctlBootSessionUUID('76A5605C-FF4D-4B31-80D8-239964198B7D\n')).toBe('76A5605C-FF4D-4B31-80D8-239964198B7D');
+    });
+
+    it('returns undefined for non-UUID output (unexpected sysctl error text, e.g. "sysctl: unknown oid")', () => {
+        expect(parseSysctlBootSessionUUID('sysctl: unknown oid \'kern.bootsessionuuid\'\n')).toBeUndefined();
+    });
+});
+
+describe('platform scope dispatch (Phase 2-B)', () => {
+    useIsolatedHapiHome();
+    let restorePlatform: (() => void) | undefined;
+
+    beforeEach(() => {
+        _resetCarrierScopeCacheForTests();
+    });
+
+    afterEach(() => {
+        restorePlatform?.();
+        restorePlatform = undefined;
+        _resetCarrierScopeCacheForTests();
+    });
+
+    it('computes darwin:<uuid>:<bootSessionId> from injected probe functions, end-to-end through prepareAgyHookCarrier', async () => {
+        restorePlatform = stubPlatform('darwin');
+        const probe: ScopeProbe = {
+            ...unusedLinuxFields,
+            readDarwinMachineId: async () => 'D8F7807A-6B93-57A4-9DF2-E9A54FA2E046',
+            readDarwinBootSessionId: async () => '76A5605C-FF4D-4B31-80D8-239964198B7D',
+        };
+        await warmCarrierScope(probe);
+
+        const carrier = prepareAgyHookCarrier('{}');
+        try {
+            expect(carrier).toBeDefined();
+            if (!carrier) return;
+            const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
+            expect(owner.scope).toBe('darwin:D8F7807A-6B93-57A4-9DF2-E9A54FA2E046:76A5605C-FF4D-4B31-80D8-239964198B7D');
+        } finally {
+            cleanupAgyHookCarrier(carrier?.carrierDir);
+        }
+    });
+
+    it('falls back to undefined (preserved, empty-string owner scope) when the darwin boot-session probe fails, even if the machine-id probe succeeds', async () => {
+        restorePlatform = stubPlatform('darwin');
+        const probe: ScopeProbe = {
+            ...unusedLinuxFields,
+            readDarwinMachineId: async () => 'D8F7807A-6B93-57A4-9DF2-E9A54FA2E046',
+            readDarwinBootSessionId: async () => { throw new Error('sysctl timed out'); },
+        };
+        await warmCarrierScope(probe);
+
+        const carrier = prepareAgyHookCarrier('{}');
+        try {
+            expect(carrier).toBeDefined();
+            if (!carrier) return;
+            const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
+            expect(owner.scope).toBe('');
+        } finally {
+            cleanupAgyHookCarrier(carrier?.carrierDir);
+        }
+    });
+
+    it('falls back to undefined without calling any probe on a platform this module does not recognize', async () => {
+        restorePlatform = stubPlatform('sunos' as NodeJS.Platform);
+        const readDarwinMachineId = vi.fn(async () => 'should-not-be-called');
+        const probe: ScopeProbe = { ...unusedLinuxFields, readDarwinMachineId };
+        await warmCarrierScope(probe);
+
+        const carrier = prepareAgyHookCarrier('{}');
+        try {
+            expect(carrier).toBeDefined();
+            if (!carrier) return;
+            const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
+            expect(owner.scope).toBe('');
+            expect(readDarwinMachineId).not.toHaveBeenCalled();
+        } finally {
+            cleanupAgyHookCarrier(carrier?.carrierDir);
+        }
+    });
+
+    it('resolves to undefined on win32 with no weak-identity fallback (dispatch falls through the same "unrecognized platform" branch as sunos above -- there is no windows-specific ScopeProbe field left to inject)', async () => {
+        restorePlatform = stubPlatform('win32');
+        // No windows-specific field exists on ScopeProbe anymore -- win32
+        // now takes the same "unrecognized platform" branch as 'sunos'
+        // above, so there is nothing platform-specific to inject; the
+        // Linux-only fields being unused (and throwing if touched) is
+        // exactly what this pins.
+        await warmCarrierScope(unusedLinuxFields);
+
+        const carrier = prepareAgyHookCarrier('{}');
+        try {
+            expect(carrier).toBeDefined();
+            if (!carrier) return;
+            const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
+            expect(owner.scope).toBe('');
+        } finally {
+            cleanupAgyHookCarrier(carrier?.carrierDir);
+        }
+    });
+
+    it('never produces colliding scope strings between linux and darwin, even fed the exact same raw id components', async () => {
+        const sameRawId = 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA';
+        let linuxCarrier: ReturnType<typeof prepareAgyHookCarrier>;
+        let darwinCarrier: ReturnType<typeof prepareAgyHookCarrier>;
+        try {
+            restorePlatform = stubPlatform('linux');
+            await warmCarrierScope({
+                readBootId: () => sameRawId,
+                readPidNamespaceId: () => sameRawId,
+                hostname: () => 'irrelevant',
+            });
+            linuxCarrier = prepareAgyHookCarrier('{}');
+            expect(linuxCarrier).toBeDefined();
+            restorePlatform();
+            _resetCarrierScopeCacheForTests();
+
+            restorePlatform = stubPlatform('darwin');
+            await warmCarrierScope({
+                ...unusedLinuxFields,
+                readDarwinMachineId: async () => sameRawId,
+                readDarwinBootSessionId: async () => sameRawId,
+            });
+            darwinCarrier = prepareAgyHookCarrier('{}');
+            expect(darwinCarrier).toBeDefined();
+
+            if (!linuxCarrier || !darwinCarrier) return;
+            const linuxOwner = JSON.parse(readFileSync(join(linuxCarrier.carrierDir, 'owner.json'), 'utf8'));
+            const darwinOwner = JSON.parse(readFileSync(join(darwinCarrier.carrierDir, 'owner.json'), 'utf8'));
+            expect(linuxOwner.scope).not.toBe(darwinOwner.scope);
+            expect(linuxOwner.scope).toBe(`linux:${sameRawId}:${sameRawId}`);
+            expect(darwinOwner.scope).toBe(`darwin:${sameRawId}:${sameRawId}`);
+        } finally {
+            cleanupAgyHookCarrier(linuxCarrier?.carrierDir);
+            cleanupAgyHookCarrier(darwinCarrier?.carrierDir);
+        }
+    });
+});
+
+describe('warmCarrierScope memoization', () => {
+    let restorePlatform: (() => void) | undefined;
+
+    beforeEach(() => {
+        _resetCarrierScopeCacheForTests();
+    });
+
+    afterEach(() => {
+        restorePlatform?.();
+        restorePlatform = undefined;
+        _resetCarrierScopeCacheForTests();
+    });
+
+    it('computes the scope only once across repeated warm calls with the same probe', async () => {
+        restorePlatform = stubPlatform('darwin');
+        const readDarwinMachineId = vi.fn(async () => 'D8F7807A-6B93-57A4-9DF2-E9A54FA2E046');
+        const readDarwinBootSessionId = vi.fn(async () => '76A5605C-FF4D-4B31-80D8-239964198B7D');
+        const probe: ScopeProbe = { ...unusedLinuxFields, readDarwinMachineId, readDarwinBootSessionId };
+
+        await warmCarrierScope(probe);
+        await warmCarrierScope(probe);
+        await warmCarrierScope(probe);
+
+        expect(readDarwinMachineId).toHaveBeenCalledTimes(1);
+        expect(readDarwinBootSessionId).toHaveBeenCalledTimes(1);
+    });
+
+    it('also memoizes a failed probe (does not retry on every warm call)', async () => {
+        restorePlatform = stubPlatform('darwin');
+        const readDarwinMachineId = vi.fn(async () => { throw new Error('ioreg not found'); });
+        const readDarwinBootSessionId = vi.fn(async () => '76A5605C-FF4D-4B31-80D8-239964198B7D');
+        const probe: ScopeProbe = { ...unusedLinuxFields, readDarwinMachineId, readDarwinBootSessionId };
+
+        await warmCarrierScope(probe);
+        await warmCarrierScope(probe);
+
+        expect(readDarwinMachineId).toHaveBeenCalledTimes(1);
+    });
+
+    it('never rejects even when every probe throws', async () => {
+        restorePlatform = stubPlatform('darwin');
+        const probe: ScopeProbe = {
+            ...unusedLinuxFields,
+            readDarwinMachineId: async () => { throw new Error('boom'); },
+            readDarwinBootSessionId: async () => { throw new Error('boom'); },
+        };
+        await expect(warmCarrierScope(probe)).resolves.toBeUndefined();
+    });
+});
+
+describe('sweepAgyHookCarriers platform branches (Phase 2-B, mutation resistance)', () => {
+    let previousHapiHome: string | undefined;
+    let customHapiHome: string;
+    let restorePlatform: (() => void) | undefined;
+
+    beforeEach(() => {
+        previousHapiHome = process.env.HAPI_HOME;
+        customHapiHome = mkdtempSync(join(tmpdir(), 'hapi-phase2b-sweep-home-'));
+        process.env.HAPI_HOME = customHapiHome;
+    });
+
+    afterEach(() => {
+        restorePlatform?.();
+        restorePlatform = undefined;
+        _resetCarrierScopeCacheForTests();
+        if (previousHapiHome === undefined) delete process.env.HAPI_HOME;
+        else process.env.HAPI_HOME = previousHapiHome;
+        rmSync(customHapiHome, { recursive: true, force: true });
+    });
+
+    const CARRIER_PREFIX = 'hapi-agy-carrier-';
+
+    function makeCarrierDir(name: string): string {
+        const root = join(customHapiHome, 'agy-carriers');
+        mkdirSync(root, { recursive: true });
+        const carrierDir = join(root, `${CARRIER_PREFIX}${name}`);
+        mkdirSync(join(carrierDir, '.agents'), { recursive: true });
+        writeFileSync(join(carrierDir, '.agents', 'hooks.json'), '{}');
+        return carrierDir;
+    }
+
+    // This is the "not vacuous" proof the plan's mutation-testing gate
+    // requires for the one remaining real platform branch: it proves darwin
+    // can actually DELETE (an observable, dangerous outcome), not merely
+    // that it fails safely into "preserve" -- a bug that always returned
+    // undefined would make every OTHER platform test above pass (everything
+    // preserved looks identical to "working"), but would make this one fail.
+    it('sweeps a darwin-scoped carrier whose owner has died (proves the branch actually deletes)', async () => {
+        restorePlatform = stubPlatform('darwin');
+        const deadPid = await spawnAndReapDeadPid();
+        const carrierDir = makeCarrierDir('darwin-dead-owner');
+        const scope = 'darwin:D8F7807A-6B93-57A4-9DF2-E9A54FA2E046:76A5605C-FF4D-4B31-80D8-239964198B7D';
+        writeFileSync(join(carrierDir, 'owner.json'), JSON.stringify({ pid: deadPid, scope }));
+
+        const probe: ScopeProbe = {
+            ...unusedLinuxFields,
+            readDarwinMachineId: async () => 'D8F7807A-6B93-57A4-9DF2-E9A54FA2E046',
+            readDarwinBootSessionId: async () => '76A5605C-FF4D-4B31-80D8-239964198B7D',
+        };
+        await sweepAgyHookCarriers(probe);
+
+        expect(existsSync(carrierDir)).toBe(false);
+    });
+
+    it('preserves a darwin-scoped carrier whose owner is alive', async () => {
+        restorePlatform = stubPlatform('darwin');
+        const carrierDir = makeCarrierDir('darwin-alive-owner');
+        const scope = 'darwin:D8F7807A-6B93-57A4-9DF2-E9A54FA2E046:76A5605C-FF4D-4B31-80D8-239964198B7D';
+        writeFileSync(join(carrierDir, 'owner.json'), JSON.stringify({ pid: process.pid, scope }));
+
+        const probe: ScopeProbe = {
+            ...unusedLinuxFields,
+            readDarwinMachineId: async () => 'D8F7807A-6B93-57A4-9DF2-E9A54FA2E046',
+            readDarwinBootSessionId: async () => '76A5605C-FF4D-4B31-80D8-239964198B7D',
+        };
+        await sweepAgyHookCarriers(probe);
+
+        expect(existsSync(carrierDir)).toBe(true);
+    });
+
+    // What this pins: win32 cannot resolve a scope at all (no ScopeProbe
+    // field exists to feed it one — see the test below), so
+    // resolveLocalCarrierScope() returns undefined and sweepAgyHookCarriers
+    // bails out before examining the directory listing at all (the
+    // `if (!localScope) return` early exit in agyHookCarrier.ts) — every
+    // carrier under HAPI_HOME is preserved on win32, this one included.
+    //
+    // What this does NOT pin (hostile-review round 2 correction): a
+    // "regression guard" in the sense of "this would have been deleted by
+    // the pre-fix code, and now it is not." That claim was checked here
+    // previously and was false — the pre-fix readWin32Scope already started
+    // with `if (!probe.readWin32MachineId) return undefined;`, and the
+    // probe below has no such field, so this exact carrier was ALWAYS
+    // preserved, before this file's Windows support existed and after it
+    // was removed alike. A genuine before/after regression test is not
+    // constructible here: it would need either a real `reg.exe` (not
+    // present on Linux CI) or the now-deleted `readWin32MachineId` seam to
+    // inject a fake one, and the seam is gone specifically so this can't be
+    // done by accident. The actual binding constraint against re-adding
+    // Windows support is computeLocalCarrierScopeAsync's docstring, not
+    // this test — this test only pins the (correct, current) win32
+    // preserve-everything behavior as a fact about the present code.
+    it('preserves a win32-scoped carrier with a dead owner pid (win32 cannot resolve any scope, so sweep bails out before examining anything)', async () => {
+        restorePlatform = stubPlatform('win32');
+        const deadPid = await spawnAndReapDeadPid();
+        const carrierDir = makeCarrierDir('win32-would-be-dead-owner');
+        const scope = 'win32:7a910be3-c121-47aa-a3a1-426ae6bd5ca8';
+        writeFileSync(join(carrierDir, 'owner.json'), JSON.stringify({ pid: deadPid, scope }));
+
+        await sweepAgyHookCarriers(unusedLinuxFields);
+
+        expect(existsSync(carrierDir)).toBe(true);
+    });
+
+    // The structural counterpart to the behavioral test above: there is no
+    // ScopeProbe field left to construct a win32 probe with, so a future
+    // reintroduction of Windows support that forgets to update BOTH the
+    // type and computeLocalCarrierScopeAsync's dispatch would be caught
+    // here at typecheck time (this file failing `bun run typecheck`, not a
+    // runtime assertion) the moment the field comes back without a
+    // corresponding removal of this @ts-expect-error.
+    it('has no injectable win32 field on ScopeProbe (compile-time regression guard)', () => {
+        // @ts-expect-error -- readWin32MachineId does not exist on
+        // ScopeProbe. If it starts existing again, this directive itself
+        // becomes an unused "@ts-expect-error" compile error.
+        const probe: ScopeProbe = { ...unusedLinuxFields, readWin32MachineId: async () => 'x' };
+        void probe;
+    });
+});
+
+describe('real defaultScopeProbe (smoke test, no macOS tooling on this Linux host)', () => {
+    // This cannot validate the SUCCESS/parsing path against the real OS
+    // tools (that needs Phase 3's live macOS verification, out of this
+    // task's scope) -- but it does exercise the real execFile-based
+    // implementation end-to-end on THIS host, where /usr/sbin/ioreg and
+    // /usr/sbin/sysctl -n kern.bootsessionuuid (macOS-only oid) either don't
+    // exist or don't behave the same way, proving the real probe resolves
+    // to undefined (via ENOENT/non-matching output) rather than hanging or
+    // throwing unhandled. Windows has no probe left to smoke-test (see
+    // computeLocalCarrierScopeAsync's docstring) -- the win32 case is
+    // already covered above as a pure dispatch/bailout test, not a
+    // real-execFile smoke test, since there is no execFile call on that
+    // path anymore.
+    useIsolatedHapiHome();
+    let restorePlatform: (() => void) | undefined;
+
+    beforeEach(() => {
+        _resetCarrierScopeCacheForTests();
+    });
+
+    afterEach(() => {
+        restorePlatform?.();
+        restorePlatform = undefined;
+        _resetCarrierScopeCacheForTests();
+    });
+
+    it('resolves to undefined (never hangs, never throws) when stubbed to darwin on a non-macOS host', async () => {
+        restorePlatform = stubPlatform('darwin');
+        await expect(warmCarrierScope()).resolves.toBeUndefined();
+
+        const carrier = prepareAgyHookCarrier('{}');
+        try {
+            expect(carrier).toBeDefined();
+            if (!carrier) return;
+            const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
+            expect(owner.scope).toBe('');
+        } finally {
+            cleanupAgyHookCarrier(carrier?.carrierDir);
+        }
+    }, 10_000);
+});

--- a/cli/src/agy/utils/agyHookCarrierScopeCache.test.ts
+++ b/cli/src/agy/utils/agyHookCarrierScopeCache.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-    __resetCarrierScopeCacheForTests,
+    _resetCarrierScopeCacheForTests,
     cleanupAgyHookCarrier,
     computeLocalCarrierScope,
     prepareAgyHookCarrier,
@@ -23,11 +23,11 @@ import {
  */
 describe('carrier scope cache (Phase 2-B infrastructure)', () => {
     beforeEach(() => {
-        __resetCarrierScopeCacheForTests();
+        _resetCarrierScopeCacheForTests();
     });
 
     afterEach(() => {
-        __resetCarrierScopeCacheForTests();
+        _resetCarrierScopeCacheForTests();
     });
 
     it('computes the scope only once across repeated warm calls with the same probe', async () => {

--- a/cli/src/agy/utils/agyHookCarrierScopeCache.test.ts
+++ b/cli/src/agy/utils/agyHookCarrierScopeCache.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    __resetCarrierScopeCacheForTests,
+    cleanupAgyHookCarrier,
+    computeLocalCarrierScope,
+    prepareAgyHookCarrier,
+    warmCarrierScope,
+    type ScopeProbe
+} from './agyHookCarrier';
+
+/**
+ * Phase 2-B introduces a process-lifetime cache for computeLocalCarrierScope,
+ * needed because the upcoming macOS/Windows probes are async child-process
+ * calls that writeOwnerMetadata (synchronous, called from prepareAgyHookCarrier)
+ * cannot await directly. This file exercises the cache mechanism itself using
+ * only the existing Linux-shaped ScopeProbe fields -- no platform-specific
+ * code exists yet at this commit (that lands in the next, feat, commit) --
+ * so this is a pure structural addition: computeLocalCarrierScope()'s
+ * observable output on this (Linux) test host is unchanged either way.
+ */
+describe('carrier scope cache (Phase 2-B infrastructure)', () => {
+    beforeEach(() => {
+        __resetCarrierScopeCacheForTests();
+    });
+
+    afterEach(() => {
+        __resetCarrierScopeCacheForTests();
+    });
+
+    it('computes the scope only once across repeated warm calls with the same probe', async () => {
+        const readBootId = vi.fn(() => 'cached-boot-id');
+        const readPidNamespaceId = vi.fn(() => '999');
+        const probe: ScopeProbe = { readBootId, readPidNamespaceId, hostname: () => 'irrelevant' };
+
+        await warmCarrierScope(probe);
+        await warmCarrierScope(probe);
+        await warmCarrierScope(probe);
+
+        expect(readBootId).toHaveBeenCalledTimes(1);
+        expect(readPidNamespaceId).toHaveBeenCalledTimes(1);
+    });
+
+    it('a second warmCarrierScope call fired before the first has settled reuses the same in-flight probe (does not double-probe)', async () => {
+        const callCount = vi.fn();
+        const probe: ScopeProbe = {
+            readBootId: () => { callCount(); return 'boot-id'; },
+            readPidNamespaceId: () => '1',
+            hostname: () => 'irrelevant',
+        };
+
+        // Both calls are fired before either has a chance to resolve --
+        // Promise.all starts them in the same microtask turn.
+        await Promise.all([warmCarrierScope(probe), warmCarrierScope(probe)]);
+        expect(callCount).toHaveBeenCalledTimes(1);
+    });
+
+    it('memoizes a failed probe too -- does not retry on every warm call', async () => {
+        const readBootId = vi.fn((): string => { throw new Error('boot id read failed'); });
+        const probe: ScopeProbe = { readBootId, readPidNamespaceId: () => '1', hostname: () => 'irrelevant' };
+
+        await warmCarrierScope(probe);
+        await warmCarrierScope(probe);
+
+        expect(readBootId).toHaveBeenCalledTimes(1);
+    });
+
+    it('never rejects, even when the probe throws', async () => {
+        const probe: ScopeProbe = {
+            readBootId: () => { throw new Error('boom'); },
+            readPidNamespaceId: () => { throw new Error('boom'); },
+            hostname: () => 'irrelevant',
+        };
+        await expect(warmCarrierScope(probe)).resolves.toBeUndefined();
+    });
+
+    describe('prepareAgyHookCarrier / writeOwnerMetadata consumption', () => {
+        let previousHapiHome: string | undefined;
+        let customHapiHome: string;
+
+        beforeEach(() => {
+            previousHapiHome = process.env.HAPI_HOME;
+            customHapiHome = mkdtempSync(join(tmpdir(), 'hapi-phase2b-cache-home-'));
+            process.env.HAPI_HOME = customHapiHome;
+        });
+
+        afterEach(() => {
+            if (previousHapiHome === undefined) delete process.env.HAPI_HOME;
+            else process.env.HAPI_HOME = previousHapiHome;
+            rmSync(customHapiHome, { recursive: true, force: true });
+        });
+
+        it('reads a warm cache instead of recomputing (owner.json reflects the warmed value, not a fresh real-/proc read)', async () => {
+            // A deliberately WRONG-looking but well-formed scope: if
+            // writeOwnerMetadata ignored the cache and fell back to the real
+            // sync Linux probe, the resulting owner.json would carry the
+            // REAL linux:<bootId>:<ns> value instead, which can never equal
+            // this fabricated one.
+            const probe: ScopeProbe = {
+                readBootId: () => 'fabricated-boot-id-not-the-real-one',
+                readPidNamespaceId: () => '424242',
+                hostname: () => 'irrelevant',
+            };
+            await warmCarrierScope(probe);
+
+            const carrier = prepareAgyHookCarrier('{}');
+            expect(carrier).toBeDefined();
+            if (!carrier) return;
+            try {
+                const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
+                expect(owner.scope).toBe('linux:fabricated-boot-id-not-the-real-one:424242');
+                expect(owner.scope).not.toBe(computeLocalCarrierScope());
+            } finally {
+                cleanupAgyHookCarrier(carrier.carrierDir);
+            }
+        });
+
+        it('falls back to the real synchronous computation when the cache was never warmed (unchanged Linux behavior)', () => {
+            // No warmCarrierScope() call at all -- this is the existing,
+            // pre-Phase-2-B code path (see agyHookCarrier.test.ts's Phase
+            // 2.8 "writes owner metadata" test for the original assertion
+            // this preserves).
+            const carrier = prepareAgyHookCarrier('{}');
+            expect(carrier).toBeDefined();
+            if (!carrier) return;
+            try {
+                const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
+                expect(owner.scope).toBe(computeLocalCarrierScope());
+            } finally {
+                cleanupAgyHookCarrier(carrier.carrierDir);
+            }
+        });
+    });
+});


### PR DESCRIPTION
### Problem

Two follow-ups on the carrier sweeping that landed recently.

**Sweeping runs on the session startup path.** `sweepAgyHookCarriers()` is called synchronously as the agy PTY session comes up, and every filesystem call inside it is synchronous too, so a full directory scan sits between the user starting a session and the session appearing. Sweeping is a backstop rather than a primary path: normal teardown already removes a session's own carrier through `cleanupAgyHookCarrier`, and sweeping only matters when that never got to run — a crash, a `kill -9`. There is no reason for it to hold up startup.

**Sweeping is inert on macOS.** `computeLocalCarrierScope()` derives its scope from `/proc/sys/kernel/random/boot_id` and `/proc/self/ns/pid`, so it returns `undefined` off Linux and sweeping preserves everything. Preserving is the safe direction and was the right default to ship with, but it does mean crash leftovers accumulate on macOS with nothing to reclaim them.

### Solution

**Move sweeping off the startup path.** Sweeping is asynchronous now (`fs/promises` throughout) and is no longer awaited before the session starts. The "never throws" contract is preserved, now covering rejections as well. Three independent properties make it safe to run alongside carrier creation, and each is pinned by a test: a carrier created after the `readdir` snapshot is not in the list at all; a carrier caught in the snapshot before its `owner.json` exists reads as unowned and is preserved; and once `owner.json` exists its PID is live, so the carrier is preserved.

**Give macOS a real scope.** Scope identity branches on `process.platform`, and each platform tags its scope string so two platforms can never compute the same value. Linux keeps `linux:<boot_id>:<pid-ns-inode>` unchanged; macOS gets `darwin:<IOPlatformUUID>:<kern.bootsessionuuid>`.

`kern.bootsessionuuid` is the macOS counterpart to Linux's `boot_id`: a UUID the kernel mints during boot and also stamps into panic logs. Reading it costs one `sysctl` (measured 18-19 ms), and `IOPlatformUUID` one `ioreg` (27-28 ms). It is worth saying why the boot *timestamp* is not used instead, since that is the more obvious choice. `sysctl kern.boottime` is recomputed from the wall clock on each read, so NTP corrections move it: on a Mac that had been up for eight days without rebooting, the reported boot time drifted 1.3 seconds between two readings. A scope built on it would stop matching the scope already recorded in a carrier's `owner.json`, and sweeping would silently stop recognising anything.

Every probe keeps the existing failure posture. Each runs as a direct child process with an absolute path and a timeout, values are shape-checked before use, and anything unexpected — a missing binary, a non-zero exit, a timeout, an unparseable value — yields `undefined`, which makes sweeping preserve everything, on any platform. There is still no weak fallback anywhere: hostname is not an identity.

Because the macOS probes are child processes rather than `/proc` reads, the scope is computed once per process and memoised, and warmed asynchronously during startup so it overlaps with hook server startup rather than adding to it.

### Tests

Unit tests cover macOS scope computation (success, partial probe failure, total failure), that platforms without a strong identity preserve every carrier and never invoke a probe, that no two platforms can produce the same scope string, that the warm-up is awaited before a carrier is created, and the three race properties above. `ScopeProbe` injection drives the platform branches directly, so no module-wide mocking is needed.

Verified live on Linux and macOS: a carrier whose owner PID has been reaped is removed, while carriers owned by a live PID, owned by a PID belonging to another user (`EPERM`), missing `owner.json`, carrying a foreign scope, or owned by the running process itself are all preserved. The same run on Windows confirms it preserves everything. End to end with two concurrent agy PTY sessions against a hub, the second session's startup sweep reclaimed only the dead carrier and left the first session's live one alone, with its own carrier created while that sweep was still in flight.
