### PR TITLE
fix(web): clarify displayed media labels

### DIFF
--- a/web/src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx
@@ -2,13 +2,21 @@ import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { HappyChatProvider } from '@/components/AssistantChat/context'
 import { GeneratedImageCard } from '@/components/AssistantChat/messages/ToolMessage'
+import { I18nProvider } from '@/lib/i18n-context'
 import type { ApiClient } from '@/api/client'
 import type { HappyChatContextValue } from '@/components/AssistantChat/context'
 
 function renderCard(options: {
     mimeType: string | null
+    locale?: 'en' | 'zh-CN'
     getGeneratedImageBlob?: ReturnType<typeof vi.fn>
 }) {
+    if (options.locale) {
+        localStorage.setItem('hapi-lang', options.locale)
+    } else {
+        localStorage.removeItem('hapi-lang')
+    }
+
     const getGeneratedImageBlob = options.getGeneratedImageBlob ?? vi.fn(async () => new Blob(['x'], { type: options.mimeType ?? 'image/png' }))
     const api = { getGeneratedImageBlob } as unknown as ApiClient
     const value: HappyChatContextValue = {
@@ -26,25 +34,41 @@ function renderCard(options: {
     }
 
     render(
-        <HappyChatProvider value={value}>
-            <GeneratedImageCard
-                block={{
-                    kind: 'generated-image',
-                    id: 'block-1',
-                    localId: null,
-                    createdAt: 1,
-                    imageId: 'img-1',
-                    fileName: 'clip.mp4',
-                    mimeType: options.mimeType,
-                }}
-            />
-        </HappyChatProvider>
+        <I18nProvider>
+            <HappyChatProvider value={value}>
+                <GeneratedImageCard
+                    block={{
+                        kind: 'generated-image',
+                        id: 'block-1',
+                        localId: null,
+                        createdAt: 1,
+                        imageId: 'img-1',
+                        fileName: 'clip.mp4',
+                        mimeType: options.mimeType,
+                    }}
+                />
+            </HappyChatProvider>
+        </I18nProvider>
     )
 
     return { getGeneratedImageBlob }
 }
 
 describe('GeneratedImageCard video fetch', () => {
+    it('labels displayed images in English without implying AI generation', () => {
+        renderCard({ mimeType: 'image/png', locale: 'en' })
+
+        expect(screen.getByText('Displayed image: clip.mp4')).toBeInTheDocument()
+        expect(screen.queryByText(/Generated image/)).not.toBeInTheDocument()
+    })
+
+    it('localizes the displayed image label in Chinese', () => {
+        renderCard({ mimeType: 'image/png', locale: 'zh-CN' })
+
+        expect(screen.getByText('展示图片：clip.mp4')).toBeInTheDocument()
+        expect(screen.queryByText(/Generated image/)).not.toBeInTheDocument()
+    })
+
     it('does not call the API for an untouched video card', async () => {
         const { getGeneratedImageBlob } = renderCard({ mimeType: 'video/mp4' })
 

--- a/web/src/components/AssistantChat/messages/ToolMessage.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.tsx
@@ -16,7 +16,8 @@ import { CliOutputBlock } from '@/components/CliOutputBlock'
 import { UserBubbleContent, getUserBubbleClassName, shouldShowMessageStatus } from '@/components/AssistantChat/messages/user-bubble'
 import { ImagePreview } from '@/components/ImagePreview'
 import { FileIcon } from '@/components/FileIcon'
-import { generatedInlineMediaLabel, isInlineAudioMimeType, isInlineImageMimeType, isInlineVideoMimeType } from '@/lib/generatedInlineMedia'
+import { useTranslation } from '@/lib/use-translation'
+import { inlineMediaLabelKey, isInlineAudioMimeType, isInlineImageMimeType, isInlineVideoMimeType } from '@/lib/generatedInlineMedia'
 
 function isToolCallBlock(value: unknown): value is ToolCallBlock {
     if (!isObject(value)) return false
@@ -65,6 +66,7 @@ export function computeTinyImageScale(width: number, height: number): number {
 /** Exported for generated-media fetch and renderer tests. */
 export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
     const ctx = useHappyChatContext()
+    const { t } = useTranslation()
     const [objectUrl, setObjectUrl] = useState<string | null>(null)
     const [error, setError] = useState<string | null>(null)
     const [imageStyle, setImageStyle] = useState<CSSProperties | undefined>(undefined)
@@ -74,7 +76,8 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
     const isAudio = isInlineAudioMimeType(props.block.mimeType)
     const isImage = isInlineImageMimeType(props.block.mimeType)
     const isFile = !isVideo && !isAudio && !isImage
-    const mediaLabel = generatedInlineMediaLabel(props.block.mimeType)
+    const mediaLabel = t(inlineMediaLabelKey(props.block.mimeType))
+    const mediaHeader = t('media.displayed.header', { label: mediaLabel, fileName: props.block.fileName })
     // Non-image media can be tens of MB; wait for explicit user intent before downloading.
     const shouldFetch = isImage || loadMedia
 
@@ -135,7 +138,7 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
     return (
         <div className="max-w-[92%] rounded-2xl border border-[var(--app-border)] bg-[var(--app-tool-card-bg)] p-3">
             <div className="mb-2 min-w-0 truncate text-xs font-medium text-[var(--app-hint)]">
-                {mediaLabel} · {props.block.fileName}
+                {mediaHeader}
             </div>
             {objectUrl ? (
                 isVideo ? (
@@ -177,7 +180,7 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
                 )
             ) : error ? (
                 <div className="text-sm text-[var(--app-hint)]">
-                    {mediaLabel} is unavailable. {error}
+                    {t('media.displayed.unavailable', { label: mediaLabel, error })}
                 </div>
             ) : !isImage && !loadMedia ? (
                 <button

--- a/web/src/lib/generatedInlineMedia.test.ts
+++ b/web/src/lib/generatedInlineMedia.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { generatedInlineMediaLabel, isInlineAudioMimeType, isInlineVideoMimeType } from './generatedInlineMedia'
+import { inlineMediaLabelKey, isInlineAudioMimeType, isInlineVideoMimeType } from './generatedInlineMedia'
 
 describe('generatedInlineMedia', () => {
     it('detects inline video MIME types', () => {
@@ -9,12 +9,12 @@ describe('generatedInlineMedia', () => {
         expect(isInlineVideoMimeType(null)).toBe(false)
     })
 
-    it('labels generated inline media by MIME type', () => {
-        expect(generatedInlineMediaLabel('video/mp4')).toBe('Generated video')
-        expect(generatedInlineMediaLabel('image/png')).toBe('Generated image')
-        expect(generatedInlineMediaLabel('audio/wav')).toBe('Generated audio')
-        expect(generatedInlineMediaLabel('application/octet-stream')).toBe('Generated file')
-        expect(generatedInlineMediaLabel(null)).toBe('Generated image')
+    it('selects the localized displayed-media label by MIME type', () => {
+        expect(inlineMediaLabelKey('video/mp4')).toBe('media.displayed.video')
+        expect(inlineMediaLabelKey('image/png')).toBe('media.displayed.image')
+        expect(inlineMediaLabelKey('audio/wav')).toBe('media.displayed.audio')
+        expect(inlineMediaLabelKey('application/octet-stream')).toBe('media.displayed.file')
+        expect(inlineMediaLabelKey(null)).toBe('media.displayed.image')
         expect(isInlineAudioMimeType('audio/mpeg')).toBe(true)
     })
 })

--- a/web/src/lib/generatedInlineMedia.ts
+++ b/web/src/lib/generatedInlineMedia.ts
@@ -10,9 +10,15 @@ export function isInlineImageMimeType(mimeType: string | null | undefined): bool
     return mimeType == null || mimeType.startsWith('image/')
 }
 
-export function generatedInlineMediaLabel(mimeType: string | null | undefined): 'Generated video' | 'Generated audio' | 'Generated image' | 'Generated file' {
-    if (isInlineVideoMimeType(mimeType)) return 'Generated video'
-    if (isInlineAudioMimeType(mimeType)) return 'Generated audio'
-    if (isInlineImageMimeType(mimeType)) return 'Generated image'
-    return 'Generated file'
+export type InlineMediaLabelKey =
+    | 'media.displayed.video'
+    | 'media.displayed.audio'
+    | 'media.displayed.image'
+    | 'media.displayed.file'
+
+export function inlineMediaLabelKey(mimeType: string | null | undefined): InlineMediaLabelKey {
+    if (isInlineVideoMimeType(mimeType)) return 'media.displayed.video'
+    if (isInlineAudioMimeType(mimeType)) return 'media.displayed.audio'
+    if (isInlineImageMimeType(mimeType)) return 'media.displayed.image'
+    return 'media.displayed.file'
 }

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -502,6 +502,14 @@ export default {
   'file.error.diffUnavailable': 'Diff unavailable.',
   'file.error.diffUnavailableWithDetail': 'Diff unavailable: {error}',
 
+  // Inline media
+  'media.displayed.image': 'Displayed image',
+  'media.displayed.video': 'Displayed video',
+  'media.displayed.audio': 'Displayed audio',
+  'media.displayed.file': 'Displayed file',
+  'media.displayed.header': '{label}: {fileName}',
+  'media.displayed.unavailable': '{label} is unavailable. {error}',
+
   // Tool card
   'tool.askQuestion': 'Other',
   'tool.edit': 'Edit',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -501,6 +501,14 @@ export default {
   'file.error.diffUnavailable': 'Diff 不可用。',
   'file.error.diffUnavailableWithDetail': 'Diff 不可用：{error}',
 
+  // 内联媒体
+  'media.displayed.image': '展示图片',
+  'media.displayed.video': '展示视频',
+  'media.displayed.audio': '展示音频',
+  'media.displayed.file': '展示文件',
+  'media.displayed.header': '{label}：{fileName}',
+  'media.displayed.unavailable': '{label}不可用：{error}',
+
   // Tool card
   'tool.askQuestion': '其他',
   'tool.edit': '编辑',


### PR DESCRIPTION
## Problem / Motivation

The live media card used `Generated image`, which could imply that the image was generated by AI even when it was sent to the user through a display-media tool.

## Summary

- Replace the misleading live media label with localized displayed-media labels.
- Add English and Simplified Chinese labels for images, videos, audio, and generic files.
- Keep MCP/tool names, wire protocol values, and session-export wording unchanged.

## Impact / Risk

- Web-only UI and i18n change.
- No API, data, migration, or dependency changes.

## Validation

- `cd web && bun run test -- src/lib/generatedInlineMedia.test.ts src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx` — 2 files, 9 tests passed.
- `cd web && bun run test` — 259 files, 2452 tests passed.
- `bun typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name display-media-label -Suite Root terminal-wrap-fidelity.spec.ts` — 2/2 passed.
- `bun run build` — passed.
- Browser smoke check against the isolated Full test environment — English and Simplified Chinese labels were visible, with no failed requests.
- `git diff --check` — passed.
- AI assistance: OpenAI Codex.

## Related Issues

None