### PR TITLE
fix(cursor): isolate HAPI MCP overlay to project mcp.json

### DIFF
--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -673,7 +673,7 @@ describe('cursorAcpRemoteLauncher', () => {
         });
     });
 
-    it('surfaces overlay install failure as a status message instead of failing closed silently', async () => {
+    it('surfaces overlay install failure as a status message and omits ACP mcpServers', async () => {
         const { MessageBuffer } = await import('@/ui/ink/messageBuffer');
         const addSpy = vi.spyOn(MessageBuffer.prototype, 'addMessage');
         harness.overlayInstallError = new Error(
@@ -687,6 +687,7 @@ describe('cursorAcpRemoteLauncher', () => {
             expect.stringContaining('HAPI MCP overlay unavailable'),
             'status',
         );
+        expect(harness.newSessionConfig?.mcpServers).toEqual([]);
         addSpy.mockRestore();
     });
 

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -30,6 +30,15 @@ const harness = vi.hoisted(() => ({
     stderrErrorHandler: null as ((error: { type: string; message: string; raw?: string }) => void) | null,
     disconnectError: null as Error | null,
     overlayCleanup: null as ReturnType<typeof vi.fn> | null,
+    overlayInstallError: null as Error | null,
+    overlayInstall: null as {
+        cwd: string;
+        serverId: string;
+        overlaySessionId?: string;
+        mcpConfigDir?: string;
+        userMcpConfigDir?: string;
+    } | null,
+    newSessionConfig: null as { cwd?: string; mcpServers?: unknown } | null,
     agentActivityListener: null as ((thinking: boolean) => void) | null
 }));
 
@@ -70,9 +79,10 @@ vi.mock('./utils/cursorAcpBackend', () => ({
                 if (harness.loadSessionError) throw harness.loadSessionError;
                 return 'loaded-acp-session';
             }),
-            newSession: vi.fn(async () => {
+            newSession: vi.fn(async (config: { cwd?: string; mcpServers?: unknown }) => {
                 harness.newSessionAttempts += 1;
                 harness.newSessionCalled = true;
+                harness.newSessionConfig = config;
                 if (harness.newSessionError && harness.newSessionAttempts === 1) {
                     harness.stderrErrorHandler?.({
                         type: 'model_not_found',
@@ -189,8 +199,29 @@ vi.mock('@/codex/utils/buildHapiMcpBridge', () => ({
 }));
 
 vi.mock('./utils/cursorMcpOverlay', () => ({
+    CURSOR_HAPI_MCP_SERVER_ID: 'hapi',
     cursorHapiMcpServerId: (sessionId: string) => `hapi-${sessionId}`,
-    installCursorMcpOverlay: () => {
+    resolveCursorMcpConfigDir: () => '/tmp/fake-user-cursor',
+    installCursorMcpOverlay: (
+        cwd: string,
+        _bridge: unknown,
+        options: {
+            serverId: string;
+            overlaySessionId?: string;
+            mcpConfigDir?: string;
+            userMcpConfigDir?: string;
+        },
+    ) => {
+        if (harness.overlayInstallError) {
+            throw harness.overlayInstallError;
+        }
+        harness.overlayInstall = {
+            cwd,
+            serverId: options.serverId,
+            overlaySessionId: options.overlaySessionId,
+            mcpConfigDir: options.mcpConfigDir,
+            userMcpConfigDir: options.userMcpConfigDir,
+        };
         harness.overlayCleanup = vi.fn();
         return { cleanup: harness.overlayCleanup };
     },
@@ -281,6 +312,9 @@ describe('cursorAcpRemoteLauncher', () => {
         harness.stderrErrorHandler = null;
         harness.disconnectError = null;
         harness.overlayCleanup = null;
+        harness.overlayInstallError = null;
+        harness.overlayInstall = null;
+        harness.newSessionConfig = null;
         harness.agentActivityListener = null;
         legacyLauncher.mockClear();
         process.stdin.isTTY = false;
@@ -621,6 +655,39 @@ describe('cursorAcpRemoteLauncher', () => {
 
         await expect(cursorAcpRemoteLauncher(session)).rejects.toThrow('disconnect failed');
         expect(harness.overlayCleanup).toHaveBeenCalled();
+        expect(harness.overlayInstall).toEqual({
+            cwd: '/tmp/project',
+            serverId: 'hapi',
+            overlaySessionId: 'test-session-id',
+            mcpConfigDir: '/tmp/project/.cursor',
+            userMcpConfigDir: '/tmp/fake-user-cursor',
+        });
+        expect(harness.newSessionConfig).toEqual({
+            cwd: '/tmp/project',
+            mcpServers: [{
+                name: 'hapi',
+                command: 'hapi',
+                args: ['mcp', '--url', 'http://127.0.0.1:1/'],
+                env: [],
+            }],
+        });
+    });
+
+    it('surfaces overlay install failure as a status message instead of failing closed silently', async () => {
+        const { MessageBuffer } = await import('@/ui/ink/messageBuffer');
+        const addSpy = vi.spyOn(MessageBuffer.prototype, 'addMessage');
+        harness.overlayInstallError = new Error(
+            'Cannot install a second live HAPI MCP mailbox in this workspace (held by session other).',
+        );
+        const session = makeSession(null);
+
+        await cursorAcpRemoteLauncher(session);
+
+        expect(addSpy).toHaveBeenCalledWith(
+            expect.stringContaining('HAPI MCP overlay unavailable'),
+            'status',
+        );
+        addSpy.mockRestore();
     });
 
 

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import React from 'react';
 import { randomUUID } from 'node:crypto';
 import { logger } from '@/ui/logger';
@@ -36,8 +37,9 @@ import type { AcpSdkBackend } from '@/agent/backends/acp';
 import type { AcpStderrError } from '@/agent/backends/acp/AcpStdioTransport';
 import { registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
 import {
-    cursorHapiMcpServerId,
+    CURSOR_HAPI_MCP_SERVER_ID,
     installCursorMcpOverlay,
+    resolveCursorMcpConfigDir,
     type CursorMcpOverlayHandle,
 } from './utils/cursorMcpOverlay';
 import {
@@ -108,12 +110,20 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                     command: hapiBridge.command,
                     args: hapiBridge.args,
                 }, {
-                    serverId: cursorHapiMcpServerId(session.client.sessionId),
+                    serverId: CURSOR_HAPI_MCP_SERVER_ID,
+                    overlaySessionId: session.client.sessionId,
+                    mcpConfigDir: join(session.path, '.cursor'),
+                    userMcpConfigDir: resolveCursorMcpConfigDir(),
                 });
             } catch (error) {
+                const detail = error instanceof Error ? error.message : String(error);
                 logger.warn(
                     '[cursor-acp] failed to install HAPI MCP overlay; continuing without inline media',
                     error,
+                );
+                messageBuffer.addMessage(
+                    `HAPI MCP overlay unavailable (${detail}). Inline media / peer MCP tools disabled for this session.`,
+                    'status',
                 );
                 this.cursorMcpOverlay = { cleanup: () => {} };
             }
@@ -226,8 +236,14 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
         );
 
         const resumeSessionId = session.sessionId;
-        // Cursor ACP ignores session/new|load mcpServers; native ~/.cursor/mcp.json is wired above.
-        const mcpServerList: McpServerStdio[] = [];
+        // Overlay isolates one project `hapi` mailbox. Also pass ACP mcpServers so a
+        // Cursor build that honors session/new attaches the same HappyServer (same name).
+        const mcpServerList: McpServerStdio[] = Object.entries(mcpServers).map(([name, entry]) => ({
+            name,
+            command: entry.command,
+            args: entry.args,
+            env: [],
+        }));
         let acpSessionId: string | undefined;
 
         for (let loadAttempt = 0; loadAttempt < 2; loadAttempt += 1) {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -104,6 +104,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
         this.happyServer = happyServer;
 
         const hapiBridge = mcpServers.hapi;
+        let overlayInstalled = false;
         if (hapiBridge) {
             try {
                 this.cursorMcpOverlay = installCursorMcpOverlay(session.path, {
@@ -115,6 +116,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                     mcpConfigDir: join(session.path, '.cursor'),
                     userMcpConfigDir: resolveCursorMcpConfigDir(),
                 });
+                overlayInstalled = true;
             } catch (error) {
                 const detail = error instanceof Error ? error.message : String(error);
                 logger.warn(
@@ -238,12 +240,16 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
         const resumeSessionId = session.sessionId;
         // Overlay isolates one project `hapi` mailbox. Also pass ACP mcpServers so a
         // Cursor build that honors session/new attaches the same HappyServer (same name).
-        const mcpServerList: McpServerStdio[] = Object.entries(mcpServers).map(([name, entry]) => ({
-            name,
-            command: entry.command,
-            args: entry.args,
-            env: [],
-        }));
+        // Fail closed on overlay install failure: do not attach ACP MCP either — otherwise
+        // a same-cwd collision can still bridge while project `hapi` belongs to another session.
+        const mcpServerList: McpServerStdio[] = (!hapiBridge || overlayInstalled)
+            ? Object.entries(mcpServers).map(([name, entry]) => ({
+                name,
+                command: entry.command,
+                args: entry.args,
+                env: [],
+            }))
+            : [];
         let acpSessionId: string | undefined;
 
         for (let loadAttempt = 0; loadAttempt < 2; loadAttempt += 1) {

--- a/cli/src/cursor/utils/cursorMcpOverlay.test.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import {
     existsSync,
     linkSync,
@@ -14,6 +14,7 @@ import {
     writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { homedir, tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import {
@@ -22,15 +23,21 @@ import {
     cursorHapiMcpServerId,
     HAPI_MCP_OVERLAY_SESSION_ENV,
     HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX,
+    appendExcludeLease,
+    appendExcludeLeaseUnlocked,
+    hapiMcpGitExcludeMarker,
     installCursorMcpOverlay,
     isProcessAlive,
     readLockOwner,
+    removeExcludeLease,
     resolveCursorMcpConfigDir,
     resolveProjectCursorConfigDir,
     shieldProjectMcpJsonFromGit,
     withMcpJsonLock,
     writeMcpJsonAtomic,
 } from './cursorMcpOverlay';
+
+const overlayModulePath = fileURLToPath(new URL('./cursorMcpOverlay.ts', import.meta.url));
 
 describe('installCursorMcpOverlay', () => {
     const roots: string[] = [];
@@ -613,6 +620,70 @@ describe('installCursorMcpOverlay', () => {
         rmSync(root, { recursive: true, force: true });
         rmSync(linked, { recursive: true, force: true });
     });
+
+    it('serializes concurrent exclude lease updates across processes', async () => {
+        const root = join(tmpdir(), `hapi-mcp-git-race-${randomUUID()}`);
+        mkdirSync(join(root, '.git', 'info'), { recursive: true });
+        const excludePath = join(root, '.git', 'info', 'exclude');
+        writeFileSync(excludePath, 'keep-me.txt\n', 'utf-8');
+        const lockPath = `${excludePath}.hapi.lock`;
+        const donePath = join(root, 'child-done');
+        const errPath = join(root, 'child-err');
+        const leaseA = 'lease-a';
+        const leaseB = 'lease-b';
+
+        // Hold the lock first so the child must wait mid-flight.
+        const childExit = new Promise<number>((resolve, reject) => {
+            withMcpJsonLock(lockPath, () => {
+                appendExcludeLeaseUnlocked(excludePath, '.cursor/mcp.json', leaseA);
+                const child = spawn('bun', [
+                    '-e',
+                    `
+                        import { appendExcludeLease } from ${JSON.stringify(overlayModulePath)};
+                        try {
+                            appendExcludeLease(${JSON.stringify(excludePath)}, '.cursor/mcp.json', ${JSON.stringify(leaseB)});
+                            await Bun.write(${JSON.stringify(donePath)}, 'ok');
+                            process.exit(0);
+                        } catch (error) {
+                            await Bun.write(${JSON.stringify(errPath)}, String(error));
+                            process.exit(1);
+                        }
+                    `,
+                ], {
+                    cwd: root,
+                    stdio: 'ignore',
+                });
+                child.on('error', reject);
+                child.on('exit', (code) => resolve(code ?? 1));
+                // Keep holding until the child has had time to enter the wait loop.
+                const end = Date.now() + 400;
+                while (Date.now() < end) {
+                    // busy-wait
+                }
+            });
+        });
+
+        const code = await childExit;
+        if (existsSync(errPath)) {
+            throw new Error(`child failed: ${readFileSync(errPath, 'utf-8')}`);
+        }
+        expect(code).toBe(0);
+        expect(existsSync(donePath)).toBe(true);
+
+        const both = readFileSync(excludePath, 'utf-8');
+        expect(both).toContain('keep-me.txt');
+        expect(both).toContain(hapiMcpGitExcludeMarker(leaseA));
+        expect(both).toContain(hapiMcpGitExcludeMarker(leaseB));
+
+        removeExcludeLease(excludePath, '.cursor/mcp.json', leaseA);
+        const afterA = readFileSync(excludePath, 'utf-8');
+        expect(afterA).toContain(hapiMcpGitExcludeMarker(leaseB));
+        expect(afterA).toContain('keep-me.txt');
+        expect(afterA).not.toContain(hapiMcpGitExcludeMarker(leaseA));
+
+        removeExcludeLease(excludePath, '.cursor/mcp.json', leaseB);
+        rmSync(root, { recursive: true, force: true });
+    }, 20_000);
 
     it('writes exclude via --git-path so linked worktrees share the common exclude', () => {
         const root = join(tmpdir(), `hapi-mcp-git-wt-main-${randomUUID()}`);

--- a/cli/src/cursor/utils/cursorMcpOverlay.test.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.test.ts
@@ -21,7 +21,7 @@ import {
     HAPI_MCP_OVERLAY_PID_ENV,
     cursorHapiMcpServerId,
     HAPI_MCP_OVERLAY_SESSION_ENV,
-    HAPI_MCP_GIT_EXCLUDE_MARKER,
+    HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX,
     installCursorMcpOverlay,
     isProcessAlive,
     readLockOwner,
@@ -513,7 +513,7 @@ describe('installCursorMcpOverlay', () => {
         });
 
         const exclude = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
-        expect(exclude).toContain(HAPI_MCP_GIT_EXCLUDE_MARKER);
+        expect(exclude).toContain(HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX);
         expect(exclude).toContain('.cursor/mcp.json');
         const check = spawnSync('git', ['check-ignore', '-v', '--', '.cursor/mcp.json'], {
             cwd: root,
@@ -523,9 +523,95 @@ describe('installCursorMcpOverlay', () => {
 
         handle.cleanup();
         const after = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
-        expect(after).not.toContain(HAPI_MCP_GIT_EXCLUDE_MARKER);
+        expect(after).not.toContain(HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX);
         expect(after).not.toContain('.cursor/mcp.json');
         rmSync(root, { recursive: true, force: true });
+    });
+
+    it('preserves pre-existing .git/info/exclude rules across install and cleanup', () => {
+        const root = join(tmpdir(), `hapi-mcp-git-preserve-${randomUUID()}`);
+        mkdirSync(root, { recursive: true });
+        spawnSync('git', ['init'], { cwd: root, encoding: 'utf-8' });
+        spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+        spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
+        writeFileSync(join(root, 'README'), 'x\n');
+        spawnSync('git', ['add', 'README'], { cwd: root });
+        spawnSync('git', ['commit', '-m', 'init'], { cwd: root });
+        mkdirSync(join(root, '.git', 'info'), { recursive: true });
+        writeFileSync(join(root, '.git', 'info', 'exclude'), 'local-secret.txt\n*.local.bak\n', 'utf-8');
+
+        const handle = installCursorMcpOverlay(root, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(root, '.cursor'),
+        });
+
+        const mid = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
+        expect(mid).toContain('local-secret.txt');
+        expect(mid).toContain('*.local.bak');
+        expect(mid).toContain('.cursor/mcp.json');
+
+        handle.cleanup();
+        const after = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
+        expect(after).toContain('local-secret.txt');
+        expect(after).toContain('*.local.bak');
+        expect(after).not.toContain(HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX);
+        expect(after).not.toContain('.cursor/mcp.json');
+        rmSync(root, { recursive: true, force: true });
+    });
+
+    it('keeps shared exclude while a sibling worktree lease is still live', () => {
+        const root = join(tmpdir(), `hapi-mcp-git-lease-main-${randomUUID()}`);
+        const linked = join(tmpdir(), `hapi-mcp-git-lease-link-${randomUUID()}`);
+        mkdirSync(root, { recursive: true });
+        spawnSync('git', ['init'], { cwd: root, encoding: 'utf-8' });
+        spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+        spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
+        writeFileSync(join(root, 'README'), 'x\n');
+        spawnSync('git', ['add', 'README'], { cwd: root });
+        spawnSync('git', ['commit', '-m', 'init'], { cwd: root });
+        expect(spawnSync('git', ['worktree', 'add', linked, 'HEAD'], {
+            cwd: root,
+            encoding: 'utf-8',
+        }).status).toBe(0);
+
+        const handleA = installCursorMcpOverlay(root, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(root, '.cursor'),
+        });
+        const handleB = installCursorMcpOverlay(linked, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-b',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(linked, '.cursor'),
+        });
+
+        handleA.cleanup();
+        const mid = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
+        expect(mid).toContain('.cursor/mcp.json');
+        expect(spawnSync('git', ['check-ignore', '-v', '--', '.cursor/mcp.json'], {
+            cwd: linked,
+            encoding: 'utf-8',
+        }).status).toBe(0);
+
+        handleB.cleanup();
+        const after = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
+        expect(after).not.toContain('.cursor/mcp.json');
+        spawnSync('git', ['worktree', 'remove', '--force', linked], { cwd: root, encoding: 'utf-8' });
+        rmSync(root, { recursive: true, force: true });
+        rmSync(linked, { recursive: true, force: true });
     });
 
     it('writes exclude via --git-path so linked worktrees share the common exclude', () => {

--- a/cli/src/cursor/utils/cursorMcpOverlay.test.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.test.ts
@@ -21,11 +21,13 @@ import {
     HAPI_MCP_OVERLAY_PID_ENV,
     cursorHapiMcpServerId,
     HAPI_MCP_OVERLAY_SESSION_ENV,
+    HAPI_MCP_GIT_EXCLUDE_MARKER,
     installCursorMcpOverlay,
     isProcessAlive,
     readLockOwner,
     resolveCursorMcpConfigDir,
     resolveProjectCursorConfigDir,
+    shieldProjectMcpJsonFromGit,
     withMcpJsonLock,
     writeMcpJsonAtomic,
 } from './cursorMcpOverlay';
@@ -487,6 +489,76 @@ describe('installCursorMcpOverlay', () => {
         };
         expect(written.mcpServers[CURSOR_HAPI_MCP_SERVER_ID]).toBeTruthy();
         handle.cleanup();
+        rmSync(root, { recursive: true, force: true });
+    });
+
+    it('adds project mcp.json to .git/info/exclude so git add -A will not scoop the mailbox', () => {
+        const root = join(tmpdir(), `hapi-mcp-git-shield-${randomUUID()}`);
+        mkdirSync(root, { recursive: true });
+        spawnSync('git', ['init'], { cwd: root, encoding: 'utf-8' });
+        spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+        spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
+        writeFileSync(join(root, 'README'), 'x\n');
+        spawnSync('git', ['add', 'README'], { cwd: root });
+        spawnSync('git', ['commit', '-m', 'init'], { cwd: root });
+
+        const handle = installCursorMcpOverlay(root, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(root, '.cursor'),
+        });
+
+        const exclude = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
+        expect(exclude).toContain(HAPI_MCP_GIT_EXCLUDE_MARKER);
+        expect(exclude).toContain('.cursor/mcp.json');
+        const check = spawnSync('git', ['check-ignore', '-v', '--', '.cursor/mcp.json'], {
+            cwd: root,
+            encoding: 'utf-8',
+        });
+        expect(check.status).toBe(0);
+
+        handle.cleanup();
+        rmSync(root, { recursive: true, force: true });
+    });
+
+    it('skip-worktrees a tracked project mcp.json for the session lifetime', () => {
+        const root = join(tmpdir(), `hapi-mcp-git-skip-${randomUUID()}`);
+        mkdirSync(join(root, '.cursor'), { recursive: true });
+        spawnSync('git', ['init'], { cwd: root, encoding: 'utf-8' });
+        spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+        spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
+        writeFileSync(join(root, '.cursor', 'mcp.json'), `${JSON.stringify({
+            mcpServers: { other: { command: 'echo', args: ['x'] } },
+        }, null, 2)}\n`);
+        spawnSync('git', ['add', '.cursor/mcp.json'], { cwd: root });
+        spawnSync('git', ['commit', '-m', 'track mcp'], { cwd: root });
+
+        const handle = installCursorMcpOverlay(root, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(root, '.cursor'),
+        });
+
+        const skipped = spawnSync('git', ['ls-files', '-v', '--', '.cursor/mcp.json'], {
+            cwd: root,
+            encoding: 'utf-8',
+        });
+        expect(skipped.stdout.trim().startsWith('S ')).toBe(true);
+
+        handle.cleanup();
+        const after = spawnSync('git', ['ls-files', '-v', '--', '.cursor/mcp.json'], {
+            cwd: root,
+            encoding: 'utf-8',
+        });
+        expect(after.stdout.trim().startsWith('S ')).toBe(false);
         rmSync(root, { recursive: true, force: true });
     });
 

--- a/cli/src/cursor/utils/cursorMcpOverlay.test.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.test.ts
@@ -20,6 +20,7 @@ import {
     CURSOR_HAPI_MCP_SERVER_ID,
     HAPI_MCP_OVERLAY_PID_ENV,
     cursorHapiMcpServerId,
+    HAPI_MCP_OVERLAY_SESSION_ENV,
     installCursorMcpOverlay,
     isProcessAlive,
     readLockOwner,
@@ -55,31 +56,38 @@ describe('installCursorMcpOverlay', () => {
         expect(resolveCursorMcpConfigDir(' /tmp/custom-cursor ')).toBe('/tmp/custom-cursor');
     });
 
-    it('writes per-session bridge into .cursor/mcp.json and removes only that id on cleanup', () => {
+    it('writes the stable hapi mailbox into the project mcp.json and removes it on cleanup', () => {
         const cwd = makeProjectDir(JSON.stringify({
             mcpServers: {
                 other: { command: 'echo', args: ['x'] },
             },
         }, null, 2));
-        const serverId = cursorHapiMcpServerId('session-a');
-
+        const serverId = CURSOR_HAPI_MCP_SERVER_ID;
         const mcpPath = join(cwd, '.cursor', 'mcp.json');
 
         const handle = installCursorMcpOverlay(cwd, {
             command: '/bin/hapi',
             args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
-        }, { serverId, enableCursorMcp: noopEnable, mcpConfigDir: join(cwd, '.cursor') });
+        }, {
+            serverId,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(cwd, '.cursor'),
+        });
 
         const merged = JSON.parse(readFileSync(mcpPath, 'utf-8')) as {
-            mcpServers: Record<string, { command: string; args: string[] }>;
+            mcpServers: Record<string, { command: string; args: string[]; env?: Record<string, string> }>;
         };
         expect(merged.mcpServers.other).toEqual({ command: 'echo', args: ['x'] });
         expect(merged.mcpServers[serverId]).toEqual({
             command: '/bin/hapi',
             args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
-            env: { [HAPI_MCP_OVERLAY_PID_ENV]: String(process.pid) },
+            env: {
+                [HAPI_MCP_OVERLAY_PID_ENV]: String(process.pid),
+                [HAPI_MCP_OVERLAY_SESSION_ENV]: 'session-a',
+            },
         });
-        expect(merged.mcpServers[CURSOR_HAPI_MCP_SERVER_ID]).toBeUndefined();
+        expect(Object.keys(merged.mcpServers).filter((id) => id.startsWith('hapi-'))).toEqual([]);
 
         handle.cleanup();
         const after = JSON.parse(readFileSync(mcpPath, 'utf-8')) as {
@@ -89,45 +97,114 @@ describe('installCursorMcpOverlay', () => {
         expect(after.mcpServers[serverId]).toBeUndefined();
     });
 
-    it('leaves a newer session bridge intact when an older session cleans up first', () => {
-        const cwd = makeProjectDir(JSON.stringify({
+    it('strips dead hapi-* keys from user mcp.json but keeps live sibling overlays', () => {
+        const cwd = makeProjectDir();
+        const userDir = join(cwd, 'user-cursor');
+        mkdirSync(userDir, { recursive: true });
+        const probe = spawnSync(process.execPath, ['-e', ''], { encoding: 'utf-8' });
+        const deadPid = probe.pid;
+        expect(typeof deadPid).toBe('number');
+        expect(isProcessAlive(deadPid!)).toBe(false);
+        writeFileSync(join(userDir, 'mcp.json'), JSON.stringify({
             mcpServers: {
-                other: { command: 'echo', args: ['x'] },
+                playwright: { command: 'echo', args: ['pw'] },
+                [cursorHapiMcpServerId('dead')]: {
+                    command: '/bin/hapi',
+                    args: ['mcp', '--url', 'http://127.0.0.1:8888/'],
+                    env: { [HAPI_MCP_OVERLAY_PID_ENV]: String(deadPid) },
+                },
+                [cursorHapiMcpServerId('sibling')]: {
+                    command: '/bin/hapi',
+                    args: ['mcp', '--url', 'http://127.0.0.1:9999/'],
+                    env: { [HAPI_MCP_OVERLAY_PID_ENV]: String(process.pid) },
+                },
             },
         }, null, 2));
-        const mcpPath = join(cwd, '.cursor', 'mcp.json');
-        const idA = cursorHapiMcpServerId('session-a');
-        const idB = cursorHapiMcpServerId('session-b');
 
-        const handleA = installCursorMcpOverlay(cwd, {
+        installCursorMcpOverlay(cwd, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(cwd, '.cursor'),
+            userMcpConfigDir: userDir,
+        }).cleanup();
+
+        const user = JSON.parse(readFileSync(join(userDir, 'mcp.json'), 'utf-8')) as {
+            mcpServers: Record<string, unknown>;
+        };
+        expect(user.mcpServers.playwright).toEqual({ command: 'echo', args: ['pw'] });
+        expect(user.mcpServers[cursorHapiMcpServerId('dead')]).toBeUndefined();
+        expect(user.mcpServers[cursorHapiMcpServerId('sibling')]).toBeDefined();
+        expect(user.mcpServers[CURSOR_HAPI_MCP_SERVER_ID]).toBeUndefined();
+    });
+
+    it('keeps one mailbox per project when two sessions use different cwds', () => {
+        const userDir = join(tmpdir(), `hapi-cursor-user-${randomUUID()}`);
+        mkdirSync(userDir, { recursive: true });
+        roots.push(userDir);
+        const cwdA = makeProjectDir();
+        const cwdB = makeProjectDir();
+
+        const handleA = installCursorMcpOverlay(cwdA, {
             command: '/bin/hapi',
             args: ['mcp', '--url', 'http://127.0.0.1:1111/'],
-        }, { serverId: idA, enableCursorMcp: noopEnable, mcpConfigDir: join(cwd, '.cursor') });
-
-        const handleB = installCursorMcpOverlay(cwd, {
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(cwdA, '.cursor'),
+            userMcpConfigDir: userDir,
+        });
+        const handleB = installCursorMcpOverlay(cwdB, {
             command: '/bin/hapi',
             args: ['mcp', '--url', 'http://127.0.0.1:2222/'],
-        }, { serverId: idB, enableCursorMcp: noopEnable, mcpConfigDir: join(cwd, '.cursor') });
-
-        handleA.cleanup();
-
-        const afterA = JSON.parse(readFileSync(mcpPath, 'utf-8')) as {
-            mcpServers: Record<string, { command: string; args: string[] }>;
-        };
-        expect(afterA.mcpServers[idA]).toBeUndefined();
-        expect(afterA.mcpServers[idB]).toEqual({
-            command: '/bin/hapi',
-            args: ['mcp', '--url', 'http://127.0.0.1:2222/'],
-            env: { [HAPI_MCP_OVERLAY_PID_ENV]: String(process.pid) },
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-b',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(cwdB, '.cursor'),
+            userMcpConfigDir: userDir,
         });
 
-        handleB.cleanup();
-
-        const afterB = JSON.parse(readFileSync(mcpPath, 'utf-8')) as {
-            mcpServers: Record<string, { command: string; args: string[] }>;
+        const a = JSON.parse(readFileSync(join(cwdA, '.cursor', 'mcp.json'), 'utf-8')) as {
+            mcpServers: Record<string, { args: string[] }>;
         };
-        expect(afterB.mcpServers[idB]).toBeUndefined();
-        expect(afterB.mcpServers.other).toEqual({ command: 'echo', args: ['x'] });
+        const b = JSON.parse(readFileSync(join(cwdB, '.cursor', 'mcp.json'), 'utf-8')) as {
+            mcpServers: Record<string, { args: string[] }>;
+        };
+        expect(a.mcpServers.hapi.args).toContain('http://127.0.0.1:1111/');
+        expect(b.mcpServers.hapi.args).toContain('http://127.0.0.1:2222/');
+        expect(existsSync(join(userDir, 'mcp.json')) ? JSON.parse(readFileSync(join(userDir, 'mcp.json'), 'utf-8')).mcpServers : {}).toEqual({});
+
+        handleA.cleanup();
+        expect(JSON.parse(readFileSync(join(cwdB, '.cursor', 'mcp.json'), 'utf-8')).mcpServers.hapi.args).toContain('http://127.0.0.1:2222/');
+        handleB.cleanup();
+    });
+
+    it('refuses a second live mailbox in the same cwd instead of multiplex keys', () => {
+        const cwd = makeProjectDir();
+        installCursorMcpOverlay(cwd, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:1111/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(cwd, '.cursor'),
+        });
+
+        expect(() => installCursorMcpOverlay(cwd, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:2222/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-b',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(cwd, '.cursor'),
+        })).toThrow(/second live HAPI MCP mailbox/);
     });
 
     it('preserves mcpServers keys added during the session on cleanup', () => {
@@ -350,12 +427,34 @@ describe('installCursorMcpOverlay', () => {
             mcpServers: Record<string, { command: string; args?: string[]; env?: Record<string, string> }>;
         };
         expect(merged.mcpServers['hapi-dead']).toBeUndefined();
-        expect(merged.mcpServers['hapi-live']?.command).toBe('/bin/hapi');
+        expect(merged.mcpServers['hapi-live']).toEqual({
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:2222/'],
+            env: { [HAPI_MCP_OVERLAY_PID_ENV]: String(process.pid) },
+        });
         expect(merged.mcpServers['hapi-user']?.command).toBe('user-owned');
         expect(merged.mcpServers.other).toEqual({ command: 'echo', args: ['x'] });
         expect(merged.mcpServers[serverId]?.env?.[HAPI_MCP_OVERLAY_PID_ENV]).toBe(String(process.pid));
 
         handle.cleanup();
+    });
+
+    it('refuses a symlinked project .cursor directory (attacker escape to ~/.cursor)', () => {
+        const cwd = makeProjectDir();
+        const realCursorDir = join(cwd, 'real-cursor');
+        mkdirSync(realCursorDir, { recursive: true });
+        writeFileSync(join(realCursorDir, 'mcp.json'), `${JSON.stringify({ mcpServers: {} }, null, 2)}\n`);
+        symlinkSync(realCursorDir, join(cwd, '.cursor'));
+
+        expect(() => installCursorMcpOverlay(cwd, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(cwd, '.cursor'),
+        })).toThrow(/Refusing a symlinked project Cursor config dir/);
     });
 
     it('refuses a symlinked .cursor/mcp.json and leaves the external target unchanged', () => {
@@ -383,23 +482,68 @@ describe('installCursorMcpOverlay', () => {
         expect(readFileSync(realConfig, 'utf-8')).toBe(original);
     });
 
-    it('refuses a symlinked .cursor directory before mutating MCP config', () => {
+    it('follows a symlinked user Cursor dir (HOME/.cursor → estate disk) when stripping', () => {
         const cwd = makeProjectDir();
-        const realCursorDir = join(cwd, 'real-cursor');
-        mkdirSync(realCursorDir, { recursive: true });
-        const externalMcp = join(realCursorDir, 'mcp.json');
-        const original = `${JSON.stringify({ mcpServers: {} }, null, 2)}\n`;
-        writeFileSync(externalMcp, original, 'utf-8');
-        symlinkSync(realCursorDir, join(cwd, '.cursor'));
+        const realUserDir = join(cwd, 'estate-user-cursor');
+        mkdirSync(realUserDir, { recursive: true });
+        const probe = spawnSync(process.execPath, ['-e', ''], { encoding: 'utf-8' });
+        const deadPid = probe.pid!;
+        writeFileSync(join(realUserDir, 'mcp.json'), JSON.stringify({
+            mcpServers: {
+                [cursorHapiMcpServerId('dead')]: {
+                    command: '/bin/hapi',
+                    args: ['mcp'],
+                    env: { [HAPI_MCP_OVERLAY_PID_ENV]: String(deadPid) },
+                },
+            },
+        }, null, 2));
+        const userLink = join(cwd, 'user-cursor-link');
+        symlinkSync(realUserDir, userLink);
 
-        expect(() => installCursorMcpOverlay(cwd, {
+        installCursorMcpOverlay(cwd, {
             command: '/bin/hapi',
             args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
-        }, { serverId: cursorHapiMcpServerId('session-a'), enableCursorMcp: noopEnable, mcpConfigDir: join(cwd, '.cursor') })).toThrow(
-            /Refusing to use a symlinked Cursor config directory/
-        );
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(cwd, '.cursor'),
+            userMcpConfigDir: userLink,
+        }).cleanup();
 
-        expect(readFileSync(externalMcp, 'utf-8')).toBe(original);
+        const user = JSON.parse(readFileSync(join(realUserDir, 'mcp.json'), 'utf-8')) as {
+            mcpServers: Record<string, unknown>;
+        };
+        expect(user.mcpServers[cursorHapiMcpServerId('dead')]).toBeUndefined();
+    });
+
+    it('does not restore a dead PID-stamped previous hapi slot on cleanup', () => {
+        const probe = spawnSync(process.execPath, ['-e', ''], { encoding: 'utf-8' });
+        const deadPid = probe.pid!;
+        expect(isProcessAlive(deadPid)).toBe(false);
+        const cwd = makeProjectDir(JSON.stringify({
+            mcpServers: {
+                [CURSOR_HAPI_MCP_SERVER_ID]: {
+                    command: '/bin/old-hapi',
+                    args: ['mcp'],
+                    env: { [HAPI_MCP_OVERLAY_PID_ENV]: String(deadPid) },
+                },
+            },
+        }, null, 2));
+        const mcpPath = join(cwd, '.cursor', 'mcp.json');
+        const handle = installCursorMcpOverlay(cwd, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(cwd, '.cursor'),
+        });
+        handle.cleanup();
+        // File may remain (hadFile was true) but the dead prior slot must not return.
+        expect(JSON.parse(readFileSync(mcpPath, 'utf-8')).mcpServers?.[CURSOR_HAPI_MCP_SERVER_ID])
+            .toBeUndefined();
     });
 
     it('writeMcpJsonAtomic preserves restrictive mode and cleans up tmp on failure path', () => {

--- a/cli/src/cursor/utils/cursorMcpOverlay.test.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.test.ts
@@ -294,8 +294,8 @@ describe('installCursorMcpOverlay', () => {
         });
     });
 
-    it('restores a pre-existing entry for the same server id instead of deleting it', () => {
-        const serverId = cursorHapiMcpServerId('session-a');
+    it('refuses to overwrite a user-owned entry for the same server id', () => {
+        const serverId = CURSOR_HAPI_MCP_SERVER_ID;
         const prior = { command: 'old-hapi', args: ['mcp'] };
         const cwd = makeProjectDir(JSON.stringify({
             mcpServers: {
@@ -304,12 +304,12 @@ describe('installCursorMcpOverlay', () => {
         }, null, 2));
 
         const mcpPath = join(cwd, '.cursor', 'mcp.json');
-        const handle = installCursorMcpOverlay(cwd, {
+        expect(() => installCursorMcpOverlay(cwd, {
             command: '/bin/hapi',
             args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
-        }, { serverId, enableCursorMcp: noopEnable, mcpConfigDir: join(cwd, '.cursor') });
-
-        handle.cleanup();
+        }, { serverId, enableCursorMcp: noopEnable, mcpConfigDir: join(cwd, '.cursor') })).toThrow(
+            /already exists/,
+        );
 
         const after = JSON.parse(readFileSync(mcpPath, 'utf-8')) as {
             mcpServers: Record<string, { command: string; args: string[] }>;
@@ -766,7 +766,7 @@ describe('installCursorMcpOverlay', () => {
         rmSync(linked, { recursive: true, force: true });
     });
 
-    it('skip-worktrees a tracked project mcp.json for the session lifetime', () => {
+    it('refuses a tracked project mcp.json instead of using skip-worktree', () => {
         const root = join(tmpdir(), `hapi-mcp-git-skip-${randomUUID()}`);
         mkdirSync(join(root, '.cursor'), { recursive: true });
         spawnSync('git', ['init'], { cwd: root, encoding: 'utf-8' });
@@ -778,7 +778,7 @@ describe('installCursorMcpOverlay', () => {
         spawnSync('git', ['add', '.cursor/mcp.json'], { cwd: root });
         spawnSync('git', ['commit', '-m', 'track mcp'], { cwd: root });
 
-        const handle = installCursorMcpOverlay(root, {
+        expect(() => installCursorMcpOverlay(root, {
             command: '/bin/hapi',
             args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
         }, {
@@ -786,55 +786,13 @@ describe('installCursorMcpOverlay', () => {
             overlaySessionId: 'session-a',
             enableCursorMcp: noopEnable,
             mcpConfigDir: join(root, '.cursor'),
-        });
+        })).toThrow(/Refusing runtime overlay for tracked/);
 
-        const skipped = spawnSync('git', ['ls-files', '-v', '--', '.cursor/mcp.json'], {
-            cwd: root,
-            encoding: 'utf-8',
-        });
-        expect(skipped.stdout.trim().startsWith('S ')).toBe(true);
-
-        handle.cleanup();
-        const after = spawnSync('git', ['ls-files', '-v', '--', '.cursor/mcp.json'], {
-            cwd: root,
-            encoding: 'utf-8',
-        });
-        expect(after.stdout.trim().startsWith('S ')).toBe(false);
-        rmSync(root, { recursive: true, force: true });
-    });
-
-    it('preserves a pre-existing skip-worktree bit on tracked mcp.json', () => {
-        const root = join(tmpdir(), `hapi-mcp-git-preskip-${randomUUID()}`);
-        mkdirSync(join(root, '.cursor'), { recursive: true });
-        spawnSync('git', ['init'], { cwd: root, encoding: 'utf-8' });
-        spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
-        spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
-        writeFileSync(join(root, '.cursor', 'mcp.json'), `${JSON.stringify({
-            mcpServers: { other: { command: 'echo', args: ['x'] } },
-        }, null, 2)}\n`);
-        spawnSync('git', ['add', '.cursor/mcp.json'], { cwd: root });
-        spawnSync('git', ['commit', '-m', 'track mcp'], { cwd: root });
-        spawnSync('git', ['update-index', '--skip-worktree', '--', '.cursor/mcp.json'], {
-            cwd: root,
-            encoding: 'utf-8',
-        });
-
-        const handle = installCursorMcpOverlay(root, {
-            command: '/bin/hapi',
-            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
-        }, {
-            serverId: CURSOR_HAPI_MCP_SERVER_ID,
-            overlaySessionId: 'session-a',
-            enableCursorMcp: noopEnable,
-            mcpConfigDir: join(root, '.cursor'),
-        });
-
-        handle.cleanup();
-        const after = spawnSync('git', ['ls-files', '-v', '--', '.cursor/mcp.json'], {
-            cwd: root,
-            encoding: 'utf-8',
-        });
-        expect(after.stdout.trim().startsWith('S ')).toBe(true);
+        const after = JSON.parse(readFileSync(join(root, '.cursor', 'mcp.json'), 'utf-8')) as {
+            mcpServers: Record<string, unknown>;
+        };
+        expect(after.mcpServers.hapi).toBeUndefined();
+        expect(after.mcpServers.other).toEqual({ command: 'echo', args: ['x'] });
         rmSync(root, { recursive: true, force: true });
     });
 

--- a/cli/src/cursor/utils/cursorMcpOverlay.test.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.test.ts
@@ -571,6 +571,47 @@ describe('installCursorMcpOverlay', () => {
         rmSync(root, { recursive: true, force: true });
     });
 
+    it('prunes dead-owner exclude leases on the next install', () => {
+        const root = join(tmpdir(), `hapi-mcp-git-dead-lease-${randomUUID()}`);
+        mkdirSync(root, { recursive: true });
+        spawnSync('git', ['init'], { cwd: root, encoding: 'utf-8' });
+        spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+        spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
+        writeFileSync(join(root, 'README'), 'x\n');
+        spawnSync('git', ['add', 'README'], { cwd: root });
+        spawnSync('git', ['commit', '-m', 'init'], { cwd: root });
+        mkdirSync(join(root, '.git', 'info'), { recursive: true });
+        const deadPid = spawnSync(process.execPath, ['-e', ''], { encoding: 'utf-8' }).pid!;
+        const deadLease = `${deadPid}:${randomUUID()}`;
+        writeFileSync(
+            join(root, '.git', 'info', 'exclude'),
+            `${hapiMcpGitExcludeMarker(deadLease)}\n.cursor/mcp.json\nkeep-me.txt\n`,
+            'utf-8',
+        );
+
+        const handle = installCursorMcpOverlay(root, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(root, '.cursor'),
+        });
+
+        const mid = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
+        expect(mid).toContain('keep-me.txt');
+        expect(mid).not.toContain(hapiMcpGitExcludeMarker(deadLease));
+        expect(mid).toContain('.cursor/mcp.json');
+        expect(mid).toMatch(new RegExp(`${HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX} ${process.pid}:`));
+
+        handle.cleanup();
+        const after = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
+        expect(after).toContain('keep-me.txt');
+        expect(after).not.toContain('.cursor/mcp.json');
+        rmSync(root, { recursive: true, force: true });
+    });
+
     it('keeps shared exclude while a sibling worktree lease is still live', () => {
         const root = join(tmpdir(), `hapi-mcp-git-lease-main-${randomUUID()}`);
         const linked = join(tmpdir(), `hapi-mcp-git-lease-link-${randomUUID()}`);

--- a/cli/src/cursor/utils/cursorMcpOverlay.test.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.test.ts
@@ -522,7 +522,50 @@ describe('installCursorMcpOverlay', () => {
         expect(check.status).toBe(0);
 
         handle.cleanup();
+        const after = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
+        expect(after).not.toContain(HAPI_MCP_GIT_EXCLUDE_MARKER);
+        expect(after).not.toContain('.cursor/mcp.json');
         rmSync(root, { recursive: true, force: true });
+    });
+
+    it('writes exclude via --git-path so linked worktrees share the common exclude', () => {
+        const root = join(tmpdir(), `hapi-mcp-git-wt-main-${randomUUID()}`);
+        const linked = join(tmpdir(), `hapi-mcp-git-wt-link-${randomUUID()}`);
+        mkdirSync(root, { recursive: true });
+        spawnSync('git', ['init'], { cwd: root, encoding: 'utf-8' });
+        spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+        spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
+        writeFileSync(join(root, 'README'), 'x\n');
+        spawnSync('git', ['add', 'README'], { cwd: root });
+        spawnSync('git', ['commit', '-m', 'init'], { cwd: root });
+        const addWt = spawnSync('git', ['worktree', 'add', linked, 'HEAD'], {
+            cwd: root,
+            encoding: 'utf-8',
+        });
+        expect(addWt.status).toBe(0);
+
+        const handle = installCursorMcpOverlay(linked, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(linked, '.cursor'),
+        });
+
+        const commonExclude = readFileSync(join(root, '.git', 'info', 'exclude'), 'utf-8');
+        expect(commonExclude).toContain('.cursor/mcp.json');
+        const check = spawnSync('git', ['check-ignore', '-v', '--', '.cursor/mcp.json'], {
+            cwd: linked,
+            encoding: 'utf-8',
+        });
+        expect(check.status).toBe(0);
+
+        handle.cleanup();
+        spawnSync('git', ['worktree', 'remove', '--force', linked], { cwd: root, encoding: 'utf-8' });
+        rmSync(root, { recursive: true, force: true });
+        rmSync(linked, { recursive: true, force: true });
     });
 
     it('skip-worktrees a tracked project mcp.json for the session lifetime', () => {
@@ -559,6 +602,41 @@ describe('installCursorMcpOverlay', () => {
             encoding: 'utf-8',
         });
         expect(after.stdout.trim().startsWith('S ')).toBe(false);
+        rmSync(root, { recursive: true, force: true });
+    });
+
+    it('preserves a pre-existing skip-worktree bit on tracked mcp.json', () => {
+        const root = join(tmpdir(), `hapi-mcp-git-preskip-${randomUUID()}`);
+        mkdirSync(join(root, '.cursor'), { recursive: true });
+        spawnSync('git', ['init'], { cwd: root, encoding: 'utf-8' });
+        spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+        spawnSync('git', ['config', 'user.name', 'test'], { cwd: root });
+        writeFileSync(join(root, '.cursor', 'mcp.json'), `${JSON.stringify({
+            mcpServers: { other: { command: 'echo', args: ['x'] } },
+        }, null, 2)}\n`);
+        spawnSync('git', ['add', '.cursor/mcp.json'], { cwd: root });
+        spawnSync('git', ['commit', '-m', 'track mcp'], { cwd: root });
+        spawnSync('git', ['update-index', '--skip-worktree', '--', '.cursor/mcp.json'], {
+            cwd: root,
+            encoding: 'utf-8',
+        });
+
+        const handle = installCursorMcpOverlay(root, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: join(root, '.cursor'),
+        });
+
+        handle.cleanup();
+        const after = spawnSync('git', ['ls-files', '-v', '--', '.cursor/mcp.json'], {
+            cwd: root,
+            encoding: 'utf-8',
+        });
+        expect(after.stdout.trim().startsWith('S ')).toBe(true);
         rmSync(root, { recursive: true, force: true });
     });
 

--- a/cli/src/cursor/utils/cursorMcpOverlay.test.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.test.ts
@@ -25,6 +25,7 @@ import {
     isProcessAlive,
     readLockOwner,
     resolveCursorMcpConfigDir,
+    resolveProjectCursorConfigDir,
     withMcpJsonLock,
     writeMcpJsonAtomic,
 } from './cursorMcpOverlay';
@@ -455,6 +456,38 @@ describe('installCursorMcpOverlay', () => {
             enableCursorMcp: noopEnable,
             mcpConfigDir: join(cwd, '.cursor'),
         })).toThrow(/Refusing a symlinked project Cursor config dir/);
+    });
+
+    it('accepts symlink-prefix mcpConfigDir when cwd is already realpath (estate ~/coding → /work/coding)', () => {
+        // Mimic oos: session.path realpath'd under /work/..., mcpConfigDir still via ~/coding symlink.
+        const root = join(tmpdir(), `hapi-coding-link-${randomUUID()}`);
+        const workRoot = join(root, 'work', 'proj');
+        const homeCoding = join(root, 'home', 'coding');
+        mkdirSync(workRoot, { recursive: true });
+        mkdirSync(join(root, 'home'), { recursive: true });
+        symlinkSync(join(root, 'work'), homeCoding);
+        const symlinkCwd = join(homeCoding, 'proj');
+        const realCwd = workRoot;
+        const viaSymlinkCursor = join(symlinkCwd, '.cursor');
+
+        expect(resolveProjectCursorConfigDir(realCwd, viaSymlinkCursor)).toBe(join(realCwd, '.cursor'));
+
+        const handle = installCursorMcpOverlay(realCwd, {
+            command: '/bin/hapi',
+            args: ['mcp', '--url', 'http://127.0.0.1:12345/'],
+        }, {
+            serverId: CURSOR_HAPI_MCP_SERVER_ID,
+            overlaySessionId: 'session-a',
+            enableCursorMcp: noopEnable,
+            mcpConfigDir: viaSymlinkCursor,
+        });
+        expect(existsSync(join(realCwd, '.cursor', 'mcp.json'))).toBe(true);
+        const written = JSON.parse(readFileSync(join(realCwd, '.cursor', 'mcp.json'), 'utf-8')) as {
+            mcpServers: Record<string, unknown>;
+        };
+        expect(written.mcpServers[CURSOR_HAPI_MCP_SERVER_ID]).toBeTruthy();
+        handle.cleanup();
+        rmSync(root, { recursive: true, force: true });
     });
 
     it('refuses a symlinked .cursor/mcp.json and leaves the external target unchanged', () => {

--- a/cli/src/cursor/utils/cursorMcpOverlay.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.ts
@@ -409,47 +409,34 @@ export function shieldProjectMcpJsonFromGit(cwd: string, mcpJsonPath: string): (
         cwd: root,
         encoding: 'utf-8',
     });
-    let setSkipWorktree = false;
+    // Skip-worktree is not crash-safe (bit lives only in-process). Refuse tracked
+    // mailboxes; untracked + exclude lease is the supported path.
     if (tracked.status === 0) {
-        const listFiles = spawnSync('git', ['ls-files', '-v', '--', gitRelativePath], {
-            cwd: root,
-            encoding: 'utf-8',
-        });
-        const wasSkipped = listFiles.status === 0
-            && listFiles.stdout.trimStart().startsWith('S ');
-        if (!wasSkipped) {
-            const skip = spawnSync('git', ['update-index', '--skip-worktree', '--', gitRelativePath], {
-                cwd: root,
-                encoding: 'utf-8',
-            });
-            if (skip.status !== 0) {
-                try {
-                    removeExcludeLease(excludePath, gitRelativePath, leaseId);
-                } catch {
-                    // best-effort undo of exclude before rethrow
-                }
-                const detail = (skip.stderr || skip.stdout || '').trim();
-                throw new Error(
-                    `Failed to mark ${gitRelativePath} skip-worktree${detail ? `: ${detail}` : ''}`,
-                );
-            }
-            setSkipWorktree = true;
+        try {
+            removeExcludeLease(excludePath, gitRelativePath, leaseId);
+        } catch {
+            // best-effort undo
         }
+        throw new Error(
+            `Refusing runtime overlay for tracked ${gitRelativePath} `
+            + '(untrack it or gitignore project .cursor/mcp.json)',
+        );
+    }
+    if (tracked.status !== 1) {
+        try {
+            removeExcludeLease(excludePath, gitRelativePath, leaseId);
+        } catch {
+            // best-effort undo
+        }
+        const detail = (tracked.stderr || tracked.stdout || '').trim();
+        throw new Error(`git ls-files failed${detail ? `: ${detail}` : ''}`);
     }
 
     return () => {
-        if (setSkipWorktree) {
-            spawnSync('git', ['update-index', '--no-skip-worktree', '--', gitRelativePath], {
-                cwd: root,
-                encoding: 'utf-8',
-            });
-        }
-        if (addedExclude && excludePath) {
-            try {
-                removeExcludeLease(excludePath, gitRelativePath, leaseId);
-            } catch (error) {
-                logger.debug('[cursor-acp] failed to remove mcp.json from git exclude', error);
-            }
+        try {
+            removeExcludeLease(excludePath, gitRelativePath, leaseId);
+        } catch (error) {
+            logger.debug('[cursor-acp] failed to remove mcp.json from git exclude', error);
         }
     };
 }
@@ -716,6 +703,11 @@ export function installCursorMcpOverlay(
 
         const existing = previous.mcpServers[serverId];
         const existingPid = overlayPid(existing);
+        if (existing && existingPid === null) {
+            throw new Error(
+                `Project MCP server "${serverId}" already exists (refusing to overwrite a non-HAPI entry)`,
+            );
+        }
         const existingSession = existing?.env?.[HAPI_MCP_OVERLAY_SESSION_ENV];
         if (
             overlaySessionId
@@ -764,6 +756,10 @@ export function installCursorMcpOverlay(
                 }
                 const current = readMcpJson(mcpJsonPath);
                 current.mcpServers ??= {};
+                const currentServer = current.mcpServers[serverId];
+                if (!sameMcpEntry(currentServer, installedHapi)) {
+                    return;
+                }
                 if (hadServer && previousServer) {
                     current.mcpServers[serverId] = previousServer;
                 } else {

--- a/cli/src/cursor/utils/cursorMcpOverlay.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.ts
@@ -184,6 +184,20 @@ export function hapiMcpGitExcludeMarker(leaseId: string): string {
     return `${HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX} ${leaseId}`;
 }
 
+/** Lease id embeds owner PID so crash recovery can prune dead markers. */
+export function makeExcludeLeaseId(pid: number = process.pid): string {
+    return `${pid}:${randomUUID()}`;
+}
+
+export function parseExcludeLeasePid(leaseId: string): number | null {
+    const match = /^(\d+):/.exec(leaseId);
+    if (!match) {
+        return null;
+    }
+    const pid = Number(match[1]);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
 /** Normalize a repo-relative path for gitignore / exclude (always `/`). */
 export function toGitExcludePattern(relPath: string): string {
     return relPath.replaceAll('\\', '/');
@@ -217,6 +231,7 @@ export function appendExcludeLease(
 ): boolean {
     let added = false;
     withMcpJsonLock(`${excludePath}.hapi.lock`, () => {
+        pruneDeadExcludeLeasesUnlocked(excludePath);
         added = appendExcludeLeaseUnlocked(excludePath, pattern, leaseId);
     });
     return added;
@@ -286,6 +301,42 @@ export function removeExcludeLeaseUnlocked(
     writeFileSync(excludePath, body, { encoding: 'utf-8', mode: 0o644 });
 }
 
+/**
+ * Drop lease blocks whose owner PID is confirmed dead (SIGKILL / power-loss recovery).
+ * Callers must hold `${excludePath}.hapi.lock`.
+ */
+export function pruneDeadExcludeLeasesUnlocked(excludePath: string): void {
+    if (!existsSync(excludePath)) {
+        return;
+    }
+    const lines = readFileSync(excludePath, 'utf-8').split(/\r?\n/);
+    const out: string[] = [];
+    let removed = false;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]!;
+        if (line.startsWith(`${HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX} `)) {
+            const leaseId = line.slice(HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX.length + 1).trim();
+            const pid = parseExcludeLeasePid(leaseId);
+            if (pid !== null && !isProcessAlive(pid)) {
+                removed = true;
+                if (lines[i + 1] !== undefined) {
+                    i += 1;
+                }
+                continue;
+            }
+        }
+        out.push(line);
+    }
+    if (!removed) {
+        return;
+    }
+    while (out.length > 0 && out[out.length - 1] === '') {
+        out.pop();
+    }
+    const body = out.length === 0 ? '' : `${out.join('\n')}\n`;
+    writeFileSync(excludePath, body, { encoding: 'utf-8', mode: 0o644 });
+}
+
 /** @deprecated Use {@link removeExcludeLease}. */
 export function removeExactExcludeBlock(excludePath: string, pattern: string): void {
     withMcpJsonLock(`${excludePath}.hapi.lock`, () => {
@@ -317,6 +368,7 @@ export function removeExactExcludeBlock(excludePath: string, pattern: string): v
  * Keep the session mailbox out of accidental commits: local exclude for
  * untracked `.cursor/mcp.json`, and `skip-worktree` when the file is already tracked
  * and was not already skipped. Undo reverses only what this call introduced.
+ * Throws when Git shielding cannot be installed so callers can roll back the mailbox write.
  */
 export function shieldProjectMcpJsonFromGit(cwd: string, mcpJsonPath: string): () => void {
     const top = spawnSync('git', ['rev-parse', '--show-toplevel'], {
@@ -335,16 +387,22 @@ export function shieldProjectMcpJsonFromGit(cwd: string, mcpJsonPath: string): (
         return () => {};
     }
     const gitRelativePath = toGitExcludePattern(relRaw);
-    const leaseId = randomUUID();
+    const leaseId = makeExcludeLeaseId();
+
+    const excludePath = resolveGitExcludePath(root);
+    if (!excludePath) {
+        throw new Error(`Cannot resolve Git exclude path for ${gitRelativePath}`);
+    }
 
     let addedExclude = false;
-    const excludePath = resolveGitExcludePath(root);
-    if (excludePath) {
-        try {
-            addedExclude = appendExcludeLease(excludePath, gitRelativePath, leaseId);
-        } catch (error) {
-            logger.debug('[cursor-acp] failed to append mcp.json to git exclude', error);
-        }
+    try {
+        addedExclude = appendExcludeLease(excludePath, gitRelativePath, leaseId);
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to exclude ${gitRelativePath}: ${detail}`);
+    }
+    if (!addedExclude) {
+        throw new Error(`Failed to exclude ${gitRelativePath}`);
     }
 
     const tracked = spawnSync('git', ['ls-files', '--error-unmatch', '--', gitRelativePath], {
@@ -364,7 +422,18 @@ export function shieldProjectMcpJsonFromGit(cwd: string, mcpJsonPath: string): (
                 cwd: root,
                 encoding: 'utf-8',
             });
-            setSkipWorktree = skip.status === 0;
+            if (skip.status !== 0) {
+                try {
+                    removeExcludeLease(excludePath, gitRelativePath, leaseId);
+                } catch {
+                    // best-effort undo of exclude before rethrow
+                }
+                const detail = (skip.stderr || skip.stdout || '').trim();
+                throw new Error(
+                    `Failed to mark ${gitRelativePath} skip-worktree${detail ? `: ${detail}` : ''}`,
+                );
+            }
+            setSkipWorktree = true;
         }
     }
 
@@ -679,7 +748,34 @@ export function installCursorMcpOverlay(
         writeMcpJsonAtomic(mcpJsonPath, config);
     });
 
-    const unshieldGit = shieldProjectMcpJsonFromGit(cwd, mcpJsonPath);
+    let unshieldGit: () => void = () => {};
+    try {
+        unshieldGit = shieldProjectMcpJsonFromGit(cwd, mcpJsonPath);
+    } catch (error) {
+        // Roll back the mailbox write so we do not leave an unshielded runtime config.
+        try {
+            withMcpJsonLock(lockPath, () => {
+                if (!existsSync(mcpJsonPath)) {
+                    return;
+                }
+                if (!hadFile) {
+                    rmSync(mcpJsonPath, { force: true });
+                    return;
+                }
+                const current = readMcpJson(mcpJsonPath);
+                current.mcpServers ??= {};
+                if (hadServer && previousServer) {
+                    current.mcpServers[serverId] = previousServer;
+                } else {
+                    delete current.mcpServers[serverId];
+                }
+                writeMcpJsonAtomic(mcpJsonPath, current);
+            });
+        } catch (rollbackError) {
+            logger.debug('[cursor-acp] rollback after git-shield failure failed', rollbackError);
+        }
+        throw error;
+    }
 
     const cleanup = (): void => {
         let safeToUnshield = false;

--- a/cli/src/cursor/utils/cursorMcpOverlay.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.ts
@@ -174,6 +174,75 @@ export type CursorMcpOverlayHandle = {
     cleanup: () => void;
 };
 
+/** Marker line in `.git/info/exclude` for session-local project mcp.json. */
+export const HAPI_MCP_GIT_EXCLUDE_MARKER = '# hapi-cursor-mcp-overlay (do not commit session mailbox)';
+
+/**
+ * Keep the session mailbox out of accidental commits: local exclude for
+ * untracked `.cursor/mcp.json`, and `skip-worktree` when the file is already tracked.
+ * Returns an undo that clears skip-worktree (exclude line is left — harmless).
+ */
+export function shieldProjectMcpJsonFromGit(cwd: string, mcpJsonPath: string): () => void {
+    const top = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+        cwd,
+        encoding: 'utf-8',
+    });
+    if (top.status !== 0) {
+        return () => {};
+    }
+    const root = top.stdout.trim();
+    if (!root) {
+        return () => {};
+    }
+    const rel = relative(root, mcpJsonPath);
+    if (!rel || rel.startsWith('..') || isAbsolute(rel)) {
+        return () => {};
+    }
+
+    const gitDirProc = spawnSync('git', ['rev-parse', '--git-dir'], {
+        cwd: root,
+        encoding: 'utf-8',
+    });
+    if (gitDirProc.status === 0) {
+        const gitDirRaw = gitDirProc.stdout.trim();
+        const gitDir = isAbsolute(gitDirRaw) ? gitDirRaw : resolvePath(root, gitDirRaw);
+        const excludePath = join(gitDir, 'info', 'exclude');
+        try {
+            mkdirSync(join(gitDir, 'info'), { recursive: true });
+            const existing = existsSync(excludePath) ? readFileSync(excludePath, 'utf-8') : '';
+            if (!existing.split(/\r?\n/).includes(rel)) {
+                const prefix = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+                writeFileSync(
+                    excludePath,
+                    `${prefix}${HAPI_MCP_GIT_EXCLUDE_MARKER}\n${rel}\n`,
+                    { encoding: 'utf-8', mode: 0o644 },
+                );
+            }
+        } catch (error) {
+            logger.debug('[cursor-acp] failed to append mcp.json to git exclude', error);
+        }
+    }
+
+    const tracked = spawnSync('git', ['ls-files', '--error-unmatch', '--', rel], {
+        cwd: root,
+        encoding: 'utf-8',
+    });
+    if (tracked.status !== 0) {
+        return () => {};
+    }
+
+    spawnSync('git', ['update-index', '--skip-worktree', '--', rel], {
+        cwd: root,
+        encoding: 'utf-8',
+    });
+    return () => {
+        spawnSync('git', ['update-index', '--no-skip-worktree', '--', rel], {
+            cwd: root,
+            encoding: 'utf-8',
+        });
+    };
+}
+
 type EnableCursorMcpResult = {
     status: number | null;
     stdout?: string | null;
@@ -468,7 +537,14 @@ export function installCursorMcpOverlay(
         writeMcpJsonAtomic(mcpJsonPath, config);
     });
 
+    const unshieldGit = shieldProjectMcpJsonFromGit(cwd, mcpJsonPath);
+
     const cleanup = (): void => {
+        try {
+            unshieldGit();
+        } catch (error) {
+            logger.debug('[cursor-acp] cursor MCP overlay git unshield failed', error);
+        }
         try {
             withMcpJsonLock(lockPath, () => {
                 if (!existsSync(mcpJsonPath)) {

--- a/cli/src/cursor/utils/cursorMcpOverlay.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.ts
@@ -208,8 +208,22 @@ function resolveGitExcludePath(root: string): string | null {
  * Append a per-install lease block (marker + pattern). Multiple live overlays
  * may share the same pattern across linked worktrees; each keeps its own lease
  * line so cleanup is reference-counted by presence of remaining leases.
+ * Serialized via {@link withMcpJsonLock} on `${excludePath}.hapi.lock`.
  */
 export function appendExcludeLease(
+    excludePath: string,
+    pattern: string,
+    leaseId: string,
+): boolean {
+    let added = false;
+    withMcpJsonLock(`${excludePath}.hapi.lock`, () => {
+        added = appendExcludeLeaseUnlocked(excludePath, pattern, leaseId);
+    });
+    return added;
+}
+
+/** Unlocked RMW — callers must hold `${excludePath}.hapi.lock`. */
+export function appendExcludeLeaseUnlocked(
     excludePath: string,
     pattern: string,
     leaseId: string,
@@ -241,6 +255,17 @@ export function removeExcludeLease(
     pattern: string,
     leaseId: string,
 ): void {
+    withMcpJsonLock(`${excludePath}.hapi.lock`, () => {
+        removeExcludeLeaseUnlocked(excludePath, pattern, leaseId);
+    });
+}
+
+/** Unlocked RMW — callers must hold `${excludePath}.hapi.lock`. */
+export function removeExcludeLeaseUnlocked(
+    excludePath: string,
+    pattern: string,
+    leaseId: string,
+): void {
     if (!existsSync(excludePath)) {
         return;
     }
@@ -263,27 +288,29 @@ export function removeExcludeLease(
 
 /** @deprecated Use {@link removeExcludeLease}. */
 export function removeExactExcludeBlock(excludePath: string, pattern: string): void {
-    if (!existsSync(excludePath)) {
-        return;
-    }
-    const lines = readFileSync(excludePath, 'utf-8').split(/\r?\n/);
-    const out: string[] = [];
-    for (let i = 0; i < lines.length; i++) {
-        const line = lines[i]!;
-        if (
-            line.startsWith(`${HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX} `)
-            && lines[i + 1] === pattern
-        ) {
-            i += 1;
-            continue;
+    withMcpJsonLock(`${excludePath}.hapi.lock`, () => {
+        if (!existsSync(excludePath)) {
+            return;
         }
-        out.push(line);
-    }
-    while (out.length > 0 && out[out.length - 1] === '') {
-        out.pop();
-    }
-    const body = out.length === 0 ? '' : `${out.join('\n')}\n`;
-    writeFileSync(excludePath, body, { encoding: 'utf-8', mode: 0o644 });
+        const lines = readFileSync(excludePath, 'utf-8').split(/\r?\n/);
+        const out: string[] = [];
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i]!;
+            if (
+                line.startsWith(`${HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX} `)
+                && lines[i + 1] === pattern
+            ) {
+                i += 1;
+                continue;
+            }
+            out.push(line);
+        }
+        while (out.length > 0 && out[out.length - 1] === '') {
+            out.pop();
+        }
+        const body = out.length === 0 ? '' : `${out.join('\n')}\n`;
+        writeFileSync(excludePath, body, { encoding: 'utf-8', mode: 0o644 });
+    });
 }
 
 /**

--- a/cli/src/cursor/utils/cursorMcpOverlay.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.ts
@@ -24,7 +24,7 @@ import {
     writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, isAbsolute, join, relative, resolve as resolvePath } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, resolve as resolvePath } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { logger } from '@/ui/logger';
@@ -177,10 +177,71 @@ export type CursorMcpOverlayHandle = {
 /** Marker line in `.git/info/exclude` for session-local project mcp.json. */
 export const HAPI_MCP_GIT_EXCLUDE_MARKER = '# hapi-cursor-mcp-overlay (do not commit session mailbox)';
 
+/** Normalize a repo-relative path for gitignore / exclude (always `/`). */
+export function toGitExcludePattern(relPath: string): string {
+    return relPath.replaceAll('\\', '/');
+}
+
+function resolveGitExcludePath(root: string): string | null {
+    const excludeProc = spawnSync('git', ['rev-parse', '--git-path', 'info/exclude'], {
+        cwd: root,
+        encoding: 'utf-8',
+    });
+    if (excludeProc.status !== 0) {
+        return null;
+    }
+    const raw = excludeProc.stdout.trim();
+    if (!raw) {
+        return null;
+    }
+    return isAbsolute(raw) ? raw : resolvePath(root, raw);
+}
+
+/** Append marker + pattern when missing. Returns true if this call wrote them. */
+export function appendExcludeIfMissing(excludePath: string, pattern: string): boolean {
+    const existing = existsSync(excludePath) ? readFileSync(excludePath, 'utf-8') : '';
+    const lines = existing.split(/\r?\n/);
+    if (lines.includes(pattern)) {
+        return false;
+    }
+    mkdirSync(dirname(excludePath), { recursive: true });
+    const prefix = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+    writeFileSync(
+        excludePath,
+        `${prefix}${HAPI_MCP_GIT_EXCLUDE_MARKER}\n${pattern}\n`,
+        { encoding: 'utf-8', mode: 0o644 },
+    );
+    return true;
+}
+
+/** Remove one marker+pattern block we added (exact lines only). */
+export function removeExactExcludeBlock(excludePath: string, pattern: string): void {
+    if (!existsSync(excludePath)) {
+        return;
+    }
+    const lines = readFileSync(excludePath, 'utf-8').split(/\r?\n/);
+    const out: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        if (
+            lines[i] === HAPI_MCP_GIT_EXCLUDE_MARKER
+            && lines[i + 1] === pattern
+        ) {
+            i += 1;
+            continue;
+        }
+        out.push(lines[i]!);
+    }
+    while (out.length > 0 && out[out.length - 1] === '') {
+        out.pop();
+    }
+    const body = out.length === 0 ? '' : `${out.join('\n')}\n`;
+    writeFileSync(excludePath, body, { encoding: 'utf-8', mode: 0o644 });
+}
+
 /**
  * Keep the session mailbox out of accidental commits: local exclude for
- * untracked `.cursor/mcp.json`, and `skip-worktree` when the file is already tracked.
- * Returns an undo that clears skip-worktree (exclude line is left — harmless).
+ * untracked `.cursor/mcp.json`, and `skip-worktree` when the file is already tracked
+ * and was not already skipped. Undo reverses only what this call introduced.
  */
 export function shieldProjectMcpJsonFromGit(cwd: string, mcpJsonPath: string): () => void {
     const top = spawnSync('git', ['rev-parse', '--show-toplevel'], {
@@ -194,52 +255,57 @@ export function shieldProjectMcpJsonFromGit(cwd: string, mcpJsonPath: string): (
     if (!root) {
         return () => {};
     }
-    const rel = relative(root, mcpJsonPath);
-    if (!rel || rel.startsWith('..') || isAbsolute(rel)) {
+    const relRaw = relative(root, mcpJsonPath);
+    if (!relRaw || relRaw.startsWith('..') || isAbsolute(relRaw)) {
         return () => {};
     }
+    const gitRelativePath = toGitExcludePattern(relRaw);
 
-    const gitDirProc = spawnSync('git', ['rev-parse', '--git-dir'], {
-        cwd: root,
-        encoding: 'utf-8',
-    });
-    if (gitDirProc.status === 0) {
-        const gitDirRaw = gitDirProc.stdout.trim();
-        const gitDir = isAbsolute(gitDirRaw) ? gitDirRaw : resolvePath(root, gitDirRaw);
-        const excludePath = join(gitDir, 'info', 'exclude');
+    let addedExclude = false;
+    const excludePath = resolveGitExcludePath(root);
+    if (excludePath) {
         try {
-            mkdirSync(join(gitDir, 'info'), { recursive: true });
-            const existing = existsSync(excludePath) ? readFileSync(excludePath, 'utf-8') : '';
-            if (!existing.split(/\r?\n/).includes(rel)) {
-                const prefix = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
-                writeFileSync(
-                    excludePath,
-                    `${prefix}${HAPI_MCP_GIT_EXCLUDE_MARKER}\n${rel}\n`,
-                    { encoding: 'utf-8', mode: 0o644 },
-                );
-            }
+            addedExclude = appendExcludeIfMissing(excludePath, gitRelativePath);
         } catch (error) {
             logger.debug('[cursor-acp] failed to append mcp.json to git exclude', error);
         }
     }
 
-    const tracked = spawnSync('git', ['ls-files', '--error-unmatch', '--', rel], {
+    const tracked = spawnSync('git', ['ls-files', '--error-unmatch', '--', gitRelativePath], {
         cwd: root,
         encoding: 'utf-8',
     });
-    if (tracked.status !== 0) {
-        return () => {};
-    }
-
-    spawnSync('git', ['update-index', '--skip-worktree', '--', rel], {
-        cwd: root,
-        encoding: 'utf-8',
-    });
-    return () => {
-        spawnSync('git', ['update-index', '--no-skip-worktree', '--', rel], {
+    let setSkipWorktree = false;
+    if (tracked.status === 0) {
+        const listFiles = spawnSync('git', ['ls-files', '-v', '--', gitRelativePath], {
             cwd: root,
             encoding: 'utf-8',
         });
+        const wasSkipped = listFiles.status === 0
+            && listFiles.stdout.trimStart().startsWith('S ');
+        if (!wasSkipped) {
+            const skip = spawnSync('git', ['update-index', '--skip-worktree', '--', gitRelativePath], {
+                cwd: root,
+                encoding: 'utf-8',
+            });
+            setSkipWorktree = skip.status === 0;
+        }
+    }
+
+    return () => {
+        if (setSkipWorktree) {
+            spawnSync('git', ['update-index', '--no-skip-worktree', '--', gitRelativePath], {
+                cwd: root,
+                encoding: 'utf-8',
+            });
+        }
+        if (addedExclude && excludePath) {
+            try {
+                removeExactExcludeBlock(excludePath, gitRelativePath);
+            } catch (error) {
+                logger.debug('[cursor-acp] failed to remove mcp.json from git exclude', error);
+            }
+        }
     };
 }
 

--- a/cli/src/cursor/utils/cursorMcpOverlay.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.ts
@@ -1,9 +1,13 @@
 /**
- * Cursor ACP does not connect MCP servers passed on session/new (upstream limitation).
- * The working path is user-level `~/.cursor/mcp.json` + `agent mcp enable <id>` (spawned
- * with the session cwd). Project `.cursor/mcp.json` is intentionally avoided so ephemeral
- * `hapi-<sessionId>` bridges cannot be `git add`ed from the checked-out tree.
- * See https://forum.cursor.com/t/acp-agent-silently-ignores-mcpservers-in-session-new/153623
+ * Cursor ACP historically ignored mcpServers on session/new, so HAPI overlays
+ * native mcp.json. Cursor **merges** user `~/.cursor/mcp.json` with project
+ * `<cwd>/.cursor/mcp.json`. Unique `hapi-<uuid>` keys in the user file therefore
+ * union-load every live session's ping_peer into every agent (wrong sender +
+ * N copies of the tool schema).
+ *
+ * Isolation: write one stable `hapi` mailbox into the **project** file, and strip
+ * PID-stamped `hapi` / `hapi-*` keys from the user file. Same-cwd second live
+ * mailbox fails closed rather than multiplexing.
  */
 
 import {
@@ -12,6 +16,7 @@ import {
     lstatSync,
     mkdirSync,
     readFileSync,
+    realpathSync,
     renameSync,
     rmSync,
     statSync,
@@ -19,18 +24,18 @@ import {
     writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join, relative, resolve as resolvePath } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { logger } from '@/ui/logger';
 
-/** Historical fixed id — prefer {@link cursorHapiMcpServerId} so concurrent sessions do not share one key. */
+/** Stable project mcp.json key — one mailbox per Cursor cwd. */
 export const CURSOR_HAPI_MCP_SERVER_ID = 'hapi';
 
 /**
- * Per-session MCP server id for user-level `~/.cursor/mcp.json`.
- * Concurrent sessions must not share a single `hapi` key — cleanup of an
- * older session would otherwise restore a dead loopback URL over a newer live bridge.
+ * Historical unique id shape (`hapi-<session>`). Production install uses
+ * {@link CURSOR_HAPI_MCP_SERVER_ID} only; keep this helper for tests / crash
+ * recovery of older overlays still present on disk.
  */
 export function cursorHapiMcpServerId(sessionId: string): string {
     const trimmed = sessionId.trim();
@@ -40,11 +45,11 @@ export function cursorHapiMcpServerId(sessionId: string): string {
     return `hapi-${trimmed}`;
 }
 
-/** Resolve the Cursor MCP config directory (override for tests; default `~/.cursor`). */
-export function resolveCursorMcpConfigDir(override?: string): string {
-    const trimmed = override?.trim();
-    return trimmed && trimmed.length > 0 ? trimmed : join(homedir(), '.cursor');
-}
+/** Marks HAPI-owned overlay entries so a later launch can prune dead PIDs. */
+export const HAPI_MCP_OVERLAY_PID_ENV = 'HAPI_MCP_OVERLAY_PID';
+
+/** Session that owns this mailbox — used to refuse a second live overlay in one cwd. */
+export const HAPI_MCP_OVERLAY_SESSION_ENV = 'HAPI_MCP_OVERLAY_SESSION';
 
 type McpServerEntry = {
     command: string;
@@ -52,8 +57,102 @@ type McpServerEntry = {
     env?: Record<string, string>;
 };
 
-/** Marks HAPI-owned overlay entries so a later launch can prune dead PIDs. */
-export const HAPI_MCP_OVERLAY_PID_ENV = 'HAPI_MCP_OVERLAY_PID';
+/** Resolve the Cursor MCP config directory (override for tests; default `~/.cursor`). */
+export function resolveCursorMcpConfigDir(override?: string): string {
+    const trimmed = override?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed : join(homedir(), '.cursor');
+}
+
+function resolveExistingPath(path: string): string {
+    try {
+        return realpathSync(path);
+    } catch {
+        return path;
+    }
+}
+
+/**
+ * Project `.cursor` is untrusted (repo can ship a symlink to ~/.cursor).
+ * Refuse links / realpaths that escape the session cwd. Operator user-dir
+ * may follow estate-disk symlinks via {@link resolveExistingPath}.
+ */
+export function resolveProjectCursorConfigDir(cwd: string, mcpConfigDir: string): string {
+    const lexical = resolvePath(resolveCursorMcpConfigDir(mcpConfigDir));
+    const entry = lstatSync(lexical, { throwIfNoEntry: false });
+    if (entry?.isSymbolicLink()) {
+        throw new Error(
+            `Refusing a symlinked project Cursor config dir: ${lexical}`,
+        );
+    }
+    const realCwd = resolveExistingPath(resolvePath(cwd));
+    const lexicalRel = relative(realCwd, lexical);
+    if (lexicalRel.startsWith('..') || isAbsolute(lexicalRel)) {
+        throw new Error(
+            `Project Cursor config dir escapes session cwd: ${lexical}`,
+        );
+    }
+    if (!existsSync(lexical)) {
+        return lexical;
+    }
+    let resolved: string;
+    try {
+        resolved = realpathSync(lexical);
+    } catch {
+        return lexical;
+    }
+    const rel = relative(realCwd, resolved);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+        throw new Error(
+            `Project Cursor config dir escapes session cwd: ${resolved}`,
+        );
+    }
+    return resolved;
+}
+
+function isHapiOverlayKey(id: string): boolean {
+    return id === CURSOR_HAPI_MCP_SERVER_ID || id.startsWith('hapi-');
+}
+
+function overlayPid(entry: McpServerEntry | undefined): number | null {
+    const pidRaw = entry?.env?.[HAPI_MCP_OVERLAY_PID_ENV];
+    if (typeof pidRaw !== 'string' || pidRaw.trim() === '') {
+        return null;
+    }
+    const pid = Number(pidRaw);
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+        return null;
+    }
+    return pid;
+}
+
+function isDeadPidStampedOverlay(entry: McpServerEntry | undefined): boolean {
+    const pid = overlayPid(entry);
+    return pid !== null && !isProcessAlive(pid);
+}
+
+/**
+ * Drop PID-stamped HAPI overlay keys whose owner PID is confirmed dead.
+ * Live stamped entries stay (driver-soup: a new CLI must not sever still-running
+ * old-binary Cursor sessions sharing the user mcp.json). `keepId` is exempt.
+ * User-owned keys without the PID stamp stay.
+ */
+export function stripPidStampedHapiOverlays(
+    servers: Record<string, McpServerEntry>,
+    keepId?: string,
+): void {
+    for (const [id, entry] of Object.entries(servers)) {
+        if (keepId && id === keepId) {
+            continue;
+        }
+        if (!isHapiOverlayKey(id)) {
+            continue;
+        }
+        if (!isDeadPidStampedOverlay(entry)) {
+            continue;
+        }
+        delete servers[id];
+    }
+}
 
 type CursorMcpJson = {
     mcpServers?: Record<string, McpServerEntry>;
@@ -260,24 +359,21 @@ function sameMcpEntry(a: McpServerEntry | undefined, b: McpServerEntry | undefin
 }
 
 /**
- * Merge the per-session HAPI stdio bridge into `~/.cursor/mcp.json` (or
- * `options.mcpConfigDir`) and approve it for Cursor's native MCP loader.
- *
- * Cleanup undoes only the exact entry this session installed under `serverId` (or restores a
- * pre-existing value for that same id). Concurrent edits to other mcpServers keys — and to
- * this id when it no longer matches the installed overlay — survive the session.
- *
- * Install and cleanup serialize via a lockfile and write mcp.json atomically so concurrent
- * CLI processes cannot clobber each other's `hapi-*` entries.
+ * Write one HAPI stdio bridge into the **project** `.cursor/mcp.json` and approve it.
+ * When `userMcpConfigDir` is set, strip PID-stamped `hapi` / `hapi-*` keys from that
+ * user-level file so Cursor cannot merge sibling session mailboxes into this agent.
  */
 export function installCursorMcpOverlay(
     cwd: string,
     bridge: { command: string; args: string[] },
     options: {
         serverId: string;
+        overlaySessionId?: string;
         enableCursorMcp?: EnableCursorMcp;
-        /** Override config dir (tests). Production uses `~/.cursor`. */
+        /** Project Cursor config dir. Default `<cwd>/.cursor`. */
         mcpConfigDir?: string;
+        /** User-level Cursor config dir to strip multiplex `hapi-*` keys from. */
+        userMcpConfigDir?: string;
     },
 ): CursorMcpOverlayHandle {
     const serverId = options.serverId.trim();
@@ -285,20 +381,40 @@ export function installCursorMcpOverlay(
         throw new Error('serverId is required for Cursor HAPI MCP overlay');
     }
 
-    const cursorDir = resolveCursorMcpConfigDir(options.mcpConfigDir);
+    const cursorDir = resolveProjectCursorConfigDir(
+        cwd,
+        options.mcpConfigDir ?? join(cwd, '.cursor'),
+    );
     const mcpJsonPath = join(cursorDir, 'mcp.json');
     const lockPath = `${mcpJsonPath}.hapi.lock`;
-    const cursorDirEntry = lstatSync(cursorDir, { throwIfNoEntry: false });
-    if (cursorDirEntry?.isSymbolicLink()) {
-        throw new Error(`Refusing to use a symlinked Cursor config directory: ${cursorDir}`);
-    }
     mkdirSync(cursorDir, { recursive: true });
 
+    const overlaySessionId = options.overlaySessionId?.trim() || undefined;
     const installedHapi: McpServerEntry = {
         command: bridge.command,
         args: [...bridge.args],
-        env: { [HAPI_MCP_OVERLAY_PID_ENV]: String(process.pid) },
+        env: {
+            [HAPI_MCP_OVERLAY_PID_ENV]: String(process.pid),
+            ...(overlaySessionId ? { [HAPI_MCP_OVERLAY_SESSION_ENV]: overlaySessionId } : {}),
+        },
     };
+
+    const userDirRaw = options.userMcpConfigDir?.trim();
+    if (userDirRaw) {
+        // User dir is operator-trusted — follow estate-disk symlinks.
+        const userDir = resolveExistingPath(resolveCursorMcpConfigDir(userDirRaw));
+        if (userDir !== cursorDir) {
+            const userJsonPath = join(userDir, 'mcp.json');
+            if (existsSync(userJsonPath) && !lstatSync(userJsonPath).isSymbolicLink()) {
+                withMcpJsonLock(`${userJsonPath}.hapi.lock`, () => {
+                    const userConfig = readMcpJson(userJsonPath);
+                    userConfig.mcpServers ??= {};
+                    stripPidStampedHapiOverlays(userConfig.mcpServers);
+                    writeMcpJsonAtomic(userJsonPath, userConfig);
+                });
+            }
+        }
+    }
 
     let hadFile = false;
     let hadServer = false;
@@ -309,27 +425,31 @@ export function installCursorMcpOverlay(
         const previous = hadFile ? readMcpJson(mcpJsonPath) : { mcpServers: {} as Record<string, McpServerEntry> };
         previous.mcpServers ??= {};
 
-        // Crash recovery: drop prior hapi-* overlays whose owner PID is gone.
-        // Only prune entries we stamped with HAPI_MCP_OVERLAY_PID — never user-owned keys.
-        for (const [id, entry] of Object.entries(previous.mcpServers)) {
-            if (!id.startsWith('hapi-')) {
-                continue;
-            }
-            const pidRaw = entry.env?.[HAPI_MCP_OVERLAY_PID_ENV];
-            if (typeof pidRaw !== 'string' || pidRaw.trim() === '') {
-                continue;
-            }
-            const pid = Number(pidRaw);
-            if (!Number.isSafeInteger(pid) || pid <= 0) {
-                continue;
-            }
-            if (!isProcessAlive(pid)) {
-                delete previous.mcpServers[id];
-            }
+        stripPidStampedHapiOverlays(previous.mcpServers, serverId);
+
+        const existing = previous.mcpServers[serverId];
+        const existingPid = overlayPid(existing);
+        const existingSession = existing?.env?.[HAPI_MCP_OVERLAY_SESSION_ENV];
+        if (
+            overlaySessionId
+            && existingPid !== null
+            && isProcessAlive(existingPid)
+            && typeof existingSession === 'string'
+            && existingSession.length > 0
+            && existingSession !== overlaySessionId
+        ) {
+            throw new Error(
+                `Cannot install a second live HAPI MCP mailbox in this workspace (held by session ${existingSession}).`,
+            );
         }
 
         hadServer = Object.prototype.hasOwnProperty.call(previous.mcpServers, serverId);
         previousServer = hadServer ? previous.mcpServers[serverId] : undefined;
+        // Crash left a dead PID-stamped slot — do not restore it on cleanup.
+        if (hadServer && isDeadPidStampedOverlay(previousServer)) {
+            hadServer = false;
+            previousServer = undefined;
+        }
 
         const config: CursorMcpJson = {
             ...previous,
@@ -353,7 +473,6 @@ export function installCursorMcpOverlay(
 
                 const currentServer = current.mcpServers[serverId];
                 if (!sameMcpEntry(currentServer, installedHapi)) {
-                    // User/Cursor replaced or removed our overlay entry — leave alone.
                     return;
                 }
 

--- a/cli/src/cursor/utils/cursorMcpOverlay.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.ts
@@ -24,7 +24,7 @@ import {
     writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { isAbsolute, join, relative, resolve as resolvePath } from 'node:path';
+import { basename, isAbsolute, join, relative, resolve as resolvePath } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { logger } from '@/ui/logger';
@@ -75,6 +75,11 @@ function resolveExistingPath(path: string): string {
  * Project `.cursor` is untrusted (repo can ship a symlink to ~/.cursor).
  * Refuse links / realpaths that escape the session cwd. Operator user-dir
  * may follow estate-disk symlinks via {@link resolveExistingPath}.
+ *
+ * Canonicalize via the parent of `.cursor` before the containment check so
+ * estate layouts like `~/coding -> /work/coding` do not false-positive when
+ * `session.path` is already realpath'd but `mcpConfigDir` still uses the
+ * symlink prefix (common on first install when `.cursor` does not exist yet).
  */
 export function resolveProjectCursorConfigDir(cwd: string, mcpConfigDir: string): string {
     const lexical = resolvePath(resolveCursorMcpConfigDir(mcpConfigDir));
@@ -85,20 +90,22 @@ export function resolveProjectCursorConfigDir(cwd: string, mcpConfigDir: string)
         );
     }
     const realCwd = resolveExistingPath(resolvePath(cwd));
-    const lexicalRel = relative(realCwd, lexical);
-    if (lexicalRel.startsWith('..') || isAbsolute(lexicalRel)) {
+    const realParent = resolveExistingPath(resolvePath(lexical, '..'));
+    const candidate = join(realParent, basename(lexical));
+    const candidateRel = relative(realCwd, candidate);
+    if (candidateRel.startsWith('..') || isAbsolute(candidateRel)) {
         throw new Error(
             `Project Cursor config dir escapes session cwd: ${lexical}`,
         );
     }
-    if (!existsSync(lexical)) {
-        return lexical;
+    if (!existsSync(candidate)) {
+        return candidate;
     }
     let resolved: string;
     try {
-        resolved = realpathSync(lexical);
+        resolved = realpathSync(candidate);
     } catch {
-        return lexical;
+        return candidate;
     }
     const rel = relative(realCwd, resolved);
     if (rel.startsWith('..') || isAbsolute(rel)) {

--- a/cli/src/cursor/utils/cursorMcpOverlay.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.ts
@@ -694,9 +694,11 @@ export function installCursorMcpOverlay(
     let hadServer = false;
     let previousServer: McpServerEntry | undefined;
 
-    withMcpJsonLock(lockPath, () => {
+    const prepareOverlayMutation = (): CursorMcpJson => {
         hadFile = existsSync(mcpJsonPath);
-        const previous = hadFile ? readMcpJson(mcpJsonPath) : { mcpServers: {} as Record<string, McpServerEntry> };
+        const previous = hadFile
+            ? readMcpJson(mcpJsonPath)
+            : { mcpServers: {} as Record<string, McpServerEntry> };
         previous.mcpServers ??= {};
 
         stripPidStampedHapiOverlays(previous.mcpServers, serverId);
@@ -729,46 +731,34 @@ export function installCursorMcpOverlay(
             hadServer = false;
             previousServer = undefined;
         }
+        return previous;
+    };
 
-        const config: CursorMcpJson = {
-            ...previous,
-            mcpServers: {
-                ...previous.mcpServers,
-                [serverId]: installedHapi,
-            },
-        };
-        writeMcpJsonAtomic(mcpJsonPath, config);
+    // Validate under lock without writing — Git shield must land before the mailbox mutate.
+    withMcpJsonLock(lockPath, () => {
+        prepareOverlayMutation();
     });
 
-    let unshieldGit: () => void = () => {};
+    // Exclude lease before any mcp.json write so a crash cannot leave an unignored mailbox.
+    const unshieldGit = shieldProjectMcpJsonFromGit(cwd, mcpJsonPath);
+
     try {
-        unshieldGit = shieldProjectMcpJsonFromGit(cwd, mcpJsonPath);
+        withMcpJsonLock(lockPath, () => {
+            const previous = prepareOverlayMutation();
+            const config: CursorMcpJson = {
+                ...previous,
+                mcpServers: {
+                    ...previous.mcpServers,
+                    [serverId]: installedHapi,
+                },
+            };
+            writeMcpJsonAtomic(mcpJsonPath, config);
+        });
     } catch (error) {
-        // Roll back the mailbox write so we do not leave an unshielded runtime config.
         try {
-            withMcpJsonLock(lockPath, () => {
-                if (!existsSync(mcpJsonPath)) {
-                    return;
-                }
-                if (!hadFile) {
-                    rmSync(mcpJsonPath, { force: true });
-                    return;
-                }
-                const current = readMcpJson(mcpJsonPath);
-                current.mcpServers ??= {};
-                const currentServer = current.mcpServers[serverId];
-                if (!sameMcpEntry(currentServer, installedHapi)) {
-                    return;
-                }
-                if (hadServer && previousServer) {
-                    current.mcpServers[serverId] = previousServer;
-                } else {
-                    delete current.mcpServers[serverId];
-                }
-                writeMcpJsonAtomic(mcpJsonPath, current);
-            });
-        } catch (rollbackError) {
-            logger.debug('[cursor-acp] rollback after git-shield failure failed', rollbackError);
+            unshieldGit();
+        } catch (unshieldError) {
+            logger.debug('[cursor-acp] unshield after mcp.json write failure failed', unshieldError);
         }
         throw error;
     }

--- a/cli/src/cursor/utils/cursorMcpOverlay.ts
+++ b/cli/src/cursor/utils/cursorMcpOverlay.ts
@@ -174,8 +174,15 @@ export type CursorMcpOverlayHandle = {
     cleanup: () => void;
 };
 
-/** Marker line in `.git/info/exclude` for session-local project mcp.json. */
-export const HAPI_MCP_GIT_EXCLUDE_MARKER = '# hapi-cursor-mcp-overlay (do not commit session mailbox)';
+/** Prefix for `.git/info/exclude` lease markers (do not commit session mailbox). */
+export const HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX = '# hapi-cursor-mcp-overlay';
+
+/** @deprecated Prefer {@link hapiMcpGitExcludeMarker} with a lease id. */
+export const HAPI_MCP_GIT_EXCLUDE_MARKER = `${HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX} (do not commit session mailbox)`;
+
+export function hapiMcpGitExcludeMarker(leaseId: string): string {
+    return `${HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX} ${leaseId}`;
+}
 
 /** Normalize a repo-relative path for gitignore / exclude (always `/`). */
 export function toGitExcludePattern(relPath: string): string {
@@ -197,24 +204,64 @@ function resolveGitExcludePath(root: string): string | null {
     return isAbsolute(raw) ? raw : resolvePath(root, raw);
 }
 
-/** Append marker + pattern when missing. Returns true if this call wrote them. */
-export function appendExcludeIfMissing(excludePath: string, pattern: string): boolean {
+/**
+ * Append a per-install lease block (marker + pattern). Multiple live overlays
+ * may share the same pattern across linked worktrees; each keeps its own lease
+ * line so cleanup is reference-counted by presence of remaining leases.
+ */
+export function appendExcludeLease(
+    excludePath: string,
+    pattern: string,
+    leaseId: string,
+): boolean {
+    const marker = hapiMcpGitExcludeMarker(leaseId);
     const existing = existsSync(excludePath) ? readFileSync(excludePath, 'utf-8') : '';
     const lines = existing.split(/\r?\n/);
-    if (lines.includes(pattern)) {
+    if (lines.includes(marker)) {
         return false;
     }
     mkdirSync(dirname(excludePath), { recursive: true });
     const prefix = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
     writeFileSync(
         excludePath,
-        `${prefix}${HAPI_MCP_GIT_EXCLUDE_MARKER}\n${pattern}\n`,
+        `${existing}${prefix}${marker}\n${pattern}\n`,
         { encoding: 'utf-8', mode: 0o644 },
     );
     return true;
 }
 
-/** Remove one marker+pattern block we added (exact lines only). */
+/** @deprecated Use {@link appendExcludeLease}. */
+export function appendExcludeIfMissing(excludePath: string, pattern: string): boolean {
+    return appendExcludeLease(excludePath, pattern, randomUUID());
+}
+
+/** Remove one lease block (exact marker + pattern lines only). */
+export function removeExcludeLease(
+    excludePath: string,
+    pattern: string,
+    leaseId: string,
+): void {
+    if (!existsSync(excludePath)) {
+        return;
+    }
+    const marker = hapiMcpGitExcludeMarker(leaseId);
+    const lines = readFileSync(excludePath, 'utf-8').split(/\r?\n/);
+    const out: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i] === marker && lines[i + 1] === pattern) {
+            i += 1;
+            continue;
+        }
+        out.push(lines[i]!);
+    }
+    while (out.length > 0 && out[out.length - 1] === '') {
+        out.pop();
+    }
+    const body = out.length === 0 ? '' : `${out.join('\n')}\n`;
+    writeFileSync(excludePath, body, { encoding: 'utf-8', mode: 0o644 });
+}
+
+/** @deprecated Use {@link removeExcludeLease}. */
 export function removeExactExcludeBlock(excludePath: string, pattern: string): void {
     if (!existsSync(excludePath)) {
         return;
@@ -222,14 +269,15 @@ export function removeExactExcludeBlock(excludePath: string, pattern: string): v
     const lines = readFileSync(excludePath, 'utf-8').split(/\r?\n/);
     const out: string[] = [];
     for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]!;
         if (
-            lines[i] === HAPI_MCP_GIT_EXCLUDE_MARKER
+            line.startsWith(`${HAPI_MCP_GIT_EXCLUDE_MARKER_PREFIX} `)
             && lines[i + 1] === pattern
         ) {
             i += 1;
             continue;
         }
-        out.push(lines[i]!);
+        out.push(line);
     }
     while (out.length > 0 && out[out.length - 1] === '') {
         out.pop();
@@ -260,12 +308,13 @@ export function shieldProjectMcpJsonFromGit(cwd: string, mcpJsonPath: string): (
         return () => {};
     }
     const gitRelativePath = toGitExcludePattern(relRaw);
+    const leaseId = randomUUID();
 
     let addedExclude = false;
     const excludePath = resolveGitExcludePath(root);
     if (excludePath) {
         try {
-            addedExclude = appendExcludeIfMissing(excludePath, gitRelativePath);
+            addedExclude = appendExcludeLease(excludePath, gitRelativePath, leaseId);
         } catch (error) {
             logger.debug('[cursor-acp] failed to append mcp.json to git exclude', error);
         }
@@ -301,7 +350,7 @@ export function shieldProjectMcpJsonFromGit(cwd: string, mcpJsonPath: string): (
         }
         if (addedExclude && excludePath) {
             try {
-                removeExactExcludeBlock(excludePath, gitRelativePath);
+                removeExcludeLease(excludePath, gitRelativePath, leaseId);
             } catch (error) {
                 logger.debug('[cursor-acp] failed to remove mcp.json from git exclude', error);
             }
@@ -606,14 +655,11 @@ export function installCursorMcpOverlay(
     const unshieldGit = shieldProjectMcpJsonFromGit(cwd, mcpJsonPath);
 
     const cleanup = (): void => {
-        try {
-            unshieldGit();
-        } catch (error) {
-            logger.debug('[cursor-acp] cursor MCP overlay git unshield failed', error);
-        }
+        let safeToUnshield = false;
         try {
             withMcpJsonLock(lockPath, () => {
                 if (!existsSync(mcpJsonPath)) {
+                    safeToUnshield = true;
                     return;
                 }
 
@@ -622,6 +668,7 @@ export function installCursorMcpOverlay(
 
                 const currentServer = current.mcpServers[serverId];
                 if (!sameMcpEntry(currentServer, installedHapi)) {
+                    safeToUnshield = true;
                     return;
                 }
 
@@ -639,13 +686,22 @@ export function installCursorMcpOverlay(
                     && Object.keys(otherTopLevel).length === 0
                 ) {
                     rmSync(mcpJsonPath, { force: true });
+                    safeToUnshield = true;
                     return;
                 }
 
                 writeMcpJsonAtomic(mcpJsonPath, current);
+                safeToUnshield = true;
             });
         } catch (error) {
             logger.debug('[cursor-acp] cursor MCP overlay cleanup failed', error);
+        }
+        if (safeToUnshield) {
+            try {
+                unshieldGit();
+            } catch (error) {
+                logger.debug('[cursor-acp] cursor MCP overlay git unshield failed', error);
+            }
         }
     };
 

--- a/cli/src/ui/doctorInlineMedia.ts
+++ b/cli/src/ui/doctorInlineMedia.ts
@@ -9,7 +9,7 @@ import { configuration } from '@/configuration'
 import { buildHubRequestHeaders } from '@/api/hubExtraHeaders'
 import { readSettings } from '@/persistence'
 import { projectPath } from '@/projectPath'
-import { cursorHapiMcpServerId } from '@/cursor/utils/cursorMcpOverlay'
+import { CURSOR_HAPI_MCP_SERVER_ID } from '@/cursor/utils/cursorMcpOverlay'
 
 export type InlineMediaDoctorCheck = {
     ok: boolean
@@ -223,11 +223,15 @@ export async function runDoctorInlineMedia(): Promise<number> {
     const cursorSessions = withBridge.filter((b) => b.flavor === 'cursor')
     if (cursorSessions.length > 0) {
         console.log(chalk.bold('\nCursor ACP'))
-        console.log(chalk.gray('  Cursor ignores session/new mcpServers. Remote sessions use ~/.cursor/mcp.json + `agent mcp enable hapi-<sessionId>`.'))
+        console.log(chalk.gray(
+            `  Cursor ignores session/new mcpServers. Remote sessions write project <cwd>/.cursor/mcp.json + \`agent mcp enable ${CURSOR_HAPI_MCP_SERVER_ID}\` (not user-level hapi-<sessionId>).`,
+        ))
         console.log(chalk.gray('  Tool names are bare: display_image, display_video, display_media, change_title (not hapi_display_image).'))
         for (const session of cursorSessions) {
-            const serverId = cursorHapiMcpServerId(session.id)
-            console.log(chalk.gray(`  Verify (${session.prefix}): agent mcp list-tools ${serverId}`))
+            const cwdHint = session.path ? ` (cwd ${session.path})` : ''
+            console.log(chalk.gray(
+                `  Verify (${session.prefix})${cwdHint}: agent mcp list-tools ${CURSOR_HAPI_MCP_SERVER_ID}`,
+            ))
         }
     }
 

--- a/cli/src/ui/doctorInlineMedia.ts
+++ b/cli/src/ui/doctorInlineMedia.ts
@@ -228,10 +228,10 @@ export async function runDoctorInlineMedia(): Promise<number> {
         ))
         console.log(chalk.gray('  Tool names are bare: display_image, display_video, display_media, change_title (not hapi_display_image).'))
         for (const session of cursorSessions) {
-            const cwdHint = session.path ? ` (cwd ${session.path})` : ''
-            console.log(chalk.gray(
-                `  Verify (${session.prefix})${cwdHint}: agent mcp list-tools ${CURSOR_HAPI_MCP_SERVER_ID}`,
-            ))
+            const verify = session.path
+                ? `cd ${shellSingleQuote(session.path)} && agent mcp list-tools ${CURSOR_HAPI_MCP_SERVER_ID}`
+                : `agent mcp list-tools ${CURSOR_HAPI_MCP_SERVER_ID}`
+            console.log(chalk.gray(`  Verify (${session.prefix}): ${verify}`))
         }
     }
 


### PR DESCRIPTION
## Summary

Cursor merges `~/.cursor/mcp.json` with `<cwd>/.cursor/mcp.json`. HAPI was writing unique `hapi-<sessionUuid>` servers into the **user** file, so every live Cursor session's peer MCP tools union-loaded into every agent (wrong sender mailbox + N copies of tool schemas = context balloon).

This PR writes one stable project `hapi` mailbox, prunes dead PID-stamped user overlays, refuses symlinked project `.cursor`, and surfaces overlay install failures.

**Not** [#1473](https://github.com/tiann/hapi/pull/1473) (peer provenance). Independent CLI/Cursor tooling fix.

## Test plan

- [x] `cursorMcpOverlay.test.ts` + `cursorAcpRemoteLauncher.test.ts` (64 tests)
- [ ] Manual: two sessions in different cwds → isolated mailboxes
- [ ] Manual: second live session same cwd fails closed
- [ ] Manual: dead `hapi-*` user stamps pruned; live stamps kept


Made with [Cursor](https://cursor.com)