### PR TITLE
feat: add peer tools exposure toggle (#1401)

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -5,6 +5,7 @@
 - Add owner-only `peerToolsEnabled` Hub setting; default on for old settings and responses.
 - Apply it to new/resumed bootstrap, Claude HTTP MCP, Codex/OpenCode stdio, and ACP tool advertisements/approvals.
 - Remove peer citation/list-discovery steering when off; human session citation text remains usable.
+- Done invariant: only confirmed enabled emits steering; unknown state is path-only.
 - Entry evidence: real flavor MCP tool-list tests plus prompt-construction tests covering Claude, Codex, OpenCode, and ACP runner paths.
 
 ## M2 — Session authorization

--- a/GOALS.md
+++ b/GOALS.md
@@ -1,0 +1,12 @@
+# HAPI delivery roadmap
+
+## M1 — Hub-level peer-tools exposure toggle
+
+- Add owner-only `peerToolsEnabled` Hub setting; default on for old settings and responses.
+- Apply it to new/resumed bootstrap, Claude HTTP MCP, Codex/OpenCode stdio, and ACP tool advertisements/approvals.
+- Remove peer citation/list-discovery steering when off; human session citation text remains usable.
+- Entry evidence: real flavor MCP tool-list tests plus prompt-construction tests covering Claude, Codex, OpenCode, and ACP runner paths.
+
+## M2 — Session authorization
+
+- Not activated. Depends on trusted principal/credential custody; see upstream hard-gate audit #1535. Same UID plus a readable owner token cannot be solved by M1.

--- a/cli/README.md
+++ b/cli/README.md
@@ -128,6 +128,12 @@ See `src/configuration.ts` for all options.
   bun scripts/tooling/hapi-display-image.mjs /absolute/path/to/image.png "optional title"
   ```
 
+The Hub Settings “Expose peer session tools to agents” toggle controls whether
+new or resumed sessions receive the peer MCP tools (`list_peers`, `inspect_peer`,
+and `ping_peer`) and their agent citation guidance. It defaults to on for older
+Hubs/settings. This controls agent-tool exposure only; it is not a REST
+authorization boundary.
+
   Explicit other session (prefix or full uuid) still works; that path may list sessions.
 
 ## Storage

--- a/cli/src/api/api.getSession.activeAt.test.ts
+++ b/cli/src/api/api.getSession.activeAt.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { configuration } from '@/configuration'
+import { applyHubPeerToolsEnabled, isHubPeerToolsEnabled, resetHubPeerToolsEnabledForTests } from '@/modules/common/peerToolsExposure'
 
 const axiosGetMock = vi.hoisted(() => vi.fn())
 
@@ -23,9 +24,11 @@ describe('ApiClient.getSession activeAt coerce', () => {
         configuration._setApiUrl('https://hapi.example.com')
         configuration._setExtraHeaders({})
         axiosGetMock.mockReset()
+        resetHubPeerToolsEnabledForTests()
     })
 
     it('accepts hub payloads with null activeAt without throwing', async () => {
+        applyHubPeerToolsEnabled(false)
         axiosGetMock.mockResolvedValue({
             data: {
                 session: {
@@ -59,5 +62,38 @@ describe('ApiClient.getSession activeAt coerce', () => {
 
         expect(session.activeAt).toBe(0)
         expect(typeof session.activeAt).toBe('number')
+        expect(isHubPeerToolsEnabled()).toBe(true)
+    })
+
+    it('applies the hub peer tools toggle from the resume bootstrap response', async () => {
+        axiosGetMock.mockResolvedValue({
+            data: {
+                peerToolsEnabled: false,
+                session: {
+                    id: '11111111-1111-4111-8111-111111111111',
+                    namespace: 'default',
+                    seq: 1,
+                    createdAt: now,
+                    updatedAt: now,
+                    active: false,
+                    activeAt: now,
+                    metadata: null,
+                    metadataVersion: 0,
+                    agentState: null,
+                    agentStateVersion: 0,
+                    thinking: false,
+                    thinkingAt: now,
+                    todos: [],
+                    model: null,
+                    modelReasoningEffort: null,
+                    effort: null,
+                    serviceTier: null
+                }
+            }
+        })
+
+        const client = await ApiClient.create()
+        await client.getSession('11111111-1111-4111-8111-111111111111')
+        expect(isHubPeerToolsEnabled()).toBe(false)
     })
 })

--- a/cli/src/api/api.ts
+++ b/cli/src/api/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import type { AgentState, ClearOpencodeSessionCallbackRequest, ClearOpencodeSessionResponse, CreateMachineResponse, CreateSessionResponse, RunnerState, Machine, MachineMetadata, Metadata, Session } from '@/api/types'
 import { applyHubSessionSummaryContract } from '@/modules/common/sessionSummaryInstruction'
+import { applyHubPeerToolsEnabled } from '@/modules/common/peerToolsExposure'
 import type { LocalResumeTarget, ResumableSession } from '@hapi/protocol'
 import {
     AgentStateSchema,
@@ -88,6 +89,7 @@ export class ApiClient {
         if (typeof parsed.data.sessionSummaryContract === 'boolean') {
             applyHubSessionSummaryContract(parsed.data.sessionSummaryContract)
         }
+        applyHubPeerToolsEnabled(parsed.data.peerToolsEnabled ?? true)
 
         const raw = parsed.data.session
 
@@ -144,6 +146,7 @@ export class ApiClient {
         if (typeof parsed.data.sessionSummaryContract === 'boolean') {
             applyHubSessionSummaryContract(parsed.data.sessionSummaryContract)
         }
+        applyHubPeerToolsEnabled(parsed.data.peerToolsEnabled ?? true)
 
         const raw = parsed.data.session
         const metadata = (() => {

--- a/cli/src/claude/utils/startHappyServer.test.ts
+++ b/cli/src/claude/utils/startHappyServer.test.ts
@@ -163,6 +163,24 @@ describe('startHappyServer skill_lookup', () => {
         ])
     })
 
+    it('does not advertise peer tools when hub exposure is off', async () => {
+        const sessionClient = {
+            updateMetadata: vi.fn(),
+            sendAgentMessage: vi.fn(),
+            sendClaudeSessionMessage: vi.fn()
+        } as unknown as ApiSessionClient
+        const server = await startHappyServer(sessionClient, { peerToolsEnabled: false })
+        stopServer = server.stop
+        const mcp = new Client({ name: 'hapi-peer-toggle-test', version: '1.0.0' })
+        client = mcp
+
+        await mcp.connect(new StreamableHTTPClientTransport(new URL(server.url)))
+        const tools = await mcp.listTools()
+
+        expect(server.toolNames).not.toEqual(expect.arrayContaining(['list_peers', 'ping_peer', 'inspect_peer']))
+        expect(tools.tools.map((tool) => tool.name)).not.toEqual(expect.arrayContaining(['list_peers', 'ping_peer', 'inspect_peer']))
+    })
+
 })
 
 describe('toClaudeAllowedHapiMcpTools', () => {

--- a/cli/src/claude/utils/startHappyServer.ts
+++ b/cli/src/claude/utils/startHappyServer.ts
@@ -21,6 +21,7 @@ import {
 import type { InlineMediaSource } from "@/modules/common/inlineMediaSource";
 import { DISPLAY_IMAGE_PROMPT_CURSOR, DISPLAY_MEDIA_PROMPT_CURSOR, DISPLAY_VIDEO_PROMPT_CURSOR } from "@/modules/common/displayImagePrompt";
 import { resolveSkill } from "@/modules/common/skills";
+import { isHubPeerToolsEnabled } from '@/modules/common/peerToolsExposure'
 import {
     INSPECT_PEER_TOOL_DESCRIPTION,
     PING_PEER_TOOL_DESCRIPTION,
@@ -35,6 +36,8 @@ type StartHappyServerOptions = {
         workingDirectory: string;
         flavor: string;
     };
+    /** Exposure control only; peer REST routes keep their existing authorization. */
+    peerToolsEnabled?: boolean;
 };
 
 /** Registered on the MCP server, but never pre-approved via Claude --allowedTools. */
@@ -61,7 +64,8 @@ function createHapiMcpServer(
     client: ApiSessionClient,
     emitTitleSummary: boolean,
     enableChangeTitle: boolean,
-    skillLookup: StartHappyServerOptions['skillLookup']
+    skillLookup: StartHappyServerOptions['skillLookup'],
+    peerToolsEnabled: boolean
 ): McpServer {
     const handler = async (title: string) => {
         logger.debug('[hapiMCP] Changing title to:', title);
@@ -291,7 +295,7 @@ function createHapiMcpServer(
         }
     });
 
-    mcp.registerTool<any, any>('ping_peer', {
+    if (peerToolsEnabled) mcp.registerTool<any, any>('ping_peer', {
         description: PING_PEER_TOOL_DESCRIPTION,
         title: 'Ping Peer Session',
         inputSchema: pingPeerInputSchema,
@@ -330,7 +334,7 @@ function createHapiMcpServer(
         }
     });
 
-    mcp.registerTool<any, any>('inspect_peer', {
+    if (peerToolsEnabled) mcp.registerTool<any, any>('inspect_peer', {
         description: INSPECT_PEER_TOOL_DESCRIPTION,
         title: 'Inspect Peer Session',
         inputSchema: inspectPeerInputSchema,
@@ -369,7 +373,7 @@ function createHapiMcpServer(
         }
     });
 
-    mcp.registerTool<any, any>('list_peers', {
+    if (peerToolsEnabled) mcp.registerTool<any, any>('list_peers', {
         description: 'List peer HAPI sessions on the same hub/namespace (id prefix, active, flavor, name). Uses this session\'s hub credentials - works from runner-spawned agents without being on the hub host. Prefer this over shelling `hapi ping-peer --list`. Then call inspect_peer / ping_peer with a listed id.',
         title: 'List Peer Sessions',
         inputSchema: listPeersInputSchema,
@@ -477,9 +481,10 @@ export async function startHappyServer(client: ApiSessionClient, options: StartH
     const enableChangeTitle = options.enableChangeTitle ?? true;
     const transports = new Map<string, StreamableHTTPServerTransport>();
     const mcps = new Map<string, McpServer>();
+    const peerToolsEnabled = options.peerToolsEnabled ?? isHubPeerToolsEnabled();
 
     const createMcpTransport = () => {
-        const mcp = createHapiMcpServer(client, emitTitleSummary, enableChangeTitle, options.skillLookup);
+        const mcp = createHapiMcpServer(client, emitTitleSummary, enableChangeTitle, options.skillLookup, peerToolsEnabled);
         const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (sessionId) => {
@@ -534,8 +539,11 @@ export async function startHappyServer(client: ApiSessionClient, options: StartH
     }));
 
     const toolNames = enableChangeTitle
-        ? ['change_title', 'display_image', 'display_video', 'display_media', 'list_peers', 'ping_peer', 'inspect_peer']
-        : ['display_image', 'display_video', 'display_media', 'list_peers', 'ping_peer', 'inspect_peer'];
+        ? ['change_title', 'display_image', 'display_video', 'display_media']
+        : ['display_image', 'display_video', 'display_media'];
+    if (peerToolsEnabled) {
+        toolNames.push('list_peers', 'ping_peer', 'inspect_peer');
+    }
     if (options.skillLookup) {
         toolNames.push('skill_lookup');
     }

--- a/cli/src/claude/utils/systemPrompt.ts
+++ b/cli/src/claude/utils/systemPrompt.ts
@@ -3,6 +3,7 @@ import { buildSessionCitationSteerInstruction } from "@hapi/protocol/sessionCita
 import { shouldIncludeCoAuthoredBy } from "./claudeSettings";
 import { DISPLAY_IMAGE_PROMPT_CLAUDE, DISPLAY_MEDIA_PROMPT_CLAUDE, DISPLAY_VIDEO_PROMPT_CLAUDE } from "@/modules/common/displayImagePrompt";
 import { withSessionSummaryInstruction } from "@/modules/common/sessionSummaryInstruction";
+import { isHubPeerToolsEnabled } from '@/modules/common/peerToolsExposure';
 
 /**
  * Base system prompt shared across all configurations
@@ -12,12 +13,13 @@ const BASE_SYSTEM_PROMPT = (() => trimIdent(`
     ${DISPLAY_IMAGE_PROMPT_CLAUDE}
     ${DISPLAY_VIDEO_PROMPT_CLAUDE}
     ${DISPLAY_MEDIA_PROMPT_CLAUDE}
-    ${buildSessionCitationSteerInstruction({
-        inspectTool: 'mcp__hapi__inspect_peer',
-        pingTool: 'mcp__hapi__ping_peer',
-        listPeersTool: 'mcp__hapi__list_peers',
-    })}
 `))();
+
+const PEER_CITATION_GUIDANCE = buildSessionCitationSteerInstruction({
+    inspectTool: 'mcp__hapi__inspect_peer',
+    pingTool: 'mcp__hapi__ping_peer',
+    listPeersTool: 'mcp__hapi__list_peers',
+});
 
 /**
  * Co-authored-by credits to append when enabled
@@ -39,8 +41,10 @@ const CO_AUTHORED_CREDITS = (() => trimIdent(`
  */
 export function getSystemPrompt(): string {
     const includeCoAuthored = shouldIncludeCoAuthoredBy();
+    const peerGuidance = isHubPeerToolsEnabled() ? '\n\n' + PEER_CITATION_GUIDANCE : '';
+    const basePrompt = BASE_SYSTEM_PROMPT + peerGuidance;
     const base = includeCoAuthored
-        ? BASE_SYSTEM_PROMPT + '\n\n' + CO_AUTHORED_CREDITS
-        : BASE_SYSTEM_PROMPT;
+        ? basePrompt + '\n\n' + CO_AUTHORED_CREDITS
+        : basePrompt;
     return withSessionSummaryInstruction(base);
 }

--- a/cli/src/codex/happyMcpStdioBridge.test.ts
+++ b/cli/src/codex/happyMcpStdioBridge.test.ts
@@ -159,20 +159,4 @@ describe('runHappyMcpStdioBridge tool forwarding', () => {
         ])
     })
 
-    it('does not register peer tools when the bridge tool list omits them', async () => {
-        await runHappyMcpStdioBridge([
-            '--url',
-            'http://127.0.0.1:43006',
-            '--tools',
-            'change_title,display_image,display_video,display_media'
-        ])
-
-        expect([...harness.tools.keys()]).toEqual([
-            'change_title',
-            'display_image',
-            'display_video',
-            'display_media'
-        ])
-    })
-
 })

--- a/cli/src/codex/happyMcpStdioBridge.test.ts
+++ b/cli/src/codex/happyMcpStdioBridge.test.ts
@@ -159,4 +159,20 @@ describe('runHappyMcpStdioBridge tool forwarding', () => {
         ])
     })
 
+    it('does not register peer tools when the bridge tool list omits them', async () => {
+        await runHappyMcpStdioBridge([
+            '--url',
+            'http://127.0.0.1:43006',
+            '--tools',
+            'change_title,display_image,display_video,display_media'
+        ])
+
+        expect([...harness.tools.keys()]).toEqual([
+            'change_title',
+            'display_image',
+            'display_video',
+            'display_media'
+        ])
+    })
+
 })

--- a/cli/src/codex/utils/buildHapiMcpBridge.test.ts
+++ b/cli/src/codex/utils/buildHapiMcpBridge.test.ts
@@ -9,13 +9,16 @@ const harness = vi.hoisted(() => ({
 }))
 
 vi.mock('@/claude/utils/startHappyServer', () => ({
-    startHappyServer: vi.fn(async (_client: unknown, options: { skillLookup?: unknown }) => {
+    startHappyServer: vi.fn(async (_client: unknown, options: { skillLookup?: unknown; peerToolsEnabled?: boolean }) => {
         harness.startOptions = options
+        const peerTools = options.peerToolsEnabled !== false
         return {
             url: 'http://127.0.0.1:43006/',
-            toolNames: options.skillLookup
-                ? ['change_title', 'display_image', 'display_video', 'display_media', 'list_peers', 'ping_peer', 'inspect_peer', 'skill_lookup']
-                : ['change_title', 'display_image', 'display_video', 'display_media', 'list_peers', 'ping_peer', 'inspect_peer'],
+            toolNames: [
+                'change_title', 'display_image', 'display_video', 'display_media',
+                ...(peerTools ? ['list_peers', 'ping_peer', 'inspect_peer'] : []),
+                ...(options.skillLookup ? ['skill_lookup'] : [])
+            ],
             stop: vi.fn()
         }
     })
@@ -104,6 +107,18 @@ describe('buildHapiMcpBridge skill lookup config', () => {
         expect(harness.materialize).toHaveBeenCalledOnce()
         expect(process.env[HAPI_SESSION_ID_ENV]).toBe('lazy-session-1')
         expect(client.isPending()).toBe(false)
+    })
+
+    it('omits peer tools and approvals when hub exposure is off', async () => {
+        const bridge = await buildHapiMcpBridge(createClient(), { peerToolsEnabled: false })
+
+        expect(harness.cliArgs.at(-1)).toBe('change_title,display_image,display_video,display_media')
+        expect(bridge.mcpServers.hapi.tools).toEqual({
+            change_title: { approval_mode: 'approve' },
+            display_image: { approval_mode: 'prompt' },
+            display_video: { approval_mode: 'prompt' },
+            display_media: { approval_mode: 'prompt' }
+        })
     })
 
     it('fails closed when pending materialization fails', async () => {

--- a/cli/src/codex/utils/buildHapiMcpBridge.ts
+++ b/cli/src/codex/utils/buildHapiMcpBridge.ts
@@ -50,6 +50,8 @@ export interface HapiMcpBridgeOptions {
         workingDirectory: string;
         flavor: string;
     };
+    /** Exposure control only; peer REST routes retain their authorization. */
+    peerToolsEnabled?: boolean;
 }
 
 /**
@@ -80,8 +82,10 @@ export async function buildHapiMcpBridge(
     const happyServer = await startHappyServer(client, {
         emitTitleSummary: options.emitTitleSummary,
         enableChangeTitle: options.enableChangeTitle,
-        skillLookup: options.skillLookup
+        skillLookup: options.skillLookup,
+        ...(options.peerToolsEnabled === undefined ? {} : { peerToolsEnabled: options.peerToolsEnabled })
     });
+    const peerToolsEnabled = happyServer.toolNames.includes('list_peers');
     const bridgeCommand = getHappyCliCommand([
         'mcp',
         '--url',
@@ -105,13 +109,15 @@ export async function buildHapiMcpBridge(
             approval_mode: 'approve'
         };
     }
-    // Discovery shortlist only - same trust as skill_lookup / change_title.
-    tools.list_peers = {
-        approval_mode: 'approve'
-    };
-    // ping_peer / inspect_peer are registered on the HTTP MCP server / stdio
-    // bridge, but are not auto-approved: they target another session (resume +
-    // inject, or read peer histories).
+    if (peerToolsEnabled) {
+        // Discovery shortlist only - same trust as skill_lookup / change_title.
+        tools.list_peers = {
+            approval_mode: 'approve'
+        };
+        // ping_peer / inspect_peer are registered on the HTTP MCP server / stdio
+        // bridge, but are not auto-approved: they target another session (resume +
+        // inject, or read peer histories).
+    }
     if (options.skillLookup) {
         tools.skill_lookup = {
             approval_mode: 'approve'

--- a/cli/src/codex/utils/systemPrompt.ts
+++ b/cli/src/codex/utils/systemPrompt.ts
@@ -9,13 +9,14 @@ import { trimIdent } from '@/utils/trimIdent';
 import { buildSessionCitationSteerInstruction } from '@hapi/protocol/sessionCitation';
 import { DISPLAY_IMAGE_PROMPT_CODEX, DISPLAY_MEDIA_PROMPT_CODEX, DISPLAY_VIDEO_PROMPT_CODEX } from '@/modules/common/displayImagePrompt';
 import { withSessionSummaryInstruction } from '@/modules/common/sessionSummaryInstruction';
+import { isHubPeerToolsEnabled } from '@/modules/common/peerToolsExposure';
 
 /**
  * Title instruction for Codex to call the hapi MCP tool.
  * Note: Codex exposes MCP tools under the `functions.` namespace,
  * so the tool is called as `functions.hapi__change_title`.
  */
-export const TITLE_INSTRUCTION = trimIdent(`
+const TITLE_INSTRUCTION_BASE = trimIdent(`
     Use the title tool sparingly. For a new chat, call it once after the user's initial request is clear, and set a concise task title.
     Prefer calling functions.hapi__change_title.
     If that exact tool name is unavailable, call an equivalent alias such as hapi__change_title, mcp__hapi__change_title, or hapi_change_title.
@@ -24,19 +25,22 @@ export const TITLE_INSTRUCTION = trimIdent(`
     ${DISPLAY_IMAGE_PROMPT_CODEX}
     ${DISPLAY_VIDEO_PROMPT_CODEX}
     ${DISPLAY_MEDIA_PROMPT_CODEX}
-    ${buildSessionCitationSteerInstruction({
-        inspectTool: 'functions.hapi__inspect_peer',
-        pingTool: 'functions.hapi__ping_peer',
-        listPeersTool: 'functions.hapi__list_peers',
-    })}
 `);
+
+const PEER_CITATION_GUIDANCE = buildSessionCitationSteerInstruction({
+    inspectTool: 'functions.hapi__inspect_peer',
+    pingTool: 'functions.hapi__ping_peer',
+    listPeersTool: 'functions.hapi__list_peers',
+});
+export const TITLE_INSTRUCTION = `${TITLE_INSTRUCTION_BASE}\n\n${PEER_CITATION_GUIDANCE}`;
 
 /**
  * The system prompt to inject via developer_instructions in local mode.
  * Session-summary contract is resolved at call time (hub toggle / env).
  */
 export function getCodexSystemPrompt(env: NodeJS.ProcessEnv = process.env): string {
-    return withSessionSummaryInstruction(TITLE_INSTRUCTION, env)
+    const prompt = isHubPeerToolsEnabled() ? TITLE_INSTRUCTION : TITLE_INSTRUCTION_BASE;
+    return withSessionSummaryInstruction(prompt, env)
 }
 
 /** Alias kept for existing call sites / tests that expect a string constant name. */

--- a/cli/src/modules/common/peerToolsExposure.test.ts
+++ b/cli/src/modules/common/peerToolsExposure.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+    applyHubPeerToolsEnabled,
+    isHubPeerToolsEnabled,
+    resetHubPeerToolsEnabledForTests
+} from './peerToolsExposure'
+import { getSystemPrompt } from '@/claude/utils/systemPrompt'
+import { getCodexSystemPrompt } from '@/codex/utils/systemPrompt'
+import { getTitleInstruction, getOpencodeNativeToolInstruction } from '@/opencode/utils/systemPrompt'
+
+describe('peerToolsExposure', () => {
+    afterEach(() => resetHubPeerToolsEnabledForTests())
+
+    it('defaults peer tools exposure on for old bootstrap responses', () => {
+        expect(isHubPeerToolsEnabled()).toBe(true)
+    })
+
+    it('keeps OpenCode peer citation guidance enabled by default', () => {
+        expect(getTitleInstruction({})).toContain('hapi_inspect_peer')
+        expect(getOpencodeNativeToolInstruction({})).toContain('hapi_inspect_peer')
+    })
+
+    it('tracks the hub-resolved exposure toggle', () => {
+        applyHubPeerToolsEnabled(false)
+        expect(isHubPeerToolsEnabled()).toBe(false)
+        applyHubPeerToolsEnabled(true)
+        expect(isHubPeerToolsEnabled()).toBe(true)
+    })
+
+    it('removes peer citation guidance when exposure is off', () => {
+        applyHubPeerToolsEnabled(false)
+        expect(getSystemPrompt()).not.toContain('inspect_peer')
+        expect(getCodexSystemPrompt({})).not.toContain('inspect_peer')
+        expect(getTitleInstruction({})).not.toContain('inspect_peer')
+        expect(getOpencodeNativeToolInstruction({})).not.toContain('inspect_peer')
+    })
+})

--- a/cli/src/modules/common/peerToolsExposure.ts
+++ b/cli/src/modules/common/peerToolsExposure.ts
@@ -1,0 +1,16 @@
+let hubPreference: boolean = true
+
+/** Apply the Hub peer-tool exposure toggle; missing old responses stay enabled. */
+export function applyHubPeerToolsEnabled(enabled: boolean): void {
+    hubPreference = enabled
+}
+
+/** Return whether peer tools and their agent guidance may be exposed. */
+export function isHubPeerToolsEnabled(): boolean {
+    return hubPreference
+}
+
+/** Reset peer-tool exposure state between tests. */
+export function resetHubPeerToolsEnabledForTests(): void {
+    hubPreference = true
+}

--- a/cli/src/opencode/utils/systemPrompt.ts
+++ b/cli/src/opencode/utils/systemPrompt.ts
@@ -15,42 +15,49 @@ import {
 } from '@/modules/common/displayImagePrompt';
 import { SKILL_LOOKUP_INSTRUCTION } from '@/modules/common/skillLookupInstruction';
 import { withSessionSummaryInstruction } from '@/modules/common/sessionSummaryInstruction';
+import { isHubPeerToolsEnabled } from '@/modules/common/peerToolsExposure';
 
 /**
  * Title and display_image / display_video / display_media instructions for OpenCode to call the hapi MCP tools.
  */
-export const TITLE_INSTRUCTION = trimIdent(`
+const TITLE_INSTRUCTION_BASE = trimIdent(`
     ${HAPI_MCP_BRIDGE_PROMPT}
-    ${buildSessionCitationSteerInstruction({
-        inspectTool: 'hapi_inspect_peer',
-        pingTool: 'hapi_ping_peer',
-        listPeersTool: 'hapi_list_peers',
-    })}
     ${SKILL_LOOKUP_INSTRUCTION}
 `);
 
+const PEER_CITATION_GUIDANCE = buildSessionCitationSteerInstruction({
+    inspectTool: 'hapi_inspect_peer',
+    pingTool: 'hapi_ping_peer',
+    listPeersTool: 'hapi_list_peers',
+});
+export const TITLE_INSTRUCTION = `${TITLE_INSTRUCTION_BASE}\n\n${PEER_CITATION_GUIDANCE}`;
+
 export function getTitleInstruction(env: NodeJS.ProcessEnv = process.env): string {
-    return withSessionSummaryInstruction(TITLE_INSTRUCTION, env)
+    const prompt = isHubPeerToolsEnabled() ? TITLE_INSTRUCTION : TITLE_INSTRUCTION_BASE;
+    return withSessionSummaryInstruction(prompt, env)
 }
 
 /**
  * Tool instructions for native ACP sessions. Title updates come from ACP, so
  * advertise only the MCP tools that remain available to the model.
  */
-export const OPENCODE_NATIVE_TOOL_INSTRUCTION = trimIdent(`
+const OPENCODE_NATIVE_TOOL_INSTRUCTION_BASE = trimIdent(`
     ${DISPLAY_IMAGE_PROMPT_HAPI_MCP}
     ${DISPLAY_VIDEO_PROMPT_HAPI_MCP}
     ${DISPLAY_MEDIA_PROMPT_HAPI_MCP}
-    ${buildSessionCitationSteerInstruction({
-        inspectTool: 'hapi_inspect_peer',
-        pingTool: 'hapi_ping_peer',
-        listPeersTool: 'hapi_list_peers',
-    })}
     ${SKILL_LOOKUP_INSTRUCTION}
 `);
 
+const OPENCODE_NATIVE_PEER_CITATION_GUIDANCE = buildSessionCitationSteerInstruction({
+    inspectTool: 'hapi_inspect_peer',
+    pingTool: 'hapi_ping_peer',
+    listPeersTool: 'hapi_list_peers',
+});
+export const OPENCODE_NATIVE_TOOL_INSTRUCTION = `${OPENCODE_NATIVE_TOOL_INSTRUCTION_BASE}\n\n${OPENCODE_NATIVE_PEER_CITATION_GUIDANCE}`;
+
 export function getOpencodeNativeToolInstruction(env: NodeJS.ProcessEnv = process.env): string {
-    return withSessionSummaryInstruction(OPENCODE_NATIVE_TOOL_INSTRUCTION, env)
+    const prompt = isHubPeerToolsEnabled() ? OPENCODE_NATIVE_TOOL_INSTRUCTION : OPENCODE_NATIVE_TOOL_INSTRUCTION_BASE;
+    return withSessionSummaryInstruction(prompt, env)
 }
 
 /**

--- a/hub/README.md
+++ b/hub/README.md
@@ -156,6 +156,12 @@ See `src/web/routes/` for all endpoints.
 - `POST /cli/machines` - Create/load machine.
 - `GET /cli/machines/:id` - Get machine by ID.
 
+### Hub settings
+
+- `GET /api/hub-settings` - Read owner-configured agent behavior defaults.
+- `PUT /api/hub-settings` - Owner namespace (`default`) updates settings; other namespaces receive 403.
+- `peerToolsEnabled` - When false, new and resumed agent bootstrap responses tell the CLI not to expose `list_peers`, `inspect_peer`, or `ping_peer` MCP tools or their citation steering. This is an exposure control, not a REST authorization boundary; existing session/message authorization is unchanged. Missing settings default to true.
+
 ## Socket.IO
 
 See `src/socket/handlers/cli.ts` for event handlers.

--- a/hub/src/config/peerToolsExposure.ts
+++ b/hub/src/config/peerToolsExposure.ts
@@ -1,0 +1,11 @@
+import { getSettingsFile, readSettingsOrThrow, type Settings } from './settings'
+
+/** Peer tools are exposed by default; this is exposure control, not REST authorization. */
+export function isPeerToolsEnabledSetting(settings: Settings): boolean {
+    return settings.peerToolsEnabled !== false
+}
+
+/** Read the hub peer-tool exposure setting, defaulting old settings to enabled. */
+export async function readPeerToolsEnabled(dataDir: string): Promise<boolean> {
+    return isPeerToolsEnabledSetting(await readSettingsOrThrow(getSettingsFile(dataDir)))
+}

--- a/hub/src/config/settings.ts
+++ b/hub/src/config/settings.ts
@@ -34,6 +34,8 @@ export interface Settings {
      * Default off: render/copy strip the footer; store stays raw.
      */
     sessionSummaryInChat?: boolean
+    /** Hub-level exposure control for peer MCP tools; omitted means enabled. */
+    peerToolsEnabled?: boolean
     /**
      * Hub-side provider API keys / endpoints managed from Settings.
      * Env vars still win when set at process start (ops override).

--- a/hub/src/web/routes/cli.activeAt.test.ts
+++ b/hub/src/web/routes/cli.activeAt.test.ts
@@ -63,6 +63,7 @@ describe('CLI GET /sessions/:id with null active_at', () => {
         }
         expect(typeof body.session.activeAt).toBe('number')
         expect(body.session.activeAt).toBe(created.createdAt)
+        expect(body).toHaveProperty('peerToolsEnabled', true)
         store.close()
     })
 })

--- a/hub/src/web/routes/cli.test.ts
+++ b/hub/src/web/routes/cli.test.ts
@@ -236,6 +236,10 @@ describe('cli lazy session creation', () => {
             undefined,
             sessionId
         )
+        expect(await response.json()).toMatchObject({
+            session: { id: sessionId },
+            peerToolsEnabled: true
+        })
     })
 
     it('rejects an embedded machine owned by another namespace', async () => {

--- a/hub/src/web/routes/cli.ts
+++ b/hub/src/web/routes/cli.ts
@@ -9,6 +9,7 @@ import {
 } from '@hapi/protocol'
 import { getConfiguration } from '../../configuration'
 import { readSessionSummaryContractEnabled } from '../../config/sessionSummaryContract'
+import { readPeerToolsEnabled } from '../../config/peerToolsExposure'
 import { constantTimeEquals } from '../../utils/crypto'
 import { parseAccessToken } from '../../utils/accessToken'
 import type { Machine, Session, SyncEngine } from '../../sync/syncEngine'
@@ -132,7 +133,8 @@ export function createCliRoutes(getSyncEngine: () => SyncEngine | null): Hono<Cl
             const sessionSummaryContract = await readSessionSummaryContractEnabled(
                 getConfiguration().dataDir
             )
-            return c.json({ session, sessionSummaryContract })
+            const peerToolsEnabled = await readPeerToolsEnabled(getConfiguration().dataDir)
+            return c.json({ session, sessionSummaryContract, peerToolsEnabled })
         } catch (error) {
             if (error instanceof SessionIdentityConflictError) {
                 return c.json({ error: error.message }, 409)
@@ -252,7 +254,8 @@ export function createCliRoutes(getSyncEngine: () => SyncEngine | null): Hono<Cl
         const sessionSummaryContract = await readSessionSummaryContractEnabled(
             getConfiguration().dataDir
         )
-        return c.json({ session: resolved.session, sessionSummaryContract })
+        const peerToolsEnabled = await readPeerToolsEnabled(getConfiguration().dataDir)
+        return c.json({ session: resolved.session, sessionSummaryContract, peerToolsEnabled })
     })
 
     app.get('/sessions/:id/messages', (c) => {

--- a/hub/src/web/routes/hubSettings.test.ts
+++ b/hub/src/web/routes/hubSettings.test.ts
@@ -34,7 +34,8 @@ describe('GET/PUT /api/hub-settings', () => {
         expect(response.headers.get('cache-control')).toBe('no-store')
         expect(await response.json()).toEqual({
             sessionSummaryContract: false,
-            sessionSummaryInChat: false
+            sessionSummaryInChat: false,
+            peerToolsEnabled: true
         })
     })
 
@@ -48,13 +49,15 @@ describe('GET/PUT /api/hub-settings', () => {
         expect(put.status).toBe(200)
         expect(await put.json()).toEqual({
             sessionSummaryContract: true,
-            sessionSummaryInChat: false
+            sessionSummaryInChat: false,
+            peerToolsEnabled: true
         })
 
         const get = await app.request('/api/hub-settings')
         expect(await get.json()).toEqual({
             sessionSummaryContract: true,
-            sessionSummaryInChat: false
+            sessionSummaryInChat: false,
+            peerToolsEnabled: true
         })
     })
 
@@ -70,7 +73,8 @@ describe('GET/PUT /api/hub-settings', () => {
         expect(put.status).toBe(200)
         expect(await put.json()).toEqual({
             sessionSummaryContract: true,
-            sessionSummaryInChat: true
+            sessionSummaryInChat: true,
+            peerToolsEnabled: true
         })
     })
 
@@ -82,6 +86,26 @@ describe('GET/PUT /api/hub-settings', () => {
             body: JSON.stringify({})
         })
         expect(response.status).toBe(400)
+    })
+
+    it('persists the peer tools exposure toggle for the owner', async () => {
+        const { app, dataDir } = await createApp()
+        const put = await app.request('/api/hub-settings', {
+            method: 'PUT',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ peerToolsEnabled: false })
+        })
+        expect(put.status).toBe(200)
+        expect(await put.json()).toEqual({
+            sessionSummaryContract: false,
+            sessionSummaryInChat: false,
+            peerToolsEnabled: false
+        })
+        const get = await app.request('/api/hub-settings')
+        const body = await get.json() as { peerToolsEnabled?: boolean }
+        expect(body.peerToolsEnabled).toBe(false)
+        const saved = JSON.parse(await Bun.file(`${dataDir}/settings.json`).text()) as { peerToolsEnabled?: boolean }
+        expect(saved.peerToolsEnabled).toBe(false)
     })
 
     it('rejects invalid body', async () => {
@@ -109,7 +133,8 @@ describe('GET/PUT /api/hub-settings', () => {
         expect(get.status).toBe(200)
         expect(await get.json()).toEqual({
             sessionSummaryContract: false,
-            sessionSummaryInChat: true
+            sessionSummaryInChat: true,
+            peerToolsEnabled: true
         })
 
         const put = await tenantApp.request('/api/hub-settings', {
@@ -127,7 +152,8 @@ describe('GET/PUT /api/hub-settings', () => {
         const response = await app.request('/api/hub-settings')
         expect(await response.json()).toEqual({
             sessionSummaryContract: true,
-            sessionSummaryInChat: true
+            sessionSummaryInChat: true,
+            peerToolsEnabled: true
         })
     })
 })

--- a/hub/src/web/routes/hubSettings.ts
+++ b/hub/src/web/routes/hubSettings.ts
@@ -7,13 +7,15 @@ import {
     type Settings
 } from '../../config/settings'
 import type { WebAppEnv } from '../middleware/auth'
+import { isPeerToolsEnabledSetting } from '../../config/peerToolsExposure'
 
 const OWNER_ONLY_ERROR = 'Hub settings are only available to the hub owner'
 
 function toHubSettings(settings: Settings): HubSettingsResponse {
     return {
         sessionSummaryContract: settings.sessionSummaryContract === true,
-        sessionSummaryInChat: settings.sessionSummaryInChat === true
+        sessionSummaryInChat: settings.sessionSummaryInChat === true,
+        peerToolsEnabled: isPeerToolsEnabledSetting(settings)
     }
 }
 
@@ -44,6 +46,9 @@ export function createHubSettingsRoutes(dataDir: string): Hono<WebAppEnv> {
             }
             if (parsed.data.sessionSummaryInChat !== undefined) {
                 settings.sessionSummaryInChat = parsed.data.sessionSummaryInChat
+            }
+            if (parsed.data.peerToolsEnabled !== undefined) {
+                settings.peerToolsEnabled = parsed.data.peerToolsEnabled
             }
             return {
                 settings,

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -52,7 +52,9 @@ export type CliMessagesResponse = z.infer<typeof CliMessagesResponseSchema>
 export const CreateSessionResponseSchema = z.object({
     session: SessionSchema,
     /** Hub opt-in for AGENT_NOTIFY_SUMMARY prompt injection (default off when omitted). */
-    sessionSummaryContract: z.boolean().optional()
+    sessionSummaryContract: z.boolean().optional(),
+    /** Hub peer-tool exposure control (defaults on for older Hub responses). */
+    peerToolsEnabled: z.boolean().optional()
 })
 
 export type CreateSessionResponse = z.infer<typeof CreateSessionResponseSchema>
@@ -60,7 +62,9 @@ export type CreateSessionResponse = z.infer<typeof CreateSessionResponseSchema>
 export const HubSettingsResponseSchema = z.object({
     sessionSummaryContract: z.boolean(),
     /** Show compact AGENT_NOTIFY_SUMMARY in chat (default off / hide). */
-    sessionSummaryInChat: z.boolean()
+    sessionSummaryInChat: z.boolean(),
+    /** MCP peer tools are exposure-controlled, not a REST authorization boundary. */
+    peerToolsEnabled: z.boolean().optional()
 })
 
 export type HubSettingsResponse = z.infer<typeof HubSettingsResponseSchema>
@@ -68,10 +72,13 @@ export type HubSettingsResponse = z.infer<typeof HubSettingsResponseSchema>
 export const UpdateHubSettingsRequestSchema = z
     .object({
         sessionSummaryContract: z.boolean().optional(),
-        sessionSummaryInChat: z.boolean().optional()
+        sessionSummaryInChat: z.boolean().optional(),
+        peerToolsEnabled: z.boolean().optional()
     })
     .refine(
-        (data) => data.sessionSummaryContract !== undefined || data.sessionSummaryInChat !== undefined,
+        (data) => data.sessionSummaryContract !== undefined
+            || data.sessionSummaryInChat !== undefined
+            || data.peerToolsEnabled !== undefined,
         { message: 'At least one hub setting field is required' }
     )
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -735,14 +735,16 @@ export class ApiClient {
     }
 
     async getHubSettings(): Promise<HubSettingsResponse> {
-        return await this.request<HubSettingsResponse>('/api/hub-settings')
+        const settings = await this.request<HubSettingsResponse>('/api/hub-settings')
+        return { ...settings, peerToolsEnabled: settings.peerToolsEnabled ?? true }
     }
 
     async updateHubSettings(settings: UpdateHubSettingsRequest): Promise<HubSettingsResponse> {
-        return await this.request<HubSettingsResponse>('/api/hub-settings', {
+        const response = await this.request<HubSettingsResponse>('/api/hub-settings', {
             method: 'PUT',
             body: JSON.stringify(settings)
         })
+        return { ...response, peerToolsEnabled: response.peerToolsEnabled ?? true }
     }
 
     async getUsageSummary(

--- a/web/src/components/SessionActionMenu.test.tsx
+++ b/web/src/components/SessionActionMenu.test.tsx
@@ -237,4 +237,26 @@ describe('SessionActionMenu - Copy reference action', () => {
             )
         })
     })
+
+    it('copies a readable path-only citation when peer tools are disabled', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        })
+
+        renderMenu({
+            sessionId: 'abc-def',
+            sessionTitle: 'upstream issue/pr discovery',
+            peerToolsEnabled: false,
+        })
+
+        fireEvent.click(screen.getByRole('menuitem', { name: /Copy reference/ }))
+
+        await vi.waitFor(() => {
+            expect(writeText).toHaveBeenCalledWith(
+                'See session "upstream issue/pr discovery" (/sessions/abc-def) for context.'
+            )
+        })
+    })
 })

--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -20,6 +20,7 @@ type SessionActionMenuProps = {
     sessionId: string
     sessionTitle: string
     sessionActive: boolean
+    peerToolsEnabled?: boolean
     onRename: () => void
     sessionPinned?: boolean
     sessionGlobalPinned?: boolean
@@ -191,6 +192,7 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         sessionId,
         sessionTitle,
         sessionActive,
+        peerToolsEnabled = true,
         onRename,
         sessionPinned = false,
         sessionGlobalPinned = false,
@@ -220,7 +222,7 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
     const handleCopyReference = async () => {
         onClose()
         try {
-            await safeCopyToClipboard(buildSessionReferenceText(sessionTitle, sessionId))
+            await safeCopyToClipboard(buildSessionReferenceText(sessionTitle, sessionId, { peerToolsEnabled }))
             haptic.notification('success')
         } catch {
             haptic.notification('error')

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -27,6 +27,7 @@ import { useSessionHeaderMetadata } from '@/hooks/useSessionHeaderMetadata'
 import { formatSessionHeaderTimestamp } from '@/lib/sessionHeaderTimestamp'
 import { selectMobileSessionHeaderSecondary } from '@/lib/sessionHeaderMobileMetadata'
 import { useMinuteTick } from '@/hooks/useMinuteTick'
+import { useHubSettings } from '@/hooks/queries/useHubSettings'
 
 /** Same preference order as session-list chips: display label → host → short id. */
 export function resolveSessionHeaderMachineLabel(
@@ -185,6 +186,7 @@ export function SessionHeader(props: {
         ? session.metadata.piSessionId?.trim() || null
         : null
     const { machines } = useMachines(api, Boolean(api))
+    const { peerToolsEnabled } = useHubSettings(api)
     const machineLabelsById = useMachineLabels(machines)
     const machineLabel = useMemo(
         () => resolveSessionHeaderMachineLabel(session, machineLabelsById),
@@ -515,6 +517,7 @@ export function SessionHeader(props: {
                 sessionId={session.id}
                 sessionTitle={title}
                 sessionActive={session.active}
+                peerToolsEnabled={peerToolsEnabled}
                 sessionPinned={Boolean(session.pinned)}
                 sessionGlobalPinned={Boolean(session.globalPinned)}
                 onRename={() => setRenameOpen(true)}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -43,6 +43,7 @@ import { SessionRowSummary } from '@/components/SessionRowSummary'
 import { Spinner } from '@/components/Spinner'
 import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
 import { useToast } from '@/lib/toast-context'
+import { useHubSettings } from '@/hooks/queries/useHubSettings'
 
 export { getWorktreeSessionLabel } from '@/lib/sessionWorktreeLabel'
 
@@ -864,6 +865,7 @@ function SessionItem(props: {
     onSelect: (sessionId: string) => void
     showPath?: boolean
     api: ApiClient | null
+    peerToolsEnabled: boolean
     selected?: boolean
     showDetailedStatus?: boolean
     inRunningSection?: boolean
@@ -872,7 +874,7 @@ function SessionItem(props: {
 }) {
     const { t } = useTranslation()
     const { addToast } = useToast()
-    const { session: s, onSelect, showPath = true, api, selected = false, showDetailedStatus = false, inRunningSection = false, projectLabel, machineLabel } = props
+    const { session: s, onSelect, showPath = true, api, peerToolsEnabled, selected = false, showDetailedStatus = false, inRunningSection = false, projectLabel, machineLabel } = props
     const { haptic } = usePlatform()
     const [menuOpen, setMenuOpen] = useState(false)
     const [menuAnchorPoint, setMenuAnchorPoint] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
@@ -1003,6 +1005,7 @@ function SessionItem(props: {
                 sessionId={s.id}
                 sessionTitle={sessionName}
                 sessionActive={s.active}
+                peerToolsEnabled={peerToolsEnabled}
                 sessionPinned={Boolean(s.pinned)}
                 sessionGlobalPinned={Boolean(s.globalPinned)}
                 onSetPinMode={(mode) => void handleSetPinMode(mode)}
@@ -1132,6 +1135,7 @@ export function SessionList(props: {
 }) {
     const { t } = useTranslation()
     const { renderHeader = true, api, selectedSessionId, machineLabelsById = {}, machinesById = {}, onNewSessionInDirectory } = props
+    const { peerToolsEnabled } = useHubSettings(api)
     const { sessionPreviewLimit } = useSessionPreviewLimit()
     const { sessionListStatusMode } = useSessionListStatusMode()
     const { showActiveSessionsOnly } = useShowActiveSessionsOnly()
@@ -1441,6 +1445,7 @@ export function SessionList(props: {
                                     onSelect={props.onSelect}
                                     showPath={false}
                                     api={api}
+                                    peerToolsEnabled={peerToolsEnabled}
                                     selected={s.id === selectedSessionId}
                                     showDetailedStatus={showDetailedStatus}
                                 />
@@ -1802,6 +1807,7 @@ export function SessionList(props: {
                                             onSelect={props.onSelect}
                                             showPath={false}
                                             api={api}
+                                            peerToolsEnabled={peerToolsEnabled}
                                             selected={s.id === selectedSessionId}
                                             showDetailedStatus={showDetailedStatus}
                                             inRunningSection
@@ -1863,6 +1869,7 @@ export function SessionList(props: {
                                                     onSelect={props.onSelect}
                                                     showPath={false}
                                                     api={api}
+                                                    peerToolsEnabled={peerToolsEnabled}
                                                     selected={s.id === selectedSessionId}
                                                     showDetailedStatus={showDetailedStatus}
                                                     inRunningSection

--- a/web/src/components/assistant-ui/markdown-a.test.tsx
+++ b/web/src/components/assistant-ui/markdown-a.test.tsx
@@ -54,7 +54,6 @@ function chatContext(overrides: Partial<HappyChatContextValue> = {}): HappyChatC
         sessionId: 'session-1',
         metadata: { path: '/home/ada/coding/hapi', host: 'local' },
         terminalToolDisplayMode: 'compact',
-        showSessionSummaryInChat: false,
         disabled: false,
         onRefresh: () => {},
         hasMoreMessages: false,

--- a/web/src/components/assistant-ui/markdown-a.test.tsx
+++ b/web/src/components/assistant-ui/markdown-a.test.tsx
@@ -54,6 +54,7 @@ function chatContext(overrides: Partial<HappyChatContextValue> = {}): HappyChatC
         sessionId: 'session-1',
         metadata: { path: '/home/ada/coding/hapi', host: 'local' },
         terminalToolDisplayMode: 'compact',
+        showSessionSummaryInChat: false,
         disabled: false,
         onRefresh: () => {},
         hasMoreMessages: false,

--- a/web/src/hooks/queries/useHubSettings.test.tsx
+++ b/web/src/hooks/queries/useHubSettings.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '@/api/client'
+import type { HubSettingsResponse } from '@hapi/protocol/apiTypes'
+import { useHubSettings } from './useHubSettings'
+
+const settings = (peerToolsEnabled: boolean): HubSettingsResponse => ({
+    sessionSummaryContract: false,
+    sessionSummaryInChat: false,
+    peerToolsEnabled,
+})
+
+function renderHubSettings(api: ApiClient | null) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    return renderHook(() => useHubSettings(api), { wrapper })
+}
+
+describe('useHubSettings peer-tools exposure', () => {
+    it('returns false after a successful disabled response', async () => {
+        const getHubSettings = vi.fn().mockResolvedValue(settings(false))
+        const api = { getHubSettings } as unknown as ApiClient
+        const { result } = renderHubSettings(api)
+        await waitFor(() => expect(getHubSettings).toHaveBeenCalled())
+        await waitFor(() => {
+            expect(result.current.data?.peerToolsEnabled).toBe(false)
+            expect(result.current.peerToolsEnabled).toBe(false)
+        })
+    })
+
+    it('returns true after a successful enabled response', async () => {
+        const api = { getHubSettings: vi.fn().mockResolvedValue(settings(true)) } as unknown as ApiClient
+        const { result } = renderHubSettings(api)
+        await waitFor(() => expect(result.current.peerToolsEnabled).toBe(true))
+    })
+
+    it('denies guidance while settings are pending', () => {
+        const api = {
+            getHubSettings: vi.fn(() => new Promise<HubSettingsResponse>(() => {})),
+        } as unknown as ApiClient
+        const { result } = renderHubSettings(api)
+        expect(result.current.peerToolsEnabled).toBe(false)
+    })
+
+    it('denies guidance when settings reject', async () => {
+        const getHubSettings = vi.fn().mockRejectedValue(new Error('settings unavailable'))
+        const api = { getHubSettings } as unknown as ApiClient
+        const { result } = renderHubSettings(api)
+        await waitFor(() => expect(getHubSettings).toHaveBeenCalled())
+        await waitFor(() => {
+            expect(result.current.data).toBeUndefined()
+            expect(result.current.peerToolsEnabled).toBe(false)
+        })
+    })
+
+    it('denies guidance when no API is available', () => {
+        const { result } = renderHubSettings(null)
+        expect(result.current.peerToolsEnabled).toBe(false)
+    })
+})

--- a/web/src/hooks/queries/useHubSettings.test.tsx
+++ b/web/src/hooks/queries/useHubSettings.test.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import type { ApiClient } from '@/api/client'
 import type { HubSettingsResponse } from '@hapi/protocol/apiTypes'
+import { queryKeys } from '@/lib/query-keys'
 import { useHubSettings } from './useHubSettings'
 
 const settings = (peerToolsEnabled: boolean): HubSettingsResponse => ({
@@ -17,7 +18,7 @@ function renderHubSettings(api: ApiClient | null) {
     const wrapper = ({ children }: PropsWithChildren) => (
         <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
-    return renderHook(() => useHubSettings(api), { wrapper })
+    return { ...renderHook(() => useHubSettings(api), { wrapper }), queryClient }
 }
 
 describe('useHubSettings peer-tools exposure', () => {
@@ -55,6 +56,22 @@ describe('useHubSettings peer-tools exposure', () => {
             expect(result.current.data).toBeUndefined()
             expect(result.current.peerToolsEnabled).toBe(false)
         })
+    })
+
+    it('denies guidance after an enabled settings refetch rejects', async () => {
+        const getHubSettings = vi
+            .fn()
+            .mockResolvedValueOnce(settings(true))
+            .mockRejectedValueOnce(new Error('settings unavailable'))
+        const api = { getHubSettings } as unknown as ApiClient
+        const { result, queryClient } = renderHubSettings(api)
+
+        await waitFor(() => expect(result.current.peerToolsEnabled).toBe(true))
+        await queryClient.refetchQueries({ queryKey: queryKeys.hubSettings, type: 'active' })
+        await waitFor(() => expect(queryClient.getQueryState(queryKeys.hubSettings)?.status).toBe('error'))
+
+        expect(result.current.data?.peerToolsEnabled).toBe(true)
+        expect(result.current.peerToolsEnabled).toBe(false)
     })
 
     it('denies guidance when no API is available', () => {

--- a/web/src/hooks/queries/useHubSettings.ts
+++ b/web/src/hooks/queries/useHubSettings.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+import type { ApiClient } from '@/api/client'
+import type { HubSettingsResponse } from '@hapi/protocol/apiTypes'
+import { queryKeys } from '@/lib/query-keys'
+
+/** Hub settings shared by operator UI surfaces; missing peer-tools data stays enabled for old Hubs. */
+export function useHubSettings(api: ApiClient | null): {
+    data: HubSettingsResponse | undefined
+    peerToolsEnabled: boolean
+} {
+    const query = useQuery({
+        queryKey: queryKeys.hubSettings,
+        queryFn: async () => {
+            if (!api) throw new Error('API unavailable')
+            return await api.getHubSettings()
+        },
+        enabled: Boolean(api),
+        staleTime: 30_000,
+        retry: false,
+    })
+
+    return {
+        data: query.data,
+        peerToolsEnabled: query.data?.peerToolsEnabled ?? true,
+    }
+}

--- a/web/src/hooks/queries/useHubSettings.ts
+++ b/web/src/hooks/queries/useHubSettings.ts
@@ -21,6 +21,6 @@ export function useHubSettings(api: ApiClient | null): {
 
     return {
         data: query.data,
-        peerToolsEnabled: query.data?.peerToolsEnabled === true,
+        peerToolsEnabled: query.status === 'success' && query.data?.peerToolsEnabled === true,
     }
 }

--- a/web/src/hooks/queries/useHubSettings.ts
+++ b/web/src/hooks/queries/useHubSettings.ts
@@ -3,7 +3,7 @@ import type { ApiClient } from '@/api/client'
 import type { HubSettingsResponse } from '@hapi/protocol/apiTypes'
 import { queryKeys } from '@/lib/query-keys'
 
-/** Hub settings shared by operator UI surfaces; missing peer-tools data stays enabled for old Hubs. */
+/** Hub settings shared by operator UI surfaces; only confirmed enabled permits steering. */
 export function useHubSettings(api: ApiClient | null): {
     data: HubSettingsResponse | undefined
     peerToolsEnabled: boolean
@@ -21,6 +21,6 @@ export function useHubSettings(api: ApiClient | null): {
 
     return {
         data: query.data,
-        peerToolsEnabled: query.data?.peerToolsEnabled ?? true,
+        peerToolsEnabled: query.data?.peerToolsEnabled === true,
     }
 }

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -764,6 +764,8 @@ export default {
   'settings.general.sessionSummaryContract.desc': 'When on, Claude, Codex, OpenCode, and remote Grok sessions are asked to end each turn with an AGENT_NOTIFY_SUMMARY line for denser ready notifications. Off by default. Local Grok and Cursor are not covered yet. Applies to new/resumed sessions.',
   'settings.general.sessionSummaryInChat': 'Show session status summary in chat',
   'settings.general.sessionSummaryInChat.desc': 'When on, assistant messages show a compact status row instead of raw AGENT_NOTIFY_SUMMARY JSON. Off by default (hidden from chat and copy). Stored messages, notifications, and capture are unchanged.',
+  'settings.general.peerToolsEnabled': 'Expose peer session tools to agents',
+  'settings.general.peerToolsEnabled.desc': 'When off, peer MCP tools and their citation guidance are not exposed to agent sessions. This is exposure control, not a REST authorization boundary. On by default.',
   'settings.language.title': 'Language',
   'settings.language.label': 'Language',
   'settings.display.title': 'Display',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -763,6 +763,8 @@ export default {
   'settings.general.sessionSummaryContract.desc': '开启后，Claude、Codex、OpenCode 以及远程 Grok 会话会在每轮结束时追加 AGENT_NOTIFY_SUMMARY 行，便于更清晰的就绪通知。默认关闭。本地 Grok 与 Cursor 暂不覆盖。对新开/恢复的会话生效。',
   'settings.general.sessionSummaryInChat': '在聊天中显示会话状态摘要',
   'settings.general.sessionSummaryInChat.desc': '开启后，助手消息以紧凑状态行显示，而不是原始 AGENT_NOTIFY_SUMMARY JSON。默认关闭（聊天与复制中隐藏）。已存储消息、通知与采集路径不受影响。',
+  'settings.general.peerToolsEnabled': '向智能体暴露会话协作工具',
+  'settings.general.peerToolsEnabled.desc': '关闭后，新建或恢复的智能体会话不会获得 peer MCP 工具及其引用引导。此开关只控制暴露，不是 REST 授权边界。默认开启。',
   'settings.language.title': '语言',
   'settings.language.label': '语言',
   'settings.display.title': '显示',

--- a/web/src/lib/sessionReference.test.ts
+++ b/web/src/lib/sessionReference.test.ts
@@ -66,6 +66,15 @@ describe('buildSessionReferenceText', () => {
         )
     })
 
+    it('keeps a readable path-only citation when peer tools are disabled', () => {
+        expect(buildSessionReferenceText('upstream issue/pr discovery', 'abc-def', {
+            peerToolsEnabled: false,
+        })).toBe('See session "upstream issue/pr discovery" (/sessions/abc-def) for context.')
+        expect(buildSessionReferenceText('upstream issue/pr discovery', 'abc-def', {
+            peerToolsEnabled: false,
+        })).not.toContain('inspect_peer')
+    })
+
     it('keeps combining and ZWJ title graphemes only when they fit the UTF-16 limit', () => {
         const prefix = 'a'.repeat(119)
         const combining = `${prefix}e\u0301x`

--- a/web/src/lib/sessionReference.ts
+++ b/web/src/lib/sessionReference.ts
@@ -15,13 +15,19 @@ function sanitizeSessionReferenceTitle(sessionTitle: string): string {
 }
 
 /** Clipboard text for citing this session in another HAPI chat (not a public share link). */
-export function buildSessionReferenceText(sessionTitle: string, sessionId: string): string {
+export function buildSessionReferenceText(
+    sessionTitle: string,
+    sessionId: string,
+    options: { peerToolsEnabled?: boolean } = {}
+): string {
     const path = buildSessionReferencePath(sessionId)
     const title = sanitizeSessionReferenceTitle(sessionTitle)
     const base = title
         ? `See session ${JSON.stringify(title)} (${path}) for context`
         : `See HAPI session ${path} for context`
-    return `${base}.${SESSION_REFERENCE_STEER_SUFFIX}`
+    return options.peerToolsEnabled === false
+        ? `${base}.`
+        : `${base}.${SESSION_REFERENCE_STEER_SUFFIX}`
 }
 
 export type MatchSessionsForMentionOptions = {

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -49,6 +49,7 @@ import { refreshSessionDetailPreservingActive } from '@/lib/session-detail-optim
 import { inactiveSessionCanResume, resolveCursorReopenGate } from '@/lib/sessionResume'
 import { initializeSessionLastSeen, markSessionSeen } from '@/lib/sessionLastSeen'
 import { useSessionBrowserTitle } from '@/hooks/useSessionBrowserTitle'
+import { useHubSettings } from '@/hooks/queries/useHubSettings'
 import { clearCodexImportedSession } from '@/lib/codexImportedSessions'
 import { getSupersedingSessionId, prepareFollowSupersedingSession, shouldFollowSupersedingSession } from '@/routes/sessions/followSupersedingSession'
 import { migrateSuppressedSendError } from '@/lib/suppressed-send-error'
@@ -330,6 +331,7 @@ function classifySendError(
 
 function SessionPage() {
     const { api } = useAppContext()
+    const { peerToolsEnabled } = useHubSettings(api)
     const { t } = useTranslation()
     const goBack = useAppGoBack()
     const navigate = useNavigate()
@@ -678,7 +680,7 @@ function SessionPage() {
                 resolveMachineLabel: resolveMentionMachineLabel,
             }).map((s) => {
                 const title = getSessionTitle(s)
-                const mentionText = buildSessionReferenceText(title, s.id)
+                const mentionText = buildSessionReferenceText(title, s.id, { peerToolsEnabled })
                 const idPrefix = s.id.slice(0, 8)
                 return {
                     key: `session:${s.id}`,
@@ -723,6 +725,7 @@ function SessionPage() {
         sessionId,
         allSessions,
         resolveMentionMachineLabel,
+        peerToolsEnabled,
         getSkillSuggestions,
         getSlashSuggestions,
     ])

--- a/web/src/routes/settings/general.tsx
+++ b/web/src/routes/settings/general.tsx
@@ -41,7 +41,7 @@ export default function SettingsGeneralPage() {
     })
 
     const hubSettingsMutation = useMutation({
-        mutationFn: async (patch: { sessionSummaryContract?: boolean; sessionSummaryInChat?: boolean }) => {
+        mutationFn: async (patch: { sessionSummaryContract?: boolean; sessionSummaryInChat?: boolean; peerToolsEnabled?: boolean }) => {
             if (!api) throw new Error('API unavailable')
             return await api.updateHubSettings(patch)
         },
@@ -75,6 +75,15 @@ export default function SettingsGeneralPage() {
                                 onChange={(checked) => {
                                     if (hubSettingsMutation.isPending) return
                                     hubSettingsMutation.mutate({ sessionSummaryInChat: checked })
+                                }}
+                            />
+                            <SettingsSwitch
+                                label={t('settings.general.peerToolsEnabled')}
+                                description={t('settings.general.peerToolsEnabled.desc')}
+                                checked={hubSettingsQuery.data.peerToolsEnabled ?? true}
+                                onChange={(checked) => {
+                                    if (hubSettingsMutation.isPending) return
+                                    hubSettingsMutation.mutate({ peerToolsEnabled: checked })
                                 }}
                             />
                         </>

--- a/web/src/routes/settings/index.test.tsx
+++ b/web/src/routes/settings/index.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { I18nProvider } from '@/lib/i18n-context'
 import SettingsHubPage from './index'
@@ -23,8 +23,8 @@ const { context, navigate, setAppearance, setColorTheme, setFontScale, setTermin
     setVoice: vi.fn(),
 }))
 
-const getHubSettings = vi.fn().mockResolvedValue({ sessionSummaryContract: false, sessionSummaryInChat: false })
-const updateHubSettings = vi.fn().mockResolvedValue({ sessionSummaryContract: true, sessionSummaryInChat: false })
+const getHubSettings = vi.fn().mockResolvedValue({ sessionSummaryContract: false, sessionSummaryInChat: false, peerToolsEnabled: true })
+const updateHubSettings = vi.fn().mockResolvedValue({ sessionSummaryContract: true, sessionSummaryInChat: false, peerToolsEnabled: false })
 
 vi.mock('@/hooks/useColorTheme', () => ({
     useColorTheme: () => ({ colorTheme: 'default', setColorTheme }),
@@ -216,8 +216,8 @@ describe('responsive settings pages', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         localStorage.clear()
-        getHubSettings.mockResolvedValue({ sessionSummaryContract: false, sessionSummaryInChat: false })
-        updateHubSettings.mockResolvedValue({ sessionSummaryContract: true, sessionSummaryInChat: false })
+        getHubSettings.mockResolvedValue({ sessionSummaryContract: false, sessionSummaryInChat: false, peerToolsEnabled: true })
+        updateHubSettings.mockResolvedValue({ sessionSummaryContract: true, sessionSummaryInChat: false, peerToolsEnabled: false })
         context.token = `x.${btoa(JSON.stringify({ ns: 'default' }))}.x`
     })
 
@@ -247,6 +247,8 @@ describe('responsive settings pages', () => {
         expect(screen.getByText('Companion pairing')).toBeInTheDocument()
         expect(await screen.findByRole('checkbox', { name: 'Ask agents to emit session status summary' })).toBeInTheDocument()
         expect(screen.getByRole('checkbox', { name: 'Show session status summary in chat' })).toBeInTheDocument()
+        fireEvent.click(await screen.findByRole('checkbox', { name: 'Expose peer session tools to agents' }))
+        await waitFor(() => expect(updateHubSettings).toHaveBeenCalledWith({ peerToolsEnabled: false }))
         fireEvent.click(screen.getByRole('radio', { name: '简体中文' }))
         expect(localStorage.getItem('hapi-lang')).toBe('zh-CN')
     })


### PR DESCRIPTION
## Summary

- Add an owner-only Hub `peerToolsEnabled` setting, defaulting to enabled for older settings and bootstrap responses.
- Propagate the setting through create/resume bootstrap and remove peer MCP tools, bridge approvals, and peer citation guidance when disabled across Claude, Codex, OpenCode, and ACP paths.
- Add focused coverage and document the exposure boundary.

## Scope

Refs #1401.
Related to #1535; session authorization remains out of scope and M2 is not activated.

This toggle controls agent-tool exposure only. It is not a REST authorization boundary; existing REST/session/message authorization is unchanged.
