### PR TITLE
fix(web): restore scroll chaining from reasoning panel to chat viewport

### DIFF
--- a/web/src/components/assistant-ui/reasoning.test.tsx
+++ b/web/src/components/assistant-ui/reasoning.test.tsx
@@ -240,4 +240,15 @@ describe('ReasoningGroup', () => {
 
         expect(onNestedScrollFollowChange.mock.calls).toEqual([[false], [true]])
     })
+
+    it('does not contain overscroll so the outer chat keeps scrolling past the panel boundary', () => {
+        // Scroll chaining is native browser behavior: once the panel reaches
+        // its bottom, the next wheel gesture must keep scrolling the outer
+        // chat viewport. overscroll-behavior-y: contain (Tailwind
+        // `overscroll-y-contain`) blocks exactly that — it was removed in
+        // #1264 and must not come back (regression from #1398).
+        const { container } = renderGroup()
+        const scroll = container.querySelector('.aui-reasoning-scroll') as HTMLDivElement
+        expect(scroll.className).not.toContain('overscroll-y-contain')
+    })
 })

--- a/web/src/components/assistant-ui/reasoning.tsx
+++ b/web/src/components/assistant-ui/reasoning.tsx
@@ -202,7 +202,13 @@ export const ReasoningGroup: FC<PropsWithChildren> = ({ children }) => {
                     onPointerDown={claimNestedPointerScroll}
                     onWheel={claimNestedWheelScroll}
                     onKeyDown={claimNestedKeyboardScroll}
-                    className="aui-reasoning-scroll max-h-[60vh] overflow-y-auto overscroll-y-contain border-t border-[var(--app-divider)] px-3.5 py-3"
+                    // No overscroll containment: native scroll chaining must pass
+                    // to the outer chat viewport once the panel reaches its
+                    // bottom (see #1264). The follow-tail coordination above
+                    // (onNestedScrollFollowChange) already pauses the outer
+                    // auto-follow while the user scrolls inside this panel, so
+                    // contain is not needed to stop the two from fighting.
+                    className="aui-reasoning-scroll max-h-[60vh] overflow-y-auto border-t border-[var(--app-divider)] px-3.5 py-3"
                 >
                     {children}
                 </div>


### PR DESCRIPTION
## Summary

Fixes #1500 — restore native scroll chaining from the Reasoning panel to the outer chat viewport.

The reasoning panel carried `overscroll-y-contain` (`overscroll-behavior-y: contain`), which disables scroll chaining: after scrolling the panel to its bottom, the outer chat viewport could not keep scrolling.

## Regression history

- **#1264** removed `overscroll-contain` from the panel exactly to allow this chaining.
- **#1398** re-added `overscroll-y-contain` while adding nested follow-tail coordination (pause the outer chat auto-follow while the user scrolls inside the panel), silently reverting #1264.

The #1398 coordination alone resolves the "fighting" problem from #1397 — interacting with the panel calls `onNestedScrollFollowChange(false)`, pausing the outer auto-follow immediately. Containment is unnecessary, so this PR drops it and keeps the coordination.

## Changes

- `web/src/components/assistant-ui/reasoning.tsx`: remove `overscroll-y-contain`, with a comment documenting why containment must not return
- `web/src/components/assistant-ui/reasoning.test.tsx`: regression test guarding the class list

## Validation

- `bun typecheck` ✓
- `bun run test:web` ✓ (251 files, 2305 tests)
- `bun run test` — only pre-existing flaky `cli/src/runner/runner.integration.test.ts` failures, reproduced identically on pristine `upstream/main` (web-only change; unrelated to runner daemon integration)
