### PR TITLE
fix(hub): make session timeout and reconnect state durable and consistent

### DIFF
--- a/hub/README.md
+++ b/hub/README.md
@@ -50,6 +50,8 @@ Dictation and voice-assistant provider keys can also be added from **Settings â†
 - `HAPI_RELAY_AUTH` - Explicit relay auth key. By default the hub obtains and persists an individually revocable key from the relay. A persisted key rejected with HTTP 403 is discarded and reissued once; an explicitly configured environment key must be updated manually.
 - `HAPI_RELAY_FORCE_TCP` - Force TCP relay mode (true/1).
 - `VAPID_SUBJECT` - Contact email/URL for Web Push.
+- `HAPI_REAPER_INTERVAL_MS` - Sweep interval for the session reaper, which archives sessions whose CLI connection dropped without a chance to exit cleanly. Default: `0` (disabled). A dropped connection plus a stale heartbeat is a suspicion the CLI process is dead, not proof - a client riding out a long network partition looks identical to a killed one from the hub's side, and archiving it while the CLI is still alive lets the reopen flow spawn a second agent on the same session before it reconnects. Set this to opt in (e.g. `300000` for 5 minutes) once you're confident that risk doesn't apply to your environment.
+- `HAPI_REAPER_STALE_MS` - How long a disconnected session must go without a heartbeat before the reaper (once enabled) considers it a candidate. Default: `1800000` (30 minutes). Only takes effect when `HAPI_REAPER_INTERVAL_MS` is also set.
 
 ## Running
 

--- a/hub/src/sync/permissionModePersistence.test.ts
+++ b/hub/src/sync/permissionModePersistence.test.ts
@@ -63,7 +63,7 @@ describe('permission mode persistence', () => {
         expect(reloadedSession?.permissionMode).toBe('yolo')
     })
 
-    it('shows persisted permission mode before keepalive after hub restart', () => {
+    it('shows persisted permission mode and active state after hub restart', () => {
         const store = new Store(':memory:')
         const engine = createEngine(store)
 
@@ -83,7 +83,9 @@ describe('permission mode persistence', () => {
         const reloadedEngine = simulateHubRestart(store)
         const reloadedSession = reloadedEngine.getSession(session.id)
 
-        expect(reloadedSession?.active).toBe(false)
+        // Reactivation is now persisted to the store (not just the
+        // in-memory cache), so it survives the hub restart too.
+        expect(reloadedSession?.active).toBe(true)
         expect(reloadedSession?.permissionMode).toBe('bypassPermissions')
     })
 

--- a/hub/src/sync/reaper.test.ts
+++ b/hub/src/sync/reaper.test.ts
@@ -1,0 +1,967 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import type { SyncEvent } from '@hapi/protocol/types'
+import { Store } from '../store'
+import type { EventPublisher } from './eventPublisher'
+import { SessionCache } from './sessionCache'
+import {
+    REAPER_DEFAULT_INTERVAL_MS,
+    REAPER_DEFAULT_STALE_MS,
+    SessionReaper
+} from './reaper'
+
+function createPublisher(events: SyncEvent[]): EventPublisher {
+    return {
+        emit: (event: SyncEvent) => {
+            events.push(event)
+        }
+    } as unknown as EventPublisher
+}
+
+/**
+ * Drives a session through the hub's real disconnect path instead of
+ * hand-mutating the cached Session object: a heartbeat at `heartbeatAt`
+ * (the same `handleSessionAlive` entrypoint every CLI keepAlive uses) then
+ * a 30s-inactivity sweep (`SessionCache.expireInactive`, the same one
+ * `SyncEngine`'s 5s timer drives) checked at `expireCheckAt`, which is the
+ * only production path that flips `active` back to `false`.
+ *
+ * Throws if the session did not actually go inactive, so a bad
+ * `expireCheckAt` (too close to `heartbeatAt`) fails loudly at the call
+ * site instead of silently producing a still-active fixture.
+ */
+function connectThenDisconnect(
+    cache: SessionCache,
+    sessionId: string,
+    heartbeatAt: number,
+    expireCheckAt: number
+): void {
+    cache.handleSessionAlive({ sid: sessionId, time: heartbeatAt })
+    const expired = cache.expireInactive(expireCheckAt)
+    if (!expired.includes(sessionId)) {
+        throw new Error(
+            `test setup: session ${sessionId} did not go inactive via expireInactive(${expireCheckAt}) ` +
+            `after heartbeat at ${heartbeatAt} - widen the gap past the 30s inactivity timeout`
+        )
+    }
+}
+
+const ORIGINAL_ENV = { ...process.env }
+
+describe('SessionReaper (hub reaper)', () => {
+    beforeEach(() => {
+        delete process.env.HAPI_REAPER_INTERVAL_MS
+        delete process.env.HAPI_REAPER_STALE_MS
+    })
+
+    afterEach(() => {
+        process.env = { ...ORIGINAL_ENV }
+    })
+
+    it('reads defaults: 5min interval, 30min staleness', () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const reaper = new SessionReaper(cache)
+
+        expect(reaper.intervalMs).toBe(REAPER_DEFAULT_INTERVAL_MS)
+        expect(reaper.staleMs).toBe(REAPER_DEFAULT_STALE_MS)
+        expect(REAPER_DEFAULT_INTERVAL_MS).toBe(5 * 60_000)
+        expect(REAPER_DEFAULT_STALE_MS).toBe(30 * 60_000)
+    })
+
+    it('honors HAPI_REAPER_INTERVAL_MS / HAPI_REAPER_STALE_MS overrides', () => {
+        process.env.HAPI_REAPER_INTERVAL_MS = '1000'
+        process.env.HAPI_REAPER_STALE_MS = '2000'
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const reaper = new SessionReaper(cache)
+
+        expect(reaper.intervalMs).toBe(1000)
+        expect(reaper.staleMs).toBe(2000)
+    })
+
+    it('archives a disconnected running session past the stale threshold, with reaper attribution', () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-stale',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        // Heartbeat lands, then the connection drops for good - the last
+        // heartbeat itself is what needs to be 31 minutes stale, not just
+        // the disconnect-detection tick.
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 31 * 60_000 })
+        const reaped = reaper.sweep()
+
+        expect(reaped).toEqual([session.id])
+        const meta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(meta?.lifecycleState).toBe('archived')
+        expect(meta?.archivedBy).toBe('hub-reaper')
+        expect(meta?.archiveReason).toBe('Connection lost (reaped by hub)')
+        expect(typeof meta?.lifecycleStateSince).toBe('number')
+    })
+
+    it('broadcasts a session-updated event for each session it reaps', () => {
+        // A reaped session's `active` is already `false` by construction
+        // (that is the reaper's own candidate precondition), so the usual
+        // `handleSessionEnd`-driven broadcast (which no-ops when the session
+        // is already inactive) never fires for it - the archive write itself
+        // must be the thing that broadcasts, or an already-open web UI
+        // tab never learns the session ended until some unrelated refetch.
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-broadcast',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+        events.length = 0 // drop the connect/disconnect noise; only the sweep's own broadcast matters here
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 31 * 60_000 })
+        expect(reaper.sweep()).toEqual([session.id])
+
+        const updates = events.filter(
+            (event): event is Extract<SyncEvent, { type: 'session-updated' }> =>
+                event.type === 'session-updated' && event.sessionId === session.id
+        )
+        expect(updates.length).toBeGreaterThan(0)
+        const metadataValue = updates
+            .map((event) => {
+                const data = event.data as { metadata?: { version: number; value: Record<string, unknown> | null } } | undefined
+                return data?.metadata?.value
+            })
+            .find((value) => value !== undefined)
+        expect(metadataValue?.lifecycleState).toBe('archived')
+        expect(metadataValue?.archivedBy).toBe('hub-reaper')
+    })
+
+    it('leaves a disconnected running session alone when under the stale threshold', () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-fresh',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 5 * 60_000 })
+        const reaped = reaper.sweep()
+
+        expect(reaped).toEqual([])
+        const meta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(meta?.lifecycleState).toBe('running')
+    })
+
+    it('does not reap a long-idle-but-recently-heartbeating session just because updatedAt is stale', () => {
+        // A session can sit quiet (no chat activity, `updatedAt` old) for a
+        // long time while the CLI keeps sending keepAlives right up until a
+        // brief network blip / lid-close drops the socket 31s before this
+        // sweep. A stale `updatedAt` alone must never doom a session whose
+        // heartbeat was fresh. (This guards against updatedAt-driven
+        // reaping; the fixture that pins the activeAt-vs-Math.max choice is
+        // "reaps a dead session even while hub-side writes keep updatedAt
+        // fresh" below.)
+        //
+        // Rewritten per review: the original fixture fed `handleSessionAlive`
+        // a `time` in the future relative to the *real* `Date.now()` -
+        // `aliveTime.ts`'s `clampAliveTime` only accepts `[now-10min, now]`
+        // and silently clamps anything past `now` down to it, so the
+        // intended "40 quiet minutes, then a fresh heartbeat" scenario never
+        // actually landed in `activeAt`. Mocking the global `Date.now()`
+        // (same pattern as `aliveEvents.test.ts`) instead of the argument lets
+        // the heartbeat's `time` legitimately equal "now" at each step while
+        // `updatedAt` (stamped once, at creation, against the *unmocked* real
+        // clock just before) stays behind.
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const t0 = Date.now()
+        const originalNow = Date.now
+
+        const session = cache.getOrCreateSession(
+            'session-idle-but-alive',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        const heartbeatAt = t0 + 40 * 60_000 // 40 quiet minutes pass, then a heartbeat lands
+        try {
+            Date.now = () => heartbeatAt
+            connectThenDisconnect(cache, session.id, heartbeatAt, heartbeatAt + 31_000) // ...and drops 31s later
+        } finally {
+            Date.now = originalNow
+        }
+
+        // `updatedAt` (session creation, ~`t0`) is ~40min+31s stale here,
+        // well past the 30min threshold - but the real heartbeat is only
+        // 31s old.
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => heartbeatAt + 31_000 + 1_000 })
+        const reaped = reaper.sweep()
+
+        expect(reaped).toEqual([])
+        expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+    })
+
+    it('reaps a session whose heartbeat itself is stale, even though updatedAt is comparatively newer', () => {
+        // `updatedAt` newer than `activeAt` must not mask a genuinely stale
+        // heartbeat. Note both clocks are past the threshold here, so this
+        // case alone does not pin the field choice - that is the job of
+        // "reaps a dead session even while hub-side writes keep updatedAt
+        // fresh" below, where `updatedAt` is still under the threshold.
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-stale-heartbeat',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        // Heartbeat drops almost immediately and never comes back.
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+        // Some later hub-side write bumps updatedAt past the heartbeat time
+        // (e.g. a delayed housekeeping touch) - still 35 minutes before the
+        // sweep, i.e. itself past the stale threshold.
+        cache.recordSessionActivity(session.id, now + 5 * 60_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 40 * 60_000 })
+        const reaped = reaper.sweep()
+
+        expect(reaped).toEqual([session.id])
+        expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('archived')
+    })
+
+    it('reaps a dead session even while hub-side writes keep updatedAt fresh (activeAt is the only staleness clock)', () => {
+        // THE discriminating fixture for the staleness-field choice, kept
+        // deliberately asymmetric: the heartbeat has been gone 40 minutes
+        // (well past the 30min threshold) while a hub-side write - a web
+        // client posting into the void 25 minutes in - leaves `updatedAt`
+        // only 15 minutes old at sweep time, i.e. UNDER the threshold.
+        // activeAt-only reaps this session; any variant that lets
+        // `updatedAt` extend the clock (e.g. Math.max(activeAt, updatedAt))
+        // skips it and lets every chattered-at zombie live forever.
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-dead-but-touched',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        // Heartbeat drops at the start and never returns.
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+        // 25 minutes in, something hub-side touches the row (web message
+        // into the dead session) - fresher than staleMs at sweep time.
+        cache.recordSessionActivity(session.id, now + 25 * 60_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 40 * 60_000 })
+        const reaped = reaper.sweep()
+
+        expect(reaped).toEqual([session.id])
+        expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('archived')
+    })
+
+    it('leaves an active (connected) session alone regardless of how stale its heartbeat looks by wall-clock', () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-active',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        cache.handleSessionAlive({ sid: session.id, time: now })
+        expect(cache.getSession(session.id)?.active).toBe(true)
+
+        // staleMs: 1 - if the `active` short-circuit were ever dropped, any
+        // nonzero elapsed time would make this reap.
+        const reaper = new SessionReaper(cache, { staleMs: 1, intervalMs: 5 * 60_000, now: () => now + 60 * 60_000 })
+        const reaped = reaper.sweep()
+
+        expect(reaped).toEqual([])
+    })
+
+    it('does not re-reap a session already lifecycleState=archived', () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-already-archived',
+            {
+                path: '/tmp/project',
+                host: 'localhost',
+                flavor: 'claude',
+                lifecycleState: 'archived',
+                archivedBy: 'cli',
+                archiveReason: 'User terminated'
+            },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 60 * 60_000 })
+        const reaped = reaper.sweep()
+
+        expect(reaped).toEqual([])
+        const meta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(meta?.archivedBy).toBe('cli')
+    })
+
+    it('reconnect after being reaped self-heals lifecycleState back to running, and a later sweep leaves it alone', () => {
+        // Regression: a session the reaper archived must
+        // stop *looking* archived the moment its CLI genuinely reconnects -
+        // the web UI must not keep showing "archived" for a live session
+        // until some unrelated manual /reopen. `SessionCache`'s reconnect-heal
+        // (invoked from `handleSessionAlive`, the entrypoint every CLI
+        // keepAlive - and so every reconnect - uses) is what restamps
+        // `lifecycleState` back to `'running'` and clears the reaper's
+        // archive attribution, with no CLI-side step required.
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-revives',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 31 * 60_000 })
+        expect(reaper.sweep()).toEqual([session.id])
+        const archivedMeta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(archivedMeta?.lifecycleState).toBe('archived')
+        const versionAfterReap = cache.getSession(session.id)?.metadataVersion
+        events.length = 0 // drop the reap's own broadcast; only the heal's broadcast matters below
+
+        // CLI reconnects for real: a keepAlive flips `active` back to `true`
+        // via the exact entrypoint every reconnect uses, and - per the fix -
+        // heals the archive metadata in the same call.
+        const reconnectAt = now + 31 * 60_000 + 5_000
+        cache.handleSessionAlive({ sid: session.id, time: reconnectAt })
+        expect(cache.getSession(session.id)?.active).toBe(true)
+
+        const healedMeta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(healedMeta?.lifecycleState).toBe('running')
+        expect(healedMeta?.archivedBy).toBeUndefined()
+        expect(healedMeta?.archiveReason).toBeUndefined()
+        expect(cache.getSession(session.id)?.metadataVersion).toBeGreaterThan(versionAfterReap ?? 0)
+
+        const updates = events.filter(
+            (event): event is Extract<SyncEvent, { type: 'session-updated' }> =>
+                event.type === 'session-updated' && event.sessionId === session.id
+        )
+        const healBroadcast = updates
+            .map((event) => {
+                const data = event.data as { metadata?: { value: Record<string, unknown> | null } } | undefined
+                return data?.metadata?.value
+            })
+            .find((value) => value?.lifecycleState === 'running')
+        expect(healBroadcast).toBeDefined()
+
+        const laterReaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => reconnectAt + 60 * 60_000 })
+        expect(laterReaper.sweep()).toEqual([])
+        expect(cache.getSession(session.id)?.active).toBe(true)
+    })
+
+    it('reconnect via markSessionActive (the resume-on-respawn path) also self-heals lifecycleState back to running', () => {
+        // Mutation-coverage gap: the heal is
+        // wired into *two* entrypoints - `handleSessionAlive` (every CLI
+        // keepAlive, exercised by the test above) and `markSessionActive`
+        // (the session-respawn/resume path). Only the former had coverage;
+        // a mutation that deleted the `healReaperArchivedSession` call
+        // inside `markSessionActive` left the full suite green. This pins
+        // that second throat point directly, mirroring the assertions of
+        // the `handleSessionAlive` variant above one-for-one.
+        const store = new Store(':memory:')
+        const events: SyncEvent[] = []
+        const cache = new SessionCache(store, createPublisher(events))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-revives-via-mark-active',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 31 * 60_000 })
+        expect(reaper.sweep()).toEqual([session.id])
+        const archivedMeta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(archivedMeta?.lifecycleState).toBe('archived')
+        const versionAfterReap = cache.getSession(session.id)?.metadataVersion
+        events.length = 0 // drop the reap's own broadcast; only the heal's broadcast matters below
+
+        // Session respawns/resumes for real: `markSessionActive` flips
+        // `active` back to `true` via the resume path - per the fix, it
+        // heals the archive metadata in the same call, same as
+        // `handleSessionAlive` does for keepAlives.
+        const reconnectAt = now + 31 * 60_000 + 5_000
+        cache.markSessionActive(session.id, reconnectAt)
+        expect(cache.getSession(session.id)?.active).toBe(true)
+
+        const healedMeta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(healedMeta?.lifecycleState).toBe('running')
+        expect(healedMeta?.archivedBy).toBeUndefined()
+        expect(healedMeta?.archiveReason).toBeUndefined()
+        expect(cache.getSession(session.id)?.metadataVersion).toBeGreaterThan(versionAfterReap ?? 0)
+
+        const updates = events.filter(
+            (event): event is Extract<SyncEvent, { type: 'session-updated' }> =>
+                event.type === 'session-updated' && event.sessionId === session.id
+        )
+        const healBroadcast = updates
+            .map((event) => {
+                const data = event.data as { metadata?: { value: Record<string, unknown> | null } } | undefined
+                return data?.metadata?.value
+            })
+            .find((value) => value?.lifecycleState === 'running')
+        expect(healBroadcast).toBeDefined()
+
+        const laterReaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => reconnectAt + 60 * 60_000 })
+        expect(laterReaper.sweep()).toEqual([])
+        expect(cache.getSession(session.id)?.active).toBe(true)
+    })
+
+    it('does not reap - and does not touch metadata on - a session whose lifecycleState the self-heal already restored to running', () => {
+        // No manual CLI-side restamp is needed: `handleSessionAlive` itself
+        // performs the heal on reconnect. This pins that a sweep with
+        // an aggressively small `staleMs` still leaves the (now genuinely
+        // `active: true`) session alone - protection must come from the
+        // `active` short-circuit at the top of `sweep()`, not from
+        // `lifecycleState` happening to no longer say 'archived'.
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const originalNow = Date.now
+        const t0 = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-revived-and-restamped',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        try {
+            Date.now = () => t0
+            connectThenDisconnect(cache, session.id, t0, t0 + 31_000)
+
+            const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => t0 + 31 * 60_000 })
+            expect(reaper.sweep()).toEqual([session.id])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('archived')
+
+            // Reconnect for real, at a later real wall-clock instant. The
+            // heal inside `handleSessionAlive` alone restamps lifecycleState.
+            const reconnectAt = t0 + 31 * 60_000 + 5_000
+            Date.now = () => reconnectAt
+            cache.handleSessionAlive({ sid: session.id, time: reconnectAt })
+            expect(cache.getSession(session.id)?.active).toBe(true)
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+
+            // staleMs: 1 - if the `active` short-circuit were ever dropped,
+            // this session (its own `activeAt` is ~1h "old" by the time this
+            // later sweep's virtual clock runs) would get reaped again.
+            const laterReaper = new SessionReaper(cache, { staleMs: 1, intervalMs: 5 * 60_000, now: () => reconnectAt + 60 * 60_000 })
+            expect(laterReaper.sweep()).toEqual([])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+        } finally {
+            Date.now = originalNow
+        }
+    })
+
+    it('leaves a manually-archived session archived across a reconnect (heal only applies to archivedBy === hub-reaper)', () => {
+        // A session archived by anything other than this
+        // reaper (a human via the web UI, or the CLI's own archive-on-exit
+        // path) meant it - reconnecting must never silently undo that.
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-manually-archived',
+            {
+                path: '/tmp/project',
+                host: 'localhost',
+                flavor: 'claude',
+                lifecycleState: 'archived',
+                archivedBy: 'cli',
+                archiveReason: 'User terminated'
+            },
+            null,
+            'default'
+        )
+
+        cache.handleSessionAlive({ sid: session.id, time: now })
+
+        expect(cache.getSession(session.id)?.active).toBe(true)
+        const meta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(meta?.lifecycleState).toBe('archived')
+        expect(meta?.archivedBy).toBe('cli')
+        expect(meta?.archiveReason).toBe('User terminated')
+    })
+
+    it('reconnect-heal is idempotent: repeated keepAlives after healing do not re-write metadata', () => {
+        // Idempotency check: the heal's guard re-reads
+        // current metadata on every call, so once `lifecycleState` is no
+        // longer `'archived'` (whether healed or never archived), further
+        // heartbeats must be no-op reads, not repeat writes that would keep
+        // bumping `metadataVersion` / `lifecycleStateSince` forever.
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-idempotent-heal',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 31 * 60_000 })
+        expect(reaper.sweep()).toEqual([session.id])
+
+        const reconnectAt = now + 31 * 60_000 + 5_000
+        cache.handleSessionAlive({ sid: session.id, time: reconnectAt })
+        const versionAfterHeal = cache.getSession(session.id)?.metadataVersion
+        const sinceAfterHeal = (cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined)
+            ?.lifecycleStateSince
+
+        // A second keepAlive shortly after must not touch metadata again.
+        cache.handleSessionAlive({ sid: session.id, time: reconnectAt + 1_000 })
+
+        expect(cache.getSession(session.id)?.metadataVersion).toBe(versionAfterHeal)
+        expect((cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined)?.lifecycleStateSince).toBe(sinceAfterHeal)
+        expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+    })
+
+    it('start() runs one sweep immediately but archives nothing: hub downtime is never charged against a session\'s staleness budget', () => {
+        // Regression: a hub that was itself down (crash,
+        // redeploy, host reboot) longer than `staleMs` used to find every
+        // session's last heartbeat already stale the instant it came back up,
+        // and its own startup sweep would mass-archive every one of them
+        // before they even had a chance to reconnect. Per the fix, disconnect
+        // duration is measured from the *later* of `activeAt` and the hub's
+        // own most recent `start()` instant - so every session gets a full,
+        // fresh `staleMs` reconnect window counted from hub start.
+        //
+        // Accepted consequence (see reaper.ts's class doc comment): the
+        // *immediate* startup sweep can therefore never archive anything on
+        // its own - every candidate's disconnect-since collapses to "hub
+        // start", i.e. age zero at that exact instant. A genuine startup
+        // zombie (CLI never reconnects) is still caught, just by the first
+        // periodic sweep that lands after `hub start + staleMs`, pinned via a
+        // mutable virtual clock below (no real `start()`/timer wait needed -
+        // `sweep()` is called directly at each simulated instant).
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-startup-zombie',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        // Heartbeat already looks 45 minutes stale by wall-clock (past the
+        // 30min threshold) - as if the hub had been down that whole time.
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        let clock = now + 45 * 60_000 // hub restarts 45 minutes "later"
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 3600_000, now: () => clock })
+        try {
+            reaper.start()
+            // Immediate startup sweep: spared, per the accepted semantic change.
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+
+            // A periodic sweep still inside the post-restart staleMs window
+            // (29 of the allotted 30 minutes since hub start): still spared.
+            clock += 29 * 60_000
+            expect(reaper.sweep()).toEqual([])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+
+            // Past hub-start + staleMs with the CLI still never having
+            // reconnected: now it is a genuine startup zombie.
+            clock += 2 * 60_000
+            expect(reaper.sweep()).toEqual([session.id])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('archived')
+        } finally {
+            reaper.stop()
+        }
+    })
+
+    it('a session that reconnects after hub start and disconnects again is judged from that heartbeat, not the hub-start floor', () => {
+        // The hub-start floor only ever *raises* the
+        // effective disconnect-since for sessions that haven't reconnected
+        // yet - once a session genuinely reconnects post-restart and then
+        // drops again, its own fresh `activeAt` becomes the later of the two
+        // clocks again (`Math.max(activeAt, hubStartedAt)`), and staleness
+        // reverts to being judged off that heartbeat exactly as before this
+        // fix.
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const t0 = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-reconnects-post-restart',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        // Already looked disconnected before the hub restarted.
+        connectThenDisconnect(cache, session.id, t0, t0 + 31_000)
+
+        let clock = t0 + 60 * 60_000 // hub restarts an hour later
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 3600_000, now: () => clock })
+        reaper.start()
+        try {
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running') // startup sweep spares it
+
+            // CLI reconnects for real shortly after hub start (heartbeat's
+            // `time` must equal real wall-clock "now" for clampAliveTime to
+            // accept it verbatim - mock Date.now for just this call, same
+            // pattern as the other reconnect-timeline tests in this file).
+            clock += 5 * 60_000
+            const reconnectAt = clock
+            const originalNow = Date.now
+            try {
+                Date.now = () => reconnectAt
+                cache.handleSessionAlive({ sid: session.id, time: reconnectAt })
+            } finally {
+                Date.now = originalNow
+            }
+            expect(cache.getSession(session.id)?.active).toBe(true)
+
+            // ...and drops again 31s later (past SessionCache's 30s
+            // inactivity timeout).
+            clock += 31_000
+            expect(cache.expireInactive(clock)).toContain(session.id)
+
+            // 29 minutes after the *reconnect* heartbeat (not 29 minutes
+            // after hub start, which was already ~34 minutes ago) - still
+            // under staleMs measured from the reconnect: must not reap. A
+            // reaper that incorrectly kept anchoring to the original
+            // hub-start floor once it had been set would also spare this,
+            // for the wrong reason - the next assertion is what actually
+            // discriminates the two.
+            clock = reconnectAt + 29 * 60_000
+            expect(reaper.sweep()).toEqual([])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+
+            // Past staleMs measured from the reconnect heartbeat: reaps.
+            clock = reconnectAt + 31 * 60_000
+            expect(reaper.sweep()).toEqual([session.id])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('archived')
+        } finally {
+            reaper.stop()
+        }
+    })
+
+    it('is disabled when constructed with staleMs: 0: start() sweeps nothing, sweep() is a no-op', () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-disabled',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 0, intervalMs: 5 * 60_000, now: () => now + 24 * 60 * 60_000 })
+        expect(reaper.enabled).toBe(false)
+        reaper.start()
+        try {
+            expect(reaper.sweep()).toEqual([])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+        } finally {
+            reaper.stop()
+        }
+    })
+
+    it('is fully disabled end-to-end via the HAPI_REAPER_STALE_MS=0 environment variable', () => {
+        process.env.HAPI_REAPER_STALE_MS = '0'
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-disabled-via-env',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        // No `staleMs` constructor override - must come from the env var.
+        const reaper = new SessionReaper(cache, { now: () => now + 24 * 60 * 60_000 })
+        expect(reaper.staleMs).toBe(0)
+        expect(reaper.enabled).toBe(false)
+
+        reaper.start()
+        try {
+            expect(reaper.sweep()).toEqual([])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+        } finally {
+            reaper.stop()
+        }
+    })
+
+    it('is fully disabled end-to-end via the HAPI_REAPER_INTERVAL_MS=0 environment variable', () => {
+        // Setting either knob to 0 disables the reaper, not just staleMs - a
+        // deployment that wants "no periodic sweeping at all" (e.g. it drives
+        // sweeps some other way) must be able to zero out the interval alone.
+        process.env.HAPI_REAPER_INTERVAL_MS = '0'
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-disabled-via-interval-env',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        // No `intervalMs` constructor override - must come from the env var.
+        // `staleMs` stays at its default (30min), which is comfortably below
+        // the 31min-stale session above, so a leftover-enabled reaper would
+        // still reap it - proving `enabled` really is gated by intervalMs too.
+        const reaper = new SessionReaper(cache, { now: () => now + 31 * 60_000 })
+        expect(reaper.intervalMs).toBe(0)
+        expect(reaper.enabled).toBe(false)
+
+        reaper.start()
+        try {
+            expect(reaper.sweep()).toEqual([])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+        } finally {
+            reaper.stop()
+        }
+    })
+
+    it('falls back to the default interval/staleness when the env override is not a valid non-negative number', () => {
+        // parseNonNegativeIntEnv's contract: garbage or negative input must
+        // fall back to the compiled-in default, not silently coerce to NaN/0
+        // (0 has the special "disabled" meaning - a typo'd negative value
+        // must not accidentally disable the reaper) and not throw.
+        process.env.HAPI_REAPER_INTERVAL_MS = 'not-a-number'
+        process.env.HAPI_REAPER_STALE_MS = '-500'
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const reaper = new SessionReaper(cache)
+
+        expect(reaper.intervalMs).toBe(REAPER_DEFAULT_INTERVAL_MS)
+        expect(reaper.staleMs).toBe(REAPER_DEFAULT_STALE_MS)
+        expect(reaper.enabled).toBe(true)
+    })
+
+    it('continues sweeping other sessions when one archive attempt throws', () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const bad = cache.getOrCreateSession(
+            'session-bad',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, bad.id, now, now + 31_000)
+        const good = cache.getOrCreateSession(
+            'session-good',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, good.id, now, now + 31_000)
+
+        const originalArchive = cache.markSessionArchivedFromHub.bind(cache)
+        cache.markSessionArchivedFromHub = ((sessionId: string, reason: string, archivedBy?: string) => {
+            if (sessionId === bad.id) {
+                throw new Error('simulated write failure')
+            }
+            return originalArchive(sessionId, reason, archivedBy)
+        }) as typeof cache.markSessionArchivedFromHub
+
+        const errors: Array<{ sessionId: string; error: unknown }> = []
+        const reaper = new SessionReaper(cache, {
+            staleMs: 30 * 60_000,
+            intervalMs: 5 * 60_000,
+            now: () => now + 60 * 60_000,
+            onError: (sessionId, error) => errors.push({ sessionId, error })
+        })
+
+        const reaped = reaper.sweep()
+
+        expect(reaped).toEqual([good.id])
+        expect(errors).toHaveLength(1)
+        expect(errors[0]?.sessionId).toBe(bad.id)
+        expect(cache.getSession(bad.id)?.metadata?.lifecycleState).toBe('running')
+        expect(cache.getSession(good.id)?.metadata?.lifecycleState).toBe('archived')
+    })
+
+    it('the reconnect-heal swallows persistence failures instead of throwing into the keepAlive hot path (deliberately the mirror image of markSessionArchivedFromHub, which throws)', () => {
+        // Mutation-coverage gap: `healReaperArchivedSession`
+        // deliberately returns instead of throwing on both a hard
+        // `{ result: 'error' }` from the store and on exhausted
+        // version-mismatch retries - the opposite of `markSessionArchivedFromHub`,
+        // which throws on both (see "continues sweeping other sessions when
+        // one archive attempt throws" above, and markSessionArchivedFromHub's
+        // own doc comment). That reversal is intentional (the heal runs
+        // inline in the hot `handleSessionAlive`/`markSessionActive` keepAlive
+        // path, where a thrown error would take the connection down with
+        // it). This pins the asymmetry so nothing breaks silently if a
+        // future edit "fixes" it by making the heal throw like its sibling.
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-heal-write-fails',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 31 * 60_000 })
+        expect(reaper.sweep()).toEqual([session.id])
+        expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('archived')
+        const versionBeforeReconnect = cache.getSession(session.id)?.metadataVersion
+
+        // Simulate the metadata store failing every write attempt (disk
+        // full, corrupted row, genuine contention exhausting all retries -
+        // any of these collapse to the same `{ result: 'error' }` /
+        // repeated `version-mismatch` shape from the heal's point of view).
+        const originalUpdateMetadata = store.sessions.updateSessionMetadata.bind(store.sessions)
+        store.sessions.updateSessionMetadata = (() => ({ result: 'error' })) as typeof store.sessions.updateSessionMetadata
+
+        let thrown: unknown
+        try {
+            cache.handleSessionAlive({ sid: session.id, time: now + 31 * 60_000 + 5_000 })
+        } catch (error) {
+            thrown = error
+        } finally {
+            store.sessions.updateSessionMetadata = originalUpdateMetadata
+        }
+
+        expect(thrown).toBeUndefined()
+        // The heal write failed, but the ordinary active-flag bookkeeping
+        // that follows it in `handleSessionAlive` must still run - the CLI
+        // really did reconnect even though the metadata heal didn't land.
+        expect(cache.getSession(session.id)?.active).toBe(true)
+        const meta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(meta?.lifecycleState).toBe('archived')
+        expect(meta?.archivedBy).toBe('hub-reaper')
+        expect(cache.getSession(session.id)?.metadataVersion).toBe(versionBeforeReconnect)
+
+        // A later heartbeat, once the store recovers, retries the heal
+        // successfully - the failure above was not a permanent lockout.
+        cache.handleSessionAlive({ sid: session.id, time: now + 32 * 60_000 })
+        const healedMeta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(healedMeta?.lifecycleState).toBe('running')
+        expect(healedMeta?.archivedBy).toBeUndefined()
+    })
+
+    it('healReaperArchivedSession gives up cleanly, without throwing or corrupting session state, once its version-mismatch retry budget is exhausted', () => {
+        // Companion to the immediate-`{ result: 'error' }` case above: here
+        // every retry attempt reports version-mismatch (a live contention
+        // shape, not a hard failure), so the loop must actually run to its
+        // retry cap and only then give up - not spin forever, and not throw
+        // into the keepAlive hot path once the cap is hit. The retry cap
+        // itself is a private constant in sessionCache.ts (currently 5); this
+        // asserts the loop terminates at exactly that many attempts rather
+        // than pinning the literal by importing an unexported symbol.
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-heal-version-mismatch-exhausted',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 31_000)
+
+        const reaper = new SessionReaper(cache, { staleMs: 30 * 60_000, intervalMs: 5 * 60_000, now: () => now + 31 * 60_000 })
+        expect(reaper.sweep()).toEqual([session.id])
+        const archivedMeta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(archivedMeta?.lifecycleState).toBe('archived')
+        const versionBeforeReconnect = cache.getSession(session.id)?.metadataVersion
+
+        let updateCalls = 0
+        const originalUpdateMetadata = store.sessions.updateSessionMetadata.bind(store.sessions)
+        store.sessions.updateSessionMetadata = (() => {
+            updateCalls += 1
+            // Every attempt loses the race - a live contention shape, distinct
+            // from the hard-error case covered above.
+            return { result: 'version-mismatch', version: 0, value: null }
+        }) as typeof store.sessions.updateSessionMetadata
+
+        let thrown: unknown
+        try {
+            cache.handleSessionAlive({ sid: session.id, time: now + 31 * 60_000 + 5_000 })
+        } catch (error) {
+            thrown = error
+        } finally {
+            store.sessions.updateSessionMetadata = originalUpdateMetadata
+        }
+
+        expect(thrown).toBeUndefined()
+        expect(updateCalls).toBe(5)
+        // Ordinary active-flag bookkeeping (the CLI really did reconnect)
+        // still runs even though the metadata heal never landed.
+        expect(cache.getSession(session.id)?.active).toBe(true)
+        const meta = cache.getSession(session.id)?.metadata as Record<string, unknown> | null | undefined
+        expect(meta?.lifecycleState).toBe('archived')
+        expect(meta?.archivedBy).toBe('hub-reaper')
+        expect(cache.getSession(session.id)?.metadataVersion).toBe(versionBeforeReconnect)
+    })
+
+    it('falls back to the default interval/staleness when the env override is a float or scientific-notation string', () => {
+        // `parseNonNegativeIntEnv`'s numeric coercion (`Number(raw)`) accepts
+        // any finite non-negative number, including fractional values and
+        // scientific notation - `Number.isFinite` alone does not distinguish
+        // "42" from "42.5" or "3e-1". Both intervalMs and staleMs are
+        // consumed as whole millisecond durations (`setInterval`, disconnect-
+        // age comparisons); a fractional override is malformed input, not a
+        // valid one, and must collapse to the compiled-in default exactly
+        // like the garbage-string case above rather than silently taking a
+        // fractional value.
+        process.env.HAPI_REAPER_INTERVAL_MS = '2.5'
+        process.env.HAPI_REAPER_STALE_MS = '3e-1'
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const reaper = new SessionReaper(cache)
+
+        expect(reaper.intervalMs).toBe(REAPER_DEFAULT_INTERVAL_MS)
+        expect(reaper.staleMs).toBe(REAPER_DEFAULT_STALE_MS)
+    })
+})

--- a/hub/src/sync/reaper.test.ts
+++ b/hub/src/sync/reaper.test.ts
@@ -132,13 +132,15 @@ describe('SessionReaper (hub reaper)', () => {
         expect(typeof meta?.lifecycleStateSince).toBe('number')
     })
 
-    it('broadcasts a session-updated event for each session it reaps', () => {
+    it('broadcasts exactly one full session-updated event for each session it reaps, via refreshSession - no duplicate metadata-patch emit', () => {
         // A reaped session's `active` is already `false` by construction
         // (that is the reaper's own candidate precondition), so the usual
         // `handleSessionEnd`-driven broadcast (which no-ops when the session
-        // is already inactive) never fires for it - the archive write itself
-        // must be the thing that broadcasts, or an already-open web UI
-        // tab never learns the session ended until some unrelated refetch.
+        // is already inactive) never fires for it. `markSessionArchivedFromHub`
+        // relies entirely on `refreshSession`'s own broadcast for this - it
+        // does not additionally hand-roll a metadata-patch emit, so exactly
+        // one `session-updated` event per reap is expected, carrying the full
+        // rebuilt `Session` (not a `{ metadata: { version, value } }` patch).
         const store = new Store(':memory:')
         const events: SyncEvent[] = []
         const cache = new SessionCache(store, createPublisher(events))
@@ -160,15 +162,10 @@ describe('SessionReaper (hub reaper)', () => {
             (event): event is Extract<SyncEvent, { type: 'session-updated' }> =>
                 event.type === 'session-updated' && event.sessionId === session.id
         )
-        expect(updates.length).toBeGreaterThan(0)
-        const metadataValue = updates
-            .map((event) => {
-                const data = event.data as { metadata?: { version: number; value: Record<string, unknown> | null } } | undefined
-                return data?.metadata?.value
-            })
-            .find((value) => value !== undefined)
-        expect(metadataValue?.lifecycleState).toBe('archived')
-        expect(metadataValue?.archivedBy).toBe('hub-reaper')
+        expect(updates).toHaveLength(1)
+        const data = updates[0]?.data as { metadata?: Record<string, unknown> | null } | undefined
+        expect(data?.metadata?.lifecycleState).toBe('archived')
+        expect(data?.metadata?.archivedBy).toBe('hub-reaper')
     })
 
     it('leaves a disconnected running session alone when under the stale threshold', () => {

--- a/hub/src/sync/reaper.test.ts
+++ b/hub/src/sync/reaper.test.ts
@@ -57,15 +57,41 @@ describe('SessionReaper (hub reaper)', () => {
         process.env = { ...ORIGINAL_ENV }
     })
 
-    it('reads defaults: 5min interval, 30min staleness', () => {
+    it('ships disabled by default: interval 0, and a 30min staleness ready for whenever an operator opts in', () => {
         const store = new Store(':memory:')
         const cache = new SessionCache(store, createPublisher([]))
         const reaper = new SessionReaper(cache)
 
         expect(reaper.intervalMs).toBe(REAPER_DEFAULT_INTERVAL_MS)
         expect(reaper.staleMs).toBe(REAPER_DEFAULT_STALE_MS)
-        expect(REAPER_DEFAULT_INTERVAL_MS).toBe(5 * 60_000)
+        expect(REAPER_DEFAULT_INTERVAL_MS).toBe(0)
         expect(REAPER_DEFAULT_STALE_MS).toBe(30 * 60_000)
+        expect(reaper.enabled).toBe(false)
+    })
+
+    it('does not start a sweep timer, and sweep() is a no-op, when constructed with no options at all (default-off)', () => {
+        const store = new Store(':memory:')
+        const cache = new SessionCache(store, createPublisher([]))
+        const now = Date.now()
+
+        const session = cache.getOrCreateSession(
+            'session-default-off',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+            null,
+            'default'
+        )
+        connectThenDisconnect(cache, session.id, now, now + 45 * 60_000)
+
+        const reaper = new SessionReaper(cache, { now: () => now + 45 * 60_000 })
+        expect(reaper.enabled).toBe(false)
+
+        reaper.start()
+        try {
+            expect(reaper.sweep()).toEqual([])
+            expect(cache.getSession(session.id)?.metadata?.lifecycleState).toBe('running')
+        } finally {
+            reaper.stop()
+        }
     })
 
     it('honors HAPI_REAPER_INTERVAL_MS / HAPI_REAPER_STALE_MS overrides', () => {
@@ -778,7 +804,10 @@ describe('SessionReaper (hub reaper)', () => {
 
         expect(reaper.intervalMs).toBe(REAPER_DEFAULT_INTERVAL_MS)
         expect(reaper.staleMs).toBe(REAPER_DEFAULT_STALE_MS)
-        expect(reaper.enabled).toBe(true)
+        // The default interval is itself 0 (disabled) - a garbage env
+        // override falling back to that default therefore still leaves the
+        // reaper disabled, not enabled.
+        expect(reaper.enabled).toBe(false)
     })
 
     it('continues sweeping other sessions when one archive attempt throws', () => {

--- a/hub/src/sync/reaper.ts
+++ b/hub/src/sync/reaper.ts
@@ -31,6 +31,14 @@
  * caught, just by the first periodic sweep that lands after
  * `hub start + staleMs` has elapsed, not by the immediate one.
  *
+ * Opt-in, not on by default: `active === false` plus a stale heartbeat is a
+ * *suspicion* the CLI process is dead, not proof - a CLI riding out a long
+ * network partition presents identically. Reaping that session while the
+ * original process is still alive lets the existing reopen flow spawn a
+ * second agent before the first one reconnects, so this sweep ships disabled
+ * (`REAPER_DEFAULT_INTERVAL_MS === 0`) until callers explicitly opt in via
+ * `HAPI_REAPER_INTERVAL_MS` (and, optionally, `HAPI_REAPER_STALE_MS`).
+ *
  * Revival: reconnecting alone (`SessionCache.markSessionActive` /
  * `handleSessionAlive` flipping `active` back to `true`) is what excludes a
  * session from the next sweep's candidate set. But a session the reaper
@@ -45,7 +53,17 @@
  */
 import { REAPER_ARCHIVED_BY, type SessionCache } from './sessionCache'
 
-export const REAPER_DEFAULT_INTERVAL_MS = 5 * 60_000
+// Disabled by default (0 = off). A dropped connection plus heartbeat age is
+// not proof the CLI process is actually dead - a client riding out a long
+// network partition looks identical to a killed one from the hub's side.
+// Archiving that session while the original CLI is still alive lets the
+// existing reopen flow spawn a second agent on the same session before the
+// first one reconnects, i.e. exactly the double-agent failure this sweep was
+// meant to prevent, not cause. Operators who know their environment (e.g. no
+// long partitions expected) can opt in with `HAPI_REAPER_INTERVAL_MS`; when
+// that is set without also setting `HAPI_REAPER_STALE_MS`, the stale
+// threshold still falls back to `REAPER_DEFAULT_STALE_MS` below.
+export const REAPER_DEFAULT_INTERVAL_MS = 0
 export const REAPER_DEFAULT_STALE_MS = 30 * 60_000
 export const REAPER_ARCHIVE_REASON = 'Connection lost (reaped by hub)'
 

--- a/hub/src/sync/reaper.ts
+++ b/hub/src/sync/reaper.ts
@@ -1,0 +1,172 @@
+/**
+ * Zombie-session reaper.
+ *
+ * A session is a "zombie" when the CLI connection has dropped (`active ===
+ * false`) but the persisted `metadata.lifecycleState` is still `'running'` —
+ * this happens when the CLI process is killed outright (SIGHUP/SIGKILL,
+ * hub-restart cascades, crashes) with no chance to run its own
+ * archive-on-exit path. Left alone these rows show as "still running"
+ * forever in web UI.
+ *
+ * The reaper periodically sweeps for sessions disconnected past a
+ * staleness threshold and archives them via the same hub-side metadata
+ * path `archiveSession()` uses when the CLI is unreachable
+ * (`SessionCache.markSessionArchivedFromHub`, versioned write +
+ * `session-updated` broadcast) — just with a distinct `archivedBy` so the
+ * two origins stay distinguishable in the UI/logs.
+ *
+ * Hub-downtime floor: disconnect duration is measured from the *later* of a
+ * session's last heartbeat (`activeAt`) and the hub's own most recent
+ * `start()` instant, never from `activeAt` alone. Without this, a hub that
+ * was itself down (crash, redeploy, host reboot) for longer than `staleMs`
+ * would find every session's heartbeat already stale the moment it comes
+ * back up, and the startup sweep in `start()` would mass-archive live
+ * sessions that simply haven't had a chance to reconnect yet. Anchoring the
+ * floor at hub start instead gives every session a full fresh `staleMs`
+ * reconnect window counted from when the hub actually became reachable
+ * again — hub downtime itself is never charged against a session. One
+ * accepted consequence: the startup sweep can no longer archive anything on
+ * its own (every session's disconnect-since collapses to "hub start", i.e.
+ * age zero); a genuine startup zombie (CLI never reconnects) still gets
+ * caught, just by the first periodic sweep that lands after
+ * `hub start + staleMs` has elapsed, not by the immediate one.
+ *
+ * Revival: reconnecting alone (`SessionCache.markSessionActive` /
+ * `handleSessionAlive` flipping `active` back to `true`) is what excludes a
+ * session from the next sweep's candidate set. But a session the reaper
+ * itself archived also needs its persisted `metadata.lifecycleState` healed
+ * back to `'running'` on reconnect, or it keeps showing "archived" in
+ * the web UI forever despite being live again — see
+ * `SessionCache`'s reconnect-heal helper (invoked from both of the entry
+ * points above) for that half of the fix. Sessions archived by anything
+ * other than this reaper (`archivedBy !== REAPER_ARCHIVED_BY`) are
+ * deliberately left alone by that heal path — a human or the CLI's own
+ * archive-on-exit meant it, and reconnecting must not silently undo it.
+ */
+import { REAPER_ARCHIVED_BY, type SessionCache } from './sessionCache'
+
+export const REAPER_DEFAULT_INTERVAL_MS = 5 * 60_000
+export const REAPER_DEFAULT_STALE_MS = 30 * 60_000
+export const REAPER_ARCHIVE_REASON = 'Connection lost (reaped by hub)'
+
+export interface SessionReaperOptions {
+    /** Sweep period. Defaults to `HAPI_REAPER_INTERVAL_MS` env or `REAPER_DEFAULT_INTERVAL_MS`. */
+    intervalMs?: number
+    /** Disconnect-age threshold to archive. Defaults to `HAPI_REAPER_STALE_MS` env or `REAPER_DEFAULT_STALE_MS`. 0 disables the reaper entirely. */
+    staleMs?: number
+    now?: () => number
+    /** Called once per session successfully archived by a sweep. */
+    onReap?: (sessionId: string) => void
+    /** Called when archiving a candidate throws (e.g. exhausted version-mismatch retries); the sweep continues with the next candidate. */
+    onError?: (sessionId: string, error: unknown) => void
+}
+
+function parseNonNegativeIntEnv(raw: string | undefined, fallback: number): number {
+    if (raw === undefined || raw.trim() === '') return fallback
+    const parsed = Number(raw)
+    return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback
+}
+
+export class SessionReaper {
+    readonly intervalMs: number
+    readonly staleMs: number
+    private readonly now: () => number
+    private readonly onReap?: (sessionId: string) => void
+    private readonly onError?: (sessionId: string, error: unknown) => void
+    private timer: ReturnType<typeof setInterval> | null = null
+    /**
+     * Captured by `start()`, `null` until then. `null` also covers every
+     * test/caller that drives `sweep()` directly without ever calling
+     * `start()` — in that case there is no hub-start floor to apply and
+     * staleness falls back to `activeAt` alone (pre-fix behavior). Reset on
+     * every `start()` call so repeated start/stop cycles (e.g. hub
+     * reconfiguration) always key off the *most recent* start.
+     */
+    private hubStartedAt: number | null = null
+
+    constructor(
+        private readonly cache: SessionCache,
+        options: SessionReaperOptions = {}
+    ) {
+        this.intervalMs = options.intervalMs ?? parseNonNegativeIntEnv(process.env.HAPI_REAPER_INTERVAL_MS, REAPER_DEFAULT_INTERVAL_MS)
+        this.staleMs = options.staleMs ?? parseNonNegativeIntEnv(process.env.HAPI_REAPER_STALE_MS, REAPER_DEFAULT_STALE_MS)
+        this.now = options.now ?? Date.now
+        this.onReap = options.onReap
+        this.onError = options.onError
+    }
+
+    /** Either knob set to 0 disables the reaper. */
+    get enabled(): boolean {
+        return this.intervalMs > 0 && this.staleMs > 0
+    }
+
+    /**
+     * Runs one sweep immediately, then arms the periodic timer. No-op when
+     * disabled. Per the hub-downtime floor (see class doc comment above),
+     * this immediate sweep can never archive anything on its own - every
+     * session's disconnect-since collapses to "hub start" (age zero) the
+     * instant `hubStartedAt` is captured, a few lines up. A genuine startup
+     * zombie is still caught, just by the first periodic sweep landing after
+     * `hub start + staleMs`, not by this one.
+     */
+    start(): void {
+        if (!this.enabled) return
+        this.hubStartedAt = this.now()
+        this.sweep()
+        this.timer = setInterval(() => this.sweep(), this.intervalMs)
+    }
+
+    stop(): void {
+        if (this.timer) {
+            clearInterval(this.timer)
+            this.timer = null
+        }
+    }
+
+    /**
+     * One reaping pass. Public (not just timer-driven) so callers/tests can
+     * trigger it deterministically. Returns the ids of sessions archived.
+     */
+    sweep(): string[] {
+        if (!this.enabled) return []
+        const cutoff = this.now()
+        const reaped: string[] = []
+        for (const session of this.cache.getSessions()) {
+            if (session.active) continue
+            if (session.metadata?.lifecycleState !== 'running') continue
+            // Staleness is disconnect duration, nothing else. `activeAt`
+            // (last heartbeat) is the only clock that tracks the CLI
+            // connection - `active === false` is *produced* by
+            // `SessionCache.expireInactive` purely off `activeAt`
+            // (now - activeAt > 30s), so activeAt is already the hub's own
+            // definition of "how long has this session been disconnected".
+            // `updatedAt` (last message/metadata write) must NOT factor in
+            // here: any hub-side touch on a dead session's row after it goes
+            // inactive (e.g. `recordSessionActivity` from a web client still
+            // sending a message into the void) would otherwise push
+            // `updatedAt` forward and indefinitely postpone reaping a
+            // genuinely dead session - see reaper.test.ts's "reaps a dead
+            // session even while hub-side writes keep updatedAt fresh"
+            // regression case (the fixture where only activeAt-only reaps).
+            // Hub-downtime floor (see class doc comment): a session that
+            // reconnected, or simply hasn't had the chance to yet, since the
+            // hub's own most recent start must never be judged stale off
+            // wall-clock alone - `hubStartedAt` (null when `sweep()` runs
+            // without ever going through `start()`) raises the floor so hub
+            // outages are never charged against a session's staleness
+            // budget.
+            const disconnectSince = this.hubStartedAt === null
+                ? session.activeAt
+                : Math.max(session.activeAt, this.hubStartedAt)
+            if (cutoff - disconnectSince < this.staleMs) continue
+            try {
+                this.cache.markSessionArchivedFromHub(session.id, REAPER_ARCHIVE_REASON, REAPER_ARCHIVED_BY)
+                reaped.push(session.id)
+                this.onReap?.(session.id)
+            } catch (error) {
+                this.onError?.(session.id, error)
+            }
+        }
+        return reaped
+    }
+}

--- a/hub/src/sync/sessionActivePersistence.test.ts
+++ b/hub/src/sync/sessionActivePersistence.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'bun:test'
+import { Store } from '../store'
+import { RpcRegistry } from '../socket/rpcRegistry'
+import { SyncEngine } from './syncEngine'
+
+function createEngine(store?: Store): SyncEngine {
+    const engine = new SyncEngine(
+        store ?? new Store(':memory:'),
+        {} as never,
+        new RpcRegistry(),
+        { broadcast() {} } as never
+    )
+    engine.stop()
+    return engine
+}
+
+function simulateHubRestart(store: Store): SyncEngine {
+    return createEngine(store)
+}
+
+describe('session active-flag persistence on reactivation', () => {
+    it('persists active=true from handleSessionAlive so it survives a hub restart', () => {
+        const store = new Store(':memory:')
+        const engine = createEngine(store)
+
+        const session = engine.getOrCreateSession(
+            'reactivate-via-alive',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude' },
+            null,
+            'default'
+        )
+        // Fresh session rows start inactive - confirm the precondition before
+        // asserting the reactivation write below.
+        expect(store.sessions.getSession(session.id)?.active).toBe(false)
+
+        engine.handleSessionAlive({ sid: session.id, time: Date.now() })
+
+        // Read straight from the store, bypassing the in-memory cache, so a
+        // fix that only flips the cached Session (and never calls
+        // store.sessions.setSessionActive) fails this assertion.
+        expect(store.sessions.getSession(session.id)?.active).toBe(true)
+
+        const reloadedEngine = simulateHubRestart(store)
+        expect(reloadedEngine.getSession(session.id)?.active).toBe(true)
+    })
+
+    it('persists active=true from markSessionActive so it survives a hub restart', () => {
+        const store = new Store(':memory:')
+        const engine = createEngine(store)
+
+        const session = engine.getOrCreateSession(
+            'reactivate-via-markactive',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude' },
+            null,
+            'default'
+        )
+        expect(store.sessions.getSession(session.id)?.active).toBe(false)
+
+        ;(engine as unknown as { sessionCache: { markSessionActive: (id: string, time?: number) => void } })
+            .sessionCache.markSessionActive(session.id, Date.now())
+
+        expect(store.sessions.getSession(session.id)?.active).toBe(true)
+
+        const reloadedEngine = simulateHubRestart(store)
+        expect(reloadedEngine.getSession(session.id)?.active).toBe(true)
+    })
+
+    it('writes the active=true persistence exactly once on activation, and does not re-issue it on a repeat heartbeat', () => {
+        const store = new Store(':memory:')
+        const engine = createEngine(store)
+
+        const session = engine.getOrCreateSession(
+            'repeat-heartbeat-no-rewrite',
+            { path: '/tmp/project', host: 'localhost', flavor: 'claude' },
+            null,
+            'default'
+        )
+
+        let calls = 0
+        const originalSetSessionActive = store.sessions.setSessionActive.bind(store.sessions)
+        store.sessions.setSessionActive = ((...args: Parameters<typeof originalSetSessionActive>) => {
+            calls += 1
+            return originalSetSessionActive(...args)
+        }) as typeof store.sessions.setSessionActive
+
+        engine.handleSessionAlive({ sid: session.id, time: Date.now() })
+
+        // Reverse-guard half of the contract: the false->true edge really
+        // does persist once. Without asserting this first, an implementation
+        // that never persists reactivation at all would also satisfy the
+        // "no rewrite on repeat" assertion below vacuously, with calls
+        // staying at 0 throughout instead of settling at 1.
+        expect(calls).toBe(1)
+        const afterFirst = store.sessions.getSession(session.id)
+        expect(afterFirst?.active).toBe(true)
+
+        engine.handleSessionAlive({ sid: session.id, time: Date.now() + 1000 })
+
+        expect(calls).toBe(1)
+    })
+
+    it('reconciles a store row left active=true past the inactivity threshold (e.g. after a hub crash) back to false on the next periodic sweep', () => {
+        const store = new Store(':memory:')
+        const engine = createEngine(store)
+
+        // Persist active=true with an activeAt already past the 30s
+        // inactivity threshold, as if the hub process died right after the
+        // last heartbeat landed and came back up later: the reactivation-
+        // persistence fix means active=true can now sit in the store across
+        // a restart (previously it was purely in-memory and always reloaded
+        // as false), so this "stuck active, stale heartbeat" row shape is
+        // newly reachable and must not be trusted as a live session forever.
+        // Both the session's creation and the heartbeat that activates it
+        // are backdated together: `setSessionActive`'s activeAt write has a
+        // monotonic guard (never regresses to an earlier value than the row
+        // already has), so activating with a stale time against a row
+        // created at the real "now" would silently keep the row's fresher
+        // creation-time activeAt instead of the stale one this fixture needs.
+        const originalNow = Date.now
+        const staleActiveAt = originalNow() - 31_000
+        Date.now = () => staleActiveAt
+        let session: ReturnType<typeof engine.getOrCreateSession>
+        try {
+            session = engine.getOrCreateSession(
+                'stale-active-survives-restart',
+                { path: '/tmp/project', host: 'localhost', flavor: 'claude' },
+                null,
+                'default'
+            )
+            engine.handleSessionAlive({ sid: session.id, time: staleActiveAt })
+        } finally {
+            Date.now = originalNow
+        }
+        expect(store.sessions.getSession(session.id)?.active).toBe(true)
+
+        const reloadedEngine = simulateHubRestart(store)
+        expect(reloadedEngine.getSession(session.id)?.active).toBe(true)
+
+        // Fire one tick of the periodic 5s expireInactive sweep that
+        // SyncEngine's constructor arms via setInterval - this is the
+        // convergence mechanism this test exists to pin, invoked directly
+        // (bypassing TypeScript's compile-time-only `private`) instead of
+        // waiting on a real timer.
+        ;(reloadedEngine as unknown as { expireInactive: () => void }).expireInactive()
+
+        expect(reloadedEngine.getSession(session.id)?.active).toBe(false)
+        // Read straight from the store, bypassing the cache, so a fix that
+        // only flips the cached Session (and never calls
+        // store.sessions.setSessionActive) fails this assertion - same
+        // bypass rationale as the reactivation tests above, mirrored for
+        // the expiry direction.
+        expect(store.sessions.getSession(session.id)?.active).toBe(false)
+    })
+})

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -334,6 +334,15 @@ export class SessionCache {
         session.active = true
         session.activeAt = Math.max(session.activeAt, t)
 
+        if (!wasActive) {
+            // Mirror the active=false convergence point (expireInactive /
+            // handleSessionEnd below): persist the reactivation to the store,
+            // not just the in-memory cache. Gated on the false->true edge
+            // only, so a running session's frequent keepalives don't hit the
+            // DB on every heartbeat.
+            this.store.sessions.setSessionActive(session.id, true, session.activeAt, session.namespace)
+        }
+
         this.lastBroadcastAtBySessionId.set(session.id, Date.now())
         this.publisher.emit({
             type: 'session-updated',
@@ -470,6 +479,13 @@ export class SessionCache {
 
         session.active = true
         session.activeAt = Math.max(session.activeAt, t)
+        if (!wasActive) {
+            // Same reactivation-persistence rule as markSessionActive: only
+            // write on the false->true edge so the frequent (every-few-
+            // seconds) keepalive heartbeat that drives this method doesn't
+            // hit the DB while the session is already active.
+            this.store.sessions.setSessionActive(session.id, true, session.activeAt, session.namespace)
+        }
         session.thinking = requestedThinking || preserveQueuedThinking
         session.thinkingAt = t
         if (!requestedThinking && preserveQueuedThinking && hasUnconsumedPrompt) {

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -7,6 +7,11 @@ import { extractTodoWriteTodosFromMessageContent, TodosSchema } from './todos'
 import { extractBackgroundTaskDelta } from './backgroundTasks'
 
 const QUEUED_MESSAGE_THINKING_GRACE_MS = 15_000
+// `archivedBy` attribution for sessions the reaper (reaper.ts) archives.
+// Owned here, not in reaper.ts, so the dependency between the two modules
+// stays one-directional (reaper.ts imports this, sessionCache.ts imports
+// nothing back from reaper.ts).
+export const REAPER_ARCHIVED_BY = 'hub-reaper'
 // tiann/hapi#919: metadata writers (renameSession, clearSessionArchiveMetadata,
 // restoreSessionArchiveMetadata) retry on version-mismatch with a fresh cache
 // snapshot. Cap retries so genuine concurrent contention still surfaces to the
@@ -235,8 +240,93 @@ export class SessionCache {
         this.refreshSession(sessionId)
     }
 
+    /**
+     * Self-heal path for the "reaped session reconnects but stays looking
+     * archived" gap: a session `SessionReaper` archived while disconnected
+     * must resume looking `'running'` the instant its CLI actually
+     * reconnects, or the web UI keeps showing it as archived forever despite
+     * it being live again - until some unrelated manual `/reopen`.
+     *
+     * This is the single throat point for that heal, called from both
+     * `markSessionActive` (the resume-on-respawn path) and
+     * `handleSessionAlive` (every CLI keepAlive - effectively every
+     * reconnect a running CLI process makes flows through this one). Both
+     * call it before doing their own active-flag bookkeeping, so no
+     * reconnect route can bypass the check by construction; if a future
+     * third "became active" entrypoint is ever added it must call this too.
+     *
+     * Deliberately scoped to `archivedBy === REAPER_ARCHIVED_BY`: a session
+     * archived by a human or by the CLI's own archive-on-exit path meant
+     * it, and reconnecting must not silently undo that.
+     *
+     * Idempotent by construction, not by a separate guard flag: the check
+     * re-reads *current* metadata on every call, so once healed (or if the
+     * session was never reaper-archived) the condition is false and every
+     * subsequent call is a no-op read - safe to call unconditionally on
+     * every heartbeat without double-writing.
+     *
+     * Uses the same versioned-write + retry-on-conflict + broadcast pattern
+     * as `markSessionArchivedFromHub` (the write this is undoing), so the
+     * two ends of the archive/revive cycle share one consistency mechanism.
+     * Unlike that method, failures here are swallowed rather than thrown:
+     * this runs inline in the hot keepAlive path, and a failure to heal
+     * must not take down the connection - worst case the session stays
+     * visibly archived until the next heartbeat's retry succeeds, or the
+     * user falls back to a manual `/reopen`.
+     */
+    private healReaperArchivedSession(sessionId: string): void {
+        for (let attempt = 0; attempt < METADATA_RETRY_ATTEMPTS; attempt += 1) {
+            const session = this.sessions.get(sessionId) ?? this.refreshSession(sessionId)
+            if (!session) return
+            const current = session.metadata
+            if (!current) return
+            if (current.lifecycleState !== 'archived' || current.archivedBy !== REAPER_ARCHIVED_BY) {
+                return
+            }
+
+            const next: Record<string, unknown> = {
+                ...current,
+                lifecycleState: 'running',
+                lifecycleStateSince: Date.now()
+            }
+            delete next.archivedBy
+            delete next.archiveReason
+
+            const result = this.store.sessions.updateSessionMetadata(
+                sessionId,
+                next,
+                session.metadataVersion,
+                session.namespace,
+                { touchUpdatedAt: false }
+            )
+
+            if (result.result === 'error') {
+                // Best-effort (see doc comment above): swallow rather than
+                // throw into the keepAlive hot path.
+                return
+            }
+
+            if (result.result === 'success') {
+                this.refreshSession(sessionId)
+                this.publisher.emit({
+                    type: 'session-updated',
+                    sessionId,
+                    data: {
+                        metadata: { version: result.version, value: result.value as Session['metadata'] }
+                    } satisfies SessionPatch
+                })
+                return
+            }
+
+            this.refreshSession(sessionId)
+        }
+        // Exhausted retries under genuine contention: best-effort, leave the
+        // row as-is for now - a subsequent heartbeat will retry the heal.
+    }
+
     markSessionActive(sessionId: string, time: number = Date.now()): void {
         const t = clampAliveTime(time) ?? Date.now()
+        this.healReaperArchivedSession(sessionId)
         const session = this.sessions.get(sessionId) ?? this.refreshSession(sessionId)
         if (!session) return
 
@@ -357,6 +447,7 @@ export class SessionCache {
         const t = clampAliveTime(payload.time)
         if (!t) return
 
+        this.healReaperArchivedSession(payload.sid)
         const session = this.sessions.get(payload.sid) ?? this.refreshSession(payload.sid)
         if (!session) return
 
@@ -624,6 +715,18 @@ export class SessionCache {
         })
     }
 
+    /**
+     * Flips `active` to `false` for sessions whose heartbeat has been silent
+     * past `sessionTimeoutMs` (30s). Deliberately only touches `active` -
+     * never `metadata.lifecycleState` - because a short network blip that
+     * misses a couple of heartbeats must not escalate into an archive; the
+     * two concerns run on very different clocks by design. Reconciling
+     * `lifecycleState` for a session that never comes back is the
+     * long-threshold job of `SessionReaper` (reaper.ts, tens of minutes by
+     * default), backstopped by the reconnect self-heal
+     * (`healReaperArchivedSession`) if the CLI does come back after the
+     * reaper already archived it.
+     */
     expireInactive(now: number = Date.now()): string[] {
         const sessionTimeoutMs = 30_000
         const expired: string[] = []
@@ -775,7 +878,7 @@ export class SessionCache {
      * `archiveSession` flow still marks the session inactive in cache via
      * `handleSessionEnd`, just without flipping the persisted lifecycle.
      */
-    markSessionArchivedFromHub(sessionId: string, reason: string): void {
+    markSessionArchivedFromHub(sessionId: string, reason: string, archivedBy: string = 'hub'): void {
         for (let attempt = 0; attempt < METADATA_RETRY_ATTEMPTS; attempt += 1) {
             const session = this.sessions.get(sessionId) ?? this.refreshSession(sessionId)
             if (!session) return
@@ -789,7 +892,7 @@ export class SessionCache {
                 ...current,
                 lifecycleState: 'archived',
                 lifecycleStateSince: Date.now(),
-                archivedBy: 'hub',
+                archivedBy,
                 archiveReason: reason
             }
 
@@ -811,6 +914,24 @@ export class SessionCache {
 
             if (result.result === 'success') {
                 this.refreshSession(sessionId)
+                // Unlike renameSession's cosmetic metadata edit, this is a
+                // *terminal* write - no CLI is coming back to send its own
+                // update-metadata broadcast afterward, and the
+                // every-candidate-here-has-active===false precondition means
+                // SyncEngine.archiveSession's fallback handleSessionEnd()
+                // call (the other markSessionArchivedFromHub caller) also
+                // no-ops on it (it early-returns when already inactive).
+                // Without this, a hub-reaped session silently stops updating
+                // in already-open web UI tabs until the next unrelated full
+                // refetch - broadcast explicitly, same shape
+                // sessionHandlers.ts's update-metadata handler uses.
+                this.publisher.emit({
+                    type: 'session-updated',
+                    sessionId,
+                    data: {
+                        metadata: { version: result.version, value: result.value as Session['metadata'] }
+                    } satisfies SessionPatch
+                })
                 return
             }
 

--- a/hub/src/sync/sessionCache.ts
+++ b/hub/src/sync/sessionCache.ts
@@ -929,25 +929,13 @@ export class SessionCache {
             }
 
             if (result.result === 'success') {
+                // `refreshSession` re-reads the row we just wrote from the
+                // store, rebuilds the in-memory `Session`, and already emits
+                // a full `session-updated` broadcast itself (see its tail
+                // above) - already-open web UI tabs pick up the archive on
+                // that broadcast alone. A second, hand-rolled metadata-patch
+                // emit here would just double-fire the same update.
                 this.refreshSession(sessionId)
-                // Unlike renameSession's cosmetic metadata edit, this is a
-                // *terminal* write - no CLI is coming back to send its own
-                // update-metadata broadcast afterward, and the
-                // every-candidate-here-has-active===false precondition means
-                // SyncEngine.archiveSession's fallback handleSessionEnd()
-                // call (the other markSessionArchivedFromHub caller) also
-                // no-ops on it (it early-returns when already inactive).
-                // Without this, a hub-reaped session silently stops updating
-                // in already-open web UI tabs until the next unrelated full
-                // refetch - broadcast explicitly, same shape
-                // sessionHandlers.ts's update-metadata handler uses.
-                this.publisher.emit({
-                    type: 'session-updated',
-                    sessionId,
-                    data: {
-                        metadata: { version: result.version, value: result.value as Session['metadata'] }
-                    } satisfies SessionPatch
-                })
                 return
             }
 

--- a/hub/src/sync/sessionModel.test.ts
+++ b/hub/src/sync/sessionModel.test.ts
@@ -1358,7 +1358,7 @@ describe('session model', () => {
         }
     })
 
-    it('marks a resumed session active in hub cache before returning success without persisting runtime active state', async () => {
+    it('marks a resumed session active in hub cache and persists it before returning success', async () => {
         const store = new Store(':memory:')
         const events: unknown[] = []
         const engine = new SyncEngine(
@@ -1397,8 +1397,10 @@ describe('session model', () => {
 
             expect(result).toEqual({ type: 'success', sessionId: session.id })
             expect(engine.getSession(session.id)?.active).toBe(true)
-            // 中文注释：active=true 是运行时状态，不能跨 Hub 重启持久化；否则旧会话会在重启后假在线。
-            expect(store.sessions.getSession(session.id)?.active).toBe(false)
+            // Reactivation is persisted to the store (not left in-memory
+            // only), so it survives a hub restart instead of showing this
+            // session as stuck inactive despite the CLI having reconnected.
+            expect(store.sessions.getSession(session.id)?.active).toBe(true)
             expect(events.some((event) => {
                 const record = event as { type?: string; sessionId?: string; data?: { active?: boolean } }
                 return record.type === 'session-updated'

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -57,6 +57,7 @@ import {
 } from './rpcGateway'
 import { SessionCache } from './sessionCache'
 import { ingestNotifySummaryFromMessage } from './workGraphNotifyIngest'
+import { SessionReaper } from './reaper'
 
 type PiResumeAttempt = NonNullable<NonNullable<Session['metadata']>['piResumeAttempt']>
 type PtyResumeAttempt = NonNullable<NonNullable<Session['metadata']>['ptyResumeAttempt']>
@@ -172,6 +173,7 @@ export class SyncEngine {
     private readonly machineCache: MachineCache
     private readonly messageService: MessageService
     private readonly rpcGateway: RpcGateway
+    private readonly reaper: SessionReaper
     private inactivityTimer: NodeJS.Timeout | null = null
     /** Sessions that emitted `session-ready` (Cursor ACP or validated Pi get_state). */
     private readonly sessionReadyIds = new Set<string>()
@@ -215,6 +217,25 @@ export class SyncEngine {
         this.rpcGateway = new RpcGateway(io, rpcRegistry)
         this.reloadAll()
         this.inactivityTimer = setInterval(() => this.expireInactive(), 5_000)
+        // hub reaper: clears sessions whose CLI connection dropped without a
+        // chance to archive on exit (SIGHUP/SIGKILL, hub-restart cascades).
+        // start() sweeps once synchronously to arm the timer, but under the
+        // hub-downtime floor (see SessionReaper's class doc comment in
+        // reaper.ts) that first sweep never archives anything - it can only
+        // measure disconnect duration from the hub's own just-captured start
+        // instant, so every session looks age-zero. A genuine pre-existing
+        // zombie (CLI never reconnects) is still caught, by the first
+        // periodic sweep landing after `hub start + staleMs`, not by this
+        // synchronous one.
+        this.reaper = new SessionReaper(this.sessionCache, {
+            onReap: (sessionId) => {
+                console.warn('[hub-reaper] archived stale session', { sessionId })
+            },
+            onError: (sessionId, error) => {
+                console.error('[hub-reaper] failed to archive stale session', { sessionId, error })
+            }
+        })
+        this.reaper.start()
     }
 
     setHubOwnerUserId(ownerUserId: string | number): void {
@@ -226,6 +247,7 @@ export class SyncEngine {
             clearInterval(this.inactivityTimer)
             this.inactivityTimer = null
         }
+        this.reaper.stop()
     }
 
     subscribe(listener: SyncEventListener): () => void {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -219,7 +219,11 @@ export class SyncEngine {
         this.inactivityTimer = setInterval(() => this.expireInactive(), 5_000)
         // hub reaper: clears sessions whose CLI connection dropped without a
         // chance to archive on exit (SIGHUP/SIGKILL, hub-restart cascades).
-        // start() sweeps once synchronously to arm the timer, but under the
+        // Disabled by default (see reaper.ts's class doc comment on why a
+        // dropped connection alone isn't proof the CLI process is dead) - an
+        // operator opts in with `HAPI_REAPER_INTERVAL_MS`, and start() below
+        // is then a no-op until that env var is set. When enabled, start()
+        // sweeps once synchronously to arm the timer, but under the
         // hub-downtime floor (see SessionReaper's class doc comment in
         // reaper.ts) that first sweep never archives anything - it can only
         // measure disconnect duration from the hub's own just-captured start

--- a/hub/src/sync/syncEngineReaper.test.ts
+++ b/hub/src/sync/syncEngineReaper.test.ts
@@ -113,6 +113,74 @@ describe('SyncEngine reaper mount point', () => {
         }
     })
 
+    it('mounts a disabled reaper by default: no env override means no sweep timer and no candidate scanning', () => {
+        // Per the Major finding from the automated review: shipping the
+        // reaper on by default let a CLI riding out a long network
+        // partition get archived on heartbeat age alone, with no proof the
+        // process was actually dead - the existing reopen flow could then
+        // spawn a second agent before the original reconnected. The reaper
+        // now defaults to off (`REAPER_DEFAULT_INTERVAL_MS === 0`); this
+        // pins that `SyncEngine`'s mount point respects that default instead
+        // of forcing an interval of its own.
+        //
+        // `enabled`/`intervalMs` alone only prove the flags were plumbed
+        // through - they don't prove the reaper actually never looks at a
+        // candidate. So this also seeds a session that is 45 minutes
+        // disconnected with `lifecycleState: 'running'` (past the 30min
+        // default staleness threshold, so it would be reaped in a heartbeat
+        // if a sweep ever ran against it), spies on
+        // `SessionReaper.prototype.sweep` to assert it is never called, and
+        // asserts the session is still `running` after construction - proof
+        // the disabled reaper does not scan candidates, not just that its
+        // config says it shouldn't.
+        const store = new Store(':memory:')
+        const originalNow = Date.now
+        const backdatedAt = Date.now() - 45 * 60_000
+        Date.now = () => backdatedAt
+        let stored: ReturnType<typeof store.sessions.getOrCreateSession>
+        try {
+            stored = store.sessions.getOrCreateSession(
+                'stale-but-untouched',
+                { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+                null,
+                'default'
+            )
+        } finally {
+            Date.now = originalNow
+        }
+        expect(stored.active).toBe(false)
+
+        let sweepCalls = 0
+        const originalSweep = SessionReaper.prototype.sweep
+        SessionReaper.prototype.sweep = function patchedSweep(this: SessionReaper): string[] {
+            sweepCalls += 1
+            return originalSweep.call(this)
+        }
+
+        let engine: SyncEngine
+        try {
+            engine = new SyncEngine(
+                store,
+                {} as never,
+                new RpcRegistry(),
+                { broadcast() {} } as never
+            )
+        } finally {
+            SessionReaper.prototype.sweep = originalSweep
+        }
+        const reaper = (engine as unknown as { reaper: SessionReaper }).reaper
+        try {
+            expect(reaper.enabled).toBe(false)
+            expect(reaper.intervalMs).toBe(0)
+            expect(sweepCalls).toBe(0)
+
+            const session = engine.getSession(stored.id)
+            expect(session?.metadata?.lifecycleState).toBe('running')
+        } finally {
+            engine.stop()
+        }
+    })
+
     it('stop() delegates to the reaper, clearing its periodic timer', () => {
         const engine = makeEngine()
         const reaper = (engine as unknown as { reaper: SessionReaper }).reaper

--- a/hub/src/sync/syncEngineReaper.test.ts
+++ b/hub/src/sync/syncEngineReaper.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { RpcRegistry } from '../socket/rpcRegistry'
+import { Store } from '../store'
+import { SessionReaper } from './reaper'
+import { SyncEngine } from './syncEngine'
+
+/**
+ * Mount-point regression for the hub reaper: `SyncEngine`'s
+ * constructor/`stop()` are the only production callers of
+ * `SessionReaper.start()`/`stop()`. Sweep-logic correctness itself is
+ * covered by reaper.test.ts; this file only pins that the wiring exists and
+ * cannot be silently dropped.
+ */
+
+const ORIGINAL_ENV = { ...process.env }
+
+function makeEngine(): SyncEngine {
+    const store = new Store(':memory:')
+    return new SyncEngine(
+        store,
+        {} as never,
+        new RpcRegistry(),
+        { broadcast() {} } as never
+    )
+}
+
+describe('SyncEngine reaper mount point', () => {
+    beforeEach(() => {
+        delete process.env.HAPI_REAPER_INTERVAL_MS
+        delete process.env.HAPI_REAPER_STALE_MS
+    })
+
+    afterEach(() => {
+        process.env = { ...ORIGINAL_ENV }
+    })
+
+    it('sweeps synchronously during construction, but the hub-downtime floor spares a pre-existing zombie until staleMs elapses past hub start', () => {
+        // Per reaper.ts's hub-downtime-floor fix, the construction-time
+        // sweep can no longer archive anything on its own - every
+        // candidate's disconnect-since is floored at the reaper's own
+        // `start()` instant (called from `SyncEngine`'s constructor here),
+        // which collapses to age zero at that exact moment regardless of how
+        // stale its heartbeat looks by wall clock. That is the whole point
+        // of the fix: a hub that was down for longer than `staleMs` must not
+        // mass-archive every session the instant it comes back up.
+        //
+        // This still needs to pin that `SyncEngine`'s constructor really
+        // does wire up and invoke `SessionReaper.start()` (this file's
+        // stated job) independently of that now-quiescent archiving
+        // outcome - done by spying on `SessionReaper.prototype.sweep` since
+        // the reaper instance itself isn't constructed until `new
+        // SyncEngine(...)` runs, so there's nothing to spy on beforehand.
+        process.env.HAPI_REAPER_STALE_MS = '60000'
+        process.env.HAPI_REAPER_INTERVAL_MS = '3600000'
+
+        const store = new Store(':memory:')
+        // `getOrCreateSession` stamps `created_at`/`active_at` from
+        // `Date.now()` at insert time and a fresh row is always `active: 0`
+        // - so mocking the global clock *during creation* backdates the
+        // heartbeat directly, which is the real production mechanism (no
+        // row is ever born already-active; `active_at` only advances
+        // forward from there via `setSessionActive`'s monotonic guard, so a
+        // post-hoc backdate through that method is silently a no-op).
+        // Restoring the real clock
+        // before constructing `SyncEngine` below is what lets the
+        // construction-time sweep see this row as genuinely 2h-disconnected
+        // by the real "now" (i.e. by `activeAt` alone - the hub-start floor
+        // is what then spares it anyway).
+        const originalNow = Date.now
+        const backdatedAt = Date.now() - 2 * 60 * 60_000
+        Date.now = () => backdatedAt
+        let stored: ReturnType<typeof store.sessions.getOrCreateSession>
+        try {
+            stored = store.sessions.getOrCreateSession(
+                'zombie-tag',
+                { path: '/tmp/project', host: 'localhost', flavor: 'claude', lifecycleState: 'running' },
+                null,
+                'default'
+            )
+        } finally {
+            Date.now = originalNow
+        }
+        expect(stored.active).toBe(false)
+
+        let sweepCalls = 0
+        const originalSweep = SessionReaper.prototype.sweep
+        SessionReaper.prototype.sweep = function patchedSweep(this: SessionReaper): string[] {
+            sweepCalls += 1
+            return originalSweep.call(this)
+        }
+
+        let engine: SyncEngine
+        try {
+            engine = new SyncEngine(
+                store,
+                {} as never,
+                new RpcRegistry(),
+                { broadcast() {} } as never
+            )
+        } finally {
+            SessionReaper.prototype.sweep = originalSweep
+        }
+        try {
+            // Wiring proof: `start()` really did run a sweep during
+            // construction, independent of whether it archived anything.
+            expect(sweepCalls).toBeGreaterThan(0)
+
+            // Outcome proof: the hub-downtime floor spared it.
+            const session = engine.getSession(stored.id)
+            expect(session?.metadata?.lifecycleState).toBe('running')
+        } finally {
+            engine.stop()
+        }
+    })
+
+    it('stop() delegates to the reaper, clearing its periodic timer', () => {
+        const engine = makeEngine()
+        const reaper = (engine as unknown as { reaper: SessionReaper }).reaper
+        expect(reaper).toBeInstanceOf(Object)
+
+        let stopCalls = 0
+        const originalStop = reaper.stop.bind(reaper)
+        reaper.stop = () => {
+            stopCalls += 1
+            originalStop()
+        }
+
+        engine.stop()
+
+        expect(stopCalls).toBe(1)
+    })
+})


### PR DESCRIPTION
Addresses item 1 (second half) of #1526 — the two defects called out there.

**Up front — this PR flips two deliberate upstream test assertions** (`hub/src/sync/permissionModePersistence.test.ts:66`, `hub/src/sync/sessionModel.test.ts:1361`). Both previously asserted that runtime `active` state must **not** persist across restarts — a deliberate, commented design decision (stale sessions would otherwise look falsely online after a restart). That concern is real; this PR bounds it instead of dismissing it: after a restart, a stale persisted `active=true` row is converged back to `false` by the existing `expireInactive` sweep within ~35s worst-case (30s heartbeat threshold + one 5s tick), and a new regression test pins exactly that convergence path. In exchange, genuinely-connected sessions no longer show as offline after every hub restart until their next keepalive lands. Context below.

**1. `active=true` was never persisted on reactivation** (pre-existing upstream bug). `markSessionActive` / `handleSessionAlive` flipped the in-memory flag but never called `store.sessions.setSessionActive(id, true, …)`, unlike both `active=false` convergence points which do persist. A session that reconnected after going inactive reverted to "inactive" on the next hub restart even though its CLI was still connected. Fixed on the false→true edge only (no store write per repeat keepalive).

**2. The timeout path didn't reconcile `metadata.lifecycleState`** — the known `inactive`/`running` split-brain. Deliberately **not** fixed at the 30s expiry point: a brief network blip that misses a couple of heartbeats must not escalate into an archive. Instead:

- A new `SessionReaper` (periodic sweep, **disabled by default** — see the review discussion below; opt in via `HAPI_REAPER_INTERVAL_MS`) archives sessions that have been disconnected **and** `lifecycleState='running'` for longer than a stale threshold (default 30 min) — `archivedBy: 'hub-reaper'`, explicit `archiveReason`, broadcast as a normal `session-updated`.
- A reconnect self-heal (`healReaperArchivedSession`) restores `lifecycleState='running'` the moment a reaper-archived session's CLI actually comes back, so the reaper can never permanently bury a live session.
- Staleness is measured from the later of the session's last heartbeat and the reaper's own start instant ("hub-downtime floor"), so a hub outage is never charged against sessions; everyone gets a fresh full window after the hub comes back.
- Residual window: between the 30s `active=false` flip and the stale threshold, a session reads `active=false` + `lifecycleState='running'` — i.e. "disconnected, not yet archived." Up to ~30 min wide at the defaults; that's a knob (`HAPI_REAPER_STALE_MS`), not code.
- Knobs: `HAPI_REAPER_INTERVAL_MS` / `HAPI_REAPER_STALE_MS` (non-negative integers; `0` disables; documented in `hub/README.md`). **Ships disabled by default** (interval `0`) per the review below — heartbeat age alone can't prove process death, so heuristic reaping is operator opt-in. Once enabled, the stale threshold defaults to 30 min.

**Behavior notes reviewers should know**

- `markSessionArchivedFromHub` now broadcasts `session-updated` on success — this also adds a broadcast to the existing `/archive` fallback path (previously silent DB update).
- Historical rows whose `metadata` predates `lifecycleState` entirely are never touched by the reaper (intentional compatibility boundary).

**On #1486 — no code coupling, but one behavioral interaction worth naming.**

Verified by review: nothing here touches operator auth, proof rebind, machine ids, or resume capability grants.

There is a behavioral overlap worth surfacing rather than leaving for someone to find. #1473 shipped machine-id rotation (`allowLegacyReenroll`) for cold-start runner recovery, so a runner returning after a reboot registers under a *new* machine id while its earlier sessions stay attached to the retired one. Those sessions are then disconnected with `lifecycleState='running'` — exactly the reaper's archive condition — and the reconnect self-heal cannot fire for them, because the CLI never reconnects under the old id. At the default threshold the reaper would archive precisely the sessions an operator-approved remap (#1486's proposal) would later want to rescue.

Three reasons I don't think that argues against the reaper: it isn't introduced by this change (without it those sessions stay `running` forever, which is the split-brain this PR exists to fix); archiving is reversible; and the threshold is an env knob, not a constant. The reaper is also already conservative about states it doesn't understand — rows whose metadata predates `lifecycleState` are never touched.

If #1486 lands and wants the reaper to leave sessions pending an operator remap alone, `SessionReaper`'s sweep predicate is the single place to add that exemption — happy to wire it once there's something to key on.

**Tests:** 1111 tests / 88 files green, `tsc --noEmit` clean. Coverage includes reaper threshold/idempotency/broadcast/downtime-floor, self-heal on both reconnect entry points (incl. retry-exhaustion under contended metadata versions), reactivation persistence (TDD, red-first), the restart-convergence guard described above, and env-knob parsing (floats rejected → defaults).

**Heads-up on CI**

The `test` job will come up red on `typecheck:web` — a pre-existing breakage on upstream `main` itself (`web/src/components/assistant-ui/markdown-a.test.tsx:52`: missing required `showSessionSummaryInChat` in a test fixture). Reproducible on a clean `main` checkout; the Release 0.27.3 CI run is red the same way. Unrelated to this PR.

**AI disclosure** (per CONTRIBUTING's Vibe Coding policy): this was produced by a multi-agent workflow — Claude Fable 5 for planning and task decomposition, Claude Sonnet for implementation, and Claude Opus for code review and acceptance. A human reviewed the result and ran the verification above.

