### PR TITLE
fix(cli): raise flaky claudeRemote first-test timeout to 15s under CI load

### DIFF
--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -69,7 +69,8 @@ async function waitFor(condition: () => boolean, timeoutMs = 300, intervalMs = 1
 }
 
 describe('claudeRemote async message handling', () => {
-    it('reports the initial normal message once after the first result', async () => {
+    // CI occasionally exceeds the default 5s under load (unrelated to job work).
+    it('reports the initial normal message once after the first result', { timeout: 15_000 }, async () => {
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');
         const onFirstResult = vi.fn();


### PR DESCRIPTION
Fixes #1491

## Problem

`cli/src/claude/claudeRemote.test.ts` — "reports the initial normal message once after the first result" — intermittently exceeds vitest's default 5s test timeout under CI load. It fails PRs that touch zero `cli/` files (observed on at least one such PR; local runs of the same PR hang/flake while the test takes ~1–2s on a quiet machine).

## Change

One-line per-test timeout bump for that single test only:

```ts
it('reports the initial normal message once after the first result', { timeout: 15_000 }, async () => {
```

No other files touched. The test imports `./claudeRemote` (heavy module graph: SDK, watcher, session check) — that's where the load variance comes from.

## Verified

- `bun typecheck` → exit 0
- `cli/src/claude/claudeRemote.test.ts` → 6/6 pass (~2s, first test 1.9s cold)
- Full `bun run test` → 223/224 files pass, 2410 tests pass; the only failing file is `runner.integration.test.ts`, which fails identically on the pristine base in this sandbox (daemon-spawn environment issue, unrelated to this diff)