### PR TITLE
fix(codex): cache codex model list to avoid spawning app-server per request

### DIFF
--- a/cli/src/modules/common/codexModels.test.ts
+++ b/cli/src/modules/common/codexModels.test.ts
@@ -92,6 +92,22 @@ describe('listCodexModels cwd', () => {
         expect(first).toHaveLength(1);
     });
 
+    it('expires the cache after the TTL so a later call respawns the app-server', async () => {
+        vi.useFakeTimers();
+        try {
+            listModelsMock.mockResolvedValue({ data: [{ id: 'gpt-5.6-sol', displayName: 'GPT-5.6-Sol' }] });
+
+            await listCodexModels();
+            expect(constructorOptions).toHaveLength(1);
+
+            vi.advanceTimersByTime(5 * 60_000 + 1);
+            await listCodexModels();
+            expect(constructorOptions).toHaveLength(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it('does not cache empty or failed results', async () => {
         listModelsMock.mockResolvedValue({ data: [] });
         await listCodexModels();

--- a/cli/src/modules/common/codexModels.test.ts
+++ b/cli/src/modules/common/codexModels.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { constructorOptions } = vi.hoisted(() => ({
-    constructorOptions: [] as unknown[]
+const { constructorOptions, listModelsMock } = vi.hoisted(() => ({
+    constructorOptions: [] as unknown[],
+    listModelsMock: vi.fn()
 }));
 
 vi.mock('node:os', async () => {
@@ -18,22 +19,88 @@ vi.mock('@/codex/codexAppServerClient', () => ({
         async connect(): Promise<void> {}
         async initialize(): Promise<void> {}
         async listModels(): Promise<{ data: unknown[] }> {
-            return { data: [] };
+            return listModelsMock();
         }
         async disconnect(): Promise<void> {}
     }
 }));
 
-import { listCodexModels } from './codexModels';
+import { listCodexModels, _resetCodexModelsCacheForTests } from './codexModels';
 
 describe('listCodexModels cwd', () => {
     beforeEach(() => {
         constructorOptions.length = 0;
+        listModelsMock.mockReset();
+        _resetCodexModelsCacheForTests();
     });
 
     it('starts discovery from the user home instead of the caller cwd', async () => {
+        listModelsMock.mockResolvedValue({ data: [] });
+
         await listCodexModels();
 
         expect(constructorOptions).toEqual([{ cwd: '/neutral-home' }]);
+    });
+
+    it('caches the model list within the TTL so repeat calls skip the app-server spawn', async () => {
+        listModelsMock.mockResolvedValue({
+            data: [{ id: 'gpt-5.6-sol', displayName: 'GPT-5.6-Sol', isDefault: true }]
+        });
+
+        const first = await listCodexModels();
+        const second = await listCodexModels();
+
+        expect(first).toEqual([expect.objectContaining({
+            id: 'gpt-5.6-sol',
+            displayName: 'GPT-5.6-Sol',
+            isDefault: true
+        })]);
+        expect(second).toEqual(first);
+        expect(constructorOptions).toHaveLength(1);
+        expect(listModelsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps visible and hidden model lists in separate cache slots', async () => {
+        listModelsMock.mockResolvedValue({ data: [{ id: 'gpt-5.6-sol', displayName: 'GPT-5.6-Sol' }] });
+
+        await listCodexModels(false);
+        await listCodexModels(false);
+        await listCodexModels(true);
+        await listCodexModels(true);
+
+        expect(constructorOptions).toHaveLength(2);
+    });
+
+    it('coalesces concurrent requests into a single app-server spawn', async () => {
+        let resolveList: (value: { data: unknown[] }) => void = () => undefined;
+        listModelsMock.mockImplementationOnce(
+            () => new Promise((res) => { resolveList = res; })
+        );
+
+        const inflight1 = listCodexModels();
+        const inflight2 = listCodexModels();
+
+        // Allow the microtasks to schedule the first request before resolving it.
+        await new Promise((resolve) => setImmediate(resolve));
+        resolveList({ data: [{ id: 'gpt-5.6-sol', displayName: 'GPT-5.6-Sol' }] });
+
+        const [first, second] = await Promise.all([inflight1, inflight2]);
+
+        expect(constructorOptions).toHaveLength(1);
+        expect(listModelsMock).toHaveBeenCalledTimes(1);
+        expect(first).toEqual(second);
+        expect(first).toHaveLength(1);
+    });
+
+    it('does not cache empty or failed results', async () => {
+        listModelsMock.mockResolvedValue({ data: [] });
+        await listCodexModels();
+        await listCodexModels();
+        expect(constructorOptions).toHaveLength(2);
+
+        listModelsMock.mockRejectedValue(new Error('app-server exploded'));
+        await expect(listCodexModels()).rejects.toThrow('app-server exploded');
+        await expect(listCodexModels()).rejects.toThrow('app-server exploded');
+        expect(constructorOptions).toHaveLength(4);
     });
 });

--- a/cli/src/modules/common/codexModels.ts
+++ b/cli/src/modules/common/codexModels.ts
@@ -81,7 +81,50 @@ function normalizeModel(entry: unknown): CodexModelSummary | null {
     };
 }
 
+interface CacheEntry {
+    expiresAt: number;
+    models: CodexModelSummary[];
+}
+
+// The Codex catalog is account-scoped and changes rarely. Each uncached call
+// spawns a fresh `codex app-server` subprocess and validates the ChatGPT
+// session, which can take 2-30s when a token refresh or network round trip is
+// involved. Cache successful lists for 5 minutes (same shape as the opencode
+// model cache) and coalesce concurrent requests into a single spawn.
+const CACHE_TTL_MS = 5 * 60_000;
+const cache = new Map<boolean, CacheEntry>();
+const inflight = new Map<boolean, Promise<CodexModelSummary[]>>();
+
 export async function listCodexModels(includeHidden: boolean = false): Promise<CodexModelSummary[]> {
+    const cached = cache.get(includeHidden);
+    if (cached && cached.expiresAt > Date.now()) {
+        return cached.models;
+    }
+
+    const existing = inflight.get(includeHidden);
+    if (existing) {
+        return existing;
+    }
+
+    const promise = fetchCodexModelsFromAppServer(includeHidden)
+        .then((models) => {
+            if (models.length > 0) {
+                cache.set(includeHidden, {
+                    expiresAt: Date.now() + CACHE_TTL_MS,
+                    models
+                });
+            }
+            return models;
+        })
+        .finally(() => {
+            inflight.delete(includeHidden);
+        });
+
+    inflight.set(includeHidden, promise);
+    return promise;
+}
+
+async function fetchCodexModelsFromAppServer(includeHidden: boolean): Promise<CodexModelSummary[]> {
     // Model discovery is account-scoped. Never inherit a session/runner cwd:
     // project config or a deleted worktree must not alter or break the catalog.
     const client = new CodexAppServerClient({ cwd: homedir() });
@@ -99,14 +142,20 @@ export async function listCodexModels(includeHidden: boolean = false): Promise<C
         });
 
         const response = await client.listModels({ includeHidden });
-        const models = Array.isArray(response.data)
+        return Array.isArray(response.data)
             ? response.data.map(normalizeModel).filter((model): model is CodexModelSummary => model !== null)
             : [];
-
-        return models;
     } catch (error) {
         throw new Error(getErrorMessage(error, 'Failed to list Codex models'));
     } finally {
         await client.disconnect().catch(() => undefined);
     }
+}
+
+/**
+ * Clear the in-process cache and any in-flight probe. Exposed for tests.
+ */
+export function _resetCodexModelsCacheForTests(): void {
+    cache.clear();
+    inflight.clear();
 }


### PR DESCRIPTION
## Summary

Fixes #1533 — `codex-models` fetch took **0.5–33s on every Codex session open** because `listCodexModels()` spawned a fresh `codex app-server` subprocess per request (version probe → app-server boot → ChatGPT session validation/token refresh → model list → kill), and the web refetches on every session open / dialog mount (`staleTime: 30s`).

Fleet measurement (all 7 machines, codex-cli 0.145.0, via the hub REST endpoint): 0.53s / 0.61s / 1.89s / 3.34s / 3.42s / 4.44s / **33.2s** (hard `initialize` 30s timeout). This supplements #806 (intermittent 120s RPC timeouts, same root cause; its fix PR #807 was closed unmerged).

## Changes

### `cli/src/modules/common/codexModels.ts`
Mirrors the existing opencode model cache (`opencodeModels.ts`):
- **5-minute TTL cache** of successful non-empty model lists, keyed by `includeHidden` (visible/hidden kept separate)
- **Single-flight coalescing** so concurrent requests (New Session dialog + session chat mount) share one app-server spawn
- **Failures and empty results are never cached** — a machine with a broken OpenAI network path retries on the next request instead of serving a stale/empty catalog
- `_resetCodexModelsCacheForTests()` for test isolation

### `cli/src/modules/common/codexModels.test.ts`
Regression tests: cache hit within TTL, separate visible/hidden slots, concurrent coalescing, and no-cache on empty/failed results.

### `web/src/components/assistant-ui/markdown-a.test.tsx` (drive-by, CI repair)
Repo-wide typecheck is currently **red on upstream main** (the v0.27.3 release commit's `test` workflow fails at `bun typecheck`): #1477 added the required `showSessionSummaryInChat` field to `HappyChatContextValue` without updating this test helper. One-line fixture addition; no behavior change. Included because the shared typecheck step blocks every PR's CI.

## Impact
- Cache hits: instant (<10ms), no app-server spawn, no network
- Cache miss: unchanged 0.5s (healthy) / up to 30s (broken network) on first request per 5 minutes
- No changes to `CodexAppServerClient`, RPC methods, or hub timeouts (the Codex/Cursor timeout coupling that blocked #807 is untouched)

## Verification
- `bun typecheck` → exit 0 (all packages)
- `bun run test` → exit 0: cli 2461 passed (1 pre-existing skip), web 2450 passed
- Targeted: `codexModels.test.ts` 5/5, `markdown-a.test.tsx` 78/78
