### PR TITLE
fix(pi): surface mid-turn LLM errors in web chat

### DIFF
--- a/cli/src/pi/piMessageAccumulator.test.ts
+++ b/cli/src/pi/piMessageAccumulator.test.ts
@@ -77,6 +77,64 @@ describe('PiMessageAccumulator', () => {
         }]);
     });
 
+    it('emits an error AgentMessage when message_end reports stopReason error, once across turn_end', () => {
+        const accumulator = new PiMessageAccumulator({ now: () => 0, streamNonceFactory: () => 'nonce' });
+        accumulator.handleEvent(event('turn_start'));
+        accumulator.handleEvent(event('message_start'));
+        expect(accumulator.handleEvent(event('message_end', {
+            message: { role: 'assistant', stopReason: 'error', errorMessage: 'Provider 529: overloaded' },
+        }))).toEqual([{ type: 'error', message: 'Provider 529: overloaded' }]);
+        // Pi repeats the failed message on turn_end — must not duplicate.
+        expect(accumulator.handleEvent(event('turn_end', {
+            message: { stopReason: 'error', errorMessage: 'Provider 529: overloaded' },
+        }))).toEqual([]);
+    });
+
+    it('appends the error after flushed partial text', () => {
+        let now = 0;
+        const accumulator = new PiMessageAccumulator({ now: () => now, streamNonceFactory: () => 'nonce' });
+        accumulator.handleEvent(event('turn_start'));
+        accumulator.handleEvent(event('message_start'));
+        expect(accumulator.handleEvent(event('message_update', {
+            assistantMessageEvent: { type: 'text_delta', delta: 'partial answer' },
+        }))).toEqual([{
+            type: 'text', text: 'partial answer', id: 'pi-nonce-turn-1-message-1-text-0', streamSnapshot: true, live: true,
+        }]);
+        expect(accumulator.handleEvent(event('message_end', {
+            message: { stopReason: 'error', errorMessage: 'stream dropped' },
+        }))).toEqual([{ type: 'error', message: 'stream dropped' }]);
+    });
+
+    it('falls back to turn_end when Pi skips message_end on stream failure', () => {
+        const accumulator = new PiMessageAccumulator({ now: () => 0, streamNonceFactory: () => 'nonce' });
+        accumulator.handleEvent(event('turn_start'));
+        accumulator.handleEvent(event('message_start'));
+        expect(accumulator.handleEvent(event('turn_end', {
+            message: { stopReason: 'error', errorMessage: 'network dropped' },
+        }))).toEqual([{ type: 'error', message: 'network dropped' }]);
+    });
+
+    it('does not emit an error for user-initiated aborts or healthy turns', () => {
+        const accumulator = new PiMessageAccumulator({ now: () => 0, streamNonceFactory: () => 'nonce' });
+        accumulator.handleEvent(event('message_start'));
+        expect(accumulator.handleEvent(event('message_end', {
+            message: { role: 'assistant', stopReason: 'aborted' },
+        }))).toEqual([]);
+
+        accumulator.handleEvent(event('message_start'));
+        expect(accumulator.handleEvent(event('message_end', {
+            message: { role: 'assistant', stopReason: 'stop' },
+        }))).toEqual([]);
+    });
+
+    it('falls back to a generic message when stopReason error carries no errorMessage', () => {
+        const accumulator = new PiMessageAccumulator({ now: () => 0, streamNonceFactory: () => 'nonce' });
+        accumulator.handleEvent(event('message_start'));
+        expect(accumulator.handleEvent(event('turn_end', {
+            message: { stopReason: 'error' },
+        }))).toEqual([{ type: 'error', message: 'Pi agent error' }]);
+    });
+
     it('does not collide across accumulator instances after a session resume', () => {
         const first = new PiMessageAccumulator({ streamNonceFactory: () => 'before-restart' });
         const second = new PiMessageAccumulator({ streamNonceFactory: () => 'after-restart' });

--- a/cli/src/pi/piMessageAccumulator.ts
+++ b/cli/src/pi/piMessageAccumulator.ts
@@ -23,10 +23,28 @@ type Segment = {
  * accumulator instance has a nonce as a session resume/restart must not reuse a
  * previous timeline stream id.
  */
+/**
+ * Extract the failure text from a Pi assistant message that ended in error.
+ *
+ * On a mid-turn LLM/API failure (auth, 5xx, network drop) Pi finalizes the
+ * assistant message with `stopReason: 'error'` and an `errorMessage`, emitted
+ * on both `message_end` and `turn_end`. `aborted` is user-initiated (web Abort)
+ * and intentionally not surfaced as an error. Returns null for anything else.
+ */
+export function extractPiTurnError(message: unknown): string | null {
+    if (typeof message !== 'object' || message === null) return null;
+    const record = message as { stopReason?: unknown; errorMessage?: unknown };
+    if (record.stopReason !== 'error') return null;
+    return typeof record.errorMessage === 'string' && record.errorMessage.length > 0
+        ? record.errorMessage
+        : 'Pi agent error';
+}
+
 export class PiMessageAccumulator {
     private active = false;
     private turnSequence = 0;
     private messageSequence = 0;
+    private errorEmitted = false;
     private readonly streamNonce: string;
     private readonly textSegments = new Map<number, Segment>();
     private readonly reasoningSegments = new Map<number, Segment>();
@@ -68,7 +86,24 @@ export class PiMessageAccumulator {
             return this.snapshotIfDue();
         }
 
-        if (event.type === 'message_end' || event.type === 'turn_end' || event.type === 'agent_end') {
+        if (event.type === 'message_end' || event.type === 'turn_end') {
+            const wasActive = this.active;
+            const messages = this.flush();
+            // Pi reports the failure on both message_end and turn_end; emit the
+            // error once (first boundary wins) so the web shows a failed turn
+            // instead of silent partial text. turn_end doubles as the safety
+            // net for Pi builds that skip message_end on stream failure.
+            if (wasActive && !this.errorEmitted && 'message' in event) {
+                const errorMessage = extractPiTurnError(event.message);
+                if (errorMessage) {
+                    messages.push({ type: 'error', message: errorMessage });
+                    this.errorEmitted = true;
+                }
+            }
+            return messages;
+        }
+
+        if (event.type === 'agent_end') {
             return this.flush();
         }
 
@@ -86,6 +121,7 @@ export class PiMessageAccumulator {
     private startMessage(): void {
         this.active = true;
         this.messageSequence += 1;
+        this.errorEmitted = false;
         this.textSegments.clear();
         this.reasoningSegments.clear();
         this.lastSnapshotAt = null;

--- a/cli/src/pi/types.ts
+++ b/cli/src/pi/types.ts
@@ -49,7 +49,7 @@ export interface PiAgentSettledEvent { type: 'agent_settled' }
 export interface PiTurnStartEvent { type: 'turn_start' }
 export interface PiTurnEndEvent {
     type: 'turn_end';
-    message?: { usage?: PiUsage; stopReason?: string };
+    message?: { usage?: PiUsage; stopReason?: string; errorMessage?: string };
     toolResults?: unknown[];
 }
 export interface PiMessageStartEvent { type: 'message_start'; message: unknown }


### PR DESCRIPTION
## Summary

Fixes #1478 — Pi mid-turn LLM/API errors (auth, 5xx, network drop) were invisible in the web chat. Pi finalizes a failed assistant message with `stopReason: 'error'` + `errorMessage` on both `message_end` and `turn_end`, but `PiMessageAccumulator` only handled `text_delta`/`thinking_delta`, so the error was silently dropped and the web showed nothing (spinner stops, partial text at most).

## Changes

- `cli/src/pi/piMessageAccumulator.ts`: emit an `AgentMessage {type:'error', message}` once per failed message. `message_end` wins; `turn_end` is the safety net for Pi builds that skip `message_end` on stream failure. `errorEmitted` is reset per `message_start`, so multi-turn runs report each failed turn once. User-initiated `aborted` stays silent (matches Claude/Codex behavior).
- `cli/src/pi/types.ts`: add `errorMessage` to `PiTurnEndEvent.message`.
- `cli/src/pi/piMessageAccumulator.test.ts`: 5 regression tests (message_end path + no duplicate across turn_end, error appended after partial text, turn_end fallback, aborted/healthy silence, generic fallback when errorMessage missing).

The web already renders `AGENT_MESSAGE_PAYLOAD_TYPE` + `data.type === 'error'` payloads as ⚠️ system messages (`web/src/chat/normalizeAgent.ts`), so this is CLI-only.

## Verification

- `bun typecheck` → clean
- `vitest run src/pi/` → 211 passed (incl. 5 new)
- `bun run test` → 2414 passed / 1 failed (`runner.integration.test.ts` stress test — verified pre-existing on base, fails identically without this diff)

## Out of scope

`auto_retry_start/end` and `extension_error` events remain hidden (unknown-event drop in `convertPiEvent`); retry spam risk — can follow up separately if wanted.