### PR TITLE
Fix Telegram Mini App polish and file tree state

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -113,6 +113,7 @@
         "@tanstack/react-query-devtools": "^5.91.1",
         "@tanstack/react-router": "^1.170.8",
         "@tanstack/router-core": "^1.171.6",
+        "@tma.js/sdk": "^3.3.0",
         "@xterm/addon-canvas": "^0.7.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -1096,6 +1097,18 @@
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
+    "@tma.js/bridge": ["@tma.js/bridge@2.3.3", "", { "dependencies": { "@tma.js/signals": "^1.0.1", "@tma.js/toolkit": "^1.0.4", "@tma.js/transformers": "^1.2.0", "@tma.js/types": "^1.0.2", "better-promises": "^1.0.0", "error-kid": "^2.0.0", "fp-ts": "^2.16.11", "mitt": "^3.0.1", "valibot": "^1.1.0" } }, "sha512-R2o/bJY/mc8Kg4F3sF515DawCEUOVpHaOnW/zGq95Tell/ptb/7XPzCa7Ko5iq8KrlmHjpiK/0xnnF423lJ4Vw=="],
+
+    "@tma.js/sdk": ["@tma.js/sdk@3.3.0", "", { "dependencies": { "@tma.js/bridge": "^2.3.3", "@tma.js/signals": "^1.0.1", "@tma.js/toolkit": "^1.0.4", "@tma.js/transformers": "^1.2.0", "@tma.js/types": "^1.0.2", "better-promises": "^1.0.0", "error-kid": "^2.0.0", "fp-ts": "^2.16.11", "valibot": "^1.1.0" } }, "sha512-Hs9cx2lgUPlHL/RO7uKBF00SrOnFV9BLpJ1/r/fW2b/ITqeo4dh4iTmJ/U6h0cSFk5682ZGUSoPVdGJVENsIuA=="],
+
+    "@tma.js/signals": ["@tma.js/signals@1.0.1", "", {}, "sha512-i2HUuwGqL4BmM5KAklAUhMhlEgUOF+F4nMHHS/zxrmD0upHE/0CiXCEdQxVeeOGN6e2RrKlonA40sDtR6OUDCw=="],
+
+    "@tma.js/toolkit": ["@tma.js/toolkit@1.0.4", "", { "dependencies": { "better-promises": "^1.0.0", "fp-ts": "^2.16.11" } }, "sha512-6CDlkgc+43WD2jy6jog3B50yt9t+/wRwrN25zOa4iSw4IzfqoFjaQcJzTupBYaRxz19C3Rrir7p0/qStS/Z8vw=="],
+
+    "@tma.js/transformers": ["@tma.js/transformers@1.2.0", "", { "dependencies": { "@tma.js/toolkit": "^1.0.4", "@tma.js/types": "^1.0.2", "fp-ts": "^2.16.11", "valibot": "^1.1.0" } }, "sha512-6bpzbcsSIwfTHa4Xpr1O9yAOL7YBx6ttk9A0lpKibLdkt3Qz60dHtfdf9lkGNndHzPbypggTlTdJQ2Rq+FwiiA=="],
+
+    "@tma.js/types": ["@tma.js/types@1.0.2", "", {}, "sha512-qs4mi+U1xZmMQBdMhWAo1X4YqUJ/ae0y28s+GNCpQq58bsJo0h8rvyVOB1RwPvXogIY9+yribbZe6z3AIJmsAQ=="],
+
     "@twsxtd/hapi": ["@twsxtd/hapi@workspace:cli"],
 
     "@twsxtd/hapi-darwin-arm64": ["@twsxtd/hapi-darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64", "bin": { "hapi": "bin/hapi" } }, "sha512-YGjyrzBL5vIaJTrx0SlrZgyVqjXvLX0VmJBympvnpEa9SKaDUhmSfT7BD/zqakKmJySZXL/aTM49OUzLvlYsdw=="],
@@ -1428,6 +1441,8 @@
 
     "body-parser": ["body-parser@1.20.4", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.14.0", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA=="],
 
+    "better-promises": ["better-promises@1.0.0", "", { "dependencies": { "error-kid": "^1.0.1" } }, "sha512-gPgL2nRgeSbMIe3QpsYdKR3K0S9OZuphVuos60Eqsw8d/6GivOkyJ5D/zmnolJ6hzh7upnnflBUWUlQh4qpU2A=="],
+
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
@@ -1728,6 +1743,8 @@
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
+    "error-kid": ["error-kid@2.0.0", "", {}, "sha512-U8lVKG2Fg7rDZ5b5bL7ZewhzWQrUYtCHlgb7SFcAgxObFgt47jR5l9dq/Kx4AW9gAmb8B2BD3VERXciU9Q9BZA=="],
+
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
@@ -1847,6 +1864,8 @@
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fp-ts": ["fp-ts@2.16.11", "", {}, "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w=="],
 
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
@@ -3061,6 +3080,8 @@
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "v8n": ["v8n@1.5.1", "", {}, "sha512-LdabyT4OffkyXFCe9UT+uMkxNBs5rcTVuZClvxQr08D5TUgo1OFKkoT65qYRCsiKBl/usHjpXvP4hHMzzDRj3A=="],
+
+    "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
         "@tanstack/react-query-devtools": "^5.91.1",
         "@tanstack/react-router": "^1.170.8",
         "@tanstack/router-core": "^1.171.6",
+        "@tma.js/sdk": "^3.3.0",
         "@xterm/addon-canvas": "^0.7.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Outlet, useLocation, useMatchRoute, useRouter } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
-import { getTelegramWebApp, isTelegramApp } from '@/hooks/useTelegram'
+import { configureTelegramWebApp, getTelegramWebApp, isTelegramApp } from '@/hooks/useTelegram'
 import { initializeChatSurfaceColors } from '@/hooks/useChatSurfaceColors'
 import { initializeTheme } from '@/hooks/useTheme'
 import { initializeThemeColors } from '@/hooks/useThemeColors'
@@ -14,6 +14,7 @@ import { useSyncingState } from '@/hooks/useSyncingState'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
 import { useViewportHeight } from '@/hooks/useViewportHeight'
 import { useVisibilityReporter } from '@/hooks/useVisibilityReporter'
+import { usePlatform, type HapticNotification } from '@/hooks/usePlatform'
 import { queryKeys } from '@/lib/query-keys'
 import { AppContextProvider } from '@/lib/app-context'
 import { clearMessageWindow, syncTailMessages } from '@/lib/message-window-store'
@@ -40,6 +41,14 @@ import type { SyncEvent } from '@/types/api'
 type ToastEvent = Extract<SyncEvent, { type: 'toast' }>
 
 const REQUIRE_SERVER_URL = requireHubUrlForLogin()
+
+function getToastHapticNotification(title: string): HapticNotification | null {
+    const normalizedTitle = title.trim()
+    if (normalizedTitle === 'Task completed') return 'success'
+    if (normalizedTitle === 'Task failed') return 'error'
+    if (normalizedTitle === 'Permission Request' || normalizedTitle === 'Ready for input') return 'warning'
+    return null
+}
 
 function withPwaBanner(content: ReactNode) {
     return (
@@ -70,14 +79,13 @@ function AppInner() {
     const matchRoute = useMatchRoute()
     const router = useRouter()
     const { addToast } = useToast()
+    const { haptic } = usePlatform()
 
     useEffect(() => {
-        const tg = getTelegramWebApp()
-        tg?.ready()
-        tg?.expand()
         initializeTheme()
         initializeThemeColors()
         initializeChatSurfaceColors()
+        configureTelegramWebApp()
     }, [])
 
     // Track visual viewport height for mobile keyboard avoidance (see useViewportHeight.ts)
@@ -333,6 +341,11 @@ function AppInner() {
     }, [t])
 
     const handleToast = useCallback((event: ToastEvent) => {
+        const feedback = getToastHapticNotification(event.data.title)
+        if (feedback && isTelegramApp()) {
+            haptic.notification(feedback)
+        }
+
         const localized = translateIncomingToast(event.data.title, event.data.body)
         addToast({
             title: localized.title,
@@ -340,7 +353,7 @@ function AppInner() {
             sessionId: event.data.sessionId,
             url: event.data.url
         })
-    }, [addToast, translateIncomingToast])
+    }, [addToast, haptic, translateIncomingToast])
 
     const globalEventSubscription = useMemo(() => getAppGlobalSseSubscription(), [])
     const sessionEventSubscription = useMemo(

--- a/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
@@ -33,6 +33,7 @@ const runtime = vi.hoisted(() => ({
     pendingSendIntentRef: null as null | { current: ComposerSendIntent },
     sentIntents: [] as ComposerSendIntent[],
     modelChanges: [] as Array<{ provider: string; modelId: string } | string | null>,
+    isTouch: false,
 }))
 
 vi.mock('@assistant-ui/react', async () => {
@@ -101,7 +102,12 @@ vi.mock('@/hooks/useComposerDraft', () => ({
     useComposerDraft: (sessionId: string | undefined) => ({ sessionId, complete: true, restoredAny: false, hasStoredAttachments: false }),
 }))
 vi.mock('@/hooks/useComposerEnterBehavior', () => ({ useComposerEnterBehavior: () => ({ composerEnterBehavior: 'send' }) }))
-vi.mock('@/hooks/usePlatform', () => ({ usePlatform: () => ({ haptic: { impact: () => {}, notification: () => {} }, isTouch: false }) }))
+vi.mock('@/hooks/usePlatform', () => ({
+    usePlatform: () => ({
+        haptic: { impact: () => {}, notification: () => {}, selection: () => {} },
+        isTouch: runtime.isTouch,
+    }),
+}))
 vi.mock('@/hooks/usePWAInstall', () => ({ usePWAInstall: () => ({ isStandalone: false, isIOS: false }) }))
 vi.mock('@/hooks/useActiveWord', () => ({ useActiveWord: () => null }))
 vi.mock('@/hooks/useActiveSuggestions', () => ({ useActiveSuggestions: () => [[], -1, () => {}, () => {}, () => {}] }))
@@ -563,6 +569,7 @@ describe('HappyComposer send intent gestures', () => {
         cleanup()
         runtime.pendingSendIntentRef = null
         runtime.sentIntents = []
+        runtime.isTouch = false
     })
 
     it('ignores Alt/Option+Enter (the old explicit-queue gesture) entirely', () => {
@@ -580,6 +587,26 @@ describe('HappyComposer send intent gestures', () => {
         renderComposer('ordinary send', null, true)
 
         fireEvent.keyDown(input(), { key: 'Enter' })
+
+        expect(runtime.sentIntents).toEqual(['default'])
+        expect(runtime.pendingSendIntentRef?.current).toBe('default')
+    })
+
+    it('keeps plain Enter as newline on touch devices', () => {
+        runtime.isTouch = true
+        renderComposer('mobile newline', null, true)
+
+        fireEvent.keyDown(input(), { key: 'Enter' })
+
+        expect(runtime.sentIntents).toEqual([])
+        expect(runtime.pendingSendIntentRef?.current).toBe('default')
+    })
+
+    it('still sends with Ctrl+Enter on touch devices', () => {
+        runtime.isTouch = true
+        renderComposer('mobile explicit send', null, true)
+
+        fireEvent.keyDown(input(), { key: 'Enter', ctrlKey: true })
 
         expect(runtime.sentIntents).toEqual(['default'])
         expect(runtime.pendingSendIntentRef?.current).toBe('default')

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -827,6 +827,7 @@ export function HappyComposer(props: {
     }, [controlledByUser])
 
     const { haptic: platformHaptic, isTouch } = usePlatform()
+    const effectiveComposerEnterBehavior = isTouch ? 'newline' : composerEnterBehavior
     const { isStandalone, isIOS } = usePWAInstall()
     const isIOSPWA = isIOS && isStandalone
     const bottomPaddingClass = isIOSPWA ? 'pb-0' : 'pb-3'
@@ -1240,9 +1241,9 @@ export function HappyComposer(props: {
             return
         }
 
-        // Only plain Enter (no modifiers) sends; other modifier combos are ignored
+        // Enter sends only when the effective behavior is send; touch devices default to newline.
         if (key === 'Enter') {
-            if (composerEnterBehavior === 'newline') {
+            if (effectiveComposerEnterBehavior === 'newline') {
                 if ((e.ctrlKey || e.metaKey) && !e.altKey && canSend) {
                     e.preventDefault()
                     flushAndSend()
@@ -1323,7 +1324,7 @@ export function HappyComposer(props: {
         canSend,
         handleSend,
         haptic,
-        composerEnterBehavior,
+        effectiveComposerEnterBehavior,
         richMentionsEnabled,
         richComposerFueStatus,
         dismissRichComposerFue,

--- a/web/src/components/SessionFiles/DirectoryTree.test.tsx
+++ b/web/src/components/SessionFiles/DirectoryTree.test.tsx
@@ -1,0 +1,158 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DirectoryTree } from '@/components/SessionFiles/DirectoryTree'
+import { ToastProvider } from '@/lib/toast-context'
+import { I18nProvider } from '@/lib/i18n-context'
+import { DEFAULT_DIRECTORY_SORT } from '@/lib/directory-sort'
+
+const STORAGE_KEY = 'hapi-dir-expanded-v2-session-1:/workspace/project'
+
+vi.mock('@/hooks/queries/useSessionDirectory', () => ({
+    useSessionDirectory: (_api: unknown, _sessionId: string, path: string) => ({
+        entries: path === ''
+            ? [
+                { name: 'src', type: 'directory' },
+                { name: 'README.md', type: 'file' },
+            ]
+            : path === 'src'
+                ? [{ name: 'index.ts', type: 'file' }]
+                : [],
+        error: null,
+        isLoading: false,
+        refetch: vi.fn(),
+    }),
+}))
+
+function renderTree(sessionId = 'session-1') {
+    return render(
+        <I18nProvider>
+            <ToastProvider>
+                <DirectoryTree
+                    api={{} as never}
+                    sessionId={sessionId}
+                    rootLabel="/workspace/project"
+                    onOpenFile={vi.fn()}
+                    sort={DEFAULT_DIRECTORY_SORT}
+                />
+            </ToastProvider>
+        </I18nProvider>
+    )
+}
+
+function DirectoryTreeHarness(props: { rootLabel: string }) {
+    return (
+        <I18nProvider>
+            <ToastProvider>
+                <DirectoryTree
+                    key={`session-1:${props.rootLabel}`}
+                    api={{} as never}
+                    sessionId="session-1"
+                    rootLabel={props.rootLabel}
+                    onOpenFile={vi.fn()}
+                    sort={DEFAULT_DIRECTORY_SORT}
+                />
+            </ToastProvider>
+        </I18nProvider>
+    )
+}
+
+describe('DirectoryTree expanded folders', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        sessionStorage.clear()
+    })
+
+    afterEach(() => {
+        cleanup()
+        vi.restoreAllMocks()
+    })
+
+    it('restores expanded folders after the file manager remounts', () => {
+        const view = renderTree()
+        fireEvent.click(screen.getByRole('button', { name: 'src' }))
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+        expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify(['', 'src']))
+
+        view.unmount()
+        renderTree()
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+    })
+
+    it('migrates the legacy sessionStorage folder state to localStorage', () => {
+        sessionStorage.setItem('hapi-dir-expanded-session-1', JSON.stringify(['', 'src']))
+
+        renderTree()
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+        expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify(['', 'src']))
+        expect(sessionStorage.getItem('hapi-dir-expanded-session-1')).toBeNull()
+    })
+
+    it('prefers the session fallback after localStorage writes fail', () => {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(['']))
+        const originalSetItem = Storage.prototype.setItem
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function setItem(this: Storage, key, value) {
+            if (this === localStorage && key === STORAGE_KEY) throw new Error('quota')
+            return originalSetItem.call(this, key, value)
+        })
+        const sessionSetItem = vi.spyOn(sessionStorage, 'setItem')
+
+        const view = renderTree()
+        fireEvent.click(screen.getByRole('button', { name: 'src' }))
+
+        expect(sessionSetItem).toHaveBeenLastCalledWith('hapi-dir-expanded-session-1', JSON.stringify(['', 'src']))
+
+        view.unmount()
+        renderTree()
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+    })
+
+    it('uses the session fallback when localStorage reads throw', () => {
+        sessionStorage.setItem('hapi-dir-expanded-session-1', JSON.stringify(['', 'src']))
+        const originalGetItem = Storage.prototype.getItem
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(function getItem(this: Storage, key) {
+            if (this === localStorage && key === 'hapi-dir-expanded-v2-session-1') throw new Error('unavailable')
+            return originalGetItem.call(this, key)
+        })
+
+        renderTree()
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+    })
+
+    it('keeps expanded folders scoped by root label', () => {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(['', 'src']))
+
+        render(
+            <I18nProvider>
+                <ToastProvider>
+                    <DirectoryTree
+                        api={{} as never}
+                        sessionId="session-1"
+                        rootLabel="/workspace/other"
+                        onOpenFile={vi.fn()}
+                        sort={DEFAULT_DIRECTORY_SORT}
+                    />
+                </ToastProvider>
+            </I18nProvider>
+        )
+
+        expect(screen.queryByRole('button', { name: 'index.ts' })).not.toBeInTheDocument()
+    })
+
+    it('restores the resolved root state when the root label changes after loading', () => {
+        localStorage.setItem('hapi-dir-expanded-v2-session-1:project', JSON.stringify(['', 'src']))
+
+        const view = render(<DirectoryTreeHarness rootLabel="session-1" />)
+
+        expect(screen.queryByRole('button', { name: 'index.ts' })).not.toBeInTheDocument()
+
+        view.rerender(<DirectoryTreeHarness rootLabel="project" />)
+
+        expect(screen.getByRole('button', { name: 'index.ts' })).toBeInTheDocument()
+        expect(localStorage.getItem('hapi-dir-expanded-v2-session-1:project')).toBe(JSON.stringify(['', 'src']))
+    })
+})

--- a/web/src/components/SessionFiles/DirectoryTree.tsx
+++ b/web/src/components/SessionFiles/DirectoryTree.tsx
@@ -225,26 +225,45 @@ function DirectoryNode(props: {
     )
 }
 
-const STORAGE_KEY_PREFIX = 'hapi-dir-expanded-'
+const STORAGE_KEY_PREFIX = 'hapi-dir-expanded-v2-'
+const LEGACY_SESSION_STORAGE_KEY_PREFIX = 'hapi-dir-expanded-'
 
-function readExpanded(sessionId: string): Set<string> {
+function getExpandedStorageKey(sessionId: string, rootLabel: string): string {
+    return `${STORAGE_KEY_PREFIX}${sessionId}:${rootLabel}`
+}
+
+function safeReadStorage(storage: Storage, key: string): string | null {
     try {
-        const raw = sessionStorage.getItem(STORAGE_KEY_PREFIX + sessionId)
-        if (raw) {
-            const parsed = JSON.parse(raw)
-            if (Array.isArray(parsed)) return new Set(parsed as string[])
-        }
+        return storage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
+function readExpanded(sessionId: string, rootLabel: string): Set<string> {
+    try {
+        const raw = safeReadStorage(sessionStorage, LEGACY_SESSION_STORAGE_KEY_PREFIX + sessionId)
+            ?? safeReadStorage(localStorage, getExpandedStorageKey(sessionId, rootLabel))
+            ?? safeReadStorage(localStorage, STORAGE_KEY_PREFIX + sessionId)
+        const parsed = raw ? JSON.parse(raw) : null
+        if (Array.isArray(parsed)) return new Set(parsed as string[])
     } catch {
         // ignore
     }
     return new Set([''])
 }
 
-function writeExpanded(sessionId: string, expanded: Set<string>) {
+function writeExpanded(sessionId: string, rootLabel: string, expanded: Set<string>) {
+    const serialized = JSON.stringify([...expanded])
     try {
-        sessionStorage.setItem(STORAGE_KEY_PREFIX + sessionId, JSON.stringify([...expanded]))
+        localStorage.setItem(getExpandedStorageKey(sessionId, rootLabel), serialized)
+        sessionStorage.removeItem(LEGACY_SESSION_STORAGE_KEY_PREFIX + sessionId)
     } catch {
-        // ignore
+        try {
+            sessionStorage.setItem(LEGACY_SESSION_STORAGE_KEY_PREFIX + sessionId, serialized)
+        } catch {
+            // ignore
+        }
     }
 }
 
@@ -255,11 +274,11 @@ export function DirectoryTree(props: {
     onOpenFile: (path: string) => void
     sort: DirectorySort
 }) {
-    const [expanded, setExpanded] = useState<Set<string>>(() => readExpanded(props.sessionId))
+    const [expanded, setExpanded] = useState<Set<string>>(() => readExpanded(props.sessionId, props.rootLabel))
 
     useEffect(() => {
-        writeExpanded(props.sessionId, expanded)
-    }, [props.sessionId, expanded])
+        writeExpanded(props.sessionId, props.rootLabel, expanded)
+    }, [props.sessionId, props.rootLabel, expanded])
 
     const handleToggle = useCallback((path: string) => {
         setExpanded((prev) => {
@@ -289,4 +308,3 @@ export function DirectoryTree(props: {
         </div>
     )
 }
-

--- a/web/src/hooks/usePlatform.ts
+++ b/web/src/hooks/usePlatform.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { getTelegramWebApp, isTelegramApp } from './useTelegram'
+import { getTelegramWebApp, isTelegramApp, markTelegramHapticFeedback } from './useTelegram'
 
 export type HapticStyle = 'light' | 'medium' | 'heavy' | 'rigid' | 'soft'
 export type HapticNotification = 'error' | 'success' | 'warning'
@@ -44,6 +44,7 @@ const haptic: PlatformHaptic = {
     impact: (style: HapticStyle) => {
         const tg = getTelegramWebApp()
         if (tg?.HapticFeedback) {
+            markTelegramHapticFeedback()
             tg.HapticFeedback.impactOccurred(style)
         } else {
             vibrate(vibrationPatterns[style])
@@ -52,6 +53,7 @@ const haptic: PlatformHaptic = {
     notification: (type: HapticNotification) => {
         const tg = getTelegramWebApp()
         if (tg?.HapticFeedback) {
+            markTelegramHapticFeedback()
             tg.HapticFeedback.notificationOccurred(type)
         } else {
             vibrate(vibrationPatterns[type])
@@ -60,6 +62,7 @@ const haptic: PlatformHaptic = {
     selection: () => {
         const tg = getTelegramWebApp()
         if (tg?.HapticFeedback) {
+            markTelegramHapticFeedback()
             tg.HapticFeedback.selectionChanged()
         } else {
             vibrate(vibrationPatterns.selection)

--- a/web/src/hooks/useTelegram.test.ts
+++ b/web/src/hooks/useTelegram.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { configureTelegramWebApp, loadTelegramSdk, normalizeCssColorToHex, syncTelegramWebAppThemeColors } from './useTelegram'
+
+afterEach(() => {
+    delete window.Telegram
+    delete window.TelegramWebviewProxy
+    document.head.querySelectorAll('script[src="https://telegram.org/js/telegram-web-app.js"]').forEach((script) => script.remove())
+    vi.useRealTimers()
+})
+
+describe('configureTelegramWebApp', () => {
+    it('marks Telegram Mini App ready, expands it, and disables vertical swipe close', () => {
+        const ready = vi.fn()
+        const expand = vi.fn()
+        const disableVerticalSwipes = vi.fn()
+        const setHeaderColor = vi.fn()
+        const setBackgroundColor = vi.fn()
+        const setBottomBarColor = vi.fn()
+
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready,
+                expand,
+                disableVerticalSwipes,
+                setHeaderColor,
+                setBackgroundColor,
+                setBottomBarColor,
+            },
+        }
+
+        configureTelegramWebApp()
+
+        expect(ready).toHaveBeenCalledOnce()
+        expect(expand).toHaveBeenCalledOnce()
+        expect(disableVerticalSwipes).toHaveBeenCalledOnce()
+    })
+
+    it('does nothing when the Telegram SDK is unavailable', () => {
+        expect(() => configureTelegramWebApp()).not.toThrow()
+    })
+
+    it('supports older Telegram clients without vertical swipe controls', () => {
+        const ready = vi.fn()
+        const expand = vi.fn()
+
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready,
+                expand,
+            },
+        }
+
+        configureTelegramWebApp()
+
+        expect(ready).toHaveBeenCalledOnce()
+        expect(expand).toHaveBeenCalledOnce()
+    })
+
+    it('syncs app background color to Telegram chrome', () => {
+        const setHeaderColor = vi.fn()
+        const setBackgroundColor = vi.fn()
+        const setBottomBarColor = vi.fn()
+
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready: vi.fn(),
+                expand: vi.fn(),
+                setHeaderColor,
+                setBackgroundColor,
+                setBottomBarColor,
+            },
+        }
+
+        syncTelegramWebAppThemeColors('#123abc')
+
+        expect(setHeaderColor).toHaveBeenCalledWith('#123abc')
+        expect(setBackgroundColor).toHaveBeenCalledWith('#123abc')
+        expect(setBottomBarColor).toHaveBeenCalledWith('#123abc')
+    })
+
+    it('falls back to raw Telegram bridge events when WebApp SDK is unavailable', () => {
+        const postEvent = vi.fn()
+        window.TelegramWebviewProxy = { postEvent }
+
+        syncTelegramWebAppThemeColors('#123abc')
+
+        expect(postEvent).toHaveBeenCalledWith('web_app_set_header_color', JSON.stringify({ color: '#123abc' }))
+        expect(postEvent).toHaveBeenCalledWith('web_app_set_background_color', JSON.stringify({ color: '#123abc' }))
+        expect(postEvent).toHaveBeenCalledWith('web_app_set_bottom_bar_color', JSON.stringify({ color: '#123abc' }))
+    })
+
+    it('does not expand through the raw bridge fallback', () => {
+        const postEvent = vi.fn()
+        window.TelegramWebviewProxy = { postEvent }
+
+        configureTelegramWebApp()
+
+        expect(postEvent).toHaveBeenCalledWith('web_app_ready', JSON.stringify({}))
+        expect(postEvent).toHaveBeenCalledWith('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }))
+        expect(postEvent).not.toHaveBeenCalledWith('web_app_expand', expect.any(String))
+    })
+
+    it('keeps syncing other Telegram chrome surfaces when one setter rejects a color', () => {
+        const setHeaderColor = vi.fn(() => {
+            throw new Error('unsupported color')
+        })
+        const setBackgroundColor = vi.fn()
+        const setBottomBarColor = vi.fn()
+
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready: vi.fn(),
+                expand: vi.fn(),
+                setHeaderColor,
+                setBackgroundColor,
+                setBottomBarColor,
+            },
+        }
+
+        syncTelegramWebAppThemeColors('#1f271d')
+
+        expect(setBackgroundColor).toHaveBeenCalledWith('#1f271d')
+        expect(setBottomBarColor).toHaveBeenCalledWith('#1f271d')
+    })
+
+    it('calls Telegram chrome setters with the WebApp receiver', () => {
+        const receivers: unknown[] = []
+        const webApp = {
+            initData: 'init-data',
+            themeParams: {},
+            ready: vi.fn(),
+            expand: vi.fn(),
+            setHeaderColor(this: unknown) {
+                receivers.push(this)
+            },
+            setBackgroundColor(this: unknown) {
+                receivers.push(this)
+            },
+            setBottomBarColor(this: unknown) {
+                receivers.push(this)
+            },
+        }
+        window.Telegram = { WebApp: webApp }
+
+        syncTelegramWebAppThemeColors('#1f271d')
+
+        expect(receivers).toEqual([webApp, webApp, webApp])
+    })
+
+    it('can defer Telegram chrome color sync until the app theme is applied', () => {
+        const setHeaderColor = vi.fn()
+        const setBackgroundColor = vi.fn()
+        const setBottomBarColor = vi.fn()
+
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready: vi.fn(),
+                expand: vi.fn(),
+                setHeaderColor,
+                setBackgroundColor,
+                setBottomBarColor,
+            },
+        }
+
+        configureTelegramWebApp({ syncThemeColors: false })
+
+        expect(setHeaderColor).not.toHaveBeenCalled()
+        expect(setBackgroundColor).not.toHaveBeenCalled()
+        expect(setBottomBarColor).not.toHaveBeenCalled()
+    })
+
+    it('repairs Telegram chrome after the Mini App becomes active again', () => {
+        vi.useFakeTimers()
+        const ready = vi.fn()
+        const expand = vi.fn()
+        const disableVerticalSwipes = vi.fn()
+        const setHeaderColor = vi.fn()
+        const setBackgroundColor = vi.fn()
+        const setBottomBarColor = vi.fn()
+
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready,
+                expand,
+                disableVerticalSwipes,
+                setHeaderColor,
+                setBackgroundColor,
+                setBottomBarColor,
+            },
+        }
+
+        configureTelegramWebApp()
+        ready.mockClear()
+        expand.mockClear()
+        disableVerticalSwipes.mockClear()
+
+        window.dispatchEvent(new Event('focus'))
+        vi.runOnlyPendingTimers()
+
+        expect(ready).toHaveBeenCalled()
+        expect(expand).toHaveBeenCalled()
+        expect(disableVerticalSwipes).toHaveBeenCalled()
+    })
+
+    it('repairs Telegram viewport changes without forcing raw expansion', () => {
+        vi.useFakeTimers()
+        const expand = vi.fn()
+        const disableVerticalSwipes = vi.fn()
+        const listeners = new Map<string, (event?: unknown) => void>()
+
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready: vi.fn(),
+                expand,
+                disableVerticalSwipes,
+                setHeaderColor: vi.fn(),
+                setBackgroundColor: vi.fn(),
+                setBottomBarColor: vi.fn(),
+                onEvent: (eventType, callback) => listeners.set(eventType, callback),
+                offEvent: (eventType) => listeners.delete(eventType),
+            },
+        }
+
+        configureTelegramWebApp()
+        expand.mockClear()
+        disableVerticalSwipes.mockClear()
+
+        listeners.get('viewportChanged')?.()
+        vi.runOnlyPendingTimers()
+
+        expect(expand).not.toHaveBeenCalled()
+        expect(disableVerticalSwipes).toHaveBeenCalled()
+
+        disableVerticalSwipes.mockClear()
+        listeners.get('visibilityChanged')?.({ is_visible: false })
+        vi.runOnlyPendingTimers()
+
+        expect(expand).not.toHaveBeenCalled()
+        expect(disableVerticalSwipes).not.toHaveBeenCalled()
+
+        listeners.get('visibilityChanged')?.({ is_visible: true })
+        vi.runOnlyPendingTimers()
+
+        expect(expand).toHaveBeenCalled()
+        expect(disableVerticalSwipes).toHaveBeenCalled()
+    })
+
+    it('normalizes CSS color values for Telegram APIs', () => {
+        expect(normalizeCssColorToHex('#abc')).toBe('#aabbcc')
+        expect(normalizeCssColorToHex('rgb(18, 58, 188)')).toBe('#123abc')
+        expect(normalizeCssColorToHex('rgba(300, -1, 16, 0.5)')).toBe('#ff0010')
+        expect(normalizeCssColorToHex('transparent')).toBeNull()
+    })
+
+    it('initializes without injecting the legacy Telegram script', async () => {
+        await loadTelegramSdk()
+
+        const script = document.head.querySelector<HTMLScriptElement>('script[src="https://telegram.org/js/telegram-web-app.js"]')
+        expect(script).toBeNull()
+    })
+
+    it('does not emit haptics for programmatic clicks', () => {
+        const impactOccurred = vi.fn()
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready: vi.fn(),
+                expand: vi.fn(),
+                HapticFeedback: {
+                    impactOccurred,
+                    notificationOccurred: vi.fn(),
+                    selectionChanged: vi.fn(),
+                },
+            },
+        }
+        const button = document.createElement('button')
+        document.body.appendChild(button)
+
+        configureTelegramWebApp()
+        button.click()
+
+        expect(impactOccurred).not.toHaveBeenCalled()
+        button.remove()
+    })
+})

--- a/web/src/hooks/useTelegram.ts
+++ b/web/src/hooks/useTelegram.ts
@@ -1,3 +1,22 @@
+import {
+    backButton,
+    hapticFeedback,
+    init as initTma,
+    initData,
+    isTMA,
+    miniApp,
+    off as offTmaEvent,
+    on as onTmaEvent,
+    retrieveLaunchParams,
+    retrieveRawInitData,
+    swipeBehavior,
+    themeParams,
+    viewport,
+} from '@tma.js/sdk'
+
+const TMA_INIT_RETRY_DELAY_MS = 500
+const TELEGRAM_RESTORE_REPAIR_DELAYS_MS = [0, 50, 250, 600] as const
+
 /**
  * Detects if the current environment is Telegram Mini App
  * by checking URL hash/query parameters that Telegram passes.
@@ -5,6 +24,9 @@
  */
 export function isTelegramEnvironment(): boolean {
     if (typeof window === 'undefined') return false
+
+    if (window.Telegram?.WebApp) return true
+    if (isTmaEnvironment()) return true
 
     // Telegram passes launch params via window.location.hash
     // Format: #tgWebAppVersion=...&tgWebAppData=...&tgWebAppPlatform=...
@@ -22,7 +44,7 @@ export function isTelegramEnvironment(): boolean {
         return true
     }
 
-    return false
+    return hasTelegramHostBridge() || isTelegramUserAgent()
 }
 
 export type TelegramWebAppThemeParams = {
@@ -52,11 +74,21 @@ export type TelegramWebApp = {
     initDataUnsafe?: TelegramWebAppInitDataUnsafe
     themeParams: TelegramWebAppThemeParams
     colorScheme?: 'light' | 'dark'
+    platform?: string
+    version?: string
+    headerColor?: string
+    backgroundColor?: string
+    bottomBarColor?: string
+    isVersionAtLeast?: (version: string) => boolean
     ready: () => void
     expand: () => void
+    disableVerticalSwipes?: () => void
+    setHeaderColor?: (color: string) => void
+    setBackgroundColor?: (color: string) => void
+    setBottomBarColor?: (color: string) => void
     close?: () => void
-    onEvent?: (eventType: string, callback: () => void) => void
-    offEvent?: (eventType: string, callback: () => void) => void
+    onEvent?: (eventType: string, callback: (event?: unknown) => void) => void
+    offEvent?: (eventType: string, callback: (event?: unknown) => void) => void
     BackButton?: {
         show: () => void
         hide: () => void
@@ -91,16 +123,94 @@ export type TelegramWebApp = {
     }
 }
 
+let lastHapticFeedbackAt = 0
+let removeTelegramInteractionHaptics: (() => void) | null = null
+let tmaInitialized = false
+let tmaInitAttempted = false
+let lastTmaInitAttemptAt = 0
+let tmaThemeCssVarsCleanup: (() => void) | null = null
+let tmaViewportCssVarsCleanup: (() => void) | null = null
+let removeTelegramRestoreRepair: (() => void) | null = null
+let telegramRestoreRepairTimers: number[] = []
+let telegramRestoreRepairWebApp: TelegramWebApp | null = null
+
+type TelegramAppChromeMethod =
+    | 'setHeaderColor'
+    | 'setBackgroundColor'
+    | 'setBottomBarColor'
+
+type TelegramBridgeMethod =
+    | 'web_app_set_header_color'
+    | 'web_app_set_background_color'
+    | 'web_app_set_bottom_bar_color'
+    | 'web_app_ready'
+    | 'web_app_setup_swipe_behavior'
+
 declare global {
     interface Window {
         Telegram?: {
             WebApp?: TelegramWebApp
         }
+        TelegramGameProxy?: unknown
+        TelegramWebviewProxy?: {
+            postEvent?: (eventType: string, eventData: string) => void
+        }
+        TelegramWebviewProxyProto?: unknown
     }
 }
 
 export function getTelegramWebApp(): TelegramWebApp | null {
-    return window.Telegram?.WebApp ?? null
+    const nativeWebApp = window.Telegram?.WebApp
+    if (nativeWebApp) return nativeWebApp
+
+    if (!isTelegramEnvironment()) return null
+    if (!initializeTmaSdk()) return null
+    const rawInitData = safeRead(() => retrieveRawInitData()) ?? ''
+    const launchParams = safeRead(() => retrieveLaunchParams())
+
+    return {
+        initData: rawInitData,
+        initDataUnsafe: {
+            start_param: initData.startParam() ?? launchParams?.tgWebAppStartParam,
+            user: normalizeTelegramUser(initData.user()),
+        },
+        themeParams: normalizeTelegramThemeParams(themeParams.state()),
+        colorScheme: themeParams.isDark() ? 'dark' : 'light',
+        platform: launchParams?.tgWebAppPlatform,
+        version: launchParams?.tgWebAppVersion,
+        headerColor: String(miniApp.headerColor()),
+        backgroundColor: String(miniApp.bgColor()),
+        bottomBarColor: String(miniApp.bottomBarColor()),
+        isVersionAtLeast: (version) => compareVersions(launchParams?.tgWebAppVersion ?? '0', version) >= 0,
+        ready: () => miniApp.ready.ifAvailable(),
+        expand: () => viewport.expand.ifAvailable(),
+        disableVerticalSwipes: () => swipeBehavior.disableVertical.ifAvailable(),
+        setHeaderColor: (color) => setTmaChromeColor('setHeaderColor', color),
+        setBackgroundColor: (color) => setTmaChromeColor('setBackgroundColor', color),
+        setBottomBarColor: (color) => setTmaChromeColor('setBottomBarColor', color),
+        close: () => miniApp.close.ifAvailable(),
+        onEvent: (eventType, callback) => {
+            if (eventType === 'themeChanged') onTmaEvent('theme_changed', callback)
+        },
+        offEvent: (eventType, callback) => {
+            if (eventType === 'themeChanged') offTmaEvent('theme_changed', callback)
+        },
+        BackButton: {
+            show: () => backButton.show.ifAvailable(),
+            hide: () => backButton.hide.ifAvailable(),
+            onClick: (callback) => {
+                backButton.onClick.ifAvailable(callback)
+            },
+            offClick: (callback) => {
+                backButton.offClick.ifAvailable(callback)
+            },
+        },
+        HapticFeedback: {
+            impactOccurred: (style) => hapticFeedback.impactOccurred.ifAvailable(style),
+            notificationOccurred: (type) => hapticFeedback.notificationOccurred.ifAvailable(type),
+            selectionChanged: () => hapticFeedback.selectionChanged.ifAvailable(),
+        },
+    }
 }
 
 /**
@@ -112,33 +222,513 @@ export function isTelegramApp(): boolean {
     return tg !== null && Boolean(tg.initData)
 }
 
-/**
- * Dynamically loads the Telegram Web App SDK with timeout.
- * Only call this if isTelegramEnvironment() returns true.
- */
-export function loadTelegramSdk(timeoutMs = 3000): Promise<void> {
-    return new Promise((resolve) => {
-        if (window.Telegram?.WebApp) {
-            resolve()
+export function configureTelegramWebApp(options: { syncThemeColors?: boolean } = {}): void {
+    const tg = getTelegramWebApp()
+    if (!tg) {
+        if (configureTelegramChromeViaBridge() && (options.syncThemeColors ?? true)) {
+            syncTelegramWebAppThemeColors()
+        }
+        installTelegramRestoreRepair()
+        return
+    }
+
+    tg.ready()
+    tg.expand()
+    tg.disableVerticalSwipes?.()
+    if (options.syncThemeColors ?? true) {
+        syncTelegramWebAppThemeColors()
+    }
+    installTelegramInteractionHaptics()
+    installTelegramRestoreRepair()
+}
+
+export function syncTelegramWebAppThemeColors(color = getResolvedAppBackgroundColor()): void {
+    const tg = getTelegramWebApp()
+    if (!color) return
+
+    if (tg) {
+        setTelegramHeaderColor(tg, color)
+        setTelegramChromeColor(tg, 'setBackgroundColor', color, ['bg_color'])
+        setTelegramChromeColor(tg, 'setBottomBarColor', color, ['bottom_bar_bg_color', 'bg_color'])
+    } else {
+        syncTelegramChromeColorsViaBridge(color)
+    }
+    resetTelegramDocumentDrift()
+}
+
+function setTelegramHeaderColor(tg: TelegramWebApp, color: string): void {
+    if (!tg.setHeaderColor) return
+
+    if (!tg.isVersionAtLeast || tg.isVersionAtLeast('6.9')) {
+        if (setTelegramChromeColor(tg, 'setHeaderColor', color)) return
+    }
+
+    setTelegramChromeColor(tg, 'setHeaderColor', color, ['bg_color', 'secondary_bg_color'])
+}
+
+function setTelegramChromeColor(
+    tg: TelegramWebApp,
+    method: TelegramAppChromeMethod,
+    color: string,
+    fallbackColors: string[] = []
+): boolean {
+    const setter = tg[method]
+    if (!setter) return false
+
+    for (const candidate of [color, ...fallbackColors]) {
+        try {
+            setter.call(tg, candidate)
+            return true
+        } catch (error) {
+            void error
+            // Some Telegram clients reject custom hex colors for specific
+            // chrome surfaces. Keep the other surfaces independent.
+        }
+    }
+
+    return false
+}
+
+function hasTelegramLaunchParams(): boolean {
+    const hashParams = new URLSearchParams(window.location.hash.slice(1))
+    if (hashParams.has('tgWebAppVersion') || hashParams.has('tgWebAppData')) return true
+    return window.location.search.includes('tgWebApp') || window.location.search.includes('initData')
+}
+
+function isTelegramUserAgent(): boolean {
+    return typeof navigator !== 'undefined' && /\bTelegram\b/i.test(navigator.userAgent)
+}
+
+function hasTelegramHostBridge(): boolean {
+    const hostWindow = window as Window & { external?: { notify?: unknown } }
+    return Boolean(
+        window.TelegramWebviewProxy
+        || window.TelegramWebviewProxyProto
+        || window.TelegramGameProxy
+        || hostWindow.external?.notify
+    )
+}
+
+function isTmaEnvironment(): boolean {
+    try {
+        return isTMA()
+    } catch {
+        return false
+    }
+}
+
+function initializeTmaSdk(): boolean {
+    if (typeof window === 'undefined') return false
+    if (tmaInitialized) return true
+    const now = Date.now()
+    if (tmaInitAttempted && now - lastTmaInitAttemptAt < TMA_INIT_RETRY_DELAY_MS) return false
+
+    tmaInitAttempted = true
+    lastTmaInitAttemptAt = now
+    try {
+        initTma()
+        tmaInitialized = true
+    } catch (error) {
+        void error
+        return false
+    }
+
+    safeCall(() => initData.restore())
+    safeCall(() => {
+        if (!themeParams.isMounted()) themeParams.mount()
+    })
+    bindTmaThemeCssVars()
+    safeCall(() => {
+        if (!miniApp.isMounted()) miniApp.mount()
+    })
+    mountTmaViewportAndBindCssVars()
+    safeCall(() => {
+        if (!swipeBehavior.isMounted()) swipeBehavior.mount()
+    })
+    safeCall(() => {
+        if (!backButton.isMounted()) backButton.mount()
+    })
+
+    return true
+}
+
+function bindTmaThemeCssVars(): void {
+    if (tmaThemeCssVarsCleanup || safeRead(() => themeParams.isCssVarsBound()) === true) return
+
+    try {
+        tmaThemeCssVarsCleanup = themeParams.bindCssVars()
+    } catch (error) {
+        void error
+    }
+}
+
+function mountTmaViewportAndBindCssVars(): void {
+    safeCall(() => {
+        if (viewport.isMounted()) {
+            scheduleTmaViewportCssVarsBind()
             return
         }
 
-        let settled = false
-        const settle = () => {
-            if (!settled) {
-                settled = true
-                resolve()
-            }
-        }
-
-        // Timeout - don't block app indefinitely
-        setTimeout(settle, timeoutMs)
-
-        const script = document.createElement('script')
-        script.src = 'https://telegram.org/js/telegram-web-app.js'
-        script.async = true
-        script.onload = settle
-        script.onerror = settle
-        document.head.appendChild(script)
+        void viewport.mount()
+            .then(scheduleTmaViewportCssVarsBind)
+            .catch(() => {
+                // Viewport data is platform/version dependent.
+            })
     })
+}
+
+function scheduleTmaViewportCssVarsBind(): void {
+    bindTmaViewportCssVars()
+    window.setTimeout(bindTmaViewportCssVars, 0)
+    window.setTimeout(bindTmaViewportCssVars, 250)
+}
+
+function bindTmaViewportCssVars(): void {
+    if (tmaViewportCssVarsCleanup || safeRead(() => viewport.isCssVarsBound()) === true) return
+
+    try {
+        const cleanup = viewport.bindCssVars()
+        tmaViewportCssVarsCleanup = cleanup
+    } catch (error) {
+        void error
+    }
+}
+
+function normalizeTelegramUser(user: ReturnType<typeof initData.user>): TelegramWebAppUser | undefined {
+    if (!user) return undefined
+    return {
+        id: user.id,
+        username: user.username,
+        first_name: user.first_name,
+        last_name: user.last_name,
+    }
+}
+
+function normalizeTelegramThemeParams(params: ReturnType<typeof themeParams.state>): TelegramWebAppThemeParams {
+    return {
+        bg_color: params.bgColor,
+        text_color: params.textColor,
+        hint_color: params.hintColor,
+        link_color: params.linkColor,
+        button_color: params.buttonColor,
+        button_text_color: params.buttonTextColor,
+        secondary_bg_color: params.secondaryBgColor,
+    }
+}
+
+function setTmaChromeColor(method: TelegramAppChromeMethod, color: string): void {
+    if (method === 'setHeaderColor') {
+        if (miniApp.setHeaderColor.isAvailable()) {
+            if (miniApp.setHeaderColor.supports('rgb')) {
+                miniApp.setHeaderColor(color)
+                return
+            }
+            miniApp.setHeaderColor('bg_color')
+        }
+        return
+    }
+
+    if (method === 'setBackgroundColor') {
+        miniApp.setBgColor.ifAvailable(color)
+        return
+    }
+
+    miniApp.setBottomBarColor.ifAvailable(color)
+}
+
+function configureTelegramChromeViaBridge(): boolean {
+    if (!hasTelegramHostBridge()) return false
+
+    postTelegramBridgeEvent('web_app_ready')
+    postTelegramBridgeEvent('web_app_setup_swipe_behavior', { allow_vertical_swipe: false })
+    resetTelegramDocumentDrift()
+    return true
+}
+
+function installTelegramRestoreRepair(): void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return
+
+    const tg = getTelegramWebApp()
+    if (tg && tg !== telegramRestoreRepairWebApp) {
+        telegramRestoreRepairWebApp?.offEvent?.('viewportChanged', handleTelegramViewportChanged)
+        telegramRestoreRepairWebApp?.offEvent?.('visibilityChanged', handleTelegramVisibilityChanged)
+        tg.onEvent?.('viewportChanged', handleTelegramViewportChanged)
+        tg.onEvent?.('visibilityChanged', handleTelegramVisibilityChanged)
+        telegramRestoreRepairWebApp = tg
+    }
+
+    if (removeTelegramRestoreRepair) return
+
+    window.addEventListener('focus', handleTelegramRestore)
+    window.addEventListener('pageshow', handleTelegramRestore)
+    document.addEventListener('visibilitychange', handleTelegramDocumentVisibilityChange)
+
+    removeTelegramRestoreRepair = () => {
+        clearTelegramRestoreRepairTimers()
+        window.removeEventListener('focus', handleTelegramRestore)
+        window.removeEventListener('pageshow', handleTelegramRestore)
+        document.removeEventListener('visibilitychange', handleTelegramDocumentVisibilityChange)
+        telegramRestoreRepairWebApp?.offEvent?.('viewportChanged', handleTelegramViewportChanged)
+        telegramRestoreRepairWebApp?.offEvent?.('visibilityChanged', handleTelegramVisibilityChanged)
+        telegramRestoreRepairWebApp = null
+        removeTelegramRestoreRepair = null
+    }
+}
+
+function handleTelegramRestore(): void {
+    scheduleTelegramRestoreRepair({ expand: true })
+}
+
+function handleTelegramDocumentVisibilityChange(): void {
+    if (document.visibilityState === 'visible') {
+        scheduleTelegramRestoreRepair({ expand: true })
+    }
+}
+
+function handleTelegramViewportChanged(): void {
+    scheduleTelegramRestoreRepair({ expand: false })
+}
+
+function handleTelegramVisibilityChanged(event?: unknown): void {
+    if (isTelegramVisibilityHiddenEvent(event)) return
+    scheduleTelegramRestoreRepair({ expand: true })
+}
+
+function isTelegramVisibilityHiddenEvent(event: unknown): boolean {
+    if (!event || typeof event !== 'object') return false
+    const visible = (event as { is_visible?: unknown; isVisible?: unknown }).is_visible
+        ?? (event as { isVisible?: unknown }).isVisible
+    return visible === false
+}
+
+function scheduleTelegramRestoreRepair(options: { expand: boolean }): void {
+    clearTelegramRestoreRepairTimers()
+    telegramRestoreRepairTimers = TELEGRAM_RESTORE_REPAIR_DELAYS_MS.map((delay) => (
+        window.setTimeout(() => repairTelegramRestore(options), delay)
+    ))
+}
+
+function clearTelegramRestoreRepairTimers(): void {
+    for (const timer of telegramRestoreRepairTimers) {
+        window.clearTimeout(timer)
+    }
+    telegramRestoreRepairTimers = []
+}
+
+function repairTelegramRestore(options: { expand: boolean }): void {
+    if (!isTelegramEnvironment()) return
+
+    const tg = getTelegramWebApp()
+    if (tg) {
+        tg.ready()
+        if (options.expand) {
+            tg.expand()
+        }
+        tg.disableVerticalSwipes?.()
+        bindTmaThemeCssVars()
+        mountTmaViewportAndBindCssVars()
+        syncTelegramWebAppThemeColors()
+        return
+    }
+
+    if (configureTelegramChromeViaBridge()) {
+        syncTelegramWebAppThemeColors()
+    }
+}
+
+function syncTelegramChromeColorsViaBridge(color: string): void {
+    if (!hasTelegramHostBridge()) return
+
+    postTelegramBridgeEvent('web_app_set_header_color', { color })
+    postTelegramBridgeEvent('web_app_set_background_color', { color })
+    postTelegramBridgeEvent('web_app_set_bottom_bar_color', { color })
+}
+
+function postTelegramBridgeEvent(
+    method: TelegramBridgeMethod,
+    params?: Record<string, unknown>
+): boolean {
+    try {
+        postTelegramRawEvent(method, params)
+        return true
+    } catch (error) {
+        void error
+        return false
+    }
+}
+
+function postTelegramRawEvent(method: TelegramBridgeMethod, params: Record<string, unknown> | undefined): void {
+    const serializedParams = JSON.stringify(params ?? {})
+    if (typeof window.TelegramWebviewProxy?.postEvent === 'function') {
+        window.TelegramWebviewProxy.postEvent(method, serializedParams)
+        return
+    }
+
+    const hostWindow = window as Window & { external?: { notify?: (message: string) => void } }
+    if (typeof hostWindow.external?.notify === 'function') {
+        hostWindow.external.notify(JSON.stringify({ eventType: method, eventData: params ?? {} }))
+        return
+    }
+
+    throw new Error('Telegram host bridge is unavailable')
+}
+
+function resetTelegramDocumentDrift(): void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return
+    if (!isTelegramEnvironment()) return
+
+    const reset = () => {
+        document.documentElement.scrollTop = 0
+        if (document.body) document.body.scrollTop = 0
+        if (window.scrollX !== 0 || window.scrollY !== 0) {
+            safeCall(() => window.scrollTo(0, 0))
+        }
+    }
+
+    window.requestAnimationFrame(reset)
+    window.setTimeout(reset, 50)
+    window.setTimeout(reset, 250)
+}
+
+function safeCall(callback: () => void): void {
+    try {
+        callback()
+    } catch {
+        // Telegram features are version/platform dependent.
+    }
+}
+
+function safeRead<T>(callback: () => T): T | null {
+    try {
+        return callback()
+    } catch {
+        return null
+    }
+}
+
+function compareVersions(a: string, b: string): number {
+    const left = a.split('.').map((part) => Number.parseInt(part, 10) || 0)
+    const right = b.split('.').map((part) => Number.parseInt(part, 10) || 0)
+    const length = Math.max(left.length, right.length)
+    for (let index = 0; index < length; index += 1) {
+        const delta = (left[index] ?? 0) - (right[index] ?? 0)
+        if (delta !== 0) return delta
+    }
+    return 0
+}
+
+export function getResolvedAppBackgroundColor(): string | null {
+    if (typeof window === 'undefined' || typeof document === 'undefined' || !document.body) return null
+
+    const probe = document.createElement('div')
+    probe.style.position = 'fixed'
+    probe.style.pointerEvents = 'none'
+    probe.style.visibility = 'hidden'
+    probe.style.backgroundColor = 'var(--app-bg)'
+
+    document.body.appendChild(probe)
+    const resolved = window.getComputedStyle(probe).backgroundColor
+    probe.remove()
+
+    return normalizeCssColorToHex(resolved)
+}
+
+export function normalizeCssColorToHex(color: string): string | null {
+    const value = color.trim().toLowerCase()
+    if (!value || value === 'transparent') return null
+
+    const hex = value.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i)
+    if (hex) {
+        const raw = hex[1]!
+        if (raw.length === 6) return `#${raw}`
+        return `#${raw.split('').map((char) => char + char).join('')}`
+    }
+
+    const rgb = value.match(/^rgba?\(([^)]+)\)$/)
+    if (!rgb) return null
+
+    const channels = rgb[1]!
+        .split(',')
+        .slice(0, 3)
+        .map((part) => Number.parseInt(part.trim(), 10))
+
+    if (channels.length !== 3 || channels.some((channel) => Number.isNaN(channel))) {
+        return null
+    }
+
+    return `#${channels.map((channel) => clampColorChannel(channel).toString(16).padStart(2, '0')).join('')}`
+}
+
+function clampColorChannel(channel: number): number {
+    return Math.min(255, Math.max(0, channel))
+}
+
+export function markTelegramHapticFeedback(): void {
+    lastHapticFeedbackAt = Date.now()
+}
+
+export function hasRecentTelegramHapticFeedback(windowMs = 120): boolean {
+    return Date.now() - lastHapticFeedbackAt < windowMs
+}
+
+export function installTelegramInteractionHaptics(): void {
+    if (removeTelegramInteractionHaptics || typeof document === 'undefined') return
+
+    const onClick = (event: MouseEvent) => {
+        if (!event.isTrusted || hasRecentTelegramHapticFeedback()) return
+
+        const target = event.target
+        if (!(target instanceof Element)) return
+
+        const interactive = target.closest<HTMLElement>(
+            'button, a[href], select, summary, input[type="checkbox"], input[type="radio"], input[type="range"], [role="button"], [role="menuitem"], [role="option"], [data-haptic]'
+        )
+        if (!interactive || isDisabledInteractiveElement(interactive)) return
+
+        const feedback = getTelegramWebApp()?.HapticFeedback
+        if (!feedback) return
+
+        markTelegramHapticFeedback()
+        if (isSelectionInteractiveElement(interactive)) {
+            feedback.selectionChanged()
+            return
+        }
+        feedback.impactOccurred('light')
+    }
+
+    document.addEventListener('click', onClick)
+    removeTelegramInteractionHaptics = () => {
+        document.removeEventListener('click', onClick)
+        removeTelegramInteractionHaptics = null
+    }
+}
+
+function isDisabledInteractiveElement(element: HTMLElement): boolean {
+    if (element.getAttribute('aria-disabled') === 'true') return true
+    if (
+        element instanceof HTMLButtonElement
+        || element instanceof HTMLInputElement
+        || element instanceof HTMLSelectElement
+    ) {
+        return element.disabled
+    }
+    return false
+}
+
+function isSelectionInteractiveElement(element: HTMLElement): boolean {
+    if (element instanceof HTMLSelectElement) return true
+    if (element instanceof HTMLInputElement) {
+        return element.type === 'checkbox' || element.type === 'radio'
+    }
+    const role = element.getAttribute('role')
+    return role === 'option' || role === 'menuitemradio' || role === 'menuitemcheckbox'
+}
+
+/**
+ * Initializes the Telegram Mini Apps SDK. Kept async for the existing bootstrap contract.
+ */
+export function loadTelegramSdk(timeoutMs = 3000): Promise<void> {
+    void timeoutMs
+    initializeTmaSdk()
+    return Promise.resolve()
 }

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
-import { getTelegramWebApp } from './useTelegram'
+import { getTelegramWebApp, syncTelegramWebAppThemeColors } from './useTelegram'
 import { applyColorTheme, getColorThemeBackground, getColorThemeStorageKey, getStoredColorTheme, type ColorScheme } from './useColorTheme'
 
 export type AppearancePreference = 'system' | 'dark' | 'light' | 'oled'
@@ -105,6 +105,7 @@ function applyTheme(scheme: ColorScheme): void {
     document.documentElement.setAttribute('data-theme', scheme)
     applyColorTheme(getStoredColorTheme(), scheme)
     applyBrowserThemeColor(scheme)
+    syncTelegramWebAppThemeColors()
 }
 
 function applyPlatform(): void {

--- a/web/src/hooks/useThemeColors.test.ts
+++ b/web/src/hooks/useThemeColors.test.ts
@@ -14,6 +14,7 @@ function setScheme(scheme: string): void {
 describe('useThemeColors', () => {
     beforeEach(() => {
         localStorage.clear()
+        delete window.Telegram
         document.documentElement.removeAttribute('data-theme')
         document.documentElement.removeAttribute('style')
     })
@@ -99,6 +100,56 @@ describe('useThemeColors', () => {
 
         expect(document.documentElement.style.getPropertyValue('--app-bg').trim()).toBe('#123456')
         expect(document.documentElement.style.getPropertyValue('--app-link').trim()).toBe('#526fff')
+    })
+
+    it('syncs Telegram chrome after applying custom background colors', () => {
+        const setHeaderColor = vi.fn()
+        const setBackgroundColor = vi.fn()
+        const setBottomBarColor = vi.fn()
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready: vi.fn(),
+                expand: vi.fn(),
+                setHeaderColor,
+                setBackgroundColor,
+                setBottomBarColor,
+            },
+        }
+        localStorage.setItem('hapi-theme-colors', JSON.stringify({ light: { background: '#123456' } }))
+        setScheme('light')
+
+        applyThemeColors()
+
+        expect(setHeaderColor).toHaveBeenCalledWith('#123456')
+        expect(setBackgroundColor).toHaveBeenCalledWith('#123456')
+        expect(setBottomBarColor).toHaveBeenCalledWith('#123456')
+    })
+
+    it('syncs Telegram chrome from the active color theme preset', () => {
+        const setHeaderColor = vi.fn()
+        const setBackgroundColor = vi.fn()
+        const setBottomBarColor = vi.fn()
+        window.Telegram = {
+            WebApp: {
+                initData: 'init-data',
+                themeParams: {},
+                ready: vi.fn(),
+                expand: vi.fn(),
+                setHeaderColor,
+                setBackgroundColor,
+                setBottomBarColor,
+            },
+        }
+        localStorage.setItem('hapi-color-theme', 'matrix')
+        setScheme('dark')
+
+        applyThemeColors()
+
+        expect(setHeaderColor).toHaveBeenCalledWith('#030806')
+        expect(setBackgroundColor).toHaveBeenCalledWith('#030806')
+        expect(setBottomBarColor).toHaveBeenCalledWith('#030806')
     })
 
     it('uses the active color theme as the custom color picker baseline', () => {

--- a/web/src/hooks/useThemeColors.ts
+++ b/web/src/hooks/useThemeColors.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { applyColorTheme, getColorThemePickerValue, getColorThemeStorageKey, getStoredColorTheme, type ColorScheme } from './useColorTheme'
+import { syncTelegramWebAppThemeColors } from './useTelegram'
 
 /**
  * Per-appearance "key color" customization.
@@ -265,6 +266,9 @@ export function applyThemeColors(): void {
             }
         }
     }
+
+    const appliedBackground = rootStyle.getPropertyValue('--app-bg').trim()
+    syncTelegramWebAppThemeColors(appliedBackground || undefined)
 }
 
 export function getThemeColorPickerValue(scheme: ThemeScheme, id: ThemeColorKeyId): string {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,7 +5,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { RouterProvider, createMemoryHistory } from '@tanstack/react-router'
 import './index.css'
 import { initializeFontScale } from '@/hooks/useFontScale'
-import { getTelegramWebApp, isTelegramEnvironment, loadTelegramSdk } from './hooks/useTelegram'
+import { configureTelegramWebApp, getTelegramWebApp, isTelegramEnvironment, loadTelegramSdk } from './hooks/useTelegram'
 import { queryClient } from './lib/query-client'
 import { createAppRouter } from './router'
 import { I18nProvider } from './lib/i18n-context'
@@ -42,6 +42,7 @@ async function bootstrap() {
     document.documentElement.dataset.telegramApp = isTelegram ? 'true' : 'false'
     if (isTelegram) {
         await loadTelegramSdk()
+        configureTelegramWebApp({ syncThemeColors: false })
     }
 
     // Handle GitHub Pages 404 redirect for SPA routing

--- a/web/src/routes/sessions/files.tsx
+++ b/web/src/routes/sessions/files.tsx
@@ -605,7 +605,7 @@ export default function FilesPage() {
                         )
                     ) : activeTab === 'directories' ? (
                         <DirectoryTree
-                            key={sessionId}
+                            key={`${sessionId}:${rootLabel}`}
                             api={api}
                             sessionId={sessionId}
                             rootLabel={rootLabel}


### PR DESCRIPTION
## Summary

This PR polishes the web client inside Telegram Mini Apps and preserves file manager tree state across remounts.

Changes included:
- initialize Telegram Mini App behavior through `@tma.js/sdk` instead of injecting the legacy Telegram script
- call ready/expand and disable vertical swipe close when the app opens in Telegram
- sync Telegram header, background, and bottom bar colors from the active HAPI theme on startup and theme changes
- fall back to raw Telegram bridge events when the WebApp object is not exposed yet
- add lightweight Telegram haptics for trusted user interactions and toast notifications
- persist expanded file manager directories locally per session/root, with storage fallback and migration from the old key

## Validation

- `bunx vitest run src/hooks/useTelegram.test.ts src/hooks/useThemeColors.test.ts src/components/SessionFiles/DirectoryTree.test.tsx`
- `bun run typecheck`
- `bun run build`
