### PR TITLE
fix(web): remove duplicate gap below queued messages

### DIFF
--- a/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
@@ -171,6 +171,19 @@ afterEach(() => {
     vi.unstubAllGlobals()
 })
 
+describe('QueuedMessagesBar layout', () => {
+    it('keeps the queue footer flush with the composer area', () => {
+        renderQueuedMessage()
+
+        const bar = screen.getByRole('status')
+        const content = bar.firstElementChild
+
+        expect(bar).not.toHaveClass('mb-1')
+        expect(content).toHaveClass('pt-2', 'pb-0')
+        expect(content).not.toHaveClass('py-2')
+    })
+})
+
 describe('QueuedMessagesBar edit restore', () => {
     it('keeps a newly typed draft and its schedule when the deferred cancel succeeds', async () => {
         const scheduledAt = Date.now() + 60_000

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -303,9 +303,9 @@ export function QueuedMessagesBar({
         <div
             role="status"
             aria-label={`${queued.length} queued message${queued.length === 1 ? '' : 's'} pending invocation`}
-            className="mx-auto w-full max-w-content mb-1"
+            className="mx-auto w-full max-w-content"
         >
-            <div className="px-3 py-2 text-sm text-[var(--app-fg-muted)]">
+            <div className="px-3 pb-0 pt-2 text-sm text-[var(--app-fg-muted)]">
                 <div className="flex items-center gap-1.5 mb-1.5 text-xs font-medium text-[var(--app-hint)]">
                     <ClockIcon />
                     <span>Queued</span>


### PR DESCRIPTION
## Summary

- Remove the duplicate bottom margin and padding from `QueuedMessagesBar`.
- Keep queued messages flush with the Composer status area.
- Add a regression test covering the layout classes.

## Problem / Motivation

When multiple messages were queued, `QueuedMessagesBar` added its own bottom padding and margin immediately before the Composer. The Composer already owns the spacing and status row below it, so the duplicated spacing created an oversized blank area between the queued messages and the input.

## Validation

- `bun run test:web -- src/components/AssistantChat/QueuedMessagesBar.test.tsx` — 33 tests passed.
- `bun run test:web` — passed.
- `bun run typecheck:web` — passed.
- `bun run build:web` — passed.

## Related Issues

None

## AI Disclosure

Implemented with assistance from OpenAI Codex using GPT 5.6.