### PR TITLE
fix(cli): skip invalid set_mode for interactive Copilot sessions

### DIFF
--- a/cli/src/copilot/copilotRemoteLauncher.test.ts
+++ b/cli/src/copilot/copilotRemoteLauncher.test.ts
@@ -94,41 +94,30 @@ describe('CopilotRemoteLauncher.applyAgentMode', () => {
         expect(internals.displayAgentMode).toBe('interactive');
     });
 
-    it('treats interactive as a no-op without calling setMode', async () => {
-        const setMode = vi.fn().mockRejectedValue(new Error('transport unavailable'));
+    it('maps interactive to the ACP agent mode via setMode', async () => {
+        const setMode = vi.fn().mockResolvedValue(undefined);
         const { launcher, internals } = createLauncher(setMode);
 
         await expect(launcher.applyAgentMode('interactive')).resolves.toBeUndefined();
 
-        expect(setMode).not.toHaveBeenCalled();
+        expect(setMode).toHaveBeenCalledWith('copilot-session', 'agent');
         expect(internals.currentAgentMode).toBe('interactive');
         expect(internals.displayAgentMode).toBe('interactive');
     });
 
-    it('classifies Invalid mode responses as unsupported runtime switching', async () => {
-        const setMode = vi.fn().mockRejectedValue(
-            new Error("Invalid mode 'plan'. Supported values: agent, plan, autopilot.")
-        );
+    it('does not permanently disable switching after an Invalid mode rejection', async () => {
+        const setMode = vi.fn()
+            .mockRejectedValueOnce(
+                new Error("Invalid mode 'plan'. Supported values: agent, plan, autopilot.")
+            )
+            .mockResolvedValueOnce(undefined);
         const { launcher, internals } = createLauncher(setMode);
 
         await expect(launcher.applyAgentMode('plan')).rejects.toThrow("Invalid mode 'plan'");
-        await expect(launcher.applyAgentMode('autopilot')).rejects.toThrow(
-            'does not support agent mode switching'
-        );
+        await expect(launcher.applyAgentMode('autopilot')).resolves.toBeUndefined();
 
-        expect(setMode).toHaveBeenCalledTimes(1);
-        expect(internals.currentAgentMode).toBe('interactive');
-    });
-
-    it('continues startup when setMode is rejected with Invalid mode', async () => {
-        const setMode = vi.fn().mockRejectedValue(new Error("Invalid mode 'plan'"));
-        const { internals } = createLauncher(setMode);
-        internals.currentAgentMode = 'plan';
-
-        await expect(internals.applyInitialAgentMode()).resolves.toBeUndefined();
-
-        expect(internals.currentAgentMode).toBe('plan');
-        expect(internals.displayAgentMode).toBe('plan');
+        expect(setMode).toHaveBeenCalledTimes(2);
+        expect(internals.currentAgentMode).toBe('autopilot');
     });
 
     it('applies Auto after an explicit model selection', async () => {

--- a/cli/src/copilot/copilotRemoteLauncher.test.ts
+++ b/cli/src/copilot/copilotRemoteLauncher.test.ts
@@ -94,6 +94,43 @@ describe('CopilotRemoteLauncher.applyAgentMode', () => {
         expect(internals.displayAgentMode).toBe('interactive');
     });
 
+    it('treats interactive as a no-op without calling setMode', async () => {
+        const setMode = vi.fn().mockRejectedValue(new Error('transport unavailable'));
+        const { launcher, internals } = createLauncher(setMode);
+
+        await expect(launcher.applyAgentMode('interactive')).resolves.toBeUndefined();
+
+        expect(setMode).not.toHaveBeenCalled();
+        expect(internals.currentAgentMode).toBe('interactive');
+        expect(internals.displayAgentMode).toBe('interactive');
+    });
+
+    it('classifies Invalid mode responses as unsupported runtime switching', async () => {
+        const setMode = vi.fn().mockRejectedValue(
+            new Error("Invalid mode 'plan'. Supported values: agent, plan, autopilot.")
+        );
+        const { launcher, internals } = createLauncher(setMode);
+
+        await expect(launcher.applyAgentMode('plan')).rejects.toThrow("Invalid mode 'plan'");
+        await expect(launcher.applyAgentMode('autopilot')).rejects.toThrow(
+            'does not support agent mode switching'
+        );
+
+        expect(setMode).toHaveBeenCalledTimes(1);
+        expect(internals.currentAgentMode).toBe('interactive');
+    });
+
+    it('continues startup when setMode is rejected with Invalid mode', async () => {
+        const setMode = vi.fn().mockRejectedValue(new Error("Invalid mode 'plan'"));
+        const { internals } = createLauncher(setMode);
+        internals.currentAgentMode = 'plan';
+
+        await expect(internals.applyInitialAgentMode()).resolves.toBeUndefined();
+
+        expect(internals.currentAgentMode).toBe('plan');
+        expect(internals.displayAgentMode).toBe('plan');
+    });
+
     it('applies Auto after an explicit model selection', async () => {
         const setModel = vi.fn().mockResolvedValue(undefined);
         const { internals } = createLauncher(vi.fn().mockResolvedValue(undefined));

--- a/cli/src/copilot/copilotRemoteLauncher.ts
+++ b/cli/src/copilot/copilotRemoteLauncher.ts
@@ -338,24 +338,21 @@ export class CopilotRemoteLauncher extends RemoteLauncherBase {
         if (!backend || !sessionId) {
             throw new Error('Copilot agent mode switching is unavailable before the remote session is ready');
         }
-        if (agentMode === 'interactive') {
-            // Interactive is the ACP server default (spawned without --mode), not a
-            // valid session/set_mode mode id; mirror buildCopilotAcpArgs as a no-op.
-            this.currentAgentMode = agentMode;
-            this.applyDisplayAgentMode(agentMode);
-            return;
-        }
         if (this.setModeSupported === false) {
             throw new Error('This Copilot CLI build does not support agent mode switching');
         }
 
+        // `interactive` is the legacy TUI name for the ACP default `agent` mode
+        // (spawned without --mode); map it to the valid ACP session mode id so
+        // runtime switches back to Interactive leave the backend in sync.
+        const backendMode = agentMode === 'interactive' ? 'agent' : agentMode;
         try {
-            await backend.setMode(sessionId, agentMode);
+            await backend.setMode(sessionId, backendMode);
             this.setModeSupported = true;
-            logger.debug(`[copilot-remote] Applied agent mode via setMode: ${agentMode}`);
+            logger.debug(`[copilot-remote] Applied agent mode via setMode: ${backendMode}`);
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
-            if (/method not found|does not support session\/set_mode|no mode config option|invalid mode/i.test(message)) {
+            if (/method not found|does not support session\/set_mode|no mode config option/i.test(message)) {
                 this.setModeSupported = false;
                 logger.warn('[copilot-remote] Copilot CLI build does not support set_mode; agent mode changes require restart');
                 this.session.sendSessionEvent({

--- a/cli/src/copilot/copilotRemoteLauncher.ts
+++ b/cli/src/copilot/copilotRemoteLauncher.ts
@@ -338,6 +338,13 @@ export class CopilotRemoteLauncher extends RemoteLauncherBase {
         if (!backend || !sessionId) {
             throw new Error('Copilot agent mode switching is unavailable before the remote session is ready');
         }
+        if (agentMode === 'interactive') {
+            // Interactive is the ACP server default (spawned without --mode), not a
+            // valid session/set_mode mode id; mirror buildCopilotAcpArgs as a no-op.
+            this.currentAgentMode = agentMode;
+            this.applyDisplayAgentMode(agentMode);
+            return;
+        }
         if (this.setModeSupported === false) {
             throw new Error('This Copilot CLI build does not support agent mode switching');
         }
@@ -348,7 +355,7 @@ export class CopilotRemoteLauncher extends RemoteLauncherBase {
             logger.debug(`[copilot-remote] Applied agent mode via setMode: ${agentMode}`);
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
-            if (/method not found|does not support session\/set_mode|no mode config option/i.test(message)) {
+            if (/method not found|does not support session\/set_mode|no mode config option|invalid mode/i.test(message)) {
                 this.setModeSupported = false;
                 logger.warn('[copilot-remote] Copilot CLI build does not support set_mode; agent mode changes require restart');
                 this.session.sendSessionEvent({


### PR DESCRIPTION
Fixes #1461

## Problem

Copilot CLI remote sessions (ACP-backed) fail at startup in the default `interactive` agent mode:

```
Invalid mode 'interactive'. Supported values: agent, plan, autopilot.
```

`applyInitialAgentMode()` unconditionally forwarded `interactive` to `session/set_mode`, but `interactive` is the legacy TUI mode name — not a valid ACP session mode. The error classifier only matched method-availability errors, so the rejection was rethrown during initial setup and the session was torn down.

## Fix

- **`cli/src/copilot/copilotRemoteLauncher.ts`**: short-circuit `applyAgentMode('interactive')` as a no-op success (keeping `currentAgentMode`/display state in sync), mirroring `buildCopilotAcpArgs` which already omits `--mode` at spawn since interactive is the ACP server default.
- Extend the unsupported-error classifier with `invalid mode` so server-side mode rejections degrade gracefully (existing "restart the session to apply Plan or Autopilot" message) instead of failing the session.

## Tests

3 new regression tests in `copilotRemoteLauncher.test.ts`:
- interactive is a no-op and never calls `setMode` (the startup regression)
- `Invalid mode` responses are classified as unsupported runtime switching
- startup continues when `setMode` is rejected with `Invalid mode`

Verified: `bun typecheck` + `bun run test` full suite green.