### PR TITLE
fix(web): exclude path-only husks from @ session mentions

### DIFF
--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -30,7 +30,7 @@ import { getSessionLastSeenAt, getSessionLastSeenSnapshot } from '@/lib/sessionL
 import { useSessionRowTooltipIds } from '@/components/HoverTooltip'
 import { subscribeCodexImportedSessions } from '@/lib/codexImportedSessions'
 import { formatReopenError } from '@/lib/reopenError'
-import { getSessionTitle } from '@/lib/sessionTitle'
+import { getSessionTitle, hasSessionTitleSignal } from '@/lib/sessionTitle'
 import { getWorktreeSessionLabel } from '@/lib/sessionWorktreeLabel'
 import type { Machine } from '@/types/api'
 import { getMachinePlatform, presentMachineHealth } from '@/lib/machineHealth'
@@ -218,20 +218,12 @@ export function deduplicateSessionsByAgentId(sessions: SessionSummary[], selecte
     return result
 }
 
-function hasSidebarTitleSignal(session: SessionSummary): boolean {
-    const meta = session.metadata
-    if (!meta) return false
-    if (meta.name?.trim()) return true
-    if (meta.summary?.text?.trim()) return true
-    return false
-}
-
 export function isSidebarEmptySessionStub(session: SessionSummary): boolean {
     if (session.active) return false
     const meta = session.metadata
     if (!meta) return true
     if (meta.agentSessionId?.trim()) return false
-    if (hasSidebarTitleSignal(session)) return false
+    if (hasSessionTitleSignal(session)) return false
     return true
 }
 

--- a/web/src/lib/sessionReference.test.ts
+++ b/web/src/lib/sessionReference.test.ts
@@ -294,6 +294,35 @@ describe('matchSessionsForMention', () => {
         })
         expect(matchSessionsForMention([husk, named], '').map((s) => s.id)).toEqual(['named-active'])
     })
+
+    it('excludes titled duplicates that sidebar dedup hides, even when their title matches better', () => {
+        const live = makeSession({
+            id: 'live-visible',
+            active: true,
+            updatedAt: 100,
+            metadata: {
+                path: '/work/session-attached-jobs',
+                name: 'Peer: session-attached jobs',
+                flavor: 'cursor',
+                agentSessionId: 'shared-acp-thread',
+                lifecycleState: 'running',
+            },
+        })
+        const hidden = makeSession({
+            id: 'stale-hidden',
+            updatedAt: 999,
+            metadata: {
+                path: '/work/session-attached-jobs',
+                name: 'session-attached-jobs',
+                flavor: 'cursor',
+                agentSessionId: 'shared-acp-thread',
+                lifecycleState: 'archived',
+            },
+        })
+        const hits = matchSessionsForMention([hidden, live], 'session-attached-jobs')
+        expect(hits.map((s) => s.id)).toEqual(['live-visible'])
+        expect(hits.map((s) => s.id)).not.toContain('stale-hidden')
+    })
 })
 
 describe('parseSessionPathHref', () => {

--- a/web/src/lib/sessionReference.test.ts
+++ b/web/src/lib/sessionReference.test.ts
@@ -197,6 +197,103 @@ describe('matchSessionsForMention', () => {
         ])
         expect(hits.map((s) => s.id)).not.toContain('ccc-old')
     })
+
+    // #1506 — mention pool is stricter than sidebar visibility.
+    it('excludes sidebar-hidden empty stubs from typed queries', () => {
+        const stub = makeSession({
+            id: 'stub-hidden',
+            updatedAt: 999,
+            metadata: {
+                path: '/home/me/coding/hapi/worktrees/session-attached-jobs',
+                lifecycleState: 'archived',
+            },
+        })
+        const live = makeSession({
+            id: 'live-named',
+            active: true,
+            updatedAt: 100,
+            metadata: {
+                path: '/home/me/coding/hapi/worktrees/session-attached-jobs',
+                name: 'Peer: session-attached jobs',
+                lifecycleState: 'running',
+            },
+        })
+        const hits = matchSessionsForMention([stub, live], 'session-attached')
+        expect(hits.map((s) => s.id)).toEqual(['live-named'])
+        expect(getSessionTitle(stub)).toBe('session-attached-jobs')
+    })
+
+    it('excludes path-only title husks even when sidebar would show them', () => {
+        // agentSessionId keeps the row in the sidebar (#836), but path fallback is not a title.
+        const husk = makeSession({
+            id: 'husk-with-agent',
+            updatedAt: 999,
+            metadata: {
+                path: '/home/me/coding/hapi/worktrees/session-attached-jobs',
+                agentSessionId: 'agent-thread-1',
+                lifecycleState: 'archived',
+            },
+        })
+        const live = makeSession({
+            id: 'live-named',
+            active: true,
+            updatedAt: 100,
+            metadata: {
+                path: '/home/me/coding/hapi/worktrees/session-attached-jobs',
+                name: 'Peer: session-attached jobs',
+                lifecycleState: 'running',
+            },
+        })
+        const hits = matchSessionsForMention([husk, live], 'session-attached')
+        expect(hits.map((s) => s.id)).toEqual(['live-named'])
+        expect(hits.map((s) => s.id)).not.toContain('husk-with-agent')
+    })
+
+    it('keeps summary-only titled sessions and still matches their id prefix', () => {
+        const summaryOnly = makeSession({
+            id: 'summary-only-uuid',
+            updatedAt: 80,
+            metadata: {
+                path: '/work/summary-only',
+                summary: { text: 'Fix mention husks' },
+                lifecycleState: 'archived',
+            },
+        })
+        const husk = makeSession({
+            id: 'husk-path-only',
+            updatedAt: 90,
+            metadata: {
+                path: '/work/mention-husks',
+                agentSessionId: 'agent-2',
+            },
+        })
+        expect(matchSessionsForMention([summaryOnly, husk], 'mention husks').map((s) => s.id)).toEqual([
+            'summary-only-uuid',
+        ])
+        expect(matchSessionsForMention([summaryOnly, husk], 'summary-o').map((s) => s.id)).toEqual([
+            'summary-only-uuid',
+        ])
+        expect(matchSessionsForMention([husk], 'husk-pat').map((s) => s.id)).toEqual([])
+    })
+
+    it('empty query also omits path-only husks from the shortlist', () => {
+        const husk = makeSession({
+            id: 'active-path-husk',
+            active: true,
+            updatedAt: 500,
+            metadata: {
+                path: '/work/session-attached-jobs',
+                agentSessionId: 'agent-3',
+            },
+        })
+        const named = makeSession({
+            id: 'named-active',
+            active: true,
+            updatedAt: 100,
+            metadata: { path: '/work/a', name: 'Real peer' },
+        })
+        expect(matchSessionsForMention([husk, named], '').map((s) => s.id)).toEqual(['named-active'])
+    })
 })
 
 describe('parseSessionPathHref', () => {

--- a/web/src/lib/sessionReference.ts
+++ b/web/src/lib/sessionReference.ts
@@ -1,5 +1,5 @@
 import type { SessionSummary } from '@/types/api'
-import { normalizeSearch, sessionMatchesQuery } from '@/components/SessionList'
+import { normalizeSearch, prepareSidebarSessions, sessionMatchesQuery } from '@/components/SessionList'
 import { truncateGraphemes } from '@/lib/graphemes'
 import { getSessionTitle, hasSessionTitleSignal } from '@/lib/sessionTitle'
 import { SESSION_REFERENCE_STEER_SUFFIX } from '@hapi/protocol/sessionCitation'
@@ -65,8 +65,9 @@ export function isMentionableSession(session: SessionSummary): boolean {
 
 /**
  * Rank sessions for composer `@` autocomplete.
- * Candidates need a real title signal (#1506); match filter then reuses
- * share/sidebar `sessionMatchesQuery`. Display/insert still use `getSessionTitle`.
+ * Pool is sidebar-visible rows (`prepareSidebarSessions`) that also have a
+ * real title signal (#1506). Path husks stay out even if sidebar shows them.
+ * Match filter then reuses share/sidebar `sessionMatchesQuery`.
  * Empty query → active/recent shortlist (excludes archived + untitled husks).
  */
 export function matchSessionsForMention(
@@ -78,9 +79,10 @@ export function matchSessionsForMention(
     const excludeId = options.excludeId
     const resolveMachineLabel = options.resolveMachineLabel ?? (() => '')
     const normalized = normalizeSearch(query)
+    const candidates = prepareSidebarSessions([...sessions], excludeId)
 
     const scored: { session: SessionSummary; score: number }[] = []
-    for (const session of sessions) {
+    for (const session of candidates) {
         if (excludeId && session.id === excludeId) continue
         if (!isMentionableSession(session)) continue
 

--- a/web/src/lib/sessionReference.ts
+++ b/web/src/lib/sessionReference.ts
@@ -1,7 +1,7 @@
 import type { SessionSummary } from '@/types/api'
 import { normalizeSearch, sessionMatchesQuery } from '@/components/SessionList'
 import { truncateGraphemes } from '@/lib/graphemes'
-import { getSessionTitle } from '@/lib/sessionTitle'
+import { getSessionTitle, hasSessionTitleSignal } from '@/lib/sessionTitle'
 import { SESSION_REFERENCE_STEER_SUFFIX } from '@hapi/protocol/sessionCitation'
 
 export function buildSessionReferencePath(sessionId: string): string {
@@ -54,10 +54,20 @@ function scoreMatchedSession(session: SessionSummary, query: string): number {
 }
 
 /**
+ * Mention pool is stricter than sidebar visibility (#1506): require a real
+ * title signal (`metadata.name` or summary text). Path last-segment fallback
+ * and id-only labels are not @-targets — including husks sidebar still shows
+ * via flattened `agentSessionId` / `claudeSessionId`.
+ */
+export function isMentionableSession(session: SessionSummary): boolean {
+    return hasSessionTitleSignal(session)
+}
+
+/**
  * Rank sessions for composer `@` autocomplete.
- * Match filter is the same code path as share/sidebar search (`sessionMatchesQuery`).
- * Display/insert still use `getSessionTitle` (name before summary).
- * Empty query → active/recent shortlist (excludes archived).
+ * Candidates need a real title signal (#1506); match filter then reuses
+ * share/sidebar `sessionMatchesQuery`. Display/insert still use `getSessionTitle`.
+ * Empty query → active/recent shortlist (excludes archived + untitled husks).
  */
 export function matchSessionsForMention(
     sessions: readonly SessionSummary[],
@@ -72,6 +82,7 @@ export function matchSessionsForMention(
     const scored: { session: SessionSummary; score: number }[] = []
     for (const session of sessions) {
         if (excludeId && session.id === excludeId) continue
+        if (!isMentionableSession(session)) continue
 
         if (!normalized) {
             // Empty / whitespace query: shortlist only — active first, then recent.

--- a/web/src/lib/sessionTitle.test.ts
+++ b/web/src/lib/sessionTitle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getSessionTitle } from './sessionTitle'
+import { getSessionTitle, hasSessionTitleSignal } from './sessionTitle'
 
 describe('getSessionTitle', () => {
     it('prefers metadata.name over summary.text (sidebar / share picker parity)', () => {
@@ -34,5 +34,23 @@ describe('getSessionTitle', () => {
 
     it('falls back to a short id when metadata is empty', () => {
         expect(getSessionTitle({ id: 'abcdef0123456789' })).toBe('abcdef01')
+    })
+})
+
+describe('hasSessionTitleSignal', () => {
+    it('is true for name or summary text and false for path-only', () => {
+        expect(hasSessionTitleSignal({
+            id: 'x',
+            metadata: { name: 'Named', path: '/tmp/foo' },
+        })).toBe(true)
+        expect(hasSessionTitleSignal({
+            id: 'x',
+            metadata: { summary: { text: 'Summary only' }, path: '/tmp/foo' },
+        })).toBe(true)
+        expect(hasSessionTitleSignal({
+            id: 'x',
+            metadata: { path: '/tmp/foo' },
+        })).toBe(false)
+        expect(hasSessionTitleSignal({ id: 'x' })).toBe(false)
     })
 })

--- a/web/src/lib/sessionTitle.ts
+++ b/web/src/lib/sessionTitle.ts
@@ -7,6 +7,18 @@ type SessionTitleSource = {
     } | null
 }
 
+/**
+ * Real title for sidebar / @ mention — not path last-segment or id fallback.
+ * Path-only husks are display labels, not reference targets (tiann/hapi#1506).
+ */
+export function hasSessionTitleSignal(session: SessionTitleSource): boolean {
+    const meta = session.metadata
+    if (!meta) return false
+    if (meta.name?.trim()) return true
+    if (meta.summary?.text?.trim()) return true
+    return false
+}
+
 export function getSessionTitle(session: SessionTitleSource): string {
     if (session.metadata?.name) {
         return session.metadata.name

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -641,7 +641,7 @@ function SessionPage() {
     const {
         getSuggestions: getSkillSuggestions,
     } = useSkills(api, sessionId)
-    // Same list + search matcher as sidebar / share picker (tiann/hapi#1213).
+    // Mention pool is stricter than sidebar (#1506): titled sessions only; match via sessionMatchesQuery.
     const { sessions: allSessions } = useSessions(api)
     const { machines: mentionMachines } = useMachines(api, true)
     const mentionMachineLabelsById = useMachineLabels(mentionMachines)


### PR DESCRIPTION
## Summary
- Composer `@` mention candidates now require a real title signal (`metadata.name` or summary text), so sidebar-hidden empty stubs and path-basename husks are not `@`-able at all.
- Ranking is unchanged for titled sessions; path fallback is no longer treated as a mentionable title (even when `agentSessionId` keeps the row visible in the sidebar).
- Shared `hasSessionTitleSignal` used by sidebar stub detection and the mention pool.

## Test plan
- [x] `bun typecheck`
- [x] `web` unit tests including new `sessionReference` / `sessionTitle` cases for stub + path husk exclusion
- [x] Peer-stack Playwright `e2e/peer/1506-session-mention-sidebar-husks.spec.ts` — `@session-attached` shows named peer only, no `@session-attached-jobs` husk
- [ ] Operator dogfood on soup `:3006` (layer promoted)

## Issues
Fixes #1506


Made with [Cursor](https://cursor.com)