### PR TITLE
feat(hub): add background-only ServerChan fallback

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -188,6 +188,7 @@ On first run, HAPI:
 | `TELEGRAM_NOTIFICATION` | `true` | `telegramNotification` | Enable Telegram notifications |
 | `SERVERCHAN_SENDKEY` | - | `serverChanSendKey` | Server酱 (ServerChan) SendKey for push notifications |
 | `SERVERCHAN_NOTIFICATION` | `true` | `serverChanNotification` | Enable ServerChan notifications |
+| `SERVERCHAN_BACKGROUND_ONLY` | `false` | `serverChanBackgroundOnly` | Only send ServerChan notifications when no visible HAPI connection exists in the namespace |
 | `HAPI_RELAY_API` | `relay.hapi.run` | - | Relay API domain for the public relay |
 | `HAPI_RELAY_AUTH` | Per-hub key issued by the relay | `relayAuthKey` | Relay auth key override (set only when an operator provides a key) |
 | `HAPI_RELAY_FORCE_TCP` | `false` | - | Force TCP mode for relay |

--- a/docs/guide/notifications.md
+++ b/docs/guide/notifications.md
@@ -49,8 +49,11 @@ Messages include a link back to the session, built from `HAPI_PUBLIC_URL`.
 Related environment variables:
 
 - `SERVERCHAN_NOTIFICATION` - Enable/disable ServerChan notifications (default: `true`)
+- `SERVERCHAN_BACKGROUND_ONLY` - Only send ServerChan notifications when the namespace has no visible HAPI connection (default: `false`)
 
-Both values can also be set in `settings.json` (`serverChanSendKey`, `serverChanNotification`).
+When `SERVERCHAN_BACKGROUND_ONLY=true`, a visible HAPI connection suppresses ServerChan for the entire namespace. Hidden, disconnected, or closed HAPI pages do not count as visible, so ServerChan can act as a background fallback. This is namespace-wide and does not select a particular device.
+
+These values can also be set in `settings.json` (`serverChanSendKey`, `serverChanNotification`, `serverChanBackgroundOnly`).
 
 ## Voice assistant setup
 

--- a/docs/public/schemas/settings.schema.json
+++ b/docs/public/schemas/settings.schema.json
@@ -64,6 +64,11 @@
       "default": true,
       "description": "Enable ServerChan notifications. ENV: SERVERCHAN_NOTIFICATION"
     },
+    "serverChanBackgroundOnly": {
+      "type": "boolean",
+      "default": false,
+      "description": "Only send ServerChan notifications when no visible HAPI connection exists in the namespace. ENV: SERVERCHAN_BACKGROUND_ONLY"
+    },
     "relayAuthKey": {
       "type": "string",
       "description": "Per-hub relay auth key issued by the relay server. Auto-obtained if not set. ENV: HAPI_RELAY_AUTH"

--- a/hub/src/config/serverSettings.test.ts
+++ b/hub/src/config/serverSettings.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -11,6 +11,10 @@ function makeTempDir(): string {
 describe('loadServerSettings', () => {
     let dir: string | null = null
     const originalBackgroundOnly = process.env.SERVERCHAN_BACKGROUND_ONLY
+
+    beforeEach(() => {
+        delete process.env.SERVERCHAN_BACKGROUND_ONLY
+    })
 
     afterEach(() => {
         if (dir) {

--- a/hub/src/config/serverSettings.test.ts
+++ b/hub/src/config/serverSettings.test.ts
@@ -10,11 +10,17 @@ function makeTempDir(): string {
 
 describe('loadServerSettings', () => {
     let dir: string | null = null
+    const originalBackgroundOnly = process.env.SERVERCHAN_BACKGROUND_ONLY
 
     afterEach(() => {
         if (dir) {
             rmSync(dir, { recursive: true, force: true })
             dir = null
+        }
+        if (originalBackgroundOnly === undefined) {
+            delete process.env.SERVERCHAN_BACKGROUND_ONLY
+        } else {
+            process.env.SERVERCHAN_BACKGROUND_ONLY = originalBackgroundOnly
         }
     })
 
@@ -27,5 +33,39 @@ describe('loadServerSettings', () => {
         }))
 
         await expect(loadServerSettings(dir)).rejects.toThrow('Unsupported old settings field')
+    })
+
+    it('defaults ServerChan background-only mode to disabled', async () => {
+        dir = makeTempDir()
+
+        const result = await loadServerSettings(dir)
+
+        expect(result.settings.serverChanBackgroundOnly).toBe(false)
+        expect(result.sources.serverChanBackgroundOnly).toBe('default')
+    })
+
+    it('loads ServerChan background-only mode from settings.json', async () => {
+        dir = makeTempDir()
+        writeFileSync(join(dir, 'settings.json'), JSON.stringify({
+            serverChanBackgroundOnly: true
+        }))
+
+        const result = await loadServerSettings(dir)
+
+        expect(result.settings.serverChanBackgroundOnly).toBe(true)
+        expect(result.sources.serverChanBackgroundOnly).toBe('file')
+    })
+
+    it('loads ServerChan background-only mode with environment precedence', async () => {
+        dir = makeTempDir()
+        writeFileSync(join(dir, 'settings.json'), JSON.stringify({
+            serverChanBackgroundOnly: false
+        }))
+        process.env.SERVERCHAN_BACKGROUND_ONLY = 'true'
+
+        const result = await loadServerSettings(dir)
+
+        expect(result.settings.serverChanBackgroundOnly).toBe(true)
+        expect(result.sources.serverChanBackgroundOnly).toBe('env')
     })
 })

--- a/hub/src/config/serverSettings.test.ts
+++ b/hub/src/config/serverSettings.test.ts
@@ -68,4 +68,13 @@ describe('loadServerSettings', () => {
         expect(result.settings.serverChanBackgroundOnly).toBe(true)
         expect(result.sources.serverChanBackgroundOnly).toBe('env')
     })
+
+    it('rejects a non-boolean ServerChan background-only setting', async () => {
+        dir = makeTempDir()
+        writeFileSync(join(dir, 'settings.json'), JSON.stringify({
+            serverChanBackgroundOnly: 'false'
+        }))
+
+        await expect(loadServerSettings(dir)).rejects.toThrow('serverChanBackgroundOnly must be a boolean')
+    })
 })

--- a/hub/src/config/serverSettings.ts
+++ b/hub/src/config/serverSettings.ts
@@ -173,9 +173,11 @@ export async function loadServerSettings(dataDir: string): Promise<ServerSetting
                 settings.serverChanBackgroundOnly = serverChanBackgroundOnly
                 needsSave = true
             }
-        } else if (settings.serverChanBackgroundOnly !== undefined) {
+        } else if (typeof settings.serverChanBackgroundOnly === 'boolean') {
             serverChanBackgroundOnly = settings.serverChanBackgroundOnly
             sources.serverChanBackgroundOnly = 'file'
+        } else if (settings.serverChanBackgroundOnly !== undefined) {
+            throw new Error('serverChanBackgroundOnly must be a boolean')
         }
 
         // listenHost: env > file > default

--- a/hub/src/config/serverSettings.ts
+++ b/hub/src/config/serverSettings.ts
@@ -17,6 +17,7 @@ export interface ServerSettings {
     telegramNotification: boolean
     serverChanSendKey: string | null
     serverChanNotification: boolean
+    serverChanBackgroundOnly: boolean
     listenHost: string
     listenPort: number
     publicUrl: string
@@ -30,6 +31,7 @@ export interface ServerSettingsResult {
         telegramNotification: 'env' | 'file' | 'default'
         serverChanSendKey: 'env' | 'file' | 'default'
         serverChanNotification: 'env' | 'file' | 'default'
+        serverChanBackgroundOnly: 'env' | 'file' | 'default'
         listenHost: 'env' | 'file' | 'default'
         listenPort: 'env' | 'file' | 'default'
         publicUrl: 'env' | 'file' | 'default'
@@ -100,6 +102,7 @@ export async function loadServerSettings(dataDir: string): Promise<ServerSetting
             telegramNotification: 'default',
             serverChanSendKey: 'default',
             serverChanNotification: 'default',
+            serverChanBackgroundOnly: 'default',
             listenHost: 'default',
             listenPort: 'default',
             publicUrl: 'default',
@@ -159,6 +162,20 @@ export async function loadServerSettings(dataDir: string): Promise<ServerSetting
         } else if (settings.serverChanNotification !== undefined) {
             serverChanNotification = settings.serverChanNotification
             sources.serverChanNotification = 'file'
+        }
+
+        // serverChanBackgroundOnly: env > file > false
+        let serverChanBackgroundOnly = false
+        if (process.env.SERVERCHAN_BACKGROUND_ONLY !== undefined) {
+            serverChanBackgroundOnly = process.env.SERVERCHAN_BACKGROUND_ONLY === 'true'
+            sources.serverChanBackgroundOnly = 'env'
+            if (settings.serverChanBackgroundOnly === undefined) {
+                settings.serverChanBackgroundOnly = serverChanBackgroundOnly
+                needsSave = true
+            }
+        } else if (settings.serverChanBackgroundOnly !== undefined) {
+            serverChanBackgroundOnly = settings.serverChanBackgroundOnly
+            sources.serverChanBackgroundOnly = 'file'
         }
 
         // listenHost: env > file > default
@@ -232,6 +249,7 @@ export async function loadServerSettings(dataDir: string): Promise<ServerSetting
                     telegramNotification,
                     serverChanSendKey,
                     serverChanNotification,
+                    serverChanBackgroundOnly,
                     listenHost,
                     listenPort,
                     publicUrl,

--- a/hub/src/config/settings.ts
+++ b/hub/src/config/settings.ts
@@ -18,6 +18,7 @@ export interface Settings {
     telegramNotification?: boolean
     serverChanSendKey?: string
     serverChanNotification?: boolean
+    serverChanBackgroundOnly?: boolean
     listenHost?: string
     listenPort?: number
     publicUrl?: string

--- a/hub/src/configuration.ts
+++ b/hub/src/configuration.ts
@@ -11,6 +11,7 @@
  * - TELEGRAM_NOTIFICATION: Enable/disable Telegram notifications (default: true)
  * - SERVERCHAN_SENDKEY: Server酱 SendKey/AppKey for push notifications
  * - SERVERCHAN_NOTIFICATION: Enable/disable Server酱 notifications (default: true)
+ * - SERVERCHAN_BACKGROUND_ONLY: Only send Server酱 notifications without visible HAPI clients (default: false)
  * - HAPI_LISTEN_HOST: Host/IP to bind the HTTP service (default: 127.0.0.1)
  * - HAPI_LISTEN_PORT: Port for HTTP service (default: 3006)
  * - HAPI_PUBLIC_URL: Public URL for external access (e.g., Telegram Mini App)
@@ -38,6 +39,7 @@ export interface ConfigSources {
     telegramNotification: ConfigSource
     serverChanSendKey: ConfigSource
     serverChanNotification: ConfigSource
+    serverChanBackgroundOnly: ConfigSource
     listenHost: ConfigSource
     listenPort: ConfigSource
     publicUrl: ConfigSource
@@ -60,6 +62,9 @@ class Configuration {
 
     /** Server酱 notifications enabled */
     public readonly serverChanNotification: boolean
+
+    /** Only send Server酱 notifications when no visible HAPI client exists */
+    public readonly serverChanBackgroundOnly: boolean
 
     /** CLI auth token (shared secret) */
     public cliApiToken: string
@@ -111,6 +116,7 @@ class Configuration {
         this.telegramNotification = serverSettings.telegramNotification
         this.serverChanSendKey = serverSettings.serverChanSendKey
         this.serverChanNotification = serverSettings.serverChanNotification
+        this.serverChanBackgroundOnly = serverSettings.serverChanBackgroundOnly
         this.listenHost = serverSettings.listenHost
         this.listenPort = serverSettings.listenPort
         this.publicUrl = serverSettings.publicUrl

--- a/hub/src/serverchan/channel.test.ts
+++ b/hub/src/serverchan/channel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from 'bun:test'
 import type { SessionEndReason } from '@hapi/protocol'
 import type { Session } from '../sync/syncEngine'
+import { VisibilityTracker } from '../visibility/visibilityTracker'
 import { ServerChanChannel } from './channel'
 
 function createSession(overrides: Partial<Session> = {}): Session {
@@ -93,6 +94,104 @@ describe('ServerChanChannel', () => {
             const init = call?.[1] as RequestInit | undefined
             expect(String(url)).toContain('https://sctapi.ftqq.com/SCT_TEST.send')
             expect((init?.body as URLSearchParams).get('title')).toBe('HAPI Session completed')
+        } finally {
+            globalThis.fetch = originalFetch
+        }
+    })
+
+    it('suppresses every notification when the namespace has a visible connection', async () => {
+        const fetchMock = mock(async () => new Response('ok', { status: 200 }))
+        const originalFetch = globalThis.fetch
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        try {
+            const visibilityTracker = new VisibilityTracker()
+            visibilityTracker.registerConnection('visible-1', 'default', 'visible')
+            const channel = new ServerChanChannel(
+                'SCT_TEST',
+                'https://hapi.example.com',
+                visibilityTracker,
+                true
+            )
+
+            await channel.sendReady(createSession())
+            await channel.sendPermissionRequest(createSession())
+            await channel.sendTaskNotification(createSession(), {
+                status: 'failed',
+                summary: 'Subtask failed'
+            })
+            await channel.sendSessionCompletion(createSession(), 'completed' satisfies SessionEndReason)
+
+            expect(fetchMock).not.toHaveBeenCalled()
+        } finally {
+            globalThis.fetch = originalFetch
+        }
+    })
+
+    it('keeps sending when background-only mode is disabled', async () => {
+        const fetchMock = mock(async () => new Response('ok', { status: 200 }))
+        const originalFetch = globalThis.fetch
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        try {
+            const visibilityTracker = new VisibilityTracker()
+            visibilityTracker.registerConnection('visible-1', 'default', 'visible')
+            const channel = new ServerChanChannel(
+                'SCT_TEST',
+                'https://hapi.example.com',
+                visibilityTracker,
+                false
+            )
+
+            await channel.sendReady(createSession())
+
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+        } finally {
+            globalThis.fetch = originalFetch
+        }
+    })
+
+    it('sends when the namespace has no visible connection', async () => {
+        const fetchMock = mock(async () => new Response('ok', { status: 200 }))
+        const originalFetch = globalThis.fetch
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        try {
+            const visibilityTracker = new VisibilityTracker()
+            visibilityTracker.registerConnection('hidden-1', 'default', 'hidden')
+            const channel = new ServerChanChannel(
+                'SCT_TEST',
+                'https://hapi.example.com',
+                visibilityTracker,
+                true
+            )
+
+            await channel.sendReady(createSession())
+
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+        } finally {
+            globalThis.fetch = originalFetch
+        }
+    })
+
+    it('only considers visible connections in the same namespace', async () => {
+        const fetchMock = mock(async () => new Response('ok', { status: 200 }))
+        const originalFetch = globalThis.fetch
+        globalThis.fetch = fetchMock as unknown as typeof fetch
+
+        try {
+            const visibilityTracker = new VisibilityTracker()
+            visibilityTracker.registerConnection('visible-1', 'other-namespace', 'visible')
+            const channel = new ServerChanChannel(
+                'SCT_TEST',
+                'https://hapi.example.com',
+                visibilityTracker,
+                true
+            )
+
+            await channel.sendReady(createSession())
+
+            expect(fetchMock).toHaveBeenCalledTimes(1)
         } finally {
             globalThis.fetch = originalFetch
         }

--- a/hub/src/serverchan/channel.ts
+++ b/hub/src/serverchan/channel.ts
@@ -2,6 +2,7 @@ import type { Session } from '../sync/syncEngine'
 import type { SessionEndReason } from '@hapi/protocol'
 import type { NotificationChannel, TaskNotification } from '../notifications/notificationTypes'
 import { getAgentName, getSessionName } from '../notifications/sessionInfo'
+import type { VisibilityTracker } from '../visibility/visibilityTracker'
 
 function buildSessionUrl(baseUrl: string, sessionId: string): string {
     try {
@@ -15,11 +16,13 @@ function buildSessionUrl(baseUrl: string, sessionId: string): string {
 export class ServerChanChannel implements NotificationChannel {
     constructor(
         private readonly sendKey: string,
-        private readonly publicUrl: string
+        private readonly publicUrl: string,
+        private readonly visibilityTracker: VisibilityTracker | null = null,
+        private readonly backgroundOnly = false
     ) {}
 
     async sendReady(session: Session): Promise<void> {
-        if (!session.active) {
+        if (!session.active || this.shouldSuppress(session)) {
             return
         }
 
@@ -30,7 +33,7 @@ export class ServerChanChannel implements NotificationChannel {
     }
 
     async sendPermissionRequest(session: Session): Promise<void> {
-        if (!session.active) {
+        if (!session.active || this.shouldSuppress(session)) {
             return
         }
 
@@ -44,7 +47,7 @@ export class ServerChanChannel implements NotificationChannel {
     }
 
     async sendTaskNotification(session: Session, notification: TaskNotification): Promise<void> {
-        if (!session.active) {
+        if (!session.active || this.shouldSuppress(session)) {
             return
         }
 
@@ -60,6 +63,10 @@ export class ServerChanChannel implements NotificationChannel {
     }
 
     async sendSessionCompletion(session: Session, _reason: SessionEndReason): Promise<void> {
+        if (this.shouldSuppress(session)) {
+            return
+        }
+
         const agentName = getAgentName(session)
         const name = getSessionName(session)
         const url = buildSessionUrl(this.publicUrl, session.id)
@@ -85,5 +92,11 @@ export class ServerChanChannel implements NotificationChannel {
             const text = await response.text().catch(() => '')
             throw new Error(`Server酱发送失败: HTTP ${response.status} ${response.statusText}${text ? ` - ${text}` : ''}`)
         }
+    }
+
+    private shouldSuppress(session: Session): boolean {
+        return this.backgroundOnly
+            && this.visibilityTracker !== null
+            && this.visibilityTracker.hasVisibleConnection(session.namespace)
     }
 }

--- a/hub/src/startHub.ts
+++ b/hub/src/startHub.ts
@@ -156,8 +156,10 @@ export async function startHub(options: StartHubOptions = {}): Promise<HubInstan
     if (config.serverChanSendKey) {
         const source = formatSource(config.sources.serverChanSendKey)
         const notificationSource = formatSource(config.sources.serverChanNotification)
+        const backgroundOnlySource = formatSource(config.sources.serverChanBackgroundOnly)
         console.log(`[Hub] ServerChan: enabled (${source})`)
         console.log(`[Hub] ServerChan notifications: ${config.serverChanNotification ? 'enabled' : 'disabled'} (${notificationSource})`)
+        console.log(`[Hub] ServerChan background-only: ${config.serverChanBackgroundOnly ? 'enabled' : 'disabled'} (${backgroundOnlySource})`)
     } else {
         console.log('[Hub] ServerChan: disabled (no SERVERCHAN_SENDKEY)')
     }
@@ -232,7 +234,12 @@ export async function startHub(options: StartHubOptions = {}): Promise<HubInstan
     )
 
     if (config.serverChanSendKey && config.serverChanNotification) {
-        notificationChannels.push(new ServerChanChannel(config.serverChanSendKey, config.publicUrl))
+        notificationChannels.push(new ServerChanChannel(
+            config.serverChanSendKey,
+            config.publicUrl,
+            visibilityTracker,
+            config.serverChanBackgroundOnly
+        ))
     }
 
     // Initialize Telegram bot (optional)

--- a/web/src/hooks/useVisibilityReporter.test.ts
+++ b/web/src/hooks/useVisibilityReporter.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '@/api/client'
+import { useVisibilityReporter } from '@/hooks/useVisibilityReporter'
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+    Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: state,
+    })
+}
+
+function deferred<T>(): {
+    promise: Promise<T>
+    resolve: (value: T) => void
+} {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve
+    })
+    return { promise, resolve }
+}
+
+afterEach(() => {
+    setVisibilityState('visible')
+})
+
+describe('useVisibilityReporter', () => {
+    it('preserves a hidden transition that arrives while a visible report is pending', async () => {
+        const visibleReport = deferred<void>()
+        const api = {
+            setVisibility: vi.fn()
+                .mockImplementationOnce(() => visibleReport.promise)
+                .mockResolvedValue(undefined),
+        } as unknown as ApiClient
+
+        setVisibilityState('visible')
+        renderHook(() => useVisibilityReporter({ api, subscriptionId: 'sub-1' }))
+
+        expect(api.setVisibility).toHaveBeenCalledWith({
+            subscriptionId: 'sub-1',
+            visibility: 'visible',
+        })
+
+        setVisibilityState('hidden')
+        act(() => {
+            document.dispatchEvent(new Event('visibilitychange'))
+        })
+
+        expect(api.setVisibility).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            visibleReport.resolve(undefined)
+        })
+
+        expect(api.setVisibility).toHaveBeenNthCalledWith(2, {
+            subscriptionId: 'sub-1',
+            visibility: 'hidden',
+        })
+    })
+
+    it('preserves a visible transition that arrives while a hidden report is pending', async () => {
+        const hiddenReport = deferred<void>()
+        const api = {
+            setVisibility: vi.fn()
+                .mockImplementationOnce(() => hiddenReport.promise)
+                .mockResolvedValue(undefined),
+        } as unknown as ApiClient
+
+        setVisibilityState('hidden')
+        renderHook(() => useVisibilityReporter({ api, subscriptionId: 'sub-1' }))
+
+        expect(api.setVisibility).toHaveBeenCalledWith({
+            subscriptionId: 'sub-1',
+            visibility: 'hidden',
+        })
+
+        setVisibilityState('visible')
+        act(() => {
+            document.dispatchEvent(new Event('visibilitychange'))
+        })
+
+        expect(api.setVisibility).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            hiddenReport.resolve(undefined)
+        })
+
+        expect(api.setVisibility).toHaveBeenNthCalledWith(2, {
+            subscriptionId: 'sub-1',
+            visibility: 'visible',
+        })
+    })
+})

--- a/web/src/hooks/useVisibilityReporter.test.ts
+++ b/web/src/hooks/useVisibilityReporter.test.ts
@@ -91,4 +91,43 @@ describe('useVisibilityReporter', () => {
             visibility: 'visible',
         })
     })
+
+    it('does not let a previous subscription unlock a new report', async () => {
+        const oldReport = deferred<void>()
+        const newReport = deferred<void>()
+        const api = {
+            setVisibility: vi.fn()
+                .mockImplementationOnce(() => oldReport.promise)
+                .mockImplementationOnce(() => newReport.promise)
+                .mockResolvedValue(undefined),
+        } as unknown as ApiClient
+
+        setVisibilityState('visible')
+        const { rerender } = renderHook(
+            ({ subscriptionId }) => useVisibilityReporter({ api, subscriptionId }),
+            { initialProps: { subscriptionId: 'sub-old' } },
+        )
+
+        rerender({ subscriptionId: 'sub-new' })
+        expect(api.setVisibility).toHaveBeenCalledTimes(2)
+
+        await act(async () => {
+            oldReport.resolve(undefined)
+        })
+
+        setVisibilityState('hidden')
+        act(() => {
+            document.dispatchEvent(new Event('visibilitychange'))
+        })
+        expect(api.setVisibility).toHaveBeenCalledTimes(2)
+
+        await act(async () => {
+            newReport.resolve(undefined)
+        })
+
+        expect(api.setVisibility).toHaveBeenNthCalledWith(3, {
+            subscriptionId: 'sub-new',
+            visibility: 'hidden',
+        })
+    })
 })

--- a/web/src/hooks/useVisibilityReporter.ts
+++ b/web/src/hooks/useVisibilityReporter.ts
@@ -80,7 +80,9 @@ export function useVisibilityReporter(options: {
                     return
                 }
                 lastStateRef.current = desired
-                pendingStateRef.current = null
+                if (pendingStateRef.current === desired) {
+                    pendingStateRef.current = null
+                }
                 clearRetry()
             }).catch((error) => {
                 if (lastSubscriptionRef.current !== activeSubscription) {

--- a/web/src/hooks/useVisibilityReporter.ts
+++ b/web/src/hooks/useVisibilityReporter.ts
@@ -97,6 +97,9 @@ export function useVisibilityReporter(options: {
                     }, 2000)
                 }
             }).finally(() => {
+                if (lastSubscriptionRef.current !== activeSubscription) {
+                    return
+                }
                 inFlightRef.current = false
                 if (hadError || retryTimerRef.current) {
                     return


### PR DESCRIPTION
## Problem / Motivation

ServerChan is useful as a fallback for browsers that do not support HAPI Web Push, but it currently sends independently of HAPI foreground visibility. This can cause duplicate or unwanted notifications when a visible HAPI client is already showing in-app notifications.

## Summary

- Add opt-in `SERVERCHAN_BACKGROUND_ONLY` / `serverChanBackgroundOnly`, defaulting to `false`.
- Wire the existing `VisibilityTracker` into `ServerChanChannel`.
- In background-only mode, suppress ServerChan notifications when any visible SSE connection exists in the same namespace.
- Allow ServerChan delivery when the namespace has no visible connection, including hidden, disconnected, or closed HAPI pages.
- Document the namespace-wide behavior and add configuration/channel regression tests.
- Preserve existing default behavior and event coverage; this change does not add device-level routing or push-capability detection.

## Validation

- `bun test hub/src/serverchan/channel.test.ts hub/src/config/serverSettings.test.ts` — 11 passed.
- `cd hub && bun run typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name serverchan-background-fallback -Suite Root terminal-wrap-fidelity.spec.ts` — 2 passed.
- `bun run test:web` — 259 test files and 2474 tests passed.
- `bun run test:shared` — 262 passed.
- `bun run build` — passed.
- `bun run --cwd docs docs:build` — passed.
- `git diff --check` — passed.

## Related Issues

Fixes #1601

## AI Disclosure

AI-assisted with OpenAI Codex (GPT-5.6).
