### PR TITLE
fix(web): keep project-pin groups above In progress

### DIFF
--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -496,6 +496,48 @@ describe('SessionList collapse behavior', () => {
         expect(screen.getByRole('button', { name: /Pinned running task/ })).toBeInTheDocument()
     })
 
+    it('renders project-pin groups above In progress when pin-in-progress is on', () => {
+        localStorage.setItem('hapi-pin-in-progress-sessions', 'true')
+        const sessions = [
+            makeSession({
+                id: 'session-global',
+                globalPinned: true,
+                updatedAt: 300,
+                metadata: { path: '/work/global', name: 'Global pin', flavor: 'codex' },
+            }),
+            makeSession({
+                id: 'session-project-pin',
+                pinned: true,
+                updatedAt: 200,
+                metadata: { path: '/work/pinned-project', name: 'Project pin', flavor: 'codex' },
+            }),
+            makeSession({
+                id: 'session-floater',
+                active: true,
+                thinking: true,
+                updatedAt: 250,
+                metadata: { path: '/work/other', name: 'Unpinned floater', flavor: 'codex' },
+            }),
+            makeSession({
+                id: 'session-idle-other',
+                updatedAt: 50,
+                metadata: { path: '/work/other', name: 'Other idle', flavor: 'codex' },
+            }),
+        ]
+        render(renderSessionList(sessions, null))
+
+        const globalSection = screen.getByTitle('Pinned sessions')
+        const projectPinGroup = screen.getByTitle('/work/pinned-project')
+        const inProgress = screen.getByTitle('In progress')
+        const otherGroup = screen.getByTitle('/work/other')
+
+        expect(globalSection).toAppearBefore(projectPinGroup)
+        expect(projectPinGroup).toAppearBefore(inProgress)
+        expect(inProgress).toAppearBefore(otherGroup)
+        expect(screen.getByRole('button', { name: /Project pin/ })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Unpinned floater/ })).toBeInTheDocument()
+    })
+
     it('does not label quiet active sessions as Idle', () => {
         const sessions = [
             makeSession({

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1283,6 +1283,16 @@ export function SessionList(props: {
         ),
         [machineFilteredSessions, pinInProgressSessions]
     )
+    // Durable project pins beat ephemeral In progress floaters: pin-containing
+    // groups render above the running section; unpinned groups stay below.
+    const pinnedProjectGroups = useMemo(
+        () => groups.filter((group) => group.hasPinnedSession),
+        [groups]
+    )
+    const otherProjectGroups = useMemo(
+        () => groups.filter((group) => !group.hasPinnedSession),
+        [groups]
+    )
     const [collapseOverrides, setCollapseOverrides] = useState<Map<string, boolean>>(
         () => new Map()
     )
@@ -1361,6 +1371,115 @@ export function SessionList(props: {
                 selectedSessionId,
                 limit: getGroupVisibleCount(group)
             }
+        )
+    }
+
+    const renderDirectoryGroup = (group: SessionGroup) => {
+        const isCollapsed = isGroupCollapsed(group)
+        const visibleGroupSessions = getVisibleGroupSessions(group)
+        const hiddenSessionCount = group.sessions.length - visibleGroupSessions.length
+        const currentLimit = Math.min(
+            getGroupVisibleCount(group),
+            group.sessions.length
+        )
+        const previousLimit = getPreviousSessionVisibleCount(currentLimit, sessionPreviewLimit)
+        const previousGroupSessions = getVisibleSessionPreview(group.sessions, {
+            selectedSessionId,
+            limit: previousLimit
+        })
+        const collapseCount = visibleGroupSessions.length - previousGroupSessions.length
+        const canShowFewerSessions = previousLimit < currentLimit && collapseCount > 0
+        const expandCount = Math.min(sessionPreviewLimit, hiddenSessionCount)
+        const canStartInGroupDirectory = group.directory !== 'Other'
+        // With multiple machines in the unfiltered view, disambiguate
+        // same-named directories by suffixing the machine label.
+        const groupTitle = showMachineFilterBar && activeMachineFilter === null
+            ? `${group.displayName} · ${resolveMachineLabel(group.machineId)}`
+            : group.displayName
+        return (
+            <div key={group.key}>
+                <div
+                    className="group/project sticky top-0 z-10 flex items-center gap-2 bg-[var(--app-bg)] py-1.5 pl-2 pr-2 text-left rounded-lg transition-colors hover:bg-[var(--app-secondary-bg)] cursor-pointer min-w-0 w-full select-none"
+                    onClick={() => toggleGroup(group.key, isCollapsed)}
+                    title={group.directory}
+                >
+                    <ChevronIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" collapsed={isCollapsed} />
+                    <span className="font-medium text-sm truncate flex-1">
+                        {groupTitle}
+                    </span>
+                    <CopyPathButton path={group.directory} className="opacity-0 group-hover/project:opacity-100 transition-opacity duration-150" />
+                    {onNewSessionInDirectory && canStartInGroupDirectory ? (
+                        <button
+                            type="button"
+                            onClick={(event) => {
+                                event.stopPropagation()
+                                onNewSessionInDirectory({
+                                    machineId: group.machineId,
+                                    directory: group.directory
+                                })
+                            }}
+                            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[var(--app-hint)] opacity-70 transition-colors hover:bg-[var(--app-secondary-bg)] hover:text-[var(--app-link)] hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
+                            title={t('sessions.group.new')}
+                            aria-label={t('sessions.group.new')}
+                        >
+                            <PlusIcon className="h-3.5 w-3.5" />
+                        </button>
+                    ) : null}
+                    <span className="text-[11px] tabular-nums text-[var(--app-hint)] shrink-0">
+                        ({group.sessions.length})
+                    </span>
+                </div>
+
+                {/* Sessions */}
+                <div className="collapsible-panel" data-open={!isCollapsed || undefined}>
+                    <div className="collapsible-inner">
+                    <div className="flex flex-col gap-0.5 ml-3 pl-1 py-1">
+                        {visibleGroupSessions.map((s, index) => (
+                            <div key={s.id} className="contents">
+                                {shouldShowPinnedDivider(visibleGroupSessions, index) ? (
+                                    <div
+                                        className="ml-2.5 mr-2 my-1 border-t border-[var(--app-border)]"
+                                        aria-hidden="true"
+                                    />
+                                ) : null}
+                                <SessionItem
+                                    session={s}
+                                    onSelect={props.onSelect}
+                                    showPath={false}
+                                    api={api}
+                                    selected={s.id === selectedSessionId}
+                                    showDetailedStatus={showDetailedStatus}
+                                />
+                            </div>
+                        ))}
+                        {group.sessions.length > sessionPreviewLimit && (hiddenSessionCount > 0 || canShowFewerSessions) ? (
+                            <div className="ml-2.5 mr-2 my-1 flex gap-1.5">
+                                {canShowFewerSessions ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => showFewerSessions(group)}
+                                        className="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md border border-dashed border-[var(--app-border)] px-2 py-1 text-center text-xs text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
+                                    >
+                                        <SessionPreviewArrowIcon direction="up" className="h-3 w-3 shrink-0" />
+                                        {t('sessions.group.collapse', { n: collapseCount })}
+                                    </button>
+                                ) : null}
+                                {hiddenSessionCount > 0 ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => showMoreSessions(group)}
+                                        className="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md border border-dashed border-[var(--app-border)] px-2 py-1 text-center text-xs text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
+                                    >
+                                        <SessionPreviewArrowIcon direction="down" className="h-3 w-3 shrink-0" />
+                                        {t('sessions.group.expand', { n: expandCount })}
+                                    </button>
+                                ) : null}
+                            </div>
+                        ) : null}
+                    </div>
+                    </div>
+                </div>
+            </div>
         )
     }
 
@@ -1702,6 +1821,8 @@ export function SessionList(props: {
                     </div>
                 ) : null}
 
+                {pinnedProjectGroups.map(renderDirectoryGroup)}
+
                 {runningSessionTotal > 0 ? (
                     <div key="running-section">
                         <div
@@ -1765,114 +1886,7 @@ export function SessionList(props: {
                         </div>
                     </div>
                 ) : null}
-                {groups.map((group) => {
-                    const isCollapsed = isGroupCollapsed(group)
-                    const visibleGroupSessions = getVisibleGroupSessions(group)
-                    const hiddenSessionCount = group.sessions.length - visibleGroupSessions.length
-                    const currentLimit = Math.min(
-                        getGroupVisibleCount(group),
-                        group.sessions.length
-                    )
-                    const previousLimit = getPreviousSessionVisibleCount(currentLimit, sessionPreviewLimit)
-                    const previousGroupSessions = getVisibleSessionPreview(group.sessions, {
-                        selectedSessionId,
-                        limit: previousLimit
-                    })
-                    const collapseCount = visibleGroupSessions.length - previousGroupSessions.length
-                    const canShowFewerSessions = previousLimit < currentLimit && collapseCount > 0
-                    const expandCount = Math.min(sessionPreviewLimit, hiddenSessionCount)
-                    const canStartInGroupDirectory = group.directory !== 'Other'
-                    // With multiple machines in the unfiltered view, disambiguate
-                    // same-named directories by suffixing the machine label.
-                    const groupTitle = showMachineFilterBar && activeMachineFilter === null
-                        ? `${group.displayName} · ${resolveMachineLabel(group.machineId)}`
-                        : group.displayName
-                    return (
-                        <div key={group.key}>
-                            <div
-                                className="group/project sticky top-0 z-10 flex items-center gap-2 bg-[var(--app-bg)] py-1.5 pl-2 pr-2 text-left rounded-lg transition-colors hover:bg-[var(--app-secondary-bg)] cursor-pointer min-w-0 w-full select-none"
-                                onClick={() => toggleGroup(group.key, isCollapsed)}
-                                title={group.directory}
-                            >
-                                <ChevronIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" collapsed={isCollapsed} />
-                                <span className="font-medium text-sm truncate flex-1">
-                                    {groupTitle}
-                                </span>
-                                <CopyPathButton path={group.directory} className="opacity-0 group-hover/project:opacity-100 transition-opacity duration-150" />
-                                {onNewSessionInDirectory && canStartInGroupDirectory ? (
-                                    <button
-                                        type="button"
-                                        onClick={(event) => {
-                                            event.stopPropagation()
-                                            onNewSessionInDirectory({
-                                                machineId: group.machineId,
-                                                directory: group.directory
-                                            })
-                                        }}
-                                        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[var(--app-hint)] opacity-70 transition-colors hover:bg-[var(--app-secondary-bg)] hover:text-[var(--app-link)] hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
-                                        title={t('sessions.group.new')}
-                                        aria-label={t('sessions.group.new')}
-                                    >
-                                        <PlusIcon className="h-3.5 w-3.5" />
-                                    </button>
-                                ) : null}
-                                <span className="text-[11px] tabular-nums text-[var(--app-hint)] shrink-0">
-                                    ({group.sessions.length})
-                                </span>
-                            </div>
-
-                            {/* Sessions */}
-                            <div className="collapsible-panel" data-open={!isCollapsed || undefined}>
-                                <div className="collapsible-inner">
-                                <div className="flex flex-col gap-0.5 ml-3 pl-1 py-1">
-                                    {visibleGroupSessions.map((s, index) => (
-                                        <div key={s.id} className="contents">
-                                            {shouldShowPinnedDivider(visibleGroupSessions, index) ? (
-                                                <div
-                                                    className="ml-2.5 mr-2 my-1 border-t border-[var(--app-border)]"
-                                                    aria-hidden="true"
-                                                />
-                                            ) : null}
-                                            <SessionItem
-                                                session={s}
-                                                onSelect={props.onSelect}
-                                                showPath={false}
-                                                api={api}
-                                                selected={s.id === selectedSessionId}
-                                                showDetailedStatus={showDetailedStatus}
-                                            />
-                                        </div>
-                                    ))}
-                                    {group.sessions.length > sessionPreviewLimit && (hiddenSessionCount > 0 || canShowFewerSessions) ? (
-                                        <div className="ml-2.5 mr-2 my-1 flex gap-1.5">
-                                            {canShowFewerSessions ? (
-                                                <button
-                                                    type="button"
-                                                    onClick={() => showFewerSessions(group)}
-                                                    className="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md border border-dashed border-[var(--app-border)] px-2 py-1 text-center text-xs text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
-                                                >
-                                                    <SessionPreviewArrowIcon direction="up" className="h-3 w-3 shrink-0" />
-                                                    {t('sessions.group.collapse', { n: collapseCount })}
-                                                </button>
-                                            ) : null}
-                                            {hiddenSessionCount > 0 ? (
-                                                <button
-                                                    type="button"
-                                                    onClick={() => showMoreSessions(group)}
-                                                    className="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md border border-dashed border-[var(--app-border)] px-2 py-1 text-center text-xs text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
-                                                >
-                                                    <SessionPreviewArrowIcon direction="down" className="h-3 w-3 shrink-0" />
-                                                    {t('sessions.group.expand', { n: expandCount })}
-                                                </button>
-                                            ) : null}
-                                        </div>
-                                    ) : null}
-                                </div>
-                                </div>
-                            </div>
-                        </div>
-                    )
-                })}
+                {otherProjectGroups.map(renderDirectoryGroup)}
             </div>
             </div>
             </div>

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -791,7 +791,7 @@ export default {
   'settings.display.activeSessionsOnly': 'Active sessions only',
   'settings.display.activeSessionsOnly.desc': 'Hide inactive sessions in the sidebar. The session you have open stays visible.',
   'settings.display.pinInProgressSessions': 'Pin in-progress sessions',
-  'settings.display.pinInProgressSessions.desc': 'Move working and pending sessions into a pinned In progress section at the top of the sidebar. Quiet active sessions stay inside their project directories. Off keeps everything in directory groups.',
+  'settings.display.pinInProgressSessions.desc': 'Move unpinned working and pending sessions into an In progress section. Global pins and projects with a project pin stay above that section; quiet actives stay in their project directories. Off keeps everything in directory groups.',
   'settings.display.sessionListStatus': 'Session list status',
   'settings.display.sessionListStatus.standard': 'Standard',
   'settings.display.sessionListStatus.detailed': 'Detailed',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -790,7 +790,7 @@ export default {
   'settings.display.activeSessionsOnly': '仅显示活跃会话',
   'settings.display.activeSessionsOnly.desc': '在侧边栏隐藏非活跃会话；当前打开的会话仍会保留显示。',
   'settings.display.pinInProgressSessions': '置顶进行中会话',
-  'settings.display.pinInProgressSessions.desc': '将运行中和待处理会话移到侧边栏顶部的「进行中」分区；安静的活跃会话仍留在各自项目目录分组中。关闭后全部保留在目录分组中。',
+  'settings.display.pinInProgressSessions.desc': '将未置顶的运行中和待处理会话移到「进行中」分区。全局置顶以及含项目置顶的项目分组仍在该分区之上；安静的活跃会话留在各自项目目录分组中。关闭后全部保留在目录分组中。',
   'settings.display.sessionListStatus': '会话列表状态',
   'settings.display.sessionListStatus.standard': '标准',
   'settings.display.sessionListStatus.detailed': '详细',


### PR DESCRIPTION
## Summary

- With Display → **Pin in-progress sessions** on, unpinned thinking/pending sessions float into the top **In progress** section and used to render above entire project groups that contain a **project pin**.
- This change keeps project-pinned rows inside their directory groups, but renders **groups that contain project pins above In progress** (still below the global pinned band).
- Settings copy (en / zh-CN) updated so the preference describes that hierarchy.

Target sidebar order:

1. Global pinned
2. Directory groups with a project pin
3. In progress (unpinned hot sessions)
4. Remaining directory groups

## Test plan

- [x] Vitest: `SessionList.directory-action.test.tsx` — new order assertion (`toAppearBefore`) plus existing pin / In progress cases (29/29)
- [x] Peer-stack Playwright proof: project-pin group above In progress above other groups
- [ ] Manual: Settings → Display → Pin in-progress ON; project-pin one session; leave another unpinned session thinking — project group sits above **In progress**

## Issues

Fixes #1431
