### PR TITLE
fix(mcp): clarify display_image user-output semantics

### DIFF
--- a/cli/src/claude/utils/startHappyServer.test.ts
+++ b/cli/src/claude/utils/startHappyServer.test.ts
@@ -118,6 +118,16 @@ describe('startHappyServer skill_lookup', () => {
         ])
     })
 
+    it('describes display_image as user output rather than image input', async () => {
+        const mcp = await connect(false)
+        const tools = await mcp.listTools()
+        const displayImage = tools.tools.find((tool) => tool.name === 'display_image')
+
+        expect(displayImage?.description).toContain('human user')
+        expect(displayImage?.description).toContain('does not provide image input to the model')
+        expect(displayImage?.description).toContain('cannot be used to read, inspect, or analyze image contents')
+    })
+
     it('displays audio through display_media and emits a generated media message', async () => {
         const path = join(sandboxDir, 'sample.wav')
         await writeFile(path, Buffer.from('RIFFxxxxWAVE'))

--- a/cli/src/claude/utils/startHappyServer.ts
+++ b/cli/src/claude/utils/startHappyServer.ts
@@ -90,8 +90,8 @@ function createHapiMcpServer(
     });
 
     const displayImageInputSchema: z.ZodTypeAny = z.object({
-        path: z.string().describe('Local filesystem path of the image to display to the user'),
-        title: z.string().optional().describe('Optional display title or filename for the image'),
+        path: z.string().describe('Absolute filesystem path of the local image to display to the human user. This file is sent for user display, not provided to the model for image inspection'),
+        title: z.string().optional().describe('Optional display title or filename shown to the human user'),
     });
 
     const skillLookupInputSchema: z.ZodTypeAny = z.object({
@@ -201,7 +201,7 @@ function createHapiMcpServer(
     }
 
     mcp.registerTool<any, any>('display_image', {
-        description: `Display a local image file inline in the current HAPI chat session. ${DISPLAY_IMAGE_PROMPT_CURSOR}`,
+        description: `Display a local image file to the human user inline in the current HAPI chat session. ${DISPLAY_IMAGE_PROMPT_CURSOR}`,
         title: 'Display Image',
         inputSchema: displayImageInputSchema,
     }, async (args: { path: string; title?: string }) => {

--- a/cli/src/codex/happyMcpStdioBridge.test.ts
+++ b/cli/src/codex/happyMcpStdioBridge.test.ts
@@ -4,6 +4,7 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>
 
 const harness = vi.hoisted(() => ({
     tools: new Map<string, ToolHandler>(),
+    configs: new Map<string, Record<string, unknown>>(),
     callTool: vi.fn(async (_request: unknown) => ({
         content: [{ type: 'text', text: 'forwarded' }],
         isError: false
@@ -12,8 +13,9 @@ const harness = vi.hoisted(() => ({
 
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
     McpServer: class {
-        registerTool(name: string, _config: unknown, handler: ToolHandler): void {
+        registerTool(name: string, config: Record<string, unknown>, handler: ToolHandler): void {
             harness.tools.set(name, handler)
+            harness.configs.set(name, config)
         }
 
         async connect(): Promise<void> {}
@@ -45,7 +47,22 @@ import { runHappyMcpStdioBridge } from './happyMcpStdioBridge'
 describe('runHappyMcpStdioBridge tool forwarding', () => {
     beforeEach(() => {
         harness.tools.clear()
+        harness.configs.clear()
         harness.callTool.mockClear()
+    })
+
+    it('describes display_image as user output rather than image input', async () => {
+        await runHappyMcpStdioBridge([
+            '--url',
+            'http://127.0.0.1:43006',
+            '--tools',
+            'display_image'
+        ])
+
+        const description = harness.configs.get('display_image')?.description
+        expect(description).toContain('human user')
+        expect(description).toContain('does not provide image input to the model')
+        expect(description).toContain('cannot be used to read, inspect, or analyze image contents')
     })
 
     it('registers and forwards skill_lookup when the HTTP server enables it', async () => {

--- a/cli/src/codex/happyMcpStdioBridge.ts
+++ b/cli/src/codex/happyMcpStdioBridge.ts
@@ -110,15 +110,15 @@ export async function runHappyMcpStdioBridge(argv: string[]): Promise<void> {
 
 
     const displayImageInputSchema: z.ZodTypeAny = z.object({
-      path: z.string().describe('Local filesystem path of the image to display to the user'),
-      title: z.string().optional().describe('Optional display title or filename for the image'),
+      path: z.string().describe('Absolute filesystem path of the local image to display to the human user. This file is sent for user display, not provided to the model for image inspection'),
+      title: z.string().optional().describe('Optional display title or filename shown to the human user'),
     });
 
     if (toolNames.has('display_image')) {
       server.registerTool<any, any>(
         'display_image',
         {
-          description: `Display a local image file inline in the current HAPI chat session. ${DISPLAY_IMAGE_PROMPT_CURSOR}`,
+          description: `Display a local image file to the human user inline in the current HAPI chat session. ${DISPLAY_IMAGE_PROMPT_CURSOR}`,
           title: 'Display Image',
           inputSchema: displayImageInputSchema,
         },

--- a/cli/src/modules/common/displayImagePrompt.test.ts
+++ b/cli/src/modules/common/displayImagePrompt.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+    DISPLAY_IMAGE_PROMPT_CLAUDE,
+    DISPLAY_IMAGE_PROMPT_CODEX,
+    DISPLAY_IMAGE_PROMPT_CURSOR,
+    DISPLAY_IMAGE_PROMPT_HAPI_MCP,
+} from './displayImagePrompt'
+
+const displayImagePrompts = [
+    DISPLAY_IMAGE_PROMPT_CLAUDE,
+    DISPLAY_IMAGE_PROMPT_CODEX,
+    DISPLAY_IMAGE_PROMPT_HAPI_MCP,
+    DISPLAY_IMAGE_PROMPT_CURSOR,
+]
+
+describe('display_image prompt semantics', () => {
+    it('describes image display as agent-to-user output, not model image input', () => {
+        for (const prompt of displayImagePrompts) {
+            expect(prompt).toContain('human user')
+            expect(prompt).toContain('absolute filesystem path')
+            expect(prompt).toContain('sends the image to the human user')
+            expect(prompt).toContain('does not provide image input to the model')
+            expect(prompt).toContain('cannot be used to read, inspect, or analyze image contents')
+        }
+    })
+
+    it('keeps each agent flavor instruction pointed at the corresponding tool alias', () => {
+        expect(DISPLAY_IMAGE_PROMPT_CLAUDE).toContain('mcp__hapi__display_image')
+        expect(DISPLAY_IMAGE_PROMPT_CODEX).toContain('functions.hapi__display_image')
+        expect(DISPLAY_IMAGE_PROMPT_HAPI_MCP).toContain('hapi_display_image')
+        expect(DISPLAY_IMAGE_PROMPT_CURSOR).toContain('"display_image"')
+    })
+})

--- a/cli/src/modules/common/displayImagePrompt.ts
+++ b/cli/src/modules/common/displayImagePrompt.ts
@@ -5,15 +5,18 @@ import { trimIdent } from '@/utils/trimIdent';
  * Inject into flavor system prompts and first-prompt bridge instructions.
  */
 export const DISPLAY_IMAGE_PROMPT_CLAUDE = trimIdent(`
-    When you create or find a local image file that the user should see, call the tool "mcp__hapi__display_image" with the image path so HAPI can show it inline.
+    When you create or find a local image file that the human user should see, call the tool "mcp__hapi__display_image" with the absolute filesystem path so HAPI can show it inline.
+    This tool sends the image to the human user for inline display in HAPI. It is not an image-reading or image-understanding tool: it does not provide image input to the model and cannot be used to read, inspect, or analyze image contents.
 `);
 
 export const DISPLAY_IMAGE_PROMPT_CODEX = trimIdent(`
-    When you create or find a local image file that the user should see, call functions.hapi__display_image with the image path. If that exact tool name is unavailable, use an equivalent alias such as hapi__display_image, mcp__hapi__display_image, or hapi_display_image.
+    When you create or find a local image file that the human user should see, call functions.hapi__display_image with the absolute filesystem path. If that exact tool name is unavailable, use an equivalent alias such as hapi__display_image, mcp__hapi__display_image, or hapi_display_image.
+    This tool sends the image to the human user for inline display in HAPI. It is not an image-reading or image-understanding tool: it does not provide image input to the model and cannot be used to read, inspect, or analyze image contents.
 `);
 
 export const DISPLAY_IMAGE_PROMPT_HAPI_MCP = trimIdent(`
-    When you create or find a local image file that the user should see, call the tool "hapi_display_image" with the image path so HAPI can show it inline. If that exact tool name is unavailable, use an equivalent alias such as display_image or mcp__hapi__display_image.
+    When you create or find a local image file that the human user should see, call the tool "hapi_display_image" with the absolute filesystem path so HAPI can show it inline. If that exact tool name is unavailable, use an equivalent alias such as display_image or mcp__hapi__display_image.
+    This tool sends the image to the human user for inline display in HAPI. It is not an image-reading or image-understanding tool: it does not provide image input to the model and cannot be used to read, inspect, or analyze image contents.
 `);
 
 export const DISPLAY_VIDEO_PROMPT_CLAUDE = trimIdent(`
@@ -29,7 +32,8 @@ export const DISPLAY_VIDEO_PROMPT_HAPI_MCP = trimIdent(`
 `);
 
 export const DISPLAY_IMAGE_PROMPT_CURSOR = trimIdent(`
-    When you create or find a local image file that the user should see, call the tool "display_image" with the absolute filesystem path so HAPI can show it inline.
+    When you create or find a local image file that the human user should see, call the tool "display_image" with the absolute filesystem path so HAPI can show it inline.
+    This tool sends the image to the human user for inline display in HAPI. It is not an image-reading or image-understanding tool: it does not provide image input to the model and cannot be used to read, inspect, or analyze image contents.
 `);
 
 export const DISPLAY_VIDEO_PROMPT_CURSOR = trimIdent(`


### PR DESCRIPTION
## Summary

- Clarify that `display_image` sends a local image to the human user for inline display in HAPI.
- Explicitly state that it is not an image-reading or image-understanding tool and does not provide image input to the model.
- Keep the existing tool name, protocol, bridge behavior, permissions, and compatibility aliases unchanged.
- Add regression coverage for the shared prompts and Claude/Codex MCP tool descriptions.

## Problem / Motivation

The current `display_image` wording can cause an AI agent to interpret the tool as a way to read or analyze image contents. This is incorrect: the tool is an agent-to-user output mechanism. The clarification reduces the chance that an agent will call it when it needs to inspect an image itself.

## Validation

- `bun run --cwd cli vitest run src/modules/common/displayImagePrompt.test.ts src/claude/utils/startHappyServer.test.ts src/codex/happyMcpStdioBridge.test.ts` — 3 files, 16 tests passed.
- `bun typecheck` — passed.
- `bun run build` — passed.
- `Invoke-HapiTaskPlaywright.ps1 -Name display-image-semantics -Suite Root terminal-wrap-fidelity.spec.ts` — 2 tests passed.
- `bun run test:web` — 259 files, 2450 tests passed.
- `bun run test:shared` — 262 tests passed.
- Full-environment Claude validation confirmed that the agent rejected using `display_image` for image analysis and did not invoke the tool.

## Related Issues

None

## AI Disclosure

Prepared with OpenAI Codex.