### PR TITLE
fix(web): add Ctrl+X / Ctrl+S to mobile terminal Control pad

### DIFF
--- a/web/src/routes/sessions/terminal.test.tsx
+++ b/web/src/routes/sessions/terminal.test.tsx
@@ -315,6 +315,19 @@ describe('TerminalPage compact command input', () => {
         expect(writeMock).toHaveBeenNthCalledWith(3, '\u001b[6~')
         expect(writeMock).toHaveBeenNthCalledWith(4, '|')
     })
+
+    it('sends dedicated Ctrl+X and Ctrl+S C0 sequences from the Control pad', () => {
+        renderWithProviders()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Direct' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel / prefix (C-x)' }))
+        fireEvent.click(screen.getByRole('button', { name: 'XOFF / search / save (C-s)' }))
+
+        expect(writeMock).toHaveBeenNthCalledWith(1, '\u0018')
+        expect(writeMock).toHaveBeenNthCalledWith(2, '\u0013')
+        // Keep Ctrl+L; density still fits a 4-col grid with the two Jed chords.
+        expect(screen.getByRole('button', { name: 'Clear screen' })).toBeInTheDocument()
+    })
 })
 
 describe('buildTerminalCommandSequence', () => {

--- a/web/src/routes/sessions/terminal.tsx
+++ b/web/src/routes/sessions/terminal.tsx
@@ -139,6 +139,9 @@ const COMPACT_DIRECT_INPUTS: Record<DirectKeyPage, QuickInput[]> = {
         { label: 'Ctrl+D', sequence: '\u0004', description: 'End of input' },
         { label: 'Ctrl+Z', sequence: '\u001a', description: 'Suspend process' },
         { label: 'Ctrl+L', sequence: '\u000c', description: 'Clear screen' },
+        // Dedicated: sticky Ctrl + softkey is flaky on mobile IME (Jed save = C-x C-s).
+        { label: 'Ctrl+X', sequence: '\u0018', description: 'Cancel / prefix (C-x)' },
+        { label: 'Ctrl+S', sequence: '\u0013', description: 'XOFF / search / save (C-s)' },
     ],
     navigation: [
         { label: '←', sequence: '\u001b[D', description: 'Arrow left' },


### PR DESCRIPTION
## Summary

- Add dedicated **Ctrl+X** (`\u0018`) and **Ctrl+S** (`\u0013`) buttons to the compact Direct → Control pad.
- Sticky Ctrl + soft-keyboard letters is unreliable on mobile IME/focus; Jed (Emacs mode) save is `C-x C-s` and was effectively unreachable.
- Layout: keep existing keys including **Ctrl+L** (clear). New chords sit on a fourth row of the 4-column grid.

## Test plan

- [x] Unit: `web/src/routes/sessions/terminal.test.tsx` — dedicated buttons send `\u0018` / `\u0013`; Ctrl+L still present
- [x] Peer-stack mobile screenshot: Control pad shows Ctrl+X + Ctrl+S
- [ ] Manual: open session terminal on phone/Quest → Direct → Control → tap Ctrl+X then Ctrl+S in Jed; file saves

## Issues

Fixes #1459
