### PR TITLE
fix(web): persist directory expansion locally

### DIFF
--- a/web/src/components/SessionFiles/DirectoryTree.test.tsx
+++ b/web/src/components/SessionFiles/DirectoryTree.test.tsx
@@ -67,4 +67,37 @@ describe('DirectoryTree expanded folders', () => {
         expect(localStorage.getItem('hapi-dir-expanded-v2-session-1')).toBe(JSON.stringify(['', 'src']))
         expect(sessionStorage.getItem('hapi-dir-expanded-session-1')).toBeNull()
     })
+
+    it('prefers the session fallback after localStorage writes fail', () => {
+        localStorage.setItem('hapi-dir-expanded-v2-session-1', JSON.stringify(['']))
+        const originalSetItem = Storage.prototype.setItem
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function setItem(this: Storage, key, value) {
+            if (this === localStorage && key === 'hapi-dir-expanded-v2-session-1') throw new Error('quota')
+            return originalSetItem.call(this, key, value)
+        })
+        const sessionSetItem = vi.spyOn(sessionStorage, 'setItem')
+
+        const view = renderTree()
+        fireEvent.click(screen.getByRole('button', { name: 'src' }))
+
+        expect(sessionSetItem).toHaveBeenLastCalledWith('hapi-dir-expanded-session-1', JSON.stringify(['', 'src']))
+
+        view.unmount()
+        renderTree()
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+    })
+
+    it('uses the session fallback when localStorage reads throw', () => {
+        sessionStorage.setItem('hapi-dir-expanded-session-1', JSON.stringify(['', 'src']))
+        const originalGetItem = Storage.prototype.getItem
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(function getItem(this: Storage, key) {
+            if (this === localStorage && key === 'hapi-dir-expanded-v2-session-1') throw new Error('unavailable')
+            return originalGetItem.call(this, key)
+        })
+
+        renderTree()
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+    })
 })

--- a/web/src/components/SessionFiles/DirectoryTree.test.tsx
+++ b/web/src/components/SessionFiles/DirectoryTree.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DirectoryTree } from '@/components/SessionFiles/DirectoryTree'
+import { ToastProvider } from '@/lib/toast-context'
+import { I18nProvider } from '@/lib/i18n-context'
+import { DEFAULT_DIRECTORY_SORT } from '@/lib/directory-sort'
+
+vi.mock('@/hooks/queries/useSessionDirectory', () => ({
+    useSessionDirectory: (_api: unknown, _sessionId: string, path: string) => ({
+        entries: path === ''
+            ? [
+                { name: 'src', type: 'directory' },
+                { name: 'README.md', type: 'file' },
+            ]
+            : path === 'src'
+                ? [{ name: 'index.ts', type: 'file' }]
+                : [],
+        error: null,
+        isLoading: false,
+        refetch: vi.fn(),
+    }),
+}))
+
+function renderTree(sessionId = 'session-1') {
+    return render(
+        <I18nProvider>
+            <ToastProvider>
+                <DirectoryTree
+                    api={{} as never}
+                    sessionId={sessionId}
+                    rootLabel="/workspace/project"
+                    onOpenFile={vi.fn()}
+                    sort={DEFAULT_DIRECTORY_SORT}
+                />
+            </ToastProvider>
+        </I18nProvider>
+    )
+}
+
+describe('DirectoryTree expanded folders', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        sessionStorage.clear()
+    })
+
+    afterEach(() => cleanup())
+
+    it('restores expanded folders after the file manager remounts', () => {
+        const view = renderTree()
+        fireEvent.click(screen.getByRole('button', { name: 'src' }))
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+        expect(localStorage.getItem('hapi-dir-expanded-v2-session-1')).toBe(JSON.stringify(['', 'src']))
+
+        view.unmount()
+        renderTree()
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+    })
+
+    it('migrates the legacy sessionStorage folder state to localStorage', () => {
+        sessionStorage.setItem('hapi-dir-expanded-session-1', JSON.stringify(['', 'src']))
+
+        renderTree()
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+        expect(localStorage.getItem('hapi-dir-expanded-v2-session-1')).toBe(JSON.stringify(['', 'src']))
+        expect(sessionStorage.getItem('hapi-dir-expanded-session-1')).toBeNull()
+    })
+})

--- a/web/src/components/SessionFiles/DirectoryTree.tsx
+++ b/web/src/components/SessionFiles/DirectoryTree.tsx
@@ -228,10 +228,18 @@ function DirectoryNode(props: {
 const STORAGE_KEY_PREFIX = 'hapi-dir-expanded-v2-'
 const LEGACY_SESSION_STORAGE_KEY_PREFIX = 'hapi-dir-expanded-'
 
+function safeReadStorage(storage: Storage, key: string): string | null {
+    try {
+        return storage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
 function readExpanded(sessionId: string): Set<string> {
     try {
-        const raw = localStorage.getItem(STORAGE_KEY_PREFIX + sessionId)
-            ?? sessionStorage.getItem(LEGACY_SESSION_STORAGE_KEY_PREFIX + sessionId)
+        const raw = safeReadStorage(sessionStorage, LEGACY_SESSION_STORAGE_KEY_PREFIX + sessionId)
+            ?? safeReadStorage(localStorage, STORAGE_KEY_PREFIX + sessionId)
         const parsed = raw ? JSON.parse(raw) : null
         if (Array.isArray(parsed)) return new Set(parsed as string[])
     } catch {

--- a/web/src/components/SessionFiles/DirectoryTree.tsx
+++ b/web/src/components/SessionFiles/DirectoryTree.tsx
@@ -225,15 +225,15 @@ function DirectoryNode(props: {
     )
 }
 
-const STORAGE_KEY_PREFIX = 'hapi-dir-expanded-'
+const STORAGE_KEY_PREFIX = 'hapi-dir-expanded-v2-'
+const LEGACY_SESSION_STORAGE_KEY_PREFIX = 'hapi-dir-expanded-'
 
 function readExpanded(sessionId: string): Set<string> {
     try {
-        const raw = sessionStorage.getItem(STORAGE_KEY_PREFIX + sessionId)
-        if (raw) {
-            const parsed = JSON.parse(raw)
-            if (Array.isArray(parsed)) return new Set(parsed as string[])
-        }
+        const raw = localStorage.getItem(STORAGE_KEY_PREFIX + sessionId)
+            ?? sessionStorage.getItem(LEGACY_SESSION_STORAGE_KEY_PREFIX + sessionId)
+        const parsed = raw ? JSON.parse(raw) : null
+        if (Array.isArray(parsed)) return new Set(parsed as string[])
     } catch {
         // ignore
     }
@@ -241,10 +241,16 @@ function readExpanded(sessionId: string): Set<string> {
 }
 
 function writeExpanded(sessionId: string, expanded: Set<string>) {
+    const serialized = JSON.stringify([...expanded])
     try {
-        sessionStorage.setItem(STORAGE_KEY_PREFIX + sessionId, JSON.stringify([...expanded]))
+        localStorage.setItem(STORAGE_KEY_PREFIX + sessionId, serialized)
+        sessionStorage.removeItem(LEGACY_SESSION_STORAGE_KEY_PREFIX + sessionId)
     } catch {
-        // ignore
+        try {
+            sessionStorage.setItem(LEGACY_SESSION_STORAGE_KEY_PREFIX + sessionId, serialized)
+        } catch {
+            // ignore
+        }
     }
 }
 
@@ -289,4 +295,3 @@ export function DirectoryTree(props: {
         </div>
     )
 }
-


### PR DESCRIPTION
## Summary
- store file-manager expanded folders in localStorage so directory state survives closing/reopening the Mini App
- keep the existing sessionStorage key as a legacy fallback and migrate it on write
- add regression coverage for remount restore and legacy sessionStorage migration

## Test plan
- cd web && bun run test src/components/SessionFiles/DirectoryTree.test.tsx
- cd web && bun run typecheck