### PR TITLE
test(cli): make the suite pass on macOS hosts

### DIFF
--- a/cli/src/agent/__tests__/runAgentPty.test.ts
+++ b/cli/src/agent/__tests__/runAgentPty.test.ts
@@ -394,26 +394,44 @@ describe('runAgentPty', () => {
     })
 
     it('injects envVars/extraEnv into the spawn env only (not process.env)', async () => {
-        const msg = deferred<{ message: string } | null>()
-        const opts = makeOpts({
-            envVars: { FLAVOR_TOKEN: 'tok' },
-            extraEnv: { CLAUDE_CONFIG_DIR: '/tmp/iso-cfg' },
-            nextMessage: () => msg.promise,
-        })
-        const promise = runAgentPty(opts)
-        await tick(0)
-        const spawnEnv = (harness.m.spawn.mock.calls[0][0] as { env: Record<string, string> }).env
-        expect(spawnEnv.FLAVOR_TOKEN).toBe('tok')
-        expect(spawnEnv.CLAUDE_CONFIG_DIR).toBe('/tmp/iso-cfg')
-        // TERM is always set so interactive TUI agents initialize (agy/bubbletea
-        // drops to its login menu without it).
-        expect(spawnEnv.TERM).toBeTruthy()
-        // process.env must stay clean so the parent's scanner is unaffected.
-        expect(process.env.CLAUDE_CONFIG_DIR).toBeUndefined()
-        expect(process.env.FLAVOR_TOKEN).toBeUndefined()
-        await reachReady()
-        msg.resolve(null)
-        await promise
+        // The host shell may legitimately carry these already (a test run
+        // launched from inside a Claude Code session exports CLAUDE_CONFIG_DIR,
+        // for example). Clear them for the duration of this test so the
+        // "no leak into process.env" assertions observe what runAgentPty did,
+        // not what the runner's environment happened to contain. Restoring in
+        // finally also keeps the tail of this test (await promise) on the
+        // non-throwing path — an assertion throw here would abandon the
+        // in-flight runAgentPty call on the shared harness, which then
+        // surfaces as an unrelated unhandled rejection in a later test.
+        const savedConfigDir = process.env.CLAUDE_CONFIG_DIR
+        const savedFlavorToken = process.env.FLAVOR_TOKEN
+        delete process.env.CLAUDE_CONFIG_DIR
+        delete process.env.FLAVOR_TOKEN
+        try {
+            const msg = deferred<{ message: string } | null>()
+            const opts = makeOpts({
+                envVars: { FLAVOR_TOKEN: 'tok' },
+                extraEnv: { CLAUDE_CONFIG_DIR: '/tmp/iso-cfg' },
+                nextMessage: () => msg.promise,
+            })
+            const promise = runAgentPty(opts)
+            await tick(0)
+            const spawnEnv = (harness.m.spawn.mock.calls[0][0] as { env: Record<string, string> }).env
+            expect(spawnEnv.FLAVOR_TOKEN).toBe('tok')
+            expect(spawnEnv.CLAUDE_CONFIG_DIR).toBe('/tmp/iso-cfg')
+            // TERM is always set so interactive TUI agents initialize (agy/bubbletea
+            // drops to its login menu without it).
+            expect(spawnEnv.TERM).toBeTruthy()
+            // process.env must stay clean so the parent's scanner is unaffected.
+            expect(process.env.CLAUDE_CONFIG_DIR).toBeUndefined()
+            expect(process.env.FLAVOR_TOKEN).toBeUndefined()
+            await reachReady()
+            msg.resolve(null)
+            await promise
+        } finally {
+            if (savedConfigDir !== undefined) process.env.CLAUDE_CONFIG_DIR = savedConfigDir
+            if (savedFlavorToken !== undefined) process.env.FLAVOR_TOKEN = savedFlavorToken
+        }
     })
 
     it('removes unsetEnv keys from the spawn env (agy SSH_* stripping)', async () => {

--- a/cli/src/agent/__tests__/runAgentPty.test.ts
+++ b/cli/src/agent/__tests__/runAgentPty.test.ts
@@ -429,8 +429,16 @@ describe('runAgentPty', () => {
             msg.resolve(null)
             await promise
         } finally {
-            if (savedConfigDir !== undefined) process.env.CLAUDE_CONFIG_DIR = savedConfigDir
-            if (savedFlavorToken !== undefined) process.env.FLAVOR_TOKEN = savedFlavorToken
+            // Restore the EXACT prior state, including "was absent". A bare
+            // `if (saved !== undefined) set` leaves a leaked value in place on
+            // the one path that matters: if the assertions above catch a real
+            // process.env leak, the throw lands here with saved === undefined,
+            // and the leak would survive into later tests - reintroducing the
+            // cascading failure this test isolation exists to prevent.
+            if (savedConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR
+            else process.env.CLAUDE_CONFIG_DIR = savedConfigDir
+            if (savedFlavorToken === undefined) delete process.env.FLAVOR_TOKEN
+            else process.env.FLAVOR_TOKEN = savedFlavorToken
         }
     })
 

--- a/cli/src/agent/__tests__/runAgentPty.test.ts
+++ b/cli/src/agent/__tests__/runAgentPty.test.ts
@@ -407,6 +407,7 @@ describe('runAgentPty', () => {
         const savedFlavorToken = process.env.FLAVOR_TOKEN
         delete process.env.CLAUDE_CONFIG_DIR
         delete process.env.FLAVOR_TOKEN
+        let promise: ReturnType<typeof runAgentPty> | undefined
         try {
             const msg = deferred<{ message: string } | null>()
             const opts = makeOpts({
@@ -414,7 +415,7 @@ describe('runAgentPty', () => {
                 extraEnv: { CLAUDE_CONFIG_DIR: '/tmp/iso-cfg' },
                 nextMessage: () => msg.promise,
             })
-            const promise = runAgentPty(opts)
+            promise = runAgentPty(opts)
             await tick(0)
             const spawnEnv = (harness.m.spawn.mock.calls[0][0] as { env: Record<string, string> }).env
             expect(spawnEnv.FLAVOR_TOKEN).toBe('tok')
@@ -439,6 +440,15 @@ describe('runAgentPty', () => {
             else process.env.CLAUDE_CONFIG_DIR = savedConfigDir
             if (savedFlavorToken === undefined) delete process.env.FLAVOR_TOKEN
             else process.env.FLAVOR_TOKEN = savedFlavorToken
+
+            // Then settle the run itself. On the throwing path the awaits above
+            // are skipped, so the in-flight runAgentPty keeps the shared harness
+            // and never resolves - and a later test flipping isRunning would
+            // settle it asynchronously, surfacing as an unhandled rejection in
+            // an unrelated test. That is the very cascade this isolation exists
+            // to prevent, so the failure path has to clean up after itself.
+            if (promise && harness.m.isRunning) harness.triggerExit(0)
+            await promise?.catch(() => {})
         }
     })
 

--- a/cli/src/agy/utils/agyHookCarrier.test.ts
+++ b/cli/src/agy/utils/agyHookCarrier.test.ts
@@ -15,6 +15,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     return { ...actual, readdir: vi.fn(actual.readdir) };
 });
 import {
+    _resetCarrierScopeCacheForTests,
     agyHookCarrierIsIntact,
     cleanupAgyHookCarrier,
     computeLocalCarrierScope,
@@ -23,6 +24,19 @@ import {
     writeAgyHooksJsonAtomic,
     type ScopeProbe
 } from './agyHookCarrier';
+
+/** Pins process.platform for the duration of a test — same pattern as
+ * agyHookCarrierPlatformScope.test.ts. Used by the tests below whose
+ * injected probes are Linux-shaped: computeLocalCarrierScopeAsync dispatches
+ * on process.platform, so on a darwin/win32 test host those probes would
+ * never be reached without this. */
+function stubPlatform(value: NodeJS.Platform): () => void {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+    return () => {
+        Object.defineProperty(process, 'platform', { value: original, configurable: true });
+    };
+}
 
 /**
  * Spawns a real child process, waits for it to exit, and returns its PID.
@@ -189,6 +203,11 @@ describe('agy hook carrier location (Phase 2.8)', () => {
     });
 
     it('writes owner metadata (pid, scope) at the carrier root, outside .agents/', () => {
+        // Deterministic starting point: a previous test in this file may have
+        // warmed the module-level scope cache (any sweepAgyHookCarriers() call
+        // with the default probe does), and writeOwnerMetadata prefers the
+        // cache over the sync computation compared against below.
+        _resetCarrierScopeCacheForTests();
         const result = prepareAgyHookCarrier('{}');
         expect(result).toBeDefined();
         if (!result) return;
@@ -204,7 +223,11 @@ describe('agy hook carrier location (Phase 2.8)', () => {
             // recorded under a different scope must never be probed by this
             // host's sweep. See computeLocalCarrierScope's docstring for why
             // hostname alone (the original Fix N6) wasn't enough.
-            expect(owner.scope).toBe(computeLocalCarrierScope());
+            // Normalized comparison: on Linux both sides are the real
+            // linux:<bootId>:<ns> string; on a host without /proc the sync
+            // path yields undefined, which writeOwnerMetadata records as an
+            // empty scope (its documented no-identity encoding).
+            expect(owner.scope ?? '').toBe(computeLocalCarrierScope() ?? '');
             // Must not land inside .agents/ — that's the directory agy itself
             // reads (hooks.json, plugins/), and owner metadata is HAPI-only
             // bookkeeping that must not pollute it.
@@ -216,12 +239,18 @@ describe('agy hook carrier location (Phase 2.8)', () => {
 });
 
 describe('computeLocalCarrierScope', () => {
-    it('computes a linux:<bootId>:<nsId> scope from real /proc reads on this (Linux) test host', () => {
+    it.runIf(process.platform === 'linux')('computes a linux:<bootId>:<nsId> scope from real /proc reads on this (Linux) test host', () => {
         // Non-vacuous: this sandbox's /proc is genuinely readable (verified
         // manually before writing this test), so this pins the real Linux
-        // success path, not just the fallback.
+        // success path, not just the fallback. Linux-only: there is no /proc
+        // to read anywhere else, hence the runIf gate.
         const scope = computeLocalCarrierScope();
         expect(scope).toMatch(/^linux:[0-9a-f-]{36}:\d+$/);
+    });
+
+    it.runIf(process.platform === 'darwin')('returns undefined on macOS — the sync path is Linux-only (macOS identity comes from the async warm cache, see warmCarrierScope)', () => {
+        _resetCarrierScopeCacheForTests();
+        expect(computeLocalCarrierScope()).toBeUndefined();
     });
 
     it('refuses to fall back to hostname when the Linux probe fails — hostname is not an identity', () => {
@@ -275,7 +304,13 @@ describe('sweepAgyHookCarriers', () => {
         return carrierDir;
     }
 
-    it('③ sweeps a carrier whose owner scope matches AND whose process has died', async () => {
+    it.runIf(process.platform === 'linux')('③ sweeps a carrier whose owner scope matches AND whose process has died', async () => {
+        // Linux-gated: the fixture's scope must equal what the sweep itself
+        // resolves, and only the Linux sync path yields a real value here
+        // (elsewhere computeLocalCarrierScope() is undefined, so the fixture
+        // would record no scope and the sweep would rightly preserve it).
+        // The cross-platform variant below covers the delete path on other
+        // hosts via an injected probe.
         const deadPid = await spawnAndReapDeadPid();
         const carrierDir = makeCarrierDir('dead-owner-matching-scope');
         writeFileSync(
@@ -289,6 +324,32 @@ describe('sweepAgyHookCarriers', () => {
         // check regresses to always-preserve — this is the one combination
         // that must actually delete.
         expect(existsSync(carrierDir)).toBe(false);
+    });
+
+    it('③ (platform-independent) sweeps a carrier whose owner scope matches AND whose process has died — injected probe', async () => {
+        // Same delete-path assertion as ③ above, but with the local scope
+        // pinned through an injected Linux-shaped probe + platform stub so it
+        // runs identically on any test host (macOS included).
+        const restorePlatform = stubPlatform('linux');
+        try {
+            const probe: ScopeProbe = {
+                readBootId: () => 'sweep-fixture-boot-id',
+                readPidNamespaceId: () => '77',
+                hostname: () => 'irrelevant',
+            };
+            const deadPid = await spawnAndReapDeadPid();
+            const carrierDir = makeCarrierDir('dead-owner-matching-scope-injected');
+            writeFileSync(
+                join(carrierDir, 'owner.json'),
+                JSON.stringify({ pid: deadPid, scope: 'linux:sweep-fixture-boot-id:77' })
+            );
+
+            await sweepAgyHookCarriers(probe);
+
+            expect(existsSync(carrierDir)).toBe(false);
+        } finally {
+            restorePlatform();
+        }
     });
 
     it('preserves a carrier whose owner process is alive — the costliest mistake is deleting a live session\'s carrier', async () => {
@@ -588,7 +649,14 @@ describe('sweepAgyHookCarriers', () => {
                 hostname: () => 'irrelevant',
             };
 
-            await sweepAgyHookCarriers(probe);
+            // The injected probe is Linux-shaped; pin the platform so the
+            // scope resolution actually invokes it on any test host.
+            const restorePlatform = stubPlatform('linux');
+            try {
+                await sweepAgyHookCarriers(probe);
+            } finally {
+                restorePlatform();
+            }
 
             // Fails (mutation check: swap the readdir()/resolveLocalCarrierScope()
             // statements in sweepAgyHookCarriers) if the scope probe ever

--- a/cli/src/agy/utils/agyHookCarrierPlatformScope.test.ts
+++ b/cli/src/agy/utils/agyHookCarrierPlatformScope.test.ts
@@ -430,7 +430,11 @@ describe('real defaultScopeProbe (smoke test, no macOS tooling on this Linux hos
         _resetCarrierScopeCacheForTests();
     });
 
-    it('resolves to undefined (never hangs, never throws) when stubbed to darwin on a non-macOS host', async () => {
+    it.runIf(process.platform !== 'darwin')('resolves to undefined (never hangs, never throws) when stubbed to darwin on a non-macOS host', async () => {
+        // Premise-gated: this asserts the real ioreg/sysctl probes FAIL
+        // cleanly, which only holds where those tools are absent or behave
+        // differently — on a genuine macOS host they succeed and resolve a
+        // real scope (covered by the darwin-host test below).
         restorePlatform = stubPlatform('darwin');
         await expect(warmCarrierScope()).resolves.toBeUndefined();
 
@@ -440,6 +444,24 @@ describe('real defaultScopeProbe (smoke test, no macOS tooling on this Linux hos
             if (!carrier) return;
             const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
             expect(owner.scope).toBe('');
+        } finally {
+            cleanupAgyHookCarrier(carrier?.carrierDir);
+        }
+    }, 10_000);
+
+    it.runIf(process.platform === 'darwin')('resolves a real darwin:<machineId>:<bootSessionId> scope on a genuine macOS host (live verification of the success/parsing path)', async () => {
+        // The header comment above defers validating the SUCCESS path against
+        // the real OS tools to a live macOS run — this is that run, whenever
+        // the suite executes on a real Mac: real /usr/sbin/ioreg + sysctl,
+        // real parsers, end to end through the warm cache into owner.json.
+        await warmCarrierScope();
+
+        const carrier = prepareAgyHookCarrier('{}');
+        try {
+            expect(carrier).toBeDefined();
+            if (!carrier) return;
+            const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
+            expect(owner.scope).toMatch(/^darwin:[0-9A-Fa-f-]{36}:[0-9A-Fa-f-]{36}$/);
         } finally {
             cleanupAgyHookCarrier(carrier?.carrierDir);
         }

--- a/cli/src/agy/utils/agyHookCarrierScopeCache.test.ts
+++ b/cli/src/agy/utils/agyHookCarrierScopeCache.test.ts
@@ -21,12 +21,31 @@ import {
  * so this is a pure structural addition: computeLocalCarrierScope()'s
  * observable output on this (Linux) test host is unchanged either way.
  */
+/** Pins process.platform for the duration of a test — same pattern as
+ * agyHookCarrierPlatformScope.test.ts. Every probe in this file is
+ * Linux-shaped (readBootId/readPidNamespaceId), so the platform dispatch in
+ * computeLocalCarrierScopeAsync must take the linux branch for the cache
+ * mechanics under test to be reachable at all; on a darwin/win32 test host
+ * the dispatch would otherwise bypass these probes entirely. */
+function stubPlatform(value: NodeJS.Platform): () => void {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+    return () => {
+        Object.defineProperty(process, 'platform', { value: original, configurable: true });
+    };
+}
+
 describe('carrier scope cache (Phase 2-B infrastructure)', () => {
+    let restorePlatform: (() => void) | undefined;
+
     beforeEach(() => {
         _resetCarrierScopeCacheForTests();
+        restorePlatform = stubPlatform('linux');
     });
 
     afterEach(() => {
+        restorePlatform?.();
+        restorePlatform = undefined;
         _resetCarrierScopeCacheForTests();
     });
 
@@ -127,7 +146,14 @@ describe('carrier scope cache (Phase 2-B infrastructure)', () => {
             if (!carrier) return;
             try {
                 const owner = JSON.parse(readFileSync(join(carrier.carrierDir, 'owner.json'), 'utf8'));
-                expect(owner.scope).toBe(computeLocalCarrierScope());
+                // Normalized comparison: on a Linux host both sides are the
+                // same real linux:<bootId>:<ns> string. On a host without
+                // /proc (macOS/Windows) the sync fallback yields undefined,
+                // which writeOwnerMetadata records as an empty scope (see its
+                // "records no scope at all" docstring) — so '' vs undefined
+                // here is the documented no-identity encoding, not a
+                // recompute-vs-cache divergence.
+                expect(owner.scope ?? '').toBe(computeLocalCarrierScope() ?? '');
             } finally {
                 cleanupAgyHookCarrier(carrier.carrierDir);
             }


### PR DESCRIPTION
## What

The `cli` test suite has 11 failures when run on a macOS host. This PR fixes them. **Test files only — no source changes.**

## These are not regressions from my tree

I found these while syncing a fork, so the first thing I checked was whether I had caused them. I hadn't: I reproduced all 11 identically on **pristine `upstream/main` (`fea42212`, v0.27.3)** in an isolated clone on this Mac, with no local changes applied.

Measured on macOS 26.6 (arm64), `bunx vitest run <file>`, one file per run:

| File | Before (pristine main) | After |
|---|---|---|
| `cli/src/agent/__tests__/runAgentPty.test.ts` | 1 failed / 34 passed | 35 passed |
| `cli/src/agy/utils/agyHookCarrier.test.ts` | 4 failed / 20 passed | 24 passed / 2 skipped |
| `cli/src/agy/utils/agyHookCarrierPlatformScope.test.ts` | 1 failed / 17 passed | 18 passed / 1 skipped |
| `cli/src/agy/utils/agyHookCarrierScopeCache.test.ts` | 5 failed / 1 passed | 6 passed |

## Root causes

Two kinds, neither of which is a product bug:

**1. Linux-host assumptions in tests (9 failures).** The agy hook-carrier tests probe `/proc` and expect Linux-shaped scope identities. On darwin the platform dispatch takes a different path, so the assertions cannot hold.

**2. One environment leak (2 symptoms, 1 fix).** `runAgentPty.test.ts`'s spawn-env isolation test inherits `CLAUDE_CONFIG_DIR` from the host shell — which is always set when the suite is launched from inside a Claude Code session. Its assertion failure also abandoned the in-flight `runAgentPty` call on the shared harness, which resurfaced later as the unhandled `testagent PTY exited before becoming ready` rejection. Clearing the inherited vars around that test fixes both symptoms.

## On the skips — please look here first

Three tests are now skipped on macOS, and I want to be explicit that this is **not** failures swept under a rug:

- Gating is `it.runIf(process.platform === 'linux')`, so the Linux-only tests still run on your Linux CI exactly as before.
- **Every Linux-gated test got a darwin twin covering the same behaviour on the other platform.** Net test count goes *up*, not down: 24 → 26 and 18 → 19 in the two affected files.
- One of the added tests is the real-macOS success path (`ioreg` + `sysctl` end to end into `owner.json`) that `agyHookCarrierPlatformScope.test.ts`'s own file header had deferred to "a live mac run". This is that run.

## Verification

Full suite on macOS after this change: cli 3617 passed / 4 skipped, hub 1113, web 2373, shared 253 — exit 0.

I do not have a Linux host to verify on, so the Linux side rests on the gating being a no-op there plus your CI. The Linux-path assertions themselves are unchanged in substance.

## AI disclosure

Per CONTRIBUTING's Vibe Coding policy: this was produced by a multi-agent workflow — Claude Fable 5 for planning and task decomposition, Claude Sonnet for implementation, and Claude Opus for code review and acceptance. A human reviewed the result and ran the verification above.
