### PR TITLE
fix(pi): sync native session name

### DIFF
--- a/cli/src/pi/loop.test.ts
+++ b/cli/src/pi/loop.test.ts
@@ -293,6 +293,24 @@ describe('wireTransportEvents', () => {
         expect(session.client.emitSessionReady).toHaveBeenCalledTimes(1);
     });
 
+    it('syncs a native sessionName from get_state as the HAPI title', () => {
+        const transport = createMockTransport();
+        wireTransportEvents(transport, session, []);
+
+        emitEvent({
+            type: 'response',
+            command: 'get_state',
+            success: true,
+            data: { sessionName: '  Native Pi Title  ' },
+        });
+
+        expect(session.client.updateMetadata).toHaveBeenCalledTimes(1);
+        const updateMetadata = session.client.updateMetadata as ReturnType<typeof vi.fn>;
+        expect(updateMetadata.mock.calls[0]![0]({ path: '/tmp/test', host: 'localhost' })).toMatchObject({
+            summary: { text: 'Native Pi Title' },
+        });
+    });
+
     it('marks session ready on get_state response (drains buffered sends) — issue #1143', () => {
         const transport = createMockTransport();
         wireTransportEvents(transport, session, []);

--- a/cli/src/pi/loop.test.ts
+++ b/cli/src/pi/loop.test.ts
@@ -311,6 +311,44 @@ describe('wireTransportEvents', () => {
         });
     });
 
+    it('syncs a live native rename from session_info_changed as the HAPI title', () => {
+        const transport = createMockTransport();
+        wireTransportEvents(transport, session, []);
+
+        emitEvent({ type: 'session_info_changed', name: 'Renamed Pi Session' });
+
+        expect(session.client.updateMetadata).toHaveBeenCalledTimes(1);
+        const updateMetadata = session.client.updateMetadata as ReturnType<typeof vi.fn>;
+        expect(updateMetadata.mock.calls[0]![0]({ path: '/tmp/test', host: 'localhost' })).toMatchObject({
+            summary: { text: 'Renamed Pi Session' },
+        });
+    });
+
+    it('dedupes identical native titles across get_state and session_info_changed', () => {
+        const transport = createMockTransport();
+        wireTransportEvents(transport, session, []);
+
+        emitEvent({
+            type: 'response',
+            command: 'get_state',
+            success: true,
+            data: { sessionName: 'Same Title' },
+        });
+        emitEvent({ type: 'session_info_changed', name: 'Same Title' });
+
+        expect(session.client.updateMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores malformed or empty session_info_changed events', () => {
+        const transport = createMockTransport();
+        wireTransportEvents(transport, session, []);
+
+        emitEvent({ type: 'session_info_changed' });
+        emitEvent({ type: 'session_info_changed', name: '   ' });
+
+        expect(session.client.updateMetadata).not.toHaveBeenCalled();
+    });
+
     it('marks session ready on get_state response (drains buffered sends) — issue #1143', () => {
         const transport = createMockTransport();
         wireTransportEvents(transport, session, []);

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -5,7 +5,7 @@ import { PiTransport } from './piTransport';
 import { convertPiEvent, convertPiTurnUsage } from './piEventConverter';
 import { PiMessageAccumulator } from './piMessageAccumulator';
 import { PiExtensionUiHandler } from './extensionUiHandler';
-import { parsePiModels, parsePiCommands, parsePiContextUsage, PiAgentEndEventSchema, PiAgentSettledEventSchema, PiExtensionUiRequestSchema, PiLifecycleEventSchema, PiResponseEventSchema, PiStateDataSchema, PiSetModelDataSchema } from './schemas';
+import { parsePiModels, parsePiCommands, parsePiContextUsage, PiAgentEndEventSchema, PiAgentSettledEventSchema, PiExtensionUiRequestSchema, PiLifecycleEventSchema, PiResponseEventSchema, PiSessionInfoChangedEventSchema, PiStateDataSchema, PiSetModelDataSchema } from './schemas';
 import type { PiContextUsage, PiResponseEvent, PiRpcCommand, PiThinkingLevel, PiTurnEndEvent } from './types';
 import type { PiSession } from './session';
 import type { PiConversationHistory } from './conversationHistory';
@@ -124,6 +124,7 @@ function applyGetState(
         isStreaming?: boolean;
     },
     session: PiSession,
+    syncNativeTitle: (title: unknown) => void,
     applyStreamingState = true,
 ): void {
 
@@ -155,7 +156,7 @@ function applyGetState(
         logger.debug(`[pi] Session ID persisted to metadata: ${data.sessionId}`);
     }
 
-    createNativeSessionTitleMetadataSync(session.client)(data.sessionName);
+    syncNativeTitle(data.sessionName);
 
     if (data.thinkingLevel) {
         session.currentThinkingLevel = data.thinkingLevel as PiThinkingLevel;
@@ -183,6 +184,7 @@ function handleResponse(
     conversationHistory?: PiConversationHistory,
     onReady?: () => void,
     shouldApplyGetStateStreaming?: (isStreaming: boolean) => boolean,
+    syncNativeTitle?: (title: unknown) => void,
 ): { rejectedPromptLocalId?: string } {
     const { command, success } = response;
     const resolver = session.rpcResolver!;
@@ -252,7 +254,7 @@ function handleResponse(
                 if (!applyStreamingState) {
                     logger.debug('[pi] Ignoring get_state isStreaming=false during an active prompt lifecycle');
                 }
-                applyGetState(state, session, applyStreamingState);
+                applyGetState(state, session, syncNativeTitle ?? (() => {}), applyStreamingState);
                 onReady?.();
             }
             resolvePendingRpc(resolver, response);
@@ -502,6 +504,10 @@ export function wireTransportEvents(
         session: session.client,
         sendResponse: (response) => transport.send(response),
     });
+    // Shared dedup state for native Pi titles (get_state startup/resume and
+    // live session_info_changed renames) so repeated identical names do not
+    // trigger redundant updateMetadata calls.
+    const syncNativeTitle = createNativeSessionTitleMetadataSync(session.client);
     const lifecycleTimeline = new PiLifecycleTimeline();
     let latestContextUsageRequest = 0;
     let deliveredSettlement = false;
@@ -692,6 +698,7 @@ export function wireTransportEvents(
                             && (activePromptId !== null || agentLifecycleSeen);
                         return !promptLifecycleActive;
                     },
+                    syncNativeTitle,
                 );
                 if (isCurrentPrompt && !parsed.data.success) {
                     const rejectedLocalId = responseOutcome.rejectedPromptLocalId ?? activePromptLocalId;
@@ -732,6 +739,19 @@ export function wireTransportEvents(
                 extensionUi.handle(parsed.data);
             } else {
                 logger.debug('[pi] Ignoring malformed extension_ui_request');
+            }
+            return;
+        }
+
+        if (event.type === 'session_info_changed') {
+            // Pi emits this for `/name` and the set_session_name RPC. Mirror the
+            // native rename into HAPI metadata so the web title stays in sync
+            // without any HAPI-injected change_title flow (issue #1440).
+            const parsed = PiSessionInfoChangedEventSchema.safeParse(event);
+            if (parsed.success) {
+                syncNativeTitle(parsed.data.name);
+            } else {
+                logger.debug('[pi] Ignoring malformed session_info_changed');
             }
             return;
         }

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -1,5 +1,6 @@
 import { logger } from '@/ui/logger';
 import { convertAgentMessage } from '@/agent/messageConverter';
+import { createNativeSessionTitleMetadataSync } from '@/agent/nativeSessionTitle';
 import { PiTransport } from './piTransport';
 import { convertPiEvent, convertPiTurnUsage } from './piEventConverter';
 import { PiMessageAccumulator } from './piMessageAccumulator';
@@ -117,6 +118,7 @@ function applyGetState(
     data: {
         model?: { id?: string; modelId?: string; provider?: string };
         sessionId?: string;
+        sessionName?: string;
         thinkingLevel?: string;
         steeringMode?: 'all' | 'one-at-a-time';
         isStreaming?: boolean;
@@ -152,6 +154,8 @@ function applyGetState(
         session.updateMetadata((meta) => ({ ...meta, piSessionId: data.sessionId }));
         logger.debug(`[pi] Session ID persisted to metadata: ${data.sessionId}`);
     }
+
+    createNativeSessionTitleMetadataSync(session.client)(data.sessionName);
 
     if (data.thinkingLevel) {
         session.currentThinkingLevel = data.thinkingLevel as PiThinkingLevel;

--- a/cli/src/pi/schemas.ts
+++ b/cli/src/pi/schemas.ts
@@ -205,6 +205,11 @@ const PiSummarizationRetryScheduledEventSchema = z.object({
     errorMessage: z.string(),
 });
 
+export const PiSessionInfoChangedEventSchema = z.object({
+    type: z.literal('session_info_changed'),
+    name: z.string(),
+}).passthrough();
+
 export const PiLifecycleEventSchema = z.union([
     PiCompactionStartEventSchema,
     PiCompactionEndEventSchema,

--- a/cli/src/pi/schemas.ts
+++ b/cli/src/pi/schemas.ts
@@ -321,6 +321,7 @@ export const PiStateDataSchema = z.object({
         provider: z.string().optional(),
     }).passthrough().optional(),
     sessionId: z.string().optional(),
+    sessionName: z.string().optional(),
     sessionFile: z.string().optional(),
     thinkingLevel: z.string().optional(),
     steeringMode: z.enum(['all', 'one-at-a-time']).optional(),


### PR DESCRIPTION
Fixes #1440.

Pi now parses `get_state.sessionName` and mirrors valid native names through the existing native-title metadata sync.

Tests:
- `bun typecheck`
- `bunx vitest run src/pi/loop.test.ts`
- Peak-hours exception: skipped `cli/src/runner/runner.integration.test.ts`.