### PR TITLE
feat(cursor): bump hub thinking on ACP harness wake

### DIFF
--- a/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
@@ -1412,4 +1412,83 @@ describe('AcpSdkBackend', () => {
             { type: 'turn_complete', stopReason: 'end_turn' }
         ]);
     });
+
+    it('notifies agent-activity listener for harness-wake activity, not usage noise (#1470)', () => {
+        const backend = new AcpSdkBackend({ command: 'agent' });
+        const activity: string[] = [];
+        backend.setAgentActivityListener(() => {
+            activity.push('bump');
+        });
+
+        const backendInternal = backend as unknown as {
+            handleSessionUpdate: (params: unknown) => void;
+        };
+
+        backendInternal.handleSessionUpdate({
+            sessionId: 'session-1',
+            update: {
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.agentMessageChunk,
+                content: { type: 'text', text: 'resumed' }
+            }
+        });
+        backendInternal.handleSessionUpdate({
+            sessionId: 'session-1',
+            update: { sessionUpdate: 'usage_update', used: 1_000, size: 200_000 }
+        });
+        backendInternal.handleSessionUpdate({
+            sessionId: 'session-1',
+            update: {
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.sessionInfoUpdate,
+                title: 'noise'
+            }
+        });
+        backendInternal.handleSessionUpdate({
+            sessionId: 'session-1',
+            update: { sessionUpdate: 'state_update', state: 'running' }
+        });
+        backendInternal.handleSessionUpdate({
+            sessionId: 'session-1',
+            update: { sessionUpdate: 'state_update', state: 'idle' }
+        });
+
+        expect(activity).toEqual(['bump', 'bump']);
+    });
+
+    it('notifies agent-activity listener when a permission request arrives (#1470)', async () => {
+        const backend = new AcpSdkBackend({ command: 'agent' });
+        const activity: string[] = [];
+        backend.setAgentActivityListener(() => {
+            activity.push('bump');
+        });
+        backend.onPermissionRequest(() => {
+            // leave pending; we only care that activity fired first
+        });
+
+        const backendInternal = backend as unknown as {
+            handlePermissionRequest: (params: unknown, requestId: string) => Promise<unknown>;
+        };
+
+        const pending = backendInternal.handlePermissionRequest({
+            sessionId: 'session-1',
+            toolCall: {
+                toolCallId: 'tc-1',
+                title: 'Shell',
+                kind: 'execute',
+                status: 'pending'
+            },
+            options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+        }, 'req-1');
+
+        expect(activity).toEqual(['bump']);
+        // Cancel so the promise does not hang the suite.
+        await backend.respondToPermission('session-1', {
+            id: 'tc-1',
+            sessionId: 'session-1',
+            toolCallId: 'tc-1',
+            title: 'Shell',
+            kind: 'execute',
+            options: []
+        }, { outcome: 'cancelled' });
+        await pending;
+    });
 });

--- a/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.test.ts
@@ -1415,9 +1415,9 @@ describe('AcpSdkBackend', () => {
 
     it('notifies agent-activity listener for harness-wake activity, not usage noise (#1470)', () => {
         const backend = new AcpSdkBackend({ command: 'agent' });
-        const activity: string[] = [];
-        backend.setAgentActivityListener(() => {
-            activity.push('bump');
+        const activity: boolean[] = [];
+        backend.setAgentActivityListener((thinking) => {
+            activity.push(thinking);
         });
 
         const backendInternal = backend as unknown as {
@@ -1451,14 +1451,14 @@ describe('AcpSdkBackend', () => {
             update: { sessionUpdate: 'state_update', state: 'idle' }
         });
 
-        expect(activity).toEqual(['bump', 'bump']);
+        expect(activity).toEqual([true, true, false]);
     });
 
     it('notifies agent-activity listener when a permission request arrives (#1470)', async () => {
         const backend = new AcpSdkBackend({ command: 'agent' });
-        const activity: string[] = [];
-        backend.setAgentActivityListener(() => {
-            activity.push('bump');
+        const activity: boolean[] = [];
+        backend.setAgentActivityListener((thinking) => {
+            activity.push(thinking);
         });
         backend.onPermissionRequest(() => {
             // leave pending; we only care that activity fired first
@@ -1479,7 +1479,7 @@ describe('AcpSdkBackend', () => {
             options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
         }, 'req-1');
 
-        expect(activity).toEqual(['bump']);
+        expect(activity).toEqual([true]);
         // Cancel so the promise does not hang the suite.
         await backend.respondToPermission('session-1', {
             id: 'tc-1',

--- a/cli/src/agent/backends/acp/AcpSdkBackend.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.ts
@@ -4,7 +4,7 @@ import { asString, isObject } from '@hapi/protocol';
 import { AcpStdioTransport, type AcpStderrError } from './AcpStdioTransport';
 import { AcpMessageHandler, type AcpTextChunkMode } from './AcpMessageHandler';
 import { ACP_SESSION_UPDATE_TYPES } from './constants';
-import { shouldBumpThinkingFromSessionUpdate } from './shouldBumpThinkingFromSessionUpdate';
+import { thinkingHintFromSessionUpdate } from './shouldBumpThinkingFromSessionUpdate';
 import { logger } from '@/ui/logger';
 import { withRetry } from '@/utils/time';
 import packageJson from '../../../../package.json';
@@ -84,7 +84,7 @@ export class AcpSdkBackend implements AgentBackend {
     private usageUpdateListener: ((msg: AgentMessage) => void) | null = null;
     private sessionInfoUpdateListener: ((update: AcpSessionInfoUpdate) => void) | null = null;
     /** Fired on real agent activity so launchers can bump hub thinking (#1470). */
-    private agentActivityListener: (() => void) | null = null;
+    private agentActivityListener: ((thinking: boolean) => void) | null = null;
     private lastForwardedUsageUpdate: AcpUsageUpdate | null = null;
     private sessionUpdateQueue: Promise<void> = Promise.resolve();
 
@@ -444,11 +444,12 @@ export class AcpSdkBackend implements AgentBackend {
     }
 
     /**
-     * Called when ACP reports real agent work (message/tool/thought/running).
-     * Launchers use this to bump `thinking` after harness resume without a new
-     * hub user message (#1470). Usage/title noise does not fire.
+     * Called when ACP reports thinking transitions for harness wake (#1470).
+     * `true` = activity / running / permission; `false` = state_update idle.
+     * Usage/title noise does not fire. Launchers should ignore no-ops when
+     * session.thinking already matches.
      */
-    setAgentActivityListener(listener: (() => void) | null): void {
+    setAgentActivityListener(listener: ((thinking: boolean) => void) | null): void {
         this.agentActivityListener = listener;
     }
 
@@ -808,10 +809,11 @@ export class AcpSdkBackend implements AgentBackend {
         if (!isObject(update)) {
             return;
         }
-        if (!shouldBumpThinkingFromSessionUpdate(update)) {
+        const hint = thinkingHintFromSessionUpdate(update);
+        if (hint === null) {
             return;
         }
-        this.agentActivityListener();
+        this.agentActivityListener(hint);
     }
 
     private forwardSessionInfoUpdate(sessionId: string | null, update: unknown): void {
@@ -990,7 +992,7 @@ export class AcpSdkBackend implements AgentBackend {
         if (this.permissionHandler) {
             try {
                 // Permission prompts imply the agent is awake (#1470).
-                this.agentActivityListener?.();
+                this.agentActivityListener?.(true);
                 this.permissionHandler(request);
             } catch (error) {
                 this.pendingPermissions.delete(toolCallId);

--- a/cli/src/agent/backends/acp/AcpSdkBackend.ts
+++ b/cli/src/agent/backends/acp/AcpSdkBackend.ts
@@ -4,6 +4,7 @@ import { asString, isObject } from '@hapi/protocol';
 import { AcpStdioTransport, type AcpStderrError } from './AcpStdioTransport';
 import { AcpMessageHandler, type AcpTextChunkMode } from './AcpMessageHandler';
 import { ACP_SESSION_UPDATE_TYPES } from './constants';
+import { shouldBumpThinkingFromSessionUpdate } from './shouldBumpThinkingFromSessionUpdate';
 import { logger } from '@/ui/logger';
 import { withRetry } from '@/utils/time';
 import packageJson from '../../../../package.json';
@@ -82,6 +83,8 @@ export class AcpSdkBackend implements AgentBackend {
     private promptUsageCallback: ((msg: AgentMessage) => void) | null = null;
     private usageUpdateListener: ((msg: AgentMessage) => void) | null = null;
     private sessionInfoUpdateListener: ((update: AcpSessionInfoUpdate) => void) | null = null;
+    /** Fired on real agent activity so launchers can bump hub thinking (#1470). */
+    private agentActivityListener: (() => void) | null = null;
     private lastForwardedUsageUpdate: AcpUsageUpdate | null = null;
     private sessionUpdateQueue: Promise<void> = Promise.resolve();
 
@@ -440,6 +443,15 @@ export class AcpSdkBackend implements AgentBackend {
         this.sessionInfoUpdateListener = listener;
     }
 
+    /**
+     * Called when ACP reports real agent work (message/tool/thought/running).
+     * Launchers use this to bump `thinking` after harness resume without a new
+     * hub user message (#1470). Usage/title noise does not fire.
+     */
+    setAgentActivityListener(listener: (() => void) | null): void {
+        this.agentActivityListener = listener;
+    }
+
     /** Reads the agent's persisted native title through stable ACP session/list. */
     async refreshSessionInfo(sessionId: string, cwd: string): Promise<void> {
         const existingTimer = this.sessionInfoRefreshTimers.get(sessionId);
@@ -771,6 +783,7 @@ export class AcpSdkBackend implements AgentBackend {
         }
         this.forwardSessionInfoUpdate(sessionId, update);
         this.captureUsageUpdate(update);
+        this.notifyAgentActivity(update);
         // Capture the handler at enqueue time. Looking up `this.messageHandler`
         // when the queued microtask runs can leak a suppressUpdatesDuring
         // update into the restored handler if earlier async image work kept
@@ -786,6 +799,19 @@ export class AcpSdkBackend implements AgentBackend {
                     error instanceof Error ? error.message : String(error)
                 );
             });
+    }
+
+    private notifyAgentActivity(update: unknown): void {
+        if (!this.agentActivityListener) {
+            return;
+        }
+        if (!isObject(update)) {
+            return;
+        }
+        if (!shouldBumpThinkingFromSessionUpdate(update)) {
+            return;
+        }
+        this.agentActivityListener();
     }
 
     private forwardSessionInfoUpdate(sessionId: string | null, update: unknown): void {
@@ -963,6 +989,8 @@ export class AcpSdkBackend implements AgentBackend {
 
         if (this.permissionHandler) {
             try {
+                // Permission prompts imply the agent is awake (#1470).
+                this.agentActivityListener?.();
                 this.permissionHandler(request);
             } catch (error) {
                 this.pendingPermissions.delete(toolCallId);

--- a/cli/src/agent/backends/acp/shouldBumpThinkingFromSessionUpdate.test.ts
+++ b/cli/src/agent/backends/acp/shouldBumpThinkingFromSessionUpdate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { shouldBumpThinkingFromSessionUpdate } from './shouldBumpThinkingFromSessionUpdate'
+import { ACP_SESSION_UPDATE_TYPES } from './constants'
+
+describe('shouldBumpThinkingFromSessionUpdate', () => {
+    it.each([
+        ACP_SESSION_UPDATE_TYPES.agentMessageChunk,
+        ACP_SESSION_UPDATE_TYPES.agentThoughtChunk,
+        ACP_SESSION_UPDATE_TYPES.toolCall,
+        ACP_SESSION_UPDATE_TYPES.toolCallUpdate,
+        ACP_SESSION_UPDATE_TYPES.plan,
+        'agent_message',
+        'agent_thought',
+        'user_message',
+        'user_message_chunk',
+        'tool_call_content_chunk',
+    ] as const)('bumps for activity type %s', (sessionUpdate) => {
+        expect(shouldBumpThinkingFromSessionUpdate({ sessionUpdate })).toBe(true)
+    })
+
+    it('bumps for ACP v2 state_update running', () => {
+        expect(shouldBumpThinkingFromSessionUpdate({
+            sessionUpdate: 'state_update',
+            state: 'running',
+        })).toBe(true)
+    })
+
+    it('bumps for ACP v2 state_update requires_action', () => {
+        expect(shouldBumpThinkingFromSessionUpdate({
+            sessionUpdate: 'state_update',
+            state: 'requires_action',
+        })).toBe(true)
+    })
+
+    it.each([
+        ACP_SESSION_UPDATE_TYPES.usageUpdate,
+        ACP_SESSION_UPDATE_TYPES.sessionInfoUpdate,
+        'available_commands_update',
+        'current_mode_update',
+        'config_option_update',
+    ] as const)('does not bump for noise type %s', (sessionUpdate) => {
+        expect(shouldBumpThinkingFromSessionUpdate({ sessionUpdate })).toBe(false)
+    })
+
+    it('does not bump for state_update idle', () => {
+        expect(shouldBumpThinkingFromSessionUpdate({
+            sessionUpdate: 'state_update',
+            state: 'idle',
+        })).toBe(false)
+    })
+
+    it('does not bump for missing or non-string sessionUpdate', () => {
+        expect(shouldBumpThinkingFromSessionUpdate(null)).toBe(false)
+        expect(shouldBumpThinkingFromSessionUpdate(undefined)).toBe(false)
+        expect(shouldBumpThinkingFromSessionUpdate({})).toBe(false)
+        expect(shouldBumpThinkingFromSessionUpdate({ sessionUpdate: 12 })).toBe(false)
+    })
+})

--- a/cli/src/agent/backends/acp/shouldBumpThinkingFromSessionUpdate.test.ts
+++ b/cli/src/agent/backends/acp/shouldBumpThinkingFromSessionUpdate.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { shouldBumpThinkingFromSessionUpdate } from './shouldBumpThinkingFromSessionUpdate'
+import {
+    shouldBumpThinkingFromSessionUpdate,
+    thinkingHintFromSessionUpdate,
+} from './shouldBumpThinkingFromSessionUpdate'
 import { ACP_SESSION_UPDATE_TYPES } from './constants'
 
-describe('shouldBumpThinkingFromSessionUpdate', () => {
+describe('thinkingHintFromSessionUpdate', () => {
     it.each([
         ACP_SESSION_UPDATE_TYPES.agentMessageChunk,
         ACP_SESSION_UPDATE_TYPES.agentThoughtChunk,
@@ -14,22 +17,31 @@ describe('shouldBumpThinkingFromSessionUpdate', () => {
         'user_message',
         'user_message_chunk',
         'tool_call_content_chunk',
-    ] as const)('bumps for activity type %s', (sessionUpdate) => {
+    ] as const)('returns true for activity type %s', (sessionUpdate) => {
+        expect(thinkingHintFromSessionUpdate({ sessionUpdate })).toBe(true)
         expect(shouldBumpThinkingFromSessionUpdate({ sessionUpdate })).toBe(true)
     })
 
-    it('bumps for ACP v2 state_update running', () => {
-        expect(shouldBumpThinkingFromSessionUpdate({
+    it('returns true for ACP v2 state_update running / requires_action', () => {
+        expect(thinkingHintFromSessionUpdate({
             sessionUpdate: 'state_update',
             state: 'running',
         })).toBe(true)
-    })
-
-    it('bumps for ACP v2 state_update requires_action', () => {
-        expect(shouldBumpThinkingFromSessionUpdate({
+        expect(thinkingHintFromSessionUpdate({
             sessionUpdate: 'state_update',
             state: 'requires_action',
         })).toBe(true)
+    })
+
+    it('returns false for ACP v2 state_update idle', () => {
+        expect(thinkingHintFromSessionUpdate({
+            sessionUpdate: 'state_update',
+            state: 'idle',
+        })).toBe(false)
+        expect(shouldBumpThinkingFromSessionUpdate({
+            sessionUpdate: 'state_update',
+            state: 'idle',
+        })).toBe(false)
     })
 
     it.each([
@@ -38,21 +50,15 @@ describe('shouldBumpThinkingFromSessionUpdate', () => {
         'available_commands_update',
         'current_mode_update',
         'config_option_update',
-    ] as const)('does not bump for noise type %s', (sessionUpdate) => {
+    ] as const)('returns null for noise type %s', (sessionUpdate) => {
+        expect(thinkingHintFromSessionUpdate({ sessionUpdate })).toBeNull()
         expect(shouldBumpThinkingFromSessionUpdate({ sessionUpdate })).toBe(false)
     })
 
-    it('does not bump for state_update idle', () => {
-        expect(shouldBumpThinkingFromSessionUpdate({
-            sessionUpdate: 'state_update',
-            state: 'idle',
-        })).toBe(false)
-    })
-
-    it('does not bump for missing or non-string sessionUpdate', () => {
-        expect(shouldBumpThinkingFromSessionUpdate(null)).toBe(false)
-        expect(shouldBumpThinkingFromSessionUpdate(undefined)).toBe(false)
-        expect(shouldBumpThinkingFromSessionUpdate({})).toBe(false)
-        expect(shouldBumpThinkingFromSessionUpdate({ sessionUpdate: 12 })).toBe(false)
+    it('returns null for missing or non-string sessionUpdate', () => {
+        expect(thinkingHintFromSessionUpdate(null)).toBeNull()
+        expect(thinkingHintFromSessionUpdate(undefined)).toBeNull()
+        expect(thinkingHintFromSessionUpdate({})).toBeNull()
+        expect(thinkingHintFromSessionUpdate({ sessionUpdate: 12 })).toBeNull()
     })
 })

--- a/cli/src/agent/backends/acp/shouldBumpThinkingFromSessionUpdate.ts
+++ b/cli/src/agent/backends/acp/shouldBumpThinkingFromSessionUpdate.ts
@@ -1,0 +1,31 @@
+/**
+ * Gate for harness/ACP resume → hub thinking (#1470).
+ *
+ * Keepalive noise (usage / session title) must not flip thinking true.
+ * Activity and ACP v2 foreground `state_update: running|requires_action` do.
+ */
+export function shouldBumpThinkingFromSessionUpdate(
+    update: { sessionUpdate?: unknown; state?: unknown } | null | undefined
+): boolean {
+    if (!update || typeof update.sessionUpdate !== 'string') {
+        return false
+    }
+
+    switch (update.sessionUpdate) {
+        case 'agent_message_chunk':
+        case 'agent_message':
+        case 'agent_thought_chunk':
+        case 'agent_thought':
+        case 'tool_call':
+        case 'tool_call_update':
+        case 'tool_call_content_chunk':
+        case 'plan':
+        case 'user_message':
+        case 'user_message_chunk':
+            return true
+        case 'state_update':
+            return update.state === 'running' || update.state === 'requires_action'
+        default:
+            return false
+    }
+}

--- a/cli/src/agent/backends/acp/shouldBumpThinkingFromSessionUpdate.ts
+++ b/cli/src/agent/backends/acp/shouldBumpThinkingFromSessionUpdate.ts
@@ -1,14 +1,18 @@
 /**
  * Gate for harness/ACP resume → hub thinking (#1470).
  *
- * Keepalive noise (usage / session title) must not flip thinking true.
- * Activity and ACP v2 foreground `state_update: running|requires_action` do.
+ * Returns:
+ * - `true` — real agent activity / foreground running (bump thinking)
+ * - `false` — ACP v2 `state_update: idle` (clear thinking)
+ * - `null` — noise / unknown (do not touch thinking)
  */
-export function shouldBumpThinkingFromSessionUpdate(
+export type SessionUpdateThinkingHint = boolean | null
+
+export function thinkingHintFromSessionUpdate(
     update: { sessionUpdate?: unknown; state?: unknown } | null | undefined
-): boolean {
+): SessionUpdateThinkingHint {
     if (!update || typeof update.sessionUpdate !== 'string') {
-        return false
+        return null
     }
 
     switch (update.sessionUpdate) {
@@ -24,8 +28,21 @@ export function shouldBumpThinkingFromSessionUpdate(
         case 'user_message_chunk':
             return true
         case 'state_update':
-            return update.state === 'running' || update.state === 'requires_action'
+            if (update.state === 'running' || update.state === 'requires_action') {
+                return true
+            }
+            if (update.state === 'idle') {
+                return false
+            }
+            return null
         default:
-            return false
+            return null
     }
+}
+
+/** @deprecated Prefer thinkingHintFromSessionUpdate; kept for call-site clarity in tests. */
+export function shouldBumpThinkingFromSessionUpdate(
+    update: { sessionUpdate?: unknown; state?: unknown } | null | undefined
+): boolean {
+    return thinkingHintFromSessionUpdate(update) === true
 }

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -135,6 +135,7 @@ vi.mock('./utils/cursorAcpBackend', () => ({
                 harness.stderrErrorHandler = handler ?? null;
             }),
             setUsageUpdateListener: vi.fn(),
+            setAgentActivityListener: vi.fn(),
             setSessionInfoUpdateListener: vi.fn(),
             refreshSessionInfo: vi.fn(async () => {}),
             onPermissionRequest: vi.fn(),

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -22,7 +22,8 @@ const harness = vi.hoisted(() => ({
     releaseLoadSession: null as (() => void) | null,
     stderrErrorHandler: null as ((error: { type: string; message: string; raw?: string }) => void) | null,
     disconnectError: null as Error | null,
-    overlayCleanup: null as ReturnType<typeof vi.fn> | null
+    overlayCleanup: null as ReturnType<typeof vi.fn> | null,
+    agentActivityListener: null as ((thinking: boolean) => void) | null
 }));
 
 const legacyLauncher = vi.hoisted(() => vi.fn());
@@ -135,7 +136,9 @@ vi.mock('./utils/cursorAcpBackend', () => ({
                 harness.stderrErrorHandler = handler ?? null;
             }),
             setUsageUpdateListener: vi.fn(),
-            setAgentActivityListener: vi.fn(),
+            setAgentActivityListener: vi.fn((listener: ((thinking: boolean) => void) | null) => {
+                harness.agentActivityListener = listener;
+            }),
             setSessionInfoUpdateListener: vi.fn(),
             refreshSessionInfo: vi.fn(async () => {}),
             onPermissionRequest: vi.fn(),
@@ -257,6 +260,7 @@ describe('cursorAcpRemoteLauncher', () => {
         harness.stderrErrorHandler = null;
         harness.disconnectError = null;
         harness.overlayCleanup = null;
+        harness.agentActivityListener = null;
         legacyLauncher.mockClear();
         process.stdin.isTTY = false;
         process.stdout.isTTY = false;
@@ -274,6 +278,45 @@ describe('cursorAcpRemoteLauncher', () => {
         expect(createCursorAcpBackend).toHaveBeenCalled();
         expect(harness.backendArgs).toEqual({ command: 'agent', args: ['acp'] });
         expect(legacyLauncher).not.toHaveBeenCalled();
+    });
+
+    it('applies harness thinking transitions once per edge (#1470)', async () => {
+        const keepAlive = vi.fn();
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const client = {
+            ...makeClient(),
+            keepAlive
+        } as unknown as ApiSessionClient;
+        const session = new CursorSession({
+            api: {} as never,
+            client,
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        // Keep the launcher in the main loop long enough to wire the listener.
+        const runPromise = cursorAcpRemoteLauncher(session);
+        await vi.waitFor(() => expect(harness.agentActivityListener).not.toBeNull());
+
+        expect(session.thinking).toBe(false);
+        keepAlive.mockClear();
+
+        harness.agentActivityListener!(true);
+        harness.agentActivityListener!(true);
+        harness.agentActivityListener!(false);
+
+        expect(session.thinking).toBe(false);
+        expect(keepAlive.mock.calls.map((call) => call[0])).toEqual([true, false]);
+
+        queue.close();
+        await runPromise;
     });
 
     it('removes the Cursor MCP overlay even when backend.disconnect rejects', async () => {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -564,8 +564,10 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
 
     /** #1470: ACP activity after idle → hub thinking via existing keepalive. */
     private wireAgentActivityThinking(backend: AcpSdkBackend, session: CursorSession): void {
-        backend.setAgentActivityListener(() => {
-            session.onThinkingChange(true);
+        backend.setAgentActivityListener((thinking) => {
+            if (session.thinking !== thinking) {
+                session.onThinkingChange(thinking);
+            }
         });
     }
 

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -138,6 +138,10 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             this.recordCursorNativeWorktreeMetadata();
 
             backend.setUsageUpdateListener((message) => this.handleAgentMessage(message));
+            // Harness resume (notify_on_output / mid-idle ACP activity) may not
+            // go through HAPI's prompt() window — bump thinking so the hub list
+            // matches reality (#1470).
+            this.wireAgentActivityThinking(backend, session);
 
             recentStderrHint = null;
             this.wireStderrErrorListener(backend, (hint) => {
@@ -248,6 +252,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                         this.backend = backend;
                         registerAcpSessionTitleSync(backend, session.client);
                         backend.setUsageUpdateListener((message) => this.handleAgentMessage(message));
+                        this.wireAgentActivityThinking(backend, session);
                         recentStderrHint = null;
                         this.wireStderrErrorListener(backend, (hint) => {
                             recentStderrHint = hint;
@@ -554,6 +559,13 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
         });
         logger.debug('[cursor-acp] CreatePlan accepted — queued continue prompt', {
             executeMode
+        });
+    }
+
+    /** #1470: ACP activity after idle → hub thinking via existing keepalive. */
+    private wireAgentActivityThinking(backend: AcpSdkBackend, session: CursorSession): void {
+        backend.setAgentActivityListener(() => {
+            session.onThinkingChange(true);
         });
     }
 

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -313,6 +313,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                         this.backend = backend;
                         registerAcpSessionTitleSync(backend, session.client);
                         backend.setUsageUpdateListener((message) => this.handleAgentMessage(message));
+                        this.wireAgentActivityThinking(backend, session);
                         recentStderrHint = null;
                         this.wireStderrErrorListener(backend, (hint) => {
                             recentStderrHint = hint;

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -51,6 +51,8 @@ hapi resume <session-id>   # Resume a specific HAPI session
 
 HAPI supports [Cursor Agent CLI](https://cursor.com/docs/cli/using) for running Cursor's AI coding agent with remote control via web and phone.
 
+When Cursor resumes mid-idle (for example after a Shell `notify_on_output` wake) and emits ACP activity, HAPI bumps session thinking over the normal `session-alive` keepalive so the list does not stay stuck idle. See [FAQ](./faq.md#why-did-my-session-look-idle-when-the-agent-woke-itself).
+
 ### Prerequisites
 
 Install Cursor Agent CLI:

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -93,6 +93,10 @@ In the session view, tap the "Files" tab to:
 
 Yes. Open any session and use the chat interface to send messages directly to the AI agent.
 
+### Why did my session look idle when the agent woke itself?
+
+Some agents (especially Cursor) can resume after idle from harness signals such as background Shell `notify_on_output` or `/loop`, without you sending a new HAPI message. HAPI treats real ACP agent activity (and permission requests) as thinking again so the session list matches the agent - same keepalive path as a normal turn. This is different from session-attached jobs (`hapi job`), which show progress while the agent stays idle on purpose.
+
 ### Can I access a terminal remotely?
 
 Yes. Open a session in the web app and tap the Terminal tab for a remote shell.


### PR DESCRIPTION
## Summary

- Cursor ACP harness wakes (mid-idle `session/update` activity, ACP v2 `state_update: running|requires_action`, or permission requests) now bump hub `thinking` via the existing `session-alive` keepalive.
- Activity gate ignores usage/title noise so keepalives alone cannot flip thinking.
- Docs: FAQ + Cursor agent note distinguishing this from `hapi job`.

## Test plan

- [x] `bunx vitest run` focused ACP + Cursor launcher suites (85 tests)
- [x] `bun typecheck`
- [ ] Dogfood: Cursor ACP session, short `notify_on_output` after turn ends; confirm hub list shows thinking without a new composer send
- [ ] If dogfood sees no ACP traffic on wake, follow up with hook escape hatch (Path B in #1470)

## Issues

Relates to #1470 (Path A only; Path B still open)

## Dogfood (2026-08-10)

- Harness wake without hub message: **FAIL** (peer + soup `:3006`) — Cursor ACP emits no post-idle activity
- Baseline hub message after idle: **PASS**
- Ready YES = Path A plumbing + tests; **not** harness dogfood PASS