### PR TITLE
Fix confirmation dialog description alignment

### DIFF
--- a/web/src/components/ui/ConfirmDialog.test.tsx
+++ b/web/src/components/ui/ConfirmDialog.test.tsx
@@ -27,9 +27,11 @@ describe('ConfirmDialog', () => {
 
         const dialog = screen.getByRole('dialog')
         const title = within(dialog).getByRole('heading', { name: 'Archive Session' })
+        const description = within(dialog).getByText('Archive this session?')
 
         expect(title.parentElement).toHaveClass('pr-0')
         expect(title).toHaveClass('min-h-6', 'px-10', 'text-center', 'leading-6')
+        expect(description).toHaveClass('mt-2', 'text-left')
         expect(within(dialog).getByRole('button', { name: 'Close' })).toHaveClass('top-3', 'h-8')
     })
 

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -71,7 +71,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
                     >
                         {title}
                     </DialogTitle>
-                    <DialogDescription className="mt-2 whitespace-pre-line">
+                    <DialogDescription className="mt-2 whitespace-pre-line text-left">
                         {description}
                     </DialogDescription>
                 </DialogHeader>


### PR DESCRIPTION
## Summary

- Left-align confirmation dialog descriptions while keeping compact dialog titles centered.
- Add a regression assertion for the shared `ConfirmDialog` component.
- Apply the fix to archive and delete confirmation flows.

## Testing

- `bun run --cwd web test -- src/components/ui/ConfirmDialog.test.tsx src/components/SessionHeader.test.tsx src/components/SessionList.test.ts` — 56 passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name dialog-body-left-align -Suite Root -TestArgs terminal-wrap-fidelity.spec.ts` — 2 passed.
- Full task environment smoke check passed: authentication, test machine availability, seeded archive/delete sessions, and local/public HTTP 200 responses.

## AI-Generated Code Policy

This change was prepared with assistance from OpenAI Codex and reviewed against the project conventions and focused test results.
