### PR TITLE
fix(web): return chat file previews to conversation

### DIFF
--- a/web/src/components/assistant-ui/markdown-file-anchor.test.tsx
+++ b/web/src/components/assistant-ui/markdown-file-anchor.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defaultComponents, UriConfirmProvider } from '@/components/assistant-ui/markdown-text'
+import { I18nProvider } from '@/lib/i18n-context'
+import { encodeBase64 } from '@/lib/utils'
+
+const mocks = vi.hoisted(() => ({
+    navigate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+    useNavigate: () => mocks.navigate,
+}))
+
+vi.mock('@/components/AssistantChat/context', () => ({
+    useOptionalHappyChatContext: () => ({ sessionId: 'session-1' }),
+}))
+
+const AnchorComponent = (defaultComponents as Record<string, unknown>).a as React.ComponentType<
+    React.ComponentPropsWithoutRef<'a'>
+>
+
+function renderFileAnchor(filePath: string) {
+    return render(
+        <I18nProvider>
+            <UriConfirmProvider>
+                <AnchorComponent href={`hapi-file:${encodeURIComponent(filePath)}`}>
+                    {filePath}
+                </AnchorComponent>
+            </UriConfirmProvider>
+        </I18nProvider>
+    )
+}
+
+beforeEach(() => {
+    mocks.navigate.mockReset()
+})
+
+describe('chat file anchors', () => {
+    it('marks file previews as originating from chat for deterministic back navigation', () => {
+        const filePath = 'docs/guide.md'
+        renderFileAnchor(filePath)
+        const link = screen.getByRole('link', { name: filePath })
+        const href = new URL(link.getAttribute('href')!, 'https://hapi.example')
+
+        expect(href.pathname).toBe('/sessions/session-1/file')
+        expect(href.searchParams.get('path')).toBe(encodeBase64(filePath))
+        expect(href.searchParams.get('origin')).toBe('chat')
+
+        fireEvent.click(link)
+
+        expect(mocks.navigate).toHaveBeenCalledWith({
+            to: '/sessions/$sessionId/file',
+            params: { sessionId: 'session-1' },
+            search: {
+                path: encodeBase64(filePath),
+                origin: 'chat',
+            },
+        })
+    })
+})

--- a/web/src/components/assistant-ui/markdown-text.tsx
+++ b/web/src/components/assistant-ui/markdown-text.tsx
@@ -496,7 +496,10 @@ function Code(props: ComponentPropsWithoutRef<'code'>) {
 function FilePathAnchor(props: ComponentPropsWithoutRef<'a'> & { filePath: string; sessionId: string }) {
     const navigate = useNavigate()
     const rel = props.target === '_blank' ? (props.rel ?? 'noreferrer') : props.rel
-    const search = new URLSearchParams({ path: encodeBase64(props.filePath) }).toString()
+    const search = new URLSearchParams({
+        path: encodeBase64(props.filePath),
+        origin: 'chat',
+    }).toString()
     const href = `/sessions/${encodeURIComponent(props.sessionId)}/file?${search}`
 
     const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
@@ -508,7 +511,10 @@ function FilePathAnchor(props: ComponentPropsWithoutRef<'a'> & { filePath: strin
         void navigate({
             to: '/sessions/$sessionId/file',
             params: { sessionId: props.sessionId },
-            search: { path: encodeBase64(props.filePath) }
+            search: {
+                path: encodeBase64(props.filePath),
+                origin: 'chat',
+            }
         })
     }
 

--- a/web/src/hooks/useAppGoBack.test.ts
+++ b/web/src/hooks/useAppGoBack.test.ts
@@ -1,5 +1,29 @@
-import { describe, expect, it } from 'vitest'
-import { getSessionFilesBackSearch, getSettingsBackTarget } from './useAppGoBack'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routerMocks = vi.hoisted(() => ({
+    navigate: vi.fn(),
+    historyBack: vi.fn(),
+    pathname: '/sessions',
+    search: {} as unknown,
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+    useNavigate: () => routerMocks.navigate,
+    useRouter: () => ({ history: { back: routerMocks.historyBack } }),
+    useLocation: ({ select }: {
+        select: (location: { pathname: string; search: unknown }) => unknown
+    }) => select({ pathname: routerMocks.pathname, search: routerMocks.search }),
+}))
+
+import { getSessionFilesBackSearch, getSettingsBackTarget, useAppGoBack } from './useAppGoBack'
+
+beforeEach(() => {
+    routerMocks.navigate.mockReset()
+    routerMocks.historyBack.mockReset()
+    routerMocks.pathname = '/sessions'
+    routerMocks.search = {}
+})
 
 describe('getSettingsBackTarget', () => {
     it.each([
@@ -35,5 +59,39 @@ describe('getSessionFilesBackSearch', () => {
             query: '',
         })).toEqual({})
         expect(getSessionFilesBackSearch(null)).toEqual({})
+    })
+})
+
+describe('useAppGoBack file preview navigation', () => {
+    it('returns directly to chat when the preview was opened from a chat link', () => {
+        routerMocks.pathname = '/sessions/session-1/file'
+        routerMocks.search = { path: 'encoded-path', origin: 'chat' }
+        const { result } = renderHook(() => useAppGoBack())
+
+        act(() => result.current())
+
+        expect(routerMocks.navigate).toHaveBeenCalledWith({
+            to: '/sessions/session-1',
+        })
+    })
+
+    it('keeps returning file-browser previews to their previous file context', () => {
+        routerMocks.pathname = '/sessions/session-1/file'
+        routerMocks.search = {
+            path: 'encoded-path',
+            tab: 'directories',
+            query: 'readme',
+        }
+        const { result } = renderHook(() => useAppGoBack())
+
+        act(() => result.current())
+
+        expect(routerMocks.navigate).toHaveBeenCalledWith({
+            to: '/sessions/session-1/files',
+            search: {
+                tab: 'directories',
+                query: 'readme',
+            },
+        })
     })
 })

--- a/web/src/hooks/useAppGoBack.ts
+++ b/web/src/hooks/useAppGoBack.ts
@@ -43,8 +43,17 @@ export function useAppGoBack(): () => void {
             return
         }
 
-        // For single file view, go back to files list
+        // Chat file links return to the conversation; file-browser previews
+        // retain their deterministic parent route and browsing context.
         if (pathname.match(/^\/sessions\/[^/]+\/file$/)) {
+            const origin = search && typeof search === 'object' && 'origin' in search
+                ? (search as { origin?: unknown }).origin
+                : undefined
+            if (origin === 'chat') {
+                navigate({ to: pathname.replace(/\/file$/, '') })
+                return
+            }
+
             const filesPath = pathname.replace(/\/file$/, '/files')
             navigate({ to: filesPath, search: getSessionFilesBackSearch(search) })
             return

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1059,6 +1059,7 @@ type SessionFileSearch = {
     staged?: boolean
     tab?: 'changes' | 'directories'
     query?: string
+    origin?: 'chat'
 }
 
 const sessionFileRoute = createRoute({
@@ -1081,6 +1082,7 @@ const sessionFileRoute = createRoute({
         const query = typeof search.query === 'string' && search.query.length > 0
             ? search.query
             : undefined
+        const origin = search.origin === 'chat' ? 'chat' : undefined
 
         const result: SessionFileSearch = { path }
         if (staged !== undefined) {
@@ -1091,6 +1093,9 @@ const sessionFileRoute = createRoute({
         }
         if (query !== undefined) {
             result.query = query
+        }
+        if (origin !== undefined) {
+            result.origin = origin
         }
         return result
     },


### PR DESCRIPTION
## Summary

Opening a `hapi-file:` link from an assistant reply currently opens the file preview, but the header Back action routes through the session's Files page. Chat-origin previews should return directly to the conversation.

- Add `origin=chat` to file-preview links generated in chat.
- Validate and preserve the origin marker in the session file route.
- Return chat-origin previews to `/sessions/:sessionId`.
- Preserve the existing Files route and tab/query context for file-browser previews.
- Add regression coverage for link generation and both back-navigation paths.

## Test plan

- [x] Targeted Vitest: 3 files, 25 tests passed.
- [x] Live Playwright regression: assistant reply file link → preview → header Back → conversation; 1 passed.
- [x] Root `terminal-wrap-fidelity.spec.ts`: 2 passed.

## AI disclosure

Implemented with OpenAI Codex.