### PR TITLE
fix(cursor): retry transient ACP connection errors

### DIFF
--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -14,6 +14,9 @@ const harness = vi.hoisted(() => ({
     newSessionAttempts: 0,
     promptCalls: 0,
     prompts: [] as unknown[][],
+    promptErrors: [] as Error[],
+    promptMessages: [] as Array<{ type: 'text'; text: string }>,
+    promptStderrErrors: [] as Array<{ type: string; message: string; raw: string }>,
     backendArgs: null as { command: string; args?: string[] } | null,
     setConfigOptionCalls: [] as Array<{ sessionId: string; configId: string; value: string }>,
     deferSetConfigOption: null as Promise<void> | null,
@@ -126,9 +129,15 @@ vi.mock('./utils/cursorAcpBackend', () => ({
                 }
                 return undefined;
             }),
-            prompt: vi.fn(async (_sessionId: string, content: unknown[]) => {
+            prompt: vi.fn(async (_sessionId: string, content: unknown[], onMessage?: (message: { type: 'text'; text: string }) => void) => {
                 harness.promptCalls++;
                 harness.prompts.push(content);
+                const message = harness.promptMessages.shift();
+                if (message) onMessage?.(message);
+                const stderrError = harness.promptStderrErrors.shift();
+                if (stderrError) harness.stderrErrorHandler?.(stderrError);
+                const error = harness.promptErrors.shift();
+                if (error) throw error;
             }),
             cancelPrompt: vi.fn(async () => {}),
             respondToPermission: vi.fn(async () => {}),
@@ -234,6 +243,7 @@ function makeClient() {
         flushMetadata: vi.fn(async () => true),
         sendSessionEvent: vi.fn(),
         sendAgentMessage: vi.fn(),
+        sendClaudeSessionMessage: vi.fn(),
         keepAlive: vi.fn(),
         emitSessionReady: vi.fn()
     } as unknown as ApiSessionClient;
@@ -252,6 +262,9 @@ describe('cursorAcpRemoteLauncher', () => {
         harness.newSessionAttempts = 0;
         harness.promptCalls = 0;
         harness.prompts = [];
+        harness.promptErrors = [];
+        harness.promptMessages = [];
+        harness.promptStderrErrors = [];
         harness.setConfigOptionCalls = [];
         harness.deferSetConfigOption = null;
         harness.releaseSetConfigOption = null;
@@ -317,6 +330,129 @@ describe('cursorAcpRemoteLauncher', () => {
 
         queue.close();
         await runPromise;
+    });
+
+    it('retries a transient Cursor connection failure three times using api_error events', async () => {
+        harness.promptErrors = [
+            new Error('Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL'),
+            new Error('Error: RetriableError: [unavailable] connection reset'),
+            new Error("ACP request 'session/prompt' timed out after 120000ms")
+        ];
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const client = makeClient() as unknown as ApiSessionClient & {
+            sendClaudeSessionMessage: ReturnType<typeof vi.fn>;
+            sendAgentMessage: ReturnType<typeof vi.fn>;
+        };
+        const session = new CursorSession({
+            api: {} as never,
+            client,
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        queue.push('finish the task', { permissionMode: 'default' });
+        queue.close();
+
+        await cursorAcpRemoteLauncher(session);
+
+        expect(harness.promptCalls).toBe(4);
+        expect(harness.prompts).toEqual(Array(4).fill([{ type: 'text', text: 'finish the task' }]));
+        expect(client.sendClaudeSessionMessage.mock.calls.map(([message]) => ({
+            subtype: message.subtype,
+            retryAttempt: message.retryAttempt,
+            maxRetries: message.maxRetries
+        }))).toEqual([
+            { subtype: 'api_error', retryAttempt: 1, maxRetries: 3 },
+            { subtype: 'api_error', retryAttempt: 2, maxRetries: 3 },
+            { subtype: 'api_error', retryAttempt: 3, maxRetries: 3 }
+        ]);
+        expect(client.sendAgentMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+
+    it('suppresses an inline Cursor connection error and retries instead of rendering it as plaintext', async () => {
+        harness.promptMessages = [
+            { type: 'text', text: 'Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL' }
+        ];
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const client = makeClient() as unknown as ApiSessionClient & {
+            sendClaudeSessionMessage: ReturnType<typeof vi.fn>;
+            sendAgentMessage: ReturnType<typeof vi.fn>;
+        };
+        const session = new CursorSession({
+            api: {} as never,
+            client,
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        queue.push('finish the task', { permissionMode: 'default' });
+        queue.close();
+
+        await cursorAcpRemoteLauncher(session);
+
+        expect(harness.promptCalls).toBe(2);
+        expect(client.sendClaudeSessionMessage).toHaveBeenCalledWith(expect.objectContaining({
+            subtype: 'api_error',
+            retryAttempt: 1,
+            maxRetries: 3
+        }));
+        expect(client.sendAgentMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('http/2 stream closed')
+        }));
+    });
+
+    it('suppresses retryable Cursor stderr while a prompt is retried', async () => {
+        harness.promptStderrErrors = [{
+            type: 'unknown',
+            message: 'http/2 stream closed with error code CANCEL',
+            raw: 'http/2 stream closed with error code CANCEL'
+        }];
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const client = makeClient() as unknown as ApiSessionClient & {
+            sendClaudeSessionMessage: ReturnType<typeof vi.fn>;
+            sendAgentMessage: ReturnType<typeof vi.fn>;
+        };
+        const session = new CursorSession({
+            api: {} as never,
+            client,
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        queue.push('finish the task', { permissionMode: 'default' });
+        queue.close();
+
+        await cursorAcpRemoteLauncher(session);
+
+        expect(harness.promptCalls).toBe(2);
+        expect(client.sendClaudeSessionMessage).toHaveBeenCalledWith(expect.objectContaining({
+            subtype: 'api_error',
+            retryAttempt: 1
+        }));
+        expect(client.sendAgentMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('http/2 stream closed')
+        }));
     });
 
     it('removes the Cursor MCP overlay even when backend.disconnect rejects', async () => {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import { MessageQueue2 } from '@/utils/MessageQueue2';
 import type { EnhancedMode } from './loop';
+import type { AgentMessage } from '@/agent/types';
 
 const harness = vi.hoisted(() => ({
     initializeError: null as Error | null,
@@ -15,7 +16,7 @@ const harness = vi.hoisted(() => ({
     promptCalls: 0,
     prompts: [] as unknown[][],
     promptErrors: [] as Error[],
-    promptMessages: [] as Array<{ type: 'text'; text: string }>,
+    promptMessages: [] as AgentMessage[],
     promptStderrErrors: [] as Array<{ type: string; message: string; raw: string }>,
     deferPrompt: null as Promise<void> | null,
     releasePrompt: null as (() => void) | null,
@@ -131,7 +132,7 @@ vi.mock('./utils/cursorAcpBackend', () => ({
                 }
                 return undefined;
             }),
-            prompt: vi.fn(async (_sessionId: string, content: unknown[], onMessage?: (message: { type: 'text'; text: string }) => void) => {
+            prompt: vi.fn(async (_sessionId: string, content: unknown[], onMessage?: (message: AgentMessage) => void) => {
                 harness.promptCalls++;
                 harness.prompts.push(content);
                 const message = harness.promptMessages.shift();
@@ -374,9 +375,9 @@ describe('cursorAcpRemoteLauncher', () => {
             retryAttempt: message.retryAttempt,
             maxRetries: message.maxRetries
         }))).toEqual([
-            { subtype: 'api_error', retryAttempt: 1, maxRetries: 3 },
-            { subtype: 'api_error', retryAttempt: 2, maxRetries: 3 },
-            { subtype: 'api_error', retryAttempt: 3, maxRetries: 3 }
+            { subtype: 'api_error', retryAttempt: 1, maxRetries: 4 },
+            { subtype: 'api_error', retryAttempt: 2, maxRetries: 4 },
+            { subtype: 'api_error', retryAttempt: 3, maxRetries: 4 }
         ]);
         expect(client.sendAgentMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
     });
@@ -413,7 +414,7 @@ describe('cursorAcpRemoteLauncher', () => {
         expect(client.sendClaudeSessionMessage).toHaveBeenCalledWith(expect.objectContaining({
             subtype: 'api_error',
             retryAttempt: 1,
-            maxRetries: 3
+            maxRetries: 4
         }));
         expect(client.sendAgentMessage).not.toHaveBeenCalledWith(expect.objectContaining({
             message: expect.stringContaining('http/2 stream closed')
@@ -502,6 +503,47 @@ describe('cursorAcpRemoteLauncher', () => {
         await launchPromise;
 
         expect(harness.promptCalls).toBe(1);
+    });
+
+    it('does not replay a prompt when a transient failure follows tool activity', async () => {
+        harness.promptMessages = [{
+            type: 'tool_call',
+            id: 'tool-1',
+            name: 'shell',
+            input: { command: 'touch output.txt' },
+            status: 'completed'
+        }];
+        harness.promptErrors = [
+            new Error('Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL')
+        ];
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const client = makeClient() as unknown as ApiSessionClient & {
+            sendAgentMessage: ReturnType<typeof vi.fn>;
+        };
+        const session = new CursorSession({
+            api: {} as never,
+            client,
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        queue.push('finish the task', { permissionMode: 'default' });
+        queue.close();
+
+        await cursorAcpRemoteLauncher(session);
+
+        expect(harness.promptCalls).toBe(1);
+        expect(client.sendAgentMessage).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'error',
+            message: expect.stringContaining('not retried')
+        }));
     });
 
     it('removes the Cursor MCP overlay even when backend.disconnect rejects', async () => {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -17,6 +17,8 @@ const harness = vi.hoisted(() => ({
     promptErrors: [] as Error[],
     promptMessages: [] as Array<{ type: 'text'; text: string }>,
     promptStderrErrors: [] as Array<{ type: string; message: string; raw: string }>,
+    deferPrompt: null as Promise<void> | null,
+    releasePrompt: null as (() => void) | null,
     backendArgs: null as { command: string; args?: string[] } | null,
     setConfigOptionCalls: [] as Array<{ sessionId: string; configId: string; value: string }>,
     deferSetConfigOption: null as Promise<void> | null,
@@ -136,6 +138,7 @@ vi.mock('./utils/cursorAcpBackend', () => ({
                 if (message) onMessage?.(message);
                 const stderrError = harness.promptStderrErrors.shift();
                 if (stderrError) harness.stderrErrorHandler?.(stderrError);
+                if (harness.deferPrompt) await harness.deferPrompt;
                 const error = harness.promptErrors.shift();
                 if (error) throw error;
             }),
@@ -265,6 +268,8 @@ describe('cursorAcpRemoteLauncher', () => {
         harness.promptErrors = [];
         harness.promptMessages = [];
         harness.promptStderrErrors = [];
+        harness.deferPrompt = null;
+        harness.releasePrompt = null;
         harness.setConfigOptionCalls = [];
         harness.deferSetConfigOption = null;
         harness.releaseSetConfigOption = null;
@@ -453,6 +458,50 @@ describe('cursorAcpRemoteLauncher', () => {
         expect(client.sendAgentMessage).not.toHaveBeenCalledWith(expect.objectContaining({
             message: expect.stringContaining('http/2 stream closed')
         }));
+    });
+
+    it('does not retry when Stop resolves a prompt after a retryable stderr signal', async () => {
+        harness.promptStderrErrors = [{
+            type: 'unknown',
+            message: 'http/2 stream closed with error code CANCEL',
+            raw: 'http/2 stream closed with error code CANCEL'
+        }];
+        harness.deferPrompt = new Promise<void>((resolve) => {
+            harness.releasePrompt = resolve;
+        });
+        const handlers = new Map<string, () => Promise<void>>();
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const client = {
+            ...makeClient(),
+            rpcHandlerManager: {
+                registerHandler: vi.fn((method: string, handler: () => Promise<void>) => handlers.set(method, handler)),
+                unregisterHandler: vi.fn()
+            }
+        } as unknown as ApiSessionClient;
+        const session = new CursorSession({
+            api: {} as never,
+            client,
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        queue.push('finish the task', { permissionMode: 'default' });
+
+        const launchPromise = cursorAcpRemoteLauncher(session);
+        await vi.waitFor(() => expect(harness.promptCalls).toBe(1));
+        await handlers.get('abort')!();
+        harness.releasePrompt!();
+        queue.close();
+        await launchPromise;
+
+        expect(harness.promptCalls).toBe(1);
     });
 
     it('removes the Cursor MCP overlay even when backend.disconnect rejects', async () => {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -17,6 +17,7 @@ const harness = vi.hoisted(() => ({
     prompts: [] as unknown[][],
     promptErrors: [] as Error[],
     promptMessages: [] as AgentMessage[],
+    promptMessageBatches: [] as AgentMessage[][],
     promptStderrErrors: [] as Array<{ type: string; message: string; raw: string }>,
     deferPrompt: null as Promise<void> | null,
     releasePrompt: null as (() => void) | null,
@@ -135,8 +136,8 @@ vi.mock('./utils/cursorAcpBackend', () => ({
             prompt: vi.fn(async (_sessionId: string, content: unknown[], onMessage?: (message: AgentMessage) => void) => {
                 harness.promptCalls++;
                 harness.prompts.push(content);
-                const message = harness.promptMessages.shift();
-                if (message) onMessage?.(message);
+                const messages = harness.promptMessageBatches.shift() ?? harness.promptMessages.splice(0, 1);
+                for (const message of messages) onMessage?.(message);
                 const stderrError = harness.promptStderrErrors.shift();
                 if (stderrError) harness.stderrErrorHandler?.(stderrError);
                 if (harness.deferPrompt) await harness.deferPrompt;
@@ -268,6 +269,7 @@ describe('cursorAcpRemoteLauncher', () => {
         harness.prompts = [];
         harness.promptErrors = [];
         harness.promptMessages = [];
+        harness.promptMessageBatches = [];
         harness.promptStderrErrors = [];
         harness.deferPrompt = null;
         harness.releasePrompt = null;
@@ -493,6 +495,39 @@ describe('cursorAcpRemoteLauncher', () => {
 
         expect(harness.promptCalls).toBe(1);
         expect(client.sendClaudeSessionMessage).not.toHaveBeenCalled();
+    });
+
+    it('retries when inline failure accompanies recovered stderr and turn_complete', async () => {
+        harness.promptStderrErrors = [{
+            type: 'unknown',
+            message: 'http/2 stream closed with error code CANCEL',
+            raw: 'http/2 stream closed with error code CANCEL'
+        }];
+        harness.promptMessageBatches = [[
+            { type: 'text', text: 'Error: RetriableError: [canceled] http/2 stream closed' },
+            { type: 'turn_complete', stopReason: 'end_turn' }
+        ]];
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const session = new CursorSession({
+            api: {} as never,
+            client: makeClient(),
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        queue.push('finish the task', { permissionMode: 'default' });
+        queue.close();
+
+        await cursorAcpRemoteLauncher(session);
+
+        expect(harness.promptCalls).toBe(2);
     });
 
     it('does not retry when Stop resolves a prompt after a retryable stderr signal', async () => {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -461,6 +461,40 @@ describe('cursorAcpRemoteLauncher', () => {
         }));
     });
 
+    it('does not retry when Cursor completes the turn after transient stderr', async () => {
+        harness.promptStderrErrors = [{
+            type: 'unknown',
+            message: 'http/2 stream closed with error code CANCEL',
+            raw: 'http/2 stream closed with error code CANCEL'
+        }];
+        harness.promptMessages = [{ type: 'turn_complete', stopReason: 'end_turn' }];
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const client = makeClient() as unknown as ApiSessionClient & {
+            sendClaudeSessionMessage: ReturnType<typeof vi.fn>;
+        };
+        const session = new CursorSession({
+            api: {} as never,
+            client,
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        queue.push('finish the task', { permissionMode: 'default' });
+        queue.close();
+
+        await cursorAcpRemoteLauncher(session);
+
+        expect(harness.promptCalls).toBe(1);
+        expect(client.sendClaudeSessionMessage).not.toHaveBeenCalled();
+    });
+
     it('does not retry when Stop resolves a prompt after a retryable stderr signal', async () => {
         harness.promptStderrErrors = [{
             type: 'unknown',

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -69,6 +69,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     private autoReviewSlashQueued = false;
     private cursorMcpOverlay: CursorMcpOverlayHandle | null = null;
     private pendingRetryableError: string | null = null;
+    private pendingRetryableFromStderr = false;
     private promptInFlight = false;
     private userAbortRequested = false;
 
@@ -466,15 +467,21 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                 this.userAbortRequested = false;
                 for (let retryAttempt = 0; retryAttempt <= CURSOR_AUTO_RETRY_LIMIT; retryAttempt += 1) {
                     this.pendingRetryableError = null;
+                    this.pendingRetryableFromStderr = false;
                     let attemptProducedToolActivity = false;
+                    let turnCompleted = false;
                     try {
                         await backend.prompt(acpSessionId, promptContent, (message) => {
+                            if (message.type === 'turn_complete') turnCompleted = true;
                             if (message.type === 'tool_call' || message.type === 'tool_result') {
                                 attemptProducedToolActivity = true;
                             }
                             this.handleAgentMessage(message);
                         });
                         if (this.userAbortRequested) break;
+                        if (turnCompleted && this.pendingRetryableFromStderr) {
+                            this.pendingRetryableError = null;
+                        }
                         if (!this.pendingRetryableError) {
                             void backend.refreshSessionInfo(acpSessionId, session.path);
                             break;
@@ -502,6 +509,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             } finally {
                 this.promptInFlight = false;
                 this.pendingRetryableError = null;
+                this.pendingRetryableFromStderr = false;
                 session.onThinkingChange(false);
                 await this.permissionAdapter?.cancelAll('Prompt finished');
                 await this.extensionAdapter?.cancelAll('Prompt finished');
@@ -559,7 +567,10 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             const hint = error.raw || error.message;
             onHint(hint);
             if (this.promptInFlight && isRetryableCursorError(hint)) {
-                if (!this.userAbortRequested) this.pendingRetryableError = hint;
+                if (!this.userAbortRequested) {
+                    this.pendingRetryableError = hint;
+                    this.pendingRetryableFromStderr = true;
+                }
                 return;
             }
             if (error.type === 'model_not_found' && extractCannotUseThisModelMessage(hint)) {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -466,8 +466,12 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                 this.userAbortRequested = false;
                 for (let retryAttempt = 0; retryAttempt <= CURSOR_AUTO_RETRY_LIMIT; retryAttempt += 1) {
                     this.pendingRetryableError = null;
+                    let attemptProducedToolActivity = false;
                     try {
                         await backend.prompt(acpSessionId, promptContent, (message) => {
+                            if (message.type === 'tool_call' || message.type === 'tool_result') {
+                                attemptProducedToolActivity = true;
+                            }
                             this.handleAgentMessage(message);
                         });
                         if (this.userAbortRequested) break;
@@ -485,6 +489,10 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                         this.pendingRetryableError = error instanceof Error ? error.message : String(error);
                     }
 
+                    if (attemptProducedToolActivity) {
+                        this.surfacePromptFailure('Cursor connection interrupted after tool activity; the prompt was not retried.');
+                        break;
+                    }
                     if (retryAttempt < CURSOR_AUTO_RETRY_LIMIT) {
                         this.surfaceRetry(retryAttempt + 1);
                         continue;
@@ -657,7 +665,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             uuid: randomUUID(),
             subtype: 'api_error',
             retryAttempt,
-            maxRetries: CURSOR_AUTO_RETRY_LIMIT,
+            maxRetries: CURSOR_AUTO_RETRY_LIMIT + 1,
             error: { message: 'Cursor connection interrupted.' }
         });
     }

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -70,6 +70,8 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     private cursorMcpOverlay: CursorMcpOverlayHandle | null = null;
     private pendingRetryableError: string | null = null;
     private pendingRetryableFromStderr = false;
+    private pendingInlineRetryableError = false;
+    private attemptProducedToolActivity = false;
     private promptInFlight = false;
     private userAbortRequested = false;
 
@@ -468,18 +470,16 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                 for (let retryAttempt = 0; retryAttempt <= CURSOR_AUTO_RETRY_LIMIT; retryAttempt += 1) {
                     this.pendingRetryableError = null;
                     this.pendingRetryableFromStderr = false;
-                    let attemptProducedToolActivity = false;
+                    this.pendingInlineRetryableError = false;
+                    this.attemptProducedToolActivity = false;
                     let turnCompleted = false;
                     try {
                         await backend.prompt(acpSessionId, promptContent, (message) => {
                             if (message.type === 'turn_complete') turnCompleted = true;
-                            if (message.type === 'tool_call' || message.type === 'tool_result') {
-                                attemptProducedToolActivity = true;
-                            }
                             this.handleAgentMessage(message);
                         });
                         if (this.userAbortRequested) break;
-                        if (turnCompleted && this.pendingRetryableFromStderr) {
+                        if (turnCompleted && this.pendingRetryableFromStderr && !this.pendingInlineRetryableError) {
                             this.pendingRetryableError = null;
                         }
                         if (!this.pendingRetryableError) {
@@ -496,7 +496,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                         this.pendingRetryableError = error instanceof Error ? error.message : String(error);
                     }
 
-                    if (attemptProducedToolActivity) {
+                    if (this.attemptProducedToolActivity) {
                         this.surfacePromptFailure('Cursor connection interrupted after tool activity; the prompt was not retried.');
                         break;
                     }
@@ -510,6 +510,8 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                 this.promptInFlight = false;
                 this.pendingRetryableError = null;
                 this.pendingRetryableFromStderr = false;
+                this.pendingInlineRetryableError = false;
+                this.attemptProducedToolActivity = false;
                 session.onThinkingChange(false);
                 await this.permissionAdapter?.cancelAll('Prompt finished');
                 await this.extensionAdapter?.cancelAll('Prompt finished');
@@ -626,11 +628,19 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     }
 
     private handleAgentMessage(message: AgentMessage): void {
+        if (this.promptInFlight && (
+            message.type === 'tool_call'
+            || message.type === 'tool_result'
+            || message.type === 'generated_image'
+        )) {
+            this.attemptProducedToolActivity = true;
+        }
         if (message.type === 'text') {
             const visibleText = stripRetryableCursorError(message.text);
             if (visibleText !== null) {
                 if (this.userAbortRequested) return;
                 this.pendingRetryableError = message.text;
+                this.pendingInlineRetryableError = true;
                 if (!visibleText) return;
                 message = { ...message, text: visibleText };
             }

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { randomUUID } from 'node:crypto';
 import { logger } from '@/ui/logger';
 import { buildHapiMcpBridge } from '@/codex/utils/buildHapiMcpBridge';
 import { convertAgentMessage } from '@/agent/messageConverter';
@@ -43,6 +44,11 @@ import {
     resolveCursorSpawnModel,
     tryRemapCursorSpawnModelFromConnectError
 } from './utils/cursorStaleModelRemap';
+import {
+    CURSOR_AUTO_RETRY_LIMIT,
+    isRetryableCursorError,
+    stripRetryableCursorError
+} from './cursorAutoRetry';
 
 class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     private readonly session: CursorSession;
@@ -62,6 +68,9 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     /** Avoid re-queueing `/auto-review` on every mid-session mode sync. */
     private autoReviewSlashQueued = false;
     private cursorMcpOverlay: CursorMcpOverlayHandle | null = null;
+    private pendingRetryableError: string | null = null;
+    private promptInFlight = false;
+    private userAbortRequested = false;
 
     constructor(session: CursorSession) {
         super(process.env.DEBUG ? session.logPath : undefined);
@@ -453,20 +462,37 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             session.onThinkingChange(true);
 
             try {
-                await backend.prompt(acpSessionId, promptContent, (message) => {
-                    this.handleAgentMessage(message);
-                });
-                void backend.refreshSessionInfo(acpSessionId, session.path);
-            } catch (error) {
-                logger.warn('[cursor-acp] prompt failed', error);
-                const errMsg = error instanceof Error ? error.message : String(error);
-                const message = `Cursor Agent failed: ${errMsg}`;
-                const converted = convertAgentMessage({ type: 'error', message });
-                if (converted) {
-                    session.sendAgentMessage(converted);
+                this.promptInFlight = true;
+                this.userAbortRequested = false;
+                for (let retryAttempt = 0; retryAttempt <= CURSOR_AUTO_RETRY_LIMIT; retryAttempt += 1) {
+                    this.pendingRetryableError = null;
+                    try {
+                        await backend.prompt(acpSessionId, promptContent, (message) => {
+                            this.handleAgentMessage(message);
+                        });
+                        if (!this.pendingRetryableError) {
+                            void backend.refreshSessionInfo(acpSessionId, session.path);
+                            break;
+                        }
+                    } catch (error) {
+                        logger.warn('[cursor-acp] prompt failed', error);
+                        if (this.userAbortRequested) break;
+                        if (!isRetryableCursorError(error)) {
+                            this.surfacePromptFailure(error instanceof Error ? error.message : String(error));
+                            break;
+                        }
+                        this.pendingRetryableError = error instanceof Error ? error.message : String(error);
+                    }
+
+                    if (retryAttempt < CURSOR_AUTO_RETRY_LIMIT) {
+                        this.surfaceRetry(retryAttempt + 1);
+                        continue;
+                    }
+                    this.surfacePromptFailure(`Cursor Agent failed after ${CURSOR_AUTO_RETRY_LIMIT} retries.`);
                 }
-                messageBuffer.addMessage(message, 'status');
             } finally {
+                this.promptInFlight = false;
+                this.pendingRetryableError = null;
                 session.onThinkingChange(false);
                 await this.permissionAdapter?.cancelAll('Prompt finished');
                 await this.extensionAdapter?.cancelAll('Prompt finished');
@@ -523,6 +549,10 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             logger.debug('[cursor-acp] stderr error', error);
             const hint = error.raw || error.message;
             onHint(hint);
+            if (this.promptInFlight && isRetryableCursorError(hint)) {
+                if (!this.userAbortRequested) this.pendingRetryableError = hint;
+                return;
+            }
             if (error.type === 'model_not_found' && extractCannotUseThisModelMessage(hint)) {
                 return;
             }
@@ -576,6 +606,15 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     }
 
     private handleAgentMessage(message: AgentMessage): void {
+        if (message.type === 'text') {
+            const visibleText = stripRetryableCursorError(message.text);
+            if (visibleText !== null) {
+                if (this.userAbortRequested) return;
+                this.pendingRetryableError = message.text;
+                if (!visibleText) return;
+                message = { ...message, text: visibleText };
+            }
+        }
         const converted = convertAgentMessage(message, this.currentBackendModel);
         if (converted) {
             this.session.sendAgentMessage(converted);
@@ -609,6 +648,23 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             default:
                 break;
         }
+    }
+
+    private surfaceRetry(retryAttempt: number): void {
+        this.session.client.sendClaudeSessionMessage({
+            type: 'system',
+            uuid: randomUUID(),
+            subtype: 'api_error',
+            retryAttempt,
+            maxRetries: CURSOR_AUTO_RETRY_LIMIT,
+            error: { message: 'Cursor connection interrupted.' }
+        });
+    }
+
+    private surfacePromptFailure(message: string): void {
+        const converted = convertAgentMessage({ type: 'error', message });
+        if (converted) this.session.sendAgentMessage(converted);
+        this.messageBuffer.addMessage(message, 'status');
     }
 
     private installLiveSessionConfigSync(
@@ -791,6 +847,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
     }
 
     private async handleAbort(): Promise<void> {
+        this.userAbortRequested = true;
         const backend = this.backend;
         const sessionId = this.session.sessionId;
         if (backend && sessionId) {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -470,6 +470,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                         await backend.prompt(acpSessionId, promptContent, (message) => {
                             this.handleAgentMessage(message);
                         });
+                        if (this.userAbortRequested) break;
                         if (!this.pendingRetryableError) {
                             void backend.refreshSessionInfo(acpSessionId, session.path);
                             break;

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -222,7 +222,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             session.client,
             backend,
             () => session.getPermissionMode(),
-            (response) => extensionAdapter.handlePermissionResponse(response)
+            (response) => this.handlePermissionResponse(extensionAdapter, response)
         );
 
         const resumeSessionId = session.sessionId;
@@ -281,7 +281,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                             session.client,
                             backend,
                             () => session.getPermissionMode(),
-                            (response) => this.extensionAdapter!.handlePermissionResponse(response)
+                            (response) => this.handlePermissionResponse(this.extensionAdapter!, response)
                         );
                         continue;
                     }
@@ -342,7 +342,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                             session.client,
                             backend,
                             () => session.getPermissionMode(),
-                            (response) => this.extensionAdapter!.handlePermissionResponse(response)
+                            (response) => this.handlePermissionResponse(this.extensionAdapter!, response)
                         );
                         continue;
                     }
@@ -613,6 +613,14 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
         logger.debug('[cursor-acp] CreatePlan accepted — queued continue prompt', {
             executeMode
         });
+    }
+
+    private handlePermissionResponse(
+        extensionAdapter: CursorExtensionAdapter,
+        response: { id: string; approved: boolean; decision?: 'approved' | 'approved_for_session' | 'denied' | 'abort' }
+    ): Promise<boolean> {
+        if (response.decision === 'abort') this.userAbortRequested = true;
+        return extensionAdapter.handlePermissionResponse(response);
     }
 
     /**

--- a/cli/src/cursor/cursorAutoRetry.test.ts
+++ b/cli/src/cursor/cursorAutoRetry.test.ts
@@ -10,5 +10,8 @@ describe('Cursor automatic retry classification', () => {
         expect(stripRetryableCursorError(
             'Partial answer\n\nError: RetriableError: [canceled] http/2 stream closed'
         )).toBe('Partial answer');
+        expect(stripRetryableCursorError(
+            'Example:\n```text\nError: RetriableError: [canceled] http/2 stream closed\n```'
+        )).toBeNull();
     });
 });

--- a/cli/src/cursor/cursorAutoRetry.test.ts
+++ b/cli/src/cursor/cursorAutoRetry.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { isRetryableCursorError, stripRetryableCursorError } from './cursorAutoRetry';
+
+describe('Cursor automatic retry classification', () => {
+    it('recognizes Cursor connection failures without treating ordinary HTTP/2 prose as inline errors', () => {
+        expect(isRetryableCursorError(new Error('http/2 stream closed with error code CANCEL'))).toBe(true);
+        expect(isRetryableCursorError(new Error('HTTP/1.1 connection reset'))).toBe(true);
+        expect(stripRetryableCursorError('HTTP/2 is a binary framing protocol.')).toBeNull();
+        expect(stripRetryableCursorError(
+            'Partial answer\n\nError: RetriableError: [canceled] http/2 stream closed'
+        )).toBe('Partial answer');
+    });
+});

--- a/cli/src/cursor/cursorAutoRetry.test.ts
+++ b/cli/src/cursor/cursorAutoRetry.test.ts
@@ -5,6 +5,7 @@ describe('Cursor automatic retry classification', () => {
     it('recognizes Cursor connection failures without treating ordinary HTTP/2 prose as inline errors', () => {
         expect(isRetryableCursorError(new Error('http/2 stream closed with error code CANCEL'))).toBe(true);
         expect(isRetryableCursorError(new Error('HTTP/1.1 connection reset'))).toBe(true);
+        expect(isRetryableCursorError(new Error('HTTP/2 401 Unauthorized'))).toBe(false);
         expect(stripRetryableCursorError('HTTP/2 is a binary framing protocol.')).toBeNull();
         expect(stripRetryableCursorError(
             'Partial answer\n\nError: RetriableError: [canceled] http/2 stream closed'

--- a/cli/src/cursor/cursorAutoRetry.ts
+++ b/cli/src/cursor/cursorAutoRetry.ts
@@ -11,5 +11,7 @@ export function isRetryableCursorError(error: unknown): boolean {
 export function stripRetryableCursorError(text: string): string | null {
     const marker = INLINE_CURSOR_ERROR.exec(text);
     if (!marker || !isRetryableCursorError(text.slice(marker.index))) return null;
+    const before = text.slice(0, marker.index);
+    if ((before.match(/^[ \t]{0,3}(?:```|~~~)/gm)?.length ?? 0) % 2 === 1) return null;
     return text.slice(0, marker.index).trimEnd();
 }

--- a/cli/src/cursor/cursorAutoRetry.ts
+++ b/cli/src/cursor/cursorAutoRetry.ts
@@ -1,6 +1,6 @@
 export const CURSOR_AUTO_RETRY_LIMIT = 3;
 
-const RETRYABLE_CURSOR_ERROR = /(?:Error: (?:T|RetriableError): \[(?:canceled|deadline_exceeded|unavailable)\]|http\/(?:1\.1|2)|connection (?:reset|stalled|closed)|timed? out after|\btimeout\b)/i;
+const RETRYABLE_CURSOR_ERROR = /(?:Error: (?:T|RetriableError): \[(?:canceled|deadline_exceeded|unavailable)\]|http\/(?:1\.1|2).*stream closed|connection (?:reset|stalled|closed)|ACP request 'session\/prompt' timed out after \d+ms)/i;
 const INLINE_CURSOR_ERROR = /^[ \t]*Error: (?:T|RetriableError):/im;
 
 export function isRetryableCursorError(error: unknown): boolean {

--- a/cli/src/cursor/cursorAutoRetry.ts
+++ b/cli/src/cursor/cursorAutoRetry.ts
@@ -1,0 +1,15 @@
+export const CURSOR_AUTO_RETRY_LIMIT = 3;
+
+const RETRYABLE_CURSOR_ERROR = /(?:Error: (?:T|RetriableError): \[(?:canceled|deadline_exceeded|unavailable)\]|http\/(?:1\.1|2)|connection (?:reset|stalled|closed)|timed? out after|\btimeout\b)/i;
+const INLINE_CURSOR_ERROR = /^[ \t]*Error: (?:T|RetriableError):/im;
+
+export function isRetryableCursorError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return RETRYABLE_CURSOR_ERROR.test(message);
+}
+
+export function stripRetryableCursorError(text: string): string | null {
+    const marker = INLINE_CURSOR_ERROR.exec(text);
+    if (!marker || !isRetryableCursorError(text.slice(marker.index))) return null;
+    return text.slice(0, marker.index).trimEnd();
+}


### PR DESCRIPTION
## Summary

- automatically retry Cursor ACP prompts up to three times for transient connection failures
- detect failures from RPC rejection, ACP stderr, and inline Cursor RetriableError text
- suppress raw inline/stdio connection errors and report retry progress through HAPI's existing api_error event
- never retry explicit user aborts or non-transient Cursor failures

This is a focused replacement for the automatic-retry portion of #987. It intentionally excludes manual retry UI, settings, banners, and notification plumbing.

Addresses the retry portion of #878.

## Test plan

- bunx vitest run src/cursor/cursorAutoRetry.test.ts src/cursor/cursorAcpRemoteLauncher.test.ts
- bun typecheck
- bun run test
