### PR TITLE
feat(cli): survive terminal hangup by switching the session to remote mode

### DIFF
--- a/cli/src/agent/__fixtures__/runnerLifecycleProcessChild.ts
+++ b/cli/src/agent/__fixtures__/runnerLifecycleProcessChild.ts
@@ -1,0 +1,42 @@
+// Standalone child process for runnerLifecycle.process.test.ts.
+//
+// Runs createRunnerLifecycle().registerProcessHandlers() in a *real*,
+// separately-spawned OS process — the only way to prove the SIGHUP handler
+// actually replaces the kernel's default terminate-on-SIGHUP action (a
+// same-process `process.emit('SIGHUP')` in a unit test only proves the
+// listener ran, not that it beat the default disposition).
+//
+// Uses fs.writeSync(1, ...) instead of console.log: stdout is a pipe when
+// spawned from the test, and Node/Bun buffer pipe writes asynchronously —
+// a subsequent process.exit() (the HAPI_EXIT_ON_HANGUP=1 path) can truncate
+// anything still in flight. Synchronous writes make every line observable
+// to the parent before exit.
+import fs from 'node:fs'
+import { createRunnerLifecycle } from '../runnerLifecycle'
+
+const session = {
+    updateMetadata: (fn: (m: Record<string, unknown>) => Record<string, unknown>) => {
+        const next = fn({})
+        fs.writeSync(1, `EVENT updateMetadata ${JSON.stringify(next)}\n`)
+    },
+    sendSessionDeath: (reason: string) => {
+        fs.writeSync(1, `EVENT sendSessionDeath ${reason}\n`)
+    },
+    flush: async () => true,
+    close: async () => {
+        fs.writeSync(1, 'EVENT close\n')
+    }
+} as unknown as Parameters<typeof createRunnerLifecycle>[0]['session']
+
+const lifecycle = createRunnerLifecycle({ session, logTag: 'child' })
+// SIGHUP survival is opt-in — this fixture exercises the opted-in flavor.
+// See runnerLifecycleProcessChildNoOptIn.ts for the un-opted-in sibling.
+lifecycle.registerProcessHandlers({ surviveTerminalHangup: true })
+
+fs.writeSync(1, 'READY\n')
+
+// Keep the event loop alive so the parent test can observe "still running"
+// well after SIGHUP — without this the process would exit on its own once
+// there is nothing left to do, which would make the survival assertion
+// meaningless.
+setInterval(() => {}, 1000)

--- a/cli/src/agent/__fixtures__/runnerLifecycleProcessChildNoOptIn.ts
+++ b/cli/src/agent/__fixtures__/runnerLifecycleProcessChildNoOptIn.ts
@@ -1,0 +1,30 @@
+// Sibling of runnerLifecycleProcessChild.ts for runnerLifecycle.process.test.ts.
+//
+// Registers process handlers WITHOUT opting into SIGHUP survival
+// (registerProcessHandlers() with no options). Proves the opt-in gate is
+// real at the OS-signal level, not just "no listener object was created" —
+// a real, separately-spawned process must actually die on SIGHUP here,
+// same as it always did before terminal-hangup survival existed.
+import fs from 'node:fs'
+import { createRunnerLifecycle } from '../runnerLifecycle'
+
+const session = {
+    updateMetadata: (fn: (m: Record<string, unknown>) => Record<string, unknown>) => {
+        const next = fn({})
+        fs.writeSync(1, `EVENT updateMetadata ${JSON.stringify(next)}\n`)
+    },
+    sendSessionDeath: (reason: string) => {
+        fs.writeSync(1, `EVENT sendSessionDeath ${reason}\n`)
+    },
+    flush: async () => true,
+    close: async () => {
+        fs.writeSync(1, 'EVENT close\n')
+    }
+} as unknown as Parameters<typeof createRunnerLifecycle>[0]['session']
+
+const lifecycle = createRunnerLifecycle({ session, logTag: 'child' })
+lifecycle.registerProcessHandlers()
+
+fs.writeSync(1, 'READY\n')
+
+setInterval(() => {}, 1000)

--- a/cli/src/agent/runnerLifecycle.process.test.ts
+++ b/cli/src/agent/runnerLifecycle.process.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawn, type ChildProcessByStdio } from 'node:child_process'
+import type { Readable } from 'node:stream'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+type SpawnedChild = ChildProcessByStdio<null, Readable, Readable>
+
+// Killing the PTY (which sends SIGHUP) must leave the process alive.
+// A same-process `process.emit('SIGHUP')` (as in runnerLifecycle.test.ts)
+// only proves the listener runs — it says nothing about whether that
+// listener actually beats the kernel's default terminate-on-SIGHUP
+// disposition, which is the entire point of registering a handler at all.
+// This suite spawns a *real* child process, sends it a *real* SIGHUP via
+// process.kill(pid, 'SIGHUP'), and asserts the OS process is still alive
+// afterwards. No PTY/node-pty dependency is needed: SIGHUP's default
+// disposition and a handler's ability to override it are process-signal
+// mechanics, not TTY mechanics — the PTY is only how the terminal-close
+// case *generates* SIGHUP in production; the test can generate it directly.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CHILD_SCRIPT = path.join(__dirname, '__fixtures__/runnerLifecycleProcessChild.ts')
+const CHILD_SCRIPT_NO_OPT_IN = path.join(__dirname, '__fixtures__/runnerLifecycleProcessChildNoOptIn.ts')
+
+function waitForLine(
+    child: SpawnedChild,
+    predicate: (line: string) => boolean,
+    timeoutMs = 5000
+): Promise<string> {
+    return new Promise((resolve, reject) => {
+        let buffer = ''
+        const timer = setTimeout(() => {
+            reject(new Error(`Timed out waiting for line matching predicate. Output so far:\n${buffer}`))
+        }, timeoutMs)
+        const onData = (chunk: Buffer) => {
+            buffer += chunk.toString('utf8')
+            const lines = buffer.split('\n')
+            for (const line of lines) {
+                if (predicate(line)) {
+                    clearTimeout(timer)
+                    child.stdout.off('data', onData)
+                    resolve(line)
+                    return
+                }
+            }
+        }
+        child.stdout.on('data', onData)
+    })
+}
+
+function isAlive(pid: number): boolean {
+    try {
+        // Signal 0 does not actually send a signal — it just probes whether
+        // the process (and our permission to signal it) still exists.
+        process.kill(pid, 0)
+        return true
+    } catch {
+        return false
+    }
+}
+
+// POSIX-only: Windows emulates SIGHUP on console close but the OS then
+// terminates the process unconditionally after a short grace period, and
+// process.kill(pid, 'SIGHUP') kills outright there — the survival contract
+// under test only holds on POSIX hosts (upstream CI runs ubuntu).
+describe.skipIf(process.platform === 'win32')('runnerLifecycle SIGHUP process survival (integration)', { timeout: 15_000 }, () => {
+    let child: SpawnedChild | null = null
+
+    afterEach(() => {
+        if (child && child.pid && isAlive(child.pid)) {
+            child.kill('SIGKILL')
+        }
+        child = null
+    })
+
+    it('stays alive after SIGHUP and never reports an archive/session-death', async () => {
+        const proc = spawn('bun', ['run', CHILD_SCRIPT], {
+            stdio: ['ignore', 'pipe', 'pipe']
+        })
+        child = proc
+        const pid = proc.pid
+        expect(pid).toBeDefined()
+
+        let stdout = ''
+        proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8') })
+        let stderr = ''
+        proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8') })
+
+        await waitForLine(proc, (line) => line.trim() === 'READY')
+
+        process.kill(pid!, 'SIGHUP')
+
+        // Give the (incorrectly, if this regresses) default disposition —
+        // or an async crash from an unguarded stream write — time to kill
+        // the process before we assert it is still up.
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+
+        expect(isAlive(pid!)).toBe(true)
+        expect(stdout).not.toContain('EVENT sendSessionDeath')
+        expect(stdout).not.toContain('EVENT close')
+        // Not `expect(stderr).toBe('')` — that's brittle against any
+        // incidental warning a future dependency bump might print (a
+        // deprecation notice, a runtime version banner, etc.), which would
+        // fail this test for reasons that have nothing to do with SIGHUP
+        // survival. What actually matters here is that surviving SIGHUP
+        // didn't itself crash the process — assert on the absence of
+        // crash/error signatures, not on total silence.
+        expect(stderr).not.toMatch(/uncaught|unhandled|panic|segmentation fault/i)
+        expect(stderr).not.toContain('Error:')
+    })
+
+    it('without the opt-in, SIGHUP falls through to the platform default and the process dies', async () => {
+        const proc = spawn('bun', ['run', CHILD_SCRIPT_NO_OPT_IN], {
+            stdio: ['ignore', 'pipe', 'pipe']
+        })
+        child = proc
+        const pid = proc.pid
+        expect(pid).toBeDefined()
+
+        const exited = new Promise<void>((resolve) => {
+            proc.once('exit', () => resolve())
+        })
+
+        await waitForLine(proc, (line) => line.trim() === 'READY')
+
+        process.kill(pid!, 'SIGHUP')
+
+        await Promise.race([
+            exited,
+            new Promise((_, reject) => setTimeout(() => reject(new Error('un-opted-in child did not die on SIGHUP within the timeout')), 5000))
+        ])
+
+        expect(isAlive(pid!)).toBe(false)
+    })
+
+    it('HAPI_EXIT_ON_HANGUP=1: SIGHUP archives gracefully and the process exits', async () => {
+        const proc = spawn('bun', ['run', CHILD_SCRIPT], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: { ...process.env, HAPI_EXIT_ON_HANGUP: '1' }
+        })
+        child = proc
+        const pid = proc.pid
+        expect(pid).toBeDefined()
+
+        let stdout = ''
+        proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8') })
+
+        const exited = new Promise<void>((resolve) => {
+            proc.once('exit', () => resolve())
+        })
+
+        await waitForLine(proc, (line) => line.trim() === 'READY')
+
+        process.kill(pid!, 'SIGHUP')
+
+        await Promise.race([
+            exited,
+            new Promise((_, reject) => setTimeout(() => reject(new Error('child did not exit after SIGHUP with HAPI_EXIT_ON_HANGUP=1')), 5000))
+        ])
+
+        expect(isAlive(pid!)).toBe(false)
+        expect(stdout).toContain('EVENT sendSessionDeath')
+        expect(stdout).toContain('EVENT close')
+        expect(stdout).toMatch(/EVENT updateMetadata .*"lifecycleState":"archived"/)
+        expect(stdout).toMatch(/EVENT updateMetadata .*"archiveReason":"SIGHUP/)
+    })
+})

--- a/cli/src/agent/runnerLifecycle.test.ts
+++ b/cli/src/agent/runnerLifecycle.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRunnerLifecycle } from './runnerLifecycle';
 import type { RunnerLifecycle } from './runnerLifecycle';
+import { isTerminalLost, __resetTerminalLossStateForTests } from './terminalLossState';
 
 // Mock heavy deps
 vi.mock('@/ui/logger', () => ({
@@ -219,5 +220,162 @@ describe('createRunnerLifecycle archiveReason defaults (tiann/hapi#914)', () => 
         expect(session.metadataWrites[0]).toMatchObject({
             archiveReason: 'User terminated'
         })
+    })
+})
+
+// SIGHUP no longer falls through to the default OS behaviour
+// (process death). It marks terminalLost and — unless the escape hatch is
+// set — keeps the process (and session) alive.
+describe('createRunnerLifecycle SIGHUP handling (session survival)', () => {
+    const originalHangupEnv = process.env.HAPI_EXIT_ON_HANGUP
+    // Track only the SIGHUP listeners this suite adds via
+    // registerProcessHandlers() and remove exactly those in afterEach —
+    // `process.removeAllListeners('SIGHUP')` would also strip any handler
+    // the test host (vitest/bun) itself registered on this shared,
+    // process-global emitter.
+    let listenersBeforeTest: Array<(...args: unknown[]) => void> = []
+
+    beforeEach(() => {
+        __resetTerminalLossStateForTests()
+        delete process.env.HAPI_EXIT_ON_HANGUP
+        listenersBeforeTest = process.listeners('SIGHUP') as Array<(...args: unknown[]) => void>
+    })
+
+    afterEach(() => {
+        const listenersAfterTest = process.listeners('SIGHUP') as Array<(...args: unknown[]) => void>
+        for (const listener of listenersAfterTest) {
+            if (!listenersBeforeTest.includes(listener)) {
+                process.removeListener('SIGHUP', listener)
+            }
+        }
+        __resetTerminalLossStateForTests()
+        if (originalHangupEnv === undefined) {
+            delete process.env.HAPI_EXIT_ON_HANGUP
+        } else {
+            process.env.HAPI_EXIT_ON_HANGUP = originalHangupEnv
+        }
+    })
+
+    it('marks terminalLost on SIGHUP instead of exiting', () => {
+        const session = createMockApiSessionWithMetadataCapture()
+        const lifecycle = createRunnerLifecycle({ session, logTag: 'test' })
+        lifecycle.registerProcessHandlers({ surviveTerminalHangup: true })
+
+        expect(isTerminalLost()).toBe(false)
+        process.emit('SIGHUP')
+
+        expect(isTerminalLost()).toBe(true)
+        expect(session.close).not.toHaveBeenCalled()
+        expect(session.sendSessionDeath).not.toHaveBeenCalled()
+    })
+
+    it('does not archive/close the session on plain SIGHUP', async () => {
+        const session = createMockApiSessionWithMetadataCapture()
+        const lifecycle = createRunnerLifecycle({ session, logTag: 'test' })
+        lifecycle.registerProcessHandlers({ surviveTerminalHangup: true })
+
+        process.emit('SIGHUP')
+        // give any (incorrectly) fired async cleanup a tick to run
+        await Promise.resolve()
+
+        expect(session.updateMetadata).not.toHaveBeenCalled()
+    })
+
+    it('HAPI_EXIT_ON_HANGUP=1 makes SIGHUP archive gracefully and exit', async () => {
+        process.env.HAPI_EXIT_ON_HANGUP = '1'
+        const session = createMockApiSessionWithMetadataCapture()
+        const lifecycle = createRunnerLifecycle({ session, logTag: 'test' })
+        lifecycle.registerProcessHandlers({ surviveTerminalHangup: true })
+
+        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((() => undefined) as unknown) as typeof process.exit)
+
+        process.emit('SIGHUP')
+        // cleanupAndExit is async (fire-and-forget from the handler)
+        await new Promise((resolve) => setImmediate(resolve))
+
+        expect(session.metadataWrites[0]).toMatchObject({
+            lifecycleState: 'archived',
+            archivedBy: 'cli'
+        })
+        expect(session.metadataWrites[0].archiveReason).toEqual(expect.stringContaining('SIGHUP'))
+        expect(session.sendSessionDeath).toHaveBeenCalled()
+        expect(session.close).toHaveBeenCalled()
+        expect(exitSpy).toHaveBeenCalled()
+
+        exitSpy.mockRestore()
+    })
+})
+
+// SIGHUP survival must be opt-in, not a blanket behaviour change for every
+// runner flavor. Only a runner that explicitly asks for it
+// (registerProcessHandlers({ surviveTerminalHangup: true })) should get a
+// SIGHUP listener at all; every other flavor must keep the platform default
+// (SIGHUP terminates the process) so an un-opted-in runner is not silently
+// left "surviving" a signal nobody asked it to survive.
+describe('createRunnerLifecycle SIGHUP opt-in gating', () => {
+    let listenersBeforeTest: Array<(...args: unknown[]) => void> = []
+
+    beforeEach(() => {
+        __resetTerminalLossStateForTests()
+        listenersBeforeTest = process.listeners('SIGHUP') as Array<(...args: unknown[]) => void>
+    })
+
+    afterEach(() => {
+        const listenersAfterTest = process.listeners('SIGHUP') as Array<(...args: unknown[]) => void>
+        for (const listener of listenersAfterTest) {
+            if (!listenersBeforeTest.includes(listener)) {
+                process.removeListener('SIGHUP', listener)
+            }
+        }
+        __resetTerminalLossStateForTests()
+    })
+
+    it('does not register a SIGHUP listener when registerProcessHandlers() is called with no options', () => {
+        const session = createMockApiSessionWithMetadataCapture()
+        const lifecycle = createRunnerLifecycle({ session, logTag: 'test' })
+
+        lifecycle.registerProcessHandlers()
+
+        const addedListeners = (process.listeners('SIGHUP') as Array<(...args: unknown[]) => void>)
+            .filter((listener) => !listenersBeforeTest.includes(listener))
+        expect(addedListeners).toHaveLength(0)
+    })
+
+    it('does not register a SIGHUP listener when surviveTerminalHangup is explicitly false', () => {
+        const session = createMockApiSessionWithMetadataCapture()
+        const lifecycle = createRunnerLifecycle({ session, logTag: 'test' })
+
+        lifecycle.registerProcessHandlers({ surviveTerminalHangup: false })
+
+        const addedListeners = (process.listeners('SIGHUP') as Array<(...args: unknown[]) => void>)
+            .filter((listener) => !listenersBeforeTest.includes(listener))
+        expect(addedListeners).toHaveLength(0)
+    })
+
+    it('registers a SIGHUP listener when surviveTerminalHangup is true', () => {
+        const session = createMockApiSessionWithMetadataCapture()
+        const lifecycle = createRunnerLifecycle({ session, logTag: 'test' })
+
+        lifecycle.registerProcessHandlers({ surviveTerminalHangup: true })
+
+        const addedListeners = (process.listeners('SIGHUP') as Array<(...args: unknown[]) => void>)
+            .filter((listener) => !listenersBeforeTest.includes(listener))
+        expect(addedListeners.length).toBeGreaterThan(0)
+    })
+
+    it('an un-opted-in runner keeps the platform default: SIGHUP does not mark terminalLost', () => {
+        const session = createMockApiSessionWithMetadataCapture()
+        const lifecycle = createRunnerLifecycle({ session, logTag: 'test' })
+        lifecycle.registerProcessHandlers()
+
+        // Emitting the signal on this process only proves whatever listeners
+        // (if any) run — it cannot prove the kernel would actually terminate
+        // an un-opted-in process for real. That is covered by the separate
+        // real-process suite (runnerLifecycle.process.test.ts) using a
+        // sibling fixture without the opt-in. This test only asserts that no
+        // handler of ours reacts, i.e. we didn't register anything.
+        process.emit('SIGHUP')
+
+        expect(isTerminalLost()).toBe(false)
     })
 })

--- a/cli/src/agent/runnerLifecycle.ts
+++ b/cli/src/agent/runnerLifecycle.ts
@@ -2,6 +2,7 @@ import type { ApiSessionClient } from '@/api/apiSession'
 import type { SessionEndReason } from '@hapi/protocol'
 import { logger } from '@/ui/logger'
 import { restoreTerminalState } from '@/ui/terminalState'
+import { markTerminalLost, installTerminalOutputGuard } from '@/agent/terminalLossState'
 
 type RunnerLifecycleOptions = {
     session: ApiSessionClient
@@ -20,7 +21,7 @@ export type RunnerLifecycle = {
     cleanup: () => Promise<void>
     cleanupConfirmed: (options?: { timeoutMs?: number }) => Promise<void>
     cleanupAndExit: (codeOverride?: number) => Promise<void>
-    registerProcessHandlers: () => void
+    registerProcessHandlers: (options?: { surviveTerminalHangup?: boolean }) => void
 }
 
 export function createRunnerLifecycle(options: RunnerLifecycleOptions): RunnerLifecycle {
@@ -180,7 +181,7 @@ export function createRunnerLifecycle(options: RunnerLifecycleOptions): RunnerLi
         sessionEndReason = 'error'
     }
 
-    const registerProcessHandlers = () => {
+    const registerProcessHandlers = (handlerOptions?: { surviveTerminalHangup?: boolean }) => {
         // tiann/hapi#914: SIGTERM is treated as the default reason ('Hub restart')
         // because the runner is restarted by systemd as part of hub restart in
         // production. If a future code path needs to distinguish "operator
@@ -206,6 +207,38 @@ export function createRunnerLifecycle(options: RunnerLifecycleOptions): RunnerLi
             markCrash(reason)
             void cleanupAndExit(1)
         })
+
+        // Closing the terminal sends SIGHUP to the whole
+        // foreground process group (this process + any local claude child).
+        // The kernel's default action (terminate) would kill the runner
+        // before graceful archive could run, leaving the hub session stuck
+        // at lifecycleState='running' forever — but only flavors that opt
+        // in via `surviveTerminalHangup: true` install a handler here at
+        // all; every other flavor keeps the platform default (SIGHUP
+        // terminates the process), unchanged from upstream.
+        //
+        // When opted in: survive. Mark terminalLost (consulted by
+        // claudeLocalLauncher to redirect a local-child death into the
+        // existing local→remote switch path instead of ending the session)
+        // and guard stdout/stderr so any in-flight writes from
+        // readline/ink components don't crash the process via EPIPE/EIO.
+        //
+        // Escape hatch: HAPI_EXIT_ON_HANGUP=1 restores something close to
+        // the old behaviour, except it now exits *gracefully* (archived,
+        // reported to hub) instead of just being killed.
+        if (handlerOptions?.surviveTerminalHangup) {
+            process.on('SIGHUP', () => {
+                if (process.env.HAPI_EXIT_ON_HANGUP === '1') {
+                    archiveReason = 'SIGHUP (terminal closed, HAPI_EXIT_ON_HANGUP set)'
+                    void cleanupAndExit()
+                    return
+                }
+
+                logger.debug(`${logPrefix} SIGHUP received (terminal lost) — surviving, marking terminalLost`)
+                markTerminalLost()
+                installTerminalOutputGuard()
+            })
+        }
     }
 
     return {

--- a/cli/src/agent/terminalLossState.test.ts
+++ b/cli/src/agent/terminalLossState.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Writable } from 'node:stream'
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: vi.fn()
+    }
+}))
+
+import {
+    markTerminalLost,
+    isTerminalLost,
+    installTerminalOutputGuard,
+    __resetTerminalLossStateForTests
+} from './terminalLossState'
+import { logger } from '@/ui/logger'
+
+// A real Writable whose _write always fails with the given error — this
+// drives errors through Node's actual Writable/EventEmitter machinery
+// (write() -> internal write callback -> stream.destroy(err) ->
+// emit('error') on next tick), the same path a real stdout/stderr pipe
+// takes when the reader (the terminal) is gone. Unlike a hand-rolled
+// {on, emitError} stub, nothing here bypasses real stream/event dispatch.
+function createErroringWritable(error: NodeJS.ErrnoException): Writable {
+    return new Writable({
+        write(_chunk, _encoding, callback) {
+            callback(error)
+        }
+    })
+}
+
+// Writable's deferred error emission (see above) needs a couple of event
+// loop turns to actually fire before we can assert on the outcome.
+async function flushMicrotasksAndTicks(): Promise<void> {
+    await new Promise((resolve) => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
+}
+
+describe('terminalLossState', () => {
+    beforeEach(() => {
+        __resetTerminalLossStateForTests()
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        __resetTerminalLossStateForTests()
+    })
+
+    it('starts with terminalLost=false', () => {
+        expect(isTerminalLost()).toBe(false)
+    })
+
+    it('flips to true once markTerminalLost is called and stays true', () => {
+        markTerminalLost()
+        expect(isTerminalLost()).toBe(true)
+        markTerminalLost()
+        expect(isTerminalLost()).toBe(true)
+    })
+
+    it('swallows an EPIPE raised by a real write() without it escaping as an uncaughtException', async () => {
+        const escaped: unknown[] = []
+        const onUncaught = (error: unknown) => escaped.push(error)
+        process.once('uncaughtException', onUncaught)
+
+        try {
+            const stdout = createErroringWritable(Object.assign(new Error('broken pipe'), { code: 'EPIPE' }))
+            const stderr = createErroringWritable(Object.assign(new Error('broken pipe'), { code: 'EPIPE' }))
+            installTerminalOutputGuard({ stdout, stderr })
+
+            stdout.write('hello')
+            stderr.write('hello')
+            await flushMicrotasksAndTicks()
+        } finally {
+            process.removeListener('uncaughtException', onUncaught)
+        }
+
+        expect(escaped).toEqual([])
+    })
+
+    it('swallows an EIO raised by a real write() without it escaping as an uncaughtException', async () => {
+        const escaped: unknown[] = []
+        const onUncaught = (error: unknown) => escaped.push(error)
+        process.once('uncaughtException', onUncaught)
+
+        try {
+            const stdout = createErroringWritable(Object.assign(new Error('io error'), { code: 'EIO' }))
+            installTerminalOutputGuard({ stdout, stderr: createErroringWritable(Object.assign(new Error('io error'), { code: 'EIO' })) })
+
+            stdout.write('hello')
+            await flushMicrotasksAndTicks()
+        } finally {
+            process.removeListener('uncaughtException', onUncaught)
+        }
+
+        expect(escaped).toEqual([])
+    })
+
+    it('logs (but does not throw or escape) unexpected stream error codes from a real write()', async () => {
+        const escaped: unknown[] = []
+        const onUncaught = (error: unknown) => escaped.push(error)
+        process.once('uncaughtException', onUncaught)
+
+        try {
+            const weirdError = Object.assign(new Error('weird'), { code: 'ENOTCONN' })
+            const stdout = createErroringWritable(weirdError)
+            installTerminalOutputGuard({ stdout, stderr: createErroringWritable(weirdError) })
+
+            stdout.write('hello')
+            await flushMicrotasksAndTicks()
+        } finally {
+            process.removeListener('uncaughtException', onUncaught)
+        }
+
+        expect(escaped).toEqual([])
+        expect(logger.debug).toHaveBeenCalledWith(
+            expect.stringContaining('unexpected stdout stream error'),
+            expect.objectContaining({ code: 'ENOTCONN' })
+        )
+    })
+
+    it('guards the stdin stream when provided, swallowing its errors the same way as stdout/stderr', async () => {
+        const escaped: unknown[] = []
+        const onUncaught = (error: unknown) => escaped.push(error)
+        process.once('uncaughtException', onUncaught)
+
+        try {
+            const stdin = createErroringWritable(Object.assign(new Error('broken pipe'), { code: 'EPIPE' }))
+            installTerminalOutputGuard({
+                stdout: createErroringWritable(Object.assign(new Error('broken pipe'), { code: 'EPIPE' })),
+                stderr: createErroringWritable(Object.assign(new Error('broken pipe'), { code: 'EPIPE' })),
+                stdin
+            })
+
+            stdin.write('hello')
+            await flushMicrotasksAndTicks()
+        } finally {
+            process.removeListener('uncaughtException', onUncaught)
+        }
+
+        expect(escaped).toEqual([])
+    })
+
+    it('logs (but does not throw or escape) an unexpected stdin stream error code', async () => {
+        const escaped: unknown[] = []
+        const onUncaught = (error: unknown) => escaped.push(error)
+        process.once('uncaughtException', onUncaught)
+
+        try {
+            const weirdError = Object.assign(new Error('weird'), { code: 'ENOTCONN' })
+            const stdin = createErroringWritable(weirdError)
+            installTerminalOutputGuard({
+                stdout: createErroringWritable(weirdError),
+                stderr: createErroringWritable(weirdError),
+                stdin
+            })
+
+            stdin.write('hello')
+            await flushMicrotasksAndTicks()
+        } finally {
+            process.removeListener('uncaughtException', onUncaught)
+        }
+
+        expect(escaped).toEqual([])
+        expect(logger.debug).toHaveBeenCalledWith(
+            expect.stringContaining('unexpected stdin stream error'),
+            expect.objectContaining({ code: 'ENOTCONN' })
+        )
+    })
+
+    it('does not double-attach a stdin error listener when installTerminalOutputGuard is called twice with the same explicit streams (idempotent against repeated calls)', () => {
+        const stdout = createErroringWritable(new Error('unused'))
+        const stderr = createErroringWritable(new Error('unused'))
+        const stdin = createErroringWritable(new Error('unused'))
+
+        installTerminalOutputGuard({ stdout, stderr, stdin })
+        installTerminalOutputGuard({ stdout, stderr, stdin })
+
+        // Repeated calls with the SAME explicit stream objects must not
+        // stack a second listener per stream — that would double-log (or,
+        // for a listener that isn't idempotent itself, double-react to)
+        // every subsequent stream error.
+        expect(stdout.listeners('error')).toHaveLength(1)
+        expect(stderr.listeners('error')).toHaveLength(1)
+        expect(stdin.listeners('error')).toHaveLength(1)
+    })
+
+    it('is idempotent against real process streams (no duplicate-install crash)', () => {
+        // installTerminalOutputGuard() with no args attaches to the real,
+        // shared process.stdout/stderr — capture the pre-existing listener
+        // set so we can remove exactly what this test adds and leave those
+        // streams as we found them for every other test file sharing this
+        // process.
+        const stdoutListenersBefore = process.stdout.listeners('error')
+        const stderrListenersBefore = process.stderr.listeners('error')
+
+        try {
+            expect(() => {
+                installTerminalOutputGuard()
+                installTerminalOutputGuard()
+            }).not.toThrow()
+        } finally {
+            for (const listener of process.stdout.listeners('error')) {
+                if (!stdoutListenersBefore.includes(listener)) {
+                    process.stdout.removeListener('error', listener as (error: NodeJS.ErrnoException) => void)
+                }
+            }
+            for (const listener of process.stderr.listeners('error')) {
+                if (!stderrListenersBefore.includes(listener)) {
+                    process.stderr.removeListener('error', listener as (error: NodeJS.ErrnoException) => void)
+                }
+            }
+        }
+    })
+})

--- a/cli/src/agent/terminalLossState.test.ts
+++ b/cli/src/agent/terminalLossState.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/ui/logger', () => ({
 import {
     markTerminalLost,
     isTerminalLost,
+    waitForTerminalLoss,
     installTerminalOutputGuard,
     __resetTerminalLossStateForTests
 } from './terminalLossState'
@@ -210,5 +211,69 @@ describe('terminalLossState', () => {
                 }
             }
         }
+    })
+})
+
+// Closes the tiann/hapi#1527 review finding: terminal close sends SIGHUP to
+// the whole foreground process group, but there is no guaranteed ordering
+// between the parent's SIGHUP handler and a child-exit callback that also
+// wants to know whether the terminal is gone. waitForTerminalLoss gives a
+// late-running markTerminalLost() a short window to still win.
+describe('waitForTerminalLoss', () => {
+    beforeEach(() => {
+        __resetTerminalLossStateForTests()
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        // Reset while fake timers are still active so the reset path's own
+        // cleanup (settling any leftover waiter) doesn't depend on real
+        // timers, then restore real timers for the rest of the suite.
+        __resetTerminalLossStateForTests()
+        vi.useRealTimers()
+    })
+
+    it('resolves true immediately when the terminal is already lost', async () => {
+        markTerminalLost()
+
+        const result = await waitForTerminalLoss(100)
+
+        expect(result).toBe(true)
+    })
+
+    it('resolves true as soon as markTerminalLost() fires within the window', async () => {
+        const pending = waitForTerminalLoss(100)
+
+        await vi.advanceTimersByTimeAsync(30)
+        markTerminalLost()
+
+        await expect(pending).resolves.toBe(true)
+    })
+
+    it('resolves false once the timeout elapses with no markTerminalLost() call', async () => {
+        const pending = waitForTerminalLoss(100)
+
+        await vi.advanceTimersByTimeAsync(100)
+
+        await expect(pending).resolves.toBe(false)
+    })
+
+    it('cleans up its timer once settled, leaving no pending timers behind', async () => {
+        const pending = waitForTerminalLoss(100)
+        markTerminalLost()
+        await pending
+
+        // If the timeout timer were not cleared on early settle, this would
+        // still have one pending timer left over.
+        expect(vi.getTimerCount()).toBe(0)
+    })
+
+    it('__resetTerminalLossStateForTests resolves a pending wait as false and clears it', async () => {
+        const pending = waitForTerminalLoss(100)
+
+        __resetTerminalLossStateForTests()
+
+        await expect(pending).resolves.toBe(false)
+        expect(vi.getTimerCount()).toBe(0)
     })
 })

--- a/cli/src/agent/terminalLossState.ts
+++ b/cli/src/agent/terminalLossState.ts
@@ -16,12 +16,61 @@ let outputGuardInstalled = false
 // semantics — it must not be reused here.
 let guardedStreams = new WeakSet<object>()
 
+type PendingTerminalLossWaiter = {
+    resolvePromise: (result: boolean) => void
+    timer: ReturnType<typeof setTimeout>
+}
+
+// Callers that read isTerminalLost() right as the parent's SIGHUP handler
+// and the child-exit callback race each other (see waitForTerminalLoss
+// below) need a way to be woken up the instant markTerminalLost() actually
+// runs, rather than only ever polling a synchronous flag. Kept as a Set
+// (not a single "next waiter") because a caller can invoke
+// waitForTerminalLoss more than once concurrently in theory.
+let pendingWaiters = new Set<PendingTerminalLossWaiter>()
+
+function settleWaiter(waiter: PendingTerminalLossWaiter, result: boolean): void {
+    pendingWaiters.delete(waiter)
+    clearTimeout(waiter.timer)
+    waiter.resolvePromise(result)
+}
+
 export function markTerminalLost(): void {
     terminalLost = true
+    // Wake every caller currently blocked in waitForTerminalLoss instead of
+    // making them ride out their full timeout — this is what lets the
+    // parent's SIGHUP handler win a race against a child-exit callback that
+    // started waiting microseconds earlier.
+    for (const waiter of [...pendingWaiters]) {
+        settleWaiter(waiter, true)
+    }
 }
 
 export function isTerminalLost(): boolean {
     return terminalLost
+}
+
+/**
+ * One-shot wait for markTerminalLost() to fire, used to close the race
+ * between the parent process's SIGHUP handler and a child-exit callback
+ * that both read terminal-loss state around the same instant (terminal
+ * close sends SIGHUP to the whole foreground process group, but there is
+ * no guaranteed ordering between the parent's signal callback and the
+ * child's exit callback). Resolves true immediately if the terminal is
+ * already known lost, true as soon as markTerminalLost() runs while this
+ * call is pending, or false once timeoutMs elapses with no such call.
+ */
+export function waitForTerminalLoss(timeoutMs: number): Promise<boolean> {
+    if (terminalLost) {
+        return Promise.resolve(true)
+    }
+    return new Promise<boolean>((resolvePromise) => {
+        const waiter: PendingTerminalLossWaiter = {
+            resolvePromise,
+            timer: setTimeout(() => settleWaiter(waiter, false), timeoutMs)
+        }
+        pendingWaiters.add(waiter)
+    })
 }
 
 /**
@@ -32,6 +81,13 @@ export function __resetTerminalLossStateForTests(): void {
     terminalLost = false
     outputGuardInstalled = false
     guardedStreams = new WeakSet<object>()
+    // Resolve rather than drop any waiter left over from a prior test —
+    // otherwise its timer keeps the event loop alive into the next test and
+    // its promise never settles.
+    for (const waiter of [...pendingWaiters]) {
+        settleWaiter(waiter, false)
+    }
+    pendingWaiters = new Set()
 }
 
 type WritableErrorStream = {

--- a/cli/src/agent/terminalLossState.ts
+++ b/cli/src/agent/terminalLossState.ts
@@ -1,0 +1,90 @@
+import { logger } from '@/ui/logger'
+
+// Process-global flag. One hapi (claude flavor)
+// process controls exactly one controlling terminal, so a module singleton is
+// sufficient — no need to thread this through Session/loop constructors.
+// Set once by the SIGHUP handler in runnerLifecycle.ts and never cleared:
+// once the terminal is gone for this process it is gone for good.
+let terminalLost = false
+let outputGuardInstalled = false
+// Tracks which explicit stream objects already have the guard attached, so
+// repeated installTerminalOutputGuard({ stdout, stderr, ... }) calls with the
+// same stream objects (e.g. re-entrant SIGHUP handling, or a caller that
+// installs the guard defensively before every use) don't stack a second
+// 'error' listener per stream. `outputGuardInstalled` above only covers the
+// implicit (no-args, real process.stdout/stderr) case and has different
+// semantics — it must not be reused here.
+let guardedStreams = new WeakSet<object>()
+
+export function markTerminalLost(): void {
+    terminalLost = true
+}
+
+export function isTerminalLost(): boolean {
+    return terminalLost
+}
+
+/**
+ * Test-only reset. Production code has no legitimate reason to un-set the
+ * flag (a lost terminal never comes back for this process).
+ */
+export function __resetTerminalLossStateForTests(): void {
+    terminalLost = false
+    outputGuardInstalled = false
+    guardedStreams = new WeakSet<object>()
+}
+
+type WritableErrorStream = {
+    on(event: 'error', listener: (error: NodeJS.ErrnoException) => void): unknown
+}
+
+/**
+ * After the controlling terminal disappears (SIGHUP), any write to
+ * stdout/stderr — including from readline/ink components that have not yet
+ * torn down — can raise EPIPE/EIO once the terminal's other end is gone. An
+ * unhandled 'error' event on a stream throws (routed via
+ * uncaughtException, which would archive-and-exit the session), which is
+ * exactly the crash we're trying to survive. Installing a listener here
+ * swallows the expected disconnect errors and logs anything unexpected to
+ * the file logger instead of the (now-gone) terminal.
+ */
+export function installTerminalOutputGuard(streams?: {
+    stdout: WritableErrorStream
+    stderr: WritableErrorStream
+    stdin?: WritableErrorStream
+}): void {
+    if (!streams && outputGuardInstalled) {
+        return
+    }
+    if (!streams) {
+        outputGuardInstalled = true
+    }
+
+    // stdin needs the same guard as stdout/stderr. spawnWithTerminalGuard and
+    // RemoteLauncherBase both
+    // call process.stdin.resume()/setRawMode() against a dead tty once the
+    // terminal is lost; the resulting 'error' event on process.stdin is just
+    // as capable of reaching uncaughtException (→ markCrash → archive+exit)
+    // as an unguarded stdout/stderr write is.
+    const targets = streams ?? { stdout: process.stdout, stderr: process.stderr, stdin: process.stdin }
+
+    const guard = (label: string, stream: WritableErrorStream) => {
+        if (guardedStreams.has(stream)) {
+            return
+        }
+        guardedStreams.add(stream)
+
+        stream.on('error', (error: NodeJS.ErrnoException) => {
+            if (error && (error.code === 'EPIPE' || error.code === 'EIO')) {
+                return
+            }
+            logger.debug(`[terminalLoss] unexpected ${label} stream error`, error)
+        })
+    }
+
+    guard('stdout', targets.stdout)
+    guard('stderr', targets.stderr)
+    if (targets.stdin) {
+        guard('stdin', targets.stdin)
+    }
+}

--- a/cli/src/claude/__fixtures__/claudeLocalLauncherRaceGrandchild.ts
+++ b/cli/src/claude/__fixtures__/claudeLocalLauncherRaceGrandchild.ts
@@ -1,0 +1,19 @@
+// Standalone process used as the "claude" local child in
+// claudeLocalLauncher.childExitsFirst.process.test.ts.
+//
+// Exits (code 0, signal null — the same "child observed the closed PTY and
+// exited gracefully" shape a real claude process can take, see the clean-exit
+// branch in claudeLocalLauncher.ts) as soon as it receives SIGHUP. It
+// deliberately does not rely on the platform's default terminate-on-SIGHUP
+// disposition, so the parent test harness can control exactly when this
+// process exits relative to the "parent" fixture's own SIGHUP.
+import fs from 'node:fs'
+
+process.on('SIGHUP', () => {
+    process.exit(0)
+})
+
+fs.writeSync(1, 'READY\n')
+
+// Keep the event loop alive until SIGHUP arrives.
+setInterval(() => {}, 1000)

--- a/cli/src/claude/__fixtures__/claudeLocalLauncherRaceParent.ts
+++ b/cli/src/claude/__fixtures__/claudeLocalLauncherRaceParent.ts
@@ -1,0 +1,52 @@
+// Standalone process for claudeLocalLauncher.childExitsFirst.process.test.ts.
+//
+// Models the exact ordering hazard from the automated review's Major
+// finding on tiann/hapi#1527: terminal close delivers SIGHUP to the whole
+// foreground process group (this "parent" process and its "claude" child)
+// at once, with no guaranteed ordering between the parent's own SIGHUP
+// callback and the child's exit callback. A same-process
+// `process.emit('SIGHUP')` unit test cannot prove anything about that
+// ordering — it needs two real, independently signalled OS processes,
+// which is what this fixture plus its harness in the test file provide.
+//
+// This process spawns a real "claude" child
+// (claudeLocalLauncherRaceGrandchild.ts), registers a SIGHUP handler that
+// calls the real markTerminalLost() — the same call runnerLifecycle's
+// production SIGHUP handler makes — and once the child exits, runs the
+// exact classification claudeLocalLauncher.ts uses on a clean child exit:
+// isTerminalLost() || await waitForTerminalLoss(100).
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawn } from 'node:child_process'
+import { isTerminalLost, waitForTerminalLoss, markTerminalLost } from '../../agent/terminalLossState'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const GRANDCHILD_SCRIPT = path.join(__dirname, 'claudeLocalLauncherRaceGrandchild.ts')
+
+process.on('SIGHUP', () => {
+    markTerminalLost()
+})
+
+const child = spawn('bun', ['run', GRANDCHILD_SCRIPT], {
+    stdio: ['ignore', 'pipe', 'ignore']
+})
+
+fs.writeSync(1, `GRANDCHILD_PID ${child.pid}\n`)
+
+child.stdout.on('data', (chunk: Buffer) => {
+    if (chunk.toString('utf8').includes('READY')) {
+        fs.writeSync(1, 'READY\n')
+    }
+})
+
+child.on('exit', () => {
+    void (async () => {
+        // Same classification claudeLocalLauncher.ts performs on a clean
+        // local-child exit — reads the flag synchronously first, then falls
+        // back to the short wait so a not-yet-delivered parent SIGHUP still
+        // gets a chance to land before this exit is classified.
+        const isSwitch = isTerminalLost() || await waitForTerminalLoss(100)
+        fs.writeSync(1, `CLASSIFICATION ${isSwitch ? 'switch' : 'exit'}\n`)
+    })()
+})

--- a/cli/src/claude/claudeLocalLauncher.childExitsFirst.process.test.ts
+++ b/cli/src/claude/claudeLocalLauncher.childExitsFirst.process.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawn, type ChildProcessByStdio } from 'node:child_process'
+import type { Readable } from 'node:stream'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+type SpawnedChild = ChildProcessByStdio<null, Readable, Readable>
+
+// Addresses the Major finding from the automated review on this PR: terminal
+// close sends SIGHUP to the whole foreground process group, but there is no
+// guaranteed ordering between the parent's SIGHUP callback and the local
+// claude child's exit callback — both of which want to know whether the
+// terminal is gone. If the child's exit callback runs first and only reads
+// the synchronous isTerminalLost() flag, it can classify the exit as a
+// genuine user /exit and end the session instead of switching to remote.
+//
+// This suite proves the fix closes that race using two real, independently
+// signalled OS processes (a same-process `process.emit('SIGHUP')` test only
+// proves a listener ran, not that it wins or loses a real ordering race):
+// the "grandchild" plays the local claude process, the "parent" fixture
+// plays claudeLocalLauncher's classification logic. The child is made to
+// exit first; the parent's own SIGHUP is delivered only after that, still
+// inside the wait window.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const PARENT_SCRIPT = path.join(__dirname, '__fixtures__/claudeLocalLauncherRaceParent.ts')
+
+function waitForLine(
+    child: SpawnedChild,
+    predicate: (line: string) => boolean,
+    timeoutMs = 5000
+): Promise<string> {
+    return new Promise((resolve, reject) => {
+        let buffer = ''
+        const timer = setTimeout(() => {
+            reject(new Error(`Timed out waiting for line matching predicate. Output so far:\n${buffer}`))
+        }, timeoutMs)
+        const onData = (chunk: Buffer) => {
+            buffer += chunk.toString('utf8')
+            const lines = buffer.split('\n')
+            for (const line of lines) {
+                if (predicate(line)) {
+                    clearTimeout(timer)
+                    child.stdout.off('data', onData)
+                    resolve(line)
+                    return
+                }
+            }
+        }
+        child.stdout.on('data', onData)
+    })
+}
+
+function isAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0)
+        return true
+    } catch {
+        return false
+    }
+}
+
+// POSIX-only, same rationale as runnerLifecycle.process.test.ts: the SIGHUP
+// survival/ordering contract under test only holds on POSIX hosts (upstream
+// CI runs ubuntu).
+describe.skipIf(process.platform === 'win32')('claudeLocalLauncher child-exits-first SIGHUP ordering (integration)', { timeout: 15_000 }, () => {
+    let parent: SpawnedChild | null = null
+
+    afterEach(() => {
+        if (parent && parent.pid && isAlive(parent.pid)) {
+            parent.kill('SIGKILL')
+        }
+        parent = null
+    })
+
+    it('child dies first, parent SIGHUP lands within the wait window: classification is switch', async () => {
+        const proc = spawn('bun', ['run', PARENT_SCRIPT], {
+            stdio: ['ignore', 'pipe', 'pipe']
+        })
+        parent = proc
+        const parentPid = proc.pid
+        expect(parentPid).toBeDefined()
+
+        let stderr = ''
+        proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8') })
+
+        const pidLine = await waitForLine(proc, (line) => line.startsWith('GRANDCHILD_PID '))
+        const grandchildPid = Number(pidLine.replace('GRANDCHILD_PID ', '').trim())
+        expect(grandchildPid).toBeGreaterThan(0)
+
+        await waitForLine(proc, (line) => line.trim() === 'READY')
+
+        // Child exits first...
+        process.kill(grandchildPid, 'SIGHUP')
+        // ...and the parent's own SIGHUP — the signal that calls the real
+        // markTerminalLost() — is only delivered afterwards, but still well
+        // inside the 100ms wait window claudeLocalLauncher.ts gives it.
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        process.kill(parentPid!, 'SIGHUP')
+
+        const classification = await waitForLine(proc, (line) => line.startsWith('CLASSIFICATION '))
+        expect(classification.trim()).toBe('CLASSIFICATION switch')
+        expect(stderr).not.toMatch(/uncaught|unhandled|panic|segmentation fault/i)
+    })
+
+    it('child dies first, no parent SIGHUP ever arrives: classification falls back to exit after the window (control)', async () => {
+        const proc = spawn('bun', ['run', PARENT_SCRIPT], {
+            stdio: ['ignore', 'pipe', 'pipe']
+        })
+        parent = proc
+        const parentPid = proc.pid
+        expect(parentPid).toBeDefined()
+
+        const pidLine = await waitForLine(proc, (line) => line.startsWith('GRANDCHILD_PID '))
+        const grandchildPid = Number(pidLine.replace('GRANDCHILD_PID ', '').trim())
+        expect(grandchildPid).toBeGreaterThan(0)
+
+        await waitForLine(proc, (line) => line.trim() === 'READY')
+
+        process.kill(grandchildPid, 'SIGHUP')
+        // Deliberately never signal the parent — this is the control that
+        // proves the "switch" result above is actually caused by the
+        // parent's (delayed) SIGHUP landing in time, not by
+        // waitForTerminalLoss always resolving true regardless of timing.
+
+        const classification = await waitForLine(proc, (line) => line.startsWith('CLASSIFICATION '), 5000)
+        expect(classification.trim()).toBe('CLASSIFICATION exit')
+        expect(isAlive(parentPid!)).toBe(true)
+    })
+})

--- a/cli/src/claude/claudeLocalLauncher.terminalLost.test.ts
+++ b/cli/src/claude/claudeLocalLauncher.terminalLost.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Metadata } from '@/api/types'
+import { markTerminalLost, __resetTerminalLossStateForTests } from '@/agent/terminalLossState'
+
+// Once the terminal is lost (SIGHUP), the local child's exit-handling path
+// needs to treat abnormal death as a trigger for switching to remote mode —
+// while still distinguishing the death cause: a SIGHUP-correlated death
+// should switch, but the user exiting claude normally (e.g. /exit) should
+// still end the session. This suite exercises the real BaseLocalLauncher
+// (not mocked) so the exit-reason contract itself is covered, not just that
+// claudeLocalLauncher calls some mock.
+//
+// Judgment rule: terminalLost already being set AT THE MOMENT the local
+// child exits is the sole signal for
+// "switch to remote" — independent of exit code/signal. A real claude child
+// can exit gracefully (code=0, no signal) when its PTY disappears, so "clean
+// resolve = user typed /exit" is not a safe inference once the terminal is
+// known gone. Only when terminalLost is NOT set does a clean exit mean a
+// genuine user /exit.
+
+const harness = vi.hoisted(() => ({
+    claudeLocalImpl: async (_opts: Record<string, unknown>): Promise<void> => {}
+}))
+
+vi.mock('./claudeLocal', () => ({
+    claudeLocal: (opts: Record<string, unknown>) => harness.claudeLocalImpl(opts)
+}))
+
+vi.mock('./utils/sessionScanner', () => ({
+    createSessionScanner: async () => ({
+        cleanup: async () => {},
+        onNewSession: () => {}
+    })
+}))
+
+vi.mock('@/ui/logger', () => ({
+    logger: { debug: vi.fn(), warn: vi.fn() }
+}))
+
+import { claudeLocalLauncher } from './claudeLocalLauncher'
+
+function createSessionStub(overrides?: { startedBy?: 'terminal' | 'runner'; startingMode?: 'local' | 'remote' }) {
+    let metadata: Metadata = { path: '/tmp/test', host: 'localhost' }
+    return {
+        sessionId: 'test-session',
+        path: '/tmp/test',
+        startedBy: overrides?.startedBy ?? 'terminal',
+        startingMode: overrides?.startingMode ?? 'local',
+        claudeEnvVars: {},
+        claudeArgs: [] as string[],
+        getModel: () => undefined,
+        mcpServers: {},
+        allowedTools: [],
+        hookSettingsPath: 'settings.json',
+        localHookSettingsPath: 'settings.json',
+        queue: { size: () => 0, reset: () => {}, setOnMessage: () => {} },
+        client: {
+            sendClaudeSessionMessage: () => {},
+            sendSessionEvent: () => {},
+            updateMetadata: (handler: (current: Metadata) => Metadata) => {
+                metadata = handler(metadata)
+            },
+            rpcHandlerManager: { registerHandler: () => {} }
+        },
+        addSessionFoundCallback: () => {},
+        removeSessionFoundCallback: () => {},
+        consumeOneTimeFlags: vi.fn(),
+        recordLocalLaunchFailure: vi.fn()
+    }
+}
+
+describe('claudeLocalLauncher terminal-loss local→remote switch', () => {
+    beforeEach(() => {
+        __resetTerminalLossStateForTests()
+    })
+
+    afterEach(() => {
+        __resetTerminalLossStateForTests()
+    })
+
+    it('a plain terminal-started local session still ends the session on normal claude exit (baseline, unaffected)', async () => {
+        harness.claudeLocalImpl = async () => {}
+        const session = createSessionStub()
+
+        const result = await claudeLocalLauncher(session as never)
+
+        expect(result).toBe('exit')
+    })
+
+    it('abnormal local-child death after terminalLost switches to remote instead of ending the session', async () => {
+        markTerminalLost()
+        harness.claudeLocalImpl = async () => {
+            throw new Error('Process terminated with signal: SIGHUP')
+        }
+        const session = createSessionStub()
+
+        const result = await claudeLocalLauncher(session as never)
+
+        expect(result).toBe('switch')
+        // Not surfaced as a launch failure — this is a controlled handoff,
+        // not a crash.
+        expect(session.recordLocalLaunchFailure).not.toHaveBeenCalled()
+        // A terminal-loss switch must consume one-time flags exactly like
+        // any other local→remote switch (RPC-triggered doSwitch, or a
+        // queued message triggering doSwitch in BaseLocalLauncher) — those
+        // paths call session.consumeOneTimeFlags() unconditionally once the
+        // in-flight launch resolves. Skipping it only for the terminal-loss
+        // path would leave one-time flags (most importantly --fork-session)
+        // still armed, so the remote relaunch this switch leads into could
+        // re-consume them and re-fork a session that was already forked.
+        expect(session.consumeOneTimeFlags).toHaveBeenCalled()
+    })
+
+    it('abnormal local-child death after terminalLost switches even for a plain terminal/local session (would otherwise "exit")', async () => {
+        markTerminalLost()
+        harness.claudeLocalImpl = async () => {
+            throw new Error('Process exited with code: 1')
+        }
+        const session = createSessionStub({ startedBy: 'terminal', startingMode: 'local' })
+
+        const result = await claudeLocalLauncher(session as never)
+
+        expect(result).toBe('switch')
+    })
+
+    it('terminalLost + a clean code=0 child exit switches to remote, does not end the session', async () => {
+        // Actual claude reacts to the PTY going away by exiting gracefully
+        // with code=0/signal=null (not a signal kill) — so claudeLocal()
+        // resolves without throwing, same shape as a real `/exit`. Once
+        // terminalLost is set, the terminal is gone and no user could have
+        // typed /exit, so ANY child exit at that point — clean resolve or
+        // thrown signal/non-zero — must be read as "terminal died out from
+        // under the child" and redirected to remote, never as session end.
+        // A same-tick race (user types /exit right as the terminal dies) is
+        // resolved in favor of the safer side: keep the session alive.
+        markTerminalLost()
+        harness.claudeLocalImpl = async () => {}
+        const session = createSessionStub()
+
+        const result = await claudeLocalLauncher(session as never)
+
+        expect(result).toBe('switch')
+        // Same invariant as the abnormal-death case above: this switch must
+        // consume one-time flags exactly like any other local→remote
+        // switch, or the remote relaunch could re-consume them.
+        expect(session.consumeOneTimeFlags).toHaveBeenCalled()
+        expect(session.recordLocalLaunchFailure).not.toHaveBeenCalled()
+    })
+
+    it('without terminalLost, an abnormal local-child death for a terminal/local session still ends the session (unrelated crash)', async () => {
+        harness.claudeLocalImpl = async () => {
+            throw new Error('Process terminated with signal: SIGKILL')
+        }
+        const session = createSessionStub({ startedBy: 'terminal', startingMode: 'local' })
+
+        const result = await claudeLocalLauncher(session as never)
+
+        expect(result).toBe('exit')
+        expect(session.recordLocalLaunchFailure).toHaveBeenCalled()
+    })
+
+    it('without terminalLost, a runner-started session still switches on abnormal death (pre-existing behavior preserved)', async () => {
+        harness.claudeLocalImpl = async () => {
+            throw new Error('Process terminated with signal: SIGTERM')
+        }
+        const session = createSessionStub({ startedBy: 'runner', startingMode: 'remote' })
+
+        const result = await claudeLocalLauncher(session as never)
+
+        expect(result).toBe('switch')
+    })
+
+    it('a terminal-loss switch consumes --fork-session so the remote relaunch does not re-fork', async () => {
+        // Regression guard against "consumeOneTimeFlags is skipped on
+        // terminal-loss switch" coming back: if that flag survives the switch,
+        // the remote relaunch that follows would see --fork-session still
+        // present in claudeArgs and branch off the already-forked native
+        // session id a second time.
+        markTerminalLost()
+        harness.claudeLocalImpl = async () => {
+            throw new Error('Process terminated with signal: SIGHUP')
+        }
+        const session = createSessionStub()
+        session.claudeArgs = ['--fork-session']
+        session.consumeOneTimeFlags = vi.fn(() => {
+            session.claudeArgs = session.claudeArgs.filter((arg: string) => arg !== '--fork-session')
+        })
+
+        const result = await claudeLocalLauncher(session as never)
+
+        expect(result).toBe('switch')
+        expect(session.consumeOneTimeFlags).toHaveBeenCalled()
+        expect(session.claudeArgs).not.toContain('--fork-session')
+    })
+})

--- a/cli/src/claude/claudeLocalLauncher.ts
+++ b/cli/src/claude/claudeLocalLauncher.ts
@@ -3,7 +3,10 @@ import { Session } from "./session";
 import { createSessionScanner } from "./utils/sessionScanner";
 import { isClaudeChatVisibleMessage } from "./utils/chatVisibility";
 import { BaseLocalLauncher } from "@/modules/common/launcher/BaseLocalLauncher";
+import type { LocalLauncherControl } from "@/modules/common/launcher/BaseLocalLauncher";
 import { applySessionTitleFallback } from './utils/sessionTitleFallback';
+import { isTerminalLost } from '@/agent/terminalLossState';
+import { logger } from '@/ui/logger';
 
 export async function claudeLocalLauncher(session: Session): Promise<'switch' | 'exit'> {
 
@@ -44,6 +47,18 @@ export async function claudeLocalLauncher(session: Session): Promise<'switch' | 
     session.addSessionFoundCallback(handleSessionFound);
 
 
+    // Assigned right after `new BaseLocalLauncher(...)` below,
+    // before `launcher.run()` is ever invoked — `launch` only runs inside
+    // `run()`, so by the time this closure executes, `control` is set.
+    let control: LocalLauncherControl | null = null;
+
+    const requestSwitch = () => {
+        if (!control) {
+            throw new Error('[claudeLocalLauncher] requestSwitch called before control was assigned');
+        }
+        control.requestSwitch();
+    };
+
     const launcher = new BaseLocalLauncher({
         label: 'local',
         failureLabel: 'Local Claude process failed',
@@ -52,17 +67,53 @@ export async function claudeLocalLauncher(session: Session): Promise<'switch' | 
         startedBy: session.startedBy,
         startingMode: session.startingMode,
         launch: async (abortSignal) => {
-            await claudeLocal({
-                path: session.path,
-                sessionId: session.sessionId,
-                abort: abortSignal,
-                claudeEnvVars: session.claudeEnvVars,
-                claudeArgs: session.claudeArgs,
-                model: session.getModel(),
-                mcpServers: session.mcpServers,
-                allowedTools: session.allowedTools,
-                hookSettingsPath: session.localHookSettingsPath,
-            });
+            try {
+                await claudeLocal({
+                    path: session.path,
+                    sessionId: session.sessionId,
+                    abort: abortSignal,
+                    claudeEnvVars: session.claudeEnvVars,
+                    claudeArgs: session.claudeArgs,
+                    model: session.getModel(),
+                    mcpServers: session.mcpServers,
+                    allowedTools: session.allowedTools,
+                    hookSettingsPath: session.localHookSettingsPath,
+                });
+            } catch (error) {
+                // The controlling terminal is gone (SIGHUP already fired):
+                // there is no user left who could have typed /exit, so any
+                // abnormal local-child death (signal kill / non-zero exit)
+                // means "terminal died out from under the child", not
+                // "session over". Redirect into the existing local→remote
+                // switch path instead of surfacing a failure and ending the
+                // session. Known edge: claude mid-generation loses the
+                // current unsaved turn; the session resumes from the last
+                // save point via --resume, same as any other local→remote
+                // handoff.
+                if (isTerminalLost()) {
+                    logger.debug('[claudeLocalLauncher] Local claude died after terminal loss — switching to remote', error);
+                    requestSwitch();
+                    return;
+                }
+                throw error;
+            }
+            // A real claude child does NOT always die by signal when its
+            // PTY disappears — it can observe the closed terminal and exit
+            // gracefully with code=0/signal=null, which is exactly the
+            // shape spawnWithAbort resolves (not throws) for. So a clean
+            // claudeLocal() resolve is NOT sufficient evidence of "user
+            // typed /exit": once terminalLost was already set at the moment
+            // the child exited, the terminal is gone and no user could have
+            // typed anything — redirect to the same local→remote switch
+            // path as the abnormal case above, rather than ending the
+            // session. (A same-tick race where the user's own /exit lands
+            // right as the terminal dies is resolved in favor of the safer
+            // side: keep the session alive rather than silently end it.)
+            if (isTerminalLost()) {
+                logger.debug('[claudeLocalLauncher] Local claude exited cleanly after terminal loss — switching to remote');
+                requestSwitch();
+                return;
+            }
         },
         onLaunchSuccess: () => {
             session.consumeOneTimeFlags();
@@ -76,6 +127,7 @@ export async function claudeLocalLauncher(session: Session): Promise<'switch' | 
         abortLogMessage: 'doAbort',
         switchLogMessage: 'doSwitch'
     });
+    control = launcher.control;
     try {
         return await launcher.run();
     } finally {

--- a/cli/src/claude/claudeLocalLauncher.ts
+++ b/cli/src/claude/claudeLocalLauncher.ts
@@ -5,7 +5,7 @@ import { isClaudeChatVisibleMessage } from "./utils/chatVisibility";
 import { BaseLocalLauncher } from "@/modules/common/launcher/BaseLocalLauncher";
 import type { LocalLauncherControl } from "@/modules/common/launcher/BaseLocalLauncher";
 import { applySessionTitleFallback } from './utils/sessionTitleFallback';
-import { isTerminalLost } from '@/agent/terminalLossState';
+import { isTerminalLost, waitForTerminalLoss } from '@/agent/terminalLossState';
 import { logger } from '@/ui/logger';
 
 export async function claudeLocalLauncher(session: Session): Promise<'switch' | 'exit'> {
@@ -90,7 +90,20 @@ export async function claudeLocalLauncher(session: Session): Promise<'switch' | 
                 // current unsaved turn; the session resumes from the last
                 // save point via --resume, same as any other local→remote
                 // handoff.
-                if (isTerminalLost()) {
+                //
+                // isTerminalLost() alone is a synchronous read of a flag set
+                // by the parent's SIGHUP handler — but SIGHUP hits the whole
+                // foreground process group at once, so there is no
+                // guaranteed ordering between that handler running and this
+                // child-exit callback running. If the child's exit callback
+                // wins the race, isTerminalLost() reads false even though
+                // the terminal is in fact already gone. Falling back to
+                // waitForTerminalLoss briefly closes that race by giving the
+                // SIGHUP handler a short window to run and mark the flag
+                // before we commit to a classification. Accepted tradeoff:
+                // every abnormal local-child death now carries up to 100ms
+                // of added latency before it is classified.
+                if (isTerminalLost() || await waitForTerminalLoss(100)) {
                     logger.debug('[claudeLocalLauncher] Local claude died after terminal loss — switching to remote', error);
                     requestSwitch();
                     return;
@@ -109,7 +122,15 @@ export async function claudeLocalLauncher(session: Session): Promise<'switch' | 
             // session. (A same-tick race where the user's own /exit lands
             // right as the terminal dies is resolved in favor of the safer
             // side: keep the session alive rather than silently end it.)
-            if (isTerminalLost()) {
+            //
+            // Same ordering caveat as the catch branch above applies here:
+            // a clean exit callback can win the race against the parent's
+            // SIGHUP handler, so isTerminalLost() alone is not conclusive.
+            // waitForTerminalLoss gives the handler a short window to catch
+            // up before this exit is classified as a genuine user /exit.
+            // Accepted tradeoff: every clean local-child exit now carries up
+            // to 100ms of added latency before it is classified.
+            if (isTerminalLost() || await waitForTerminalLoss(100)) {
                 logger.debug('[claudeLocalLauncher] Local claude exited cleanly after terminal loss — switching to remote');
                 requestSwitch();
                 return;

--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -229,7 +229,7 @@ export async function runClaude(options: StartOptions = {}): Promise<void> {
         }
     });
 
-    lifecycle.registerProcessHandlers();
+    lifecycle.registerProcessHandlers({ surviveTerminalHangup: true });
     registerKillSessionHandler(session.rpcHandlerManager, lifecycle);
     registerLocalHandoffHandler(session.rpcHandlerManager, lifecycle);
 

--- a/cli/src/modules/common/remote/RemoteLauncherBase.test.ts
+++ b/cli/src/modules/common/remote/RemoteLauncherBase.test.ts
@@ -1,6 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ReactElement } from 'react'
 import { RemoteLauncherBase, type LaunchOutcome } from './RemoteLauncherBase'
+import { markTerminalLost, __resetTerminalLossStateForTests } from '@/agent/terminalLossState'
+
+const inkHarness = vi.hoisted(() => ({ renderCalls: 0 }))
+
+vi.mock('ink', () => ({
+    render: vi.fn(() => {
+        inkHarness.renderCalls++
+        return { unmount: () => {} }
+    })
+}))
+
+vi.mock('@/ui/terminalState', () => ({
+    restoreTerminalState: vi.fn()
+}))
 
 // Concrete subclass that exposes the protected respawn loop so the real
 // template-method logic (backoff, give-up bound, counter reset) can be driven
@@ -22,6 +36,16 @@ class TestLauncher extends RemoteLauncherBase {
     // Stop the `while (!this.exitReason)` loop from outside the scripted outcomes.
     public stop(): void {
         this.exitReason = 'exit'
+    }
+
+    public getHasTTY(): boolean {
+        return this.hasTTY
+    }
+    public runSetupTerminal(handlers: Parameters<RemoteLauncherBase['setupTerminal']>[0]): void {
+        this.setupTerminal(handlers)
+    }
+    public runFinalizeTerminal(): void {
+        this.finalizeTerminal()
     }
 }
 
@@ -144,5 +168,117 @@ describe('RemoteLauncherBase.runRespawnLoop', () => {
         })
 
         expect(consumedBy).toEqual([2])
+    })
+})
+
+// Once the controlling terminal is gone (terminalLost, set by the SIGHUP
+// handler), a RemoteLauncherBase
+// entered afterwards must not act as if it still owns a TTY — even though
+// process.stdout.isTTY / process.stdin.isTTY on the (now slave-side-dead)
+// fd can still read `true` at this point. ClaudeRemoteLauncher constructs a
+// fresh launcher on every local→remote switch, so this is exactly the path
+// hit by the SIGHUP-triggered switch.
+describe('RemoteLauncherBase TTY gating after terminal loss', () => {
+    const originalStdoutIsTTY = process.stdout.isTTY
+    const originalStdinIsTTY = process.stdin.isTTY
+    const originalSetRawMode = (process.stdin as unknown as { setRawMode?: (mode: boolean) => void }).setRawMode
+
+    afterEach(() => {
+        __resetTerminalLossStateForTests()
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: originalStdoutIsTTY })
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: originalStdinIsTTY })
+        if (originalSetRawMode) {
+            Object.defineProperty(process.stdin, 'setRawMode', { configurable: true, value: originalSetRawMode })
+        } else {
+            delete (process.stdin as unknown as { setRawMode?: unknown }).setRawMode
+        }
+        vi.restoreAllMocks()
+        inkHarness.renderCalls = 0
+    })
+
+    it('still treats a live terminal as hasTTY when terminalLost is not set (baseline)', () => {
+        __resetTerminalLossStateForTests()
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true })
+
+        const launcher = new TestLauncher()
+
+        expect(launcher.getHasTTY()).toBe(true)
+    })
+
+    it('reports hasTTY=false once terminalLost is set, even though the fd still reads isTTY=true', () => {
+        __resetTerminalLossStateForTests()
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true })
+        markTerminalLost()
+
+        const launcher = new TestLauncher()
+
+        expect(launcher.getHasTTY()).toBe(false)
+    })
+
+    it('setupTerminal() does not clear the screen, render ink, or touch stdin raw mode once terminalLost is set', () => {
+        __resetTerminalLossStateForTests()
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true })
+        const setRawModeStub = vi.fn()
+        Object.defineProperty(process.stdin, 'setRawMode', { configurable: true, value: setRawModeStub })
+        const resumeSpy = vi.spyOn(process.stdin, 'resume').mockImplementation(() => process.stdin)
+        const clearSpy = vi.spyOn(console, 'clear').mockImplementation(() => {})
+        markTerminalLost()
+
+        const launcher = new TestLauncher()
+        launcher.runSetupTerminal({ onExit: async () => {}, onSwitchToLocal: async () => {} })
+
+        expect(clearSpy).not.toHaveBeenCalled()
+        expect(inkHarness.renderCalls).toBe(0)
+        expect(resumeSpy).not.toHaveBeenCalled()
+        expect(setRawModeStub).not.toHaveBeenCalled()
+    })
+
+    it('finalizeTerminal() does not pause stdin once terminalLost is set (no live terminal to restore)', () => {
+        __resetTerminalLossStateForTests()
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true })
+        const pauseSpy = vi.spyOn(process.stdin, 'pause').mockImplementation(() => process.stdin)
+        markTerminalLost()
+
+        const launcher = new TestLauncher()
+        launcher.runFinalizeTerminal()
+
+        expect(pauseSpy).not.toHaveBeenCalled()
+    })
+
+    // The two tests above only cover terminalLost being set BEFORE the
+    // launcher is constructed. In production a launcher instance is
+    // long-lived across the SIGHUP event: it is constructed while the
+    // terminal is still alive, and only later — mid-lifetime, from the
+    // SIGHUP handler — does the terminal go away. If hasTTY is computed
+    // once in the constructor and never revisited, a launcher built before
+    // SIGHUP keeps acting as if it still has a live terminal for the rest
+    // of its life, even after markTerminalLost() flips.
+    it('short-circuits console.clear/ink render/setRawMode once terminalLost flips AFTER construction (hasTTY must be re-evaluated live, not cached at construction time)', () => {
+        __resetTerminalLossStateForTests()
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true })
+        const setRawModeStub = vi.fn()
+        Object.defineProperty(process.stdin, 'setRawMode', { configurable: true, value: setRawModeStub })
+        const resumeSpy = vi.spyOn(process.stdin, 'resume').mockImplementation(() => process.stdin)
+        const clearSpy = vi.spyOn(console, 'clear').mockImplementation(() => {})
+
+        // Constructed while the terminal is still alive.
+        const launcher = new TestLauncher()
+        expect(launcher.getHasTTY()).toBe(true)
+
+        // The terminal disappears sometime later, mid-lifetime — this is
+        // what the SIGHUP handler does to an already-running launcher.
+        markTerminalLost()
+
+        launcher.runSetupTerminal({ onExit: async () => {}, onSwitchToLocal: async () => {} })
+
+        expect(clearSpy).not.toHaveBeenCalled()
+        expect(inkHarness.renderCalls).toBe(0)
+        expect(resumeSpy).not.toHaveBeenCalled()
+        expect(setRawModeStub).not.toHaveBeenCalled()
     })
 })

--- a/cli/src/modules/common/remote/RemoteLauncherBase.ts
+++ b/cli/src/modules/common/remote/RemoteLauncherBase.ts
@@ -2,6 +2,7 @@ import { render } from 'ink';
 import type { ReactElement } from 'react';
 import { MessageBuffer } from '@/ui/ink/messageBuffer';
 import { restoreTerminalState } from '@/ui/terminalState';
+import { isTerminalLost } from '@/agent/terminalLossState';
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 
 export type RemoteLauncherExitReason = 'switch' | 'exit';
@@ -38,7 +39,6 @@ type RpcHandlerManagerLike = {
 
 export abstract class RemoteLauncherBase {
     protected readonly messageBuffer: MessageBuffer;
-    protected readonly hasTTY: boolean;
     protected readonly logPath?: string;
     protected exitReason: RemoteLauncherExitReason | null = null;
     protected shouldExit: boolean = false;
@@ -47,8 +47,21 @@ export abstract class RemoteLauncherBase {
 
     protected constructor(logPath?: string) {
         this.logPath = logPath;
-        this.hasTTY = Boolean(process.stdout.isTTY && process.stdin.isTTY);
         this.messageBuffer = new MessageBuffer();
+    }
+
+    // A fresh launcher is constructed on every local→remote switch (e.g.
+    // ClaudeRemoteLauncher), but the terminal can also disappear (SIGHUP)
+    // AFTER an existing launcher instance has already been constructed and
+    // is mid-run. Once the controlling terminal is gone, the slave-side fd
+    // can still read isTTY=true even though nothing is reading/writing it
+    // anymore — so this must be evaluated live on every access (not cached
+    // once at construction time), and `isTerminalLost()` must short-circuit
+    // it regardless of what isTTY reports, or setupTerminal()/
+    // finalizeTerminal() below would still console.clear(), ink-render, and
+    // touch raw mode against a dead terminal.
+    protected get hasTTY(): boolean {
+        return Boolean(process.stdout.isTTY && process.stdin.isTTY) && !isTerminalLost();
     }
 
     protected abstract createDisplay(context: RemoteLauncherDisplayContext): ReactElement;

--- a/cli/src/ui/terminalState.test.ts
+++ b/cli/src/ui/terminalState.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { restoreTerminalState } from './terminalState'
+
+describe('restoreTerminalState', () => {
+    const originalStdoutIsTTY = process.stdout.isTTY
+    const originalStdinIsTTY = process.stdin.isTTY
+    const originalSetRawMode = (process.stdin as unknown as { setRawMode?: (mode: boolean) => void }).setRawMode
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: originalStdoutIsTTY })
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: originalStdinIsTTY })
+        if (originalSetRawMode) {
+            Object.defineProperty(process.stdin, 'setRawMode', { configurable: true, value: originalSetRawMode })
+        } else {
+            delete (process.stdin as unknown as { setRawMode?: unknown }).setRawMode
+        }
+    })
+
+    // Once the controlling terminal is gone (SIGHUP), the slave-side fd can
+    // still read isTTY=true even though nothing reads these writes anymore —
+    // write() against a dead tty can throw synchronously (not just emit an
+    // async 'error'). restoreTerminalState() wraps the escape-sequence
+    // writes in try/catch so a terminal-loss cleanup call never crashes the
+    // process it is trying to shut down gracefully.
+    it('does not throw when process.stdout.write() throws synchronously against a dead tty', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+        vi.spyOn(process.stdout, 'write').mockImplementation(() => {
+            throw Object.assign(new Error('write EIO'), { code: 'EIO' })
+        })
+
+        expect(() => restoreTerminalState()).not.toThrow()
+    })
+
+    it('still attempts to disable raw mode even when the stdout writes threw', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true })
+        vi.spyOn(process.stdout, 'write').mockImplementation(() => {
+            throw Object.assign(new Error('write EIO'), { code: 'EIO' })
+        })
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true })
+        const setRawModeSpy = vi.fn()
+        Object.defineProperty(process.stdin, 'setRawMode', { configurable: true, value: setRawModeSpy })
+
+        restoreTerminalState()
+
+        expect(setRawModeSpy).toHaveBeenCalledWith(false)
+    })
+})

--- a/cli/src/ui/terminalState.ts
+++ b/cli/src/ui/terminalState.ts
@@ -1,10 +1,20 @@
 export function restoreTerminalState(): void {
     if (process.stdout.isTTY) {
-        // Disable kitty keyboard protocol / CSI u key release reporting if enabled.
-        process.stdout.write('\x1b[>4;0m');
-        // Disable focus reporting to avoid stray ^[[I on mode switches.
-        process.stdout.write('\x1b[?1004l');
-        process.stdout.write('\x1b[?2004l');
+        // Once the controlling terminal is gone (SIGHUP), the
+        // slave-side fd can still read isTTY=true even though nothing reads
+        // these writes anymore — write() against a dead tty can throw
+        // synchronously (not just emit an async 'error'). Swallow it here so
+        // a terminal-loss cleanup call never crashes the process it's trying
+        // to shut down gracefully.
+        try {
+            // Disable kitty keyboard protocol / CSI u key release reporting if enabled.
+            process.stdout.write('\x1b[>4;0m');
+            // Disable focus reporting to avoid stray ^[[I on mode switches.
+            process.stdout.write('\x1b[?1004l');
+            process.stdout.write('\x1b[?2004l');
+        } catch {
+            // Ignore if the terminal is gone.
+        }
     }
     if (process.stdin.isTTY) {
         try {

--- a/cli/src/utils/spawnWithTerminalGuard.test.ts
+++ b/cli/src/utils/spawnWithTerminalGuard.test.ts
@@ -75,6 +75,34 @@ describe('spawnWithTerminalGuard', () => {
         await expect(spawnWithTerminalGuard(dummyOptions)).rejects.toThrow(error);
     });
 
+    // Once the controlling terminal is gone, process.stdin.resume() (or
+    // restoreTerminalState()'s own writes to the dead tty) can itself
+    // throw/reject. Each cleanup step runs in its own try/catch, isolated
+    // from the others and from the spawn result, so a teardown failure can
+    // neither turn a clean spawn into a crash nor mask the real spawn
+    // failure with an unrelated terminal-teardown error.
+    it('a stdin.resume() failure during cleanup does not mask a successful spawn or crash the caller', async () => {
+        mockSpawnWithAbort.mockResolvedValue();
+        stdinResumeSpy.mockImplementationOnce(() => { throw Object.assign(new Error('EIO'), { code: 'EIO' }); });
+
+        await expect(spawnWithTerminalGuard(dummyOptions)).resolves.toBeUndefined();
+    });
+
+    it('a stdin.resume() failure during cleanup does not replace the original spawn error', async () => {
+        const spawnError = new Error('process exited with code 1');
+        mockSpawnWithAbort.mockRejectedValue(spawnError);
+        stdinResumeSpy.mockImplementationOnce(() => { throw Object.assign(new Error('EIO'), { code: 'EIO' }); });
+
+        await expect(spawnWithTerminalGuard(dummyOptions)).rejects.toThrow(spawnError);
+    });
+
+    it('a restoreTerminalState() failure during cleanup does not mask a successful spawn or crash the caller', async () => {
+        mockSpawnWithAbort.mockResolvedValue();
+        mockRestoreTerminalState.mockImplementationOnce(() => { throw new Error('write EIO'); });
+
+        await expect(spawnWithTerminalGuard(dummyOptions)).resolves.toBeUndefined();
+    });
+
     it('calls pause before spawn, and resume after spawn', async () => {
         mockSpawnWithAbort.mockResolvedValue();
 

--- a/cli/src/utils/spawnWithTerminalGuard.ts
+++ b/cli/src/utils/spawnWithTerminalGuard.ts
@@ -1,16 +1,31 @@
+import { logger } from '@/ui/logger';
 import { restoreTerminalState } from '@/ui/terminalState';
 import { spawnWithAbort, type SpawnWithAbortOptions } from '@/utils/spawnWithAbort';
 
 /**
  * Guards the terminal around a spawnWithAbort call: pauses stdin before spawn,
  * then resumes stdin and restores terminal escape state in finally.
+ *
+ * Once the controlling terminal is
+ * gone, stdin.resume() / restoreTerminalState() can themselves throw against
+ * the dead tty. Each cleanup step is isolated in its own try/catch so a
+ * teardown failure never masks a successful spawn or replaces the real
+ * spawn error the caller actually needs to see.
  */
 export async function spawnWithTerminalGuard(options: SpawnWithAbortOptions): Promise<void> {
     process.stdin.pause();
     try {
         await spawnWithAbort(options);
     } finally {
-        process.stdin.resume();
-        restoreTerminalState();
+        try {
+            process.stdin.resume();
+        } catch (error) {
+            logger.debug('[spawnWithTerminalGuard] stdin.resume() failed', error);
+        }
+        try {
+            restoreTerminalState();
+        } catch (error) {
+            logger.debug('[spawnWithTerminalGuard] restoreTerminalState() failed', error);
+        }
     }
 }


### PR DESCRIPTION
Addresses item 1 (first half) of #1526.

Closing the local controlling terminal (SSH drop, terminal app quit, tmux/screen detach without a persistent session) sends `SIGHUP` to the foreground process group. There was no handler for it, so the kernel default killed the runner before it could archive gracefully — leaving the hub session stuck at `lifecycleState='running'` forever (the split-brain case `hub/src/web/routes/sessions.ts` documents at the archive endpoint).

**What this does**

- **Opt-in, scoped to the claude flavor.** `registerProcessHandlers()` takes an optional `{ surviveTerminalHangup?: boolean }`. Only `runClaude.ts` opts in. Every other flavor (codex, cursor, copilot, grok, pi, agy, kimi, opencode) calls it with no options and keeps the platform default — SIGHUP still terminates the process, byte-for-byte unchanged from upstream.
- When opted in, SIGHUP marks the terminal as lost and installs an output guard on stdout/stderr/stdin, so in-flight writes from readline/ink don't crash the process via `EPIPE`/`EIO` once the terminal's far end is gone.
- Once the terminal is marked lost, the local claude child dying — by signal, non-zero exit, **or a clean `code=0` exit** (a real claude child can exit gracefully when its PTY disappears) — is treated as "the terminal died out from under the child," and is redirected into the existing local→remote switch path. The switch consumes one-time flags (`--fork-session` etc.) exactly like any other local→remote switch.
- `RemoteLauncherBase`'s `hasTTY` is evaluated live (`isTTY && !isTerminalLost()`), not cached at construction, so a terminal that dies mid-run stops `console.clear()`/ink render/`setRawMode` immediately.
- Escape hatch: `HAPI_EXIT_ON_HANGUP=1` (strict string match) makes SIGHUP do a graceful archive-and-exit instead — close to the old behavior, but reported to the hub properly. There's no canonical env-var reference page in `docs/` today; happy to document this wherever you prefer.

**Events covered (deliberately narrow for this first PR)**

`SIGHUP` only. stdin EOF/close, parent-process death, and PTY loss that doesn't produce a SIGHUP (e.g. a disowned/non-foreground process) are **not** detected here — the terminal-app-quit / SSH-drop / window-close family all arrive as SIGHUP via the kernel's foreground-process-group rule, which is the case this targets. The others are natural follow-ups if you want them.

**Platform note**

Effectively POSIX-only. Windows emulates SIGHUP on console close and the handler does run, but the OS then terminates the process unconditionally after a short grace period, so a session can't outlive its console there. The real-process integration tests are gated `describe.skipIf(process.platform === 'win32')`.

**Behavior matrix** — see the matrix in the #1526 comment accompanying this PR.

**Tests**

New/updated suites cover: opt-in gating (no SIGHUP listener without the flag — asserted at the `process.listeners` level and with a real spawned child that dies on SIGHUP without opt-in); survival with opt-in (real child process, real signal); `HAPI_EXIT_ON_HANGUP=1` graceful archive (unit + real process); output-guard behavior incl. stdin, unexpected error codes, and idempotency; clean-exit-vs-`/exit` disambiguation; `--fork-session` one-shot consumption across the terminal-loss switch; live `hasTTY` for launchers constructed before the terminal died. Full `cli` suite: 2483 passed / 10 failed — the 10 are the pre-existing macOS-host baseline addressed separately in #1525 (with #1525's commits stacked locally, the suite is fully green: 2493 passed / 0 failed).

**Known edges**

- Mid-generation terminal loss drops the current unsaved turn; the session resumes from the last save point via `--resume` (same as any local→remote handoff).
- `/exit` racing terminal death in the same tick resolves to "keep the session alive, switch to remote" — worst case is an extra remote session to end manually, judged safer than silently losing a live session.

**Heads-up on CI**

The `test` job will come up red on `typecheck:web` — a pre-existing breakage on upstream `main` itself (`web/src/components/assistant-ui/markdown-a.test.tsx:52`: the test's context object is missing the required `showSessionSummaryInChat` field). Reproducible on a clean `main` checkout, and the Release 0.27.3 CI run is red the same way. Unrelated to this PR.

**AI disclosure** (per CONTRIBUTING's Vibe Coding policy): this was produced by a multi-agent workflow — Claude Fable 5 for planning and task decomposition, Claude Sonnet for implementation, and Claude Opus for code review and acceptance. A human reviewed the result and ran the verification above.
