### PR TITLE
fix(shared): parse AGENT_NOTIFY_SUMMARY with glued last-line prose

### DIFF
--- a/shared/src/messages.test.ts
+++ b/shared/src/messages.test.ts
@@ -122,6 +122,23 @@ describe('extractNotifySummary', () => {
         expect(r?.summary).toBe('Published v0.1.0')
     })
 
+    test('parses when prose is glued onto the same last line before the token', () => {
+        // Agents sometimes omit the newline before the footer.
+        const glued = 'Ownership session pinged.AGENT_NOTIFY_SUMMARY {"version":1,"status":"done","summary":"ok"}'
+        const r = extractNotifySummary(glued)
+        expect(r).not.toBeNull()
+        expect(r?.version).toBe(1)
+        expect(r?.status).toBe('done')
+        expect(r?.summary).toBe('ok')
+    })
+
+    test('parses glued token after multi-line prose (token still on last line)', () => {
+        const text = `Did the work.\n\nOwnership session pinged.AGENT_NOTIFY_SUMMARY {"version":1,"status":"done","summary":"ok"}`
+        const r = extractNotifySummary(text)
+        expect(r?.summary).toBe('ok')
+        expect(r?.status).toBe('done')
+    })
+
     test('tolerates trailing whitespace and blank lines', () => {
         const r = extractNotifySummary(`prose\n\n${FULL_LINE}\n\n  \n`)
         expect(r?.summary).toBe('Published v0.1.0')
@@ -130,6 +147,14 @@ describe('extractNotifySummary', () => {
     test('returns null when summary is not on the LAST non-empty line', () => {
         // Operator wrote prose AFTER the line - non-compliant.
         const text = `${FULL_LINE}\nOh, one more thing.`
+        expect(extractNotifySummary(text)).toBeNull()
+    })
+
+    test('ignores mid-message token that is not on the last non-empty line', () => {
+        const text = [
+            'See AGENT_NOTIFY_SUMMARY {"version":1,"status":"done","summary":"mid"} for the contract.',
+            'More prose after that quote.',
+        ].join('\n')
         expect(extractNotifySummary(text)).toBeNull()
     })
 

--- a/shared/src/messages.test.ts
+++ b/shared/src/messages.test.ts
@@ -195,6 +195,21 @@ describe('extractNotifySummary', () => {
         expect(r?.summary).toBe('thing {nested} thing')
         expect(r?.status).toBe('done')
     })
+
+    test('parses when a JSON string value mentions the token literal', () => {
+        // lastIndexOf would start inside the summary value and fail.
+        const text = 'AGENT_NOTIFY_SUMMARY {"summary":"Fixed AGENT_NOTIFY_SUMMARY parsing","status":"done"}'
+        const r = extractNotifySummary(text)
+        expect(r?.summary).toBe('Fixed AGENT_NOTIFY_SUMMARY parsing')
+        expect(r?.status).toBe('done')
+    })
+
+    test('parses glued prose when a JSON string value mentions the token', () => {
+        const text = 'Done.AGENT_NOTIFY_SUMMARY {"summary":"mentions AGENT_NOTIFY_SUMMARY here","status":"done"}'
+        const r = extractNotifySummary(text)
+        expect(r?.summary).toBe('mentions AGENT_NOTIFY_SUMMARY here')
+        expect(r?.status).toBe('done')
+    })
 })
 
 describe('extractNotifySummary + extractAssistantPlainText (integration)', () => {

--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -142,17 +142,26 @@ export type NotifySummary = {
  * Match a well-formed `AGENT_NOTIFY_SUMMARY {...}` footer on a single line.
  *
  * Allows an optional prose prefix on the same line (agents sometimes glue
- * trailing text and the token without a newline). The token must be the
- * last occurrence on the line, and the JSON object must run through the
- * end of the line.
+ * trailing text and the token without a newline). Scans left-to-right and
+ * returns the first token occurrence whose remainder is valid JSON through
+ * end of line - so a literal `AGENT_NOTIFY_SUMMARY ` inside a JSON string
+ * value does not steal the match from the real footer.
  */
 function matchNotifySummaryLine(line: string): string | null {
-    const idx = line.lastIndexOf(NOTIFY_SUMMARY_PREFIX)
-    if (idx < 0) return null
-
-    const jsonPart = line.slice(idx + NOTIFY_SUMMARY_PREFIX.length).trim()
-    if (!jsonPart.startsWith('{') || !jsonPart.endsWith('}')) return null
-    return jsonPart
+    for (
+        let idx = line.indexOf(NOTIFY_SUMMARY_PREFIX);
+        idx >= 0;
+        idx = line.indexOf(NOTIFY_SUMMARY_PREFIX, idx + NOTIFY_SUMMARY_PREFIX.length)
+    ) {
+        const jsonPart = line.slice(idx + NOTIFY_SUMMARY_PREFIX.length).trim()
+        if (!jsonPart.startsWith('{') || !jsonPart.endsWith('}')) continue
+        try {
+            if (isObject(JSON.parse(jsonPart))) return jsonPart
+        } catch {
+            // Try the next occurrence (e.g. token mentioned inside a value).
+        }
+    }
+    return null
 }
 
 /**

--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -139,14 +139,31 @@ export type NotifySummary = {
 }
 
 /**
- * Look for an `AGENT_NOTIFY_SUMMARY {...json...}` line as the **last
+ * Match a well-formed `AGENT_NOTIFY_SUMMARY {...}` footer on a single line.
+ *
+ * Allows an optional prose prefix on the same line (agents sometimes glue
+ * trailing text and the token without a newline). The token must be the
+ * last occurrence on the line, and the JSON object must run through the
+ * end of the line.
+ */
+function matchNotifySummaryLine(line: string): string | null {
+    const idx = line.lastIndexOf(NOTIFY_SUMMARY_PREFIX)
+    if (idx < 0) return null
+
+    const jsonPart = line.slice(idx + NOTIFY_SUMMARY_PREFIX.length).trim()
+    if (!jsonPart.startsWith('{') || !jsonPart.endsWith('}')) return null
+    return jsonPart
+}
+
+/**
+ * Look for an `AGENT_NOTIFY_SUMMARY {...json...}` footer as the **last
  * non-empty line** of an agent's plain-text message.
  *
- * Strict end-anchor: anything below the JSON line (even whitespace) is
- * fine, but if the agent wrote prose AFTER the line we treat it as
- * non-compliant and return null. This also makes false positives from
- * `AGENT_NOTIFY_SUMMARY` quoted inside an earlier paragraph harmless,
- * because such a quote is never the last line.
+ * End-anchor: trailing blank lines are fine, but prose on a later
+ * non-empty line is non-compliant and returns null. Mid-body quotes of
+ * the token are ignored for the same reason. An optional prose prefix on
+ * the last line itself is tolerated when the line still ends with a
+ * well-formed `AGENT_NOTIFY_SUMMARY {…}` payload.
  *
  * Returns the parsed object on success, `null` on any deviation. The
  * shape is intentionally loose - we only trust `summary`, `action`, and
@@ -161,11 +178,8 @@ export function extractNotifySummary(text: unknown): NotifySummary | null {
     while (lastIdx >= 0 && lines[lastIdx].trim() === '') lastIdx -= 1
     if (lastIdx < 0) return null
 
-    const lastLine = lines[lastIdx].trim()
-    if (!lastLine.startsWith(NOTIFY_SUMMARY_PREFIX)) return null
-
-    const jsonPart = lastLine.slice(NOTIFY_SUMMARY_PREFIX.length).trim()
-    if (!jsonPart.startsWith('{') || !jsonPart.endsWith('}')) return null
+    const jsonPart = matchNotifySummaryLine(lines[lastIdx].trim())
+    if (jsonPart === null) return null
 
     try {
         const parsed: unknown = JSON.parse(jsonPart)


### PR DESCRIPTION
## Summary

`extractNotifySummary` previously required the last non-empty line to *start with* `AGENT_NOTIFY_SUMMARY `. Some agent turns glue trailing prose and the footer on one line (no newline), so FCM/ready composition missed a valid contract payload.

This hardens last-line matching: optional prose prefix is OK when the line still ends with a well-formed `AGENT_NOTIFY_SUMMARY {…}` object. Mid-body quotes that are not on the last non-empty line remain ignored. No historical backfill.

## Test plan

- [x] Unit: clean last-line footer still parses
- [x] Unit: glued `prose.AGENT_NOTIFY_SUMMARY {…}` on last line parses
- [x] Unit: mid-message mention (not last line) still ignored
- [x] Unit: malformed JSON on last line still null
- [x] Existing FCM notify-summary tests still pass (`hub/src/fcm/fcmNotificationChannel.test.ts`)
- [x] `bun typecheck` + `bun run test:shared` + `bun run test:hub`

## Issues

Fixes #1425