### PR TITLE
fix(pi): offer model-accurate thinking levels in the create-session form

### DIFF
--- a/cli/src/modules/common/piModels.test.ts
+++ b/cli/src/modules/common/piModels.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { parsePiModelsProbeLine } from './piModels'
 
+const PROBE_RPC_ID = 'hapi-machine-models-probe'
+
 function probeResponseLine(data: unknown): string {
     return JSON.stringify({
-        id: 'hapi-machine-models-probe',
+        id: PROBE_RPC_ID,
         type: 'response',
         command: 'get_available_models',
         success: true,
@@ -13,7 +15,7 @@ function probeResponseLine(data: unknown): string {
 
 describe('parsePiModelsProbeLine', () => {
     it('parses the get_available_models response with full model records', () => {
-        const models = parsePiModelsProbeLine(probeResponseLine({
+        const result = parsePiModelsProbeLine(probeResponseLine({
             models: [
                 {
                     id: 'claude-opus-5',
@@ -26,17 +28,20 @@ describe('parsePiModelsProbeLine', () => {
                 { id: 'gpt-4o', provider: 'openai', reasoning: false },
             ],
         }))
-        expect(models).toEqual([
-            {
-                provider: 'anthropic',
-                modelId: 'claude-opus-5',
-                name: 'Claude Opus 5',
-                contextWindow: 200000,
-                reasoning: true,
-                thinkingLevelMap: { off: 'off', minimal: null, xhigh: 'xhigh', max: 'max' },
-            },
-            { provider: 'openai', modelId: 'gpt-4o', reasoning: false },
-        ])
+        expect(result).toEqual({
+            kind: 'models',
+            models: [
+                {
+                    provider: 'anthropic',
+                    modelId: 'claude-opus-5',
+                    name: 'Claude Opus 5',
+                    contextWindow: 200000,
+                    reasoning: true,
+                    thinkingLevelMap: { off: 'off', minimal: null, xhigh: 'xhigh', max: 'max' },
+                },
+                { provider: 'openai', modelId: 'gpt-4o', reasoning: false },
+            ],
+        })
     })
 
     it('ignores non-JSON lines and unrelated RPC traffic', () => {
@@ -45,32 +50,50 @@ describe('parsePiModelsProbeLine', () => {
         expect(parsePiModelsProbeLine('{not json')).toBeNull()
         expect(parsePiModelsProbeLine(JSON.stringify({ type: 'event', event: 'agent_start' }))).toBeNull()
         expect(parsePiModelsProbeLine(JSON.stringify({
-            id: 'x', type: 'response', command: 'get_state', success: true, data: {},
+            id: PROBE_RPC_ID, type: 'response', command: 'get_state', success: true, data: {},
         }))).toBeNull()
     })
 
-    it('treats a failed get_available_models response as no result', () => {
+    it('ignores a get_available_models response addressed to another request id', () => {
         expect(parsePiModelsProbeLine(JSON.stringify({
-            id: 'x',
+            id: 'someone-else',
+            type: 'response',
+            command: 'get_available_models',
+            success: true,
+            data: { models: [{ id: 'm', provider: 'p' }] },
+        }))).toBeNull()
+    })
+
+    it('surfaces an explicit RPC failure with its error text', () => {
+        expect(parsePiModelsProbeLine(JSON.stringify({
+            id: PROBE_RPC_ID,
             type: 'response',
             command: 'get_available_models',
             success: false,
-            error: 'boom',
-        }))).toBeNull()
+            error: 'Unknown command',
+        }))).toEqual({ kind: 'error', error: 'Unknown command' })
+    })
+
+    it('falls back to a generic message when the failure carries no error text', () => {
+        expect(parsePiModelsProbeLine(JSON.stringify({
+            id: PROBE_RPC_ID,
+            type: 'response',
+            command: 'get_available_models',
+            success: false,
+        }))).toEqual({ kind: 'error', error: 'Pi rejected the model probe request' })
     })
 
     it('returns an empty catalog for a malformed data payload', () => {
-        expect(parsePiModelsProbeLine(probeResponseLine('not-an-object'))).toEqual([])
-        expect(parsePiModelsProbeLine(probeResponseLine({}))).toEqual([])
+        expect(parsePiModelsProbeLine(probeResponseLine('not-an-object'))).toEqual({ kind: 'models', models: [] })
+        expect(parsePiModelsProbeLine(probeResponseLine({}))).toEqual({ kind: 'models', models: [] })
     })
 
     it('drops entries without an id but keeps the rest', () => {
-        const models = parsePiModelsProbeLine(probeResponseLine({
+        expect(parsePiModelsProbeLine(probeResponseLine({
             models: [
                 { provider: 'openai' },
                 { id: 'kept', provider: 'openai' },
             ],
-        }))
-        expect(models).toEqual([{ provider: 'openai', modelId: 'kept' }])
+        }))).toEqual({ kind: 'models', models: [{ provider: 'openai', modelId: 'kept' }] })
     })
 })

--- a/cli/src/modules/common/piModels.test.ts
+++ b/cli/src/modules/common/piModels.test.ts
@@ -1,43 +1,76 @@
 import { describe, expect, it } from 'vitest'
-import { parsePiModelsTable } from './piModels'
+import { parsePiModelsProbeLine } from './piModels'
 
-const SAMPLE_TABLE = `provider      model                     context  max-out  thinking  images
-openai-codex  gpt-5.3-codex-spark       128K     128K     yes       no
-openai-codex  gpt-5.6-sol               272K     128K     yes       yes
-opencode-go   deepseek-v4-pro           1M       384K     yes       no
-opencode-go   gpt-5.6-luna              1.1M     128K     yes       yes
-opencode-go   qwen3.6-plus              1M       65.5K    yes       yes
-`
+function probeResponseLine(data: unknown): string {
+    return JSON.stringify({
+        id: 'hapi-machine-models-probe',
+        type: 'response',
+        command: 'get_available_models',
+        success: true,
+        data,
+    })
+}
 
-describe('parsePiModelsTable', () => {
-    it('parses provider/model columns and reasoning flag', () => {
-        const models = parsePiModelsTable(SAMPLE_TABLE)
+describe('parsePiModelsProbeLine', () => {
+    it('parses the get_available_models response with full model records', () => {
+        const models = parsePiModelsProbeLine(probeResponseLine({
+            models: [
+                {
+                    id: 'claude-opus-5',
+                    provider: 'anthropic',
+                    name: 'Claude Opus 5',
+                    contextWindow: 200000,
+                    reasoning: true,
+                    thinkingLevelMap: { off: 'off', minimal: null, xhigh: 'xhigh', max: 'max' },
+                },
+                { id: 'gpt-4o', provider: 'openai', reasoning: false },
+            ],
+        }))
         expect(models).toEqual([
-            { provider: 'openai-codex', modelId: 'gpt-5.3-codex-spark', reasoning: true },
-            { provider: 'openai-codex', modelId: 'gpt-5.6-sol', reasoning: true },
-            { provider: 'opencode-go', modelId: 'deepseek-v4-pro', reasoning: true },
-            { provider: 'opencode-go', modelId: 'gpt-5.6-luna', reasoning: true },
-            { provider: 'opencode-go', modelId: 'qwen3.6-plus', reasoning: true },
+            {
+                provider: 'anthropic',
+                modelId: 'claude-opus-5',
+                name: 'Claude Opus 5',
+                contextWindow: 200000,
+                reasoning: true,
+                thinkingLevelMap: { off: 'off', minimal: null, xhigh: 'xhigh', max: 'max' },
+            },
+            { provider: 'openai', modelId: 'gpt-4o', reasoning: false },
         ])
     })
 
-    it('skips the header, separators, and short lines', () => {
-        const models = parsePiModelsTable(`provider model context max-out thinking images
-=== === === === === ===
-junk
-`)
-        expect(models).toEqual([])
+    it('ignores non-JSON lines and unrelated RPC traffic', () => {
+        expect(parsePiModelsProbeLine('starting up...')).toBeNull()
+        expect(parsePiModelsProbeLine('')).toBeNull()
+        expect(parsePiModelsProbeLine('{not json')).toBeNull()
+        expect(parsePiModelsProbeLine(JSON.stringify({ type: 'event', event: 'agent_start' }))).toBeNull()
+        expect(parsePiModelsProbeLine(JSON.stringify({
+            id: 'x', type: 'response', command: 'get_state', success: true, data: {},
+        }))).toBeNull()
     })
 
-    it('treats non-reasoning models as reasoning false', () => {
-        const models = parsePiModelsTable(`provider      model                     context  max-out  thinking  images
-anthropic     claude-haiku             200K     64K      no        no
-`)
-        expect(models).toEqual([{ provider: 'anthropic', modelId: 'claude-haiku', reasoning: false }])
+    it('treats a failed get_available_models response as no result', () => {
+        expect(parsePiModelsProbeLine(JSON.stringify({
+            id: 'x',
+            type: 'response',
+            command: 'get_available_models',
+            success: false,
+            error: 'boom',
+        }))).toBeNull()
     })
 
-    it('dedupes identical provider/model pairs', () => {
-        const models = parsePiModelsTable(SAMPLE_TABLE + 'openai-codex  gpt-5.6-sol               272K     128K     yes       yes\n')
-        expect(models.filter((m) => m.modelId === 'gpt-5.6-sol')).toHaveLength(1)
+    it('returns an empty catalog for a malformed data payload', () => {
+        expect(parsePiModelsProbeLine(probeResponseLine('not-an-object'))).toEqual([])
+        expect(parsePiModelsProbeLine(probeResponseLine({}))).toEqual([])
+    })
+
+    it('drops entries without an id but keeps the rest', () => {
+        const models = parsePiModelsProbeLine(probeResponseLine({
+            models: [
+                { provider: 'openai' },
+                { id: 'kept', provider: 'openai' },
+            ],
+        }))
+        expect(models).toEqual([{ provider: 'openai', modelId: 'kept' }])
     })
 })

--- a/cli/src/modules/common/piModels.ts
+++ b/cli/src/modules/common/piModels.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import type { PiModelSummary, PiModelsResponse } from '@hapi/protocol/apiTypes'
+import { parsePiModels } from '../../pi/schemas'
 import { getErrorMessage } from './rpcResponses'
 
 export type ListPiModelsForMachineRequest = Record<string, never>
@@ -17,90 +18,107 @@ const cache = new Map<string, CacheEntry>()
 const inflight = new Map<string, Promise<ListPiModelsForMachineResponse>>()
 
 /**
- * Parse the `pi --list-models` table:
+ * Machine-level Pi model discovery via a short-lived `pi --mode rpc` probe.
  *
- * ```
- * provider      model                     context  max-out  thinking  images
- * openai-codex  gpt-5.6-sol              272K     128K     yes       yes
- * ```
+ * The previous `pi --list-models` text-table probe lost every field the
+ * table does not print — most importantly `thinkingLevelMap`, so the
+ * create-session form could never offer model-accurate thinking levels
+ * (xhigh/max are map-opt-in and were permanently hidden). The RPC probe
+ * returns the same full model records as the session-scoped
+ * `get_available_models` RPC and goes through the same `parsePiModels`
+ * schema, so machine-level and session-level catalogs cannot drift.
  *
- * Column values never contain whitespace, so splitting on runs of whitespace
- * is stable. `context`/`max-out` are human sizes (`128K`, `1M`, `202.8K`);
- * they are retained as strings — the session-scoped `get_available_models`
- * RPC remains the authoritative source for the numeric context window.
+ * The probe is spawned with discovery disabled (`--no-session,
+ * --no-extensions, --no-skills, --no-prompt-templates, --no-tools`): no
+ * session file is written, no user extensions run, and startup stays fast
+ * (measured ~0.6s vs ~1.6-2.4s for the old table probe).
  */
-export function parsePiModelsTable(output: string): PiModelSummary[] {
-    const models: PiModelSummary[] = []
-    const seen = new Set<string>()
+const PI_PROBE_ARGS = [
+    '--mode', 'rpc',
+    '--no-session',
+    '--no-extensions',
+    '--no-skills',
+    '--no-prompt-templates',
+    '--no-tools',
+] as const
 
-    for (const rawLine of output.split(/\r?\n/)) {
-        const line = rawLine.trim()
-        if (!line || line.startsWith('provider') || line.startsWith('===')) {
-            continue
-        }
-        const columns = line.split(/\s{2,}/)
-        if (columns.length < 5) {
-            continue
-        }
-        const [provider, modelId, , , thinking] = columns
-        if (!provider || !modelId || seen.has(`${provider}/${modelId}`)) {
-            continue
-        }
-        seen.add(`${provider}/${modelId}`)
-        models.push({
-            provider,
-            modelId,
-            reasoning: thinking === 'yes',
-        })
+const PROBE_RPC_ID = 'hapi-machine-models-probe'
+
+/** Extract the get_available_models response from one stdout line, if present. */
+export function parsePiModelsProbeLine(line: string): PiModelSummary[] | null {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('{')) return null
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(trimmed)
+    } catch {
+        return null
     }
-
-    return models
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const record = parsed as Record<string, unknown>
+    if (record.type !== 'response' || record.command !== 'get_available_models') return null
+    if (record.success !== true) return null
+    return parsePiModels(record.data)
 }
 
 function runPiModelsProbe(): Promise<ListPiModelsForMachineResponse> {
     return new Promise((resolve, reject) => {
-        const child = spawn('pi', ['--list-models'], {
+        const child = spawn('pi', [...PI_PROBE_ARGS], {
             env: process.env,
-            stdio: ['ignore', 'pipe', 'pipe'],
+            stdio: ['pipe', 'pipe', 'pipe'],
             shell: process.platform === 'win32',
             windowsHide: process.platform === 'win32',
         })
-        let stdout = ''
+        let stdoutBuffer = ''
         let stderr = ''
         let settled = false
 
-        const timeout = setTimeout(() => {
+        const finish = (settle: () => void) => {
             if (settled) return
             settled = true
+            clearTimeout(timeout)
+            // The probe child has no further use once the response (or a
+            // failure) landed; never leave an interactive pi process behind.
             child.kill('SIGTERM')
-            reject(new Error('Pi model discovery timed out'))
+            settle()
+        }
+
+        const timeout = setTimeout(() => {
+            finish(() => reject(new Error('Pi model discovery timed out')))
         }, PROBE_TIMEOUT_MS)
 
         child.stdout?.on('data', (chunk) => {
-            stdout += chunk.toString()
+            stdoutBuffer += chunk.toString()
+            // The RPC stream is line-delimited JSON; scan every complete line
+            // for the get_available_models response and ignore the rest
+            // (lifecycle events, unrelated responses).
+            let newlineIndex = stdoutBuffer.indexOf('\n')
+            while (newlineIndex !== -1 && !settled) {
+                const line = stdoutBuffer.slice(0, newlineIndex)
+                stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1)
+                newlineIndex = stdoutBuffer.indexOf('\n')
+                const availableModels = parsePiModelsProbeLine(line)
+                if (availableModels !== null) {
+                    finish(() => resolve({ success: true, availableModels, currentModelId: null }))
+                    return
+                }
+            }
         })
         child.stderr?.on('data', (chunk) => {
             stderr += chunk.toString()
         })
         child.on('error', (error) => {
-            if (settled) return
-            settled = true
-            clearTimeout(timeout)
-            reject(error)
+            finish(() => reject(error))
         })
         child.on('close', (code) => {
-            if (settled) return
-            settled = true
-            clearTimeout(timeout)
-            if (code !== 0) {
-                reject(new Error(
-                    stderr.trim() || `pi --list-models exited with code ${code ?? 'unknown'}`
-                ))
-                return
-            }
-            const availableModels = parsePiModelsTable(stdout)
-            resolve({ success: true, availableModels, currentModelId: null })
+            finish(() => reject(new Error(
+                stderr.trim() || `pi exited with code ${code ?? 'unknown'} before answering the model probe`
+            )))
         })
+        // pi exiting before the request lands must surface as the close-path
+        // error, not an unhandled EPIPE crash.
+        child.stdin?.on('error', () => { /* handled via close */ })
+        child.stdin?.write(`${JSON.stringify({ id: PROBE_RPC_ID, type: 'get_available_models' })}\n`)
     })
 }
 

--- a/cli/src/modules/common/piModels.ts
+++ b/cli/src/modules/common/piModels.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { homedir } from 'node:os'
+import { parse } from 'node:path'
 import type { PiModelSummary, PiModelsResponse } from '@hapi/protocol/apiTypes'
 import { parsePiModels } from '../../pi/schemas'
 import { killProcessByChildProcess } from '../../utils/process'
@@ -90,20 +91,40 @@ export function parsePiModelsProbeLine(line: string): PiModelsProbeLineResult | 
     return { kind: 'models', models: parsePiModels(record.data) }
 }
 
+/**
+ * Working directory for the probe child.
+ *
+ * Normally the runner's own cwd: a runner started inside a project must keep
+ * seeing that project's `.pi/extensions` providers, which the replaced
+ * `--list-models` probe also surfaced (verified: a project-local provider is
+ * present from the project dir and absent from home).
+ *
+ * A filesystem root is the exception. Under launchd/systemd the runner cwd is
+ * `/`, and starting Pi there is pathological — project discovery plus
+ * extensions that scan from the working directory walk the entire tree.
+ * Measured on macOS with 9 global extensions: 16.8s at `/` (past
+ * PROBE_TIMEOUT_MS, so discovery failed on every call) versus 1.3s at home
+ * and 2.8s in a real project. There is no project to discover at a root
+ * anyway, so home loses nothing there.
+ */
+export function resolveProbeCwd(): string {
+    let cwd: string
+    try {
+        cwd = process.cwd()
+    } catch {
+        // cwd can be gone (deleted directory); home is always resolvable.
+        return homedir()
+    }
+    return cwd === parse(cwd).root ? homedir() : cwd
+}
+
 function runPiModelsProbe(): Promise<ListPiModelsForMachineResponse> {
     return new Promise((resolve, reject) => {
         const child = spawn('pi', [...PI_PROBE_ARGS], {
             env: process.env,
-            // Probe from the user's home directory, never the runner's cwd.
-            // Under launchd/systemd the runner's cwd is `/`, and a Pi startup
-            // there is pathological: project discovery and extensions that
-            // scan from the working directory walk the entire filesystem root.
-            // Measured on macOS with 9 global extensions: 16.8s at cwd=/ (past
-            // the 15s timeout, so discovery failed 100% of the time) versus
-            // 1.4s at $HOME, same 29 models. The catalog is machine-scoped and
-            // does not depend on cwd, so home is both safe and representative
-            // (global extensions still load; see PI_PROBE_ARGS).
-            cwd: homedir(),
+            // Probe from the runner's cwd, falling back to home at a
+            // filesystem root (see resolveProbeCwd).
+            cwd: resolveProbeCwd(),
             stdio: ['pipe', 'pipe', 'pipe'],
             shell: process.platform === 'win32',
             windowsHide: process.platform === 'win32',

--- a/cli/src/modules/common/piModels.ts
+++ b/cli/src/modules/common/piModels.ts
@@ -100,14 +100,43 @@ function runPiModelsProbe(): Promise<ListPiModelsForMachineResponse> {
             clearTimeout(timeout)
             // The probe child has no further use once the response (or a
             // failure) landed; never leave an interactive pi process behind.
-            // killProcessByChildProcess tears down the full process tree
-            // (taskkill /T on Windows where shell:true makes `child` the
-            // shell, tree kill on Unix) and polls until the processes are
-            // gone (SIGKILL escalation included) — only then settle, so the
-            // caller never observes completion with a live probe child.
-            void killProcessByChildProcess(child, false)
-                .catch(() => { /* best effort; SIGKILL escalation already attempted */ })
-                .finally(settle)
+            // killProcessByChildProcess tears down the whole tree (taskkill /T
+            // on Windows, where shell:true makes `child` the shell; tree kill
+            // on Unix) and returns false when something survived.
+            //
+            // A surviving process must not be ignored: the Windows graceful
+            // path is `taskkill /T` without /F and escalates nothing on its
+            // own, so a repeatedly-refused probe child would accumulate
+            // interactive Pi processes. Escalate to the forced path, and only
+            // settle once the tree is confirmed gone — the caller never
+            // observes completion while a probe child is still alive.
+            void (async () => {
+                // No pid means the child never started (e.g. spawn ENOENT):
+                // there is nothing to leak, and the real spawn error is
+                // already on its way through the 'error' handler.
+                if (!child.pid) {
+                    settle()
+                    return
+                }
+                let stopped = false
+                try {
+                    stopped = await killProcessByChildProcess(child, false)
+                    if (!stopped) {
+                        stopped = await killProcessByChildProcess(child, true)
+                    }
+                } catch {
+                    stopped = false
+                }
+                if (!stopped) {
+                    // Report the leak instead of caching a result that came
+                    // with an orphaned child; the next call re-probes.
+                    reject(new Error(
+                        `Pi model probe could not be stopped (pid ${child.pid ?? 'unknown'}); refusing to report a result with a surviving probe process`
+                    ))
+                    return
+                }
+                settle()
+            })()
         }
 
         const timeout = setTimeout(() => {
@@ -156,6 +185,12 @@ function runPiModelsProbe(): Promise<ListPiModelsForMachineResponse> {
         child.stdin?.on('error', () => { /* handled via close */ })
         child.stdin?.write(`${JSON.stringify({ id: PROBE_RPC_ID, type: 'get_available_models' })}\n`)
     })
+}
+
+/** Clear the module-level probe cache and in-flight map between tests. */
+export function _resetPiModelsCacheForTests(): void {
+    cache.clear()
+    inflight.clear()
 }
 
 export async function listPiModelsForMachine(): Promise<ListPiModelsForMachineResponse> {

--- a/cli/src/modules/common/piModels.ts
+++ b/cli/src/modules/common/piModels.ts
@@ -29,15 +29,22 @@ const inflight = new Map<string, Promise<ListPiModelsForMachineResponse>>()
  * `get_available_models` RPC and goes through the same `parsePiModels`
  * schema, so machine-level and session-level catalogs cannot drift.
  *
- * The probe is spawned with discovery disabled (`--no-session,
- * --no-extensions, --no-skills, --no-prompt-templates, --no-tools`): no
- * session file is written, no user extensions run, and startup stays fast
- * (measured ~0.6s vs ~1.6-2.4s for the old table probe).
+ * Extensions must stay enabled: `pi.registerProvider` lets an extension
+ * contribute whole model providers, and the old `--list-models` probe listed
+ * those models. Verified with a project-local `.pi/extensions` provider:
+ * `--no-extensions` returned 29 models while the default run and the old table
+ * probe both returned 30 (the extension's model present). Disabling them would
+ * silently hide those models from the create-session form only.
+ *
+ * Discovery that cannot contribute models is still disabled (`--no-session`,
+ * `--no-skills`, `--no-prompt-templates`, `--no-tools`): no session file is
+ * written and no skill/prompt/tool loading is paid for. The probe still starts
+ * faster than the old table probe (~2.1s vs ~1.6-2.4s measured, with a 60s
+ * cache in front of it).
  */
 const PI_PROBE_ARGS = [
     '--mode', 'rpc',
     '--no-session',
-    '--no-extensions',
     '--no-skills',
     '--no-prompt-templates',
     '--no-tools',

--- a/cli/src/modules/common/piModels.ts
+++ b/cli/src/modules/common/piModels.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import type { PiModelSummary, PiModelsResponse } from '@hapi/protocol/apiTypes'
 import { parsePiModels } from '../../pi/schemas'
+import { killProcessByChildProcess } from '../../utils/process'
 import { getErrorMessage } from './rpcResponses'
 
 export type ListPiModelsForMachineRequest = Record<string, never>
@@ -44,8 +45,20 @@ const PI_PROBE_ARGS = [
 
 const PROBE_RPC_ID = 'hapi-machine-models-probe'
 
-/** Extract the get_available_models response from one stdout line, if present. */
-export function parsePiModelsProbeLine(line: string): PiModelSummary[] | null {
+/**
+ * Result of scanning one RPC stdout line for the probe response.
+ *
+ * - `null`: unrelated traffic (events, other responses, non-JSON noise).
+ * - `models`: successful get_available_models response for our probe id.
+ * - `error`: explicit failure response — surface Pi's own error text
+ *   immediately instead of letting the probe run into the generic timeout
+ *   (the RPC child is interactive and will not exit on its own).
+ */
+export type PiModelsProbeLineResult =
+    | { kind: 'models'; models: PiModelSummary[] }
+    | { kind: 'error'; error: string }
+
+export function parsePiModelsProbeLine(line: string): PiModelsProbeLineResult | null {
     const trimmed = line.trim()
     if (!trimmed.startsWith('{')) return null
     let parsed: unknown
@@ -57,8 +70,16 @@ export function parsePiModelsProbeLine(line: string): PiModelSummary[] | null {
     if (typeof parsed !== 'object' || parsed === null) return null
     const record = parsed as Record<string, unknown>
     if (record.type !== 'response' || record.command !== 'get_available_models') return null
-    if (record.success !== true) return null
-    return parsePiModels(record.data)
+    // Only accept the response to our own request id so a future probe that
+    // multiplexes RPCs cannot mis-attribute another get_available_models call.
+    if (record.id !== PROBE_RPC_ID) return null
+    if (record.success !== true) {
+        const error = typeof record.error === 'string' && record.error.trim()
+            ? record.error
+            : 'Pi rejected the model probe request'
+        return { kind: 'error', error }
+    }
+    return { kind: 'models', models: parsePiModels(record.data) }
 }
 
 function runPiModelsProbe(): Promise<ListPiModelsForMachineResponse> {
@@ -79,8 +100,14 @@ function runPiModelsProbe(): Promise<ListPiModelsForMachineResponse> {
             clearTimeout(timeout)
             // The probe child has no further use once the response (or a
             // failure) landed; never leave an interactive pi process behind.
-            child.kill('SIGTERM')
-            settle()
+            // killProcessByChildProcess tears down the full process tree
+            // (taskkill /T on Windows where shell:true makes `child` the
+            // shell, tree kill on Unix) and polls until the processes are
+            // gone (SIGKILL escalation included) — only then settle, so the
+            // caller never observes completion with a live probe child.
+            void killProcessByChildProcess(child, false)
+                .catch(() => { /* best effort; SIGKILL escalation already attempted */ })
+                .finally(settle)
         }
 
         const timeout = setTimeout(() => {
@@ -97,11 +124,20 @@ function runPiModelsProbe(): Promise<ListPiModelsForMachineResponse> {
                 const line = stdoutBuffer.slice(0, newlineIndex)
                 stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1)
                 newlineIndex = stdoutBuffer.indexOf('\n')
-                const availableModels = parsePiModelsProbeLine(line)
-                if (availableModels !== null) {
-                    finish(() => resolve({ success: true, availableModels, currentModelId: null }))
+                const probeResult = parsePiModelsProbeLine(line)
+                if (probeResult === null) continue
+                if (probeResult.kind === 'error') {
+                    // Explicit RPC failure: surface Pi's own error right away
+                    // instead of degrading it into the generic timeout.
+                    finish(() => reject(new Error(probeResult.error)))
                     return
                 }
+                finish(() => resolve({
+                    success: true,
+                    availableModels: probeResult.models,
+                    currentModelId: null,
+                }))
+                return
             }
         })
         child.stderr?.on('data', (chunk) => {

--- a/cli/src/modules/common/piModels.ts
+++ b/cli/src/modules/common/piModels.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { homedir } from 'node:os'
 import type { PiModelSummary, PiModelsResponse } from '@hapi/protocol/apiTypes'
 import { parsePiModels } from '../../pi/schemas'
 import { killProcessByChildProcess } from '../../utils/process'
@@ -93,6 +94,16 @@ function runPiModelsProbe(): Promise<ListPiModelsForMachineResponse> {
     return new Promise((resolve, reject) => {
         const child = spawn('pi', [...PI_PROBE_ARGS], {
             env: process.env,
+            // Probe from the user's home directory, never the runner's cwd.
+            // Under launchd/systemd the runner's cwd is `/`, and a Pi startup
+            // there is pathological: project discovery and extensions that
+            // scan from the working directory walk the entire filesystem root.
+            // Measured on macOS with 9 global extensions: 16.8s at cwd=/ (past
+            // the 15s timeout, so discovery failed 100% of the time) versus
+            // 1.4s at $HOME, same 29 models. The catalog is machine-scoped and
+            // does not depend on cwd, so home is both safe and representative
+            // (global extensions still load; see PI_PROBE_ARGS).
+            cwd: homedir(),
             stdio: ['pipe', 'pipe', 'pipe'],
             shell: process.platform === 'win32',
             windowsHide: process.platform === 'win32',

--- a/cli/src/modules/common/piModelsProbe.test.ts
+++ b/cli/src/modules/common/piModelsProbe.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { homedir } from 'node:os'
+import { parse } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { spawnMock, killMock } = vi.hoisted(() => ({
@@ -53,12 +54,31 @@ afterEach(() => {
 })
 
 describe('runPiModelsProbe spawn', () => {
-    it('probes from the home directory, not the runner cwd', async () => {
+    it('probes from the runner cwd so project-local providers stay visible', async () => {
+        // A runner started inside a project must keep seeing that project's
+        // .pi/extensions providers, which the replaced --list-models probe
+        // also surfaced.
+        killMock.mockResolvedValue(true)
+        const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/work/project')
+
+        const pending = listPiModelsForMachine()
+        child.emitModelsResponse([{ id: 'm1', provider: 'p1' }])
+        await pending
+
+        expect(spawnMock).toHaveBeenCalledWith(
+            'pi',
+            expect.any(Array),
+            expect.objectContaining({ cwd: '/work/project' }),
+        )
+        cwdSpy.mockRestore()
+    })
+
+    it('falls back to home when the runner cwd is a filesystem root', async () => {
         // Under launchd/systemd the runner cwd is `/`, where a Pi startup that
         // loads extensions took 16.8s locally and blew the 15s timeout on every
-        // call. The catalog is machine-scoped, so probing from $HOME is both
-        // safe and fast (1.4s for the same 29 models).
+        // call (1.3s from home). No project exists at a root to lose.
         killMock.mockResolvedValue(true)
+        const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(parse(process.cwd()).root)
 
         const pending = listPiModelsForMachine()
         child.emitModelsResponse([{ id: 'm1', provider: 'p1' }])
@@ -69,6 +89,27 @@ describe('runPiModelsProbe spawn', () => {
             expect.any(Array),
             expect.objectContaining({ cwd: homedir() }),
         )
+        cwdSpy.mockRestore()
+    })
+
+    it('falls back to home when the runner cwd cannot be resolved', async () => {
+        // A deleted working directory makes process.cwd() throw; home always
+        // resolves, so discovery must not die with it.
+        killMock.mockResolvedValue(true)
+        const cwdSpy = vi.spyOn(process, 'cwd').mockImplementation(() => {
+            throw new Error('ENOENT: uv_cwd')
+        })
+
+        const pending = listPiModelsForMachine()
+        child.emitModelsResponse([{ id: 'm1', provider: 'p1' }])
+        await pending
+
+        expect(spawnMock).toHaveBeenCalledWith(
+            'pi',
+            expect.any(Array),
+            expect.objectContaining({ cwd: homedir() }),
+        )
+        cwdSpy.mockRestore()
     })
 
     it('keeps extensions enabled so registered providers still surface', async () => {

--- a/cli/src/modules/common/piModelsProbe.test.ts
+++ b/cli/src/modules/common/piModelsProbe.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { homedir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { spawnMock, killMock } = vi.hoisted(() => ({
@@ -49,6 +50,40 @@ beforeEach(() => {
 
 afterEach(() => {
     vi.useRealTimers()
+})
+
+describe('runPiModelsProbe spawn', () => {
+    it('probes from the home directory, not the runner cwd', async () => {
+        // Under launchd/systemd the runner cwd is `/`, where a Pi startup that
+        // loads extensions took 16.8s locally and blew the 15s timeout on every
+        // call. The catalog is machine-scoped, so probing from $HOME is both
+        // safe and fast (1.4s for the same 29 models).
+        killMock.mockResolvedValue(true)
+
+        const pending = listPiModelsForMachine()
+        child.emitModelsResponse([{ id: 'm1', provider: 'p1' }])
+        await pending
+
+        expect(spawnMock).toHaveBeenCalledWith(
+            'pi',
+            expect.any(Array),
+            expect.objectContaining({ cwd: homedir() }),
+        )
+    })
+
+    it('keeps extensions enabled so registered providers still surface', async () => {
+        // pi.registerProvider lets an extension contribute whole providers, and
+        // the replaced `--list-models` probe listed those models.
+        killMock.mockResolvedValue(true)
+
+        const pending = listPiModelsForMachine()
+        child.emitModelsResponse([{ id: 'm1', provider: 'p1' }])
+        await pending
+
+        const args = spawnMock.mock.calls[0]?.[1] as string[]
+        expect(args).not.toContain('--no-extensions')
+        expect(args).toEqual(expect.arrayContaining(['--mode', 'rpc', '--no-session']))
+    })
 })
 
 describe('runPiModelsProbe teardown', () => {

--- a/cli/src/modules/common/piModelsProbe.test.ts
+++ b/cli/src/modules/common/piModelsProbe.test.ts
@@ -1,0 +1,114 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock, killMock } = vi.hoisted(() => ({
+    spawnMock: vi.fn(),
+    killMock: vi.fn(),
+}))
+
+vi.mock('node:child_process', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:child_process')>()
+    return { ...actual, spawn: spawnMock }
+})
+
+vi.mock('../../utils/process', () => ({
+    killProcessByChildProcess: killMock,
+}))
+
+import { _resetPiModelsCacheForTests, listPiModelsForMachine } from './piModels'
+
+const PROBE_RPC_ID = 'hapi-machine-models-probe'
+
+class FakeChild extends EventEmitter {
+    stdout = new EventEmitter()
+    stderr = new EventEmitter()
+    stdin = Object.assign(new EventEmitter(), { write: vi.fn() })
+    pid: number | undefined = 4242
+    kill = vi.fn()
+
+    emitModelsResponse(models: Array<Record<string, unknown>>): void {
+        this.stdout.emit('data', `${JSON.stringify({
+            id: PROBE_RPC_ID,
+            type: 'response',
+            command: 'get_available_models',
+            success: true,
+            data: { models },
+        })}\n`)
+    }
+}
+
+let child: FakeChild
+
+beforeEach(() => {
+    _resetPiModelsCacheForTests()
+    child = new FakeChild()
+    spawnMock.mockReset()
+    spawnMock.mockImplementation(() => child)
+    killMock.mockReset()
+})
+
+afterEach(() => {
+    vi.useRealTimers()
+})
+
+describe('runPiModelsProbe teardown', () => {
+    it('escalates to a forced kill when the graceful teardown reports survivors', async () => {
+        killMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+        const pending = listPiModelsForMachine()
+        child.emitModelsResponse([{ id: 'm1', provider: 'p1' }])
+        const response = await pending
+
+        expect(response.availableModels).toEqual([{ provider: 'p1', modelId: 'm1' }])
+        expect(killMock).toHaveBeenNthCalledWith(1, child, false)
+        expect(killMock).toHaveBeenNthCalledWith(2, child, true)
+    })
+
+    it('rejects and caches nothing when even the forced teardown fails', async () => {
+        killMock.mockResolvedValue(false)
+
+        const pending = listPiModelsForMachine()
+        child.emitModelsResponse([{ id: 'm1', provider: 'p1' }])
+        await expect(pending).rejects.toThrow(/could not be stopped/)
+
+        // A surviving probe child must not leave a cached catalog behind: the
+        // next call has to re-probe rather than serve a result that came with
+        // an orphan.
+        killMock.mockReset()
+        killMock.mockResolvedValue(true)
+        const secondChild = new FakeChild()
+        spawnMock.mockImplementation(() => secondChild)
+
+        const second = listPiModelsForMachine()
+        secondChild.emitModelsResponse([{ id: 'm2', provider: 'p2' }])
+        await expect(second).resolves.toMatchObject({
+            availableModels: [{ provider: 'p2', modelId: 'm2' }],
+        })
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not report a teardown failure when the child never started', async () => {
+        child.pid = undefined
+        killMock.mockResolvedValue(false)
+
+        const pending = listPiModelsForMachine()
+        child.emit('error', new Error('spawn pi ENOENT'))
+
+        // The spawn failure must survive as-is instead of being replaced by a
+        // misleading "could not be stopped" error.
+        await expect(pending).rejects.toThrow(/ENOENT/)
+        expect(killMock).not.toHaveBeenCalled()
+    })
+
+    it('tears the tree down once on the timeout path', async () => {
+        vi.useFakeTimers()
+        killMock.mockResolvedValue(true)
+
+        // Attach the rejection assertion before advancing timers so the
+        // rejection can never escape as an unhandled one.
+        const assertion = expect(listPiModelsForMachine()).rejects.toThrow(/timed out/)
+        await vi.advanceTimersByTimeAsync(15_000)
+        await assertion
+        expect(killMock).toHaveBeenCalledWith(child, false)
+    })
+})

--- a/web/src/components/NewSession/EffortField.test.tsx
+++ b/web/src/components/NewSession/EffortField.test.tsx
@@ -76,6 +76,23 @@ describe('EffortField', () => {
         expect(container.querySelector('select')).toBeNull()
     })
 
+    it('filters Pi thinking levels by the selected model thinkingLevelMap', () => {
+        const { container } = render(
+            <EffortField
+                {...baseProps}
+                agent="pi"
+                piSelectedModel={{
+                    reasoning: true,
+                    thinkingLevelMap: { off: null, minimal: null, xhigh: 'xhigh', max: 'max' },
+                }}
+            />
+        )
+        const select = container.querySelector('select') as HTMLSelectElement
+        expect(Array.from(select.options).map((option) => option.value)).toEqual([
+            'auto', 'low', 'medium', 'high', 'xhigh', 'max'
+        ])
+    })
+
     it('renders Codex reasoning effort options', () => {
         const { container } = render(
             <EffortField {...baseProps} agent="codex" />

--- a/web/src/components/NewSession/EffortField.tsx
+++ b/web/src/components/NewSession/EffortField.tsx
@@ -1,4 +1,4 @@
-import { getAgentConfigDescriptor } from '@hapi/protocol'
+import { getAgentConfigDescriptor, type PiThinkingLevelMap } from '@hapi/protocol'
 import { getPiThinkingLevelOptions } from '@/components/AssistantChat/piThinkingLevelOptions'
 import { getCodexComposerReasoningEffortOptions } from '@/components/AssistantChat/codexReasoningEffortOptions'
 import { useTranslation } from '@/lib/use-translation'
@@ -19,8 +19,8 @@ export type EffortFieldProps = {
     grokOptions?: Array<{ value: string; label: string }>
     /** Model-dependent reasoning-effort options (Codex). */
     codexReasoningOptions?: Array<{ value: string; name?: string }>
-    /** Selected Pi model — hides effort when the model cannot reason. */
-    piSelectedModel?: { reasoning?: boolean } | null
+    /** Selected Pi model — hides effort when the model cannot reason and filters levels via thinkingLevelMap. */
+    piSelectedModel?: { reasoning?: boolean; thinkingLevelMap?: PiThinkingLevelMap } | null
 }
 
 /**
@@ -30,7 +30,8 @@ export type EffortFieldProps = {
  * One component serves every flavor with an `effort` field:
  * - Claude: static launch-effort levels.
  * - Grok: model-dependent launch-effort levels.
- * - Pi: static thinking levels (hidden when the selected model cannot reason).
+ * - Pi: model-dependent thinking levels (filtered by the selected model's
+ *   thinkingLevelMap; hidden when the model cannot reason).
  * - Codex / OpenCode: model-dependent reasoning-effort levels.
  */
 export function EffortField(props: EffortFieldProps) {
@@ -52,7 +53,7 @@ export function EffortField(props: EffortFieldProps) {
         }
         options = [
             { value: 'auto', label: t('newSession.model.default') },
-            ...getPiThinkingLevelOptions(props.effort)
+            ...getPiThinkingLevelOptions(props.effort, props.piSelectedModel?.thinkingLevelMap)
         ]
     } else if (isReasoningEffort) {
         const modelOptions = props.agent === 'codex'

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -865,6 +865,75 @@ describe('NewSession launch preferences', () => {
         })
     })
 
+    it('resets a restored effort the Default Pi selection cannot offer', async () => {
+        savePreferredAgent('pi')
+        mocks.piModels = [
+            {
+                provider: 'openai-codex',
+                modelId: 'gpt-5.6-sol',
+                reasoning: true,
+                thinkingLevelMap: { xhigh: 'xhigh', max: 'max' },
+            },
+        ]
+        // Default model (auto) renders the effort field without a map, which
+        // hides xhigh — the restored hidden level must not survive into create.
+        savePreferredLaunchSettings('machine-1', 'pi', {
+            model: 'auto',
+            cursorSelectedBase: 'auto',
+            effort: 'xhigh',
+            modelReasoningEffort: 'default',
+        })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('launch-effort')).toHaveTextContent('auto')
+        })
+    })
+
+    it('keeps a restored xhigh effort when the selected model map opts in', async () => {
+        savePreferredAgent('pi')
+        mocks.piModels = [
+            {
+                provider: 'openai-codex',
+                modelId: 'gpt-5.6-sol',
+                reasoning: true,
+                thinkingLevelMap: { xhigh: 'xhigh', max: 'max' },
+            },
+        ]
+        savePreferredLaunchSettings('machine-1', 'pi', {
+            model: 'openai-codex/gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'xhigh',
+            modelReasoningEffort: 'default',
+        })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('model')).toHaveTextContent('openai-codex/gpt-5.6-sol')
+            expect(screen.getByTestId('launch-effort')).toHaveTextContent('xhigh')
+        })
+    })
+
     it('shows Pi machine models and thinking-level effort and forwards both on create', async () => {
         savePreferredAgent('pi')
         mocks.piModels = [

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
     piDialogSelection: ['pi-native-1'] as string[],
     piModels: [] as PiModelSummary[],
     piModelsLoading: false,
+    piModelsError: null as string | null,
     nextModelValue: 'gpt-5.6-terra',
     refetchSessions: vi.fn(),
     addToast: vi.fn()
@@ -140,7 +141,7 @@ vi.mock('@/hooks/queries/usePiModelsForMachine', () => ({
         availableModels: mocks.piModels,
         currentModelId: null,
         isLoading: mocks.piModelsLoading,
-        error: null
+        error: mocks.piModelsError
     })
 }))
 vi.mock('../../utils/formatRunnerSpawnError', () => ({
@@ -263,6 +264,7 @@ describe('NewSession launch preferences', () => {
         mocks.piDialogSelection = ['pi-native-1']
         mocks.piModels = []
         mocks.piModelsLoading = false
+        mocks.piModelsError = null
         mocks.nextModelValue = 'gpt-5.6-terra'
         mocks.refetchSessions.mockReset()
         mocks.refetchSessions.mockResolvedValue(undefined)
@@ -932,6 +934,48 @@ describe('NewSession launch preferences', () => {
             expect(screen.getByTestId('model')).toHaveTextContent('openai-codex/gpt-5.6-sol')
             expect(screen.getByTestId('launch-effort')).toHaveTextContent('xhigh')
         })
+    })
+
+    it('does not submit a hidden restored effort when Pi model discovery fails', async () => {
+        savePreferredAgent('pi')
+        // A failed catalog never resolves the restored model, so the effort
+        // field renders with an undefined map and hides xhigh. Creation is not
+        // blocked on error (only on loading), so the hidden level must have
+        // been reconciled away rather than forwarded.
+        mocks.piModels = []
+        mocks.piModelsError = 'probe failed'
+        savePreferredLaunchSettings('machine-1', 'pi', {
+            model: 'openai-codex/gpt-5.6-sol',
+            cursorSelectedBase: 'auto',
+            effort: 'xhigh',
+            modelReasoningEffort: 'default',
+        })
+
+        render(
+            <NewSession
+                api={api}
+                machines={[machine]}
+                initialMachineId="machine-1"
+                initialDirectory="C:\\repo"
+                onSuccess={mocks.onSuccess}
+                onCancel={() => {}}
+            />
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId('launch-effort')).toHaveTextContent('auto')
+        })
+
+        act(() => {
+            mocks.spawnSession.mockImplementation(async () => ({ type: 'success', sessionId: 'session-1' }))
+        })
+        fireEvent.click(screen.getByTestId('create'))
+
+        await waitFor(() => expect(mocks.onSuccess).toHaveBeenCalledWith('session-1'))
+        expect(mocks.spawnSession).toHaveBeenCalledWith(expect.objectContaining({
+            agent: 'pi',
+            effort: undefined,
+        }))
     })
 
     it('shows Pi machine models and thinking-level effort and forwards both on create', async () => {

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ApiClient } from '@/api/client'
-import type { Machine } from '@/types/api'
+import type { Machine, PiModelSummary } from '@/types/api'
 import { saveNewSessionFormDraft } from './newSessionFormDraft'
 import {
     loadPreferredLaunchSettings,
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => ({
     opencodeModels: [] as Array<{ modelId: string; name?: string }>,
     opencodeModelsLoading: false,
     piDialogSelection: ['pi-native-1'] as string[],
-    piModels: [] as Array<{ provider: string; modelId: string; name?: string; reasoning?: boolean }>,
+    piModels: [] as PiModelSummary[],
     piModelsLoading: false,
     nextModelValue: 'gpt-5.6-terra',
     refetchSessions: vi.fn(),

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -629,10 +629,20 @@ export function NewSession(props: {
             setEffort('auto')
             return
         }
-        if (piSelectedModel && !isThinkingLevelSupported(effort, piSelectedModel.thinkingLevelMap)) {
+        // Reset a level the current selection cannot offer. Covers both a
+        // resolved model whose map excludes the level and the Default
+        // selection (model === 'auto', piSelectedModel null): the field then
+        // renders with an undefined map, which hides xhigh/max, and a stale
+        // hidden level must not be submitted. While a concrete model is
+        // still resolving (model !== 'auto', piSelectedModel null) do not
+        // reset — the map may prove a restored xhigh/max valid.
+        if (
+            (model === 'auto' || piSelectedModel)
+            && !isThinkingLevelSupported(effort, piSelectedModel?.thinkingLevelMap)
+        ) {
             setEffort('auto')
         }
-    }, [agent, piSelectedModel, effort])
+    }, [agent, model, piSelectedModel, effort])
     useEffect(() => {
         // Reconcile a restored Pi selection with the live machine catalog
         // (mirrors the Codex/Grok/Copilot validation effects). A model that

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -629,20 +629,26 @@ export function NewSession(props: {
             setEffort('auto')
             return
         }
-        // Reset a level the current selection cannot offer. Covers both a
-        // resolved model whose map excludes the level and the Default
-        // selection (model === 'auto', piSelectedModel null): the field then
-        // renders with an undefined map, which hides xhigh/max, and a stale
-        // hidden level must not be submitted. While a concrete model is
-        // still resolving (model !== 'auto', piSelectedModel null) do not
-        // reset — the map may prove a restored xhigh/max valid.
+        // Reset a level the current selection cannot offer, so a level the
+        // field no longer renders can never be submitted. This covers:
+        //   - a resolved model whose map excludes the level;
+        //   - the Default selection (model === 'auto', no map, hides xhigh/max);
+        //   - a failed catalog request, where a restored explicit model stays
+        //     unresolved for good and creation is not blocked (only loading
+        //     gates it), so waiting for a map that will never arrive would let
+        //     the hidden level through.
+        // While a concrete model is still resolving (no error yet) do not
+        // reset — the map may still prove a restored xhigh/max valid.
+        const piSelectionSettled = model === 'auto'
+            || Boolean(piSelectedModel)
+            || Boolean(piModelsState.error)
         if (
-            (model === 'auto' || piSelectedModel)
+            piSelectionSettled
             && !isThinkingLevelSupported(effort, piSelectedModel?.thinkingLevelMap)
         ) {
             setEffort('auto')
         }
-    }, [agent, model, piSelectedModel, effort])
+    }, [agent, model, piSelectedModel, piModelsState.error, effort])
     useEffect(() => {
         // Reconcile a restored Pi selection with the live machine catalog
         // (mirrors the Codex/Grok/Copilot validation effects). A model that

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -55,6 +55,7 @@ import { EffortField } from './EffortField'
 import { shouldEnableOpencodeModelDiscovery } from './opencodeModelsGate'
 import { buildGrokEffortOptions, buildGrokModelOptions, shouldEnableGrokModelDiscovery } from './grokModels'
 import { groupModelsByProvider } from '@/components/AssistantChat/piModelGroups'
+import { isThinkingLevelSupported } from '@/components/AssistantChat/piThinkingLevelOptions'
 import {
     loadPreferredAgent,
     loadPreferredLaunchSettings,
@@ -618,8 +619,17 @@ export function NewSession(props: {
     }, [agent, model, piModelsState.availableModels])
     useEffect(() => {
         // A non-reasoning Pi model must not carry a stale launch effort (the
-        // CLI would reject it and fall back to Pi's default).
-        if (agent === 'pi' && piSelectedModel?.reasoning === false && effort !== 'auto') {
+        // CLI would reject it and fall back to Pi's default), and a level the
+        // selected model's thinkingLevelMap marks unsupported must not survive
+        // a model switch (mirrors the HappyComposer effort reconciliation).
+        if (agent !== 'pi' || effort === 'auto') {
+            return
+        }
+        if (piSelectedModel?.reasoning === false) {
+            setEffort('auto')
+            return
+        }
+        if (piSelectedModel && !isThinkingLevelSupported(effort, piSelectedModel.thinkingLevelMap)) {
             setEffort('auto')
         }
     }, [agent, piSelectedModel, effort])


### PR DESCRIPTION
## Problem

On the create-session form, the Pi effort (thinking level) selector was effectively hardcoded to `auto/off/minimal/low/medium/high`. It never reflected the selected model's capabilities:

- `EffortField` called `getPiThinkingLevelOptions(effort)` **without** the selected model's `thinkingLevelMap`, so levels a model marks unsupported (`null`) stayed visible, and `xhigh`/`max` — which are map-opt-in by design — could never appear, even for models that explicitly support them.
- The upstream data never arrived either: the machine-level probe parsed the `pi --list-models` text table, which only prints `provider / model / context / max-out / thinking(yes|no) / images`. `thinkingLevelMap` (plus `name` and the numeric `contextWindow`) was structurally absent, so no amount of front-end filtering could work.

The chat composer already did this correctly (`HappyComposer` passes `selectedPiModel?.thinkingLevelMap`), so the two surfaces disagreed: a model offering `max` in an existing session could not be launched with `max` from the create form.

## Changes

**web — filter by the selected model's map**
- `EffortField` accepts `thinkingLevelMap` on `piSelectedModel` and forwards it to `getPiThinkingLevelOptions`, matching the composer.
- `NewSession/index.tsx` reconciles a stale effort on model switch: a level the newly selected model cannot offer falls back to `auto`. This also covers the Default selection (`model === 'auto'`, no map ⇒ `xhigh`/`max` hidden), so a hidden level can never be submitted. It intentionally does **not** reset while a concrete model is still resolving, so a restored `xhigh`/`max` survives until the catalog can prove it valid.

**cli — make the machine probe carry the full model record**
- Replace the `pi --list-models` table probe with a short-lived `pi --mode rpc` child issuing `get_available_models`, parsed through the **same** `parsePiModels` schema the session path uses, so machine-level and session-level catalogs cannot drift.
- The probe runs with model-irrelevant discovery disabled (`--no-session --no-skills --no-prompt-templates --no-tools`): no session file is written and no skill/prompt/tool loading is paid for. Extensions stay **enabled** on purpose — `pi.registerProvider` lets an extension contribute whole model providers, and the old `--list-models` probe listed those models, so disabling them would silently hide models from this form only.
- The probe keeps the runner's cwd, falling back to `homedir()` only when that cwd is a filesystem root. A runner started inside a project must keep seeing that project's `.pi/extensions` providers (the replaced `--list-models` probe surfaced them); a runner started by launchd/systemd sits at `/`, where project discovery plus directory-scanning extensions walk the entire tree. `process.cwd()` throwing on a deleted directory also falls back to home. Measured on macOS with 9 global extensions:

  | cwd | extensions | time | outcome |
  |---|---|---|---|
  | `/` | on | 16.8s | past the 15s timeout — discovery failed every time |
  | `/` | off | 0.6s | fast, but loses extension-contributed providers |
  | `$HOME` | on | 1.3s | 29 models, complete |
  | project dir | on | 2.8s | 30 models — includes the project-local provider |

  With the fix, verified under the runner's launchd environment: from `/` it probes home (1.6s, 29 models); from a project directory it stays there (1.4s, 30 models including the project-local provider). Both are at or below the old table probe (~1.6–2.4s), behind the existing 60s cache. The replaced `--list-models` probe was immune to the cwd problem because it never initialized a session.
- Teardown uses the repo's `killProcessByChildProcess` (taskkill `/T` on Windows, tree kill on Unix, SIGKILL escalation) and settles only after the tree is gone. This matters because `shell: true` on Windows makes the direct child the shell, so killing that PID alone would orphan the interactive Pi process on every probe.
- An explicit `success: false` response is surfaced immediately with Pi's own error text (and the response `id` is validated) instead of hanging until the generic 15s timeout — the previous behaviour lost the diagnostic that the old non-zero-exit/stderr path provided.
- `parsePiModelsTable` and its tests are removed; the whitespace-table dependency is gone.

Cache TTL, in-flight dedupe, and the 15s timeout are unchanged. The probe still only runs when the create form has Pi selected with a machine.

## Semantics preserved

`xhigh`/`max` remain opt-in via `thinkingLevelMap`, mirroring Pi's own `getSupportedThinkingLevels` (levels mapped to `null` are excluded; `xhigh`/`max` require an explicit entry). A model with `reasoning: false` still hides the selector entirely.

## Testing

- `cli`: 2386 tests pass; new coverage for the probe-line parser (success, explicit failure with/without error text, foreign response id, malformed payload, entries without an id).
- `web`: 2558 tests pass; new coverage for map-driven option filtering, reset-to-`auto` when switching to Default, and retention of a restored `xhigh` when the model's map opts in (the latter guards the former against a false green from the restore path).
- `bunx tsc --noEmit` clean in both packages.
- Live end-to-end probe on macOS: 30 models returned (including a project-local `.pi/extensions` provider registered via `pi.registerProvider`), all with `thinkingLevelMap`, in ~1.96s; second call served from cache in 0ms; no orphaned `pi --mode rpc` process afterwards.
- Probe lifecycle tests (spawn and teardown helper mocked): graceful→forced escalation, reject-without-caching when both fail, no-pid spawn failure, and the timeout path.

## Known limitations

The Windows process-tree teardown path was not exercised on a Windows host — it relies on the existing `killProcessByChildProcess` contract. The forced-timeout and ignored-SIGTERM paths are likewise covered by code review rather than live runs.



