### PR TITLE
fix(web): keep Pi controls available during message send

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
@@ -32,6 +32,7 @@ const runtime = vi.hoisted(() => ({
     setSnapshot: null as null | ((updater: (current: FakeRuntimeState) => FakeRuntimeState) => void),
     pendingSendIntentRef: null as null | { current: ComposerSendIntent },
     sentIntents: [] as ComposerSendIntent[],
+    modelChanges: [] as Array<{ provider: string; modelId: string } | string | null>,
 }))
 
 vi.mock('@assistant-ui/react', async () => {
@@ -107,7 +108,20 @@ vi.mock('@/hooks/useActiveSuggestions', () => ({ useActiveSuggestions: () => [[]
 vi.mock('@/components/ChatInput/FloatingOverlay', () => ({ FloatingOverlay: ({ children }: { children: ReactNode }) => <>{children}</> }))
 vi.mock('@/components/ChatInput/Autocomplete', () => ({ Autocomplete: () => null }))
 vi.mock('@/components/AssistantChat/StatusBar', () => ({ StatusBar: () => null }))
-vi.mock('./PiModelPanel', () => ({ PiModelPanel: () => null }))
+vi.mock('./PiModelPanel', () => ({
+    PiModelPanel: (props: {
+        controlsDisabled?: boolean
+        onSelect: (model: { provider: string; modelId: string }) => void
+    }) => (
+        <button
+            type="button"
+            disabled={props.controlsDisabled}
+            onClick={() => props.onSelect({ provider: 'pi', modelId: 'pi-next' })}
+        >
+            select model
+        </button>
+    ),
+}))
 vi.mock('./PiThinkingLevelPanel', () => ({ PiThinkingLevelPanel: () => null }))
 vi.mock('@/components/AssistantChat/ComposerButtons', () => ({
     ComposerButtons: (props: {
@@ -117,6 +131,9 @@ vi.mock('@/components/AssistantChat/ComposerButtons', () => ({
         pendingSchedule: PendingSchedule | null
         expanded: boolean
         onExpandedToggle: () => void
+        piModelLabel?: string
+        piModelDisabled?: boolean
+        onPiModelToggle?: () => void
     }) => (
         <div>
             <button type="button" onClick={props.onSend}>send</button>
@@ -125,6 +142,9 @@ vi.mock('@/components/AssistantChat/ComposerButtons', () => ({
             </button>
             <button type="button" onClick={() => props.onSchedule({ type: 'absolute', ms: 9000 })}>select schedule</button>
             <button type="button" onClick={props.onClearSchedule}>clear schedule</button>
+            {props.piModelLabel ? (
+                <button type="button" disabled={props.piModelDisabled} onClick={props.onPiModelToggle}>model</button>
+            ) : null}
             <output data-testid="pending-schedule">{JSON.stringify(props.pendingSchedule)}</output>
         </div>
     ),
@@ -138,6 +158,8 @@ type HarnessControls = {
     remount: () => void
     programmaticSetText: (text: string) => void
     acceptSend: () => void
+    setSending: (sending: boolean) => void
+    setThreadDisabled: (disabled: boolean) => void
     settleSend: (error?: ComposerSendError) => void
     settleAttachmentSendFailure: () => void
     getClearErrorCalls: () => number
@@ -192,6 +214,11 @@ function ComposerHarness(props: {
             setSendSettlement(null)
             setSendAcceptance({ attemptId: 'attempt-1' })
         },
+        setSending: setIsSending,
+        setThreadDisabled: (disabled) => setSnapshot((current) => ({
+            ...current,
+            thread: { ...current.thread, isDisabled: disabled },
+        })),
         settleSend: (error) => {
             if (error) setSendError(error)
             setSendSettlement({ attemptId: 'attempt-1', status: error ? 'error' : 'success' })
@@ -227,6 +254,8 @@ function ComposerHarness(props: {
                 )}
                 agentFlavor="pi"
                 thinking={props.piRunning}
+                piModels={[{ provider: 'pi', modelId: 'pi-model', name: 'Pi model' }]}
+                onModelChange={(model) => runtime.modelChanges.push(model)}
                 pendingSendIntentRef={pendingSendIntentRef}
             />
         </I18nProvider>
@@ -240,6 +269,7 @@ function renderComposer(
 ) {
     const controls: { current: HarnessControls | null } = { current: null }
     runtime.sentIntents = []
+    runtime.modelChanges = []
     render(<ComposerHarness initialText={initialText} initialSchedule={initialSchedule} piRunning={piRunning} controls={controls} />)
     return controls
 }
@@ -256,6 +286,18 @@ function fail(
 function send() {
     fireEvent.click(screen.getByRole('button', { name: 'send' }))
 }
+
+it('keeps Pi model selection available while a message is pending', () => {
+    const controls = renderComposer()
+
+    act(() => controls.current!.setThreadDisabled(true))
+
+    expect(screen.getByRole('button', { name: 'model' })).not.toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'model' }))
+    expect(screen.getByRole('button', { name: 'select model' })).not.toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'select model' }))
+    expect(runtime.modelChanges).toEqual([{ provider: 'pi', modelId: 'pi-next' }])
+})
 
 function acceptAndClearSchedule(controls: { current: HarnessControls | null }) {
     act(() => controls.current!.acceptAndClearSchedule())

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -502,7 +502,8 @@ export function HappyComposer(props: {
         onScratchlistParkingChange?.(isParkingScratchlist)
     }, [isParkingScratchlist, onScratchlistParkingChange])
 
-    const controlsDisabled = disabled || (!active && !allowSendWhenInactive) || threadIsDisabled || isParkingScratchlist
+    const configurationControlsDisabled = (!active && !allowSendWhenInactive) || isParkingScratchlist
+    const controlsDisabled = disabled || threadIsDisabled || configurationControlsDisabled
     const trimmed = composerText.trim()
     const hasText = trimmed.length > 0
     const hasAttachments = attachments.length > 0
@@ -1438,11 +1439,11 @@ export function HappyComposer(props: {
     }, [clearCursorDrillDown])
 
     const handleModelChange = useCallback((nextModel: { provider: string; modelId: string } | string | null) => {
-        if (!onModelChange || controlsDisabled) return
+        if (!onModelChange || configurationControlsDisabled) return
         onModelChange(nextModel)
         dismissSettings()
         haptic('light')
-    }, [onModelChange, controlsDisabled, haptic, dismissSettings])
+    }, [onModelChange, configurationControlsDisabled, haptic, dismissSettings])
 
     const handleCursorModelRowClick = useCallback((nextModel: string | null) => {
         if (!onModelChange || controlsDisabled) return
@@ -1537,11 +1538,11 @@ export function HappyComposer(props: {
     }, [onModelReasoningEffortChange, controlsDisabled, haptic, dismissSettings])
 
     const handleEffortChange = useCallback((nextEffort: string | null) => {
-        if (!onEffortChange || controlsDisabled) return
+        if (!onEffortChange || configurationControlsDisabled) return
         onEffortChange(nextEffort)
         dismissSettings()
         haptic('light')
-    }, [onEffortChange, controlsDisabled, haptic, dismissSettings])
+    }, [onEffortChange, configurationControlsDisabled, haptic, dismissSettings])
 
     const handleServiceTierChange = useCallback((nextServiceTier: string | null) => {
         if (!onServiceTierChange || controlsDisabled) return
@@ -1612,20 +1613,20 @@ export function HappyComposer(props: {
     }, [clearCursorDrillDown])
 
     const handlePiModelToggle = useCallback(() => {
-        if (controlsDisabled) return
+        if (configurationControlsDisabled) return
         setShowPiModelPanel((v) => !v)
         setShowSettings(false)
         setShowPiThinkingPanel(false)
         haptic('light')
-    }, [controlsDisabled, haptic])
+    }, [configurationControlsDisabled, haptic])
 
     const handlePiThinkingToggle = useCallback(() => {
-        if (controlsDisabled) return
+        if (configurationControlsDisabled) return
         setShowPiThinkingPanel((v) => !v)
         setShowSettings(false)
         setShowPiModelPanel(false)
         haptic('light')
-    }, [controlsDisabled, haptic])
+    }, [configurationControlsDisabled, haptic])
 
     const overlayPositionClass = isExpanded
         ? 'absolute z-10 bottom-12 mb-2'
@@ -1645,7 +1646,7 @@ export function HappyComposer(props: {
                         <PiModelPanel
                             models={piModels}
                             currentModel={currentPiModel ? { provider: currentPiModel.provider, modelId: currentPiModel.modelId } : null}
-                            controlsDisabled={controlsDisabled}
+                            controlsDisabled={configurationControlsDisabled}
                             onSelect={(piModel) => {
                                 handleModelChange({ provider: piModel.provider, modelId: piModel.modelId })
                             }}
@@ -1663,7 +1664,7 @@ export function HappyComposer(props: {
                             currentLevel={effort}
                             reasoning={selectedPiModel?.reasoning}
                             thinkingLevelMap={selectedPiModel?.thinkingLevelMap}
-                            controlsDisabled={controlsDisabled}
+                            controlsDisabled={configurationControlsDisabled}
                             onSelect={(level) => handleEffortChange(level)}
                             onClose={closeAllPanels}
                         />
@@ -2320,11 +2321,11 @@ export function HappyComposer(props: {
                             onClearSchedule={onUserClearSchedule}
                             hasAttachments={blocksScheduling}
                             piModelLabel={piModelLabel}
-                            piModelDisabled={controlsDisabled || !piHasModels}
+                            piModelDisabled={configurationControlsDisabled || !piHasModels}
                             piModelOpen={showPiModelPanel}
                             onPiModelToggle={handlePiModelToggle}
                             piThinkingLabel={piThinkingLabel}
-                            piThinkingDisabled={controlsDisabled || !piHasModels || !selectedPiModel || selectedPiModel.reasoning === false}
+                            piThinkingDisabled={configurationControlsDisabled || !piHasModels || !selectedPiModel || selectedPiModel.reasoning === false}
                             piThinkingOpen={showPiThinkingPanel}
                             onPiThinkingToggle={handlePiThinkingToggle}
                             scratchlistMode={props.scratchlistMode}


### PR DESCRIPTION
Fixes #1437.

Separates message-send disabling from Pi model/thinking configuration controls, so the model selector remains usable while a send is pending.

Tests:
- `bunx vitest run src/components/AssistantChat/HappyComposer.sendError.test.tsx`
- `bun run typecheck`
- Full `bun run test` was attempted; unrelated runner stress integration test failed under constrained capacity (tracked in #1441).