### PR TITLE
fix(web): reuse existing PWA window for notification clicks

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,6 +35,7 @@ import { LoadingState } from '@/components/LoadingState'
 import { ToastContainer } from '@/components/ToastContainer'
 import { PwaUpdateProvider } from '@/lib/pwa-update-context'
 import { ToastProvider, useToast } from '@/lib/toast-context'
+import { getNotificationClickHref, NOTIFICATION_CLICK_ACK_TYPE } from '@/lib/notificationClick'
 import type { SyncEvent } from '@/types/api'
 
 type ToastEvent = Extract<SyncEvent, { type: 'toast' }>
@@ -79,6 +80,24 @@ function AppInner() {
         initializeThemeColors()
         initializeChatSurfaceColors()
     }, [])
+
+    useEffect(() => {
+        if (!('serviceWorker' in navigator)) {
+            return
+        }
+
+        const handleServiceWorkerMessage = (event: MessageEvent<unknown>) => {
+            const href = getNotificationClickHref(event.data, window.location.origin)
+            if (!href) return
+            router.history.push(href)
+            event.ports[0]?.postMessage({ type: NOTIFICATION_CLICK_ACK_TYPE })
+        }
+
+        navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessage)
+        return () => {
+            navigator.serviceWorker.removeEventListener('message', handleServiceWorkerMessage)
+        }
+    }, [router])
 
     // Track visual viewport height for mobile keyboard avoidance (see useViewportHeight.ts)
     useViewportHeight()

--- a/web/src/lib/notificationClick.test.ts
+++ b/web/src/lib/notificationClick.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+    focusOrOpenNotificationClient,
+    getNotificationClickHref,
+    NOTIFICATION_CLICK_ACK_TYPE,
+    NOTIFICATION_CLICK_MESSAGE_TYPE,
+    type NotificationClickClient,
+    type NotificationClickClients
+} from './notificationClick'
+
+function createClient(
+    url: string,
+    overrides: Partial<NotificationClickClient> = {}
+): NotificationClickClient {
+    return {
+        url,
+        focused: false,
+        focus: vi.fn().mockResolvedValue(undefined),
+        navigate: vi.fn().mockResolvedValue(null),
+        ...overrides
+    }
+}
+
+function createClients(
+    windows: NotificationClickClient[],
+    opened: NotificationClickClient | null = null
+): NotificationClickClients {
+    return {
+        matchAll: vi.fn().mockResolvedValue(windows),
+        openWindow: vi.fn().mockResolvedValue(opened)
+    }
+}
+
+describe('focusOrOpenNotificationClient', () => {
+    it('sends the route to an existing HAPI window instead of opening another', async () => {
+        const existing = createClient('https://hapi.test/', {
+            postMessage: vi.fn((_message, transfer) => {
+                transfer[0] && (transfer[0] as MessagePort).postMessage({ type: NOTIFICATION_CLICK_ACK_TYPE })
+            })
+        })
+        const clients = createClients([existing])
+
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+
+        expect(clients.matchAll).toHaveBeenCalledWith({ type: 'window', includeUncontrolled: true })
+        expect(existing.postMessage).toHaveBeenCalledWith(
+            {
+                type: NOTIFICATION_CLICK_MESSAGE_TYPE,
+                url: 'https://hapi.test/sessions/session-1'
+            },
+            expect.any(Array)
+        )
+        expect(existing.navigate).not.toHaveBeenCalled()
+        expect(existing.focus).toHaveBeenCalledOnce()
+        expect(clients.openWindow).not.toHaveBeenCalled()
+    })
+
+    it('delivers repeated notification clicks to the same existing window', async () => {
+        const existing = createClient('https://hapi.test/', {
+            postMessage: vi.fn((_message, transfer) => {
+                transfer[0] && (transfer[0] as MessagePort).postMessage({ type: NOTIFICATION_CLICK_ACK_TYPE })
+            })
+        })
+        const clients = createClients([existing])
+
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-2')
+
+        expect(existing.postMessage).toHaveBeenCalledTimes(2)
+        expect(existing.navigate).not.toHaveBeenCalled()
+        expect(existing.focus).toHaveBeenCalledTimes(2)
+        expect(clients.openWindow).not.toHaveBeenCalled()
+    })
+
+    it('focuses an existing window already at the notification URL', async () => {
+        const existing = createClient('https://hapi.test/sessions/session-1')
+        const clients = createClients([existing])
+
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+
+        expect(existing.focus).toHaveBeenCalledOnce()
+        expect(existing.navigate).not.toHaveBeenCalled()
+        expect(clients.openWindow).not.toHaveBeenCalled()
+    })
+
+    it('opens and focuses a new window when no HAPI window exists', async () => {
+        const opened = createClient('https://hapi.test/')
+        const clients = createClients([], opened)
+
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+
+        expect(clients.openWindow).toHaveBeenCalledWith('https://hapi.test/sessions/session-1')
+        expect(opened.focus).toHaveBeenCalledOnce()
+    })
+
+    it('focuses the existing window even if navigation fails', async () => {
+        const existing = createClient('https://hapi.test/', {
+            navigate: vi.fn().mockRejectedValue(new Error('navigation failed'))
+        })
+        const clients = createClients([existing])
+
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+
+        expect(existing.navigate).toHaveBeenCalledWith('https://hapi.test/sessions/session-1')
+        expect(existing.focus).toHaveBeenCalledOnce()
+        expect(clients.openWindow).not.toHaveBeenCalled()
+    })
+
+    it('falls back to navigation if the existing window cannot receive the route message', async () => {
+        const existing = createClient('https://hapi.test/', {
+            postMessage: vi.fn(() => {
+                throw new Error('message failed')
+            })
+        })
+        const clients = createClients([existing])
+
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+
+        expect(existing.navigate).toHaveBeenCalledWith('https://hapi.test/sessions/session-1')
+        expect(existing.focus).toHaveBeenCalledOnce()
+        expect(clients.openWindow).not.toHaveBeenCalled()
+    })
+})
+
+describe('getNotificationClickHref', () => {
+    it('converts a same-origin notification message into a router href', () => {
+        expect(getNotificationClickHref({
+            type: NOTIFICATION_CLICK_MESSAGE_TYPE,
+            url: 'https://hapi.test/sessions/session-1?tab=activity#latest'
+        }, 'https://hapi.test')).toBe('/sessions/session-1?tab=activity#latest')
+    })
+
+    it('ignores malformed and cross-origin messages', () => {
+        expect(getNotificationClickHref(null, 'https://hapi.test')).toBeNull()
+        expect(getNotificationClickHref({ type: 'OTHER', url: 'https://hapi.test/sessions/session-1' }, 'https://hapi.test')).toBeNull()
+        expect(getNotificationClickHref({
+            type: NOTIFICATION_CLICK_MESSAGE_TYPE,
+            url: 'https://attacker.test/sessions/session-1'
+        }, 'https://hapi.test')).toBeNull()
+    })
+})

--- a/web/src/lib/notificationClick.test.ts
+++ b/web/src/lib/notificationClick.test.ts
@@ -8,6 +8,8 @@ import {
     type NotificationClickClients
 } from './notificationClick'
 
+const APP_SCOPE = 'https://hapi.test/'
+
 function createClient(
     url: string,
     overrides: Partial<NotificationClickClient> = {}
@@ -40,7 +42,7 @@ describe('focusOrOpenNotificationClient', () => {
         })
         const clients = createClients([existing])
 
-        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1', APP_SCOPE)
 
         expect(clients.matchAll).toHaveBeenCalledWith({ type: 'window', includeUncontrolled: true })
         expect(existing.postMessage).toHaveBeenCalledWith(
@@ -63,8 +65,8 @@ describe('focusOrOpenNotificationClient', () => {
         })
         const clients = createClients([existing])
 
-        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
-        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-2')
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1', APP_SCOPE)
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-2', APP_SCOPE)
 
         expect(existing.postMessage).toHaveBeenCalledTimes(2)
         expect(existing.navigate).not.toHaveBeenCalled()
@@ -76,7 +78,7 @@ describe('focusOrOpenNotificationClient', () => {
         const existing = createClient('https://hapi.test/sessions/session-1')
         const clients = createClients([existing])
 
-        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1', APP_SCOPE)
 
         expect(existing.focus).toHaveBeenCalledOnce()
         expect(existing.navigate).not.toHaveBeenCalled()
@@ -87,7 +89,7 @@ describe('focusOrOpenNotificationClient', () => {
         const opened = createClient('https://hapi.test/')
         const clients = createClients([], opened)
 
-        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1', APP_SCOPE)
 
         expect(clients.openWindow).toHaveBeenCalledWith('https://hapi.test/sessions/session-1')
         expect(opened.focus).toHaveBeenCalledOnce()
@@ -99,7 +101,7 @@ describe('focusOrOpenNotificationClient', () => {
         })
         const clients = createClients([existing])
 
-        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1', APP_SCOPE)
 
         expect(existing.navigate).toHaveBeenCalledWith('https://hapi.test/sessions/session-1')
         expect(existing.focus).toHaveBeenCalledOnce()
@@ -114,11 +116,32 @@ describe('focusOrOpenNotificationClient', () => {
         })
         const clients = createClients([existing])
 
-        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1')
+        await focusOrOpenNotificationClient(clients, 'https://hapi.test/sessions/session-1', APP_SCOPE)
 
         expect(existing.navigate).toHaveBeenCalledWith('https://hapi.test/sessions/session-1')
         expect(existing.focus).toHaveBeenCalledOnce()
         expect(clients.openWindow).not.toHaveBeenCalled()
+    })
+
+    it('does not reuse an uncontrolled same-origin window outside the app scope', async () => {
+        const unrelated = createClient('https://hapi.test/other/', {
+            focused: true,
+            postMessage: vi.fn()
+        })
+        const opened = createClient('https://hapi.test/app/')
+        const clients = createClients([unrelated], opened)
+
+        await focusOrOpenNotificationClient(
+            clients,
+            'https://hapi.test/app/sessions/session-1',
+            'https://hapi.test/app/'
+        )
+
+        expect(unrelated.postMessage).not.toHaveBeenCalled()
+        expect(unrelated.navigate).not.toHaveBeenCalled()
+        expect(unrelated.focus).not.toHaveBeenCalled()
+        expect(clients.openWindow).toHaveBeenCalledWith('https://hapi.test/app/sessions/session-1')
+        expect(opened.focus).toHaveBeenCalledOnce()
     })
 })
 

--- a/web/src/lib/notificationClick.test.ts
+++ b/web/src/lib/notificationClick.test.ts
@@ -4,6 +4,7 @@ import {
     getNotificationClickHref,
     NOTIFICATION_CLICK_ACK_TYPE,
     NOTIFICATION_CLICK_MESSAGE_TYPE,
+    resolveNotificationTarget,
     type NotificationClickClient,
     type NotificationClickClients
 } from './notificationClick'
@@ -160,5 +161,12 @@ describe('getNotificationClickHref', () => {
             type: NOTIFICATION_CLICK_MESSAGE_TYPE,
             url: 'https://attacker.test/sessions/session-1'
         }, 'https://hapi.test')).toBeNull()
+    })
+})
+
+describe('resolveNotificationTarget', () => {
+    it('resolves root-relative routes inside a subpath service-worker scope', () => {
+        expect(resolveNotificationTarget('/sessions/session-1', 'https://hapi.test/app/'))
+            .toBe('https://hapi.test/app/sessions/session-1')
     })
 })

--- a/web/src/lib/notificationClick.ts
+++ b/web/src/lib/notificationClick.ts
@@ -1,0 +1,149 @@
+export const NOTIFICATION_CLICK_MESSAGE_TYPE = 'HAPI_NOTIFICATION_CLICK'
+export const NOTIFICATION_CLICK_ACK_TYPE = 'HAPI_NOTIFICATION_CLICK_HANDLED'
+
+export type NotificationClickMessage = {
+    type: typeof NOTIFICATION_CLICK_MESSAGE_TYPE
+    url: string
+}
+
+export type NotificationClickAck = {
+    type: typeof NOTIFICATION_CLICK_ACK_TYPE
+}
+
+export function getNotificationClickHref(message: unknown, origin: string): string | null {
+    if (!message || typeof message !== 'object') {
+        return null
+    }
+
+    const candidate = message as { type?: unknown; url?: unknown }
+    if (candidate.type !== NOTIFICATION_CLICK_MESSAGE_TYPE || typeof candidate.url !== 'string') {
+        return null
+    }
+
+    let targetUrl: URL
+    try {
+        targetUrl = new URL(candidate.url, origin)
+    } catch {
+        return null
+    }
+    if (targetUrl.origin !== origin) {
+        return null
+    }
+
+    return `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`
+}
+
+export type NotificationClickClient = {
+    url: string
+    focused?: boolean
+    focus: () => Promise<unknown>
+    navigate: (url: string) => Promise<NotificationClickClient | null>
+    postMessage?: (message: NotificationClickMessage, transfer: Transferable[]) => void
+}
+
+export type NotificationClickClients = {
+    matchAll: (options: { type: 'window'; includeUncontrolled: true }) => Promise<readonly NotificationClickClient[]>
+    openWindow?: (url: string) => Promise<NotificationClickClient | null>
+}
+
+async function deliverNotificationClickMessage(
+    client: NotificationClickClient,
+    targetUrl: string
+): Promise<boolean> {
+    if (!client.postMessage) {
+        return false
+    }
+    const postMessage = (message: NotificationClickMessage, transfer: Transferable[]) => {
+        client.postMessage?.(message, transfer)
+    }
+
+    if (typeof MessageChannel === 'undefined') {
+        try {
+            postMessage({
+                type: NOTIFICATION_CLICK_MESSAGE_TYPE,
+                url: targetUrl
+            }, [])
+            return false
+        } catch {
+            return false
+        }
+    }
+
+    const channel = new MessageChannel()
+    return new Promise((resolve) => {
+        let settled = false
+        const timeoutId = setTimeout(() => finish(false), 1000)
+
+        const finish = (handled: boolean) => {
+            if (settled) return
+            settled = true
+            clearTimeout(timeoutId)
+            channel.port1.close()
+            resolve(handled)
+        }
+
+        channel.port1.onmessage = (event) => {
+            const data = event.data as { type?: unknown } | null
+            if (data?.type === NOTIFICATION_CLICK_ACK_TYPE) {
+                finish(true)
+            }
+        }
+        channel.port1.start()
+
+        try {
+            postMessage({
+                type: NOTIFICATION_CLICK_MESSAGE_TYPE,
+                url: targetUrl
+            }, [channel.port2])
+        } catch {
+            finish(false)
+        }
+    })
+}
+
+export async function focusOrOpenNotificationClient(
+    clients: NotificationClickClients,
+    targetUrl: string
+): Promise<void> {
+    const windowClients = await clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true
+    })
+    const targetOrigin = new URL(targetUrl).origin
+    const sameOriginClients = windowClients.filter((client) => {
+        try {
+            return new URL(client.url).origin === targetOrigin
+        } catch {
+            return false
+        }
+    })
+    const targetClient = sameOriginClients.find((client) => client.url === targetUrl)
+        ?? sameOriginClients.find((client) => client.focused)
+        ?? sameOriginClients[0]
+
+    if (targetClient) {
+        if (targetClient.url === targetUrl) {
+            await targetClient.focus()
+            return
+        }
+
+        // Keep the SPA's router in control of an already-open app window. Some
+        // installed browser runtimes resolve WindowClient.navigate() without
+        // updating the active SPA route on subsequent notification clicks.
+        if (await deliverNotificationClickMessage(targetClient, targetUrl)) {
+            await targetClient.focus()
+            return
+        }
+
+        try {
+            const navigatedClient = await targetClient.navigate(targetUrl)
+            await (navigatedClient ?? targetClient).focus()
+        } catch {
+            await targetClient.focus()
+        }
+        return
+    }
+
+    const openedClient = await clients.openWindow?.(targetUrl)
+    await openedClient?.focus()
+}

--- a/web/src/lib/notificationClick.ts
+++ b/web/src/lib/notificationClick.ts
@@ -10,6 +10,11 @@ export type NotificationClickAck = {
     type: typeof NOTIFICATION_CLICK_ACK_TYPE
 }
 
+export function resolveNotificationTarget(rawUrl: string | undefined, appScope: string): string {
+    const route = (rawUrl ?? '/').replace(/^\/+/, '')
+    return new URL(route, appScope).toString()
+}
+
 export function getNotificationClickHref(message: unknown, origin: string): string | null {
     if (!message || typeof message !== 'object') {
         return null

--- a/web/src/lib/notificationClick.ts
+++ b/web/src/lib/notificationClick.ts
@@ -103,23 +103,30 @@ async function deliverNotificationClickMessage(
 
 export async function focusOrOpenNotificationClient(
     clients: NotificationClickClients,
-    targetUrl: string
+    targetUrl: string,
+    appScope: string
 ): Promise<void> {
     const windowClients = await clients.matchAll({
         type: 'window',
         includeUncontrolled: true
     })
+    const scopeUrl = new URL(appScope)
+    const scopePath = scopeUrl.pathname.endsWith('/')
+        ? scopeUrl.pathname
+        : `${scopeUrl.pathname}/`
     const targetOrigin = new URL(targetUrl).origin
-    const sameOriginClients = windowClients.filter((client) => {
+    const appClients = windowClients.filter((client) => {
         try {
-            return new URL(client.url).origin === targetOrigin
+            const clientUrl = new URL(client.url)
+            return clientUrl.origin === targetOrigin
+                && (clientUrl.pathname === scopeUrl.pathname || clientUrl.pathname.startsWith(scopePath))
         } catch {
             return false
         }
     })
-    const targetClient = sameOriginClients.find((client) => client.url === targetUrl)
-        ?? sameOriginClients.find((client) => client.focused)
-        ?? sameOriginClients[0]
+    const targetClient = appClients.find((client) => client.url === targetUrl)
+        ?? appClients.find((client) => client.focused)
+        ?? appClients[0]
 
     if (targetClient) {
         if (targetClient.url === targetUrl) {

--- a/web/src/sw.ts
+++ b/web/src/sw.ts
@@ -138,7 +138,7 @@ self.addEventListener('notificationclick', (event) => {
     event.notification.close()
     const data = event.notification.data as { url?: string } | undefined
     const url = new URL(data?.url ?? '/', self.location.origin).toString()
-    event.waitUntil(focusOrOpenNotificationClient(self.clients, url))
+    event.waitUntil(focusOrOpenNotificationClient(self.clients, url, self.registration.scope))
 })
 
 // Web Share Target — manifest declares POST /share, Android Chrome posts a

--- a/web/src/sw.ts
+++ b/web/src/sw.ts
@@ -9,7 +9,7 @@ import {
     putShareTransfer,
 } from './lib/shareTransfer'
 import { shareTargetPathname } from './lib/sharePath'
-import { focusOrOpenNotificationClient } from './lib/notificationClick'
+import { focusOrOpenNotificationClient, resolveNotificationTarget } from './lib/notificationClick'
 
 const sharePath = shareTargetPathname()
 
@@ -137,7 +137,7 @@ self.addEventListener('push', (event) => {
 self.addEventListener('notificationclick', (event) => {
     event.notification.close()
     const data = event.notification.data as { url?: string } | undefined
-    const url = new URL(data?.url ?? '/', self.location.origin).toString()
+    const url = resolveNotificationTarget(data?.url, self.registration.scope)
     event.waitUntil(focusOrOpenNotificationClient(self.clients, url, self.registration.scope))
 })
 

--- a/web/src/sw.ts
+++ b/web/src/sw.ts
@@ -9,6 +9,7 @@ import {
     putShareTransfer,
 } from './lib/shareTransfer'
 import { shareTargetPathname } from './lib/sharePath'
+import { focusOrOpenNotificationClient } from './lib/notificationClick'
 
 const sharePath = shareTargetPathname()
 
@@ -136,8 +137,8 @@ self.addEventListener('push', (event) => {
 self.addEventListener('notificationclick', (event) => {
     event.notification.close()
     const data = event.notification.data as { url?: string } | undefined
-    const url = data?.url ?? '/'
-    event.waitUntil(self.clients.openWindow(url))
+    const url = new URL(data?.url ?? '/', self.location.origin).toString()
+    event.waitUntil(focusOrOpenNotificationClient(self.clients, url))
 })
 
 // Web Share Target — manifest declares POST /share, Android Chrome posts a


### PR DESCRIPTION
## Summary

- Replace unconditional `clients.openWindow(url)` notification handling with existing-window reuse.
- Resolve root-relative notification routes inside the current service-worker/PWA scope, including subpath deployments.
- Focus an existing same-origin HAPI PWA window and deliver the target route to the SPA through `postMessage`.
- Let TanStack Router perform the in-window navigation.
- Restrict reusable windows to the current service-worker scope so unrelated same-origin tabs are never reused.
- Keep `WindowClient.navigate()` and `openWindow()` as fallbacks.
- Add regression tests for repeated clicks, subpath route resolution, service-worker scope validation, same-origin validation, and fallback behavior.

## Problem / Motivation

Every PWA notification click previously called `clients.openWindow(url)`, which opened a new HAPI window instead of reusing the already-open HAPI application.

This was especially visible when HAPI was installed as a PWA in Windows 10 Edge.

## User Impact

Notification clicks now focus the existing HAPI PWA window and navigate it to the notification target instead of opening another HAPI window. Deployments hosted under a URL subpath also keep notification routes within that subpath.

## Validation

- `bun typecheck` — passed
- `bun run test:web -- --reporter=dot` — 260 files, 2460 tests passed
- `cd web && bun run test -- src/lib/notificationClick.test.ts src/hooks/usePushNotifications.test.ts` — 13 tests passed
- `bun run build` — passed

## Related Issues

None.

## AI Disclosure

AI assistance: OpenAI Codex was used for implementation, testing, and validation.