### PR TITLE
fix(a2a): stamp causing inbound on work_ad notify ingest

### DIFF
--- a/cli/src/api/apiSession.createdAt.test.ts
+++ b/cli/src/api/apiSession.createdAt.test.ts
@@ -113,6 +113,10 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
         const [, payload] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
         expect(payload.sid).toBe('session-1')
         expect(payload).not.toHaveProperty('createdAt')
+        expect(payload.message).toMatchObject({
+            role: 'user',
+            meta: { sentFrom: 'cli', isTranscriptEcho: true }
+        })
     })
 
     it('agent message without a parseable timestamp: omits createdAt (hub falls back to Date.now())', () => {

--- a/cli/src/api/apiSession.createdAt.test.ts
+++ b/cli/src/api/apiSession.createdAt.test.ts
@@ -150,7 +150,7 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
 
     it('remote hub prompt: matching Claude transcript row stamps isTranscriptEcho', () => {
         const { client, fakeSocket } = makeClient()
-        fireIncomingUserMessage(fakeSocket, { seq: 1, text: 'hello from web', sentFrom: 'webapp' })
+        client.notePendingHubPromptEcho('hello from web', 'local-1')
 
         client.sendClaudeSessionMessage({
             type: 'user',
@@ -168,9 +168,67 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
         })
     })
 
-    it('unmatched local Claude prompt stays unmarked when a different hub prompt is pending', () => {
+    it('formatted Claude prompt (attachments/plan) matches the queue-boundary text, not raw hub text', () => {
         const { client, fakeSocket } = makeClient()
         fireIncomingUserMessage(fakeSocket, { seq: 1, text: 'hello from web', sentFrom: 'webapp' })
+        client.notePendingHubPromptEcho('/path/to/file.ts\nhello from web', 'local-1')
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-echo-fmt',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:00.000Z',
+            message: { role: 'user', content: '/path/to/file.ts\nhello from web' }
+        } as unknown as RawJSONLines)
+
+        const [, payload] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect(payload.message).toMatchObject({
+            role: 'user',
+            meta: { sentFrom: 'cli', isTranscriptEcho: true }
+        })
+    })
+
+    it('raw hub delivery alone does not stamp isTranscriptEcho', () => {
+        const { client, fakeSocket } = makeClient()
+        fireIncomingUserMessage(fakeSocket, { seq: 1, text: 'hello from web', sentFrom: 'webapp' })
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-raw-1',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:00.000Z',
+            message: { role: 'user', content: 'hello from web' }
+        } as unknown as RawJSONLines)
+
+        const [, payload] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect((payload.message as { meta?: { isTranscriptEcho?: boolean } }).meta?.isTranscriptEcho)
+            .not.toBe(true)
+    })
+
+    it('cancelled queued prompt does not misclassify a later matching local prompt', () => {
+        const { client, fakeSocket } = makeClient()
+        client.notePendingHubPromptEcho('hello from web', 'local-1')
+        client.discardPendingHubPromptEcho('local-1')
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-local-cancel',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:00.000Z',
+            message: { role: 'user', content: 'hello from web' }
+        } as unknown as RawJSONLines)
+
+        const [, payload] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect((payload.message as { meta?: { isTranscriptEcho?: boolean } }).meta?.isTranscriptEcho)
+            .not.toBe(true)
+    })
+
+    it('unmatched local Claude prompt stays unmarked when a different hub prompt is pending', () => {
+        const { client, fakeSocket } = makeClient()
+        client.notePendingHubPromptEcho('hello from web', 'local-1')
 
         client.sendClaudeSessionMessage({
             type: 'user',

--- a/cli/src/api/apiSession.createdAt.test.ts
+++ b/cli/src/api/apiSession.createdAt.test.ts
@@ -74,6 +74,33 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
         return { client, fakeSocket }
     }
 
+    function fireIncomingUserMessage(
+        fakeSocket: { on: ReturnType<typeof vi.fn> },
+        message: { seq: number; text: string; sentFrom: 'webapp' | 'telegram-bot' }
+    ): void {
+        const handler = fakeSocket.on.mock.calls.find((call) => call[0] === 'update')?.[1] as
+            | ((data: unknown) => void)
+            | undefined
+        if (typeof handler !== 'function') {
+            throw new Error('ApiSessionClient did not register an update handler')
+        }
+        handler({
+            body: {
+                t: 'new-message',
+                message: {
+                    id: `hub-${message.seq}`,
+                    seq: message.seq,
+                    localId: null,
+                    content: {
+                        role: 'user',
+                        content: { type: 'text', text: message.text },
+                        meta: { sentFrom: message.sentFrom }
+                    }
+                }
+            }
+        })
+    }
+
     beforeEach(() => {
         configuration._setApiUrl('https://hapi.example.com')
         ioMock.mockReset()
@@ -96,7 +123,7 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
         }))
     })
 
-    it('external user message (echoed prompt): does not add createdAt — path is unchanged', () => {
+    it('local Claude prompt: does not add createdAt and does not stamp isTranscriptEcho', () => {
         const { client, fakeSocket } = makeClient()
         const body = {
             type: 'user',
@@ -115,8 +142,48 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
         expect(payload).not.toHaveProperty('createdAt')
         expect(payload.message).toMatchObject({
             role: 'user',
+            meta: { sentFrom: 'cli' }
+        })
+        expect((payload.message as { meta?: { isTranscriptEcho?: boolean } }).meta?.isTranscriptEcho)
+            .not.toBe(true)
+    })
+
+    it('remote hub prompt: matching Claude transcript row stamps isTranscriptEcho', () => {
+        const { client, fakeSocket } = makeClient()
+        fireIncomingUserMessage(fakeSocket, { seq: 1, text: 'hello from web', sentFrom: 'webapp' })
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-echo-1',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:00.000Z',
+            message: { role: 'user', content: 'hello from web' }
+        } as unknown as RawJSONLines)
+
+        const [, payload] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect(payload.message).toMatchObject({
+            role: 'user',
             meta: { sentFrom: 'cli', isTranscriptEcho: true }
         })
+    })
+
+    it('unmatched local Claude prompt stays unmarked when a different hub prompt is pending', () => {
+        const { client, fakeSocket } = makeClient()
+        fireIncomingUserMessage(fakeSocket, { seq: 1, text: 'hello from web', sentFrom: 'webapp' })
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-local-1',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:00.000Z',
+            message: { role: 'user', content: 'typed in the TTY' }
+        } as unknown as RawJSONLines)
+
+        const [, payload] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect((payload.message as { meta?: { isTranscriptEcho?: boolean } }).meta?.isTranscriptEcho)
+            .not.toBe(true)
     })
 
     it('agent message without a parseable timestamp: omits createdAt (hub falls back to Date.now())', () => {

--- a/cli/src/api/apiSession.createdAt.test.ts
+++ b/cli/src/api/apiSession.createdAt.test.ts
@@ -281,6 +281,60 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
             .not.toBe(true)
     })
 
+    it('id-less rebatch replaces the previous id-less echo marker', () => {
+        const { client, fakeSocket } = makeClient()
+        client.notePendingHubPromptEcho('hello from web')
+        client.notePendingHubPromptEcho('hello from web\nqueued while retrying')
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-idless-combined',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:00.000Z',
+            message: { role: 'user', content: 'hello from web\nqueued while retrying' }
+        } as unknown as RawJSONLines)
+
+        const [, combined] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect(combined.message).toMatchObject({
+            role: 'user',
+            meta: { sentFrom: 'cli', isTranscriptEcho: true }
+        })
+
+        fakeSocket.emit.mockClear()
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-local-after-idless',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:01.000Z',
+            message: { role: 'user', content: 'hello from web' }
+        } as unknown as RawJSONLines)
+
+        const [, local] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect((local.message as { meta?: { isTranscriptEcho?: boolean } }).meta?.isTranscriptEcho)
+            .not.toBe(true)
+    })
+
+    it('id-less dropped marker does not misclassify a later matching local prompt', () => {
+        const { client, fakeSocket } = makeClient()
+        client.notePendingHubPromptEcho('hello from web')
+        client.discardPendingHubPromptEchoText('hello from web')
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-local-after-idless-drop',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:00.000Z',
+            message: { role: 'user', content: 'hello from web' }
+        } as unknown as RawJSONLines)
+
+        const [, payload] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect((payload.message as { meta?: { isTranscriptEcho?: boolean } }).meta?.isTranscriptEcho)
+            .not.toBe(true)
+    })
+
     it('unmatched local Claude prompt stays unmarked when a different hub prompt is pending', () => {
         const { client, fakeSocket } = makeClient()
         client.notePendingHubPromptEcho('hello from web', 'local-1')

--- a/cli/src/api/apiSession.createdAt.test.ts
+++ b/cli/src/api/apiSession.createdAt.test.ts
@@ -168,6 +168,26 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
         })
     })
 
+    it('batched same-mode prompts match the joined Claude transcript row', () => {
+        const { client, fakeSocket } = makeClient()
+        client.notePendingHubPromptEcho('one\ntwo')
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-batch-1',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:00.000Z',
+            message: { role: 'user', content: 'one\ntwo' }
+        } as unknown as RawJSONLines)
+
+        const [, payload] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect(payload.message).toMatchObject({
+            role: 'user',
+            meta: { sentFrom: 'cli', isTranscriptEcho: true }
+        })
+    })
+
     it('formatted Claude prompt (attachments/plan) matches the queue-boundary text, not raw hub text', () => {
         const { client, fakeSocket } = makeClient()
         fireIncomingUserMessage(fakeSocket, { seq: 1, text: 'hello from web', sentFrom: 'webapp' })

--- a/cli/src/api/apiSession.createdAt.test.ts
+++ b/cli/src/api/apiSession.createdAt.test.ts
@@ -246,6 +246,41 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
             .not.toBe(true)
     })
 
+    it('rebatched restored prompt replaces the original echo marker', () => {
+        const { client, fakeSocket } = makeClient()
+        client.notePendingHubPromptEcho('hello from web', 'local-1')
+        client.notePendingHubPromptEcho('hello from web\nqueued while retrying', ['local-1', 'local-2'])
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-rebatch-combined',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:00.000Z',
+            message: { role: 'user', content: 'hello from web\nqueued while retrying' }
+        } as unknown as RawJSONLines)
+
+        const [, combined] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect(combined.message).toMatchObject({
+            role: 'user',
+            meta: { sentFrom: 'cli', isTranscriptEcho: true }
+        })
+
+        fakeSocket.emit.mockClear()
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'user-local-after-rebatch',
+            userType: 'external',
+            isSidechain: false,
+            timestamp: '2024-03-10T00:00:01.000Z',
+            message: { role: 'user', content: 'hello from web' }
+        } as unknown as RawJSONLines)
+
+        const [, local] = fakeSocket.emit.mock.calls[0] as [string, Record<string, unknown>]
+        expect((local.message as { meta?: { isTranscriptEcho?: boolean } }).meta?.isTranscriptEcho)
+            .not.toBe(true)
+    })
+
     it('unmatched local Claude prompt stays unmarked when a different hub prompt is pending', () => {
         const { client, fakeSocket } = makeClient()
         client.notePendingHubPromptEcho('hello from web', 'local-1')

--- a/cli/src/api/apiSession.createdAt.test.ts
+++ b/cli/src/api/apiSession.createdAt.test.ts
@@ -229,8 +229,8 @@ describe('sendClaudeSessionMessage createdAt propagation', () => {
 
     it('cancelled queued prompt does not misclassify a later matching local prompt', () => {
         const { client, fakeSocket } = makeClient()
-        client.notePendingHubPromptEcho('hello from web', 'local-1')
-        client.discardPendingHubPromptEcho('local-1')
+        client.notePendingHubPromptEcho('hello from web', ['local-1', 'local-2'])
+        client.discardPendingHubPromptEcho('local-2')
 
         client.sendClaudeSessionMessage({
             type: 'user',

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -696,6 +696,12 @@ export class ApiSessionClient extends EventEmitter {
             this.pendingHubPromptEchoes = this.pendingHubPromptEchoes.filter(
                 (entry) => !entry.localIds.some((id) => replacementIds.has(id))
             )
+        } else {
+            // SendMessageRequest allows omitting localId. One id-less delivery
+            // is in flight at a time; replace the previous nameless marker.
+            this.pendingHubPromptEchoes = this.pendingHubPromptEchoes.filter(
+                (entry) => entry.localIds.length > 0
+            )
         }
         if (this.pendingHubPromptEchoes.some((entry) => entry.text === normalized)) return
         this.pendingHubPromptEchoes.push({ text: normalized, localIds })
@@ -706,6 +712,14 @@ export class ApiSessionClient extends EventEmitter {
 
     discardPendingHubPromptEcho(localId: string): void {
         const index = this.pendingHubPromptEchoes.findIndex((entry) => entry.localIds.includes(localId))
+        if (index < 0) return
+        this.pendingHubPromptEchoes.splice(index, 1)
+    }
+
+    discardPendingHubPromptEchoText(text: string): void {
+        const normalized = text.trim()
+        if (!normalized) return
+        const index = this.pendingHubPromptEchoes.findIndex((entry) => entry.text === normalized)
         if (index < 0) return
         this.pendingHubPromptEchoes.splice(index, 1)
     }

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -801,7 +801,8 @@ export class ApiSessionClient extends EventEmitter {
                     text: extractRawUserTextContent(body.message.content) ?? ''
                 },
                 meta: {
-                    sentFrom: 'cli'
+                    sentFrom: 'cli',
+                    isTranscriptEcho: true
                 }
             }
         } else {

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -685,9 +685,19 @@ export class ApiSessionClient extends EventEmitter {
     notePendingHubPromptEcho(text: string, localId?: string | readonly string[]): void {
         const normalized = text.trim()
         if (!normalized) return
-        if (this.pendingHubPromptEchoes.some((entry) => entry.text === normalized)) return
         const localIds = (Array.isArray(localId) ? localId : localId ? [localId] : [])
             .filter((id) => id.length > 0)
+        // Recoverable launch failure restores the original items; a later
+        // same-mode prompt can rebatch them under new delivered text. Drop
+        // the stale marker that still names those localIds so a later
+        // identical local prompt is not stamped isTranscriptEcho.
+        if (localIds.length > 0) {
+            const replacementIds = new Set(localIds)
+            this.pendingHubPromptEchoes = this.pendingHubPromptEchoes.filter(
+                (entry) => !entry.localIds.some((id) => replacementIds.has(id))
+            )
+        }
+        if (this.pendingHubPromptEchoes.some((entry) => entry.text === normalized)) return
         this.pendingHubPromptEchoes.push({ text: normalized, localIds })
         if (this.pendingHubPromptEchoes.length > 32) {
             this.pendingHubPromptEchoes.shift()

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -239,7 +239,7 @@ export class ApiSessionClient extends EventEmitter {
     private agentStateVersion: number
     private readonly socket: Socket<ServerToClientEvents, ClientToServerEvents>
     private pendingMessages: { message: UserMessage; localId?: string }[] = []
-    private pendingHubPromptEchoes: { text: string; localId?: string }[] = []
+    private pendingHubPromptEchoes: { text: string; localIds: string[] }[] = []
     private pendingMessageCallback: ((message: UserMessage, localId?: string) => void) | null = null
     private cancelQueuedMessageCallback: ((localId: string) => boolean) | null = null
     private readonly incomingFilter = new IncomingMessageFilter()
@@ -682,18 +682,20 @@ export class ApiSessionClient extends EventEmitter {
      * formatting). Matching transcript rows then stamp isTranscriptEcho.
      * Call this at the queue boundary, not on raw hub delivery.
      */
-    notePendingHubPromptEcho(text: string, localId?: string): void {
+    notePendingHubPromptEcho(text: string, localId?: string | readonly string[]): void {
         const normalized = text.trim()
         if (!normalized) return
         if (this.pendingHubPromptEchoes.some((entry) => entry.text === normalized)) return
-        this.pendingHubPromptEchoes.push({ text: normalized, localId })
+        const localIds = (Array.isArray(localId) ? localId : localId ? [localId] : [])
+            .filter((id) => id.length > 0)
+        this.pendingHubPromptEchoes.push({ text: normalized, localIds })
         if (this.pendingHubPromptEchoes.length > 32) {
             this.pendingHubPromptEchoes.shift()
         }
     }
 
     discardPendingHubPromptEcho(localId: string): void {
-        const index = this.pendingHubPromptEchoes.findIndex((entry) => entry.localId === localId)
+        const index = this.pendingHubPromptEchoes.findIndex((entry) => entry.localIds.includes(localId))
         if (index < 0) return
         this.pendingHubPromptEchoes.splice(index, 1)
     }

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -685,6 +685,7 @@ export class ApiSessionClient extends EventEmitter {
     notePendingHubPromptEcho(text: string, localId?: string): void {
         const normalized = text.trim()
         if (!normalized) return
+        if (this.pendingHubPromptEchoes.some((entry) => entry.text === normalized)) return
         this.pendingHubPromptEchoes.push({ text: normalized, localId })
         if (this.pendingHubPromptEchoes.length > 32) {
             this.pendingHubPromptEchoes.shift()

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -239,7 +239,7 @@ export class ApiSessionClient extends EventEmitter {
     private agentStateVersion: number
     private readonly socket: Socket<ServerToClientEvents, ClientToServerEvents>
     private pendingMessages: { message: UserMessage; localId?: string }[] = []
-    private pendingHubPromptEchoes: string[] = []
+    private pendingHubPromptEchoes: { text: string; localId?: string }[] = []
     private pendingMessageCallback: ((message: UserMessage, localId?: string) => void) | null = null
     private cancelQueuedMessageCallback: ((localId: string) => boolean) | null = null
     private readonly incomingFilter = new IncomingMessageFilter()
@@ -677,19 +677,30 @@ export class ApiSessionClient extends EventEmitter {
         }
     }
 
-    private notePendingHubPromptEcho(message: UserMessage): void {
-        const text = message.content.text.trim()
-        if (!text) return
-        this.pendingHubPromptEchoes.push(text)
+    /**
+     * Record the text Claude will actually see (after attachment/skill//plan
+     * formatting). Matching transcript rows then stamp isTranscriptEcho.
+     * Call this at the queue boundary, not on raw hub delivery.
+     */
+    notePendingHubPromptEcho(text: string, localId?: string): void {
+        const normalized = text.trim()
+        if (!normalized) return
+        this.pendingHubPromptEchoes.push({ text: normalized, localId })
         if (this.pendingHubPromptEchoes.length > 32) {
             this.pendingHubPromptEchoes.shift()
         }
     }
 
+    discardPendingHubPromptEcho(localId: string): void {
+        const index = this.pendingHubPromptEchoes.findIndex((entry) => entry.localId === localId)
+        if (index < 0) return
+        this.pendingHubPromptEchoes.splice(index, 1)
+    }
+
     private consumePendingHubPromptEcho(text: string): boolean {
         const normalized = text.trim()
         if (!normalized) return false
-        const index = this.pendingHubPromptEchoes.indexOf(normalized)
+        const index = this.pendingHubPromptEchoes.findIndex((entry) => entry.text === normalized)
         if (index < 0) return false
         this.pendingHubPromptEchoes.splice(index, 1)
         return true
@@ -708,7 +719,6 @@ export class ApiSessionClient extends EventEmitter {
             if (userResult.data.meta?.sentFrom === 'cli') {
                 return
             }
-            this.notePendingHubPromptEcho(userResult.data)
             this.enqueueUserMessage(userResult.data, message.localId ?? undefined)
             return
         }

--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -239,6 +239,7 @@ export class ApiSessionClient extends EventEmitter {
     private agentStateVersion: number
     private readonly socket: Socket<ServerToClientEvents, ClientToServerEvents>
     private pendingMessages: { message: UserMessage; localId?: string }[] = []
+    private pendingHubPromptEchoes: string[] = []
     private pendingMessageCallback: ((message: UserMessage, localId?: string) => void) | null = null
     private cancelQueuedMessageCallback: ((localId: string) => boolean) | null = null
     private readonly incomingFilter = new IncomingMessageFilter()
@@ -676,6 +677,24 @@ export class ApiSessionClient extends EventEmitter {
         }
     }
 
+    private notePendingHubPromptEcho(message: UserMessage): void {
+        const text = message.content.text.trim()
+        if (!text) return
+        this.pendingHubPromptEchoes.push(text)
+        if (this.pendingHubPromptEchoes.length > 32) {
+            this.pendingHubPromptEchoes.shift()
+        }
+    }
+
+    private consumePendingHubPromptEcho(text: string): boolean {
+        const normalized = text.trim()
+        if (!normalized) return false
+        const index = this.pendingHubPromptEchoes.indexOf(normalized)
+        if (index < 0) return false
+        this.pendingHubPromptEchoes.splice(index, 1)
+        return true
+    }
+
     private handleIncomingMessage(message: { id?: string; seq?: number; localId?: string | null; content: unknown }): void {
         if (!this.incomingFilter.accept({ id: message.id, seq: message.seq })) {
             return
@@ -689,6 +708,7 @@ export class ApiSessionClient extends EventEmitter {
             if (userResult.data.meta?.sentFrom === 'cli') {
                 return
             }
+            this.notePendingHubPromptEcho(userResult.data)
             this.enqueueUserMessage(userResult.data, message.localId ?? undefined)
             return
         }
@@ -794,15 +814,17 @@ export class ApiSessionClient extends EventEmitter {
         let createdAt: number | undefined
 
         if (isExternalUserMessage(body)) {
+            const text = extractRawUserTextContent(body.message.content) ?? ''
+            const isTranscriptEcho = this.consumePendingHubPromptEcho(text)
             content = {
                 role: 'user',
                 content: {
                     type: 'text',
-                    text: extractRawUserTextContent(body.message.content) ?? ''
+                    text
                 },
                 meta: {
                     sentFrom: 'cli',
-                    isTranscriptEcho: true
+                    ...(isTranscriptEcho ? { isTranscriptEcho: true } : {})
                 }
             }
         } else {

--- a/cli/src/api/types.ts
+++ b/cli/src/api/types.ts
@@ -71,6 +71,9 @@ export type {
 
 export const MessageMetaSchema = z.object({
     sentFrom: z.string().optional(),
+    // Claude jsonl echoes the remote (web/telegram) prompt as a second user row.
+    // Hub notify ingest skips these so they do not consume a work_ad cause slot.
+    isTranscriptEcho: z.boolean().optional(),
     // Queue remains the default for existing clients. Pi-aware callers may
     // explicitly request native steering while a turn is streaming.
     deliveryMode: z.enum(['queue', 'steer']).optional(),

--- a/cli/src/claude/claudeRemoteLauncher.launchFailure.test.ts
+++ b/cli/src/claude/claudeRemoteLauncher.launchFailure.test.ts
@@ -41,6 +41,8 @@ function makeClient() {
         }),
         sendSessionEvent: vi.fn(),
         sendClaudeSessionMessage: vi.fn(),
+        notePendingHubPromptEcho: vi.fn(),
+        discardPendingHubPromptEcho: vi.fn(),
         sendAgentMessage: vi.fn(),
         keepAlive: vi.fn(),
         emitMessagesConsumed: vi.fn()

--- a/cli/src/claude/claudeRemoteLauncher.launchFailure.test.ts
+++ b/cli/src/claude/claudeRemoteLauncher.launchFailure.test.ts
@@ -43,6 +43,7 @@ function makeClient() {
         sendClaudeSessionMessage: vi.fn(),
         notePendingHubPromptEcho: vi.fn(),
         discardPendingHubPromptEcho: vi.fn(),
+        discardPendingHubPromptEchoText: vi.fn(),
         sendAgentMessage: vi.fn(),
         keepAlive: vi.fn(),
         emitMessagesConsumed: vi.fn()

--- a/cli/src/claude/claudeRemoteLauncher.modeGate.test.ts
+++ b/cli/src/claude/claudeRemoteLauncher.modeGate.test.ts
@@ -98,7 +98,8 @@ function createClientStub() {
         sendClaudeSessionMessage: () => {},
         sendSessionEvent: () => {},
         notePendingHubPromptEcho: () => {},
-        discardPendingHubPromptEcho: () => {}
+        discardPendingHubPromptEcho: () => {},
+        discardPendingHubPromptEchoText: () => {}
     }
 }
 

--- a/cli/src/claude/claudeRemoteLauncher.modeGate.test.ts
+++ b/cli/src/claude/claudeRemoteLauncher.modeGate.test.ts
@@ -96,7 +96,9 @@ function createClientStub() {
         updateMetadata: (mutator: (metadata: any) => any) => { mutator({}) },
         emitMessagesConsumed: () => {},
         sendClaudeSessionMessage: () => {},
-        sendSessionEvent: () => {}
+        sendSessionEvent: () => {},
+        notePendingHubPromptEcho: () => {},
+        discardPendingHubPromptEcho: () => {}
     }
 }
 

--- a/cli/src/claude/claudeRemoteLauncher.test.ts
+++ b/cli/src/claude/claudeRemoteLauncher.test.ts
@@ -104,7 +104,8 @@ function createClientStub() {
         sendClaudeSessionMessage: () => {},
         sendSessionEvent: () => {},
         notePendingHubPromptEcho: () => {},
-        discardPendingHubPromptEcho: () => {}
+        discardPendingHubPromptEcho: () => {},
+        discardPendingHubPromptEchoText: () => {}
     }
 }
 

--- a/cli/src/claude/claudeRemoteLauncher.test.ts
+++ b/cli/src/claude/claudeRemoteLauncher.test.ts
@@ -102,7 +102,9 @@ function createClientStub() {
         updateMetadata: (mutator: (metadata: any) => any) => { mutator({}) },
         emitMessagesConsumed: () => {},
         sendClaudeSessionMessage: () => {},
-        sendSessionEvent: () => {}
+        sendSessionEvent: () => {},
+        notePendingHubPromptEcho: () => {},
+        discardPendingHubPromptEcho: () => {}
     }
 }
 

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -368,6 +368,7 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                     items: Array<{ message: string; localId?: string }>;
                     mode: EnhancedMode;
                     isolate: boolean;
+                    deliveredText: string;
                 };
                 // The `as InFlightMessage | null` (rather than plain `= null`)
                 // is required, not decorative: the only assignments of a
@@ -421,9 +422,9 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                                 // mid-session model switch), so a construction-time snapshot
                                 // would go stale. See SDKToLogConverter.updateSelectedModel.
                                 sdkToLogConverter.updateSelectedModel(p.mode.model ?? null);
-                                inFlightMessage = { items: p.items, mode: p.mode, isolate: p.isolate };
                                 deliveredMessageThisAttempt = true;
                                 const deliveredText = session.expandSkillReference(p.message)
+                                inFlightMessage = { items: p.items, mode: p.mode, isolate: p.isolate, deliveredText };
                                 session.client.notePendingHubPromptEcho(
                                     deliveredText,
                                     p.items.flatMap((item) => item.localId ? [item.localId] : [])
@@ -456,9 +457,9 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                                 mode = msg.mode;
                                 permissionHandler.handleModeChange(mode.permissionMode);
                                 sdkToLogConverter.updateSelectedModel(mode.model ?? null);
-                                inFlightMessage = { items: msg.items, mode: msg.mode, isolate: msg.isolate };
                                 deliveredMessageThisAttempt = true;
                                 const deliveredText = session.expandSkillReference(msg.message)
+                                inFlightMessage = { items: msg.items, mode: msg.mode, isolate: msg.isolate, deliveredText };
                                 session.client.notePendingHubPromptEcho(
                                     deliveredText,
                                     msg.items.flatMap((item) => item.localId ? [item.localId] : [])
@@ -606,6 +607,9 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                                 if (item.localId) {
                                     session.client.discardPendingHubPromptEcho(item.localId)
                                 }
+                            }
+                            if (inFlightMessage?.deliveredText) {
+                                session.client.discardPendingHubPromptEchoText(inFlightMessage.deliveredText)
                             }
                             inFlightMessage = null;
                             session.client.sendSessionEvent({

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -453,8 +453,10 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                                 sdkToLogConverter.updateSelectedModel(mode.model ?? null);
                                 inFlightMessage = { items: msg.items, mode: msg.mode, isolate: msg.isolate };
                                 deliveredMessageThisAttempt = true;
+                                const deliveredText = session.expandSkillReference(msg.message)
+                                session.client.notePendingHubPromptEcho(deliveredText)
                                 return {
-                                    message: session.expandSkillReference(msg.message),
+                                    message: deliveredText,
                                     mode: msg.mode
                                 };
                             }

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -423,7 +423,9 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                                 sdkToLogConverter.updateSelectedModel(p.mode.model ?? null);
                                 inFlightMessage = { items: p.items, mode: p.mode, isolate: p.isolate };
                                 deliveredMessageThisAttempt = true;
-                                return { ...p, message: session.expandSkillReference(p.message) };
+                                const deliveredText = session.expandSkillReference(p.message)
+                                session.client.notePendingHubPromptEcho(deliveredText)
+                                return { ...p, message: deliveredText };
                             }
 
                             let msg = await session.queue.waitForMessagesAndGetAsString(controller.signal);

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -424,7 +424,10 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                                 inFlightMessage = { items: p.items, mode: p.mode, isolate: p.isolate };
                                 deliveredMessageThisAttempt = true;
                                 const deliveredText = session.expandSkillReference(p.message)
-                                session.client.notePendingHubPromptEcho(deliveredText)
+                                session.client.notePendingHubPromptEcho(
+                                    deliveredText,
+                                    p.items.flatMap((item) => item.localId ? [item.localId] : [])
+                                )
                                 return { ...p, message: deliveredText };
                             }
 
@@ -456,7 +459,10 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                                 inFlightMessage = { items: msg.items, mode: msg.mode, isolate: msg.isolate };
                                 deliveredMessageThisAttempt = true;
                                 const deliveredText = session.expandSkillReference(msg.message)
-                                session.client.notePendingHubPromptEcho(deliveredText)
+                                session.client.notePendingHubPromptEcho(
+                                    deliveredText,
+                                    msg.items.flatMap((item) => item.localId ? [item.localId] : [])
+                                )
                                 return {
                                     message: deliveredText,
                                     mode: msg.mode

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -602,6 +602,11 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                             // Reset the streak and keep the loop (and this OS
                             // process) alive so an unrelated later message
                             // gets its own fresh budget.
+                            for (const item of inFlightMessage?.items ?? []) {
+                                if (item.localId) {
+                                    session.client.discardPendingHubPromptEcho(item.localId)
+                                }
+                            }
                             inFlightMessage = null;
                             session.client.sendSessionEvent({
                                 type: 'message',

--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -398,6 +398,7 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             };
             // Use raw text only, ignore attachments for special commands
             const commandText = specialCommand.originalMessage || message.content.text;
+            session.notePendingHubPromptEcho(commandText, localId);
             messageQueue.pushIsolateAndClear(commandText, enhancedMode, localId);
             logger.debugLargeJson('[start] /compact command pushed to queue:', message);
             return;
@@ -417,6 +418,7 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             };
             // Use raw text only, ignore attachments for special commands
             const commandText = specialCommand.originalMessage || message.content.text;
+            session.notePendingHubPromptEcho(commandText, localId);
             messageQueue.pushIsolateAndClear(commandText, enhancedMode, localId);
             logger.debugLargeJson('[start] /clear command pushed to queue:', message);
             return;
@@ -445,6 +447,7 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
 
             if (!specialCommand.prompt) {
                 if (localId) {
+                    session.discardPendingHubPromptEcho(localId);
                     session.emitMessagesConsumed([localId]);
                 }
                 logger.debugLargeJson('[start] /plan command applied without prompt:', message);
@@ -452,6 +455,7 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             }
 
             const planPrompt = formatMessageWithAttachments(specialCommand.prompt, message.content.attachments);
+            session.notePendingHubPromptEcho(planPrompt, localId);
             messageQueue.push(planPrompt, enhancedMode, localId);
             logger.debugLargeJson('[start] /plan command prompt pushed to queue:', message);
             return;
@@ -468,6 +472,7 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             allowedTools: messageAllowedTools,
             disallowedTools: messageDisallowedTools
         };
+        session.notePendingHubPromptEcho(formattedText, localId);
         messageQueue.push(formattedText, enhancedMode, localId);
         logger.debugLargeJson('User message pushed to queue:', message)
     };
@@ -486,6 +491,7 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
     });
 
     session.onCancelQueuedMessage((localId) => {
+        session.discardPendingHubPromptEcho(localId);
         const deferredIndex = deferredMessages.findIndex(([, id]) => id === localId);
         if (deferredIndex >= 0) {
             deferredMessages.splice(deferredIndex, 1);

--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -398,7 +398,6 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             };
             // Use raw text only, ignore attachments for special commands
             const commandText = specialCommand.originalMessage || message.content.text;
-            session.notePendingHubPromptEcho(commandText, localId);
             messageQueue.pushIsolateAndClear(commandText, enhancedMode, localId);
             logger.debugLargeJson('[start] /compact command pushed to queue:', message);
             return;
@@ -418,7 +417,6 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             };
             // Use raw text only, ignore attachments for special commands
             const commandText = specialCommand.originalMessage || message.content.text;
-            session.notePendingHubPromptEcho(commandText, localId);
             messageQueue.pushIsolateAndClear(commandText, enhancedMode, localId);
             logger.debugLargeJson('[start] /clear command pushed to queue:', message);
             return;
@@ -447,7 +445,6 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
 
             if (!specialCommand.prompt) {
                 if (localId) {
-                    session.discardPendingHubPromptEcho(localId);
                     session.emitMessagesConsumed([localId]);
                 }
                 logger.debugLargeJson('[start] /plan command applied without prompt:', message);
@@ -455,7 +452,6 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             }
 
             const planPrompt = formatMessageWithAttachments(specialCommand.prompt, message.content.attachments);
-            session.notePendingHubPromptEcho(planPrompt, localId);
             messageQueue.push(planPrompt, enhancedMode, localId);
             logger.debugLargeJson('[start] /plan command prompt pushed to queue:', message);
             return;
@@ -472,7 +468,6 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
             allowedTools: messageAllowedTools,
             disallowedTools: messageDisallowedTools
         };
-        session.notePendingHubPromptEcho(formattedText, localId);
         messageQueue.push(formattedText, enhancedMode, localId);
         logger.debugLargeJson('User message pushed to queue:', message)
     };
@@ -491,13 +486,16 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
     });
 
     session.onCancelQueuedMessage((localId) => {
-        session.discardPendingHubPromptEcho(localId);
         const deferredIndex = deferredMessages.findIndex(([, id]) => id === localId);
         if (deferredIndex >= 0) {
             deferredMessages.splice(deferredIndex, 1);
+            session.discardPendingHubPromptEcho(localId);
             return true;
         }
         const removed = messageQueue.cancelByLocalId(localId);
+        if (removed) {
+            session.discardPendingHubPromptEcho(localId);
+        }
         logger.debug(`[claude] cancelByLocalId(${localId}): ${removed ? 'removed' : 'not found (best-effort)'}`);
         return removed;
     });

--- a/hub/src/store/messageStore.ts
+++ b/hub/src/store/messageStore.ts
@@ -32,6 +32,7 @@ import {
     copyMessagesToSession as copyStoredMessagesToSession,
     getAllMessages,
     getMessagesAfterSeq,
+    getMessageSeqById,
     truncateMessagesFromLocalId,
     type CancelQueuedMessageResult,
     type LookupQueuedMessageResult,
@@ -75,6 +76,10 @@ export class MessageStore {
 
     getMessagesAfterSeq(sessionId: string, afterSeq: number): StoredMessage[] {
         return getMessagesAfterSeq(this.db, sessionId, afterSeq)
+    }
+
+    getSeqById(sessionId: string, messageId: string): number | null {
+        return getMessageSeqById(this.db, sessionId, messageId)
     }
 
     getMessages(sessionId: string, limit: number = 200): StoredMessage[] {

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -320,6 +320,18 @@ export function getMessagesAfterSeq(
     return rows.map(toStoredMessage)
 }
 
+/** Current seq for a message that still lives on this session (merge-stable id). */
+export function getMessageSeqById(
+    db: Database,
+    sessionId: string,
+    messageId: string
+): number | null {
+    const row = db.prepare(
+        'SELECT seq FROM messages WHERE id = ? AND session_id = ?'
+    ).get(messageId, sessionId) as { seq: number } | undefined
+    return row ? row.seq : null
+}
+
 export function getFirstMessages(
     db: Database,
     sessionId: string,

--- a/hub/src/store/workGraph.test.ts
+++ b/hub/src/store/workGraph.test.ts
@@ -187,6 +187,29 @@ describe('WorkGraphStore', () => {
         expect(store.workGraph.listWorkAdsByRelatedSession('beta', 'sess-a')).toEqual([])
     })
 
+    it('lists work_ads in insert order even when a later row has an older ts', () => {
+        const store = new Store(':memory:')
+        const first = store.workGraph.insertEvent('default', {
+            source_kind: 'session',
+            source_ref: 'sess-a',
+            event_type: 'work_ad',
+            related_session_id: 'sess-a',
+            summary: 'inserted first',
+            principal: humanPrincipal
+        }, { ts: 5000 })
+        const second = store.workGraph.insertEvent('default', {
+            source_kind: 'session',
+            source_ref: 'sess-a',
+            event_type: 'work_ad',
+            related_session_id: 'sess-a',
+            summary: 'inserted second, older ts',
+            principal: humanPrincipal
+        }, { ts: 1000 })
+
+        const ads = store.workGraph.listWorkAdsByRelatedSession('default', 'sess-a')
+        expect(ads.map((event) => event.id)).toEqual([first.event.id, second.event.id])
+    })
+
     it('accepts agent principal with on_behalf_of human owner', () => {
         const store = new Store(':memory:')
         const result = store.workGraph.insertEvent('default', {

--- a/hub/src/store/workGraph.test.ts
+++ b/hub/src/store/workGraph.test.ts
@@ -155,6 +155,38 @@ describe('WorkGraphStore', () => {
         expect(store.workGraph.listLinksForEvent('default', handoff.event.id)).toHaveLength(1)
     })
 
+    it('lists work_ads for a session in chronological order without the HTTP cap', () => {
+        const store = new Store(':memory:')
+        const first = store.workGraph.insertEvent('default', {
+            source_kind: 'session',
+            source_ref: 'sess-a',
+            event_type: 'work_ad',
+            related_session_id: 'sess-a',
+            summary: 'first',
+            principal: humanPrincipal
+        }, { ts: 1000 })
+        store.workGraph.insertEvent('default', {
+            source_kind: 'session',
+            source_ref: 'sess-a',
+            event_type: 'handoff',
+            related_session_id: 'sess-a',
+            summary: 'not an ad',
+            principal: humanPrincipal
+        }, { ts: 1500 })
+        const second = store.workGraph.insertEvent('default', {
+            source_kind: 'session',
+            source_ref: 'sess-a',
+            event_type: 'work_ad',
+            related_session_id: 'sess-a',
+            summary: 'second',
+            principal: humanPrincipal
+        }, { ts: 2000 })
+
+        const ads = store.workGraph.listWorkAdsByRelatedSession('default', 'sess-a')
+        expect(ads.map((event) => event.id)).toEqual([first.event.id, second.event.id])
+        expect(store.workGraph.listWorkAdsByRelatedSession('beta', 'sess-a')).toEqual([])
+    })
+
     it('accepts agent principal with on_behalf_of human owner', () => {
         const store = new Store(':memory:')
         const result = store.workGraph.insertEvent('default', {

--- a/hub/src/store/workGraph.test.ts
+++ b/hub/src/store/workGraph.test.ts
@@ -225,4 +225,42 @@ describe('WorkGraphStore', () => {
             on_behalf_of: '1'
         })
     })
+
+    it('reassigns only AGENT_NOTIFY_SUMMARY rows onto the surviving session', () => {
+        const store = new Store(':memory:')
+        const notify = store.workGraph.insertEvent('default', {
+            source_kind: 'session',
+            source_ref: 'sess-old',
+            event_type: 'work_ad',
+            related_session_id: 'sess-old',
+            summary: 'notify',
+            provenance: 'AGENT_NOTIFY_SUMMARY',
+            idempotency_key: 'session:sess-old:message:msg-1:notify',
+            principal: { kind: 'agent', id: 'session:sess-old', on_behalf_of: '1' }
+        })
+        const posted = store.workGraph.insertEvent('default', {
+            source_kind: 'session',
+            source_ref: 'sess-old',
+            event_type: 'work_ad',
+            related_session_id: 'sess-old',
+            summary: 'http posted',
+            principal: humanPrincipal
+        })
+
+        expect(store.workGraph.reassignNotifySession('default', 'sess-old', 'sess-new')).toBe(1)
+
+        const moved = store.workGraph.getEvent(notify.event.id, 'default')
+        expect(moved?.relatedSessionId).toBe('sess-new')
+        expect(moved?.sourceRef).toBe('sess-new')
+        expect(moved?.idempotencyKey).toBe('session:sess-new:message:msg-1:notify')
+        expect(moved?.principal).toEqual({
+            kind: 'agent',
+            id: 'session:sess-new',
+            on_behalf_of: '1'
+        })
+
+        const untouched = store.workGraph.getEvent(posted.event.id, 'default')
+        expect(untouched?.relatedSessionId).toBe('sess-old')
+        expect(untouched?.sourceRef).toBe('sess-old')
+    })
 })

--- a/hub/src/store/workGraph.ts
+++ b/hub/src/store/workGraph.ts
@@ -279,6 +279,20 @@ export function listWorkGraphEventsByRelatedSession(
     return rows.map(toEvent)
 }
 
+/** Full-session work_ad history for notify-ingest cause resolution (no HTTP list cap). */
+export function listWorkGraphWorkAdsByRelatedSession(
+    db: Database,
+    namespace: string,
+    relatedSessionId: string
+): WorkGraphEvent[] {
+    const rows = db.prepare(`
+        SELECT * FROM events
+        WHERE namespace = ? AND related_session_id = ? AND event_type = 'work_ad'
+        ORDER BY ts ASC, id ASC
+    `).all(namespace, relatedSessionId) as EventRow[]
+    return rows.map(toEvent)
+}
+
 export function insertWorkGraphEventLink(
     db: Database,
     namespace: string,

--- a/hub/src/store/workGraph.ts
+++ b/hub/src/store/workGraph.ts
@@ -288,7 +288,7 @@ export function listWorkGraphWorkAdsByRelatedSession(
     const rows = db.prepare(`
         SELECT * FROM events
         WHERE namespace = ? AND related_session_id = ? AND event_type = 'work_ad'
-        ORDER BY ts ASC, id ASC
+        ORDER BY ts ASC, rowid ASC
     `).all(namespace, relatedSessionId) as EventRow[]
     return rows.map(toEvent)
 }

--- a/hub/src/store/workGraph.ts
+++ b/hub/src/store/workGraph.ts
@@ -288,7 +288,7 @@ export function listWorkGraphWorkAdsByRelatedSession(
     const rows = db.prepare(`
         SELECT * FROM events
         WHERE namespace = ? AND related_session_id = ? AND event_type = 'work_ad'
-        ORDER BY ts ASC, rowid ASC
+        ORDER BY rowid ASC
     `).all(namespace, relatedSessionId) as EventRow[]
     return rows.map(toEvent)
 }

--- a/hub/src/store/workGraph.ts
+++ b/hub/src/store/workGraph.ts
@@ -337,6 +337,84 @@ export function insertWorkGraphEventLink(
     return toLink(row)
 }
 
+/**
+ * Move hub-elevated notify work_ads onto the surviving session id.
+ * HTTP-posted rows keep their original session keys.
+ */
+export function reassignWorkGraphNotifySession(
+    db: Database,
+    namespace: string,
+    oldSessionId: string,
+    newSessionId: string
+): number {
+    if (oldSessionId === newSessionId) return 0
+    const rows = db.prepare(`
+        SELECT id, related_session_id, source_ref, idempotency_key, principal_json
+        FROM events
+        WHERE namespace = ?
+          AND provenance = 'AGENT_NOTIFY_SUMMARY'
+          AND (related_session_id = ? OR source_ref = ?)
+    `).all(namespace, oldSessionId, oldSessionId) as Array<{
+        id: string
+        related_session_id: string | null
+        source_ref: string
+        idempotency_key: string | null
+        principal_json: string
+    }>
+    if (rows.length === 0) return 0
+
+    const update = db.prepare(`
+        UPDATE events
+        SET related_session_id = ?,
+            source_ref = ?,
+            idempotency_key = ?,
+            principal_json = ?
+        WHERE id = ? AND namespace = ?
+    `)
+    const oldPrefix = `session:${oldSessionId}:`
+    const newPrefix = `session:${newSessionId}:`
+    const oldPrincipal = `session:${oldSessionId}`
+    const newPrincipal = `session:${newSessionId}`
+
+    return db.transaction(() => {
+        let changed = 0
+        for (const row of rows) {
+            const relatedSessionId = row.related_session_id === oldSessionId
+                ? newSessionId
+                : row.related_session_id
+            const sourceRef = row.source_ref === oldSessionId ? newSessionId : row.source_ref
+            let idempotencyKey = row.idempotency_key
+            if (idempotencyKey?.startsWith(oldPrefix)) {
+                idempotencyKey = newPrefix + idempotencyKey.slice(oldPrefix.length)
+            }
+            const principalJson = row.principal_json.includes(oldPrincipal)
+                ? row.principal_json.split(oldPrincipal).join(newPrincipal)
+                : row.principal_json
+            try {
+                update.run(
+                    relatedSessionId,
+                    sourceRef,
+                    idempotencyKey,
+                    principalJson,
+                    row.id,
+                    namespace
+                )
+            } catch {
+                update.run(
+                    relatedSessionId,
+                    sourceRef,
+                    row.idempotency_key,
+                    principalJson,
+                    row.id,
+                    namespace
+                )
+            }
+            changed += 1
+        }
+        return changed
+    })()
+}
+
 export function listWorkGraphEventLinksForEvent(
     db: Database,
     namespace: string,

--- a/hub/src/store/workGraphStore.ts
+++ b/hub/src/store/workGraphStore.ts
@@ -11,6 +11,7 @@ import {
     insertWorkGraphEventLink,
     listWorkGraphEventLinksForEvent,
     listWorkGraphEventsByRelatedSession,
+    listWorkGraphWorkAdsByRelatedSession,
     type InsertWorkGraphEventResult
 } from './workGraph'
 
@@ -39,6 +40,10 @@ export class WorkGraphStore {
         options?: { limit?: number }
     ): WorkGraphEvent[] {
         return listWorkGraphEventsByRelatedSession(this.db, namespace, relatedSessionId, options)
+    }
+
+    listWorkAdsByRelatedSession(namespace: string, relatedSessionId: string): WorkGraphEvent[] {
+        return listWorkGraphWorkAdsByRelatedSession(this.db, namespace, relatedSessionId)
     }
 
     insertLink(namespace: string, input: WorkGraphEventLinkCreate): WorkGraphEventLink {

--- a/hub/src/store/workGraphStore.ts
+++ b/hub/src/store/workGraphStore.ts
@@ -12,6 +12,7 @@ import {
     listWorkGraphEventLinksForEvent,
     listWorkGraphEventsByRelatedSession,
     listWorkGraphWorkAdsByRelatedSession,
+    reassignWorkGraphNotifySession,
     type InsertWorkGraphEventResult
 } from './workGraph'
 
@@ -44,6 +45,10 @@ export class WorkGraphStore {
 
     listWorkAdsByRelatedSession(namespace: string, relatedSessionId: string): WorkGraphEvent[] {
         return listWorkGraphWorkAdsByRelatedSession(this.db, namespace, relatedSessionId)
+    }
+
+    reassignNotifySession(namespace: string, oldSessionId: string, newSessionId: string): number {
+        return reassignWorkGraphNotifySession(this.db, namespace, oldSessionId, newSessionId)
     }
 
     insertLink(namespace: string, input: WorkGraphEventLinkCreate): WorkGraphEventLink {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -1076,6 +1076,7 @@ export class SessionCache {
         }
 
         const movedMessages = this.store.messages.mergeSessionMessages(oldSessionId, newSessionId)
+        this.store.workGraph.reassignNotifySession(namespace, oldSessionId, newSessionId)
         if (movedMessages.moved > 0) {
             this.store.usage.transferSession(oldSessionId, newSessionId)
             if (!options.deleteOldSession) {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -1076,7 +1076,11 @@ export class SessionCache {
         }
 
         const movedMessages = this.store.messages.mergeSessionMessages(oldSessionId, newSessionId)
-        this.store.workGraph.reassignNotifySession(namespace, oldSessionId, newSessionId)
+        // mergeSessions deletes the source. mergeSessionHistory keeps it alive
+        // with the original socket, so its notify chain must stay on that id.
+        if (options.deleteOldSession) {
+            this.store.workGraph.reassignNotifySession(namespace, oldSessionId, newSessionId)
+        }
         if (movedMessages.moved > 0) {
             this.store.usage.transferSession(oldSessionId, newSessionId)
             if (!options.deleteOldSession) {

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -887,6 +887,48 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         expect(onSurvivor).toContain(second!.event.id)
     })
 
+    it('keeps notify history on the live source after mergeSessionHistory', async () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, {
+            emit: (_event: SyncEvent) => {}
+        } as EventPublisher)
+        const source = cache.getOrCreateSession(
+            'sess-cause-hist-src',
+            { path: '/tmp/project', host: 'localhost' },
+            null,
+            'default'
+        )
+        const target = cache.getOrCreateSession(
+            'sess-cause-hist-tgt',
+            { path: '/tmp/project', host: 'localhost' },
+            null,
+            'default'
+        )
+
+        const firstUser = store.messages.addMessage(source.id, userInbound('live source prompt'))
+        const firstAssistant = store.messages.addMessage(source.id, assistantOutput(notifyFooter('Before history merge')))
+        const first = ingestNotify(store, source.id, 'default', firstAssistant.content, firstAssistant.id)
+        expect(first?.inserted).toBe(true)
+
+        await cache.mergeSessionHistory(source.id, target.id, 'default', { mergeAgentState: false })
+
+        const nextUser = store.messages.addMessage(source.id, userInbound('still on the live source'))
+        const nextAssistant = store.messages.addMessage(source.id, assistantOutput(notifyFooter('After history merge')))
+        const second = ingestNotify(store, source.id, 'default', nextAssistant.content, nextAssistant.id)
+
+        expect(second?.event.relatedEventId).toBe(first!.event.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: nextUser.id,
+            causeText: 'still on the live source'
+        })
+        expect((second?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
+            .not.toBe(firstUser.id)
+        const onSource = store.workGraph.listWorkAdsByRelatedSession('default', source.id)
+            .map((event) => event.id)
+        expect(onSource).toContain(first!.event.id)
+        expect(onSource).toContain(second!.event.id)
+    })
+
     it('does not re-attribute a prior batch after surviving-session seq-shift', () => {
         const store = new Store(':memory:')
         const surviving = store.sessions.getOrCreateSession('sess-cause-shift-live', {}, null, 'default')

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -562,6 +562,85 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         expect(causeText.startsWith('qq')).toBe(true)
     })
 
+    it('1:1 consume: extra queued inbounds wait for later work_ads, they do not attach to this turn', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-burst', {}, null, 'default')
+        const one = store.messages.addMessage(session.id, userInbound('one: read the file'))
+        const two = store.messages.addMessage(session.id, userInbound('two: also fix the typo'))
+        const three = store.messages.addMessage(session.id, userInbound('three: and push'))
+        const firstAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Drained queue')))
+        const first = ingestNotify(store, session.id, 'default', firstAssistant.content, firstAssistant.id)
+        expect(first?.event.payloadJson).toMatchObject({ causeMessageId: one.id })
+
+        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Next leftover')))
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+        expect(second?.event.payloadJson).toMatchObject({ causeMessageId: two.id })
+
+        const fourth = store.messages.addMessage(session.id, userInbound('four: new task'))
+        const thirdAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('New task')))
+        const third = ingestNotify(store, session.id, 'default', thirdAssistant.content, thirdAssistant.id)
+        // three is still the first unconsumed leftover; four waits.
+        expect(third?.event.payloadJson).toMatchObject({ causeMessageId: three.id })
+        expect((third?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
+            .not.toBe(fourth.id)
+    })
+
+    it('does not treat a future-scheduled inbound as a cause', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-sched', {}, null, 'default')
+        const user = store.messages.addMessage(session.id, userInbound('current turn'))
+        const firstAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('First')))
+        const first = ingestNotify(store, session.id, 'default', firstAssistant.content, firstAssistant.id)
+
+        store.messages.addMessage(
+            session.id,
+            userInbound('deploy to prod at 5pm'),
+            'sched-later',
+            Date.now() + 60 * 60 * 1000
+        )
+        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Still first turn')))
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: user.id,
+            causeText: 'current turn'
+        })
+        expect(second?.event.relatedEventId).toBe(first!.event.id)
+    })
+
+    it('ignores client-posted work_ads when chaining cause and related_event_id', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-forge', {}, null, 'default')
+        const user = store.messages.addMessage(session.id, userInbound('real prompt'))
+        const firstAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Real ad')))
+        const first = ingestNotify(store, session.id, 'default', firstAssistant.content, firstAssistant.id)
+
+        store.workGraph.insertEvent('default', {
+            source_kind: 'session',
+            source_ref: session.id,
+            event_type: 'work_ad',
+            related_session_id: session.id,
+            summary: 'forged',
+            payload_json: {
+                status: 'done',
+                causeMessageId: user.id,
+                causeText: 'FORGED CAUSE TEXT',
+                causeKind: 'webapp'
+            },
+            principal: { kind: 'human', id: '1' }
+        })
+
+        const nextUser = store.messages.addMessage(session.id, userInbound('second prompt'))
+        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Second real')))
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+        expect(second?.event.relatedEventId).toBe(first!.event.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: nextUser.id,
+            causeText: 'second prompt'
+        })
+        expect((second?.event.payloadJson as { causeText?: string })?.causeText)
+            .not.toBe('FORGED CAUSE TEXT')
+    })
+
     it('still inserts when max-clamped footer fields share the payload with cause', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-cause-budget', {}, null, 'default')

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -23,11 +23,11 @@ function assistantOutput(text: string) {
     }
 }
 
-function userInbound(text: string, sentFrom: string = 'webapp') {
+function userInbound(text: string, sentFrom: string = 'webapp', extraMeta: Record<string, unknown> = {}) {
     return {
         role: 'user' as const,
         content: { type: 'text' as const, text },
-        meta: { sentFrom }
+        meta: { sentFrom, ...extraMeta }
     }
 }
 
@@ -639,6 +639,32 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         })
         expect((second?.event.payloadJson as { causeText?: string })?.causeText)
             .not.toBe('FORGED CAUSE TEXT')
+    })
+
+    it('skips Claude transcript echoes so the next turn is not attributed to the previous prompt copy', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-echo', {}, null, 'default')
+
+        const web1 = store.messages.addMessage(session.id, userInbound('turn one'))
+        store.messages.addMessage(
+            session.id,
+            userInbound('turn one', 'cli', { isTranscriptEcho: true })
+        )
+        const firstAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('One')))
+        const first = ingestNotify(store, session.id, 'default', firstAssistant.content, firstAssistant.id)
+        expect(first?.event.payloadJson).toMatchObject({ causeMessageId: web1.id })
+
+        const web2 = store.messages.addMessage(session.id, userInbound('turn two'))
+        store.messages.addMessage(
+            session.id,
+            userInbound('turn two', 'cli', { isTranscriptEcho: true })
+        )
+        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Two')))
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: web2.id,
+            causeText: 'turn two'
+        })
     })
 
     it('still inserts when max-clamped footer fields share the payload with cause', () => {

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -586,6 +586,41 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
             .not.toBe(fourth.id)
     })
 
+    it('does not treat an uninvoked queued inbound as a cause', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-uninvoked', {}, null, 'default')
+        const causing = store.messages.addMessage(session.id, userInbound('current turn'))
+        const queued = store.messages.addMessage(
+            session.id,
+            userInbound('queued not yet started'),
+            'queued-local'
+        )
+        expect(queued.invokedAt).toBeNull()
+        const firstAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('First')))
+        const first = ingestNotify(store, session.id, 'default', firstAssistant.content, firstAssistant.id)
+        expect(first?.event.payloadJson).toMatchObject({
+            causeMessageId: causing.id,
+            causeText: 'current turn'
+        })
+
+        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Still first turn')))
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: causing.id,
+            causeText: 'current turn'
+        })
+        expect((second?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
+            .not.toBe(queued.id)
+
+        store.messages.markMessagesInvoked(session.id, ['queued-local'], Date.now())
+        const thirdAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Queued turn')))
+        const third = ingestNotify(store, session.id, 'default', thirdAssistant.content, thirdAssistant.id)
+        expect(third?.event.payloadJson).toMatchObject({
+            causeMessageId: queued.id,
+            causeText: 'queued not yet started'
+        })
+    })
+
     it('does not treat a future-scheduled inbound as a cause', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-cause-sched', {}, null, 'default')

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -466,7 +466,11 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
 
         const causing = store.messages.addMessage(session.id, userInbound('start the long turn'))
         store.messages.addMessage(session.id, agentToolRow())
-        const queued = store.messages.addMessage(session.id, userInbound('queued while in flight'))
+        const queued = store.messages.addMessage(
+            session.id,
+            userInbound('queued while in flight'),
+            'queued-while-in-flight'
+        )
         const assistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Finished long turn')))
 
         const first = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
@@ -477,6 +481,7 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         expect((first?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
             .not.toBe(queued.id)
 
+        store.messages.markMessagesInvoked(session.id, ['queued-while-in-flight'], Date.now())
         const secondAssistant = store.messages.addMessage(
             session.id,
             assistantOutput(notifyFooter('Queued turn'))
@@ -563,27 +568,50 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         expect(causeText.startsWith('qq')).toBe(true)
     })
 
-    it('1:1 consume: extra queued inbounds wait for later work_ads, they do not attach to this turn', () => {
+    it('1:1 consume: extra uninvoked queued inbounds wait for later work_ads', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-cause-burst', {}, null, 'default')
         const one = store.messages.addMessage(session.id, userInbound('one: read the file'))
-        const two = store.messages.addMessage(session.id, userInbound('two: also fix the typo'))
-        const three = store.messages.addMessage(session.id, userInbound('three: and push'))
+        const two = store.messages.addMessage(session.id, userInbound('two: also fix the typo'), 'burst-two')
+        const three = store.messages.addMessage(session.id, userInbound('three: and push'), 'burst-three')
         const firstAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Drained queue')))
         const first = ingestNotify(store, session.id, 'default', firstAssistant.content, firstAssistant.id)
         expect(first?.event.payloadJson).toMatchObject({ causeMessageId: one.id })
 
-        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Next leftover')))
+        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Still first turn')))
         const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
-        expect(second?.event.payloadJson).toMatchObject({ causeMessageId: two.id })
+        expect(second?.event.payloadJson).toMatchObject({ causeMessageId: one.id })
 
-        const fourth = store.messages.addMessage(session.id, userInbound('four: new task'))
-        const thirdAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('New task')))
+        store.messages.markMessagesInvoked(session.id, ['burst-two'], Date.now())
+        const thirdAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Next leftover')))
         const third = ingestNotify(store, session.id, 'default', thirdAssistant.content, thirdAssistant.id)
-        // three is still the first unconsumed leftover; four waits.
-        expect(third?.event.payloadJson).toMatchObject({ causeMessageId: three.id })
+        expect(third?.event.payloadJson).toMatchObject({ causeMessageId: two.id })
         expect((third?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
-            .not.toBe(fourth.id)
+            .not.toBe(three.id)
+    })
+
+    it('advances causeSeq past every invoked inbound in the same Claude batch', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-batch', {}, null, 'default')
+        const one = store.messages.addMessage(session.id, userInbound('one'))
+        const two = store.messages.addMessage(session.id, userInbound('two'))
+        const three = store.messages.addMessage(session.id, userInbound('three'))
+        const assistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Batched')))
+        const first = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
+        expect(first?.event.payloadJson).toMatchObject({
+            causeMessageId: one.id,
+            causeSeq: three.seq
+        })
+
+        const next = store.messages.addMessage(session.id, userInbound('next turn'))
+        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Next')))
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: next.id,
+            causeText: 'next turn'
+        })
+        expect((second?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
+            .not.toBe(two.id)
     })
 
     it('does not treat an uninvoked queued inbound as a cause', () => {

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -23,6 +23,51 @@ function assistantOutput(text: string) {
     }
 }
 
+function userInbound(text: string, sentFrom: string = 'webapp') {
+    return {
+        role: 'user' as const,
+        content: { type: 'text' as const, text },
+        meta: { sentFrom }
+    }
+}
+
+function agentToolRow() {
+    return {
+        role: 'agent' as const,
+        content: {
+            type: 'output',
+            data: { type: 'tool_use', name: 'Read', id: 'tool-1' }
+        }
+    }
+}
+
+function notifyFooter(summary: string): string {
+    return `Prose.\n\nAGENT_NOTIFY_SUMMARY ${JSON.stringify({
+        version: 1,
+        status: 'done',
+        summary
+    })}`
+}
+
+function ingestNotify(
+    store: Store,
+    sessionId: string,
+    namespace: string,
+    content: unknown,
+    messageId: string,
+    ts: number = Date.now()
+) {
+    return ingestNotifySummaryFromMessage({
+        store,
+        namespace,
+        sessionId,
+        messageId,
+        content,
+        ts,
+        ownerUserId: 1
+    })
+}
+
 describe('mapNotifyStatusToWorkAdStatus', () => {
     it('maps notify contract statuses onto RFC WorkAd vocabulary', () => {
         expect(mapNotifyStatusToWorkAdStatus('done')).toBe('done')
@@ -370,5 +415,172 @@ describe('ingestNotifySummaryFromMessage', () => {
         const escaped = JSON.stringify(action).slice(1, -1)
         expect(new TextEncoder().encode(escaped).byteLength).toBeLessThanOrEqual(WORK_GRAPH_MAX_STRING)
         expect(store.workGraph.listByRelatedSession('default', session.id)).toHaveLength(1)
+    })
+})
+
+describe('ingestNotifySummaryFromMessage cause stamping', () => {
+    it('happy path: first unconsumed inbound is the cause; previous work_ad is related', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-happy', {}, null, 'default')
+
+        const firstUser = store.messages.addMessage(session.id, userInbound('do the first thing'))
+        const firstAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Turn one')))
+        const first = ingestNotify(store, session.id, 'default', firstAssistant.content, firstAssistant.id)
+
+        expect(first?.inserted).toBe(true)
+        expect(first?.event.relatedEventId).toBeNull()
+        expect(first?.event.payloadJson).toMatchObject({
+            messageId: firstAssistant.id,
+            causeMessageId: firstUser.id,
+            causeText: 'do the first thing',
+            causeKind: 'webapp'
+        })
+
+        const secondUser = store.messages.addMessage(session.id, userInbound('do the second thing', 'cli'))
+        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Turn two')))
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+
+        expect(second?.inserted).toBe(true)
+        expect(second?.event.relatedEventId).toBe(first!.event.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            messageId: secondAssistant.id,
+            causeMessageId: secondUser.id,
+            causeText: 'do the second thing',
+            causeKind: 'cli'
+        })
+
+        const links = store.workGraph.listLinksForEvent('default', second!.event.id)
+        expect(links).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                fromEventId: second!.event.id,
+                toEventId: first!.event.id,
+                relationType: 'follows'
+            })
+        ]))
+    })
+
+    it('queued inbound: cause is the unconsumed inbound, not the nearest user before the assistant', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-queued', {}, null, 'default')
+
+        const causing = store.messages.addMessage(session.id, userInbound('start the long turn'))
+        store.messages.addMessage(session.id, agentToolRow())
+        const queued = store.messages.addMessage(session.id, userInbound('queued while in flight'))
+        const assistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Finished long turn')))
+
+        const first = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
+        expect(first?.event.payloadJson).toMatchObject({
+            causeMessageId: causing.id,
+            causeText: 'start the long turn'
+        })
+        expect((first?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
+            .not.toBe(queued.id)
+
+        const secondAssistant = store.messages.addMessage(
+            session.id,
+            assistantOutput(notifyFooter('Queued turn'))
+        )
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: queued.id,
+            causeText: 'queued while in flight'
+        })
+        expect(second?.event.relatedEventId).toBe(first!.event.id)
+    })
+
+    it('sticky cause: two summaries with no new inbound reuse the previous cause', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-sticky', {}, null, 'default')
+
+        const user = store.messages.addMessage(session.id, userInbound('keep going'))
+        const firstAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('First summary')))
+        const first = ingestNotify(store, session.id, 'default', firstAssistant.content, firstAssistant.id)
+
+        const secondAssistant = store.messages.addMessage(
+            session.id,
+            assistantOutput(notifyFooter('Second summary same turn'))
+        )
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+
+        expect(second?.event.payloadJson).toMatchObject({
+            messageId: secondAssistant.id,
+            causeMessageId: user.id,
+            causeText: 'keep going',
+            causeKind: 'webapp'
+        })
+        expect(second?.event.relatedEventId).toBe(first!.event.id)
+        expect(second?.event.summary).toBe('Second summary same turn')
+        expect(first?.event.summary).toBe('First summary')
+    })
+
+    it('peer inbound meta.sentFrom counts as cause', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-peer', {}, null, 'default')
+
+        const peer = store.messages.addMessage(
+            session.id,
+            userInbound('please take this handoff', 'peer')
+        )
+        const assistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Ack peer')))
+        const result = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
+
+        expect(result?.event.payloadJson).toMatchObject({
+            messageId: assistant.id,
+            causeMessageId: peer.id,
+            causeText: 'please take this handoff',
+            causeKind: 'peer'
+        })
+    })
+
+    it('skips agent-role tool/prose rows when choosing cause', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-skip-agent', {}, null, 'default')
+
+        const user = store.messages.addMessage(session.id, userInbound('the real prompt'))
+        store.messages.addMessage(session.id, agentToolRow())
+        store.messages.addMessage(session.id, assistantOutput('intermediate prose, no footer'))
+        const assistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Done')))
+
+        const result = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
+        expect(result?.event.payloadJson).toMatchObject({
+            causeMessageId: user.id,
+            causeText: 'the real prompt'
+        })
+    })
+
+    it('clamps oversized inbound causeText so elevation still inserts', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-bound', {}, null, 'default')
+        const fat = 'q'.repeat(WORK_GRAPH_MAX_SUMMARY + 400)
+        store.messages.addMessage(session.id, userInbound(fat))
+        const assistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('ok')))
+        const result = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
+
+        expect(result?.inserted).toBe(true)
+        const causeText = (result?.event.payloadJson as { causeText?: string })?.causeText ?? ''
+        expect(causeText.length).toBeLessThanOrEqual(WORK_GRAPH_MAX_SUMMARY)
+        expect(causeText.startsWith('qq')).toBe(true)
+    })
+
+    it('still inserts when max-clamped footer fields share the payload with cause', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-budget', {}, null, 'default')
+        store.messages.addMessage(session.id, userInbound('prompt'))
+        const fat = 'a'.repeat(6_000)
+        const assistant = store.messages.addMessage(session.id, assistantOutput(
+            `AGENT_NOTIFY_SUMMARY ${JSON.stringify({
+                status: 'done',
+                summary: 'ok',
+                action: fat,
+                project: fat,
+                agent: fat
+            })}`
+        ))
+        const result = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
+        expect(result?.inserted).toBe(true)
+        expect(result?.event.payloadJson).toMatchObject({
+            causeText: 'prompt',
+            action: fat
+        })
     })
 })

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'bun:test'
 import { WORK_GRAPH_MAX_STRING, WORK_GRAPH_MAX_SUMMARY } from '@hapi/protocol'
+import type { SyncEvent } from '@hapi/protocol/types'
 import { Store } from '../store'
+import type { EventPublisher } from './eventPublisher'
+import { SessionCache } from './sessionCache'
 import {
     WORK_AD_DEFAULT_TTL_MS,
     buildWorkAdFromNotify,
@@ -434,7 +437,8 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
             causeMessageId: firstUser.id,
             causeText: 'do the first thing',
             causeKind: 'webapp',
-            causeSeq: firstUser.seq
+            causeSeq: firstUser.seq,
+            causeCursorMessageId: firstUser.id
         })
 
         const secondUser = store.messages.addMessage(session.id, userInbound('do the second thing', 'cli'))
@@ -593,14 +597,16 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
     it('advances causeSeq past every invoked inbound in the same Claude batch', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-cause-batch', {}, null, 'default')
-        const one = store.messages.addMessage(session.id, userInbound('one'))
-        const two = store.messages.addMessage(session.id, userInbound('two'))
-        const three = store.messages.addMessage(session.id, userInbound('three'))
+        const one = store.messages.addMessage(session.id, userInbound('one'), 'batch-1')
+        const two = store.messages.addMessage(session.id, userInbound('two'), 'batch-2')
+        const three = store.messages.addMessage(session.id, userInbound('three'), 'batch-3')
+        store.messages.markMessagesInvoked(session.id, ['batch-1', 'batch-2', 'batch-3'], 1_700_000_111_000)
         const assistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Batched')))
         const first = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
         expect(first?.event.payloadJson).toMatchObject({
             causeMessageId: one.id,
-            causeSeq: three.seq
+            causeSeq: three.seq,
+            causeCursorMessageId: three.id
         })
 
         const next = store.messages.addMessage(session.id, userInbound('next turn'))
@@ -839,5 +845,74 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
             causeText: 'prompt',
             action: fat
         })
+    })
+
+    it('preserves notify history across mergeSessions into the surviving id', async () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, {
+            emit: (_event: SyncEvent) => {}
+        } as EventPublisher)
+        const oldSession = cache.getOrCreateSession(
+            'sess-cause-merge-old',
+            { path: '/tmp/project', host: 'localhost' },
+            null,
+            'default'
+        )
+        const newSession = cache.getOrCreateSession(
+            'sess-cause-merge-new',
+            { path: '/tmp/project', host: 'localhost' },
+            null,
+            'default'
+        )
+
+        store.messages.addMessage(oldSession.id, userInbound('from the old session'))
+        const firstAssistant = store.messages.addMessage(oldSession.id, assistantOutput(notifyFooter('Old turn')))
+        const first = ingestNotify(store, oldSession.id, 'default', firstAssistant.content, firstAssistant.id)
+        expect(first?.inserted).toBe(true)
+
+        await cache.mergeSessions(oldSession.id, newSession.id, 'default')
+
+        const nextUser = store.messages.addMessage(newSession.id, userInbound('after merge'))
+        const nextAssistant = store.messages.addMessage(newSession.id, assistantOutput(notifyFooter('New turn')))
+        const second = ingestNotify(store, newSession.id, 'default', nextAssistant.content, nextAssistant.id)
+
+        expect(second?.event.relatedEventId).toBe(first!.event.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: nextUser.id,
+            causeText: 'after merge'
+        })
+        const onSurvivor = store.workGraph.listWorkAdsByRelatedSession('default', newSession.id)
+            .map((event) => event.id)
+        expect(onSurvivor).toContain(first!.event.id)
+        expect(onSurvivor).toContain(second!.event.id)
+    })
+
+    it('does not re-attribute a prior batch after surviving-session seq-shift', () => {
+        const store = new Store(':memory:')
+        const surviving = store.sessions.getOrCreateSession('sess-cause-shift-live', {}, null, 'default')
+        const incoming = store.sessions.getOrCreateSession('sess-cause-shift-in', {}, null, 'default')
+
+        const one = store.messages.addMessage(surviving.id, userInbound('one'), 'shift-1')
+        const two = store.messages.addMessage(surviving.id, userInbound('two'), 'shift-2')
+        store.messages.addMessage(surviving.id, userInbound('three'), 'shift-3')
+        store.messages.markMessagesInvoked(surviving.id, ['shift-1', 'shift-2', 'shift-3'], 1_700_000_222_000)
+        const assistant = store.messages.addMessage(surviving.id, assistantOutput(notifyFooter('Batched')))
+        const first = ingestNotify(store, surviving.id, 'default', assistant.content, assistant.id)
+        expect(first?.event.payloadJson).toMatchObject({ causeMessageId: one.id })
+
+        store.messages.addMessage(incoming.id, userInbound('history from the other id'))
+        store.messages.mergeSessionMessages(incoming.id, surviving.id)
+
+        const secondAssistant = store.messages.addMessage(
+            surviving.id,
+            assistantOutput(notifyFooter('Sticky after merge'))
+        )
+        const second = ingestNotify(store, surviving.id, 'default', secondAssistant.content, secondAssistant.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: one.id,
+            causeText: 'one'
+        })
+        expect((second?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
+            .not.toBe(two.id)
     })
 })

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -433,7 +433,8 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
             messageId: firstAssistant.id,
             causeMessageId: firstUser.id,
             causeText: 'do the first thing',
-            causeKind: 'webapp'
+            causeKind: 'webapp',
+            causeSeq: firstUser.seq
         })
 
         const secondUser = store.messages.addMessage(session.id, userInbound('do the second thing', 'cli'))
@@ -639,6 +640,54 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         })
         expect((second?.event.payloadJson as { causeText?: string })?.causeText)
             .not.toBe('FORGED CAUSE TEXT')
+    })
+
+    it('later notifies bound the scan after the previous causeSeq', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-after-seq', {}, null, 'default')
+        const firstUser = store.messages.addMessage(session.id, userInbound('first'))
+        const firstAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('First')))
+        const first = ingestNotify(store, session.id, 'default', firstAssistant.content, firstAssistant.id)
+        expect(first?.event.payloadJson).toMatchObject({ causeSeq: firstUser.seq })
+
+        const nextUser = store.messages.addMessage(session.id, userInbound('second'))
+        const secondAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Second')))
+        const second = ingestNotify(store, session.id, 'default', secondAssistant.content, secondAssistant.id)
+        expect(second?.event.payloadJson).toMatchObject({
+            causeMessageId: nextUser.id,
+            causeText: 'second',
+            causeSeq: nextUser.seq
+        })
+    })
+
+    it('legacy notify without causeSeq still consumes inbounds at or before that assistant', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-legacy-seq', {}, null, 'default')
+        const oldUser = store.messages.addMessage(session.id, userInbound('old prompt'))
+        const oldAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Legacy')))
+        store.workGraph.insertEvent('default', {
+            source_kind: 'session',
+            source_ref: session.id,
+            event_type: 'work_ad',
+            related_session_id: session.id,
+            summary: 'legacy',
+            provenance: 'AGENT_NOTIFY_SUMMARY',
+            payload_json: {
+                status: 'done',
+                messageId: oldAssistant.id
+            },
+            principal: { kind: 'agent', id: `session:${session.id}`, on_behalf_of: '1' }
+        })
+
+        const nextUser = store.messages.addMessage(session.id, userInbound('new prompt'))
+        const nextAssistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Next')))
+        const result = ingestNotify(store, session.id, 'default', nextAssistant.content, nextAssistant.id)
+        expect(result?.event.payloadJson).toMatchObject({
+            causeMessageId: nextUser.id,
+            causeText: 'new prompt'
+        })
+        expect((result?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
+            .not.toBe(oldUser.id)
     })
 
     it('treats an unmarked local CLI prompt as a cause', () => {

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -641,6 +641,19 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
             .not.toBe('FORGED CAUSE TEXT')
     })
 
+    it('treats an unmarked local CLI prompt as a cause', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-local-cli', {}, null, 'default')
+        const local = store.messages.addMessage(session.id, userInbound('typed in the TTY', 'cli'))
+        const assistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Local turn')))
+        const result = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
+        expect(result?.event.payloadJson).toMatchObject({
+            causeMessageId: local.id,
+            causeText: 'typed in the TTY',
+            causeKind: 'cli'
+        })
+    })
+
     it('skips Claude transcript echoes so the next turn is not attributed to the previous prompt copy', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-cause-echo', {}, null, 'default')

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -705,6 +705,33 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
             .not.toBe('FORGED CAUSE TEXT')
     })
 
+    it('first notify after copied history uses the latest invoked inbound, not the oldest copy', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-fork-hydrate', {}, null, 'default')
+        const copied = store.messages.addMessage(
+            session.id,
+            userInbound('copied prefix'),
+            undefined,
+            undefined,
+            1_000
+        )
+        const forkPrompt = store.messages.addMessage(
+            session.id,
+            userInbound('fork prompt'),
+            undefined,
+            undefined,
+            2_000
+        )
+        const assistant = store.messages.addMessage(session.id, assistantOutput(notifyFooter('Forked')))
+        const result = ingestNotify(store, session.id, 'default', assistant.content, assistant.id)
+        expect(result?.event.payloadJson).toMatchObject({
+            causeMessageId: forkPrompt.id,
+            causeText: 'fork prompt'
+        })
+        expect((result?.event.payloadJson as { causeMessageId?: string })?.causeMessageId)
+            .not.toBe(copied.id)
+    })
+
     it('later notifies bound the scan after the previous causeSeq', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-cause-after-seq', {}, null, 'default')

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -301,9 +301,17 @@ export function resolveWorkAdCause(params: {
 }): { cause: WorkAdCause | null; previousEventId: string | null } {
     const previous = params.previousWorkAds.at(-1) ?? null
     const consumed = consumedInboundIds(params.messages, params.previousWorkAds)
-    const inbound = params.messages.find(
-        (message) => isCauseCandidate(message) && !consumed.has(message.id)
-    )
+    const inbound = params.messages
+        .filter((message) => (
+            isCauseCandidate(message)
+            && !consumed.has(message.id)
+            && (params.assistantSeq == null || message.seq < params.assistantSeq)
+        ))
+        .sort((left, right) => {
+            const invokedDelta = (right.invokedAt ?? 0) - (left.invokedAt ?? 0)
+            if (invokedDelta !== 0) return invokedDelta
+            return left.seq - right.seq
+        })[0]
     if (inbound) {
         const text = extractInboundCauseText(inbound.content)
         return {

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -274,14 +274,30 @@ function consumedInboundIds(
 }
 
 /**
- * Sequential rule: first unconsumed inbound (role=user) in session order.
- * Each work_ad consumes exactly one inbound (queued leftovers wait for later
- * events — that is the in-flight queued exception, not a drain of the whole queue).
- * No new inbound → sticky copy of the previous event's cause.
+ * Sequential rule: first unconsumed invoked inbound is the cause identity.
+ * causeSeq advances past other invoked inbounds before this assistant (one
+ * Claude batch can join several same-mode prompts). Uninvoked leftovers wait.
+ * No new invoked inbound → sticky copy of the previous event's cause.
  */
+function batchCauseSeq(
+    messages: StoredMessage[],
+    inbound: StoredMessage,
+    assistantSeq: number | null
+): number {
+    let maxSeq = inbound.seq
+    for (const message of messages) {
+        if (assistantSeq != null && message.seq >= assistantSeq) continue
+        if (message.seq <= inbound.seq) continue
+        if (!isCauseCandidate(message)) continue
+        if (message.seq > maxSeq) maxSeq = message.seq
+    }
+    return maxSeq
+}
+
 export function resolveWorkAdCause(params: {
     messages: StoredMessage[]
     previousWorkAds: WorkGraphEvent[]
+    assistantSeq?: number | null
 }): { cause: WorkAdCause | null; previousEventId: string | null } {
     const previous = params.previousWorkAds.at(-1) ?? null
     const consumed = consumedInboundIds(params.messages, params.previousWorkAds)
@@ -295,7 +311,7 @@ export function resolveWorkAdCause(params: {
                 causeMessageId: inbound.id,
                 causeText: text === null ? null : clampJsonUtf8(text, WORK_GRAPH_MAX_SUMMARY),
                 causeKind: extractInboundSentFrom(inbound.content),
-                causeSeq: inbound.seq
+                causeSeq: batchCauseSeq(params.messages, inbound, params.assistantSeq ?? null)
             },
             previousEventId: previous?.id ?? null
         }
@@ -417,9 +433,12 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
 
     // Cause is hub-derived from session messages SQL (no REST 200 cap).
     const previousWorkAds = listPreviousWorkAds(input.store, input.namespace, input.sessionId)
+    const messages = loadMessagesForCause(input.store, input.sessionId, previousWorkAds)
+    const assistantSeq = messages.find((message) => message.id === input.messageId)?.seq ?? null
     const { cause, previousEventId } = resolveWorkAdCause({
-        messages: loadMessagesForCause(input.store, input.sessionId, previousWorkAds),
-        previousWorkAds
+        messages,
+        previousWorkAds,
+        assistantSeq
     })
 
     const create = buildWorkAdFromNotify({

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -154,6 +154,9 @@ function isInboundUserMessage(content: unknown): boolean {
 
 function isCauseCandidate(message: StoredMessage, now: number = Date.now()): boolean {
     if (!isInboundUserMessage(message.content)) return false
+    const meta = asRecord(asRecord(message.content)?.meta)
+    // Claude jsonl echoes the remote prompt as a second role=user row (sentFrom cli).
+    if (meta?.isTranscriptEcho === true) return false
     // Future-scheduled rows are persisted before delivery; they are not this turn's cause.
     if (message.scheduledAt != null && message.scheduledAt > now) return false
     return true

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -10,7 +10,7 @@ import {
     type WorkGraphEventCreate
 } from '@hapi/protocol'
 import type { Store, StoredMessage } from '../store'
-import { WorkGraphNotFoundError, WorkGraphValidationError } from '../store'
+import { WorkGraphValidationError } from '../store'
 import type { InsertWorkGraphEventResult } from '../store/workGraph'
 
 const WORK_GRAPH_MAX_TAG = 256
@@ -152,6 +152,13 @@ function isInboundUserMessage(content: unknown): boolean {
     return asRecord(content)?.role === 'user'
 }
 
+function isCauseCandidate(message: StoredMessage, now: number = Date.now()): boolean {
+    if (!isInboundUserMessage(message.content)) return false
+    // Future-scheduled rows are persisted before delivery; they are not this turn's cause.
+    if (message.scheduledAt != null && message.scheduledAt > now) return false
+    return true
+}
+
 function extractInboundSentFrom(content: unknown): string | null {
     const meta = asRecord(asRecord(content)?.meta)
     return typeof meta?.sentFrom === 'string' && meta.sentFrom.trim().length > 0
@@ -200,7 +207,14 @@ function listPreviousWorkAds(
     namespace: string,
     sessionId: string
 ): WorkGraphEvent[] {
-    return store.workGraph.listWorkAdsByRelatedSession(namespace, sessionId)
+    // Only hub notify elevation. Client POST /work-graph/events can mint
+    // work_ad rows; those must not steal related_event_id, follows, or sticky cause.
+    return store.workGraph
+        .listWorkAdsByRelatedSession(namespace, sessionId)
+        .filter((event) => (
+            event.provenance === 'AGENT_NOTIFY_SUMMARY'
+            && event.sourceRef === sessionId
+        ))
 }
 
 function consumedInboundIds(
@@ -222,7 +236,7 @@ function consumedInboundIds(
         const assistant = assistantId ? byId.get(assistantId) : undefined
         if (!assistant) continue
         for (const message of messages) {
-            if (message.seq <= assistant.seq && isInboundUserMessage(message.content)) {
+            if (message.seq <= assistant.seq && isCauseCandidate(message)) {
                 consumed.add(message.id)
             }
         }
@@ -232,19 +246,18 @@ function consumedInboundIds(
 
 /**
  * Sequential rule: first unconsumed inbound (role=user) in session order.
- * Queued inbound during an in-flight turn stays unconsumed for the next event.
+ * Each work_ad consumes exactly one inbound (queued leftovers wait for later
+ * events — that is the in-flight queued exception, not a drain of the whole queue).
  * No new inbound → sticky copy of the previous event's cause.
  */
 export function resolveWorkAdCause(params: {
     messages: StoredMessage[]
     previousWorkAds: WorkGraphEvent[]
 }): { cause: WorkAdCause | null; previousEventId: string | null } {
-    const previousWorkAds = [...params.previousWorkAds]
-        .sort((a, b) => (a.ts !== b.ts ? a.ts - b.ts : a.id.localeCompare(b.id)))
-    const previous = previousWorkAds.at(-1) ?? null
-    const consumed = consumedInboundIds(params.messages, previousWorkAds)
+    const previous = params.previousWorkAds.at(-1) ?? null
+    const consumed = consumedInboundIds(params.messages, params.previousWorkAds)
     const inbound = params.messages.find(
-        (message) => isInboundUserMessage(message.content) && !consumed.has(message.id)
+        (message) => isCauseCandidate(message) && !consumed.has(message.id)
     )
     if (inbound) {
         const text = extractInboundCauseText(inbound.content)
@@ -398,8 +411,8 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
                     to_event_id: previousEventId,
                     relation_type: 'follows'
                 })
-            } catch (error) {
-                if (!(error instanceof WorkGraphNotFoundError)) throw error
+            } catch {
+                // Best-effort edge; related_event_id is already on the row.
             }
         }
         return result

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -140,6 +140,7 @@ export type WorkAdCause = {
     causeMessageId: string
     causeText: string | null
     causeKind: string | null
+    causeSeq: number | null
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -193,6 +194,13 @@ function extractInboundCauseText(content: unknown): string | null {
     return null
 }
 
+function readCauseSeq(payload: unknown): number | null {
+    const record = asRecord(payload)
+    return typeof record?.causeSeq === 'number' && Number.isInteger(record.causeSeq)
+        ? record.causeSeq
+        : null
+}
+
 function readCauseFromPayload(payload: unknown): WorkAdCause | null {
     const record = asRecord(payload)
     if (typeof record?.causeMessageId !== 'string' || record.causeMessageId.length === 0) {
@@ -201,8 +209,25 @@ function readCauseFromPayload(payload: unknown): WorkAdCause | null {
     return {
         causeMessageId: record.causeMessageId,
         causeText: typeof record.causeText === 'string' ? record.causeText : null,
-        causeKind: typeof record.causeKind === 'string' ? record.causeKind : null
+        causeKind: typeof record.causeKind === 'string' ? record.causeKind : null,
+        causeSeq: readCauseSeq(payload)
     }
+}
+
+function loadMessagesForCause(
+    store: Store,
+    sessionId: string,
+    previousWorkAds: WorkGraphEvent[]
+): StoredMessage[] {
+    const previous = previousWorkAds.at(-1) ?? null
+    const afterSeq = readCauseSeq(previous?.payloadJson)
+    // First event / legacy rows without causeSeq still need the full session.
+    // Later notifies only need rows after the previous cause (not every
+    // compressed agent/tool blob since session start).
+    if (afterSeq == null) {
+        return store.messages.getAllMessages(sessionId)
+    }
+    return store.messages.getMessagesAfterSeq(sessionId, afterSeq)
 }
 
 function listPreviousWorkAds(
@@ -268,7 +293,8 @@ export function resolveWorkAdCause(params: {
             cause: {
                 causeMessageId: inbound.id,
                 causeText: text === null ? null : clampJsonUtf8(text, WORK_GRAPH_MAX_SUMMARY),
-                causeKind: extractInboundSentFrom(inbound.content)
+                causeKind: extractInboundSentFrom(inbound.content),
+                causeSeq: inbound.seq
             },
             previousEventId: previous?.id ?? null
         }
@@ -345,7 +371,8 @@ export function buildWorkAdFromNotify(params: {
                 ? {
                     causeMessageId,
                     causeText,
-                    causeKind
+                    causeKind,
+                    causeSeq: cause.causeSeq
                 }
                 : {})
         },
@@ -387,10 +414,10 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
         return null
     }
 
-    // Cause is hub-derived from the full session messages table (no REST 200 cap).
+    // Cause is hub-derived from session messages SQL (no REST 200 cap).
     const previousWorkAds = listPreviousWorkAds(input.store, input.namespace, input.sessionId)
     const { cause, previousEventId } = resolveWorkAdCause({
-        messages: input.store.messages.getAllMessages(input.sessionId),
+        messages: loadMessagesForCause(input.store, input.sessionId, previousWorkAds),
         previousWorkAds
     })
 

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -158,7 +158,8 @@ function isCauseCandidate(message: StoredMessage, now: number = Date.now()): boo
     const meta = asRecord(asRecord(message.content)?.meta)
     // Claude jsonl echoes the remote prompt as a second role=user row (sentFrom cli).
     if (meta?.isTranscriptEcho === true) return false
-    // Future-scheduled rows are persisted before delivery; they are not this turn's cause.
+    // Queued (localId, not yet acked) and unmatured scheduled rows are not this turn.
+    if (message.invokedAt === null) return false
     if (message.scheduledAt != null && message.scheduledAt > now) return false
     return true
 }

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -6,10 +6,11 @@ import {
     extractNotifySummary,
     unwrapRoleWrappedRecordEnvelope,
     type NotifySummary,
+    type WorkGraphEvent,
     type WorkGraphEventCreate
 } from '@hapi/protocol'
-import type { Store } from '../store'
-import { WorkGraphValidationError } from '../store'
+import type { Store, StoredMessage } from '../store'
+import { WorkGraphNotFoundError, WorkGraphValidationError } from '../store'
 import type { InsertWorkGraphEventResult } from '../store/workGraph'
 
 const WORK_GRAPH_MAX_TAG = 256
@@ -135,6 +136,136 @@ function isAgentMessageContent(content: unknown): boolean {
     return false
 }
 
+export type WorkAdCause = {
+    causeMessageId: string
+    causeText: string | null
+    causeKind: string | null
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : null
+}
+
+function isInboundUserMessage(content: unknown): boolean {
+    return asRecord(content)?.role === 'user'
+}
+
+function extractInboundSentFrom(content: unknown): string | null {
+    const meta = asRecord(asRecord(content)?.meta)
+    return typeof meta?.sentFrom === 'string' && meta.sentFrom.trim().length > 0
+        ? meta.sentFrom.trim()
+        : null
+}
+
+function extractInboundCauseText(content: unknown): string | null {
+    const record = asRecord(content)
+    if (!record) return null
+    const inner = record.content
+    if (typeof inner === 'string') {
+        const text = inner.trim()
+        return text.length > 0 ? text : null
+    }
+    if (Array.isArray(inner)) {
+        const parts = inner.flatMap((block) => {
+            const item = asRecord(block)
+            return item?.type === 'text' && typeof item.text === 'string' ? [item.text] : []
+        })
+        const text = parts.join(' ').trim()
+        return text.length > 0 ? text : null
+    }
+    const nested = asRecord(inner)
+    if (nested?.type === 'text' && typeof nested.text === 'string') {
+        const text = nested.text.trim()
+        return text.length > 0 ? text : null
+    }
+    return null
+}
+
+function readCauseFromPayload(payload: unknown): WorkAdCause | null {
+    const record = asRecord(payload)
+    if (typeof record?.causeMessageId !== 'string' || record.causeMessageId.length === 0) {
+        return null
+    }
+    return {
+        causeMessageId: record.causeMessageId,
+        causeText: typeof record.causeText === 'string' ? record.causeText : null,
+        causeKind: typeof record.causeKind === 'string' ? record.causeKind : null
+    }
+}
+
+function listPreviousWorkAds(
+    store: Store,
+    namespace: string,
+    sessionId: string
+): WorkGraphEvent[] {
+    return store.workGraph.listWorkAdsByRelatedSession(namespace, sessionId)
+}
+
+function consumedInboundIds(
+    messages: StoredMessage[],
+    previousWorkAds: WorkGraphEvent[]
+): Set<string> {
+    const consumed = new Set<string>()
+    const byId = new Map(messages.map((message) => [message.id, message]))
+    for (const event of previousWorkAds) {
+        const stamped = readCauseFromPayload(event.payloadJson)
+        if (stamped) {
+            consumed.add(stamped.causeMessageId)
+            continue
+        }
+        // Legacy notify rows have no causeMessageId. Treat inbounds at/before
+        // that notify as consumed so the next turn does not re-attribute them.
+        const payload = asRecord(event.payloadJson)
+        const assistantId = typeof payload?.messageId === 'string' ? payload.messageId : null
+        const assistant = assistantId ? byId.get(assistantId) : undefined
+        if (!assistant) continue
+        for (const message of messages) {
+            if (message.seq <= assistant.seq && isInboundUserMessage(message.content)) {
+                consumed.add(message.id)
+            }
+        }
+    }
+    return consumed
+}
+
+/**
+ * Sequential rule: first unconsumed inbound (role=user) in session order.
+ * Queued inbound during an in-flight turn stays unconsumed for the next event.
+ * No new inbound → sticky copy of the previous event's cause.
+ */
+export function resolveWorkAdCause(params: {
+    messages: StoredMessage[]
+    previousWorkAds: WorkGraphEvent[]
+}): { cause: WorkAdCause | null; previousEventId: string | null } {
+    const previousWorkAds = [...params.previousWorkAds]
+        .sort((a, b) => (a.ts !== b.ts ? a.ts - b.ts : a.id.localeCompare(b.id)))
+    const previous = previousWorkAds.at(-1) ?? null
+    const consumed = consumedInboundIds(params.messages, previousWorkAds)
+    const inbound = params.messages.find(
+        (message) => isInboundUserMessage(message.content) && !consumed.has(message.id)
+    )
+    if (inbound) {
+        const text = extractInboundCauseText(inbound.content)
+        return {
+            cause: {
+                causeMessageId: inbound.id,
+                causeText: text === null ? null : clampJsonUtf8(text, WORK_GRAPH_MAX_SUMMARY),
+                causeKind: extractInboundSentFrom(inbound.content)
+            },
+            previousEventId: previous?.id ?? null
+        }
+    }
+    if (previous) {
+        const sticky = readCauseFromPayload(previous.payloadJson)
+        if (sticky) {
+            return { cause: sticky, previousEventId: previous.id }
+        }
+    }
+    return { cause: null, previousEventId: previous?.id ?? null }
+}
+
 function buildTags(notify: NotifySummary, flavor: string | null | undefined): string[] {
     // Project stays in tags + payload for now. Indexed `project` column /
     // project-scoped list query is deferred to #1374 / P4 (cold review M4).
@@ -159,6 +290,8 @@ export function buildWorkAdFromNotify(params: {
     ts: number
     flavor?: string | null
     expiresAt?: number
+    cause?: WorkAdCause | null
+    relatedEventId?: string | null
 }): WorkGraphEventCreate {
     const status = mapNotifyStatusToWorkAdStatus(params.notify.status)
     // Footer fields are untrusted. Clamp to ledger schema bounds so elevation
@@ -167,6 +300,16 @@ export function buildWorkAdFromNotify(params: {
     const action = clampJsonUtf8Opt(params.notify.action, WORK_GRAPH_MAX_STRING) ?? null
     const project = clampJsonUtf8Opt(params.notify.project, WORK_GRAPH_MAX_STRING) ?? null
     const agent = clampJsonUtf8Opt(params.notify.agent, WORK_GRAPH_MAX_STRING) ?? null
+    const cause = params.cause
+    const causeMessageId = cause
+        ? clampJsonUtf8(cause.causeMessageId, 256)
+        : null
+    const causeText = cause?.causeText == null
+        ? null
+        : clampJsonUtf8(cause.causeText, WORK_GRAPH_MAX_SUMMARY)
+    const causeKind = cause?.causeKind == null
+        ? null
+        : clampJsonUtf8(cause.causeKind, WORK_GRAPH_MAX_TAG)
     // Audit principal is always session-bound. notify.agent is untrusted
     // self-label text and stays advisory in payload/tags only.
     // Do not nest a full notify_summary copy — duplicating clamped strings
@@ -181,10 +324,18 @@ export function buildWorkAdFromNotify(params: {
             action,
             project,
             agent,
-            messageId: params.messageId
+            messageId: params.messageId,
+            ...(cause && causeMessageId
+                ? {
+                    causeMessageId,
+                    causeText,
+                    causeKind
+                }
+                : {})
         },
         tags: buildTags(params.notify, params.flavor),
         related_session_id: params.sessionId,
+        related_event_id: params.relatedEventId || undefined,
         provenance: 'AGENT_NOTIFY_SUMMARY',
         idempotency_key: `session:${params.sessionId}:message:${params.messageId}:notify`,
         expires_at: params.expiresAt ?? (params.ts + WORK_AD_DEFAULT_TTL_MS),
@@ -220,17 +371,38 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
         return null
     }
 
+    // Cause is hub-derived from the full session messages table (no REST 200 cap).
+    const previousWorkAds = listPreviousWorkAds(input.store, input.namespace, input.sessionId)
+    const { cause, previousEventId } = resolveWorkAdCause({
+        messages: input.store.messages.getAllMessages(input.sessionId),
+        previousWorkAds
+    })
+
     const create = buildWorkAdFromNotify({
         sessionId: input.sessionId,
         messageId: input.messageId,
         notify,
         ownerUserId: input.ownerUserId,
         flavor: input.flavor,
-        ts: input.ts
+        ts: input.ts,
+        cause,
+        relatedEventId: previousEventId
     })
 
     try {
-        return input.store.workGraph.insertEvent(input.namespace, create, { ts: input.ts })
+        const result = input.store.workGraph.insertEvent(input.namespace, create, { ts: input.ts })
+        if (result.inserted && previousEventId) {
+            try {
+                input.store.workGraph.insertLink(input.namespace, {
+                    from_event_id: result.event.id,
+                    to_event_id: previousEventId,
+                    relation_type: 'follows'
+                })
+            } catch (error) {
+                if (!(error instanceof WorkGraphNotFoundError)) throw error
+            }
+        }
+        return result
     } catch (error) {
         // Best-effort capture: never break message ingest on ledger bounds.
         if (error instanceof WorkGraphValidationError) {

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -141,6 +141,7 @@ export type WorkAdCause = {
     causeText: string | null
     causeKind: string | null
     causeSeq: number | null
+    causeCursorMessageId: string | null
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -202,6 +203,13 @@ function readCauseSeq(payload: unknown): number | null {
         : null
 }
 
+function readCauseCursorMessageId(payload: unknown): string | null {
+    const record = asRecord(payload)
+    return typeof record?.causeCursorMessageId === 'string' && record.causeCursorMessageId.length > 0
+        ? record.causeCursorMessageId
+        : null
+}
+
 function readCauseFromPayload(payload: unknown): WorkAdCause | null {
     const record = asRecord(payload)
     if (typeof record?.causeMessageId !== 'string' || record.causeMessageId.length === 0) {
@@ -211,7 +219,8 @@ function readCauseFromPayload(payload: unknown): WorkAdCause | null {
         causeMessageId: record.causeMessageId,
         causeText: typeof record.causeText === 'string' ? record.causeText : null,
         causeKind: typeof record.causeKind === 'string' ? record.causeKind : null,
-        causeSeq: readCauseSeq(payload)
+        causeSeq: readCauseSeq(payload),
+        causeCursorMessageId: readCauseCursorMessageId(payload)
     }
 }
 
@@ -221,6 +230,14 @@ function loadMessagesForCause(
     previousWorkAds: WorkGraphEvent[]
 ): StoredMessage[] {
     const previous = previousWorkAds.at(-1) ?? null
+    const cursorId = readCauseCursorMessageId(previous?.payloadJson)
+    if (cursorId) {
+        const cursorSeq = store.messages.getSeqById(sessionId, cursorId)
+        if (cursorSeq != null) {
+            return store.messages.getMessagesAfterSeq(sessionId, cursorSeq)
+        }
+        return store.messages.getAllMessages(sessionId)
+    }
     const afterSeq = readCauseSeq(previous?.payloadJson)
     // First event / legacy rows without causeSeq still need the full session.
     // Later notifies only need rows after the previous cause (not every
@@ -279,19 +296,22 @@ function consumedInboundIds(
  * Claude batch can join several same-mode prompts). Uninvoked leftovers wait.
  * No new invoked inbound → sticky copy of the previous event's cause.
  */
-function batchCauseSeq(
+function batchCauseCursor(
     messages: StoredMessage[],
     inbound: StoredMessage,
     assistantSeq: number | null
-): number {
+): { causeSeq: number; causeCursorMessageId: string } {
     let maxSeq = inbound.seq
+    let cursorId = inbound.id
     for (const message of messages) {
         if (assistantSeq != null && message.seq >= assistantSeq) continue
-        if (message.seq <= inbound.seq) continue
         if (!isCauseCandidate(message)) continue
-        if (message.seq > maxSeq) maxSeq = message.seq
+        if (message.seq > maxSeq) {
+            maxSeq = message.seq
+            cursorId = message.id
+        }
     }
-    return maxSeq
+    return { causeSeq: maxSeq, causeCursorMessageId: cursorId }
 }
 
 export function resolveWorkAdCause(params: {
@@ -314,12 +334,14 @@ export function resolveWorkAdCause(params: {
         })[0]
     if (inbound) {
         const text = extractInboundCauseText(inbound.content)
+        const cursor = batchCauseCursor(params.messages, inbound, params.assistantSeq ?? null)
         return {
             cause: {
                 causeMessageId: inbound.id,
                 causeText: text === null ? null : clampJsonUtf8(text, WORK_GRAPH_MAX_SUMMARY),
                 causeKind: extractInboundSentFrom(inbound.content),
-                causeSeq: batchCauseSeq(params.messages, inbound, params.assistantSeq ?? null)
+                causeSeq: cursor.causeSeq,
+                causeCursorMessageId: cursor.causeCursorMessageId
             },
             previousEventId: previous?.id ?? null
         }
@@ -397,7 +419,10 @@ export function buildWorkAdFromNotify(params: {
                     causeMessageId,
                     causeText,
                     causeKind,
-                    causeSeq: cause.causeSeq
+                    causeSeq: cause.causeSeq,
+                    ...(cause.causeCursorMessageId
+                        ? { causeCursorMessageId: clampJsonUtf8(cause.causeCursorMessageId, 256) }
+                        : {})
                 }
                 : {})
         },

--- a/hub/src/web/routes/workGraph.test.ts
+++ b/hub/src/web/routes/workGraph.test.ts
@@ -178,6 +178,33 @@ describe('work-graph routes', () => {
         expect(response.status).toBe(413)
     })
 
+    it('rejects reserved AGENT_NOTIFY_SUMMARY provenance on HTTP writes', async () => {
+        const store = new Store(':memory:')
+        const app = createApp(store)
+        const headers = await authHeaders('default')
+        const response = await app.request('/api/work-graph/events', {
+            method: 'POST',
+            headers: { ...headers, 'content-type': 'application/json' },
+            body: JSON.stringify({
+                source_kind: 'session',
+                source_ref: 'sess-1',
+                event_type: 'work_ad',
+                related_session_id: 'sess-1',
+                provenance: 'AGENT_NOTIFY_SUMMARY',
+                payload_json: {
+                    status: 'done',
+                    causeMessageId: 'msg-forged',
+                    causeText: 'FORGED CAUSE TEXT'
+                },
+                principal: { kind: 'human', id: '1' }
+            })
+        })
+        expect(response.status).toBe(400)
+        const body = await response.json() as { error: string }
+        expect(body.error).toBe('Reserved provenance')
+        expect(store.workGraph.listByRelatedSession('default', 'sess-1')).toHaveLength(0)
+    })
+
     it('rejects fractional list limit with 400 (not SQLite 500)', async () => {
         const store = new Store(':memory:')
         const app = createApp(store)

--- a/hub/src/web/routes/workGraph.ts
+++ b/hub/src/web/routes/workGraph.ts
@@ -41,6 +41,10 @@ export function createWorkGraphRoutes(store: Store): Hono<WebAppEnv> {
             }, 403)
         }
 
+        if (parsed.data.provenance === 'AGENT_NOTIFY_SUMMARY') {
+            return c.json({ error: 'Reserved provenance' }, 400)
+        }
+
         try {
             const result = store.workGraph.insertEvent(namespace, parsed.data)
             return c.json({


### PR DESCRIPTION
## Summary

Notify ingest (`AGENT_NOTIFY_SUMMARY` → `work_ad`) stored the assistant `messageId` but not the inbound that started the turn. Consumers then guessed from a truncated transcript and mis-attributed queued inbounds.

At insert the hub now resolves cause from the full session `messages` table (not the REST 200-cap list) and stamps:

- `payload_json.causeMessageId` / `causeText` / `causeKind` (`meta.sentFrom`)
- `related_event_id` to the previous notify-derived `work_ad`
- a `follows` event link to that previous row

Sequential rule: first unconsumed `role=user` inbound (human or peer). Each `work_ad` consumes one inbound, so a queued inbound during an in-flight turn is not the nearest-user-before-assistant guess; leftovers wait for later events. No new inbound → sticky copy of the previous cause. Agent-role rows and future-scheduled rows are skipped. Client-posted `work_ad` rows do not participate in the chain.

Assistant `messageId` and the raw notify footer are unchanged.

## Test plan

- [x] `bun run typecheck:hub`
- [x] `bun run test:hub` (1050 pass)
- [x] Happy path, queued inbound, sticky cause, peer `sentFrom`, skip agent rows
- [x] Future-scheduled inbound is not a cause
- [x] HTTP-posted `work_ad` cannot steal `related_event_id` or sticky cause text

## Issues

Closes #1508
