### PR TITLE
fix(web): prevent Rewind crashes when message history resets

### DIFF
--- a/web/src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@assistant-ui/react', async (importOriginal) => {
         useAuiState: (selector: (state: unknown) => unknown) => selector({
             thread: { extras: undefined }
         }),
+        unstable_useThreadMessageIds: () => [],
         ThreadPrimitive: {
             ...actual.ThreadPrimitive,
             Root: ({ children, className }: PropsWithChildren<{ className?: string }>) => (

--- a/web/src/components/AssistantChat/HappyThread.test.tsx
+++ b/web/src/components/AssistantChat/HappyThread.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
-import type { ComponentProps } from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState, type ComponentProps } from 'react'
 import { I18nProvider } from '@/lib/i18n-context'
 import {
     ConversationOutlinePanel,
@@ -15,7 +15,10 @@ import {
     restoreScrollAnchor,
     shouldLoadOlderForViewport,
     shouldCancelInitialScrollSettling,
+    ThreadMessagesById,
 } from '@/components/AssistantChat/HappyThread'
+import { AssistantRuntimeProvider, useExternalStoreRuntime } from '@assistant-ui/react'
+import type { ThreadMessageLike } from '@assistant-ui/react'
 import type { ConversationOutlineItem } from '@/chat/outline'
 
 const outlineItems: ConversationOutlineItem[] = [
@@ -54,6 +57,65 @@ describe('nested scroll event ownership', () => {
         expect(isNestedScrollEvent(childEvent)).toBe(true)
 
         nested.remove()
+    })
+})
+
+describe('ThreadMessagesById', () => {
+    it('does not crash when rewind shortens the transcript and then clears it', async () => {
+        type TestMessage = { id: string; role: 'user' | 'assistant'; text: string }
+        let setMessages!: (messages: TestMessage[]) => void
+        function Harness() {
+            const [messages, updateMessages] = useState<TestMessage[]>([
+                { id: 'user-1', role: 'user', text: 'first' },
+                { id: 'assistant-1', role: 'assistant', text: 'answer' },
+                { id: 'user-2', role: 'user', text: 'second' },
+                { id: 'assistant-2', role: 'assistant', text: 'second answer' }
+            ])
+            setMessages = updateMessages
+            const runtime = useExternalStoreRuntime({
+                messages,
+                convertMessage: (message): ThreadMessageLike => ({
+                    id: message.id,
+                    role: message.role,
+                    content: [{ type: 'text', text: message.text }]
+                }),
+                onNew: async () => {}
+            })
+            return (
+                <AssistantRuntimeProvider runtime={runtime}>
+                    <ThreadMessagesById components={{
+                        UserMessage: () => <div data-testid="user-message" />,
+                        AssistantMessage: () => <div data-testid="assistant-message" />,
+                        SystemMessage: () => <div data-testid="system-message" />
+                    }} />
+                </AssistantRuntimeProvider>
+            )
+        }
+
+        render(<Harness />)
+        expect(screen.getAllByTestId('user-message')).toHaveLength(2)
+        expect(screen.getAllByTestId('assistant-message')).toHaveLength(2)
+
+        await act(async () => {
+            setMessages([
+                { id: 'user-1', role: 'user', text: 'first' },
+                { id: 'assistant-1', role: 'assistant', text: 'answer' }
+            ])
+        })
+
+        await waitFor(() => {
+            expect(screen.getAllByTestId('user-message')).toHaveLength(1)
+            expect(screen.getAllByTestId('assistant-message')).toHaveLength(1)
+        })
+
+        await act(async () => {
+            setMessages([])
+        })
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('user-message')).not.toBeInTheDocument()
+            expect(screen.queryByTestId('assistant-message')).not.toBeInTheDocument()
+        })
     })
 })
 

--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { ThreadPrimitive, useAuiState } from '@assistant-ui/react'
+import { ThreadPrimitive, unstable_useThreadMessageIds, useAuiState } from '@assistant-ui/react'
+import type { ComponentProps } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import type { ApiClient } from '@/api/client'
 import type { HappyRuntimeExtras } from '@/lib/assistant-runtime'
@@ -300,6 +301,32 @@ const THREAD_MESSAGE_COMPONENTS = {
     AssistantMessage: HappyAssistantMessage,
     SystemMessage: HappySystemMessage
 } as const
+
+type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.Unstable_MessageById>['components']
+
+/**
+ * Render messages by stable id instead of their current array index.
+ *
+ * Rewind can replace a non-empty transcript with an empty one in a single
+ * external-runtime update. Index-based providers may then ask assistant-ui
+ * for message 0 while its lookup table is already empty. Stable id providers
+ * unmount removed rows without consulting a stale index.
+ */
+export function ThreadMessagesById({ components }: { components: ThreadMessageComponents }) {
+    const messageIds = unstable_useThreadMessageIds()
+
+    return (
+        <>
+            {messageIds.map((messageId) => (
+                <ThreadPrimitive.Unstable_MessageById
+                    key={messageId}
+                    messageId={messageId}
+                    components={components}
+                />
+            ))}
+        </>
+    )
+}
 
 export function ConversationOutlinePanel(props: {
     items: readonly ConversationOutlineItem[]
@@ -1648,7 +1675,7 @@ export function HappyThread(props: {
                                 </>
                             )}
                             <div className="happy-thread-messages flex flex-col gap-3">
-                                <ThreadPrimitive.Messages components={THREAD_MESSAGE_COMPONENTS} />
+                                <ThreadMessagesById components={THREAD_MESSAGE_COMPONENTS} />
                             </div>
                         </div>
                     </div>

--- a/web/src/components/assistant-ui/markdown-a.test.tsx
+++ b/web/src/components/assistant-ui/markdown-a.test.tsx
@@ -60,6 +60,7 @@ function chatContext(overrides: Partial<HappyChatContextValue> = {}): HappyChatC
         isSyncingTail: false,
         isLoadingMoreMessages: false,
         loadOlderMessagesPreservingScroll: async () => 'loaded',
+        showSessionSummaryInChat: false,
         ...overrides,
     }
 }


### PR DESCRIPTION
## Summary

- Prevent Rewind crashes when the assistant-ui transcript changes from non-empty to empty or to a retained prefix.
- Render thread messages by stable message ID instead of the current array index.
- Add regression coverage for middle-message truncation followed by an empty reset.
- Update the markdown test fixture for the required session-summary context field.

## Validation

- `bun typecheck` — passed.
- `bun run test:e2e -- terminal-wrap-fidelity.spec.ts` — 2 passed.
- `bun run test:web` — passed (2,445 tests).
- `bun run --cwd web test -- src/components/AssistantChat/HappyThread.test.tsx src/components/AssistantChat/HappyThread.mobile-scroll.test.tsx src/components/assistant-ui/markdown-a.test.tsx src/lib/message-window-store.test.ts` — 141 passed.
- `bun run build` — passed.
- Full task-environment Playwright verification — first-message and middle-message Rewind requests returned HTTP 200 with no error page, page errors, or console errors.

## Related Issues

None.

## AI Disclosure

Implemented and validated with OpenAI Codex.