### PR TITLE
feat: restore mid-turn steer for Codex and Cursor

### DIFF
--- a/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
@@ -1142,6 +1142,193 @@ describe('AcpSdkBackend', () => {
         expect(registered.get('cursor/ask_question')).toBe(handler);
     });
 
+    it('beginSoftSteerPrompt sends concurrent session/prompt without cancel', () => {
+        const backend = new AcpSdkBackend({ command: 'agent' });
+        const calls: Array<{ method: string; params: unknown }> = [];
+        const backendInternal = backend as unknown as {
+            transport: {
+                sendRequestWithDispatch: (method: string, params: unknown, options?: { timeoutMs?: number }) => { dispatched: Promise<void>; completed: Promise<unknown> };
+                sendNotification: (method: string, params: unknown) => void;
+                close: () => Promise<void>;
+            } | null;
+            isProcessingMessage: boolean;
+        };
+        backendInternal.isProcessingMessage = true;
+        backendInternal.transport = {
+            sendRequestWithDispatch: (method, params) => {
+                calls.push({ method, params });
+                return { dispatched: Promise.resolve(), completed: Promise.resolve({ stopReason: 'end_turn' }) };
+            },
+            sendNotification: () => {},
+            close: async () => {}
+        };
+
+        backend.beginSoftSteerPrompt('session-1', [{ type: 'text', text: 'pivot now' }]);
+
+        expect(calls).toEqual([{
+            method: 'session/prompt',
+            params: {
+                sessionId: 'session-1',
+                prompt: [{ type: 'text', text: 'pivot now' }]
+            }
+        }]);
+    });
+
+    it('beginSoftSteerPrompt drains buffered output after completion', async () => {
+        const backend = new AcpSdkBackend({ command: 'agent' });
+        const backendInternal = backend as unknown as {
+            transport: {
+                sendRequestWithDispatch: (method: string, params: unknown, options?: { timeoutMs?: number }) => { dispatched: Promise<void>; completed: Promise<unknown> };
+                close: () => Promise<void>;
+            } | null;
+            isProcessingMessage: boolean;
+            waitForSessionUpdateQuiet: (quietMs: number, timeoutMs: number) => Promise<void>;
+            drainLateBuffers: () => Promise<void>;
+            messageHandler: { drainBuffers: () => void } | null;
+        };
+        const events: string[] = [];
+        backendInternal.isProcessingMessage = true;
+        backendInternal.transport = {
+            sendRequestWithDispatch: () => {
+                events.push('request');
+                return { dispatched: Promise.resolve(), completed: Promise.resolve({ stopReason: 'end_turn' }) };
+            },
+            close: async () => {}
+        };
+        backendInternal.waitForSessionUpdateQuiet = async () => {
+            events.push('quiet');
+        };
+        backendInternal.messageHandler = {
+            drainBuffers: () => events.push('drain')
+        };
+        backendInternal.drainLateBuffers = async () => {
+            events.push('late');
+        };
+
+        await backend.beginSoftSteerPrompt('session-1', [{ type: 'text', text: 'pivot now' }]).completed;
+
+        expect(events).toEqual(['request', 'quiet', 'drain', 'late', 'drain']);
+    });
+
+    it('beginSoftSteerPrompt returns a pending promise without blocking the caller', async () => {
+        const backend = new AcpSdkBackend({ command: 'agent' });
+        let resolvePrompt: ((value: unknown) => void) | null = null;
+        const backendInternal = backend as unknown as {
+            transport: {
+                sendRequestWithDispatch: (method: string, params: unknown, options?: { timeoutMs?: number }) => { dispatched: Promise<void>; completed: Promise<unknown> };
+                sendNotification: (method: string, params: unknown) => void;
+                close: () => Promise<void>;
+            } | null;
+            isProcessingMessage: boolean;
+        };
+        backendInternal.isProcessingMessage = true;
+        backendInternal.transport = {
+            sendRequestWithDispatch: () => ({
+                dispatched: Promise.resolve(),
+                completed: new Promise((resolve) => { resolvePrompt = resolve; })
+            }),
+            sendNotification: () => {},
+            close: async () => {}
+        };
+
+        // Must not hang waiting for the ACP prompt response (hub RPC is 30s).
+        let settled = false;
+        const pending = backend.beginSoftSteerPrompt('session-1', [{ type: 'text', text: 'pivot now' }]).completed.then(() => {
+            settled = true;
+        });
+        expect(resolvePrompt).not.toBeNull();
+        expect(settled).toBe(false);
+        resolvePrompt!({ stopReason: 'end_turn' });
+        await pending;
+        expect(settled).toBe(true);
+    });
+
+    it('keeps response completion pending until a concurrent soft steer settles', async () => {
+        const backend = new AcpSdkBackend({ command: 'agent' });
+        let resolvePrompt: ((value: unknown) => void) | null = null;
+        const backendInternal = backend as unknown as {
+            transport: { sendRequestWithDispatch: () => { dispatched: Promise<void>; completed: Promise<unknown> }; close: () => Promise<void> } | null;
+            isProcessingMessage: boolean;
+            activePromptRequests: number;
+            finishPromptRequest: () => void;
+            waitForSessionUpdateQuiet: () => Promise<void>;
+            drainLateBuffers: () => Promise<void>;
+        };
+        backendInternal.isProcessingMessage = true;
+        backendInternal.activePromptRequests = 1;
+        backendInternal.transport = {
+            sendRequestWithDispatch: () => ({
+                dispatched: Promise.resolve(),
+                completed: new Promise((resolve) => { resolvePrompt = resolve; })
+            }),
+            close: async () => {}
+        };
+        backendInternal.waitForSessionUpdateQuiet = async () => {};
+        backendInternal.drainLateBuffers = async () => {};
+
+        const pendingSteer = backend.beginSoftSteerPrompt('session-1', [{ type: 'text', text: 'pivot now' }]);
+        let responseComplete = false;
+        const responseWait = backend.waitForResponseComplete().then(() => { responseComplete = true; });
+
+        backendInternal.finishPromptRequest();
+        await Promise.resolve();
+        expect(backend.processingMessage).toBe(true);
+        expect(responseComplete).toBe(false);
+
+        resolvePrompt!({ stopReason: 'end_turn' });
+        await pendingSteer.completed;
+        await responseWait;
+        expect(backend.processingMessage).toBe(false);
+        expect(responseComplete).toBe(true);
+    });
+
+    it('softSteerPrompt awaits session/prompt completion', async () => {
+        const backend = new AcpSdkBackend({ command: 'agent' });
+        let resolvePrompt: ((value: unknown) => void) | null = null;
+        const backendInternal = backend as unknown as {
+            transport: {
+                sendRequest: (method: string, params: unknown, options?: { timeoutMs?: number }) => Promise<unknown>;
+                sendNotification: (method: string, params: unknown) => void;
+                close: () => Promise<void>;
+            } | null;
+            isProcessingMessage: boolean;
+        };
+        backendInternal.isProcessingMessage = true;
+        backendInternal.transport = {
+            sendRequest: () => new Promise((resolve) => {
+                resolvePrompt = resolve;
+            }),
+            sendNotification: () => {},
+            close: async () => {}
+        };
+
+        let done = false;
+        const pending = backend.softSteerPrompt('session-1', [{ type: 'text', text: 'pivot now' }]).then(() => {
+            done = true;
+        });
+        await Promise.resolve();
+        expect(done).toBe(false);
+        resolvePrompt!({ stopReason: 'end_turn' });
+        await pending;
+        expect(done).toBe(true);
+    });
+
+    it('beginSoftSteerPrompt rejects when no prompt is in flight', () => {
+        const backend = new AcpSdkBackend({ command: 'agent' });
+        const backendInternal = backend as unknown as {
+            transport: { sendRequest: () => Promise<unknown>; close: () => Promise<void> } | null;
+            isProcessingMessage: boolean;
+        };
+        backendInternal.isProcessingMessage = false;
+        backendInternal.transport = {
+            sendRequest: async () => null,
+            close: async () => {}
+        };
+
+        expect(() => backend.beginSoftSteerPrompt('session-1', [{ type: 'text', text: 'x' }]))
+            .toThrow(/No active ACP prompt/);
+    });
+
     it('suppressUpdatesDuring drops session/update notifications that would otherwise leak into the previous turn\'s onUpdate, then restores normal forwarding', async () => {
         // Reproduces the real /compact duplicate-summary bug: OpenCode keeps
         // streaming session/update notifications (over the same ACP

--- a/cli/src/agent/backends/acp/AcpSdkBackend.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.ts
@@ -77,6 +77,7 @@ export class AcpSdkBackend implements AgentBackend {
     private initializeInFlight: Promise<void> | null = null;
     private setModeSupported: boolean | undefined = undefined;
     private isProcessingMessage = false;
+    private activePromptRequests = 0;
     private promptRequestInFlight = false;
     private responseCompleteResolvers: Array<() => void> = [];
     private lastSessionUpdateAt = 0;
@@ -557,7 +558,7 @@ export class AcpSdkBackend implements AgentBackend {
             textChunkMode: this.options.textChunkMode,
             flavor: this.options.flavor,
         });
-        this.isProcessingMessage = true;
+        this.beginPromptRequest();
         this.lastSessionUpdateAt = Date.now();
         this.latestUsageUpdate = null;
         this.lastForwardedUsageUpdate = null;
@@ -635,8 +636,7 @@ export class AcpSdkBackend implements AgentBackend {
                 }
             } finally {
                 this.promptUsageCallback = null;
-                this.isProcessingMessage = false;
-                this.notifyResponseComplete();
+                this.finishPromptRequest();
             }
         }
     }
@@ -647,6 +647,83 @@ export class AcpSdkBackend implements AgentBackend {
         }
 
         this.transport.sendNotification('session/cancel', { sessionId });
+    }
+
+    /**
+     * Soft-inject a follow-up `session/prompt` while another prompt is in flight.
+     *
+     * Used for Cursor mid-turn steer (GUI "Send" / next-opportune soft send).
+     * Does **not** cancel the active prompt and does **not** swap message handlers —
+     * `session/update` notifications keep flowing to the in-flight turn's handler.
+     *
+     * Awaits the full concurrent `session/prompt` JSON-RPC response (turn completion
+     * for that inject). Do **not** call this from the hub `SteerQueuedMessage` handler —
+     * that RPC uses a 30s Socket.IO timeout. Use {@link beginSoftSteerPrompt} there.
+     */
+    async softSteerPrompt(sessionId: string, content: PromptContent[]): Promise<void> {
+        if (!this.transport) {
+            throw new Error('ACP transport not initialized');
+        }
+        if (!this.isProcessingMessage) {
+            throw new Error('No active ACP prompt to soft-steer into');
+        }
+
+        this.beginPromptRequest();
+        try {
+            await this.transport.sendRequest('session/prompt', {
+                sessionId,
+                prompt: content
+            }, { timeoutMs: Infinity });
+        } finally {
+            this.finishPromptRequest();
+        }
+    }
+
+    /**
+     * Kick off a soft steer without blocking the hub RPC on turn completion.
+     * Separates transport dispatch from prompt completion so callers can commit
+     * queue state only after stdin accepted the request without waiting for the turn.
+     */
+    beginSoftSteerPrompt(sessionId: string, content: PromptContent[]): {
+        dispatched: Promise<void>;
+        completed: Promise<void>;
+    } {
+        if (!this.transport) {
+            throw new Error('ACP transport not initialized');
+        }
+        if (!this.isProcessingMessage) {
+            throw new Error('No active ACP prompt to soft-steer into');
+        }
+
+        const transport = this.transport;
+        this.beginPromptRequest();
+        const request = transport.sendRequestWithDispatch('session/prompt', {
+            sessionId,
+            prompt: content
+        }, { timeoutMs: Infinity });
+        const completed = (async () => {
+            try {
+                await request.completed;
+            } finally {
+                try {
+                    await this.waitForSessionUpdateQuiet(
+                        AcpSdkBackend.UPDATE_QUIET_PERIOD_MS,
+                        AcpSdkBackend.UPDATE_DRAIN_TIMEOUT_MS
+                    );
+                    this.messageHandler?.drainBuffers();
+                    await this.drainLateBuffers();
+                    this.messageHandler?.drainBuffers();
+                } finally {
+                    this.finishPromptRequest();
+                }
+            }
+        })();
+
+        void completed.catch((error) => {
+            logger.warn('[ACP] soft-steer session/prompt failed', error);
+        });
+
+        return { dispatched: request.dispatched, completed };
     }
 
     async respondToPermission(
@@ -750,7 +827,7 @@ export class AcpSdkBackend implements AgentBackend {
      * Useful for checking if it's safe to perform session operations.
      */
     get processingMessage(): boolean {
-        return this.isProcessingMessage;
+        return this.activePromptRequests > 0;
     }
 
     isPromptRequestInFlight(): boolean {
@@ -768,7 +845,7 @@ export class AcpSdkBackend implements AgentBackend {
      * like session swap or sending task_complete.
      */
     async waitForResponseComplete(): Promise<void> {
-        if (!this.isProcessingMessage) {
+        if (this.activePromptRequests === 0) {
             return;
         }
         return new Promise<void>((resolve) => {
@@ -787,6 +864,7 @@ export class AcpSdkBackend implements AgentBackend {
         this.messageHandler?.drainBuffers();
         this.messageHandler = null;
         this.activeSessionId = null;
+        this.activePromptRequests = 0;
         this.isProcessingMessage = false;
         this.sessionModelsMetadata.clear();
         this.initialAvailableCommands.clear();
@@ -1065,6 +1143,19 @@ export class AcpSdkBackend implements AgentBackend {
         }
 
         return await responsePromise;
+    }
+
+    private beginPromptRequest(): void {
+        this.activePromptRequests++;
+        this.isProcessingMessage = true;
+    }
+
+    private finishPromptRequest(): void {
+        this.activePromptRequests = Math.max(0, this.activePromptRequests - 1);
+        this.isProcessingMessage = this.activePromptRequests > 0;
+        if (!this.isProcessingMessage) {
+            this.notifyResponseComplete();
+        }
     }
 
     private notifyResponseComplete(): void {

--- a/cli/src/agent/backends/acp/AcpStdioTransport.test.ts
+++ b/cli/src/agent/backends/acp/AcpStdioTransport.test.ts
@@ -74,7 +74,11 @@ vi.mock('node:child_process', () => ({
             },
             stdin: {
                 end: (...args: unknown[]) => spawnState.stdinEnd(...args),
-                write: (chunk: string) => spawnState.stdinWrite(chunk)
+                write: (chunk: string, callback?: (error?: Error | null) => void) => {
+                    const result = spawnState.stdinWrite(chunk);
+                    callback?.();
+                    return result;
+                }
             },
             on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
                 if (event === 'exit') {
@@ -91,7 +95,7 @@ vi.mock('node:child_process', () => ({
     })
 }));
 
-import { AcpStdioTransport } from './AcpStdioTransport';
+import { AcpRpcResponseError, AcpStdioTransport } from './AcpStdioTransport';
 import { killProcessByChildProcess } from '@/utils/process';
 
 function emitStdout(chunk: string): void {
@@ -235,6 +239,25 @@ describe('AcpStdioTransport plain-text stdout', () => {
         await expect(pending).resolves.toEqual({ ok: true });
         expect(spawnState.stdinEnd).not.toHaveBeenCalled();
         expect(killProcessByChildProcess).not.toHaveBeenCalled();
+        await transport.close();
+    });
+
+    test('classifies JSON-RPC error responses separately from transport failures', async () => {
+        const transport = await AcpStdioTransport.create({ command: 'gemini' });
+        const pending = transport.sendRequest('session/prompt');
+
+        emitStdout(`${JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            error: { code: -32602, message: 'prompt rejected', data: { reason: 'busy' } }
+        })}\n`);
+
+        await expect(pending).rejects.toMatchObject({
+            name: 'AcpRpcResponseError',
+            code: -32602,
+            data: { reason: 'busy' }
+        });
+        await expect(pending).rejects.toBeInstanceOf(AcpRpcResponseError);
         await transport.close();
     });
 
@@ -600,7 +623,11 @@ describe('AcpStdioTransport closed stdin writes', () => {
         });
 
         const transport = await AcpStdioTransport.create({ command: 'gemini' });
-        await expect(transport.sendRequest('initialize')).rejects.toThrow('WritableIterable is closed');
+        const request = transport.sendRequestWithDispatch('initialize');
+        await Promise.all([
+            expect(request.dispatched).rejects.toThrow('WritableIterable is closed'),
+            expect(request.completed).rejects.toThrow('WritableIterable is closed')
+        ]);
         await expect(transport.sendRequest('session/new')).rejects.toThrow('WritableIterable is closed');
     });
 });

--- a/cli/src/agent/backends/acp/AcpStdioTransport.ts
+++ b/cli/src/agent/backends/acp/AcpStdioTransport.ts
@@ -50,6 +50,18 @@ export type AcpStderrError = {
     raw: string;
 };
 
+export class AcpRpcResponseError extends Error {
+    readonly code: number;
+    readonly data?: unknown;
+
+    constructor(message: string, options: { code: number; data?: unknown }) {
+        super(message);
+        this.name = 'AcpRpcResponseError';
+        this.code = options.code;
+        this.data = options.data;
+    }
+}
+
 /** @internal Exported for regression tests. */
 export function buildAcpStdioSpawnOptions(env?: Record<string, string>): SpawnOptions {
     return {
@@ -244,10 +256,19 @@ export class AcpStdioTransport {
     static readonly DEFAULT_TIMEOUT_MS = 120_000;
 
     async sendRequest(method: string, params?: unknown, options?: { timeoutMs?: number }): Promise<unknown> {
+        const request = this.sendRequestWithDispatch(method, params, options);
+        void request.dispatched.catch(() => {});
+        return request.completed;
+    }
+
+    sendRequestWithDispatch(
+        method: string,
+        params?: unknown,
+        options?: { timeoutMs?: number }
+    ): { dispatched: Promise<void>; completed: Promise<unknown> } {
         if (this.closed || this.exited) {
-            return Promise.reject(
-                this.closeError ?? this.exitError ?? new Error('ACP transport is closed')
-            );
+            const error = this.closeError ?? this.exitError ?? new Error('ACP transport is closed');
+            return { dispatched: Promise.reject(error), completed: Promise.reject(error) };
         }
 
         const id = this.nextId++;
@@ -260,36 +281,54 @@ export class AcpStdioTransport {
 
         const timeoutMs = options?.timeoutMs ?? AcpStdioTransport.DEFAULT_TIMEOUT_MS;
 
-        // Skip timeout for infinite/no-timeout requests (e.g., long-running prompts)
-        if (!Number.isFinite(timeoutMs)) {
-            return new Promise<unknown>((resolve, reject) => {
-                this.pending.set(id, { resolve, reject });
-                this.writePayload(payload);
-            });
-        }
-
-        return new Promise<unknown>((resolve, reject) => {
-            const timer = setTimeout(() => {
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        let resolveCompleted!: (value: unknown) => void;
+        let rejectCompleted!: (error: Error) => void;
+        const completed = new Promise<unknown>((resolve, reject) => {
+            resolveCompleted = resolve;
+            rejectCompleted = reject;
+        });
+        if (Number.isFinite(timeoutMs)) {
+            timer = setTimeout(() => {
                 if (this.pending.has(id)) {
                     this.pending.delete(id);
-                    reject(new Error(`ACP request '${method}' timed out after ${timeoutMs}ms`));
+                    rejectCompleted(new Error(`ACP request '${method}' timed out after ${timeoutMs}ms`));
                 }
             }, timeoutMs);
-            // Don't let timer keep Node alive if process wants to exit
             timer.unref();
+        }
 
-            this.pending.set(id, {
-                resolve: (value) => {
-                    clearTimeout(timer);
-                    resolve(value);
-                },
-                reject: (error) => {
-                    clearTimeout(timer);
-                    reject(error);
-                }
-            });
-            this.writePayload(payload);
+        this.pending.set(id, {
+            resolve: (value) => {
+                if (timer) clearTimeout(timer);
+                resolveCompleted(value);
+            },
+            reject: (error) => {
+                if (timer) clearTimeout(timer);
+                rejectCompleted(error);
+            }
         });
+
+        const dispatched = new Promise<void>((resolve, reject) => {
+            try {
+                const serialized = JSON.stringify(payload);
+                this.process.stdin.write(`${serialized}\n`, (error) => {
+                    if (error) {
+                        const writeError = error instanceof Error ? error : new Error(String(error));
+                        this.markClosed(writeError);
+                        reject(writeError);
+                        return;
+                    }
+                    resolve();
+                });
+            } catch (error) {
+                const writeError = error instanceof Error ? error : new Error(String(error));
+                this.markClosed(writeError);
+                reject(writeError);
+            }
+        });
+
+        return { dispatched, completed };
     }
 
     sendNotification(method: string, params?: unknown): void {
@@ -443,7 +482,10 @@ export class AcpStdioTransport {
         this.pending.delete(response.id);
 
         if (response.error) {
-            pending.reject(new Error(response.error.message));
+            pending.reject(new AcpRpcResponseError(response.error.message, {
+                code: response.error.code,
+                data: response.error.data
+            }));
             return;
         }
 

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -30,7 +30,10 @@ const harness = vi.hoisted(() => ({
     stderrErrorHandler: null as ((error: { type: string; message: string; raw?: string }) => void) | null,
     disconnectError: null as Error | null,
     overlayCleanup: null as ReturnType<typeof vi.fn> | null,
-    agentActivityListener: null as ((thinking: boolean) => void) | null
+    agentActivityListener: null as ((thinking: boolean) => void) | null,
+    rpcHandlers: new Map<string, (payload: unknown) => unknown>(),
+    softSteerDispatched: Promise.resolve() as Promise<void>,
+    softSteerCompleted: Promise.resolve() as Promise<void>
 }));
 
 const legacyLauncher = vi.hoisted(() => vi.fn());
@@ -144,6 +147,13 @@ vi.mock('./utils/cursorAcpBackend', () => ({
                 const error = harness.promptErrors.shift();
                 if (error) throw error;
             }),
+            beginSoftSteerPrompt: vi.fn((_sessionId: string, content: unknown[]) => {
+                harness.prompts.push(content);
+                return {
+                    dispatched: harness.softSteerDispatched,
+                    completed: harness.softSteerCompleted
+                };
+            }),
             cancelPrompt: vi.fn(async () => {}),
             respondToPermission: vi.fn(async () => {}),
             onStderrError: vi.fn((handler) => {
@@ -241,7 +251,9 @@ function makeClient() {
     return {
         sessionId: 'test-session-id',
         rpcHandlerManager: {
-            registerHandler: vi.fn(),
+            registerHandler: vi.fn((method: string, handler: (payload: unknown) => unknown) => {
+                harness.rpcHandlers.set(method, handler);
+            }),
             unregisterHandler: vi.fn()
         },
         updateMetadata: vi.fn(),
@@ -250,7 +262,11 @@ function makeClient() {
         sendAgentMessage: vi.fn(),
         sendClaudeSessionMessage: vi.fn(),
         keepAlive: vi.fn(),
-        emitSessionReady: vi.fn()
+        emitSessionReady: vi.fn(),
+        updateAgentState: vi.fn(),
+        setSteerDeliveryState: vi.fn(async () => true),
+        emitSteerIndeterminate: vi.fn(),
+        emitMessagesConsumed: vi.fn()
     } as unknown as ApiSessionClient;
 }
 
@@ -282,6 +298,9 @@ describe('cursorAcpRemoteLauncher', () => {
         harness.disconnectError = null;
         harness.overlayCleanup = null;
         harness.agentActivityListener = null;
+        harness.rpcHandlers.clear();
+        harness.softSteerDispatched = Promise.resolve();
+        harness.softSteerCompleted = Promise.resolve();
         legacyLauncher.mockClear();
         process.stdin.isTTY = false;
         process.stdout.isTTY = false;
@@ -299,6 +318,42 @@ describe('cursorAcpRemoteLauncher', () => {
         expect(createCursorAcpBackend).toHaveBeenCalled();
         expect(harness.backendArgs).toEqual({ command: 'agent', args: ['acp'] });
         expect(legacyLauncher).not.toHaveBeenCalled();
+    });
+
+    it('soft-steers a queued message into an active Cursor ACP prompt', async () => {
+        let releasePrompt!: () => void;
+        harness.deferPrompt = new Promise((resolve) => { releasePrompt = resolve; });
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const client = makeClient();
+        const session = new CursorSession({
+            api: {} as never,
+            client,
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        const mode: EnhancedMode = { permissionMode: 'default' };
+        queue.push('main prompt', mode, 'main');
+        const running = cursorAcpRemoteLauncher(session);
+
+        await vi.waitFor(() => expect(harness.promptCalls).toBe(1));
+        queue.push('change direction', mode, 'steer');
+        const handler = harness.rpcHandlers.get('steer-queued-message');
+        expect(handler).toBeDefined();
+        await expect(Promise.resolve(handler?.({ localId: 'steer' }))).resolves.toEqual({ steered: true });
+        await vi.waitFor(() => expect(client.emitMessagesConsumed).toHaveBeenCalledWith(['steer'], { steered: true }));
+        expect(harness.prompts.at(-1)).toEqual([{ type: 'text', text: 'change direction' }]);
+
+        queue.close();
+        releasePrompt();
+        await running;
     });
 
     it('applies harness thinking transitions once per edge (#1470)', async () => {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -33,8 +33,9 @@ import { cursorPassThroughStatusMessage, parseCursorSpecialCommand } from './cur
 import { buildCursorModelsSeedPayload, seedCursorModelsCache } from '@/modules/common/cursorModels';
 import { readSharedCursorModelsCache } from '@/modules/common/cursorModelsSharedCache';
 import type { AcpSdkBackend } from '@/agent/backends/acp';
-import type { AcpStderrError } from '@/agent/backends/acp/AcpStdioTransport';
+import { AcpRpcResponseError, type AcpStderrError } from '@/agent/backends/acp/AcpStdioTransport';
 import { registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
+import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 import {
     cursorHapiMcpServerId,
     installCursorMcpOverlay,
@@ -74,6 +75,8 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     private attemptProducedToolActivity = false;
     private promptInFlight = false;
     private userAbortRequested = false;
+    private activePromptModeHash: string | null = null;
+    private softSteerWaiters: Promise<void>[] = [];
 
     constructor(session: CursorSession) {
         super(process.env.DEBUG ? session.logPath : undefined);
@@ -94,6 +97,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     protected async runMainLoop(): Promise<void> {
         const session = this.session;
         const messageBuffer = this.messageBuffer;
+        session.client.updateAgentState?.((state) => ({ ...state, steeringActive: false }));
 
         const { server: happyServer, mcpServers } = await buildHapiMcpBridge(session.client, {
             enableChangeTitle: false,
@@ -414,6 +418,99 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             onSwitch: () => this.handleSwitchRequest()
         });
 
+        session.client.rpcHandlerManager.registerHandler(
+            RPC_METHODS.SteerQueuedMessage,
+            async (payload: unknown) => {
+                const localId = typeof (payload as { localId?: unknown } | null)?.localId === 'string'
+                    ? (payload as { localId: string }).localId
+                    : '';
+                if (!localId) return { steered: false, error: 'Missing localId' };
+                if (!this.promptInFlight || !this.acpSessionId || !this.backend) {
+                    return { steered: false, error: 'No active steerable turn' };
+                }
+                if (this.softSteerWaiters.length > 0) {
+                    return { steered: false, error: 'Another steer is already in progress' };
+                }
+
+                const taken = session.queue.takeByLocalId(localId);
+                if (!taken) return { steered: false, error: 'Message not in queue' };
+                const isControlCommand = Boolean(taken.item.isolate)
+                    || parseCursorSpecialCommand(taken.item.message).type !== null;
+                if (isControlCommand) {
+                    session.queue.restoreReservation(taken);
+                    return { steered: false, error: 'Control commands cannot be steered' };
+                }
+                if (this.activePromptModeHash !== taken.item.modeHash) {
+                    session.queue.restoreReservation(taken);
+                    return { steered: false, error: 'Queued message mode differs from the active turn' };
+                }
+                if (!session.queue.beginReservationDispatch(taken)) {
+                    return { steered: false, error: 'Steer cancelled' };
+                }
+                if (!await session.client.setSteerDeliveryState([localId], 'dispatching')) {
+                    session.queue.markReservationIndeterminate(taken);
+                    session.client.emitSteerIndeterminate([localId]);
+                    return { steered: false, error: 'Steer state is indeterminate' };
+                }
+
+                const restoreQueued = async () => {
+                    if (!await session.client.setSteerDeliveryState([localId], 'queued')) {
+                        session.queue.markReservationIndeterminate(taken);
+                        session.client.emitSteerIndeterminate([localId]);
+                        return false;
+                    }
+                    return session.queue.restoreReservation(taken);
+                };
+
+                let steer: ReturnType<AcpSdkBackend['beginSoftSteerPrompt']>;
+                try {
+                    steer = this.backend.beginSoftSteerPrompt(this.acpSessionId, [{
+                        type: 'text',
+                        text: taken.item.message
+                    }]);
+                } catch (error) {
+                    await restoreQueued();
+                    return {
+                        steered: false,
+                        error: error instanceof Error ? error.message : 'Failed to soft-steer into active turn'
+                    };
+                }
+                const settle = (async () => {
+                    try {
+                        await steer.dispatched;
+                        await steer.completed;
+                        session.queue.commitReservation(taken);
+                        messageBuffer.addMessage(taken.item.message, 'user');
+                        session.client.emitMessagesConsumed([localId], { steered: true });
+                    } catch (error) {
+                        if (error instanceof AcpRpcResponseError) {
+                            await restoreQueued();
+                            return;
+                        }
+                        session.queue.markReservationIndeterminate(taken);
+                        session.client.emitSteerIndeterminate([localId]);
+                    }
+                })();
+                this.softSteerWaiters.push(settle);
+                void settle.catch((error) => {
+                    logger.debug('[cursor-acp] failed to settle soft steer', error);
+                }).finally(() => {
+                    this.softSteerWaiters = this.softSteerWaiters.filter((waiter) => waiter !== settle);
+                });
+
+                try {
+                    await steer.dispatched;
+                    return { steered: true };
+                } catch (error) {
+                    await settle;
+                    return {
+                        steered: false,
+                        error: error instanceof Error ? error.message : 'Failed to soft-steer into active turn'
+                    };
+                }
+            }
+        );
+
         const sendReady = () => {
             session.sendSessionEvent({ type: 'ready' });
         };
@@ -466,6 +563,8 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
 
             try {
                 this.promptInFlight = true;
+                this.activePromptModeHash = batch.hash;
+                session.client.updateAgentState?.((state) => ({ ...state, steeringActive: true }));
                 this.userAbortRequested = false;
                 for (let retryAttempt = 0; retryAttempt <= CURSOR_AUTO_RETRY_LIMIT; retryAttempt += 1) {
                     this.pendingRetryableError = null;
@@ -508,10 +607,16 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                 }
             } finally {
                 this.promptInFlight = false;
+                session.client.updateAgentState?.((state) => ({ ...state, steeringActive: false }));
                 this.pendingRetryableError = null;
                 this.pendingRetryableFromStderr = false;
                 this.pendingInlineRetryableError = false;
                 this.attemptProducedToolActivity = false;
+                if (this.softSteerWaiters.length > 0) {
+                    await Promise.allSettled(this.softSteerWaiters);
+                    this.softSteerWaiters = [];
+                }
+                this.activePromptModeHash = null;
                 session.onThinkingChange(false);
                 await this.permissionAdapter?.cancelAll('Prompt finished');
                 await this.extensionAdapter?.cancelAll('Prompt finished');
@@ -530,6 +635,11 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
 
         try {
             this.clearAbortHandlers(this.session.client.rpcHandlerManager);
+            this.session.client.rpcHandlerManager.registerHandler(RPC_METHODS.SteerQueuedMessage, async () => ({
+                steered: false,
+                error: 'Session ending'
+            }));
+            this.session.client.updateAgentState?.((state) => ({ ...state, steeringActive: false }));
             this.unregisterModelApplyHandler?.();
             this.unregisterModelApplyHandler = null;
 
@@ -894,6 +1004,8 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
         await this.permissionAdapter?.cancelAll('User aborted');
         await this.extensionAdapter?.cancelAll('User aborted');
         this.session.queue.reset();
+        this.activePromptModeHash = null;
+        this.session.client.updateAgentState?.((state) => ({ ...state, steeringActive: false }));
         this.session.onThinkingChange(false);
         this.abortController.abort();
         this.abortController = new AbortController();

--- a/shared/src/modes.test.ts
+++ b/shared/src/modes.test.ts
@@ -133,10 +133,10 @@ describe('claude auto permission mode', () => {
 })
 
 describe('isSteeringSupportedForFlavor', () => {
-    it('supports codex and pi only', () => {
+    it('supports codex, pi, and cursor', () => {
         expect(isSteeringSupportedForFlavor('codex')).toBe(true)
         expect(isSteeringSupportedForFlavor('pi')).toBe(true)
-        expect(isSteeringSupportedForFlavor('cursor')).toBe(false)
+        expect(isSteeringSupportedForFlavor('cursor')).toBe(true)
         expect(isSteeringSupportedForFlavor('claude')).toBe(false)
         expect(isSteeringSupportedForFlavor('opencode')).toBe(false)
         expect(isSteeringSupportedForFlavor(undefined)).toBe(false)
@@ -150,13 +150,18 @@ describe('isSteeringSupportedForSession', () => {
         expect(isSteeringSupportedForSession({ flavor: 'pi' })).toBe(true)
     })
 
-    it('rejects cursor until its steer handler lands', () => {
+    it('supports Cursor ACP and rejects legacy stream-json sessions', () => {
         expect(isSteeringSupportedForSession({
             flavor: 'cursor',
             cursorSessionProtocol: 'acp',
             cursorSessionId: 'sess-1',
+        })).toBe(true)
+        expect(isSteeringSupportedForSession({
+            flavor: 'cursor',
+            cursorSessionProtocol: 'stream-json',
+            cursorSessionId: 'sess-1',
         })).toBe(false)
-        expect(isSteeringSupportedForSession({ flavor: 'cursor' })).toBe(false)
+        expect(isSteeringSupportedForSession({ flavor: 'cursor' })).toBe(true)
     })
 
     it('rejects non-steerable flavors', () => {

--- a/shared/src/modes.ts
+++ b/shared/src/modes.ts
@@ -195,7 +195,7 @@ export function getCodexCollaborationModeOptions(): CodexCollaborationModeOption
  *
  * Claude / others: not supported (no reachable soft-steer path) — UI hides Steer.
  */
-export const STEERING_SUPPORTED_FLAVORS = ['codex', 'pi'] as const
+export const STEERING_SUPPORTED_FLAVORS = ['codex', 'pi', 'cursor'] as const
 
 export function isSteeringSupportedForFlavor(flavor?: string | null): boolean {
     return (STEERING_SUPPORTED_FLAVORS as readonly string[]).includes(flavor ?? '')
@@ -217,5 +217,8 @@ export function isSteeringSupportedForSession(metadata?: {
     if (metadata?.flavor === 'codex' || metadata?.flavor === 'pi') {
         return true
     }
-    return false
+    if (metadata?.flavor !== 'cursor') return false
+    if (metadata.cursorSessionProtocol === 'stream-json') return false
+    if (!metadata.cursorSessionProtocol && metadata.cursorSessionId) return false
+    return true
 }


### PR DESCRIPTION
## Summary

- restore per-message **Steer** for queued Codex messages via app-server `turn/steer`
- support Cursor ACP soft send without interrupting the active prompt
- expose live steer availability in session state and preserve the steered marker in the web timeline
- keep Pi automatic steer unchanged; Claude and legacy Cursor remain unsupported

This rebases and supersedes #906 on current `main`, with additional queue-race, shutdown, dispatch, Hub, and Web double-click coverage.

Original implementation by @swear01. The commit retains the original author as co-author.

## Testing

- `bun typecheck`
- targeted: Codex launcher 78, MessageQueue2 37, Cursor ACP/relevant CLI 206, Hub 3, Web queued bar 33
- prior full package runs: Hub 1004 passed / 3 skipped; Web 2287 passed; Shared 228 passed
- full CLI: 2337 passed / 1 skipped; 10 existing AGY platform-scope failures reproduced unchanged on upstream

No browser binaries were installed or run.