### PR TITLE
fix(agy): preserve PTY running status

### DIFF
--- a/cli/src/agent/__tests__/runAgentPty.test.ts
+++ b/cli/src/agent/__tests__/runAgentPty.test.ts
@@ -204,6 +204,80 @@ describe('runAgentPty', () => {
         vi.useRealTimers()
     })
 
+    it('keeps thinking through a quiet turn when the silence watchdog is disabled', async () => {
+        vi.useFakeTimers()
+        const thinking = vi.fn()
+        const promise = runAgentPty(makeOpts({
+            promptMarkers: ['READY'],
+            busyMarkers: ['Generating'],
+            idleMarkers: ['? for shortcuts'],
+            requirePromptMarker: true,
+            thinkingSilenceTimeoutMs: null,
+            nextMessage: vi.fn()
+                .mockResolvedValueOnce({ message: 'first' })
+                .mockImplementationOnce(() => new Promise<{ message: string } | null>(() => {})),
+            onThinkingChange: thinking,
+        }))
+
+        harness.triggerData('READY')
+        await vi.advanceTimersByTimeAsync(520)
+        expect(thinking).toHaveBeenLastCalledWith(true)
+
+        await vi.advanceTimersByTimeAsync(3000)
+        expect(thinking).not.toHaveBeenCalledWith(false)
+
+        harness.triggerData('? for shortcuts')
+        expect(thinking).toHaveBeenLastCalledWith(false)
+
+        harness.triggerExit(0)
+        await vi.advanceTimersByTimeAsync(100)
+        await promise
+        vi.useRealTimers()
+    })
+
+    it('recognizes a busy marker fragmented across PTY output chunks', async () => {
+        const pending = deferred<{ message: string } | null>()
+        const thinking = vi.fn()
+        const promise = runAgentPty(makeOpts({
+            promptMarkers: ['READY'],
+            busyMarkers: ['Generating'],
+            requirePromptMarker: true,
+            nextMessage: () => pending.promise,
+            onThinkingChange: thinking,
+        }))
+
+        harness.triggerData('READY')
+        await tick(220)
+        harness.triggerData('Gener')
+        harness.triggerData('ating...')
+
+        expect(thinking).toHaveBeenCalledWith(true)
+
+        harness.triggerExit(0)
+        await promise
+    })
+
+    it('recognizes a busy marker interrupted by ANSI output', async () => {
+        const pending = deferred<{ message: string } | null>()
+        const thinking = vi.fn()
+        const promise = runAgentPty(makeOpts({
+            promptMarkers: ['READY'],
+            busyMarkers: ['Generating'],
+            requirePromptMarker: true,
+            nextMessage: () => pending.promise,
+            onThinkingChange: thinking,
+        }))
+
+        harness.triggerData('READY')
+        await tick(220)
+        harness.triggerData('Gener\x1b[31mating...')
+
+        expect(thinking).toHaveBeenCalledWith(true)
+
+        harness.triggerExit(0)
+        await promise
+    })
+
     it('does not let an armed silence watchdog complete a run after its idle marker already did', async () => {
         vi.useFakeTimers()
         const done = deferred<{ message: string } | null>()

--- a/cli/src/agent/__tests__/runAgentPty.test.ts
+++ b/cli/src/agent/__tests__/runAgentPty.test.ts
@@ -235,6 +235,41 @@ describe('runAgentPty', () => {
         vi.useRealTimers()
     })
 
+    it('lets a trailing idle marker win when it shares a chunk with a busy marker (no watchdog)', async () => {
+        vi.useFakeTimers()
+        const thinking = vi.fn()
+        const nextMessage = vi.fn()
+            .mockResolvedValueOnce({ message: 'first' })
+            .mockImplementationOnce(() => new Promise<{ message: string } | null>(() => {}))
+        const promise = runAgentPty(makeOpts({
+            promptMarkers: ['READY'],
+            busyMarkers: ['Generating'],
+            idleMarkers: ['? for shortcuts'],
+            requirePromptMarker: true,
+            thinkingSilenceTimeoutMs: null,
+            nextMessage,
+            onThinkingChange: thinking,
+        }))
+
+        harness.triggerData('READY')
+        await vi.advanceTimersByTimeAsync(520)
+        expect(thinking).toHaveBeenLastCalledWith(true)
+
+        // One ANSI-decorated chunk carries both the busy frame and the final
+        // idle footer. With the watchdog disabled the busy marker alone would
+        // strand the run in the running state forever; the trailing idle marker
+        // must win and make the prompt input-ready again.
+        harness.triggerData('Generating \x1b[31m...\x1b[0m\r\n? for shortcuts')
+        expect(thinking).toHaveBeenLastCalledWith(false)
+        await vi.advanceTimersByTimeAsync(200)
+        expect(nextMessage).toHaveBeenCalledTimes(2)
+
+        harness.triggerExit(0)
+        await vi.advanceTimersByTimeAsync(100)
+        await promise
+        vi.useRealTimers()
+    })
+
     it('recognizes a busy marker fragmented across PTY output chunks', async () => {
         const pending = deferred<{ message: string } | null>()
         const thinking = vi.fn()

--- a/cli/src/agent/__tests__/runAgentPty.test.ts
+++ b/cli/src/agent/__tests__/runAgentPty.test.ts
@@ -270,6 +270,42 @@ describe('runAgentPty', () => {
         vi.useRealTimers()
     })
 
+    it('sees a busy marker in a single callback larger than the prompt buffer', async () => {
+        vi.useFakeTimers()
+        const thinking = vi.fn()
+        const onAgentRunCompleted = vi.fn()
+        const promise = runAgentPty(makeOpts({
+            promptMarkers: ['READY'],
+            busyMarkers: ['Generating'],
+            idleMarkers: ['? for shortcuts'],
+            requirePromptMarker: true,
+            thinkingSilenceTimeoutMs: null,
+            nextMessage: vi.fn()
+                .mockResolvedValueOnce({ message: 'first' })
+                .mockImplementationOnce(() => new Promise<{ message: string } | null>(() => {})),
+            onThinkingChange: thinking,
+            onAgentRunCompleted,
+        }))
+
+        harness.triggerData('READY')
+        await vi.advanceTimersByTimeAsync(520)
+        expect(thinking).toHaveBeenLastCalledWith(true)
+
+        // One callback: busy marker, then more than PROMPT_BUFFER_SIZE bytes,
+        // then the idle footer. The busy marker must not be lost to the
+        // truncation, or the agent run never completes and the pending web
+        // delivery stays blocked.
+        const filler = 'x'.repeat(5000)
+        harness.triggerData(`Generating ${filler}\r\n? for shortcuts`)
+        expect(thinking).toHaveBeenLastCalledWith(false)
+        expect(onAgentRunCompleted).toHaveBeenCalledTimes(1)
+
+        harness.triggerExit(0)
+        await vi.advanceTimersByTimeAsync(100)
+        await promise
+        vi.useRealTimers()
+    })
+
     it('recognizes a busy marker fragmented across PTY output chunks', async () => {
         const pending = deferred<{ message: string } | null>()
         const thinking = vi.fn()

--- a/cli/src/agent/runAgentPty.ts
+++ b/cli/src/agent/runAgentPty.ts
@@ -194,16 +194,15 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
             if (typeof marker === 'string') {
                 return Math.max(last, data.lastIndexOf(marker))
             }
-            // Non-global RegExp (as required above): scan forward for the last
-            // match instead of relying on stateful lastIndex.
-            let searchFrom = 0
+            // Non-global RegExp (as required above): clone with the g flag and
+            // scan the original string so anchors keep their meaning, and bump
+            // past zero-width matches so the scan terminates.
+            const scan = new RegExp(marker.source, `${marker.flags}g`)
             let markerLast = -1
-            for (;;) {
-                const match = marker.exec(data.slice(searchFrom))
-                if (!match) break
-                const abs = searchFrom + match.index
-                markerLast = abs
-                searchFrom = abs + (match[0].length || 1)
+            let match: RegExpExecArray | null
+            while ((match = scan.exec(data)) !== null) {
+                markerLast = match.index
+                if (match[0].length === 0) scan.lastIndex += 1
             }
             return Math.max(last, markerLast)
         }, -1)
@@ -394,8 +393,12 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
                 let reachedIdleMarker = false
                 sawOutput = true
                 lastOutputAt = Date.now()
-                promptBuffer = (promptBuffer + data).slice(-PROMPT_BUFFER_SIZE)
-                const markerBuffer = promptBuffer.replace(/\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/g, '')
+                // Scan the full incoming chunk (plus the retained tail) before
+                // truncating, so a busy marker followed by more than
+                // PROMPT_BUFFER_SIZE bytes in one callback is still seen.
+                const markerInput = promptBuffer + data
+                promptBuffer = markerInput.slice(-PROMPT_BUFFER_SIZE)
+                const markerBuffer = markerInput.replace(/\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/g, '')
                 // Auto-approve the first-run trust/safety prompt (Enter = default
                 // "Yes"). Do this BEFORE prompt detection so the trust screen
                 // isn't mistaken for the input prompt — otherwise the first user
@@ -425,6 +428,10 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
                 const busyAt = busyMarkers.length > 0 ? lastMarkerIndex(markerBuffer, busyMarkers) : -1
                 const idleAt = idleMarkers.length > 0 ? lastMarkerIndex(markerBuffer, idleMarkers) : -1
                 if (idleAt > busyAt) {
+                    // The busy marker was seen earlier in this same chunk: the
+                    // run that produced it is the one ending now, so keep the
+                    // confirmation that lets completeAgentRun fire.
+                    if (agentRunActive && busyAt >= 0) agentRunSawBusyMarker = true
                     setThinking(false)
                     inputReady = true
                     reachedIdleMarker = true

--- a/cli/src/agent/runAgentPty.ts
+++ b/cli/src/agent/runAgentPty.ts
@@ -186,6 +186,27 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
         typeof marker === 'string' ? data.includes(marker) : marker.test(data)
     const anyMarker = (data: string, list: (string | RegExp)[]): boolean =>
         list.some((m) => markerMatches(data, m))
+    // Position of the last marker occurrence in the chunk, or -1 when absent.
+    // When a chunk contains both busy and idle markers, the one whose text
+    // appears last reflects the final repaint, so it decides the state.
+    const lastMarkerIndex = (data: string, list: (string | RegExp)[]): number =>
+        list.reduce((last, marker) => {
+            if (typeof marker === 'string') {
+                return Math.max(last, data.lastIndexOf(marker))
+            }
+            // Non-global RegExp (as required above): scan forward for the last
+            // match instead of relying on stateful lastIndex.
+            let searchFrom = 0
+            let markerLast = -1
+            for (;;) {
+                const match = marker.exec(data.slice(searchFrom))
+                if (!match) break
+                const abs = searchFrom + match.index
+                markerLast = abs
+                searchFrom = abs + (match[0].length || 1)
+            }
+            return Math.max(last, markerLast)
+        }, -1)
 
     const markers = opts.promptMarkers ?? []
     const hasMarkers = markers.length > 0
@@ -396,18 +417,22 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
                     && anyMarker(data, authFailureMarkers)) {
                     sawAuthFailureScreen = true
                 }
-                // Track the working/idle state from the live footer. The busy
-                // marker (spinner/"esc to interrupt") wins when both appear in a
-                // chunk; chunks with neither leave the state unchanged.
-                if (busyMarkers.length > 0 && anyMarker(markerBuffer, busyMarkers)) {
-                    if (agentRunActive) agentRunSawBusyMarker = true
-                    setThinking(true)
-                    inputReady = false
-                    promptBuffer = ''
-                } else if (idleMarkers.length > 0 && anyMarker(markerBuffer, idleMarkers)) {
+                // Track the working/idle state from the live footer. When a
+                // chunk carries both a busy and an idle marker, the marker whose
+                // text comes LAST wins: a trailing idle footer means the turn
+                // completed, while trailing "Generating" output means it is still
+                // running. Chunks with neither marker leave the state unchanged.
+                const busyAt = busyMarkers.length > 0 ? lastMarkerIndex(markerBuffer, busyMarkers) : -1
+                const idleAt = idleMarkers.length > 0 ? lastMarkerIndex(markerBuffer, idleMarkers) : -1
+                if (idleAt > busyAt) {
                     setThinking(false)
                     inputReady = true
                     reachedIdleMarker = true
+                    promptBuffer = ''
+                } else if (busyAt >= 0) {
+                    if (agentRunActive) agentRunSawBusyMarker = true
+                    setThinking(true)
+                    inputReady = false
                     promptBuffer = ''
                 } else if (thinking) {
                     // Still producing output (e.g. streaming response text with no

--- a/cli/src/agent/runAgentPty.ts
+++ b/cli/src/agent/runAgentPty.ts
@@ -95,6 +95,8 @@ export type RunAgentPtyOpts = {
      * Strings match as substrings; RegExps match with `.test()`.
      */
     idleMarkers?: (string | RegExp)[]
+    /** Time without PTY output before clearing thinking; null waits for an idle marker. */
+    thinkingSilenceTimeoutMs?: number | null
     debugPrefix: string
     signal?: AbortSignal
     nextMessage: () => Promise<{ message: string } | null>
@@ -223,10 +225,11 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
     // turn never started (a --resume replay swallowed the first message). A working
     // claude repaints its spinner footer every few hundred ms, so once output has
     // been SILENT for IDLE_SILENCE_MS while we still think it's busy, the turn is
-    // really over → force idle. Scoped to agents with a busy marker (claude): agy
-    // can sit silent mid-inference (no animated spinner), so it keeps marker-only
-    // clearing and no silence watchdog.
-    const IDLE_SILENCE_MS = 3000
+    // really over → force idle. Agents with a reliable idle marker can disable
+    // this and wait for that explicit completion signal instead.
+    const thinkingSilenceTimeoutMs = opts.thinkingSilenceTimeoutMs === undefined
+        ? 3000
+        : opts.thinkingSilenceTimeoutMs
     let idleWatchdog: ReturnType<typeof setTimeout> | null = null
     let agentRunActive = false
     let agentRunSawBusyMarker = false
@@ -245,12 +248,12 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
     // (Re)start the silence timer. Called when thinking begins and on every output
     // chunk while thinking, so the window only elapses once claude has gone quiet.
     const armIdleWatchdog = (): void => {
-        if (!hasBusyMarkers || !thinking) return
+        if (!hasBusyMarkers || !thinking || thinkingSilenceTimeoutMs === null) return
         disarmIdleWatchdog()
         idleWatchdog = setTimeout(() => {
             idleWatchdog = null
             if (thinking) {
-                logger.debug(`${debugPrefix} idle watchdog: ${IDLE_SILENCE_MS}ms of silence; forcing idle`)
+                logger.debug(`${debugPrefix} idle watchdog: ${thinkingSilenceTimeoutMs}ms of silence; forcing idle`)
                 thinking = false
                 // The turn really ended even though no idle marker arrived, so the
                 // prompt is usable again — let the next queued message proceed.
@@ -258,7 +261,7 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
                 opts.onThinkingChange?.(false)
                 completeAgentRun()
             }
-        }, IDLE_SILENCE_MS)
+        }, thinkingSilenceTimeoutMs)
         idleWatchdog.unref?.()
     }
     const setThinking = (next: boolean): void => {
@@ -371,6 +374,7 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
                 sawOutput = true
                 lastOutputAt = Date.now()
                 promptBuffer = (promptBuffer + data).slice(-PROMPT_BUFFER_SIZE)
+                const markerBuffer = promptBuffer.replace(/\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/g, '')
                 // Auto-approve the first-run trust/safety prompt (Enter = default
                 // "Yes"). Do this BEFORE prompt detection so the trust screen
                 // isn't mistaken for the input prompt — otherwise the first user
@@ -379,7 +383,7 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
                     trustHandled = true
                     logger.debug(`${debugPrefix} trust prompt detected; auto-approving with Enter`)
                     manager.write('\r')
-                } else if (hasMarkers && !promptSeen && anyMarker(promptBuffer, markers)) {
+                } else if (hasMarkers && !promptSeen && anyMarker(markerBuffer, markers)) {
                     promptSeen = true
                     inputReady = true
                 }
@@ -395,12 +399,12 @@ export async function runAgentPty(opts: RunAgentPtyOpts): Promise<void> {
                 // Track the working/idle state from the live footer. The busy
                 // marker (spinner/"esc to interrupt") wins when both appear in a
                 // chunk; chunks with neither leave the state unchanged.
-                if (busyMarkers.length > 0 && anyMarker(data, busyMarkers)) {
+                if (busyMarkers.length > 0 && anyMarker(markerBuffer, busyMarkers)) {
                     if (agentRunActive) agentRunSawBusyMarker = true
                     setThinking(true)
                     inputReady = false
                     promptBuffer = ''
-                } else if (idleMarkers.length > 0 && anyMarker(promptBuffer, idleMarkers)) {
+                } else if (idleMarkers.length > 0 && anyMarker(markerBuffer, idleMarkers)) {
                     setThinking(false)
                     inputReady = true
                     reachedIdleMarker = true

--- a/cli/src/agy/agyPty.test.ts
+++ b/cli/src/agy/agyPty.test.ts
@@ -23,7 +23,12 @@
  *    first message is submitted.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+const { runAgentPty } = vi.hoisted(() => ({ runAgentPty: vi.fn() }))
+
+vi.mock('@/agent/runAgentPty', () => ({ runAgentPty }))
+
 import {
     AGY_PROMPT_MARKERS,
     AGY_TRUST_MARKERS,
@@ -33,6 +38,7 @@ import {
     AGY_IDLE_READY_MS,
     buildAgyPtyArgs,
     buildAgyPtyExtraEnv,
+    agyPty,
     type AgyPtyOpts,
 } from './agyPty'
 
@@ -134,16 +140,14 @@ describe('AGY_IDLE_MARKERS', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Busy markers — enable the silence watchdog that clears the thinking state
+// Busy markers — detect native terminal activity
 // ---------------------------------------------------------------------------
 describe('AGY_BUSY_MARKERS', () => {
     it('contains the "Generating" spinner text agy 1.0.8 animates while working', () => {
         expect(AGY_BUSY_MARKERS).toContain('Generating')
     })
 
-    it('is non-empty so runAgentPty enables the output-silence watchdog (clears thinking)', () => {
-        // With no busy marker hasBusyMarkers is false and the watchdog never runs,
-        // leaving the optimistic post-submit thinking=true stuck forever.
+    it('is non-empty so direct terminal input can enter the thinking state', () => {
         expect(AGY_BUSY_MARKERS.length).toBeGreaterThan(0)
     })
 
@@ -174,6 +178,22 @@ describe('buildAgyPtyArgs', () => {
 describe('AGY_IDLE_READY_MS', () => {
     it('is at least 1000 ms to accommodate banner render after sign-in', () => {
         expect(AGY_IDLE_READY_MS).toBeGreaterThanOrEqual(1000)
+    })
+})
+
+describe('agyPty', () => {
+    it('waits for the explicit idle marker instead of a silence timeout', async () => {
+        await agyPty({
+            sessionId: null,
+            path: '/tmp',
+            nextMessage: async () => null,
+            onReady: () => {},
+            onMessage: () => {},
+        })
+
+        expect(runAgentPty).toHaveBeenCalledWith(expect.objectContaining({
+            thinkingSilenceTimeoutMs: null,
+        }))
     })
 })
 

--- a/cli/src/agy/agyPty.ts
+++ b/cli/src/agy/agyPty.ts
@@ -93,12 +93,8 @@ export const AGY_AUTH_FAILURE_MARKERS = ['Select login method']
 // Generating frame is an explicit user-message agent-run boundary.
 export const AGY_IDLE_MARKERS = ['? for shortcuts']
 
-// agy animates a "Generating..." spinner continuously while it works — it does
-// NOT sit silent mid-turn. This busy marker flags thinking=true AND, crucially,
-// enables runAgentPty's output-silence watchdog (gated on hasBusyMarkers): once
-// the turn ends and the spinner stops repainting, the watchdog clears the
-// thinking state. Without it the optimistic post-submit setThinking(true) would
-// never clear and the chat would sit "busy" forever.
+// agy may be silent mid-turn. This marker lets native terminal activity set
+// thinking=true; completion relies on AGY_IDLE_MARKERS.
 export const AGY_BUSY_MARKERS = ['Generating']
 
 // After the input footer appears, give the TUI time to finish painting before
@@ -143,6 +139,7 @@ export async function agyPty(opts: AgyPtyOpts): Promise<void> {
         busyMarkers: AGY_BUSY_MARKERS,
         idleReadyMs: AGY_IDLE_READY_MS,
         idleMarkers: AGY_IDLE_MARKERS,
+        thinkingSilenceTimeoutMs: null,
         debugPrefix: '[agyPty]',
         signal: opts.signal,
         nextMessage: opts.nextMessage,


### PR DESCRIPTION
Closes #1453

## Summary
- keep agy turns marked running until its explicit idle prompt returns
- detect fragmented, ANSI-decorated PTY activity markers
- cover quiet turns and fragmented busy markers

## Tests
- `bunx vitest run src/agent/__tests__/runAgentPty.test.ts src/agy/agyPty.test.ts`
- `bun typecheck && bun run test`