### PR TITLE
fix(web): lower context usage warning thresholds

### DIFF
--- a/web/src/components/AssistantChat/StatusBar.test.ts
+++ b/web/src/components/AssistantChat/StatusBar.test.ts
@@ -2,9 +2,26 @@ import { describe, expect, it } from 'vitest'
 import {
     formatCompactContextUsageLabel,
     formatContextUsageLabel,
+    getContextWarning,
     getContextUsageDetails,
     shouldShowCodexFastBadge
 } from './StatusBar'
+
+describe('context warning colors', () => {
+    it('keeps usage below 70% muted', () => {
+        expect(getContextWarning(69, 100).color).toBe('text-[var(--app-hint)]')
+    })
+
+    it('shows a warning from 70% through below 90%', () => {
+        expect(getContextWarning(70, 100).color).toBe('text-amber-500')
+        expect(getContextWarning(89, 100).color).toBe('text-amber-500')
+    })
+
+    it('shows danger at 90% and above', () => {
+        expect(getContextWarning(90, 100).color).toBe('text-red-500')
+        expect(getContextWarning(95, 100).color).toBe('text-red-500')
+    })
+})
 
 describe('context usage labels', () => {
     it('keeps the desktop label compact and expresses used capacity', () => {

--- a/web/src/components/AssistantChat/StatusBar.tsx
+++ b/web/src/components/AssistantChat/StatusBar.tsx
@@ -47,6 +47,9 @@ const PERMISSION_TONE_CLASSES: Record<PermissionModeTone, string> = {
     danger: 'text-red-500'
 }
 
+const CONTEXT_WARNING_THRESHOLD_PERCENT = 70
+const CONTEXT_DANGER_THRESHOLD_PERCENT = 90
+
 function getConnectionStatus(
     active: boolean,
     thinking: boolean,
@@ -112,13 +115,12 @@ function getConnectionStatus(
     }
 }
 
-function getContextWarning(contextSize: number, maxContextSize: number): { color: string } | null {
+export function getContextWarning(contextSize: number, maxContextSize: number): { color: string } {
     const percentageUsed = (contextSize / maxContextSize) * 100
-    const percentageRemaining = Math.max(0, 100 - percentageUsed)
 
-    if (percentageRemaining <= 5) {
+    if (percentageUsed >= CONTEXT_DANGER_THRESHOLD_PERCENT) {
         return { color: 'text-red-500' }
-    } else if (percentageRemaining <= 10) {
+    } else if (percentageUsed >= CONTEXT_WARNING_THRESHOLD_PERCENT) {
         return { color: 'text-amber-500' }
     } else {
         return { color: 'text-[var(--app-hint)]' }


### PR DESCRIPTION
## Summary

- Change context status bar warning thresholds to:
  - muted below 70% used
  - amber from 70% to below 90%
  - red at 90% and above
- Keep context usage calculation and automatic compaction behavior unchanged.
- Add boundary tests covering 69%, 70%, 89%, 90%, and 95%.

## Validation

- `bun run --cwd web test --run src/components/AssistantChat/StatusBar.test.ts`
- `bun run test:web`
- `bun typecheck`
- `bun run build`
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name context-warning-thresholds -Suite Root -TestArgs 'terminal-wrap-fidelity.spec.ts'`
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name context-warning-thresholds -Suite Live`

The focused test, Web test suite, typecheck, build, Root terminal-wrap E2E, and Live validation all passed. Live validation used isolated seeded historical sessions at 70%, 90%, and 95% context usage.

## Related Issues

Refs #855

## AI Disclosure

Implemented with OpenAI Codex, model GPT-5.6.