### PR TITLE
feat(cli): follow conversation language in status summaries

### DIFF
--- a/cli/src/modules/common/sessionSummaryInstruction.test.ts
+++ b/cli/src/modules/common/sessionSummaryInstruction.test.ts
@@ -9,6 +9,21 @@ import {
     withSessionSummaryInstruction
 } from './sessionSummaryInstruction'
 
+const PREVIOUS_SESSION_SUMMARY_INSTRUCTION = [
+    'Session status summary:',
+    'End every response with a single machine-readable status line (no backticks)',
+    'so this workspace\'s session tracking can record progress. Put it on its own',
+    'final line after all other content:',
+    'AGENT_NOTIFY_SUMMARY {"version":1,"agent":"<agent-id>","project":"<project>","status":"done|blocked|needs_review|needs_decision|failed|stalled","action":"<=12 words","summary":"one-line triage"}',
+    'Use status "blocked" if unsure. Keep action to 12 words or fewer when status',
+    'is "done" and follow-up remains.'
+].join('\n')
+
+const USER_LANGUAGE_INSTRUCTION = [
+    'Use the language used by the user in the current conversation for the',
+    'human-readable "action" and "summary" values.'
+].join('\n')
+
 describe('sessionSummaryInstruction', () => {
     afterEach(() => {
         resetSessionSummaryContractForTests()
@@ -49,6 +64,25 @@ describe('sessionSummaryInstruction', () => {
         expect(body.toLowerCase()).toContain('session tracking')
         expect(body.toLowerCase()).not.toContain('overseer')
         expect(body.toLowerCase()).not.toContain('surveillance')
+    })
+
+    it('adds user-language guidance without changing the existing prompt contract', () => {
+        applyHubSessionSummaryContract(true)
+        const body = sessionSummaryInstructionOrEmpty({})
+        const previousLines = PREVIOUS_SESSION_SUMMARY_INSTRUCTION.split('\n')
+        const expected = [
+            ...previousLines.slice(0, 5),
+            USER_LANGUAGE_INSTRUCTION,
+            ...previousLines.slice(5)
+        ].join('\n')
+
+        expect(body).toBe(expected)
+    })
+
+    it('preserves the exact machine-readable footer format', () => {
+        expect(SESSION_SUMMARY_CONTRACT_LINE).toBe(
+            'AGENT_NOTIFY_SUMMARY {"version":1,"agent":"<agent-id>","project":"<project>","status":"done|blocked|needs_review|needs_decision|failed|stalled","action":"<=12 words","summary":"one-line triage"}'
+        )
     })
 
     it('appends to an existing base prompt when enabled', () => {

--- a/cli/src/modules/common/sessionSummaryInstruction.ts
+++ b/cli/src/modules/common/sessionSummaryInstruction.ts
@@ -53,6 +53,8 @@ export function buildSessionSummaryInstruction(): string {
         'so this workspace\'s session tracking can record progress. Put it on its own',
         'final line after all other content:',
         SESSION_SUMMARY_CONTRACT_LINE,
+        'Use the language used by the user in the current conversation for the',
+        'human-readable "action" and "summary" values.',
         'Use status "blocked" if unsure. Keep action to 12 words or fewer when status',
         'is "done" and follow-up remains.'
     ].join('\n')


### PR DESCRIPTION
## Summary

- Update the optional `AGENT_NOTIFY_SUMMARY` instruction to use the language used by the user in the current conversation for human-readable `action` and `summary` values.
- Keep the change limited to the existing CLI prompt injection path.
- Preserve the machine-readable footer, JSON fields, status values, and action-length guidance.
- Add before/after prompt comparison and exact footer-format regression coverage.

## Problem / Motivation

The status-summary instruction is written in English, so agents may produce English human-readable values even when the user is communicating in Chinese or another language.

For this use case, prompt guidance based on the current conversation is sufficient and avoids the additional state, synchronization, and API surface required by a UI-locale-based implementation.

## Compatibility / Risk

- The `AGENT_NOTIFY_SUMMARY` parser contract is unchanged.
- No migration, configuration, or runtime service changes are required.
- Language selection is prompt-guided rather than enforced by a persisted locale; mixed-language conversations may be less deterministic.

## Validation

- `bunx vitest run src/modules/common/sessionSummaryInstruction.test.ts` from `cli/` — 9 passed.
- `bun run typecheck:cli` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name notify-summary-prompt-language -Suite Root -TestArgs terminal-wrap-fidelity.spec.ts` — 2 passed.
- `bun run test:web` — 259 files / 2,474 tests passed.
- `bun run test:shared` — 262 tests passed.
- `bun run build` — passed.
- `git diff --check` — passed.
- No Hub or Runner test environment was required for this prompt-only change.

## Related Issues

Refs #1532

## Related PRs

Supersedes #1548

## AI Assistance

AI-assisted with OpenAI Codex using GPT-5.6.