### PR TITLE
fix(web): lazy render collapsed reasoning

### DIFF
--- a/web/src/components/assistant-ui/reasoning.test.tsx
+++ b/web/src/components/assistant-ui/reasoning.test.tsx
@@ -63,6 +63,13 @@ describe('ReasoningGroup', () => {
         expect(isCollapsed(container)).toBe(true)
     })
 
+    it('does not mount reasoning content while collapsed', () => {
+        const { container, queryByTestId } = renderGroup()
+
+        expect(isCollapsed(container)).toBe(true)
+        expect(queryByTestId('reasoning-content')).toBeNull()
+    })
+
     it('expands on click', () => {
         const { container } = renderGroup()
         const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
@@ -70,6 +77,19 @@ describe('ReasoningGroup', () => {
         fireEvent.click(container.querySelector('button')!)
         expect(isCollapsed(container)).toBe(false)
         expect(scroll.tabIndex).toBe(0)
+        expect(container.querySelector('[data-testid="reasoning-content"]')).not.toBeNull()
+    })
+
+    it('unmounts reasoning content after collapsing again', () => {
+        const { container, queryByTestId } = renderGroup()
+
+        fireEvent.click(container.querySelector('button')!)
+        expect(queryByTestId('reasoning-content')).not.toBeNull()
+
+        fireEvent.click(container.querySelector('button')!)
+
+        expect(isCollapsed(container)).toBe(true)
+        expect(queryByTestId('reasoning-content')).toBeNull()
     })
 
     it('auto-expands while streaming', () => {

--- a/web/src/components/assistant-ui/reasoning.tsx
+++ b/web/src/components/assistant-ui/reasoning.tsx
@@ -72,6 +72,7 @@ export const ReasoningGroup: FC<PropsWithChildren> = ({ children }) => {
         && message.content[message.content.length - 1]?.type === 'reasoning'
     const { reasoningCollapsed } = useReasoningCollapse()
     const chatContext = useOptionalHappyChatContext()
+    const shouldRenderContent = isOpen
 
     useEffect(() => {
         if (!isStreaming) return
@@ -204,7 +205,7 @@ export const ReasoningGroup: FC<PropsWithChildren> = ({ children }) => {
                     onKeyDown={claimNestedKeyboardScroll}
                     className="aui-reasoning-scroll max-h-[60vh] overflow-y-auto overscroll-y-contain border-t border-[var(--app-divider)] px-3.5 py-3"
                 >
-                    {children}
+                    {shouldRenderContent ? children : null}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- avoid mounting collapsed reasoning markdown content while browsing loaded history
- render reasoning content only after the user expands the reasoning panel
- keep the existing streaming behavior: live reasoning still auto-expands unless the user enabled the collapsed preference
- add regression coverage for collapsed/unmounted and expand/remount behavior

## Test plan
- cd web && bun run test src/components/assistant-ui/reasoning.test.tsx
- cd web && bun run typecheck

This is a frontend lazy-render step. It reduces DOM/Markdown work during history pagination without changing the message API or storage format.