### PR TITLE
fix(web): hide chat viewport focus outline after Home/End

### DIFF
--- a/web/e2e/mermaid-lightbox-session.spec.ts
+++ b/web/e2e/mermaid-lightbox-session.spec.ts
@@ -104,4 +104,53 @@ test.describe('mermaid lightbox (live HAPI session)', () => {
             await page.waitForSelector('[role="dialog"]', { state: 'detached', timeout: 5000 }).catch(() => undefined)
         })
     }
+
+    test('live session chat viewport keeps keyboard focus visible', async ({ page }) => {
+        const baseUrl = getHapiBaseUrl()
+        const sessionId = getMermaidTestSessionId()
+        const token = readCliAccessToken()
+
+        await installHapiAuth(page, baseUrl, token)
+        await page.goto(`${baseUrl}/sessions/${sessionId}`, {
+            waitUntil: 'domcontentloaded',
+            timeout: 60_000,
+        })
+        const viewport = page.locator('.chat-scroll-y')
+        await viewport.waitFor({ state: 'visible', timeout: 30_000 })
+        await page.waitForTimeout(1500)
+
+        await page.evaluate(() => {
+            document.body.focus()
+        })
+        let viewportFocused = false
+        for (let index = 0; index < 40; index += 1) {
+            await page.keyboard.press('Tab')
+            viewportFocused = await viewport.evaluate((element) => document.activeElement === element)
+            if (viewportFocused) break
+        }
+        expect(viewportFocused).toBe(true)
+
+        const readFocusState = () => viewport.evaluate((element) => {
+            const style = getComputedStyle(element)
+            return {
+                active: document.activeElement === element,
+                focusVisible: element.matches(':focus-visible'),
+                outlineStyle: style.outlineStyle,
+                boxShadow: style.boxShadow,
+            }
+        })
+        const afterTab = await readFocusState()
+        expect(afterTab).toMatchObject({ active: true, focusVisible: true, outlineStyle: 'none' })
+        expect(afterTab.boxShadow).not.toBe('none')
+
+        await page.keyboard.press('Home')
+        const afterHome = await readFocusState()
+        await page.keyboard.press('End')
+        const afterEnd = await readFocusState()
+
+        expect(afterHome).toMatchObject({ active: true, focusVisible: true, outlineStyle: 'none' })
+        expect(afterHome.boxShadow).not.toBe('none')
+        expect(afterEnd).toMatchObject({ active: true, focusVisible: true, outlineStyle: 'none' })
+        expect(afterEnd.boxShadow).not.toBe('none')
+    })
 })

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -1613,7 +1613,7 @@ export function HappyThread(props: {
                 >
                     <div
                         ref={viewportRef}
-                        className="app-scroll-y chat-scroll-y min-h-0 flex-1 overflow-x-hidden"
+                        className="app-scroll-y chat-scroll-y min-h-0 flex-1 overflow-x-hidden focus:outline-none"
                         tabIndex={0}
                     >
                         <div ref={contentRef} className="chat-scroll-content mx-auto w-full max-w-content min-w-0 p-3">

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -1613,7 +1613,7 @@ export function HappyThread(props: {
                 >
                     <div
                         ref={viewportRef}
-                        className="app-scroll-y chat-scroll-y min-h-0 flex-1 overflow-x-hidden focus:outline-none"
+                        className="app-scroll-y chat-scroll-y min-h-0 flex-1 overflow-x-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--app-link)]"
                         tabIndex={0}
                     >
                         <div ref={contentRef} className="chat-scroll-content mx-auto w-full max-w-content min-w-0 p-3">


### PR DESCRIPTION
## Summary

- Hide the browser's default focus outline on the keyboard-scrollable chat viewport.
- Preserve the existing focus behavior and Home/End scrolling logic.
- Retain a visible application-colored focus ring for keyboard users.

## Root Cause

The chat viewport uses `tabIndex={0}` to receive keyboard scrolling. Pressing Home or End focuses the viewport and causes the browser's default focus outline to appear around the chat area.

The viewport now suppresses the native outline and uses the existing application link color for its `:focus-visible` ring. No scrolling or keyboard event logic was changed.

## Validation

- Focused HappyThread tests — 31 passed.
- Live keyboard-focus regression — 1 passed; Tab, Home, and End retain a visible focus ring while the native outline remains hidden.
- Test deployment endpoint returned HTTP 200.