### PR TITLE
Fix dictation locale for OpenAI-compatible transcription

### DIFF
--- a/hub/src/web/routes/voice.test.ts
+++ b/hub/src/web/routes/voice.test.ts
@@ -161,6 +161,46 @@ describe('voice transcription routes', () => {
         else process.env.OPENAI_API_KEY = previousKey
     })
 
+    test('preserves the selected locale for OpenAI-compatible transcription', async () => {
+        const app = createApp()
+        const headers = await authHeaders()
+        const previous = {
+            baseUrl: process.env.TRANSCRIPTION_BASE_URL,
+            model: process.env.TRANSCRIPTION_MODEL,
+            apiKey: process.env.TRANSCRIPTION_API_KEY
+        }
+        process.env.TRANSCRIPTION_BASE_URL = 'http://localhost:8000/v1'
+        process.env.TRANSCRIPTION_MODEL = 'local-whisper'
+        process.env.TRANSCRIPTION_API_KEY = 'server-only-key'
+        const originalFetch = global.fetch
+        let upstreamInit: RequestInit | undefined
+        // @ts-expect-error test override
+        global.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+            upstreamInit = init
+            return new Response(JSON.stringify({ text: 'transcribed text' }), { status: 200 })
+        }) as typeof fetch
+
+        const form = new FormData()
+        form.set('provider', 'openai-compatible')
+        form.set('mode', 'standard')
+        form.set('language', 'zh-TW')
+        form.set('file', new File(['audio bytes'], 'speech.webm', { type: 'audio/webm' }))
+        const res = await app.request('/api/voice/transcription', { method: 'POST', headers, body: form })
+
+        expect(res.status).toBe(200)
+        expect((upstreamInit?.body as FormData).get('language')).toBe('zh-TW')
+
+        global.fetch = originalFetch
+        for (const [key, value] of Object.entries({
+            TRANSCRIPTION_BASE_URL: previous.baseUrl,
+            TRANSCRIPTION_MODEL: previous.model,
+            TRANSCRIPTION_API_KEY: previous.apiKey
+        })) {
+            if (value === undefined) delete process.env[key]
+            else process.env[key] = value
+        }
+    })
+
     test('rejects unsupported files before calling a provider', async () => {
         const app = createApp()
         const headers = await authHeaders()

--- a/hub/src/web/routes/voice.ts
+++ b/hub/src/web/routes/voice.ts
@@ -135,6 +135,7 @@ async function transcribeStandard(
         if (baseLanguage) {
             if (provider === 'elevenlabs') form.set('language_code', baseLanguage)
             else if (provider === 'openai') form.set('languages[]', normalizeOpenAILanguage(language) ?? baseLanguage)
+            else if (provider === 'openai-compatible') form.set('language', language ?? baseLanguage)
             else form.set('language', baseLanguage)
         }
         url = provider === 'elevenlabs'


### PR DESCRIPTION
Fixes #1444

Preserves the selected BCP-47 locale, such as `zh-TW`, when sending standard dictation requests to OpenAI-compatible providers.

Tests: `bun typecheck`; all test suites passed with only the explicitly skipped runner stress test.

Generated with OpenAI Codex.