### PR TITLE
fix(web): keep single tildes literal in markdown

### DIFF
--- a/web/src/components/assistant-ui/markdown-text.test.ts
+++ b/web/src/components/assistant-ui/markdown-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { unified } from 'unified'
+import { unified, type PluggableList } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { toHtml } from 'hast-util-to-html'
@@ -8,6 +8,8 @@ import remarkNonHttpsAutolink from '@/lib/remark-non-https-autolink'
 import remarkStripCjkAutolink from '@/lib/remark-strip-cjk-autolink'
 import {
     MARKDOWN_PLUGINS,
+    MARKDOWN_PLUGINS_STANDALONE,
+    MARKDOWN_PLUGINS_STANDALONE_WITH_BREAKS,
     MARKDOWN_PLUGINS_WITH_BREAKS,
     MARKDOWN_REHYPE_PLUGINS,
 } from '@/components/assistant-ui/markdown-text'
@@ -30,15 +32,37 @@ describe('MARKDOWN_PLUGINS integration', () => {
     })
 })
 
-function render(markdown: string): string {
+function render(markdown: string, plugins: PluggableList = MARKDOWN_PLUGINS): string {
     const processor = unified()
         .use(remarkParse)
-        .use(MARKDOWN_PLUGINS)
+        .use(plugins)
         .use(remarkRehype)
         .use(MARKDOWN_REHYPE_PLUGINS)
     const tree = processor.runSync(processor.parse(markdown))
     return toHtml(tree as never)
 }
+
+describe('MARKDOWN_PLUGINS — GFM strikethrough', () => {
+    const pluginVariants = [
+        ['default', MARKDOWN_PLUGINS],
+        ['standalone', MARKDOWN_PLUGINS_STANDALONE],
+        ['with breaks', MARKDOWN_PLUGINS_WITH_BREAKS],
+        ['standalone with breaks', MARKDOWN_PLUGINS_STANDALONE_WITH_BREAKS],
+    ] as const
+
+    it.each(pluginVariants)(
+        'keeps a single tilde literal in terminal prompts (%s)',
+        (_, plugins) => {
+            const terminalPrompt = 'ims@ims-dev-1:~$ ls\ndev\nims@ims-dev-1:~$'
+            const html = render(terminalPrompt, plugins)
+
+            expect(html).not.toContain('<del>')
+            expect(html).toContain('ims@ims-dev-1:~$ ls')
+            expect(html).toContain('ims@ims-dev-1:~$')
+            expect(render('status: ~~removed~~', plugins)).toContain('<del>removed</del>')
+        }
+    )
+})
 
 describe('MARKDOWN_PLUGINS — currency prose vs KaTeX', () => {
     // Regression: prose with multiple "$N" amounts must NOT be eaten by KaTeX.

--- a/web/src/components/assistant-ui/markdown-text.tsx
+++ b/web/src/components/assistant-ui/markdown-text.tsx
@@ -72,14 +72,21 @@ const MARKDOWN_PLUGIN_TAIL_STANDALONE = [
     [remarkFilePathLinks, { rewriteExplicitLinks: false }],
 ] satisfies NonNullable<MarkdownTextPrimitiveProps['remarkPlugins']>
 
-export const MARKDOWN_PLUGINS = [
+// A single tilde is common in shell prompts (for example, `user@host:~$`).
+// Keep it literal while preserving GFM strikethrough via double tildes.
+const REMARK_GFM_PLUGIN = [
     remarkGfm,
+    { singleTilde: false },
+] satisfies NonNullable<MarkdownTextPrimitiveProps['remarkPlugins']>[number]
+
+export const MARKDOWN_PLUGINS = [
+    REMARK_GFM_PLUGIN,
     remarkRepairTables,
     ...MARKDOWN_PLUGIN_TAIL,
 ] satisfies NonNullable<MarkdownTextPrimitiveProps['remarkPlugins']>
 
 export const MARKDOWN_PLUGINS_STANDALONE = [
-    remarkGfm,
+    REMARK_GFM_PLUGIN,
     remarkRepairTables,
     ...MARKDOWN_PLUGIN_TAIL_STANDALONE,
 ] satisfies NonNullable<MarkdownTextPrimitiveProps['remarkPlugins']>
@@ -87,14 +94,14 @@ export const MARKDOWN_PLUGINS_STANDALONE = [
 // User-authored prompts should preserve Shift+Enter/newline intent without
 // changing assistant/tool markdown behavior globally.
 export const MARKDOWN_PLUGINS_WITH_BREAKS = [
-    remarkGfm,
+    REMARK_GFM_PLUGIN,
     remarkRepairTables,
     remarkBreaks,
     ...MARKDOWN_PLUGIN_TAIL,
 ] satisfies NonNullable<MarkdownTextPrimitiveProps['remarkPlugins']>
 
 export const MARKDOWN_PLUGINS_STANDALONE_WITH_BREAKS = [
-    remarkGfm,
+    REMARK_GFM_PLUGIN,
     remarkRepairTables,
     remarkBreaks,
     ...MARKDOWN_PLUGIN_TAIL_STANDALONE,


### PR DESCRIPTION
## Summary

Configure all four shared `remark-gfm` plugin variants with `singleTilde: false` so terminal prompts such as `user@host:~$` remain literal. Standard GFM strikethrough written with `~~double tildes~~` is preserved.

Fixes #1261.

## Root cause and approach

`remark-gfm` enables single-tilde strikethrough by default. In the reporter's corrected multiline reproduction, the two tildes in separate shell prompts are therefore treated as the opening and closing delimiters of one `<del>` span.

This change defines one shared configured plugin tuple and reuses it in `MARKDOWN_PLUGINS`, `MARKDOWN_PLUGINS_STANDALONE`, `MARKDOWN_PLUGINS_WITH_BREAKS`, and `MARKDOWN_PLUGINS_STANDALONE_WITH_BREAKS`. Keeping the option in one tuple prevents the four rendering paths from drifting while leaving all other Markdown plugins and ordering unchanged.

## Verification

- `bun run test -- src/components/assistant-ui/markdown-text.test.ts` — 10 passed.
- The new parameterized regression covers all four plugin variants with the exact corrected terminal-prompt reproduction from the issue.
- The same regression verifies that `~~removed~~` still renders as `<del>removed</del>`.
- A full local web test run reached 2,285 passed and 3 unrelated existing failures caused by the checkout's case-insensitive `StorageUsagePie.tsx` / `storageUsagePie.ts` filename collision; local type-checking is blocked by that same collision.
- Remote GitHub Actions reached 2,321 passed and 1 skipped; its only failure was an untouched CLI test, `cli/src/claude/claudeRemote.test.ts`, timing out at 5 seconds. On the same PR head, an isolated rerun of that file passed all 6 tests (the timed-out case completed in about 619 ms). GitHub does not permit the fork author to rerun the upstream job without repository admin access, so no unrelated code is changed to mask the result.

## Scope

Only the shared GFM plugin configuration and its focused integration test are changed. No renderer selection, sanitization, link handling, math handling, or other Markdown behavior is modified.

## AI assistance

OpenAI Codex (GPT-5) was used to inspect the rendering pipeline, implement the focused change, and run/review the tests and final diff. This usage is disclosed per the repository's AI-generated code policy.
