### PR TITLE
feat(pi): support Pi slash commands from HAPI web (compact/session/model/help)

### DIFF
--- a/cli/src/api/apiSession.ts
+++ b/cli/src/api/apiSession.ts
@@ -1042,6 +1042,13 @@ export class ApiSessionClient extends EventEmitter {
         // Carries the exact in-flight prompt text the web should restore.
         type: 'abort-restore'
         text: string
+    } | {
+        // Structured result of Pi's compact RPC: the web chat renders the
+        // summary as a dedicated block instead of a small status line.
+        type: 'compact-summary'
+        summary: string
+        tokensBefore?: number
+        estimatedTokensAfter?: number
     }, id?: string): void {
         const content = {
             role: 'agent',
@@ -1057,7 +1064,7 @@ export class ApiSessionClient extends EventEmitter {
                 sid: this.sessionId,
                 message: content
             })
-        }, event.type === 'message' || event.type === 'error' ? 'lossless' : 'droppable')
+        }, event.type === 'message' || event.type === 'error' || event.type === 'compact-summary' ? 'lossless' : 'droppable')
     }
 
     emitAgentTerminalOutput(data: string): void {

--- a/cli/src/modules/common/piSessions.test.ts
+++ b/cli/src/modules/common/piSessions.test.ts
@@ -73,6 +73,16 @@ describe('local Pi sessions', () => {
             createdAt: Date.parse('2026-08-04T01:00:01Z'),
             content: { role: 'user' }
         })
+        expect(sessions[0]?.messages.find((message) => message.localId.endsWith(':compaction'))).toMatchObject({
+            content: {
+                content: {
+                    data: {
+                        type: 'compact-summary',
+                        summary: 'condensed context'
+                    }
+                }
+            }
+        })
         rmSync(root, { recursive: true, force: true })
     })
 

--- a/cli/src/modules/common/piSessions.ts
+++ b/cli/src/modules/common/piSessions.ts
@@ -301,14 +301,28 @@ function convertVisibleMetadataRecord(
     createdAt: number
 ): PiImportedMessage[] {
     let text: string | null = null
+    let structured: PiImportedMessageContent | null = null
     if (record.type === 'custom_message' && record.display === true) {
         text = extractText(record.content).trim() || null
     } else if (record.type === 'compaction') {
         const summary = asString(record.summary)
-        if (summary) text = `[Compaction summary]\n\n${summary}`
+        if (summary) {
+            // Structured event: the web chat renders compaction summaries as a
+            // dedicated block (same shape as the live pi wrapper's compact RPC
+            // result).
+            structured = importedAgent({
+                type: 'compact-summary',
+                summary,
+            })
+        }
     } else if (record.type === 'branch_summary') {
         const summary = asString(record.summary)
         if (summary) text = `[Branch summary]\n\n${summary}`
+    }
+    if (structured) {
+        const result: PiImportedMessage[] = []
+        pushImportedMessage(result, sessionId, entryId, parentEntryId, createdAt, String(record.type), structured)
+        return result
     }
     if (!text) return []
     const result: PiImportedMessage[] = []

--- a/cli/src/modules/common/piSessions.ts
+++ b/cli/src/modules/common/piSessions.ts
@@ -308,12 +308,17 @@ function convertVisibleMetadataRecord(
         const summary = asString(record.summary)
         if (summary) {
             // Structured event: the web chat renders compaction summaries as a
-            // dedicated block (same shape as the live pi wrapper's compact RPC
-            // result).
-            structured = importedAgent({
-                type: 'compact-summary',
-                summary,
-            })
+            // dedicated block (same event envelope as the live pi wrapper's
+            // compact RPC result; the codex payload envelope is dropped by
+            // the web normalizer).
+            structured = {
+                role: 'agent',
+                content: {
+                    type: 'event',
+                    data: { type: 'compact-summary', summary },
+                },
+                meta: { sentFrom: 'cli' },
+            }
         }
     } else if (record.type === 'branch_summary') {
         const summary = asString(record.summary)

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -326,7 +326,12 @@ function handleResponse(
                                     onStartupFailure?.(new Error(`Pi startup model outcome is indeterminate: ${error.message}`));
                                     return;
                                 }
-                                logger.debug(`[pi] Startup model set_model rejected, keeping Pi default: ${error instanceof Error ? error.message : String(error)}`);
+                                const detail = error instanceof Error ? error.message : String(error);
+                                logger.debug(`[pi] Startup model set_model rejected, keeping Pi default: ${detail}`);
+                                session.sendSessionEvent({
+                                    type: 'message',
+                                    message: `⚠️ Startup model switch failed: ${detail}`,
+                                });
                             }
                         })();
                     } else {

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -195,8 +195,10 @@ function handleResponse(
         resolvePendingRpc(resolver, response);
         // get_session_stats is a best-effort compatibility probe. Older Pi
         // versions may reject it, so fall back silently instead of surfacing an
-        // error event to the user on every completed turn.
-        if (command !== 'get_session_stats' && command !== 'steer') {
+        // error event to the user on every completed turn. compact/set_model
+        // are owned by the awaited slash-command/config handlers, which report
+        // their own formatted failure message.
+        if (!['get_session_stats', 'steer', 'compact', 'set_model'].includes(command)) {
             session.sendSessionEvent({ type: 'message', message: error });
         }
         if (command === 'prompt' && pendingLocalIds.length > 0) {

--- a/cli/src/pi/promptQueue.test.ts
+++ b/cli/src/pi/promptQueue.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { PiPromptQueue } from './promptQueue';
+import { PiPromptQueue, isPiSpecialQueued, type PiPreparedPrompt, type PiPromptQueueEntry } from './promptQueue';
+
+/** Narrow a dequeued entry to the prompt variant for assertions. */
+function promptOf(entry: PiPromptQueueEntry | undefined): PiPreparedPrompt {
+    expect(entry).toBeDefined();
+    if (!entry || isPiSpecialQueued(entry)) {
+        throw new Error('expected a prompt entry');
+    }
+    return entry;
+}
 
 describe('PiPromptQueue', () => {
     it('preserves FIFO and permits cancellation before a Pi turn starts', () => {
@@ -8,8 +17,8 @@ describe('PiPromptQueue', () => {
         queue.enqueue({ message: 'cancel', images: [], outboundSequence: 2, localId: 'two' });
         queue.enqueue({ message: 'third', images: [], outboundSequence: 3, localId: 'three' });
         expect(queue.cancelByLocalId('two')).toBe(true);
-        expect(queue.dequeue()?.message).toBe('first');
-        expect(queue.dequeue()?.message).toBe('third');
+        expect(promptOf(queue.dequeue()).message).toBe('first');
+        expect(promptOf(queue.dequeue()).message).toBe('third');
         expect(queue.dequeue()).toBeUndefined();
     });
 
@@ -18,8 +27,8 @@ describe('PiPromptQueue', () => {
         queue.enqueue({ message: 'later ordinary', images: [], outboundSequence: 2, localId: 'two' });
         queue.enqueue({ message: 'earlier steer fallback', images: [], outboundSequence: 1, localId: 'one' });
 
-        expect(queue.dequeue()?.message).toBe('earlier steer fallback');
-        expect(queue.dequeue()?.message).toBe('later ordinary');
+        expect(promptOf(queue.dequeue()).message).toBe('earlier steer fallback');
+        expect(promptOf(queue.dequeue()).message).toBe('later ordinary');
     });
 
     it('removes a queued entry by localId for explicit steer promotion', () => {
@@ -29,11 +38,11 @@ describe('PiPromptQueue', () => {
         queue.enqueue({ message: 'third', images: [], outboundSequence: 3, localId: 'three' });
 
         const removed = queue.removeByLocalId('two');
-        expect(removed?.message).toBe('steer me');
-        expect(removed?.localId).toBe('two');
+        expect(promptOf(removed).message).toBe('steer me');
+        expect(promptOf(removed).localId).toBe('two');
         // Remaining order preserved.
-        expect(queue.dequeue()?.message).toBe('first');
-        expect(queue.dequeue()?.message).toBe('third');
+        expect(promptOf(queue.dequeue()).message).toBe('first');
+        expect(promptOf(queue.dequeue()).message).toBe('third');
         expect(queue.dequeue()).toBeUndefined();
     });
 
@@ -43,7 +52,7 @@ describe('PiPromptQueue', () => {
 
         expect(queue.removeByLocalId('missing')).toBeUndefined();
         expect(queue.removeByLocalId('')).toBeUndefined();
-        expect(queue.removeByLocalId('one')?.message).toBe('only');
+        expect(promptOf(queue.removeByLocalId('one')).message).toBe('only');
         expect(queue.removeByLocalId('one')).toBeUndefined();
     });
 });

--- a/cli/src/pi/promptQueue.ts
+++ b/cli/src/pi/promptQueue.ts
@@ -47,6 +47,10 @@ export class PiPromptQueue {
         return this.entries.shift();
     }
 
+    peek(): PiPromptQueueEntry | undefined {
+        return this.entries[0];
+    }
+
     cancelByLocalId(localId: string): boolean {
         if (!localId) return false;
         const index = this.entries.findIndex((entry) => entry.localId === localId);

--- a/cli/src/pi/promptQueue.ts
+++ b/cli/src/pi/promptQueue.ts
@@ -1,4 +1,5 @@
 import type { PiImageContent } from './types';
+import type { PiSpecialCommand } from './specialCommands';
 
 export type PiPreparedPrompt = {
     message: string;
@@ -9,6 +10,24 @@ export type PiPreparedPrompt = {
 };
 
 /**
+ * A Pi built-in slash command queued through the same FIFO as prompts so
+ * dispatch order matches message arrival order (a /compact typed after a
+ * prompt never jumps the queue).
+ */
+export type PiSpecialQueued = {
+    kind: 'special';
+    command: PiSpecialCommand;
+    outboundSequence: number;
+    localId?: string;
+};
+
+export type PiPromptQueueEntry = PiPreparedPrompt | PiSpecialQueued;
+
+export function isPiSpecialQueued(entry: PiPromptQueueEntry): entry is PiSpecialQueued {
+    return 'kind' in entry && entry.kind === 'special';
+}
+
+/**
  * Small cancellable FIFO: HAPI owns queueing, Pi receives only real turns.
  *
  * A native steer can asynchronously degrade to a prompt after a later ordinary
@@ -16,15 +35,15 @@ export type PiPreparedPrompt = {
  * that boundary instead of using completion order.
  */
 export class PiPromptQueue {
-    private readonly entries: PiPreparedPrompt[] = [];
+    private readonly entries: PiPromptQueueEntry[] = [];
 
-    enqueue(prompt: PiPreparedPrompt): void {
-        const index = this.entries.findIndex((entry) => entry.outboundSequence > prompt.outboundSequence);
-        if (index === -1) this.entries.push(prompt);
-        else this.entries.splice(index, 0, prompt);
+    enqueue(entry: PiPromptQueueEntry): void {
+        const index = this.entries.findIndex((item) => item.outboundSequence > entry.outboundSequence);
+        if (index === -1) this.entries.push(entry);
+        else this.entries.splice(index, 0, entry);
     }
 
-    dequeue(): PiPreparedPrompt | undefined {
+    dequeue(): PiPromptQueueEntry | undefined {
         return this.entries.shift();
     }
 
@@ -41,7 +60,7 @@ export class PiPromptQueue {
      * into the active turn (explicit steer). Returns undefined when the entry
      * is absent (already dispatched, cancelled, or still preparing).
      */
-    removeByLocalId(localId: string): PiPreparedPrompt | undefined {
+    removeByLocalId(localId: string): PiPromptQueueEntry | undefined {
         if (!localId) return undefined;
         const index = this.entries.findIndex((entry) => entry.localId === localId);
         if (index === -1) return undefined;

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1671,6 +1671,33 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
+    it('fails closed when the direct compact-abort RPC times out', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'timeout-abort-id');
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' })));
+
+        vi.useFakeTimers();
+        const abort = harness.rpcHandlers.get(RPC_METHODS.Abort)!;
+        const abortPromise = abort({});
+        // Attach the settlement handler before advancing timers so the
+        // rejection is never observed as unhandled.
+        const settled = abortPromise.then(() => 'ok', () => 'failed');
+        await vi.advanceTimersByTimeAsync(10);
+        expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'abort' }));
+
+        // The abort RPC never answers: the compaction outcome is
+        // indeterminate (the compact RPC keeps the mutation lease for up to
+        // 120s), so the session must fail closed exactly like the ordinary
+        // Abort path and never release the prompt FIFO.
+        await vi.advanceTimersByTimeAsync(30_000);
+        expect(await settled).toBe('failed');
+        expect(harness.cleanupCount).toBe(1);
+        vi.useRealTimers();
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
     it('fails the session when compaction times out with a queued prompt', async () => {
         const { running, onUserMessage } = await startReadySession();
         // Fake timers must be installed before the compact RPC is issued so

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1660,6 +1660,28 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
+    it('cancels a slash command canceled while command discovery is pending', async () => {
+        const { running, onUserMessage } = await startReadySession([]);
+        const onCancelQueuedMessage = harness.session.onCancelQueuedMessage.mock.calls.at(-1)![0] as (localId: string) => boolean;
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'discover-cancel-id');
+
+        // Discovery RPC is in flight (empty cache is not cached).
+        await vi.waitFor(() => expect(harness.sent.filter((item) => (item as { type?: string }).type === 'get_commands').length).toBeGreaterThan(1));
+        // Cancel while discovery is pending is acknowledged (reservation held)...
+        expect(onCancelQueuedMessage('discover-cancel-id')).toBe(true);
+
+        // ...and must still win once discovery resolves: no compact RPC, no
+        // consumption (the hub deletes the row instead).
+        const pending = harness.sent.filter((item) => (item as { type?: string }).type === 'get_commands').at(-1) as { id: string };
+        harness.onEvent!({ type: 'response', id: pending.id, command: 'get_commands', success: true, data: { commands: [{ name: 'ext', description: 'Ext', source: 'extension' }] } });
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'compact' }));
+        expect(harness.session.emitMessagesConsumed).not.toHaveBeenCalledWith(['discover-cancel-id'], expect.anything());
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
     it('treats reserved-name path prefixes as ordinary prompts', async () => {
         const { running, onUserMessage } = await startReadySession();
         onUserMessage({ role: 'user', content: { type: 'text', text: '/compact.md notes' } }, 'path-id');

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1253,6 +1253,7 @@ describe('Pi steer-queued-message RPC', () => {
 
 describe('Pi built-in slash commands', () => {
     beforeEach(() => {
+        vi.useRealTimers();
         harness.sent.length = 0;
         harness.throwOnGetCommands = false;
         harness.onError = null;
@@ -1452,257 +1453,45 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
-    it('shows help and flags terminal-only Pi builtins instead of passing them to the model', async () => {
+    it('fails the session when compaction times out with a queued prompt', async () => {
         const { running, onUserMessage } = await startReadySession();
+        // Fake timers must be installed before the compact RPC is issued so
+        // its 120s timeout timer is mocked.
+        vi.useFakeTimers();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'timeout-id');
+        onUserMessage({ role: 'user', content: { type: 'text', text: 'queued behind compaction' } }, 'queued-id');
+        await vi.advanceTimersByTimeAsync(10);
 
-        onUserMessage({ role: 'user', content: { type: 'text', text: '/help' } }, 'help-id');
-        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: expect.stringContaining('/compact [instructions]'),
-        })));
-
-        onUserMessage({ role: 'user', content: { type: 'text', text: '/tree 42' } }, 'tree-id');
-        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: expect.stringContaining('/tree is a Pi terminal-only command'),
-        })));
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['tree-id'], { clearQueuedThinkingGrace: true }));
+        expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' }));
         expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
 
-        harness.onError?.(new Error('finish test'));
-        await running;
-    });
-
-    it('leaves unknown slash text on the normal prompt path', async () => {
-        const { running, onUserMessage } = await startReadySession();
-        onUserMessage({ role: 'user', content: { type: 'text', text: '/some-custom-thing arg' } }, 'custom-id');
-        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
-            type: 'prompt', message: '/some-custom-thing arg',
-        })));
-
-        harness.onError?.(new Error('finish test'));
-        await running;
-    });
-
-    it('merges HAPI builtins with Pi extension commands in the slash-command list', async () => {
-        const { running } = await startReadySession();
-        const slashHandler = harness.rpcHandlers.get(RPC_METHODS.ListSlashCommands)!;
-
-        await vi.waitFor(() => expect(harness.sent.some((item) => (item as { type?: string }).type === 'get_commands')).toBe(true));
-        const getCommands = harness.sent.find((item) => (item as { type?: string }).type === 'get_commands') as { id: string };
-        harness.onEvent!({ type: 'response', id: getCommands.id, command: 'get_commands', success: true, data: {
-            commands: [
-                { name: 'session-name', description: 'Rename session', source: 'extension' },
-                { name: 'fix-tests', description: 'Fix tests', source: 'prompt' },
-                { name: 'skill:brave-search', description: 'Search the web', source: 'skill' },
-            ],
-        } });
-
-        const result = await slashHandler({ agent: 'pi' });
-        const names = (result as { commands: Array<{ name: string }> }).commands.map((command) => command.name);
-        expect(names).toEqual(expect.arrayContaining(['compact', 'session', 'model', 'help', 'session-name', 'fix-tests']));
-        // Skills stay out of slash completion; they surface via $ instead.
-        expect(names).not.toContain('skill:brave-search');
-
-        harness.onError?.(new Error('finish test'));
-        await running;
-    });
-});
-
-describe('Pi built-in slash commands', () => {
-    beforeEach(() => {
-        harness.sent.length = 0;
-        harness.throwOnGetCommands = false;
-        harness.onError = null;
-        harness.onEvent = null;
-        harness.rpcHandlers.clear();
-        harness.session.onUserMessage.mockReset();
-        harness.session.onCancelQueuedMessage.mockReset();
-        harness.session.emitMessagesConsumed.mockReset();
-        harness.session.sendSessionEvent.mockReset();
-        harness.session.updateMetadata.mockReset();
-        harness.cleanupCount = 0;
-        harness.killCount = 0;
-        harness.session.rpcHandlerManager.registerHandler.mockReset();
-        harness.session.rpcHandlerManager.registerHandler.mockImplementation((method: string, handler: (payload: unknown) => Promise<unknown>) => {
-            harness.rpcHandlers.set(method, handler);
-        });
-    });
-
-    async function startReadySession(): Promise<{
-        running: Promise<void>;
-        onUserMessage: (message: {
-            role: 'user';
-            content: { type: 'text'; text: string };
-            meta?: { deliveryMode?: 'queue' | 'steer' };
-        }, localId: string) => void;
-    }> {
-        const running = runPi({ workingDirectory: '/work' });
-        await vi.waitFor(() => expect(harness.onEvent).not.toBeNull());
-        harness.onEvent!({
-            type: 'response', command: 'get_state', success: true,
-            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: false },
-        });
-        await completeHistoryInitialization();
-        const onUserMessage = harness.session.onUserMessage.mock.calls.at(-1)![0] as (message: {
-            role: 'user';
-            content: { type: 'text'; text: string };
-            meta?: { deliveryMode?: 'queue' | 'steer' };
-        }, localId: string) => void;
-        return { running, onUserMessage };
-    }
-
-    it('executes /compact via Pi RPC, reports the summary, and holds queued prompts until it completes', async () => {
-        const { running, onUserMessage } = await startReadySession();
-        onUserMessage({
-            role: 'user',
-            content: { type: 'text', text: '/compact focus on the API design' },
-        }, 'compact-id');
-
-        onUserMessage({
-            role: 'user',
-            content: { type: 'text', text: 'continue after compaction' },
-        }, 'after-id');
-
-        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
-            type: 'compact', customInstructions: 'focus on the API design',
-        })));
-        // While the compact RPC is outstanding, the FIFO must not release the
-        // following prompt — Pi rejects prompts during compaction.
+        // The compact RPC never answers: the outcome is indeterminate and the
+        // runtime lease stays poisoned, so the session must be torn down and
+        // the prompt FIFO must never be reopened into a possibly-compacting Pi.
+        await vi.advanceTimersByTimeAsync(120_000);
+        expect(harness.cleanupCount).toBe(1);
         expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
-
-        const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string };
-        harness.onEvent!({
-            type: 'response', id: compact.id, command: 'compact', success: true,
-            data: { summary: 'API design focused summary', tokensBefore: 1000, estimatedTokensAfter: 120 },
-        });
-
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['compact-id'], { clearQueuedThinkingGrace: true }));
-        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: '📦 Compaction completed (tokens: 1000 → 120)',
-        }));
-        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: '📦 Compaction summary:\nAPI design focused summary',
-        }));
-
-        // The queued prompt may only flow once compaction completed.
-        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
-            type: 'prompt', message: 'continue after compaction',
-        })));
+        vi.useRealTimers();
 
         harness.onError?.(new Error('finish test'));
         await running;
     });
 
-    it('intercepts /compact even when delivered as a steer while streaming', async () => {
+    it('does not acknowledge cancellation while a special command is executing', async () => {
         const { running, onUserMessage } = await startReadySession();
-        harness.onEvent!({
-            type: 'response', command: 'get_state', success: true,
-            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: true },
-        });
-        onUserMessage({
-            role: 'user',
-            content: { type: 'text', text: '/compact' },
-            meta: { deliveryMode: 'steer' },
-        }, 'steer-compact-id');
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'in-flight-id');
 
         await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' })));
-        const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string; customInstructions?: string };
-        expect(compact.customInstructions).toBeUndefined();
-        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'steer' }));
 
-        harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: true, data: {} });
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['steer-compact-id'], { clearQueuedThinkingGrace: true }));
+        // The reservation is released before execution starts, so a cancel that
+        // lands while the compact RPC is in flight is not acknowledged — the
+        // hub keeps the queued row instead of deleting it mid-execution.
+        const onCancelQueuedMessage = harness.session.onCancelQueuedMessage.mock.calls.at(-1)![0] as (localId: string) => boolean;
+        expect(onCancelQueuedMessage('in-flight-id')).toBe(false);
 
-        harness.onError?.(new Error('finish test'));
-        await running;
-    });
-
-    it('reports compact failures as a visible message', async () => {
-        const { running, onUserMessage } = await startReadySession();
-        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'fail-id');
-
-        const compact = await vi.waitFor(() => {
-            const found = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string } | undefined;
-            expect(found).toBeDefined();
-            return found!;
-        });
-        harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: false, error: 'no model selected' });
-
-        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: '⚠️ Compaction failed: no model selected',
-        })));
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['fail-id'], { clearQueuedThinkingGrace: true }));
-
-        harness.onError?.(new Error('finish test'));
-        await running;
-    });
-
-    it('shows session stats for /session', async () => {
-        const { running, onUserMessage } = await startReadySession();
-        onUserMessage({ role: 'user', content: { type: 'text', text: '/session' } }, 'stats-id');
-
-        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'get_session_stats' })));
-        const statsCmd = harness.sent.find((item) => (item as { type?: string }).type === 'get_session_stats') as { id: string };
-        harness.onEvent!({
-            type: 'response', id: statsCmd.id, command: 'get_session_stats', success: true,
-            data: {
-                totalMessages: 42,
-                tokens: { input: 3000, output: 2000, total: 5000 },
-                cost: 0.1234,
-                contextUsage: { tokens: 4000, contextWindow: 200000, percent: 2 },
-            },
-        });
-
-        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: expect.stringContaining('Messages: 42'),
-        })));
-        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: expect.stringContaining('Tokens: total 5000 · in 3000 · out 2000'),
-        }));
-        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: expect.stringContaining('Cost: $0.1234'),
-        }));
-        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: expect.stringContaining('Context: 4000 / 200000 tokens (2%)'),
-        }));
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['stats-id'], { clearQueuedThinkingGrace: true }));
-
-        harness.onError?.(new Error('finish test'));
-        await running;
-    });
-
-    it('lists or switches the model for /model', async () => {
-        const { running, onUserMessage } = await startReadySession();
-        harness.onEvent!({ type: 'response', command: 'get_available_models', success: true, data: {
-            models: [
-                { id: 'gpt-5.2', provider: 'openai' },
-                { id: 'gpt-4.1', provider: 'openai' },
-            ],
-        } });
-        await vi.waitFor(() => expect(harness.session.updateMetadata).toHaveBeenCalled());
-
-        onUserMessage({ role: 'user', content: { type: 'text', text: '/model' } }, 'list-id');
-        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: expect.stringContaining('Available: gpt-5.2, gpt-4.1'),
-        })));
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['list-id'], { clearQueuedThinkingGrace: true }));
-
-        onUserMessage({ role: 'user', content: { type: 'text', text: '/model gpt-4.1' } }, 'switch-id');
-        const setModel = await vi.waitFor(() => {
-            const found = harness.sent.find((item) => (item as { type?: string }).type === 'set_model') as { id: string; provider?: string; modelId?: string } | undefined;
-            expect(found).toBeDefined();
-            return found!;
-        });
-        expect(setModel).toMatchObject({ provider: 'openai', modelId: 'gpt-4.1' });
-        harness.onEvent!({ type: 'response', id: setModel.id, command: 'set_model', success: true });
-        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: 'Model switched to gpt-4.1',
-        })));
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['switch-id'], { clearQueuedThinkingGrace: true }));
-
-        onUserMessage({ role: 'user', content: { type: 'text', text: '/model does-not-exist' } }, 'unknown-id');
-        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: '⚠️ Unknown model: does-not-exist. Use /model to list available models.',
-        })));
+        const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string };
+        harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: true, data: { summary: 'done' } });
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['in-flight-id'], { clearQueuedThinkingGrace: true }));
 
         harness.onError?.(new Error('finish test'));
         await running;

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1331,12 +1331,20 @@ describe('Pi built-in slash commands', () => {
             data: { summary: 'API design focused summary', tokensBefore: 1000, estimatedTokensAfter: 120 },
         });
 
-        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: '📦 Compaction completed (tokens: 1000 → 120)',
-        })));
-        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: '📦 Compaction summary:\nAPI design focused summary',
-        })));
+        // The summary lands as a structured event (the web renders it as a
+        // dedicated block), not as a plain status message. (The /compact row
+        // was already consumed at dispatch above.)
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith({
+            type: 'compact-summary',
+            summary: 'API design focused summary',
+            tokensBefore: 1000,
+            estimatedTokensAfter: 120,
+        }));
+        expect(harness.session.sendSessionEvent).not.toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Compaction summary'),
+        }));
+
+        // The queued prompt may only flow once compaction completed.
         await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
             type: 'prompt', message: 'continue after compaction',
         })));

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1726,6 +1726,12 @@ describe('Pi built-in slash commands', () => {
         await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
             message: 'Model switched to azure/gpt-5.2',
         })));
+        // The web picker prefers piSelectedModel metadata, so a
+        // provider-qualified switch must persist it (a bare keepalive model
+        // cannot represent the provider dimension).
+        await vi.waitFor(() => expect(harness.session.updateMetadata).toHaveBeenCalledWith(expect.any(Function)));
+        const metadataUpdater = harness.session.updateMetadata.mock.calls.at(-1)![0] as (meta: Record<string, unknown>) => Record<string, unknown>;
+        expect(metadataUpdater({})).toEqual({ piSelectedModel: { provider: 'azure', modelId: 'gpt-5.2' } });
 
         harness.onError?.(new Error('finish test'));
         await running;

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1337,7 +1337,7 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
-    it('intercepts /compact even when delivered as a steer while streaming', async () => {
+    it('queues /compact in FIFO order even when delivered as a steer while streaming', async () => {
         const { running, onUserMessage } = await startReadySession();
         harness.onEvent!({
             type: 'response', command: 'get_state', success: true,
@@ -1349,6 +1349,16 @@ describe('Pi built-in slash commands', () => {
             meta: { deliveryMode: 'steer' },
         }, 'steer-compact-id');
 
+        // While the turn is streaming the command stays queued — no compact RPC
+        // and no native steer into the active turn.
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'compact' }));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'steer' }));
+
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: false },
+        });
         await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' })));
         const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string; customInstructions?: string };
         expect(compact.customInstructions).toBeUndefined();
@@ -1356,6 +1366,44 @@ describe('Pi built-in slash commands', () => {
 
         harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: true, data: {} });
         await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['steer-compact-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('dispatches a prompt queued before /compact ahead of the command (FIFO)', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: true },
+        });
+        onUserMessage({ role: 'user', content: { type: 'text', text: 'queued prompt B' } }, 'b-id');
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'compact-after-b-id');
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'compact' }));
+
+        // Turn settles: prompt B is dispatched first; /compact must wait.
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: false },
+        });
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'prompt', message: 'queued prompt B',
+        })));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'compact' }));
+
+        // Settle prompt B, then the queued /compact executes. The lifecycle
+        // fallback reads the append log before retiring the entry.
+        const promptB = harness.sent.find((item) => (item as { type?: string }).type === 'prompt') as { id: string };
+        vi.useFakeTimers();
+        harness.onEvent!({ type: 'response', id: promptB.id, command: 'prompt', success: true });
+        await vi.advanceTimersByTimeAsync(1_100);
+        const appendSync = harness.sent.filter((item) => (item as { type?: string }).type === 'get_entries').at(-1) as { id: string };
+        harness.onEvent!({ type: 'response', id: appendSync.id, command: 'get_entries', success: true, data: { entries: [], leafId: null } });
+        await vi.advanceTimersByTimeAsync(10);
+        vi.useRealTimers();
+        expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' }));
 
         harness.onError?.(new Error('finish test'));
         await running;
@@ -1492,6 +1540,39 @@ describe('Pi built-in slash commands', () => {
         const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string };
         harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: true, data: { summary: 'done' } });
         await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['in-flight-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('refuses ambiguous bare model IDs shared across providers and accepts qualified ones', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        harness.onEvent!({ type: 'response', command: 'get_available_models', success: true, data: {
+            models: [
+                { id: 'gpt-5.2', provider: 'openai' },
+                { id: 'gpt-5.2', provider: 'azure' },
+            ],
+        } });
+        await vi.waitFor(() => expect(harness.session.updateMetadata).toHaveBeenCalled());
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model gpt-5.2' } }, 'ambig-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '⚠️ Ambiguous model: gpt-5.2. Use openai/gpt-5.2, azure/gpt-5.2.',
+        })));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'set_model' }));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['ambig-id'], { clearQueuedThinkingGrace: true }));
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model azure/gpt-5.2' } }, 'qualified-id');
+        const setModel = await vi.waitFor(() => {
+            const found = harness.sent.find((item) => (item as { type?: string }).type === 'set_model') as { id: string; provider?: string; modelId?: string } | undefined;
+            expect(found).toBeDefined();
+            return found!;
+        });
+        expect(setModel).toMatchObject({ provider: 'azure', modelId: 'gpt-5.2' });
+        harness.onEvent!({ type: 'response', id: setModel.id, command: 'set_model', success: true });
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: 'Model switched to azure/gpt-5.2',
+        })));
 
         harness.onError?.(new Error('finish test'));
         await running;

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -19,6 +19,8 @@ const harness = vi.hoisted(() => ({
         onCancelQueuedMessage: vi.fn(),
         emitMessagesConsumed: vi.fn(),
         sendSessionEvent: vi.fn(),
+        sendAgentMessage: vi.fn(),
+        updateAgentState: vi.fn(),
         updateMetadata: vi.fn(),
         getMetadata: vi.fn(() => null),
         emitSessionReady: vi.fn(),
@@ -1643,6 +1645,27 @@ describe('Pi built-in slash commands', () => {
         } finally {
             spy.mockRestore();
         }
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('retires pending extension UI requests when /compact interrupts a streaming turn', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: true },
+        });
+        harness.onEvent!({ type: 'extension_ui_request', id: 'ui-blocking', method: 'input', title: 'Need input' });
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'ui-compact-id');
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' })));
+
+        // The stale input card must be cancelled and removed from agent state
+        // exactly like the Abort path does, so the web is not stuck on it.
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'extension_ui_response', id: 'ui-blocking', cancelled: true,
+        })));
 
         harness.onError?.(new Error('finish test'));
         await running;

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1605,6 +1605,49 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
+    it('cancels a /compact still queued on the runtime-mutation lock when Abort lands first', async () => {
+        const { running, onUserMessage } = await startReadySession();
+
+        // Hold the runtime-mutation lock open so the compact RPC cannot be
+        // issued before Abort arrives.
+        const { PiSession } = await import('./session');
+        const realRunRuntimeMutation = PiSession.prototype.runRuntimeMutation;
+        let gate: Promise<void> | null = null;
+        let releaseGate!: () => void;
+        const spy = vi.spyOn(PiSession.prototype, 'runRuntimeMutation').mockImplementation(async function (this: unknown, op, opts) {
+            if (gate) await gate;
+            return realRunRuntimeMutation.call(this, op, opts);
+        });
+        try {
+            gate = new Promise<void>((resolve) => { releaseGate = resolve; });
+            onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'prestart-id');
+            await vi.waitFor(() => expect(spy).toHaveBeenCalled());
+
+            const abort = harness.rpcHandlers.get(RPC_METHODS.Abort)!;
+            await abort({});
+
+            // No abort RPC may be sent: the compact RPC never started, so
+            // there is nothing on Pi's side to interrupt.
+            expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'abort' }));
+            expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'compact' }));
+
+            // Release the lock: the compact RPC must be skipped entirely and
+            // the row still consumed.
+            releaseGate();
+            await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['prestart-id'], undefined));
+            expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'compact' }));
+            expect(harness.cleanupCount).toBe(0);
+            expect(harness.session.sendSessionEvent).not.toHaveBeenCalledWith(expect.objectContaining({
+                message: expect.stringContaining('Compaction'),
+            }));
+        } finally {
+            spy.mockRestore();
+        }
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
     it('fails the session when compaction times out with a queued prompt', async () => {
         const { running, onUserMessage } = await startReadySession();
         // Fake timers must be installed before the compact RPC is issued so

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1444,6 +1444,9 @@ describe('Pi built-in slash commands', () => {
         await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
             message: '⚠️ Compaction failed: no model selected',
         })));
+        // The raw Pi error must not be emitted a second time by the common
+        // response handler (compact owns its failure reporting).
+        expect(harness.session.sendSessionEvent).not.toHaveBeenCalledWith({ type: 'message', message: 'no model selected' });
         await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['fail-id'], { clearQueuedThinkingGrace: true }));
 
         harness.onError?.(new Error('finish test'));
@@ -1496,7 +1499,7 @@ describe('Pi built-in slash commands', () => {
 
         onUserMessage({ role: 'user', content: { type: 'text', text: '/model' } }, 'list-id');
         await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
-            message: expect.stringContaining('Available: gpt-5.2, gpt-4.1'),
+            message: expect.stringContaining('Available: openai/gpt-5.2, openai/gpt-4.1'),
         })));
         await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['list-id'], { clearQueuedThinkingGrace: true }));
 
@@ -1576,6 +1579,11 @@ describe('Pi built-in slash commands', () => {
         } });
         await vi.waitFor(() => expect(harness.session.updateMetadata).toHaveBeenCalled());
 
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model' } }, 'list-ambig-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Available: openai/gpt-5.2, azure/gpt-5.2'),
+        })));
+
         onUserMessage({ role: 'user', content: { type: 'text', text: '/model gpt-5.2' } }, 'ambig-id');
         await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
             message: '⚠️ Ambiguous model: gpt-5.2. Use openai/gpt-5.2, azure/gpt-5.2.',
@@ -1594,6 +1602,29 @@ describe('Pi built-in slash commands', () => {
         await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
             message: 'Model switched to azure/gpt-5.2',
         })));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('reports a rejected model switch once, without the raw Pi error', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        harness.onEvent!({ type: 'response', command: 'get_available_models', success: true, data: {
+            models: [{ id: 'gpt-5.2', provider: 'openai' }],
+        } });
+        await vi.waitFor(() => expect(harness.session.updateMetadata).toHaveBeenCalled());
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model gpt-5.2' } }, 'reject-id');
+        const setModel = await vi.waitFor(() => {
+            const found = harness.sent.find((item) => (item as { type?: string }).type === 'set_model') as { id: string } | undefined;
+            expect(found).toBeDefined();
+            return found!;
+        });
+        harness.onEvent!({ type: 'response', id: setModel.id, command: 'set_model', success: false, error: 'model rejected' });
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '⚠️ Model switch failed: model rejected',
+        })));
+        expect(harness.session.sendSessionEvent).not.toHaveBeenCalledWith({ type: 'message', message: 'model rejected' });
 
         harness.onError?.(new Error('finish test'));
         await running;

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1321,6 +1321,10 @@ describe('Pi built-in slash commands', () => {
         // executed by HAPI and never delivered to Pi as prompts, so they must
         // not linger in the web queued bar for the duration of the command.
         await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['compact-id'], undefined));
+        // Compaction keeps working for minutes without a Pi streaming event,
+        // so the session reports thinking while the RPC is outstanding and
+        // clears it once the run settles.
+        await vi.waitFor(() => expect(harness.session.keepAlive).toHaveBeenCalledWith(true, expect.anything(), expect.anything()));
         // While the compact RPC is outstanding, the FIFO must not release the
         // following prompt — Pi rejects prompts during compaction.
         expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
@@ -1343,6 +1347,7 @@ describe('Pi built-in slash commands', () => {
         expect(harness.session.sendSessionEvent).not.toHaveBeenCalledWith(expect.objectContaining({
             message: expect.stringContaining('Compaction summary'),
         }));
+        await vi.waitFor(() => expect(harness.session.keepAlive).toHaveBeenCalledWith(false, expect.anything(), expect.anything()));
 
         // The queued prompt may only flow once compaction completed.
         await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1542,6 +1542,36 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
+    it('recovers /model from an empty model cache by retrying discovery', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        // No get_available_models was answered at startup: the cache is empty
+        // and the first /model must retry the discovery RPC instead of
+        // reporting the catalog as unknown.
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model' } }, 'retry-list-id');
+
+        const discovery = await vi.waitFor(() => {
+            // Pick the latest discovery request: the startup probe may also
+            // still be outstanding.
+            const found = harness.sent.filter((item) => (item as { type?: string }).type === 'get_available_models').at(-1) as { id: string } | undefined;
+            expect(found).toBeDefined();
+            return found!;
+        });
+        harness.onEvent!({ type: 'response', id: discovery.id, command: 'get_available_models', success: true, data: {
+            models: [
+                { id: 'gpt-5.2', provider: 'openai' },
+                { id: 'gpt-4.1', provider: 'openai' },
+            ],
+        } });
+
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Available: openai/gpt-5.2, openai/gpt-4.1'),
+        })));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['retry-list-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
     it('fails the session when compaction times out with a queued prompt', async () => {
         const { running, onUserMessage } = await startReadySession();
         // Fake timers must be installed before the compact RPC is issued so

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1317,6 +1317,10 @@ describe('Pi built-in slash commands', () => {
         await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
             type: 'compact', customInstructions: 'focus on the API design',
         })));
+        // The /compact row is consumed at dispatch: slash commands are
+        // executed by HAPI and never delivered to Pi as prompts, so they must
+        // not linger in the web queued bar for the duration of the command.
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['compact-id'], { clearQueuedThinkingGrace: true }));
         // While the compact RPC is outstanding, the FIFO must not release the
         // following prompt — Pi rejects prompts during compaction.
         expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
@@ -1327,15 +1331,12 @@ describe('Pi built-in slash commands', () => {
             data: { summary: 'API design focused summary', tokensBefore: 1000, estimatedTokensAfter: 120 },
         });
 
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['compact-id'], { clearQueuedThinkingGrace: true }));
-        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
             message: '📦 Compaction completed (tokens: 1000 → 120)',
-        }));
-        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+        })));
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
             message: '📦 Compaction summary:\nAPI design focused summary',
-        }));
-
-        // The queued prompt may only flow once compaction completed.
+        })));
         await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
             type: 'prompt', message: 'continue after compaction',
         })));
@@ -1439,6 +1440,10 @@ describe('Pi built-in slash commands', () => {
             expect(found).toBeDefined();
             return found!;
         });
+        // Consumption happens at dispatch, before the command outcome is
+        // known: a failing /compact still leaves the queue immediately and
+        // surfaces its failure through the ⚠️ event message instead.
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['fail-id'], { clearQueuedThinkingGrace: true }));
         harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: false, error: 'no model selected' });
 
         await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
@@ -1447,7 +1452,6 @@ describe('Pi built-in slash commands', () => {
         // The raw Pi error must not be emitted a second time by the common
         // response handler (compact owns its failure reporting).
         expect(harness.session.sendSessionEvent).not.toHaveBeenCalledWith({ type: 'message', message: 'no model selected' });
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['fail-id'], { clearQueuedThinkingGrace: true }));
 
         harness.onError?.(new Error('finish test'));
         await running;
@@ -1555,9 +1559,10 @@ describe('Pi built-in slash commands', () => {
 
         await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' })));
 
-        // The reservation is released before execution starts, so a cancel that
-        // lands while the compact RPC is in flight is not acknowledged — the
-        // hub keeps the queued row instead of deleting it mid-execution.
+        // The row is consumed at dispatch (the command executes out-of-band
+        // and is never delivered to Pi), so a cancel that lands while the
+        // compact RPC is in flight is not acknowledged — the entry is already
+        // gone from the queue.
         const onCancelQueuedMessage = harness.session.onCancelQueuedMessage.mock.calls.at(-1)![0] as (localId: string) => boolean;
         expect(onCancelQueuedMessage('in-flight-id')).toBe(false);
 

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1272,7 +1272,10 @@ describe('Pi built-in slash commands', () => {
         });
     });
 
-    async function startReadySession(): Promise<{
+    async function startReadySession(commands: Array<Record<string, unknown>> = [
+        { name: 'test-extension', description: 'Test extension', source: 'extension' },
+        { name: 'skill:brave-search', description: 'Search the web', source: 'skill' },
+    ]): Promise<{
         running: Promise<void>;
         onUserMessage: (message: {
             role: 'user';
@@ -1287,6 +1290,10 @@ describe('Pi built-in slash commands', () => {
             data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: false },
         });
         await completeHistoryInitialization();
+        // Warm the command cache: slash-message handling consults discovered
+        // commands to decide extension-vs-builtin precedence.
+        const getCommands = harness.sent.find((item) => (item as { type?: string }).type === 'get_commands') as { id: string };
+        harness.onEvent!({ type: 'response', id: getCommands.id, command: 'get_commands', success: true, data: { commands } });
         const onUserMessage = harness.session.onUserMessage.mock.calls.at(-1)![0] as (message: {
             role: 'user';
             content: { type: 'text'; text: string };
@@ -1337,7 +1344,7 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
-    it('queues /compact in FIFO order even when delivered as a steer while streaming', async () => {
+    it('dispatches a head-of-line /compact even when delivered as a steer while streaming', async () => {
         const { running, onUserMessage } = await startReadySession();
         harness.onEvent!({
             type: 'response', command: 'get_state', success: true,
@@ -1349,16 +1356,9 @@ describe('Pi built-in slash commands', () => {
             meta: { deliveryMode: 'steer' },
         }, 'steer-compact-id');
 
-        // While the turn is streaming the command stays queued — no compact RPC
-        // and no native steer into the active turn.
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'compact' }));
-        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'steer' }));
-
-        harness.onEvent!({
-            type: 'response', command: 'get_state', success: true,
-            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: false },
-        });
+        // /compact stays interruptible while streaming: Pi's compact() aborts
+        // the active generation itself, and the command must never degrade to
+        // a native steer.
         await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' })));
         const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string; customInstructions?: string };
         expect(compact.customInstructions).toBeUndefined();
@@ -1366,6 +1366,27 @@ describe('Pi built-in slash commands', () => {
 
         harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: true, data: {} });
         await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['steer-compact-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('keeps non-compact commands queued while streaming (FIFO head rule)', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: true },
+        });
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/session' } }, 'session-id');
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'get_session_stats' }));
+
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: false },
+        });
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'get_session_stats' })));
 
         harness.onError?.(new Error('finish test'));
         await running;
@@ -1612,21 +1633,40 @@ describe('Pi built-in slash commands', () => {
         const { running } = await startReadySession();
         const slashHandler = harness.rpcHandlers.get(RPC_METHODS.ListSlashCommands)!;
 
-        await vi.waitFor(() => expect(harness.sent.some((item) => (item as { type?: string }).type === 'get_commands')).toBe(true));
-        const getCommands = harness.sent.find((item) => (item as { type?: string }).type === 'get_commands') as { id: string };
-        harness.onEvent!({ type: 'response', id: getCommands.id, command: 'get_commands', success: true, data: {
-            commands: [
-                { name: 'session-name', description: 'Rename session', source: 'extension' },
-                { name: 'fix-tests', description: 'Fix tests', source: 'prompt' },
-                { name: 'skill:brave-search', description: 'Search the web', source: 'skill' },
-            ],
-        } });
-
         const result = await slashHandler({ agent: 'pi' });
         const names = (result as { commands: Array<{ name: string }> }).commands.map((command) => command.name);
-        expect(names).toEqual(expect.arrayContaining(['compact', 'session', 'model', 'help', 'session-name', 'fix-tests']));
+        expect(names).toEqual(expect.arrayContaining(['compact', 'session', 'model', 'help', 'test-extension']));
         // Skills stay out of slash completion; they surface via $ instead.
         expect(names).not.toContain('skill:brave-search');
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('lets a discovered extension named compact override the builtin', async () => {
+        const { running, onUserMessage } = await startReadySession([
+            { name: 'compact', description: 'Custom compact', source: 'extension' },
+        ]);
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'ext-compact-id');
+
+        // The menu lists the extension over the builtin, so the message must
+        // reach Pi as an ordinary prompt instead of the HAPI compact RPC.
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'prompt', message: '/compact',
+        })));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'compact' }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('treats reserved-name path prefixes as ordinary prompts', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact.md notes' } }, 'path-id');
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'prompt', message: '/compact.md notes',
+        })));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'compact' }));
 
         harness.onError?.(new Error('finish test'));
         await running;

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1250,3 +1250,515 @@ describe('Pi steer-queued-message RPC', () => {
         await running;
     });
 });
+
+describe('Pi built-in slash commands', () => {
+    beforeEach(() => {
+        harness.sent.length = 0;
+        harness.throwOnGetCommands = false;
+        harness.onError = null;
+        harness.onEvent = null;
+        harness.rpcHandlers.clear();
+        harness.session.onUserMessage.mockReset();
+        harness.session.onCancelQueuedMessage.mockReset();
+        harness.session.emitMessagesConsumed.mockReset();
+        harness.session.sendSessionEvent.mockReset();
+        harness.session.updateMetadata.mockReset();
+        harness.cleanupCount = 0;
+        harness.killCount = 0;
+        harness.session.rpcHandlerManager.registerHandler.mockReset();
+        harness.session.rpcHandlerManager.registerHandler.mockImplementation((method: string, handler: (payload: unknown) => Promise<unknown>) => {
+            harness.rpcHandlers.set(method, handler);
+        });
+    });
+
+    async function startReadySession(): Promise<{
+        running: Promise<void>;
+        onUserMessage: (message: {
+            role: 'user';
+            content: { type: 'text'; text: string };
+            meta?: { deliveryMode?: 'queue' | 'steer' };
+        }, localId: string) => void;
+    }> {
+        const running = runPi({ workingDirectory: '/work' });
+        await vi.waitFor(() => expect(harness.onEvent).not.toBeNull());
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: false },
+        });
+        await completeHistoryInitialization();
+        const onUserMessage = harness.session.onUserMessage.mock.calls.at(-1)![0] as (message: {
+            role: 'user';
+            content: { type: 'text'; text: string };
+            meta?: { deliveryMode?: 'queue' | 'steer' };
+        }, localId: string) => void;
+        return { running, onUserMessage };
+    }
+
+    it('executes /compact via Pi RPC, reports the summary, and holds queued prompts until it completes', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({
+            role: 'user',
+            content: { type: 'text', text: '/compact focus on the API design' },
+        }, 'compact-id');
+
+        onUserMessage({
+            role: 'user',
+            content: { type: 'text', text: 'continue after compaction' },
+        }, 'after-id');
+
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'compact', customInstructions: 'focus on the API design',
+        })));
+        // While the compact RPC is outstanding, the FIFO must not release the
+        // following prompt — Pi rejects prompts during compaction.
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
+
+        const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string };
+        harness.onEvent!({
+            type: 'response', id: compact.id, command: 'compact', success: true,
+            data: { summary: 'API design focused summary', tokensBefore: 1000, estimatedTokensAfter: 120 },
+        });
+
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['compact-id'], { clearQueuedThinkingGrace: true }));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '📦 Compaction completed (tokens: 1000 → 120)',
+        }));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '📦 Compaction summary:\nAPI design focused summary',
+        }));
+
+        // The queued prompt may only flow once compaction completed.
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'prompt', message: 'continue after compaction',
+        })));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('intercepts /compact even when delivered as a steer while streaming', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: true },
+        });
+        onUserMessage({
+            role: 'user',
+            content: { type: 'text', text: '/compact' },
+            meta: { deliveryMode: 'steer' },
+        }, 'steer-compact-id');
+
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' })));
+        const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string; customInstructions?: string };
+        expect(compact.customInstructions).toBeUndefined();
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'steer' }));
+
+        harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: true, data: {} });
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['steer-compact-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('reports compact failures as a visible message', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'fail-id');
+
+        const compact = await vi.waitFor(() => {
+            const found = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string } | undefined;
+            expect(found).toBeDefined();
+            return found!;
+        });
+        harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: false, error: 'no model selected' });
+
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '⚠️ Compaction failed: no model selected',
+        })));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['fail-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('shows session stats for /session', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/session' } }, 'stats-id');
+
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'get_session_stats' })));
+        const statsCmd = harness.sent.find((item) => (item as { type?: string }).type === 'get_session_stats') as { id: string };
+        harness.onEvent!({
+            type: 'response', id: statsCmd.id, command: 'get_session_stats', success: true,
+            data: {
+                totalMessages: 42,
+                tokens: { input: 3000, output: 2000, total: 5000 },
+                cost: 0.1234,
+                contextUsage: { tokens: 4000, contextWindow: 200000, percent: 2 },
+            },
+        });
+
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Messages: 42'),
+        })));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Tokens: total 5000 · in 3000 · out 2000'),
+        }));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Cost: $0.1234'),
+        }));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Context: 4000 / 200000 tokens (2%)'),
+        }));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['stats-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('lists or switches the model for /model', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        harness.onEvent!({ type: 'response', command: 'get_available_models', success: true, data: {
+            models: [
+                { id: 'gpt-5.2', provider: 'openai' },
+                { id: 'gpt-4.1', provider: 'openai' },
+            ],
+        } });
+        await vi.waitFor(() => expect(harness.session.updateMetadata).toHaveBeenCalled());
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model' } }, 'list-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Available: gpt-5.2, gpt-4.1'),
+        })));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['list-id'], { clearQueuedThinkingGrace: true }));
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model gpt-4.1' } }, 'switch-id');
+        const setModel = await vi.waitFor(() => {
+            const found = harness.sent.find((item) => (item as { type?: string }).type === 'set_model') as { id: string; provider?: string; modelId?: string } | undefined;
+            expect(found).toBeDefined();
+            return found!;
+        });
+        expect(setModel).toMatchObject({ provider: 'openai', modelId: 'gpt-4.1' });
+        harness.onEvent!({ type: 'response', id: setModel.id, command: 'set_model', success: true });
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: 'Model switched to gpt-4.1',
+        })));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['switch-id'], { clearQueuedThinkingGrace: true }));
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model does-not-exist' } }, 'unknown-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '⚠️ Unknown model: does-not-exist. Use /model to list available models.',
+        })));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('shows help and flags terminal-only Pi builtins instead of passing them to the model', async () => {
+        const { running, onUserMessage } = await startReadySession();
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/help' } }, 'help-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('/compact [instructions]'),
+        })));
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/tree 42' } }, 'tree-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('/tree is a Pi terminal-only command'),
+        })));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['tree-id'], { clearQueuedThinkingGrace: true }));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('leaves unknown slash text on the normal prompt path', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/some-custom-thing arg' } }, 'custom-id');
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'prompt', message: '/some-custom-thing arg',
+        })));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('merges HAPI builtins with Pi extension commands in the slash-command list', async () => {
+        const { running } = await startReadySession();
+        const slashHandler = harness.rpcHandlers.get(RPC_METHODS.ListSlashCommands)!;
+
+        await vi.waitFor(() => expect(harness.sent.some((item) => (item as { type?: string }).type === 'get_commands')).toBe(true));
+        const getCommands = harness.sent.find((item) => (item as { type?: string }).type === 'get_commands') as { id: string };
+        harness.onEvent!({ type: 'response', id: getCommands.id, command: 'get_commands', success: true, data: {
+            commands: [
+                { name: 'session-name', description: 'Rename session', source: 'extension' },
+                { name: 'fix-tests', description: 'Fix tests', source: 'prompt' },
+                { name: 'skill:brave-search', description: 'Search the web', source: 'skill' },
+            ],
+        } });
+
+        const result = await slashHandler({ agent: 'pi' });
+        const names = (result as { commands: Array<{ name: string }> }).commands.map((command) => command.name);
+        expect(names).toEqual(expect.arrayContaining(['compact', 'session', 'model', 'help', 'session-name', 'fix-tests']));
+        // Skills stay out of slash completion; they surface via $ instead.
+        expect(names).not.toContain('skill:brave-search');
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+});
+
+describe('Pi built-in slash commands', () => {
+    beforeEach(() => {
+        harness.sent.length = 0;
+        harness.throwOnGetCommands = false;
+        harness.onError = null;
+        harness.onEvent = null;
+        harness.rpcHandlers.clear();
+        harness.session.onUserMessage.mockReset();
+        harness.session.onCancelQueuedMessage.mockReset();
+        harness.session.emitMessagesConsumed.mockReset();
+        harness.session.sendSessionEvent.mockReset();
+        harness.session.updateMetadata.mockReset();
+        harness.cleanupCount = 0;
+        harness.killCount = 0;
+        harness.session.rpcHandlerManager.registerHandler.mockReset();
+        harness.session.rpcHandlerManager.registerHandler.mockImplementation((method: string, handler: (payload: unknown) => Promise<unknown>) => {
+            harness.rpcHandlers.set(method, handler);
+        });
+    });
+
+    async function startReadySession(): Promise<{
+        running: Promise<void>;
+        onUserMessage: (message: {
+            role: 'user';
+            content: { type: 'text'; text: string };
+            meta?: { deliveryMode?: 'queue' | 'steer' };
+        }, localId: string) => void;
+    }> {
+        const running = runPi({ workingDirectory: '/work' });
+        await vi.waitFor(() => expect(harness.onEvent).not.toBeNull());
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: false },
+        });
+        await completeHistoryInitialization();
+        const onUserMessage = harness.session.onUserMessage.mock.calls.at(-1)![0] as (message: {
+            role: 'user';
+            content: { type: 'text'; text: string };
+            meta?: { deliveryMode?: 'queue' | 'steer' };
+        }, localId: string) => void;
+        return { running, onUserMessage };
+    }
+
+    it('executes /compact via Pi RPC, reports the summary, and holds queued prompts until it completes', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({
+            role: 'user',
+            content: { type: 'text', text: '/compact focus on the API design' },
+        }, 'compact-id');
+
+        onUserMessage({
+            role: 'user',
+            content: { type: 'text', text: 'continue after compaction' },
+        }, 'after-id');
+
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'compact', customInstructions: 'focus on the API design',
+        })));
+        // While the compact RPC is outstanding, the FIFO must not release the
+        // following prompt — Pi rejects prompts during compaction.
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
+
+        const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string };
+        harness.onEvent!({
+            type: 'response', id: compact.id, command: 'compact', success: true,
+            data: { summary: 'API design focused summary', tokensBefore: 1000, estimatedTokensAfter: 120 },
+        });
+
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['compact-id'], { clearQueuedThinkingGrace: true }));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '📦 Compaction completed (tokens: 1000 → 120)',
+        }));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '📦 Compaction summary:\nAPI design focused summary',
+        }));
+
+        // The queued prompt may only flow once compaction completed.
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'prompt', message: 'continue after compaction',
+        })));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('intercepts /compact even when delivered as a steer while streaming', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-session', sessionFile: '/tmp/pi-slash.jsonl', isStreaming: true },
+        });
+        onUserMessage({
+            role: 'user',
+            content: { type: 'text', text: '/compact' },
+            meta: { deliveryMode: 'steer' },
+        }, 'steer-compact-id');
+
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'compact' })));
+        const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string; customInstructions?: string };
+        expect(compact.customInstructions).toBeUndefined();
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'steer' }));
+
+        harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: true, data: {} });
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['steer-compact-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('reports compact failures as a visible message', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'fail-id');
+
+        const compact = await vi.waitFor(() => {
+            const found = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string } | undefined;
+            expect(found).toBeDefined();
+            return found!;
+        });
+        harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: false, error: 'no model selected' });
+
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '⚠️ Compaction failed: no model selected',
+        })));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['fail-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('shows session stats for /session', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/session' } }, 'stats-id');
+
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'get_session_stats' })));
+        const statsCmd = harness.sent.find((item) => (item as { type?: string }).type === 'get_session_stats') as { id: string };
+        harness.onEvent!({
+            type: 'response', id: statsCmd.id, command: 'get_session_stats', success: true,
+            data: {
+                totalMessages: 42,
+                tokens: { input: 3000, output: 2000, total: 5000 },
+                cost: 0.1234,
+                contextUsage: { tokens: 4000, contextWindow: 200000, percent: 2 },
+            },
+        });
+
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Messages: 42'),
+        })));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Tokens: total 5000 · in 3000 · out 2000'),
+        }));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Cost: $0.1234'),
+        }));
+        expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Context: 4000 / 200000 tokens (2%)'),
+        }));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['stats-id'], { clearQueuedThinkingGrace: true }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('lists or switches the model for /model', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        harness.onEvent!({ type: 'response', command: 'get_available_models', success: true, data: {
+            models: [
+                { id: 'gpt-5.2', provider: 'openai' },
+                { id: 'gpt-4.1', provider: 'openai' },
+            ],
+        } });
+        await vi.waitFor(() => expect(harness.session.updateMetadata).toHaveBeenCalled());
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model' } }, 'list-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Available: gpt-5.2, gpt-4.1'),
+        })));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['list-id'], { clearQueuedThinkingGrace: true }));
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model gpt-4.1' } }, 'switch-id');
+        const setModel = await vi.waitFor(() => {
+            const found = harness.sent.find((item) => (item as { type?: string }).type === 'set_model') as { id: string; provider?: string; modelId?: string } | undefined;
+            expect(found).toBeDefined();
+            return found!;
+        });
+        expect(setModel).toMatchObject({ provider: 'openai', modelId: 'gpt-4.1' });
+        harness.onEvent!({ type: 'response', id: setModel.id, command: 'set_model', success: true });
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: 'Model switched to gpt-4.1',
+        })));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['switch-id'], { clearQueuedThinkingGrace: true }));
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model does-not-exist' } }, 'unknown-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: '⚠️ Unknown model: does-not-exist. Use /model to list available models.',
+        })));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('shows help and flags terminal-only Pi builtins instead of passing them to the model', async () => {
+        const { running, onUserMessage } = await startReadySession();
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/help' } }, 'help-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('/compact [instructions]'),
+        })));
+
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/tree 42' } }, 'tree-id');
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('/tree is a Pi terminal-only command'),
+        })));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['tree-id'], { clearQueuedThinkingGrace: true }));
+        expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('leaves unknown slash text on the normal prompt path', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/some-custom-thing arg' } }, 'custom-id');
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'prompt', message: '/some-custom-thing arg',
+        })));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('merges HAPI builtins with Pi extension commands in the slash-command list', async () => {
+        const { running } = await startReadySession();
+        const slashHandler = harness.rpcHandlers.get(RPC_METHODS.ListSlashCommands)!;
+
+        await vi.waitFor(() => expect(harness.sent.some((item) => (item as { type?: string }).type === 'get_commands')).toBe(true));
+        const getCommands = harness.sent.find((item) => (item as { type?: string }).type === 'get_commands') as { id: string };
+        harness.onEvent!({ type: 'response', id: getCommands.id, command: 'get_commands', success: true, data: {
+            commands: [
+                { name: 'session-name', description: 'Rename session', source: 'extension' },
+                { name: 'fix-tests', description: 'Fix tests', source: 'prompt' },
+                { name: 'skill:brave-search', description: 'Search the web', source: 'skill' },
+            ],
+        } });
+
+        const result = await slashHandler({ agent: 'pi' });
+        const names = (result as { commands: Array<{ name: string }> }).commands.map((command) => command.name);
+        expect(names).toEqual(expect.arrayContaining(['compact', 'session', 'model', 'help', 'session-name', 'fix-tests']));
+        // Skills stay out of slash completion; they surface via $ instead.
+        expect(names).not.toContain('skill:brave-search');
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+});

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1572,6 +1572,39 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
+    it('aborts an in-flight /compact directly instead of waiting on the mutation lease', async () => {
+        const { running, onUserMessage } = await startReadySession();
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/compact' } }, 'abortable-id');
+
+        const compact = await vi.waitFor(() => {
+            const found = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string } | undefined;
+            expect(found).toBeDefined();
+            return found!;
+        });
+
+        // The Abort action must interrupt the compaction via the abort RPC —
+        // waiting for the runtime-mutation lease would exceed the 25s abort
+        // deadline while compaction may run for up to 120s.
+        const abort = harness.rpcHandlers.get(RPC_METHODS.Abort)!;
+        const abortPromise = abort({});
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'abort' })));
+        const abortRpc = harness.sent.find((item) => (item as { type?: string }).type === 'abort') as { id: string };
+        harness.onEvent!({ type: 'response', id: abortRpc.id, command: 'abort', success: true });
+        await abortPromise;
+        expect(harness.cleanupCount).toBe(0);
+
+        // Pi reports the cancellation through its lifecycle event; the RPC
+        // error is the same cancellation and must not double-report a failure.
+        harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: false, error: 'Compaction cancelled' });
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['abortable-id'], undefined));
+        expect(harness.session.sendSessionEvent).not.toHaveBeenCalledWith(expect.objectContaining({
+            message: expect.stringContaining('Compaction failed'),
+        }));
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
     it('fails the session when compaction times out with a queued prompt', async () => {
         const { running, onUserMessage } = await startReadySession();
         // Fake timers must be installed before the compact RPC is issued so

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1320,7 +1320,7 @@ describe('Pi built-in slash commands', () => {
         // The /compact row is consumed at dispatch: slash commands are
         // executed by HAPI and never delivered to Pi as prompts, so they must
         // not linger in the web queued bar for the duration of the command.
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['compact-id'], { clearQueuedThinkingGrace: true }));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['compact-id'], undefined));
         // While the compact RPC is outstanding, the FIFO must not release the
         // following prompt — Pi rejects prompts during compaction.
         expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
@@ -1366,7 +1366,7 @@ describe('Pi built-in slash commands', () => {
         expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'steer' }));
 
         harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: true, data: {} });
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['steer-compact-id'], { clearQueuedThinkingGrace: true }));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['steer-compact-id'], undefined));
 
         harness.onError?.(new Error('finish test'));
         await running;
@@ -1443,7 +1443,7 @@ describe('Pi built-in slash commands', () => {
         // Consumption happens at dispatch, before the command outcome is
         // known: a failing /compact still leaves the queue immediately and
         // surfaces its failure through the ⚠️ event message instead.
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['fail-id'], { clearQueuedThinkingGrace: true }));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['fail-id'], undefined));
         harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: false, error: 'no model selected' });
 
         await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
@@ -1568,7 +1568,7 @@ describe('Pi built-in slash commands', () => {
 
         const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string };
         harness.onEvent!({ type: 'response', id: compact.id, command: 'compact', success: true, data: { summary: 'done' } });
-        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['in-flight-id'], { clearQueuedThinkingGrace: true }));
+        await vi.waitFor(() => expect(harness.session.emitMessagesConsumed).toHaveBeenCalledWith(['in-flight-id'], undefined));
 
         harness.onError?.(new Error('finish test'));
         await running;

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -11,7 +11,7 @@ import { PiConversationHistory, PiHistoryRestoreError } from './conversationHist
 import { parsePiModels, parsePiCommands, PiRpcTimeoutError, sendPiRpcAndWait, wireTransportEvents } from './loop';
 import { PiThinkingLevelSchema, SetSessionConfigPayloadSchema, PiCompactResultSchema, PiFullSessionStatsSchema } from './schemas';
 import type { PiImageContent, PiThinkingLevel } from './types';
-import { parsePiSpecialCommand, type PiSpecialCommand } from './specialCommands';
+import { parsePiSpecialCommand, parseLeadingSlashName, type PiSpecialCommand } from './specialCommands';
 import { PiPromptQueue, isPiSpecialQueued, type PiPreparedPrompt } from './promptQueue';
 import { PiSteerDispatcher } from './steerDispatcher';
 import { getBuiltinSlashCommands, mergeSlashCommands } from '@hapi/protocol/slashCommands';
@@ -508,40 +508,48 @@ export async function runPi(opts: {
         }
         if (
             !piSession.isReady
-            || piSession.piIsStreaming
-            || promptCommandInFlight
             || abortInFlight
             || piSpecialCommandInFlight
             // Earlier steers can fall back only after async preparation/runtime
             // lock wait. Do not let a later normal prompt overtake that result.
             || steerDispatcher?.hasPending
         ) return;
-        const next = promptQueue.dequeue();
-        if (!next) return;
-        if (isPiSpecialQueued(next)) {
+        // A head-of-line /compact stays interruptible while Pi is streaming:
+        // Pi's compact() aborts the active generation itself, so a long or
+        // stuck turn can still be compacted from HAPI. Every other item waits
+        // for the stream to settle (FIFO order preserved).
+        const next = promptQueue.peek();
+        const canInterrupt = next !== undefined
+            && isPiSpecialQueued(next)
+            && next.command.type === 'compact'
+            && piSession.piIsStreaming;
+        if (!canInterrupt && (piSession.piIsStreaming || promptCommandInFlight)) return;
+        const dequeued = promptQueue.dequeue();
+        if (!dequeued) return;
+        if (isPiSpecialQueued(dequeued)) {
             // Slash commands share the prompt FIFO so dispatch order matches
             // arrival order; execute out-of-band while the pump stays blocked.
             piSpecialCommandInFlight = true;
             const finish = (): void => {
                 piSpecialCommandInFlight = false;
-                if (next.localId) {
-                    piSession.emitMessagesConsumed([next.localId], { clearQueuedThinkingGrace: true });
+                if (dequeued.localId) {
+                    piSession.emitMessagesConsumed([dequeued.localId], { clearQueuedThinkingGrace: true });
                 }
                 pumpPromptQueue();
             };
-            void handlePiSpecialCommand(next.command).finally(finish);
+            void handlePiSpecialCommand(dequeued.command).finally(finish);
             return;
         }
         setPromptCommandInFlight(true);
-        activePromptLocalId = next.localId;
+        activePromptLocalId = dequeued.localId;
         agentLifecycleStarted = false;
         const promptId = randomUUID();
         transportEvents?.beginPromptLifecycle(promptId);
-        if (next.localId) {
-            conversationHistory.registerUserEntry(next.localId);
-            pendingLocalIds.push(next.localId);
+        if (dequeued.localId) {
+            conversationHistory.registerUserEntry(dequeued.localId);
+            pendingLocalIds.push(dequeued.localId);
         }
-        transport.send({ id: promptId, type: 'prompt', message: next.message, ...(next.images.length > 0 ? { images: next.images } : {}) });
+        transport.send({ id: promptId, type: 'prompt', message: dequeued.message, ...(dequeued.images.length > 0 ? { images: dequeued.images } : {}) });
     };
 
     transportEvents = wireTransportEvents(transport, piSession, pendingLocalIds, {
@@ -988,7 +996,18 @@ export async function runPi(opts: {
                 return;
             }
 
-            const specialCommand = parsePiSpecialCommand(message.content.text);
+            const name = parseLeadingSlashName(message.content.text);
+            // Discovered extension commands / prompt templates win over HAPI
+            // builtins: the menu already lets them override same-name entries,
+            // so a user extension named "compact" must keep executing instead
+            // of being swallowed by the builtin interception.
+            const discovered = name
+                ? await getPiCommands()
+                : piSession.cachedPiCommands;
+            const isCustomCommand = Boolean(name && discovered.some((item) => item.name.toLowerCase() === name.toLowerCase()));
+            const specialCommand = isCustomCommand
+                ? null
+                : parsePiSpecialCommand(message.content.text);
             if (specialCommand) {
                 // Enter the same FIFO as prompts so dispatch order matches
                 // arrival order (a /compact typed after a queued prompt never

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -979,6 +979,14 @@ export async function runPi(opts: {
                         });
                         piSession.currentModel = match.modelId;
                         piSession.currentProvider = match.provider;
+                        // The web picker prefers piSelectedModel metadata for
+                        // selection, context-window resolution, and effort
+                        // options; a bare keepalive model is not enough to
+                        // reflect a provider-qualified switch.
+                        piSession.updateMetadata((meta) => ({
+                            ...meta,
+                            piSelectedModel: { provider: match.provider, modelId: match.modelId },
+                        }));
                         piSession.pushKeepAlive();
                     }, { poisonOnError: (error) => error instanceof PiRpcTimeoutError });
                     sendEvent(`Model switched to ${command.modelId}`);

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -968,6 +968,12 @@ export async function runPi(opts: {
                 return;
             }
             case 'compact': {
+                // A compaction run can take minutes without any Pi streaming
+                // event, so mark the session as thinking for the duration;
+                // the 15s queued-thinking grace alone would let the web show
+                // the session idle while compaction and any queued prompts
+                // are still pending.
+                piSession.updateThinkingState(true)
                 try {
                     const data = await piSession.runRuntimeMutation(async () => {
                         return await sendPiRpcAndWait(piSession, transport, {
@@ -1010,6 +1016,8 @@ export async function runPi(opts: {
                         return;
                     }
                     sendEvent(`⚠️ Compaction failed: ${errorDetail(error)}`);
+                } finally {
+                    piSession.updateThinkingState(false)
                 }
                 return;
             }

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -939,18 +939,18 @@ export async function runPi(opts: {
                     if (result.summary) sendEvent(`📦 Compaction summary:\n${result.summary}`);
                 } catch (error) {
                     if (error instanceof PiRpcTimeoutError) {
-                        // Outcome is unknown but Pi's own compaction lifecycle
-                        // events still report completion/failure; the pump stays
-                        // blocked while compaction is genuinely running, and a
-                        // prompt sent into a stuck compaction is rejected by Pi
-                        // with a visible error. Do not poison the session.
-                        sendEvent(`⚠️ Compaction timed out — outcome unknown. If it is still running, prompts may be rejected until it finishes.`);
-                    } else {
-                        sendEvent(`⚠️ Compaction failed: ${errorDetail(error)}`);
+                        // The runtime lease is deliberately retained on timeout
+                        // (poisonOnError), so the session is indeterminate: Pi
+                        // may still be compacting while model switches, steers,
+                        // and history mutations can no longer run. Fail the
+                        // session instead of reopening the prompt FIFO.
+                        failNativeStartup(new Error(`Pi compaction outcome is indeterminate: ${error.message}`));
+                        return;
                     }
+                    sendEvent(`⚠️ Compaction failed: ${errorDetail(error)}`);
                 } finally {
                     piCompactInFlight = false;
-                    pumpPromptQueue();
+                    if (!cleanupInitiated) pumpPromptQueue();
                 }
                 return;
             }
@@ -979,11 +979,18 @@ export async function runPi(opts: {
 
             const specialCommand = parsePiSpecialCommand(message.content.text);
             if (specialCommand) {
+                // Release the cancellation reservation before executing: a
+                // cancel that lands while the command runs (startup wait or the
+                // long compact RPC) must not be acknowledged, or the hub would
+                // delete the queued row while the command still executes.
+                if (localId) {
+                    preparingLocalIds.delete(localId);
+                    if (cancelledWhilePreparing.delete(localId)) return;
+                }
                 try {
                     await handlePiSpecialCommand(specialCommand);
                 } finally {
                     if (localId) {
-                        preparingLocalIds.delete(localId);
                         piSession.emitMessagesConsumed([localId], { clearQueuedThinkingGrace: true });
                     }
                 }

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -12,10 +12,10 @@ import { parsePiModels, parsePiCommands, PiRpcTimeoutError, sendPiRpcAndWait, wi
 import { PiThinkingLevelSchema, SetSessionConfigPayloadSchema, PiCompactResultSchema, PiFullSessionStatsSchema } from './schemas';
 import type { PiImageContent, PiThinkingLevel } from './types';
 import { parsePiSpecialCommand, type PiSpecialCommand } from './specialCommands';
-import { PiPromptQueue, type PiPreparedPrompt } from './promptQueue';
+import { PiPromptQueue, isPiSpecialQueued, type PiPreparedPrompt } from './promptQueue';
 import { PiSteerDispatcher } from './steerDispatcher';
 import { getBuiltinSlashCommands, mergeSlashCommands } from '@hapi/protocol/slashCommands';
-import type { ListPiModelsResponse, PiCommandSummary, SlashCommand, SlashCommandsResponse } from '@hapi/protocol/apiTypes';
+import type { ListPiModelsResponse, PiCommandSummary, PiModelSummary, SlashCommand, SlashCommandsResponse } from '@hapi/protocol/apiTypes';
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 import type { ListSkillsResponse, SkillSummary } from '@/modules/common/skills';
 import type { AttachmentMetadata } from '@/api/types';
@@ -408,12 +408,12 @@ export async function runPi(opts: {
     let preparationChain = Promise.resolve();
     let promptCommandInFlight = false;
     let abortInFlight = false;
-    // Set while a manual /compact RPC is outstanding. Pi's compact() aborts
-    // any active stream itself, so piIsStreaming/promptCommandInFlight can go
-    // false mid-compaction; this flag keeps the prompt pump from sending a
-    // prompt Pi would reject ("Cannot submit a prompt while compaction is in
-    // progress").
-    let piCompactInFlight = false;
+    // Set while a queued Pi special command (e.g. /compact) is executing. Pi's
+    // compact() aborts any active stream itself, so piIsStreaming/
+    // promptCommandInFlight can go false mid-compaction; this flag keeps the
+    // prompt pump from dispatching the next FIFO item Pi would reject
+    // ("Cannot submit a prompt while compaction is in progress").
+    let piSpecialCommandInFlight = false;
     let activePromptLocalId: string | undefined;
     let historyPumpDeferred = false;
     let agentLifecycleStarted = false;
@@ -511,13 +511,27 @@ export async function runPi(opts: {
             || piSession.piIsStreaming
             || promptCommandInFlight
             || abortInFlight
-            || piCompactInFlight
+            || piSpecialCommandInFlight
             // Earlier steers can fall back only after async preparation/runtime
             // lock wait. Do not let a later normal prompt overtake that result.
             || steerDispatcher?.hasPending
         ) return;
         const next = promptQueue.dequeue();
         if (!next) return;
+        if (isPiSpecialQueued(next)) {
+            // Slash commands share the prompt FIFO so dispatch order matches
+            // arrival order; execute out-of-band while the pump stays blocked.
+            piSpecialCommandInFlight = true;
+            const finish = (): void => {
+                piSpecialCommandInFlight = false;
+                if (next.localId) {
+                    piSession.emitMessagesConsumed([next.localId], { clearQueuedThinkingGrace: true });
+                }
+                pumpPromptQueue();
+            };
+            void handlePiSpecialCommand(next.command).finally(finish);
+            return;
+        }
         setPromptCommandInFlight(true);
         activePromptLocalId = next.localId;
         agentLifecycleStarted = false;
@@ -638,6 +652,12 @@ export async function runPi(opts: {
         const entry = promptQueue.removeByLocalId(localId);
         if (!entry) {
             return { steered: false, error: 'Message not found or already dispatched' };
+        }
+        // Slash commands are not steerable prompts: restoring them into the FIFO
+        // lets the pump execute them in arrival order once the turn settles.
+        if (isPiSpecialQueued(entry)) {
+            promptQueue.enqueue(entry);
+            return { steered: false, error: 'Slash commands cannot be steered' };
         }
         // Only steer into a live Pi generation. Otherwise restore the entry to
         // its FIFO position (enqueue re-orders by outboundSequence) and let the
@@ -853,20 +873,6 @@ export async function runPi(opts: {
         };
         const errorDetail = (error: unknown): string => error instanceof Error ? error.message : String(error);
 
-        // RPC-backed commands need the transport wired and the history baseline
-        // established. Prompts are buffered until ready via runWhenReady, so
-        // defer the same way instead of racing the readiness transition (the
-        // ready queue drains FIFO on markReady, preserving arrival order).
-        if (command.type === 'compact' || command.type === 'session' || command.type === 'model') {
-            await new Promise<void>((resolve) => {
-                if (piSession.isReady) {
-                    resolve();
-                    return;
-                }
-                piSession.runWhenReady(resolve);
-            });
-        }
-
         switch (command.type) {
             case 'help':
                 sendEvent(PI_HELP_TEXT);
@@ -889,8 +895,17 @@ export async function runPi(opts: {
                     sendEvent(`Current model: ${piSession.currentModel ?? 'unset'}.\nAvailable: ${available || 'unknown — use /model <modelId>'}`);
                     return;
                 }
-                const match = piSession.cachedPiModels.find((model) => model.modelId === command.modelId)
-                    ?? piSession.cachedPiModels.find((model) => `${model.provider}/${model.modelId}` === command.modelId);
+                // The catalog is provider-qualified; prefer an exact
+                // provider/modelId match and refuse bare IDs shared by more
+                // than one provider instead of silently picking the first.
+                const qualified = (model: PiModelSummary): string => `${model.provider}/${model.modelId}`;
+                const exact = piSession.cachedPiModels.find((model) => qualified(model) === command.modelId);
+                const bare = piSession.cachedPiModels.filter((model) => model.modelId === command.modelId);
+                if (!exact && bare.length > 1) {
+                    sendEvent(`⚠️ Ambiguous model: ${command.modelId}. Use ${bare.map(qualified).join(', ')}.`);
+                    return;
+                }
+                const match = exact ?? bare[0];
                 if (!match) {
                     sendEvent(`⚠️ Unknown model: ${command.modelId}. Use /model to list available models.`);
                     return;
@@ -917,7 +932,6 @@ export async function runPi(opts: {
                 return;
             }
             case 'compact': {
-                piCompactInFlight = true;
                 try {
                     const data = await piSession.runRuntimeMutation(async () => {
                         return await sendPiRpcAndWait(piSession, transport, {
@@ -948,9 +962,6 @@ export async function runPi(opts: {
                         return;
                     }
                     sendEvent(`⚠️ Compaction failed: ${errorDetail(error)}`);
-                } finally {
-                    piCompactInFlight = false;
-                    if (!cleanupInitiated) pumpPromptQueue();
                 }
                 return;
             }
@@ -979,21 +990,22 @@ export async function runPi(opts: {
 
             const specialCommand = parsePiSpecialCommand(message.content.text);
             if (specialCommand) {
-                // Release the cancellation reservation before executing: a
-                // cancel that lands while the command runs (startup wait or the
-                // long compact RPC) must not be acknowledged, or the hub would
-                // delete the queued row while the command still executes.
+                // Enter the same FIFO as prompts so dispatch order matches
+                // arrival order (a /compact typed after a queued prompt never
+                // jumps it). Release the cancellation reservation first: a
+                // cancel that lands while the queued command is being dispatched
+                // or executing is handled by the queue itself (cancelByLocalId)
+                // and must not be acknowledged via preparingLocalIds.
                 if (localId) {
                     preparingLocalIds.delete(localId);
-                    if (cancelledWhilePreparing.delete(localId)) return;
                 }
-                try {
-                    await handlePiSpecialCommand(specialCommand);
-                } finally {
-                    if (localId) {
-                        piSession.emitMessagesConsumed([localId], { clearQueuedThinkingGrace: true });
-                    }
-                }
+                promptQueue.enqueue({
+                    kind: 'special',
+                    command: specialCommand,
+                    outboundSequence,
+                    ...(localId ? { localId } : {}),
+                });
+                pumpPromptQueue();
                 return;
             }
 

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -1239,10 +1239,23 @@ export async function runPi(opts: {
                     activeCompact.cancelled = true;
                     return Promise.resolve({ success: true } as const);
                 })();
-            abortPromise = interrupted.finally(() => {
-                abortInFlight = false;
-                abortPromise = null;
-            });
+            abortPromise = interrupted
+                .catch((error) => {
+                    // Mirror the ordinary Abort path: an unanswered abort RPC
+                    // leaves the compaction outcome indeterminate (the compact
+                    // RPC can keep the mutation lease for up to 120s), so fail
+                    // the session instead of presenting the wrapper as live.
+                    if (error instanceof PiRpcTimeoutError) {
+                        const fatal = new Error(`Pi abort failed closed: ${error.message}`);
+                        failNativeStartup(fatal);
+                        throw fatal;
+                    }
+                    throw error;
+                })
+                .finally(() => {
+                    abortInFlight = false;
+                    abortPromise = null;
+                });
             return await abortPromise;
         }
         piSession.assertNoHistoryTransaction('abort Pi');

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -870,6 +870,20 @@ export async function runPi(opts: {
         }
     };
 
+    const getPiModels = async (): Promise<PiModelSummary[]> => {
+        // Startup model discovery can be late or fail once; retry the RPC on
+        // an empty cache so /model never reports valid models as unknown.
+        if (piSession.cachedPiModels.length > 0) return piSession.cachedPiModels;
+        try {
+            const data = await sendPiRpcAndWait(piSession, transport, { type: 'get_available_models' });
+            const models = parsePiModels(data);
+            if (models.length > 0) piSession.cachedPiModels = models;
+            return models;
+        } catch {
+            return [];
+        }
+    };
+
     // --- Pi commands and skills ---
     apiSession.rpcHandlerManager.registerHandler<{ agent?: string }, SlashCommandsResponse>(
         RPC_METHODS.ListSlashCommands,
@@ -921,6 +935,7 @@ export async function runPi(opts: {
             }
             case 'model': {
                 const qualified = (model: PiModelSummary): string => `${model.provider}/${model.modelId}`;
+                const models = await getPiModels();
                 if (!command.modelId) {
                     // List qualified selectors: duplicate bare IDs across
                     // providers are rejected by the switch path, so every
@@ -928,15 +943,15 @@ export async function runPi(opts: {
                     const current = piSession.currentModel && piSession.currentProvider
                         ? qualified({ provider: piSession.currentProvider, modelId: piSession.currentModel })
                         : piSession.currentModel ?? 'unset';
-                    const available = piSession.cachedPiModels.map(qualified).join(', ');
+                    const available = models.map(qualified).join(', ');
                     sendEvent(`Current model: ${current}.\nAvailable: ${available || 'unknown — use /model <modelId>'}`);
                     return;
                 }
                 // The catalog is provider-qualified; prefer an exact
                 // provider/modelId match and refuse bare IDs shared by more
                 // than one provider instead of silently picking the first.
-                const exact = piSession.cachedPiModels.find((model) => qualified(model) === command.modelId);
-                const bare = piSession.cachedPiModels.filter((model) => model.modelId === command.modelId);
+                const exact = models.find((model) => qualified(model) === command.modelId);
+                const bare = models.filter((model) => model.modelId === command.modelId);
                 if (!exact && bare.length > 1) {
                     sendEvent(`⚠️ Ambiguous model: ${command.modelId}. Use ${bare.map(qualified).join(', ')}.`);
                     return;

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -1006,6 +1006,12 @@ export async function runPi(opts: {
                 // the session idle while compaction and any queued prompts
                 // are still pending.
                 piSession.updateThinkingState(true)
+                // Interrupting a turn with /compact must retire pending
+                // extension UI requests exactly like the Abort path does;
+                // editor requests have no timeout, so a stale input/permission
+                // card would otherwise stick in AgentState.requests and the
+                // next answer could be routed to the aborted turn.
+                transportEvents?.cancelPendingExtensionUi('Pi prompt compacted', { sendResponse: true });
                 try {
                     const data = await piSession.runRuntimeMutation(async () => {
                         // Abort can land while this compact is still queued on

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -530,14 +530,19 @@ export async function runPi(opts: {
             // Slash commands share the prompt FIFO so dispatch order matches
             // arrival order; execute out-of-band while the pump stays blocked.
             piSpecialCommandInFlight = true;
-            const finish = (): void => {
+            // Special commands are executed by HAPI itself and are never
+            // delivered to Pi as prompts. Consume the queue row the moment
+            // dispatch starts: deferring consumption until the command
+            // finishes would keep the row stuck in the web queued bar for the
+            // whole execution — a /compact run performs an LLM summarization
+            // pass that can take minutes.
+            if (dequeued.localId) {
+                piSession.emitMessagesConsumed([dequeued.localId], { clearQueuedThinkingGrace: true });
+            }
+            void handlePiSpecialCommand(dequeued.command).finally(() => {
                 piSpecialCommandInFlight = false;
-                if (dequeued.localId) {
-                    piSession.emitMessagesConsumed([dequeued.localId], { clearQueuedThinkingGrace: true });
-                }
                 pumpPromptQueue();
-            };
-            void handlePiSpecialCommand(dequeued.command).finally(finish);
+            });
             return;
         }
         setPromptCommandInFlight(true);

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -896,17 +896,21 @@ export async function runPi(opts: {
                 return;
             }
             case 'model': {
+                const qualified = (model: PiModelSummary): string => `${model.provider}/${model.modelId}`;
                 if (!command.modelId) {
-                    const available = piSession.cachedPiModels
-                        .map((model) => model.modelId)
-                        .join(', ');
-                    sendEvent(`Current model: ${piSession.currentModel ?? 'unset'}.\nAvailable: ${available || 'unknown — use /model <modelId>'}`);
+                    // List qualified selectors: duplicate bare IDs across
+                    // providers are rejected by the switch path, so every
+                    // listed entry must be copy-paste usable.
+                    const current = piSession.currentModel && piSession.currentProvider
+                        ? qualified({ provider: piSession.currentProvider, modelId: piSession.currentModel })
+                        : piSession.currentModel ?? 'unset';
+                    const available = piSession.cachedPiModels.map(qualified).join(', ');
+                    sendEvent(`Current model: ${current}.\nAvailable: ${available || 'unknown — use /model <modelId>'}`);
                     return;
                 }
                 // The catalog is provider-qualified; prefer an exact
                 // provider/modelId match and refuse bare IDs shared by more
                 // than one provider instead of silently picking the first.
-                const qualified = (model: PiModelSummary): string => `${model.provider}/${model.modelId}`;
                 const exact = piSession.cachedPiModels.find((model) => qualified(model) === command.modelId);
                 const bare = piSession.cachedPiModels.filter((model) => model.modelId === command.modelId);
                 if (!exact && bare.length > 1) {

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -414,6 +414,7 @@ export async function runPi(opts: {
     // prompt pump from dispatching the next FIFO item Pi would reject
     // ("Cannot submit a prompt while compaction is in progress").
     let piSpecialCommandInFlight = false;
+    let activeSpecialCommand: PiSpecialCommand | null = null;
     let activePromptLocalId: string | undefined;
     let historyPumpDeferred = false;
     let agentLifecycleStarted = false;
@@ -530,6 +531,7 @@ export async function runPi(opts: {
             // Slash commands share the prompt FIFO so dispatch order matches
             // arrival order; execute out-of-band while the pump stays blocked.
             piSpecialCommandInFlight = true;
+            activeSpecialCommand = dequeued.command;
             // Special commands are executed by HAPI itself and are never
             // delivered to Pi as prompts. Consume the queue row the moment
             // dispatch starts: deferring consumption until the command
@@ -560,6 +562,7 @@ export async function runPi(opts: {
                 })
                 .finally(() => {
                     piSpecialCommandInFlight = false;
+                    activeSpecialCommand = null;
                     pumpPromptQueue();
                 });
             return;
@@ -1030,7 +1033,15 @@ export async function runPi(opts: {
                         failNativeStartup(new Error(`Pi compaction outcome is indeterminate: ${error.message}`));
                         return;
                     }
-                    sendEvent(`⚠️ Compaction failed: ${errorDetail(error)}`);
+                    const detail = errorDetail(error);
+                    if (/cancell?ed/i.test(detail)) {
+                        // Interrupted by the Abort action: Pi already emitted
+                        // the compaction_end(aborted) lifecycle event
+                        // ("📦 Compaction canceled"), so do not double-report
+                        // the same cancellation as a failure.
+                        return;
+                    }
+                    sendEvent(`⚠️ Compaction failed: ${detail}`);
                 } finally {
                     piSession.updateThinkingState(false)
                 }
@@ -1176,6 +1187,22 @@ export async function runPi(opts: {
     let abortPromise: Promise<{ success: true }> | null = null;
     apiSession.rpcHandlerManager.registerHandler(RPC_METHODS.Abort, async () => {
         if (abortPromise) return await abortPromise;
+        // /compact owns the runtime-mutation lease for up to
+        // PI_COMPACT_TIMEOUT_MS (120s), far beyond the 25s abort deadline —
+        // waiting on the lease would fail closed and tear down the session.
+        // Interrupt the compaction directly: Pi's abort RPC cancels its
+        // compaction AbortController, and Pi reports the cancellation through
+        // the compaction_end lifecycle event.
+        if (piSpecialCommandInFlight && activeSpecialCommand?.type === 'compact') {
+            abortInFlight = true;
+            abortPromise = sendPiRpcAndWait(piSession, transport, { type: 'abort' }, PI_ABORT_OPERATION_TIMEOUT_MS)
+                .then(() => ({ success: true } as const))
+                .finally(() => {
+                    abortInFlight = false;
+                    abortPromise = null;
+                });
+            return await abortPromise;
+        }
         piSession.assertNoHistoryTransaction('abort Pi');
         const deadlineAt = Date.now() + PI_ABORT_OPERATION_TIMEOUT_MS;
         abortInFlight = true;

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -9,10 +9,12 @@ import { PiTransport } from './piTransport';
 import { PiSession } from './session';
 import { PiConversationHistory, PiHistoryRestoreError } from './conversationHistory';
 import { parsePiModels, parsePiCommands, PiRpcTimeoutError, sendPiRpcAndWait, wireTransportEvents } from './loop';
-import { PiThinkingLevelSchema, SetSessionConfigPayloadSchema } from './schemas';
+import { PiThinkingLevelSchema, SetSessionConfigPayloadSchema, PiCompactResultSchema, PiFullSessionStatsSchema } from './schemas';
 import type { PiImageContent, PiThinkingLevel } from './types';
+import { parsePiSpecialCommand, type PiSpecialCommand } from './specialCommands';
 import { PiPromptQueue, type PiPreparedPrompt } from './promptQueue';
 import { PiSteerDispatcher } from './steerDispatcher';
+import { getBuiltinSlashCommands, mergeSlashCommands } from '@hapi/protocol/slashCommands';
 import type { ListPiModelsResponse, PiCommandSummary, SlashCommand, SlashCommandsResponse } from '@hapi/protocol/apiTypes';
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 import type { ListSkillsResponse, SkillSummary } from '@/modules/common/skills';
@@ -26,6 +28,44 @@ import { isAuthorizedUploadFile, isPathWithinUploadDir, type UploadFileIdentity 
 // but healthy startup still flips ready via get_state first (issue #1143).
 const PI_READY_FALLBACK_MS = 30_000;
 const PI_ABORT_OPERATION_TIMEOUT_MS = 25_000;
+// Manual compaction runs an LLM summarization pass; give it a generous window
+// far above the 10s default Pi RPC timeout.
+const PI_COMPACT_TIMEOUT_MS = 120_000;
+
+const PI_HELP_TEXT = [
+    'Supported HAPI Pi commands:',
+    '/compact [instructions] — compress conversation history to save context',
+    '/session — show session stats (tokens, cost, context usage)',
+    '/model [modelId] — show or switch the active model',
+    '/help — show this message',
+].join('\n');
+
+function formatPiSessionStatsMessage(stats: {
+    totalMessages?: number;
+    tokens?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; total?: number };
+    cost?: number;
+    contextUsage?: { tokens?: number | null; contextWindow?: number; percent?: number };
+}): string {
+    const lines: string[] = ['📊 Pi session stats'];
+    if (stats.totalMessages !== undefined) lines.push(`Messages: ${stats.totalMessages}`);
+    const tokens = stats.tokens;
+    if (tokens && tokens.total !== undefined) {
+        const parts = [`total ${tokens.total}`];
+        if (tokens.input !== undefined) parts.push(`in ${tokens.input}`);
+        if (tokens.output !== undefined) parts.push(`out ${tokens.output}`);
+        if (tokens.cacheRead !== undefined) parts.push(`cacheR ${tokens.cacheRead}`);
+        if (tokens.cacheWrite !== undefined) parts.push(`cacheW ${tokens.cacheWrite}`);
+        lines.push(`Tokens: ${parts.join(' · ')}`);
+    }
+    if (stats.cost !== undefined) lines.push(`Cost: $${stats.cost.toFixed(4)}`);
+    const usage = stats.contextUsage;
+    if (usage && usage.tokens !== null && usage.tokens !== undefined) {
+        const window = usage.contextWindow ? ` / ${usage.contextWindow}` : '';
+        const percent = usage.percent !== undefined && usage.percent !== null ? ` (${usage.percent}%)` : '';
+        lines.push(`Context: ${usage.tokens}${window} tokens${percent}`);
+    }
+    return lines.join('\n');
+}
 
 function isPiNoActiveAbortError(detail: string): boolean {
     return /no active|nothing.*abort/i.test(detail);
@@ -368,6 +408,12 @@ export async function runPi(opts: {
     let preparationChain = Promise.resolve();
     let promptCommandInFlight = false;
     let abortInFlight = false;
+    // Set while a manual /compact RPC is outstanding. Pi's compact() aborts
+    // any active stream itself, so piIsStreaming/promptCommandInFlight can go
+    // false mid-compaction; this flag keeps the prompt pump from sending a
+    // prompt Pi would reject ("Cannot submit a prompt while compaction is in
+    // progress").
+    let piCompactInFlight = false;
     let activePromptLocalId: string | undefined;
     let historyPumpDeferred = false;
     let agentLifecycleStarted = false;
@@ -465,6 +511,7 @@ export async function runPi(opts: {
             || piSession.piIsStreaming
             || promptCommandInFlight
             || abortInFlight
+            || piCompactInFlight
             // Earlier steers can fall back only after async preparation/runtime
             // lock wait. Do not let a later normal prompt overtake that result.
             || steerDispatcher?.hasPending
@@ -778,7 +825,11 @@ export async function runPi(opts: {
             const { slashCommands } = buildPiCommandInventory(await getPiCommands());
             return {
                 success: true,
-                commands: slashCommands,
+                // Pi's get_commands only reports extension commands, prompt
+                // templates, and skills — never its TUI builtins. Merge the
+                // HAPI-side builtin list (the subset translatable to Pi RPC)
+                // so the web / menu exposes /compact, /session, /model, /help.
+                commands: mergeSlashCommands([...getBuiltinSlashCommands('pi'), ...slashCommands]),
             };
         }
     );
@@ -791,7 +842,124 @@ export async function runPi(opts: {
         }
     );
 
-    // --- User message handler ---
+    // --- Pi built-in slash commands ---
+    // pi only runs as `pi --mode rpc` over piped stdio, so TUI slash commands
+    // typed in web would otherwise fall through to the LLM as plain text and
+    // silently do nothing. Intercept the subset HAPI can translate to Pi RPC
+    // (compact/session/model/help) and make terminal-only commands explicit.
+    const handlePiSpecialCommand = async (command: PiSpecialCommand): Promise<void> => {
+        const sendEvent = (message: string): void => {
+            piSession.sendSessionEvent({ type: 'message', message });
+        };
+        const errorDetail = (error: unknown): string => error instanceof Error ? error.message : String(error);
+
+        // RPC-backed commands need the transport wired and the history baseline
+        // established. Prompts are buffered until ready via runWhenReady, so
+        // defer the same way instead of racing the readiness transition (the
+        // ready queue drains FIFO on markReady, preserving arrival order).
+        if (command.type === 'compact' || command.type === 'session' || command.type === 'model') {
+            await new Promise<void>((resolve) => {
+                if (piSession.isReady) {
+                    resolve();
+                    return;
+                }
+                piSession.runWhenReady(resolve);
+            });
+        }
+
+        switch (command.type) {
+            case 'help':
+                sendEvent(PI_HELP_TEXT);
+                return;
+            case 'session': {
+                try {
+                    const data = await sendPiRpcAndWait(piSession, transport, { type: 'get_session_stats' });
+                    const parsed = PiFullSessionStatsSchema.safeParse(data);
+                    sendEvent(formatPiSessionStatsMessage(parsed.success ? parsed.data : {}));
+                } catch (error) {
+                    sendEvent(`⚠️ Could not read Pi session stats: ${errorDetail(error)}`);
+                }
+                return;
+            }
+            case 'model': {
+                if (!command.modelId) {
+                    const available = piSession.cachedPiModels
+                        .map((model) => model.modelId)
+                        .join(', ');
+                    sendEvent(`Current model: ${piSession.currentModel ?? 'unset'}.\nAvailable: ${available || 'unknown — use /model <modelId>'}`);
+                    return;
+                }
+                const match = piSession.cachedPiModels.find((model) => model.modelId === command.modelId)
+                    ?? piSession.cachedPiModels.find((model) => `${model.provider}/${model.modelId}` === command.modelId);
+                if (!match) {
+                    sendEvent(`⚠️ Unknown model: ${command.modelId}. Use /model to list available models.`);
+                    return;
+                }
+                try {
+                    await piSession.runRuntimeMutation(async () => {
+                        await sendPiRpcAndWait(piSession, transport, {
+                            type: 'set_model',
+                            provider: match.provider,
+                            modelId: match.modelId,
+                        });
+                        piSession.currentModel = match.modelId;
+                        piSession.currentProvider = match.provider;
+                        piSession.pushKeepAlive();
+                    }, { poisonOnError: (error) => error instanceof PiRpcTimeoutError });
+                    sendEvent(`Model switched to ${command.modelId}`);
+                } catch (error) {
+                    if (error instanceof PiRpcTimeoutError) {
+                        failNativeStartup(new Error(`Pi model switch outcome is indeterminate: ${error.message}`));
+                    } else {
+                        sendEvent(`⚠️ Model switch failed: ${errorDetail(error)}`);
+                    }
+                }
+                return;
+            }
+            case 'compact': {
+                piCompactInFlight = true;
+                try {
+                    const data = await piSession.runRuntimeMutation(async () => {
+                        return await sendPiRpcAndWait(piSession, transport, {
+                            type: 'compact',
+                            ...(command.instructions ? { customInstructions: command.instructions } : {}),
+                        }, PI_COMPACT_TIMEOUT_MS);
+                    }, { poisonOnError: (error) => error instanceof PiRpcTimeoutError });
+                    // Pi emits compaction_start/compaction_end lifecycle events
+                    // which surface as "📦 Compaction …" status messages; add
+                    // the actual summary and token delta on top.
+                    const parsed = PiCompactResultSchema.safeParse(data);
+                    const result = parsed.success ? parsed.data : {};
+                    const delta: string[] = [];
+                    if (result.tokensBefore !== undefined) delta.push(String(result.tokensBefore));
+                    delta.push('→');
+                    if (result.estimatedTokensAfter !== undefined) delta.push(String(result.estimatedTokensAfter));
+                    else delta.push('?');
+                    sendEvent(`📦 Compaction completed (tokens: ${delta.join(' ')})`);
+                    if (result.summary) sendEvent(`📦 Compaction summary:\n${result.summary}`);
+                } catch (error) {
+                    if (error instanceof PiRpcTimeoutError) {
+                        // Outcome is unknown but Pi's own compaction lifecycle
+                        // events still report completion/failure; the pump stays
+                        // blocked while compaction is genuinely running, and a
+                        // prompt sent into a stuck compaction is rejected by Pi
+                        // with a visible error. Do not poison the session.
+                        sendEvent(`⚠️ Compaction timed out — outcome unknown. If it is still running, prompts may be rejected until it finishes.`);
+                    } else {
+                        sendEvent(`⚠️ Compaction failed: ${errorDetail(error)}`);
+                    }
+                } finally {
+                    piCompactInFlight = false;
+                    pumpPromptQueue();
+                }
+                return;
+            }
+            case 'unsupported':
+                sendEvent(`⚠️ /${command.name} is a Pi terminal-only command and cannot run from HAPI web. Supported here: /compact, /session, /model, /help.`);
+                return;
+        }
+    };
+
     // Preparation reads image files asynchronously. A single promise chain keeps
     // attachment completion order identical to user-message arrival order.
     apiSession.onUserMessage((message, localId) => {
@@ -808,6 +976,20 @@ export async function runPi(opts: {
                 preparingLocalIds.delete(localId);
                 return;
             }
+
+            const specialCommand = parsePiSpecialCommand(message.content.text);
+            if (specialCommand) {
+                try {
+                    await handlePiSpecialCommand(specialCommand);
+                } finally {
+                    if (localId) {
+                        preparingLocalIds.delete(localId);
+                        piSession.emitMessagesConsumed([localId], { clearQueuedThinkingGrace: true });
+                    }
+                }
+                return;
+            }
+
             const prepared = await preparePiUserMessage(
                 message.content.text,
                 message.content.attachments,

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -414,7 +414,11 @@ export async function runPi(opts: {
     // prompt pump from dispatching the next FIFO item Pi would reject
     // ("Cannot submit a prompt while compaction is in progress").
     let piSpecialCommandInFlight = false;
-    let activeSpecialCommand: PiSpecialCommand | null = null;
+    // Tracks a dequeued /compact through the gap between queue dispatch and
+    // the compact RPC actually being issued (the runtime-mutation lock can
+    // be held by an earlier mutation). Abort uses it to cancel a compact
+    // that has not started yet, or to interrupt one that has.
+    let activeCompact: { rpcStarted: boolean; cancelled: boolean } | null = null;
     let activePromptLocalId: string | undefined;
     let historyPumpDeferred = false;
     let agentLifecycleStarted = false;
@@ -531,7 +535,9 @@ export async function runPi(opts: {
             // Slash commands share the prompt FIFO so dispatch order matches
             // arrival order; execute out-of-band while the pump stays blocked.
             piSpecialCommandInFlight = true;
-            activeSpecialCommand = dequeued.command;
+            if (dequeued.command.type === 'compact') {
+                activeCompact = { rpcStarted: false, cancelled: false };
+            }
             // Special commands are executed by HAPI itself and are never
             // delivered to Pi as prompts. Consume the queue row the moment
             // dispatch starts: deferring consumption until the command
@@ -562,7 +568,7 @@ export async function runPi(opts: {
                 })
                 .finally(() => {
                     piSpecialCommandInFlight = false;
-                    activeSpecialCommand = null;
+                    activeCompact = null;
                     pumpPromptQueue();
                 });
             return;
@@ -994,11 +1000,27 @@ export async function runPi(opts: {
                 piSession.updateThinkingState(true)
                 try {
                     const data = await piSession.runRuntimeMutation(async () => {
-                        return await sendPiRpcAndWait(piSession, transport, {
-                            type: 'compact',
-                            ...(command.instructions ? { customInstructions: command.instructions } : {}),
-                        }, PI_COMPACT_TIMEOUT_MS);
+                        // Abort can land while this compact is still queued on
+                        // the runtime-mutation lock; skip it once the lock
+                        // arrives instead of starting a compaction the user
+                        // already cancelled.
+                        const state = activeCompact;
+                        if (state?.cancelled) return null;
+                        if (state) state.rpcStarted = true;
+                        try {
+                            return await sendPiRpcAndWait(piSession, transport, {
+                                type: 'compact',
+                                ...(command.instructions ? { customInstructions: command.instructions } : {}),
+                            }, PI_COMPACT_TIMEOUT_MS);
+                        } finally {
+                            if (state) state.rpcStarted = false;
+                        }
                     }, { poisonOnError: (error) => error instanceof PiRpcTimeoutError });
+                    if (data === null) {
+                        // Cancelled by Abort before the RPC was issued;
+                        // nothing ran, so there is nothing to report.
+                        return;
+                    }
                     // Pi emits compaction_start/compaction_end lifecycle events
                     // which surface as "📦 Compaction …" status messages. The
                     // summary itself is a structured event so the web chat can
@@ -1192,15 +1214,21 @@ export async function runPi(opts: {
         // waiting on the lease would fail closed and tear down the session.
         // Interrupt the compaction directly: Pi's abort RPC cancels its
         // compaction AbortController, and Pi reports the cancellation through
-        // the compaction_end lifecycle event.
-        if (piSpecialCommandInFlight && activeSpecialCommand?.type === 'compact') {
+        // the compaction_end lifecycle event. If the compact RPC has not been
+        // issued yet (still queued on the mutation lock), cancel it in place
+        // instead so it never starts.
+        if (piSpecialCommandInFlight && activeCompact) {
             abortInFlight = true;
-            abortPromise = sendPiRpcAndWait(piSession, transport, { type: 'abort' }, PI_ABORT_OPERATION_TIMEOUT_MS)
-                .then(() => ({ success: true } as const))
-                .finally(() => {
-                    abortInFlight = false;
-                    abortPromise = null;
-                });
+            const interrupted = activeCompact.rpcStarted
+                ? sendPiRpcAndWait(piSession, transport, { type: 'abort' }, PI_ABORT_OPERATION_TIMEOUT_MS).then(() => ({ success: true } as const))
+                : (() => {
+                    activeCompact.cancelled = true;
+                    return Promise.resolve({ success: true } as const);
+                })();
+            abortPromise = interrupted.finally(() => {
+                abortInFlight = false;
+                abortPromise = null;
+            });
             return await abortPromise;
         }
         piSession.assertNoHistoryTransaction('abort Pi');

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -537,7 +537,17 @@ export async function runPi(opts: {
             // whole execution — a /compact run performs an LLM summarization
             // pass that can take minutes.
             if (dequeued.localId) {
-                piSession.emitMessagesConsumed([dequeued.localId], { clearQueuedThinkingGrace: true });
+                piSession.emitMessagesConsumed(
+                    [dequeued.localId],
+                    // The queued-thinking grace is session-scoped; only drop
+                    // it for commands that finish synchronously. /compact
+                    // keeps working for minutes with queued prompts behind it
+                    // still awaiting their turn, so its acknowledgement must
+                    // not clear their grace.
+                    dequeued.command.type === 'compact'
+                        ? undefined
+                        : { clearQueuedThinkingGrace: true },
+                );
             }
             void handlePiSpecialCommand(dequeued.command)
                 .catch((error) => {

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -539,10 +539,19 @@ export async function runPi(opts: {
             if (dequeued.localId) {
                 piSession.emitMessagesConsumed([dequeued.localId], { clearQueuedThinkingGrace: true });
             }
-            void handlePiSpecialCommand(dequeued.command).finally(() => {
-                piSpecialCommandInFlight = false;
-                pumpPromptQueue();
-            });
+            void handlePiSpecialCommand(dequeued.command)
+                .catch((error) => {
+                    // All known command failures surface as events inside
+                    // handlePiSpecialCommand; this catch only guards against
+                    // an unexpected rejection leaving an unhandled promise
+                    // rejection, and always keeps the pump unblocked via the
+                    // finally below.
+                    logger.warn(`[pi] Special command ${dequeued.command.type} failed unexpectedly: ${error instanceof Error ? error.message : String(error)}`);
+                })
+                .finally(() => {
+                    piSpecialCommandInFlight = false;
+                    pumpPromptQueue();
+                });
             return;
         }
         setPromptCommandInFlight(true);

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -976,17 +976,29 @@ export async function runPi(opts: {
                         }, PI_COMPACT_TIMEOUT_MS);
                     }, { poisonOnError: (error) => error instanceof PiRpcTimeoutError });
                     // Pi emits compaction_start/compaction_end lifecycle events
-                    // which surface as "📦 Compaction …" status messages; add
-                    // the actual summary and token delta on top.
+                    // which surface as "📦 Compaction …" status messages. The
+                    // summary itself is a structured event so the web chat can
+                    // render it as a dedicated block instead of a tiny status
+                    // line; the token delta rides on the same event.
                     const parsed = PiCompactResultSchema.safeParse(data);
                     const result = parsed.success ? parsed.data : {};
-                    const delta: string[] = [];
-                    if (result.tokensBefore !== undefined) delta.push(String(result.tokensBefore));
-                    delta.push('→');
-                    if (result.estimatedTokensAfter !== undefined) delta.push(String(result.estimatedTokensAfter));
-                    else delta.push('?');
-                    sendEvent(`📦 Compaction completed (tokens: ${delta.join(' ')})`);
-                    if (result.summary) sendEvent(`📦 Compaction summary:\n${result.summary}`);
+                    if (result.summary) {
+                        piSession.sendSessionEvent({
+                            type: 'compact-summary',
+                            summary: result.summary,
+                            tokensBefore: result.tokensBefore,
+                            estimatedTokensAfter: result.estimatedTokensAfter,
+                        });
+                    } else {
+                        // No summary in the RPC result (defensive): fall back to
+                        // the plain status line so the token delta still lands.
+                        const delta: string[] = [];
+                        if (result.tokensBefore !== undefined) delta.push(String(result.tokensBefore));
+                        delta.push('→');
+                        if (result.estimatedTokensAfter !== undefined) delta.push(String(result.estimatedTokensAfter));
+                        else delta.push('?');
+                        sendEvent(`📦 Compaction completed (tokens: ${delta.join(' ')})`);
+                    }
                 } catch (error) {
                     if (error instanceof PiRpcTimeoutError) {
                         // The runtime lease is deliberately retained on timeout

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -1004,6 +1004,12 @@ export async function runPi(opts: {
             const discovered = name
                 ? await getPiCommands()
                 : piSession.cachedPiCommands;
+            // Discovery can take an RPC round-trip; a cancel acknowledged during
+            // that window must still win over the command.
+            if (localId && cancelledWhilePreparing.delete(localId)) {
+                preparingLocalIds.delete(localId);
+                return;
+            }
             const isCustomCommand = Boolean(name && discovered.some((item) => item.name.toLowerCase() === name.toLowerCase()));
             const specialCommand = isCustomCommand
                 ? null

--- a/cli/src/pi/schemas.ts
+++ b/cli/src/pi/schemas.ts
@@ -316,6 +316,46 @@ const PiSessionStatsDataSchema = z.object({
 }).passthrough();
 
 // ============================================================================
+// Pi compact response data
+// ============================================================================
+
+export const PiCompactResultSchema = z.object({
+    summary: z.string().optional(),
+    firstKeptEntryId: z.string().optional(),
+    tokensBefore: z.number().optional(),
+    estimatedTokensAfter: z.number().optional(),
+}).passthrough();
+
+// ============================================================================
+// Pi get_session_stats response data (used by the /session slash command)
+// ============================================================================
+
+export const PiFullSessionStatsSchema = z.object({
+    sessionId: z.string().optional(),
+    sessionFile: z.string().optional(),
+    userMessages: z.number().optional(),
+    assistantMessages: z.number().optional(),
+    toolCalls: z.number().optional(),
+    toolResults: z.number().optional(),
+    totalMessages: z.number().optional(),
+    tokens: z.object({
+        input: z.number().optional(),
+        output: z.number().optional(),
+        cacheRead: z.number().optional(),
+        cacheWrite: z.number().optional(),
+        total: z.number().optional(),
+    }).passthrough().optional(),
+    cost: z.number().optional(),
+    contextUsage: z.object({
+        tokens: asContextTokens,
+        contextWindow: asOptPositiveNum,
+        percent: asOptNum,
+    }).passthrough().optional(),
+}).passthrough();
+
+export type PiFullSessionStats = z.infer<typeof PiFullSessionStatsSchema>;
+
+// ============================================================================
 // Pi State (get_state response data)
 // ============================================================================
 

--- a/cli/src/pi/specialCommands.test.ts
+++ b/cli/src/pi/specialCommands.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { parsePiSpecialCommand } from './specialCommands';
+
+describe('parsePiSpecialCommand', () => {
+    it('parses /compact with optional custom instructions', () => {
+        expect(parsePiSpecialCommand('/compact')).toEqual({ type: 'compact' });
+        expect(parsePiSpecialCommand('/compact focus on the API design'))
+            .toEqual({ type: 'compact', instructions: 'focus on the API design' });
+        expect(parsePiSpecialCommand('  /compact   keep tests green  '))
+            .toEqual({ type: 'compact', instructions: 'keep tests green' });
+        expect(parsePiSpecialCommand('/compact\nmulti-line instructions'))
+            .toEqual({ type: 'compact', instructions: 'multi-line instructions' });
+    });
+
+    it('parses /session, /model, and /help', () => {
+        expect(parsePiSpecialCommand('/session')).toEqual({ type: 'session' });
+        expect(parsePiSpecialCommand('/session extra args')).toEqual({ type: 'session' });
+        expect(parsePiSpecialCommand('/model')).toEqual({ type: 'model' });
+        expect(parsePiSpecialCommand('/model gpt-5.2')).toEqual({ type: 'model', modelId: 'gpt-5.2' });
+        expect(parsePiSpecialCommand('/model openai/gpt-5.2')).toEqual({ type: 'model', modelId: 'openai/gpt-5.2' });
+        expect(parsePiSpecialCommand('/help')).toEqual({ type: 'help' });
+        expect(parsePiSpecialCommand('/COMPACT')).toEqual({ type: 'compact' });
+    });
+
+    it('flags terminal-only Pi builtins as unsupported', () => {
+        for (const name of ['tree', 'export', 'import', 'reload', 'settings', 'new', 'name', 'login', 'logout', 'quit', 'hotkeys', 'changelog', 'share', 'resume', 'trust', 'fork', 'clone', 'copy', 'scoped-models', 'llama']) {
+            expect(parsePiSpecialCommand(`/${name}`)).toEqual({ type: 'unsupported', name });
+        }
+        expect(parsePiSpecialCommand('/tree some entry')).toEqual({ type: 'unsupported', name: 'tree' });
+    });
+
+    it('leaves extension commands, skills, templates, and prose untouched', () => {
+        expect(parsePiSpecialCommand('/my-extension arg')).toBeNull();
+        expect(parsePiSpecialCommand('/skill:brave-search latest news')).toBeNull();
+        expect(parsePiSpecialCommand('/my_template')).toBeNull();
+        expect(parsePiSpecialCommand('/etc/hosts is a path')).toBeNull();
+        expect(parsePiSpecialCommand('please /compact now')).toBeNull();
+        expect(parsePiSpecialCommand('normal message')).toBeNull();
+        expect(parsePiSpecialCommand('')).toBeNull();
+        expect(parsePiSpecialCommand('/')).toBeNull();
+    });
+});

--- a/cli/src/pi/specialCommands.test.ts
+++ b/cli/src/pi/specialCommands.test.ts
@@ -29,6 +29,13 @@ describe('parsePiSpecialCommand', () => {
         expect(parsePiSpecialCommand('/tree some entry')).toEqual({ type: 'unsupported', name: 'tree' });
     });
 
+    it('requires a command-token boundary (no path-like prefixes)', () => {
+        expect(parsePiSpecialCommand('/compact.md notes')).toBeNull();
+        expect(parsePiSpecialCommand('/compact/notes')).toBeNull();
+        expect(parsePiSpecialCommand('/model/config.json')).toBeNull();
+        expect(parsePiSpecialCommand('/session-settings')).toBeNull();
+    });
+
     it('leaves extension commands, skills, templates, and prose untouched', () => {
         expect(parsePiSpecialCommand('/my-extension arg')).toBeNull();
         expect(parsePiSpecialCommand('/skill:brave-search latest news')).toBeNull();

--- a/cli/src/pi/specialCommands.ts
+++ b/cli/src/pi/specialCommands.ts
@@ -1,0 +1,74 @@
+/**
+ * Pi built-in commands that exist in the pi TUI but cannot run through HAPI
+ * (pi only runs as `pi --mode rpc` with piped stdio; these commands need the
+ * interactive TUI). Typing them in web today passes the literal text to the
+ * LLM as an ordinary prompt — silently doing nothing. Intercepting them with
+ * an explicit message makes the failure visible instead.
+ */
+export const PI_TERMINAL_ONLY_COMMANDS = [
+    'login',
+    'logout',
+    'llama',
+    'scoped-models',
+    'settings',
+    'resume',
+    'new',
+    'name',
+    'tree',
+    'trust',
+    'fork',
+    'clone',
+    'copy',
+    'export',
+    'import',
+    'share',
+    'reload',
+    'hotkeys',
+    'changelog',
+    'quit',
+] as const;
+
+export type PiTerminalOnlyCommand = (typeof PI_TERMINAL_ONLY_COMMANDS)[number];
+
+export type PiSpecialCommand =
+    | { type: 'compact'; instructions?: string }
+    | { type: 'session' }
+    | { type: 'model'; modelId?: string }
+    | { type: 'help' }
+    | { type: 'unsupported'; name: string };
+
+const PI_TERMINAL_ONLY_SET: ReadonlySet<string> = new Set<string>(PI_TERMINAL_ONLY_COMMANDS);
+
+/**
+ * Parse a user message that targets a Pi built-in command.
+ *
+ * Returns null for anything that is not a recognized Pi built-in (including
+ * extension commands, /skill:name, prompt templates, and plain prose starting
+ * with `/`), so those keep flowing through the normal prompt path.
+ */
+export function parsePiSpecialCommand(message: string): PiSpecialCommand | null {
+    const trimmed = message.trim();
+    if (!trimmed.startsWith('/')) return null;
+    // Pi commands are case-insensitive in the TUI; match on the lowercased
+    // line but slice args from the original text to preserve their case.
+    const lower = trimmed.toLowerCase();
+    const nameMatch = /^\/[a-z0-9:_-]+/.exec(lower);
+    if (!nameMatch) return null;
+
+    const name = nameMatch[0].slice(1);
+    const args = trimmed.slice(nameMatch[0].length).trim();
+    switch (name) {
+        case 'compact':
+            return { type: 'compact', ...(args ? { instructions: args } : {}) };
+        case 'session':
+            return { type: 'session' };
+        case 'model':
+            return { type: 'model', ...(args ? { modelId: args } : {}) };
+        case 'help':
+            return { type: 'help' };
+        default:
+            return PI_TERMINAL_ONLY_SET.has(name)
+                ? { type: 'unsupported', name }
+                : null;
+    }
+}

--- a/cli/src/pi/specialCommands.ts
+++ b/cli/src/pi/specialCommands.ts
@@ -40,6 +40,18 @@ export type PiSpecialCommand =
 const PI_TERMINAL_ONLY_SET: ReadonlySet<string> = new Set<string>(PI_TERMINAL_ONLY_COMMANDS);
 
 /**
+ * Extract the leading slash token of a message, or null when the message does
+ * not start with a well-formed `/name` token (a command boundary — whitespace
+ * or end of line — is required, so `/compact.md` is not treated as `/compact`).
+ */
+export function parseLeadingSlashName(message: string): string | null {
+    const trimmed = message.trim();
+    if (!trimmed.startsWith('/')) return null;
+    const match = /^\/[a-z0-9:_-]+(?=\s|$)/i.exec(trimmed);
+    return match ? match[0].slice(1) : null;
+}
+
+/**
  * Parse a user message that targets a Pi built-in command.
  *
  * Returns null for anything that is not a recognized Pi built-in (including
@@ -52,7 +64,7 @@ export function parsePiSpecialCommand(message: string): PiSpecialCommand | null 
     // Pi commands are case-insensitive in the TUI; match on the lowercased
     // line but slice args from the original text to preserve their case.
     const lower = trimmed.toLowerCase();
-    const nameMatch = /^\/[a-z0-9:_-]+/.exec(lower);
+    const nameMatch = /^\/[a-z0-9:_-]+(?=\s|$)/i.exec(lower);
     if (!nameMatch) return null;
 
     const name = nameMatch[0].slice(1);

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -242,6 +242,15 @@ If a remote session reports authentication failure, run `grok login --device-aut
 - **Antigravity** (`hapi agy`) — Google's Antigravity CLI (`agy`), driven as an interactive PTY with hook-based permission bridging. [Google Antigravity](https://antigravity.google)
 - **Pi** (`hapi pi`) — the Pi coding agent running as `pi --mode rpc` (JSON-line RPC over piped stdio); remote-control only, no local TUI input path. [badlogic/pi-mono](https://github.com/badlogic/pi-mono)
 
+  HAPI translates a subset of Pi's TUI slash commands to native Pi RPC calls, so they work from the web chat as well:
+
+  - `/compact [instructions]` — manually compact context with optional custom summary instructions (runs Pi's `compact` RPC; the summary and token delta are reported back as chat messages).
+  - `/session` — show session stats (messages, tokens, cost, context usage).
+  - `/model [modelId]` — show the current model and available models, or switch with `/model <modelId>`.
+  - `/help` — list the commands supported from HAPI.
+
+  Pi's extension commands and prompt templates (discovered via `get_commands`) keep working from the `/` menu, and skills are available through `$skill-name` like other ACP flavors. Other Pi TUI builtins (e.g. `/tree`, `/export`, `/reload`) cannot run over RPC; typing them in web shows an explicit "terminal-only" notice instead of silently forwarding the text to the model.
+
 ## Related
 
 - [How it Works](./how-it-works.md) - Architecture and data flow

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -244,7 +244,7 @@ If a remote session reports authentication failure, run `grok login --device-aut
 
   HAPI translates a subset of Pi's TUI slash commands to native Pi RPC calls, so they work from the web chat as well:
 
-  - `/compact [instructions]` — manually compact context with optional custom summary instructions (runs Pi's `compact` RPC; the summary and token delta are reported back as chat messages).
+  - `/compact [instructions]` — manually compact context with optional custom summary instructions (runs Pi's `compact` RPC; the summary is rendered as a dedicated block in the chat with the token delta in its header).
   - `/session` — show session stats (messages, tokens, cost, context usage).
   - `/model [modelId]` — show the current model and available models, or switch with `/model <modelId>`.
   - `/help` — list the commands supported from HAPI.

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -177,6 +177,11 @@ export const CodexImportedMessageSchema = z.union([
         role: z.literal('agent'),
         content: z.object({ type: z.literal('codex'), data: z.unknown() }),
         meta: z.object({ sentFrom: z.literal('cli') })
+    }),
+    z.object({
+        role: z.literal('agent'),
+        content: z.object({ type: z.literal('event'), data: z.unknown() }),
+        meta: z.object({ sentFrom: z.literal('cli') })
     })
 ])
 

--- a/shared/src/slashCommands.ts
+++ b/shared/src/slashCommands.ts
@@ -75,7 +75,16 @@ export const BUILTIN_SLASH_COMMANDS = {
         { name: 'usage', description: 'Show session usage metrics', source: 'builtin' },
     ],
     kimi: [],
-    pi: [],
+    // Pi runs `pi --mode rpc` over stdio; only commands HAPI can translate
+    // to Pi RPC calls are listed. Terminal-only Pi builtins (e.g. /tree,
+    // /export, /reload) are intercepted with an explicit "not supported"
+    // message instead of being passed to the model as plain text.
+    pi: [
+        { name: 'help', description: 'Show supported HAPI Pi slash commands', source: 'builtin' },
+        { name: 'compact', description: 'Compress conversation history to save context (optional custom instructions)', source: 'builtin' },
+        { name: 'session', description: 'Show Pi session stats (tokens, cost, context usage)', source: 'builtin' },
+        { name: 'model', description: 'Show or switch the Pi model, e.g. /model gpt-5.2', source: 'builtin' },
+    ],
 } as const satisfies Record<string, readonly SlashCommand[]>
 
 export function getBuiltinSlashCommands(agent: string): SlashCommand[] {

--- a/web/src/chat/presentation.test.ts
+++ b/web/src/chat/presentation.test.ts
@@ -252,6 +252,20 @@ describe('getEventPresentation — recap (away_summary)', () => {
     })
 })
 
+describe('getEventPresentation — compact-summary', () => {
+    it('keeps the label short (the chat renders the full summary as a block)', () => {
+        const result = getEventPresentation({
+            type: 'compact-summary',
+            summary: '## Goal\nLong summary content',
+            tokensBefore: 1000,
+            estimatedTokensAfter: 120
+        })
+
+        expect(result.icon).toBe('📦')
+        expect(result.text).toBe('Context compacted')
+    })
+})
+
 describe('formatResetTime', () => {
     it('formats a unix timestamp to a non-empty string', () => {
         const result = formatResetTime(1774278000)

--- a/web/src/chat/presentation.ts
+++ b/web/src/chat/presentation.ts
@@ -255,6 +255,11 @@ export function getEventPresentation(event: AgentEvent): EventPresentation {
     if (event.type === 'compact') {
         return { icon: '📦', text: 'Conversation compacted' }
     }
+    if (event.type === 'compact-summary') {
+        // The chat renders the full summary as a dedicated block; this label
+        // only feeds compact contexts (outline anchors, tool traces).
+        return { icon: '📦', text: 'Context compacted' }
+    }
     if (event.type === 'recap') {
         // Lowercase `recap:` intentionally mirrors Claude Code's own TUI recap label.
         const text = typeof event.text === 'string' ? event.text : ''

--- a/web/src/chat/types.ts
+++ b/web/src/chat/types.ts
@@ -26,6 +26,8 @@ export type AgentEvent =
     | { type: 'turn-duration'; durationMs: number; targetMessageId?: string }
     | { type: 'microcompact'; trigger: string; preTokens: number; tokensSaved: number }
     | { type: 'compact'; trigger: string; preTokens: number }
+    // Structured result of Pi's compact RPC; rendered as a dedicated chat block.
+    | { type: 'compact-summary'; summary: string; tokensBefore?: number; estimatedTokensAfter?: number }
     // Claude Code's automatic away-summary recap (TUI window blur 5min+, then focus).
     | { type: 'recap'; text: string }
     | { type: 'thread-goal-updated'; goal: ThreadGoal; threadId?: string; turnId?: string }

--- a/web/src/components/AssistantChat/messages/SystemMessage.tsx
+++ b/web/src/components/AssistantChat/messages/SystemMessage.tsx
@@ -1,8 +1,19 @@
 import { MessagePrimitive, useAuiState } from '@assistant-ui/react'
 import { getEventPresentation } from '@/chat/presentation'
+import type { AgentEvent } from '@/chat/types'
 import type { HappyChatMessageMetadata } from '@/lib/assistant-runtime'
 import { getConversationMessageAnchorId } from '@/chat/outline'
 import { MessageTimestamp } from '@/components/AssistantChat/messages/MessageTimestamp'
+import { MarkdownRenderer } from '@/components/MarkdownRenderer'
+
+function formatTokenDelta(event: AgentEvent | undefined): string | null {
+    if (!event || event.type !== 'compact-summary') return null
+    const parts: string[] = []
+    if (typeof event.tokensBefore === 'number') parts.push(event.tokensBefore.toLocaleString())
+    if (typeof event.estimatedTokensAfter === 'number') parts.push(event.estimatedTokensAfter.toLocaleString())
+    if (parts.length === 0) return null
+    return parts.length === 2 ? `${parts[0]} → ${parts[1]} tokens` : `${parts[0]} tokens`
+}
 
 export function HappySystemMessage() {
     const role = useAuiState((s) => s.message.role)
@@ -17,8 +28,37 @@ export function HappySystemMessage() {
         const event = custom?.kind === 'event' ? custom.event : undefined
         return event ? getEventPresentation(event).icon : null
     })
+    const compactSummary = useAuiState((s) => {
+        if (s.message.role !== 'system') return undefined
+        const custom = s.message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined
+        return custom?.kind === 'compact-summary' ? custom.event : undefined
+    })
 
     if (role !== 'system') return null
+
+    // Pi compaction summaries are real content, not status: render them as an
+    // independent block (header with token delta + the summary markdown)
+    // instead of the tiny centered status line used for other events.
+    if (compactSummary && compactSummary.type === 'compact-summary') {
+        const delta = formatTokenDelta(compactSummary)
+        return (
+            <MessagePrimitive.Root id={getConversationMessageAnchorId(messageId)} className="scroll-mt-4 py-1">
+                <div className="mx-auto max-w-[92%] rounded-lg border border-[var(--app-border)] bg-[var(--app-subtle-bg)] px-3 py-2">
+                    <div className="flex items-center gap-1.5 text-xs text-[var(--app-hint)]">
+                        <span aria-hidden="true">📦</span>
+                        <span className="font-medium">Context compacted</span>
+                        {delta ? <span className="font-normal">{delta}</span> : null}
+                        <MessageTimestamp className="text-[10px]" />
+                    </div>
+                    {text ? (
+                        <div className="max-h-96 overflow-y-auto pr-1">
+                            <MarkdownRenderer standalone content={text} />
+                        </div>
+                    ) : null}
+                </div>
+            </MessagePrimitive.Root>
+        )
+    }
 
     return (
         <MessagePrimitive.Root id={getConversationMessageAnchorId(messageId)} className="scroll-mt-4 py-1">

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -31,7 +31,7 @@ export type AggregatedAssistantMeta = {
 }
 
 export type HappyChatMessageMetadata = {
-    kind: 'user' | 'assistant' | 'tool' | 'event' | 'cli-output' | 'codex-review'
+    kind: 'user' | 'assistant' | 'tool' | 'event' | 'cli-output' | 'codex-review' | 'compact-summary'
     status?: HappyMessageStatus
     localId?: string | null
     originalText?: string
@@ -522,6 +522,25 @@ function toThreadMessageLike(
     }
 
     if (block.kind === 'agent-event') {
+        // Pi compaction summaries carry a real payload; surface them as a
+        // dedicated system message so the chat can render an independent
+        // block instead of a small status line.
+        if (block.event.type === 'compact-summary' && typeof block.event.summary === 'string') {
+            return {
+                role: 'system',
+                id: threadMessageId,
+                createdAt: new Date(timestamp),
+                content: [{ type: 'text', text: block.event.summary }],
+                metadata: {
+                    custom: {
+                        kind: 'compact-summary',
+                        event: block.event,
+                        invokedAt: block.invokedAt,
+                        model: block.model
+                    } satisfies HappyChatMessageMetadata
+                }
+            }
+        }
         return {
             role: 'system',
             id: threadMessageId,

--- a/web/src/lib/codexSlashCommands.test.ts
+++ b/web/src/lib/codexSlashCommands.test.ts
@@ -27,8 +27,15 @@ describe('getBuiltinSlashCommands', () => {
         )
     })
 
-    it.each(['pi', 'kimi'])('does not fall back to Claude commands for %s', (flavor) => {
-        expect(getBuiltinSlashCommands(flavor)).toEqual([])
+    it('keeps pi builtins as its own list (no Claude fallback)', () => {
+        const commands = getBuiltinSlashCommands('pi')
+        expect(commands.length).toBeGreaterThan(0)
+        expect(commands.map((command) => command.name)).not.toContain('clear')
+        expect(commands.map((command) => command.name)).toContain('compact')
+    })
+
+    it('does not fall back to Claude commands for kimi', () => {
+        expect(getBuiltinSlashCommands('kimi')).toEqual([])
     })
 
     it('includes debug only in Cursor permission modes', () => {


### PR DESCRIPTION
## Summary

Pi only runs as `pi --mode rpc` over piped stdio, so Pi TUI slash commands typed in HAPI web chat previously fell through to the LLM as plain text — **silently doing nothing** (notably `/compact`). This PR makes Pi slash command support complete:

- **Web `/` menu** now shows Pi builtins (`/compact`, `/session`, `/model`, `/help`) via the shared `BUILTIN_SLASH_COMMANDS` list + the CLI's `ListSlashCommands` RPC (which now merges HAPI builtins with Pi extension commands/templates/skills).
- **`/compact [instructions]`** executes Pi's native `compact` RPC (with optional `customInstructions`), works while streaming (Pi aborts the active turn itself), and renders the resulting summary as a **dedicated chat block** (token delta in the header, summary markdown below) via a structured `compact-summary` event — no more wall-of-tiny-text status lines. The prompt pump is gated by `piCompactInFlight` so queued prompts aren't rejected mid-compaction. Imported Pi session files surface compaction entries the same way.
- **`/session`** → `get_session_stats` formatted stats; **`/model [modelId]`** → list/switch via `set_model`; **`/help`** → supported list.
- **Terminal-only Pi builtins** (`/tree`, `/export`, `/reload`, `/settings`, …) now produce an explicit "terminal-only" notice instead of silently passing the text to the model. Unknown slash text (extension commands, `/skill:name`, templates) keeps passing through unchanged.
- Commands are buffered via `runWhenReady` like prompts (no startup race), and RPC-backed commands serialize on the existing runtime mutation lock.

## Verification

- `bun typecheck` — clean (all packages)
- CLI: 225 files / 2479 tests pass (ran with `--maxWorkers=2`; the machine's full-parallel run hits worker limits unrelated to this diff)
- Hub: 1080 tests, 0 fail · Shared: 262 tests, 0 fail · Web: 259 files / 2450 tests pass
- New tests: `specialCommands.ts` parser unit tests + 8 `runPi` integration tests (compact execution, steer interception, failure reporting, FIFO blocking, model switch, unsupported commands, slash list merge); updated web `codexSlashCommands.test.ts` for the new pi builtin list

## Notes

- Runner integration suite (`test:cli:integration`, separate CI job) fails on this dev machine even on a clean checkout (environment issue, unrelated to this diff).