### PR TITLE
fix(pi): settle autonomous agent lifecycles instead of swallowing them

### DIFF
--- a/cli/src/pi/loop.test.ts
+++ b/cli/src/pi/loop.test.ts
@@ -1259,6 +1259,48 @@ describe('Pi settlement compatibility fallbacks', () => {
         expect(h.onAgentSettled).not.toHaveBeenCalled();
     });
 
+    it('settles an autonomous agent lifecycle that starts after the previous prompt already settled', () => {
+        const h = setup();
+
+        // A normal prompt lifecycle runs to settlement.
+        h.controller.beginPromptLifecycle('prompt-1');
+        h.emit({ type: 'response', id: 'prompt-1', command: 'prompt', success: true });
+        h.emit({ type: 'agent_start' });
+        h.emit({ type: 'agent_end', willRetry: false });
+        h.emit({ type: 'agent_settled' });
+        expect(h.onAgentSettled).toHaveBeenCalledTimes(1);
+        expect(h.stateSession.piIsStreaming).toBe(false);
+
+        // Pi wakes up on its own (subagent completion, scheduled work) with no
+        // HAPI prompt in flight. Its settlement must not be swallowed by the
+        // already-delivered previous cycle, or thinking stays true forever.
+        h.emit({ type: 'agent_start' });
+        expect(h.stateSession.piIsStreaming).toBe(true);
+        h.emit({ type: 'agent_end', willRetry: false });
+        h.emit({ type: 'agent_settled' });
+        expect(h.onAgentSettled).toHaveBeenCalledTimes(2);
+        expect(h.stateSession.piIsStreaming).toBe(false);
+    });
+
+    it('settles an autonomous agent lifecycle through the legacy agent_end grace when agent_settled never arrives', async () => {
+        vi.useFakeTimers();
+        const h = setup();
+
+        h.controller.beginPromptLifecycle('prompt-1');
+        h.emit({ type: 'response', id: 'prompt-1', command: 'prompt', success: true });
+        h.emit({ type: 'agent_start' });
+        h.emit({ type: 'agent_end', willRetry: false });
+        h.emit({ type: 'agent_settled' });
+        expect(h.onAgentSettled).toHaveBeenCalledTimes(1);
+
+        h.emit({ type: 'agent_start' });
+        expect(h.stateSession.piIsStreaming).toBe(true);
+        h.emit({ type: 'agent_end', willRetry: false });
+        await vi.advanceTimersByTimeAsync(500);
+        expect(h.onAgentSettled).toHaveBeenCalledTimes(2);
+        expect(h.stateSession.piIsStreaming).toBe(false);
+    });
+
     it('rejects a matching prompt after turn_start already consumed its local ID', async () => {
         vi.useFakeTimers();
         const pendingLocalIds = ['local-a'];

--- a/cli/src/pi/loop.test.ts
+++ b/cli/src/pi/loop.test.ts
@@ -1301,6 +1301,52 @@ describe('Pi settlement compatibility fallbacks', () => {
         expect(h.stateSession.piIsStreaming).toBe(false);
     });
 
+    it('does not let a stale in-flight settlement callback settle a newly started autonomous lifecycle', async () => {
+        let listener: ((event: Record<string, unknown>) => void) | null = null;
+        const transport = {
+            onEvent: vi.fn((handler: (event: Record<string, unknown>) => void) => { listener = handler; }),
+            send: vi.fn(),
+        } as unknown as PiTransport;
+        const stateSession = createMockSession();
+        const onAgentSettled = vi.fn();
+        let releaseSync: (() => void) | null = null;
+        const conversationHistory = {
+            syncEntries: vi.fn(() => new Promise<void>((resolve) => { releaseSync = resolve; })),
+            observeEntry: vi.fn(),
+        } as unknown as PiConversationHistory;
+        const controller = wireTransportEvents(transport, stateSession, [], { onAgentSettled, conversationHistory });
+        const emit = (event: Record<string, unknown>) => listener?.(event);
+
+        controller.beginPromptLifecycle('prompt-1');
+        emit({ type: 'response', id: 'prompt-1', command: 'prompt', success: true });
+        emit({ type: 'agent_start' });
+        emit({ type: 'agent_end', willRetry: false });
+        emit({ type: 'agent_settled' });
+        // Settlement delivered, but its history sync (and therefore the
+        // onAgentSettled notification) is still in flight.
+        expect(onAgentSettled).not.toHaveBeenCalled();
+
+        // Pi wakes up autonomously before the sync completes.
+        emit({ type: 'agent_start' });
+        expect(stateSession.piIsStreaming).toBe(true);
+
+        // The stale callback resolves now — it must not settle the new
+        // lifecycle's boundary.
+        releaseSync!();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(onAgentSettled).not.toHaveBeenCalled();
+
+        // The autonomous lifecycle settles through its own events.
+        emit({ type: 'agent_end', willRetry: false });
+        emit({ type: 'agent_settled' });
+        releaseSync!();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(onAgentSettled).toHaveBeenCalledTimes(1);
+        expect(stateSession.piIsStreaming).toBe(false);
+    });
+
     it('rejects a matching prompt after turn_start already consumed its local ID', async () => {
         vi.useFakeTimers();
         const pendingLocalIds = ['local-a'];

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -757,6 +757,21 @@ export function wireTransportEvents(
         }
 
         if (event.type === 'agent_start' || event.type === 'turn_start') {
+            if (deliveredSettlement) {
+                // Pi can start an agent lifecycle on its own — subagent
+                // completion wake-ups, scheduled work — with no HAPI prompt in
+                // flight. The previous prompt lifecycle already delivered its
+                // settlement, so every settlement path below is gated shut and
+                // this turn's agent_settled/agent_end would be swallowed,
+                // leaving thinking=true (and the FIFO pump blocked) forever.
+                // Open a fresh settlement cycle for the autonomous lifecycle.
+                // Prompt-driven lifecycles are unaffected: beginPromptLifecycle
+                // has already reset deliveredSettlement to false by the time
+                // their agent_start arrives.
+                deliveredSettlement = false;
+                agentEndObserved = false;
+                activeAgentSettledSeen = false;
+            }
             clearCompactionRetryPending();
             agentLifecycleSeen = true;
             clearLegacySettleFallback();

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -599,9 +599,18 @@ export function wireTransportEvents(
         clearPromptLifecycleFallback();
         session.updateThinkingState(false);
         if (options.conversationHistory) {
+            // The settled notification fires after an async history sync. A new
+            // lifecycle (e.g. an autonomous wake-up) can begin in the meantime;
+            // generation-scope the callback so a stale settlement cannot mark
+            // that newer lifecycle's abort boundary as settled.
+            const settlementGeneration = lifecycleGeneration;
             void options.conversationHistory.syncEntries()
                 .catch(() => {})
-                .finally(() => options.onAgentSettled?.());
+                .finally(() => {
+                    if (settlementGeneration === lifecycleGeneration) {
+                        options.onAgentSettled?.();
+                    }
+                });
         } else {
             options.onAgentSettled?.();
         }
@@ -768,6 +777,10 @@ export function wireTransportEvents(
                 // Prompt-driven lifecycles are unaffected: beginPromptLifecycle
                 // has already reset deliveredSettlement to false by the time
                 // their agent_start arrives.
+                // Advance the generation so a previous settlement's async
+                // history-sync callback (still in flight) turns stale and
+                // cannot mark this new lifecycle's abort boundary as settled.
+                lifecycleGeneration += 1;
                 deliveredSettlement = false;
                 agentEndObserved = false;
                 activeAgentSettledSeen = false;


### PR DESCRIPTION
## Problem

When a Pi session is driven through HAPI, an agent lifecycle that Pi starts **on its own** — e.g. an async subagent completing and waking the session up, or scheduled/background work — permanently wedges the session:

- the status stays *thinking/brewing* forever even though Pi finished and went idle;
- new messages are accepted into the queue but never delivered (the FIFO pump is blocked by `piIsStreaming`);
- Stop appears to do nothing, because the abort path waits on a settlement that can never arrive;
- the only escape is killing the session.

## Root cause

`deliveredSettlement` in `cli/src/pi/loop.ts` is a per-prompt-lifecycle latch: it is reset only by `beginPromptLifecycle()`, which runs when HAPI sends a prompt. An autonomous lifecycle never goes through `beginPromptLifecycle()`, so when its `agent_start` arrives, the flag is still `true` from the previous prompt's settlement.

`agent_start` unconditionally sets `thinking=true`, but every settlement path is gated on `deliveredSettlement` being `false`:

- `deliverSettlement()` returns immediately;
- `scheduleLegacySettleFallback()` (the `agent_end` grace timer) returns immediately;
- `schedulePromptLifecycleFallback()` is only armed from the prompt-response branch, which never runs.

So the autonomous turn's `agent_end` + `agent_settled` are swallowed. `thinking`/`piIsStreaming` stay `true` forever, `pumpPromptQueue()` refuses to dequeue (`runPi.ts` gates on `piIsStreaming`), and a user-initiated abort blocks on `abortBoundary.promise`, which is resolved by the same `onAgentSettled` that will never fire — which is why Stop is also dead.

**Evidence** (local repro, hapi 0.27.3): CLI log shows `19:24:07 agent_start / turn_start` with **no** `Prompt accepted` (subagent-completion wake-up), then `19:25:40 agent_end` → `agent_settled` — both swallowed. The session stayed *brewing* for 27+ minutes (Pi idle the whole time) until it was killed.

## Fix

When `agent_start`/`turn_start` arrives while `deliveredSettlement` is still `true` (previous cycle fully settled, no HAPI prompt in flight), open a fresh settlement cycle for the autonomous lifecycle by resetting `deliveredSettlement`, `agentEndObserved`, and `activeAgentSettledSeen`. The existing settlement paths (direct `agent_settled`, legacy `agent_end` grace) then apply to the autonomous turn unchanged.

Deliberately **not** reused: `beginPromptLifecycle()` — it would fabricate prompt/FIFO state (`activePromptId`, pending local-ID association) for a turn that has no HAPI message behind it.

Non-impact on existing flows:

- **Prompt-driven lifecycles**: `beginPromptLifecycle()` is called synchronously *before* `transport.send({type:'prompt'})` (`runPi.ts`), so `deliveredSettlement` is already `false` when their `agent_start` arrives — the new branch does not trigger.
- **Mid-cycle retries** (`agent_end willRetry` → `auto_retry_start` → `agent_start`): the cycle has not settled, flag is still `false` — no trigger.
- **Tool-loop `turn_start`s** inside a running cycle: same, no trigger.

## Tests

Two new cases in `cli/src/pi/loop.test.ts` (`Pi settlement compatibility fallbacks`):

1. autonomous lifecycle settles via `agent_settled` after a fully settled prompt lifecycle;
2. autonomous lifecycle settles via the legacy `agent_end` grace when `agent_settled` never arrives.

Validation: `vitest run src/pi/` — 10 files, 222 tests passed; `tsc --noEmit` clean.