### PR TITLE
fix(agy): sync native Anti-Gravity conversation titles

### DIFF
--- a/cli/src/agy/agyPtyLauncher.test.ts
+++ b/cli/src/agy/agyPtyLauncher.test.ts
@@ -255,6 +255,8 @@ function createSessionStub(opts?: {
             waitForMessagesAndGetAsString: vi.fn().mockResolvedValue(null),
         },
         client: {
+            getMetadata: vi.fn().mockReturnValue(null),
+            updateMetadata: vi.fn(),
             sendAgySessionMessage: vi.fn(),
             sendSessionEvent: vi.fn(),
             emitSessionReady: vi.fn(),
@@ -440,6 +442,20 @@ describe('agyPtyLauncher session-found wiring (brain UUID -> scanner)', () => {
         harness.exitReason = 'exit'
         msgPromise.resolve(null)
         await launcherPromise
+    })
+
+    it('wires the native title callback into HAPI metadata synchronization', async () => {
+        const { session } = createSessionStub()
+        await agyPtyLauncher(session as never)
+
+        const onTitle = harness.scannerOpts!.onTitle as (title: unknown) => void
+        onTitle('Native AGY title')
+
+        expect(session.client.updateMetadata).toHaveBeenCalledWith(expect.any(Function))
+        const update = vi.mocked(session.client.updateMetadata).mock.calls[0][0]
+        expect(update({ path: '/tmp/agy-pty-test' })).toMatchObject({
+            summary: { text: 'Native AGY title' },
+        })
     })
 
     it('persists the discovered UUID through a respawn, so the next agy spawn resumes via --conversation instead of silently starting a fresh brain (hostile-review finding: crash-recovery resume gap)', async () => {

--- a/cli/src/agy/agyPtyLauncher.ts
+++ b/cli/src/agy/agyPtyLauncher.ts
@@ -8,6 +8,7 @@ import { isAgyAskQuestionToolCall, buildCanonicalAskUserQuestionInput, type AgyA
 import { buildAgyQuestionKeys } from "./utils/agyQuestionKeys"
 import { buildAgyModelNavigationKeys, buildAgyModelPickerTarget, findAgyCurrentModelRow } from './utils/agyModelKeys'
 import { agyHookCarrierIsIntact, prepareAgyHookCarrier, writeAgyHooksJsonAtomic } from './utils/agyHookCarrier'
+import { createNativeSessionTitleMetadataSync } from '@/agent/nativeSessionTitle'
 import { logger } from "@/ui/logger"
 import {
     RemoteLauncherBase,
@@ -123,6 +124,7 @@ export function userRequestMatches(message: string, content: string): boolean {
 
 class AgyPtyLauncher extends RemoteLauncherBase {
     private readonly session: AgySession
+    private readonly syncNativeTitle: (title: unknown) => void
     private scanner: any = null
     // The agy brain UUID for the current conversation. Set from the pre-known
     // resume ID (if this is a resume) or adopted via handleSessionFound, which
@@ -350,6 +352,7 @@ class AgyPtyLauncher extends RemoteLauncherBase {
     constructor(session: AgySession) {
         super(process.env.DEBUG ? session.logPath : undefined)
         this.session = session
+        this.syncNativeTitle = createNativeSessionTitleMetadataSync(session.client)
         // If the session already carries an agySessionId (passed in from the
         // hub on resume), pre-seed it so the first spawn can --conversation to it.
         this.agySessionId = session.sessionId
@@ -758,6 +761,7 @@ class AgyPtyLauncher extends RemoteLauncherBase {
         const resumeBrainUuid = this.agySessionId ?? undefined
         this.scanner = await createAgySessionScanner({
             resumeBrainUuid,
+            onTitle: this.syncNativeTitle,
             onEntry: (entry) => {
                 if (entry.type === 'USER_INPUT') {
                     if (!this.observeUserInput(entry.content ?? '')) {

--- a/cli/src/agy/utils/agySessionScanner.test.ts
+++ b/cli/src/agy/utils/agySessionScanner.test.ts
@@ -148,6 +148,22 @@ describe('AgySessionScanner — resume support', () => {
         await scanner.cleanup()
     })
 
+    it('forwards the native title while scanning a known brain', async () => {
+        const emitted: AgyTranscriptEntry[] = []
+        const onTitle = vi.fn()
+        const readTitle = vi.fn(async () => 'Native AGY title')
+        const scanner = await createAgySessionScanner({
+            resumeBrainUuid: TEST_UUID,
+            onEntry: (e) => emitted.push(e),
+            onTitle,
+            readTitle,
+        })
+
+        await vi.waitFor(() => expect(onTitle).toHaveBeenCalledWith('Native AGY title'), { timeout: 1200 })
+        expect(readTitle).toHaveBeenCalledWith(TEST_UUID)
+        await scanner.cleanup()
+    })
+
     it('new entry appended after resume is emitted (only the new one)', async () => {
         // Pre-existing transcript.
         const existingLines = [

--- a/cli/src/agy/utils/agySessionScanner.test.ts
+++ b/cli/src/agy/utils/agySessionScanner.test.ts
@@ -164,6 +164,59 @@ describe('AgySessionScanner — resume support', () => {
         await scanner.cleanup()
     })
 
+    it('re-reads the native title when it appears late or changes (delayed generation, renames)', async () => {
+        // Pre-existing transcript so the known brain has something to watch; the
+        // title DB is not the watched file, so appends drive the rescan that
+        // re-reads the title (mirrors the "new entry appended" test below).
+        const existingLines = makeTranscriptLine(0, 'USER_INPUT', 'prior-msg') + '\n'
+        const { logPath } = makeTempBrain(TEST_UUID, existingLines)
+
+        const emitted: AgyTranscriptEntry[] = []
+        const onTitle = vi.fn()
+        let currentTitle: string | null = null
+        const readTitle = vi.fn(async () => currentTitle)
+        const scanner = await createAgySessionScanner({
+            resumeBrainUuid: TEST_UUID,
+            onEntry: (e) => emitted.push(e),
+            onTitle,
+            readTitle,
+        })
+
+        // Title not generated yet at first scan.
+        await vi.waitFor(() => expect(onTitle).toHaveBeenCalledWith(null), { timeout: 1200 })
+
+        // Late generation: the next scan picks it up.
+        currentTitle = 'Delayed title'
+        writeFileSync(logPath, existingLines + makeTranscriptLine(1, 'PLANNER_RESPONSE', 'a') + '\n', 'utf-8')
+        await vi.waitFor(() => expect(onTitle).toHaveBeenCalledWith('Delayed title'), { timeout: 1200 })
+
+        // Rename: picked up on a later scan.
+        currentTitle = 'Renamed title'
+        writeFileSync(logPath, existingLines + makeTranscriptLine(1, 'PLANNER_RESPONSE', 'a') + makeTranscriptLine(2, 'PLANNER_RESPONSE', 'b') + '\n', 'utf-8')
+        await vi.waitFor(() => expect(onTitle).toHaveBeenCalledWith('Renamed title'), { timeout: 1200 })
+
+        await scanner.cleanup()
+    })
+
+    it('stops reading the native title after scanner cleanup', async () => {
+        const emitted: AgyTranscriptEntry[] = []
+        const onTitle = vi.fn()
+        const readTitle = vi.fn(async () => 'Title')
+        const scanner = await createAgySessionScanner({
+            resumeBrainUuid: TEST_UUID,
+            onEntry: (e) => emitted.push(e),
+            onTitle,
+            readTitle,
+        })
+
+        await vi.waitFor(() => expect(onTitle).toHaveBeenCalledWith('Title'), { timeout: 1200 })
+        const readsBeforeCleanup = readTitle.mock.calls.length
+        await scanner.cleanup()
+        // Give the (now stopped) interval a chance to fire; it must not re-read.
+        await new Promise((resolve) => setTimeout(resolve, 300))
+        expect(readTitle.mock.calls.length).toBe(readsBeforeCleanup)
+    })
+
     it('new entry appended after resume is emitted (only the new one)', async () => {
         // Pre-existing transcript.
         const existingLines = [

--- a/cli/src/agy/utils/agySessionScanner.ts
+++ b/cli/src/agy/utils/agySessionScanner.ts
@@ -5,6 +5,7 @@ import { BaseSessionScanner } from "@/modules/common/session/BaseSessionScanner"
 import { logger } from "@/lib"
 import type { AgyTranscriptEntry } from "./agyTranscriptTypes"
 import { resolveAgyTurnModels } from "./agyConversationModel"
+import { readAgyConversationTitle, type ReadAgyConversationTitle } from "./agySessionTitle"
 
 const AGY_BRAIN_DIR = join(homedir(), '.gemini', 'antigravity-cli', 'brain')
 const LOG_REL_PATH = join('.system_generated', 'logs', 'transcript_full.jsonl')
@@ -72,6 +73,10 @@ function brainLogPath(uuid: string): string {
 
 type CreateAgySessionScannerOpts = {
     onEntry: (entry: AgyTranscriptEntry) => void
+    /** Called with the current native title while the known brain is scanned. */
+    onTitle?: (title: string | null) => void
+    /** Injectable for tests; production reads Anti-Gravity's summary database. */
+    readTitle?: ReadAgyConversationTitle
     /**
      * When set, the scanner seeds the existing transcript as processed and
      * uses this brain UUID directly. Used on resume: the launcher knows the
@@ -100,12 +105,16 @@ export async function createAgySessionScanner(opts: CreateAgySessionScannerOpts)
 
 class AgySessionScanner extends BaseSessionScanner<AgyTranscriptEntry> {
     private readonly onEntry: (entry: AgyTranscriptEntry) => void
+    private readonly onTitle: ((title: string | null) => void) | undefined
+    private readonly readTitle: ReadAgyConversationTitle
     private foundBrainUuid: string | null = null
     private readonly modelSettlingAbortController = new AbortController()
 
     constructor(opts: CreateAgySessionScannerOpts) {
         super({ intervalMs: 5000 })
         this.onEntry = opts.onEntry
+        this.onTitle = opts.onTitle
+        this.readTitle = opts.readTitle ?? readAgyConversationTitle
         if (opts.resumeBrainUuid) {
             this.foundBrainUuid = opts.resumeBrainUuid
             logger.debug(`[agy-scanner] resume: pre-seeded brain UUID ${opts.resumeBrainUuid}`)
@@ -139,6 +148,11 @@ class AgySessionScanner extends BaseSessionScanner<AgyTranscriptEntry> {
 
     protected shouldScan(): boolean {
         return this.foundBrainUuid !== null
+    }
+
+    protected async beforeScan(): Promise<void> {
+        if (!this.foundBrainUuid || !this.onTitle) return
+        this.onTitle(await this.readTitle(this.foundBrainUuid))
     }
 
     /**

--- a/cli/src/agy/utils/agySessionTitle.test.ts
+++ b/cli/src/agy/utils/agySessionTitle.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readAgyConversationTitle } from './agySessionTitle'
+
+describe('readAgyConversationTitle', () => {
+    const conversationId = '00000000-0000-4000-8000-000000000001'
+
+    it('reads and normalizes a native title', async () => {
+        const query = vi.fn(async () => '  Native AGY title  ')
+
+        await expect(readAgyConversationTitle(conversationId, query)).resolves.toBe('Native AGY title')
+        expect(query).toHaveBeenCalledWith(conversationId)
+    })
+
+    it('ignores empty and placeholder native titles', async () => {
+        const query = vi.fn(async () => 'New Session')
+
+        await expect(readAgyConversationTitle(conversationId, query)).resolves.toBeNull()
+    })
+
+    it('rejects invalid conversation IDs before querying', async () => {
+        const query = vi.fn(async () => 'Should not be read')
+
+        await expect(readAgyConversationTitle('../other.db', query)).resolves.toBeNull()
+        expect(query).not.toHaveBeenCalled()
+    })
+
+    it('treats database failures as an unavailable title', async () => {
+        const query = vi.fn(async () => { throw new Error('database is locked') })
+
+        await expect(readAgyConversationTitle(conversationId, query)).resolves.toBeNull()
+    })
+})

--- a/cli/src/agy/utils/agySessionTitle.ts
+++ b/cli/src/agy/utils/agySessionTitle.ts
@@ -1,0 +1,50 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { normalizeNativeSessionTitle } from '@/agent/nativeSessionTitle'
+import { logger } from '@/ui/logger'
+
+const AGY_CONVERSATION_SUMMARIES_DB = join(
+    homedir(),
+    '.gemini',
+    'antigravity-cli',
+    'conversation_summaries.db',
+)
+const CANONICAL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+type AgyConversationSummaryRow = {
+    title?: unknown
+}
+
+export type ReadAgyConversationTitle = (conversationId: string) => Promise<string | null>
+
+type QueryAgyConversationTitle = (conversationId: string) => Promise<unknown>
+
+/** Reads a native Anti-Gravity title and applies HAPI's placeholder filtering. */
+export async function readAgyConversationTitle(
+    conversationId: string,
+    query: QueryAgyConversationTitle = queryAgyConversationTitle,
+): Promise<string | null> {
+    if (!CANONICAL_UUID_RE.test(conversationId)) {
+        return null
+    }
+
+    try {
+        return normalizeNativeSessionTitle(await query(conversationId))
+    } catch (error) {
+        logger.debug('[agy-title] native title lookup unavailable', error)
+        return null
+    }
+}
+
+async function queryAgyConversationTitle(conversationId: string): Promise<unknown> {
+    const { Database } = await import('bun:sqlite')
+    const db = new Database(AGY_CONVERSATION_SUMMARIES_DB, { readonly: true })
+    try {
+        const row = db.query(
+            'SELECT title FROM conversation_summaries WHERE conversation_id = ? LIMIT 1',
+        ).get(conversationId) as AgyConversationSummaryRow | null
+        return row?.title ?? null
+    } finally {
+        db.close()
+    }
+}


### PR DESCRIPTION
Fixes #1439

## Problem
HAPI's Anti-Gravity (`agy`) sessions never get a title from Anti-Gravity's native conversation title, so the web UI falls back to workspace path / session id even when Anti-Gravity generated one.

## Change
- New `cli/src/agy/utils/agySessionTitle.ts`: reads the native title for a validated brain UUID from `~/.gemini/antigravity-cli/conversation_summaries.db`, applies the shared `normalizeNativeSessionTitle` placeholder filtering, and degrades to no-op on DB errors (missing/locked/schema drift).
- `agySessionScanner`: while a brain UUID is known (resume seed or hook discovery), each 5s scan cycle surfaces the current native title through an `onTitle` callback.
- `agyPtyLauncher`: wires `createNativeSessionTitleMetadataSync` so the title lands in `metadata.summary` (deduped, never creating a chat row). A user-defined `metadata.name` still wins in the web title logic (`name > summary > path`).

## Tests
- `agySessionTitle.test.ts` (new): normalization, placeholder/empty filtering, invalid UUID rejection, DB failure no-op.
- `agySessionScanner.test.ts`: title callback invoked while scanning a known brain.
- `agyPtyLauncher.test.ts`: launcher wires the callback into `updateMetadata` summary sync.

## Verification
- `bun typecheck` (cli + web + hub): pass.
- Targeted AGY suites: 62/62 pass.
- `bun run test:hub` 1004 pass / `test:web` 2282 pass / `test:shared` 223 pass.
- `bun run test:cli`: 2325 pass, 3 environment-flaky failures (`runner.integration` stress spawn test — reproduced on the pristine base with this diff stashed; `cursorLegacyRemoteLauncher` auth-banner timing — passed on retry; unrelated to this change).