### PR TITLE
fix(web): map codex-enveloped compact-summary to the chat block

### DIFF
--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1332,6 +1332,11 @@ describe('Pi built-in slash commands', () => {
         expect(harness.sent).not.toContainEqual(expect.objectContaining({ type: 'prompt' }));
 
         const compact = harness.sent.find((item) => (item as { type?: string }).type === 'compact') as { id: string };
+        // The compact RPC holds the session in the thinking state for its
+        // whole duration (web would otherwise mark it idle after the hub's
+        // 15s queued-thinking grace).
+        const keepAliveCalls = harness.session.keepAlive.mock.calls;
+        expect(keepAliveCalls[keepAliveCalls.length - 1]?.[0]).toBe(true);
         harness.onEvent!({
             type: 'response', id: compact.id, command: 'compact', success: true,
             data: { summary: 'API design focused summary', tokensBefore: 1000, estimatedTokensAfter: 120 },
@@ -1350,6 +1355,12 @@ describe('Pi built-in slash commands', () => {
             message: expect.stringContaining('Compaction summary'),
         }));
         await vi.waitFor(() => expect(harness.session.keepAlive).toHaveBeenCalledWith(false, expect.anything(), expect.anything()));
+
+        // The thinking state is released once the RPC completes.
+        await vi.waitFor(() => {
+            const calls = harness.session.keepAlive.mock.calls;
+            expect(calls[calls.length - 1]?.[0]).toBe(false);
+        });
 
         // The queued prompt may only flow once compaction completed.
         await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({

--- a/web/src/chat/normalizeAgent.test.ts
+++ b/web/src/chat/normalizeAgent.test.ts
@@ -209,3 +209,24 @@ describe('normalizeAgentRecord — agentTimestamp exposure', () => {
         expect(normalized).toMatchObject({ role: 'agent', agentTimestamp: null })
     })
 })
+
+describe('normalizeAgentRecord — imported pi compact-summary (codex envelope)', () => {
+    it('maps an imported compaction summary to the compact-summary agent event', () => {
+        const normalized = normalizeAgentRecord('pi-compact-1', null, 1, {
+            type: 'codex',
+            data: {
+                type: 'compact-summary',
+                summary: '## Goal\ncondensed context'
+            }
+        })
+
+        expect(normalized).toMatchObject({
+            role: 'event',
+            content: {
+                type: 'compact-summary',
+                summary: '## Goal\ncondensed context'
+            }
+        })
+        expect((normalized as { content: { tokensBefore?: number } }).content.tokensBefore).toBeUndefined()
+    })
+})

--- a/web/src/chat/normalizeAgent.ts
+++ b/web/src/chat/normalizeAgent.ts
@@ -1034,6 +1034,28 @@ export function normalizeAgentRecord(
             }
         }
 
+        // Defensive parity with context_compacted above: a compact-summary
+        // arriving in the codex envelope (e.g. from an older import path or a
+        // future producer) must not be silently dropped by the codex-content
+        // filter — map it to the same agent-event the live pi wrapper emits
+        // so it renders as the dedicated chat block.
+        if (data.type === 'compact-summary' && typeof data.summary === 'string') {
+            return {
+                id: messageId,
+                localId,
+                createdAt,
+                role: 'event',
+                content: {
+                    type: 'compact-summary',
+                    summary: data.summary,
+                    tokensBefore: asNumber(data.tokensBefore) ?? undefined,
+                    estimatedTokensAfter: asNumber(data.estimatedTokensAfter) ?? undefined
+                },
+                isSidechain: false,
+                meta
+            }
+        }
+
         if (data.type === 'token_count') {
             const usage = normalizeCodexTokenUsage(data.info, data)
             return usage ? {

--- a/web/src/components/assistant-ui/markdown-a.test.tsx
+++ b/web/src/components/assistant-ui/markdown-a.test.tsx
@@ -61,7 +61,6 @@ function chatContext(overrides: Partial<HappyChatContextValue> = {}): HappyChatC
         isLoadingMoreMessages: false,
         showSessionSummaryInChat: false,
         loadOlderMessagesPreservingScroll: async () => 'loaded',
-        showSessionSummaryInChat: false,
         ...overrides,
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1570 (merged): Pi compaction summaries now render as a dedicated chat block, but only when they arrive through the `event` envelope. A `compact-summary` in the codex payload envelope — the shape older import paths and any future producer would emit — is silently dropped by the codex-content filter (`web/src/chat/normalize.ts`), so imported sessions could lose the summary block entirely.

This PR:

- **`web/src/chat/normalizeAgent.ts`** — map codex-enveloped `compact-summary` data to the same agent-event the live pi wrapper emits (mirrors the existing `context_compacted` handling), so it renders as the dedicated block instead of being dropped.
- **`web/src/chat/normalizeAgent.test.ts`** — regression test for the codex-envelope mapping.
- **`cli/src/pi/runPi.test.ts`** — tighten the `/compact` thinking-state assertions: the last `keepAlive` must be `true` while the RPC is outstanding and `false` once it settles.
- **`web/src/components/assistant-ui/markdown-a.test.tsx`** — one-line cleanup of a duplicate `showSessionSummaryInChat` key introduced by #1530, which currently breaks `bun typecheck` on upstream/main (the push `Test` workflow is failing). Included because the PR's own CI cannot go green otherwise; no behavior change.

## Verification

- `bun typecheck` — exit 0 (cli/web/hub)
- `bun run test` — exit 0: cli 226 files / 2490 passed, web 259 files / 2475 passed (isolated TMPDIR)
- Targeted: web normalizeAgent 12/12, cli runPi 57/57