### PR TITLE
feat(web): anchor the composer settings sheet to the clicked value button

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.modelEffortButtons.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.modelEffortButtons.test.tsx
@@ -167,13 +167,49 @@ describe('HappyComposer generic model/effort value buttons', () => {
         expect(screen.getByRole('button', { name: 'Settings' })).toBeTruthy()
     })
 
-    it('opens the settings sheet from the model button with Model before Permission', () => {
+    it('opens only the Model section from the model button (anchored open)', () => {
         renderComposer('claude')
         fireEvent.click(screen.getByRole('button', { name: 'Sonnet 4' }))
+        expect(screen.getByText('Model')).toBeTruthy()
+        // Anchored open: the other sections stay collapsed.
+        expect(screen.queryByText('Permission Mode')).toBeNull()
+        expect(screen.queryByText('Effort')).toBeNull()
+    })
+
+    it('opens only the Effort section from the effort button (anchored open)', () => {
+        renderComposer('claude')
+        fireEvent.click(screen.getByRole('button', { name: 'High' }))
+        expect(screen.getByText('Effort')).toBeTruthy()
+        expect(screen.queryByText('Model')).toBeNull()
+        expect(screen.queryByText('Permission Mode')).toBeNull()
+    })
+
+    it('switches from the Model to the Effort section without closing the sheet', () => {
+        renderComposer('claude')
+        fireEvent.click(screen.getByRole('button', { name: 'Sonnet 4' }))
+        expect(screen.getByText('Model')).toBeTruthy()
+        fireEvent.click(screen.getByRole('button', { name: 'High' }))
+        expect(screen.getByText('Effort')).toBeTruthy()
+        expect(screen.queryByText('Model')).toBeNull()
+    })
+
+    it('opens the full sheet from the gear with Model before Permission', () => {
+        renderComposer('claude')
+        fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
         const model = screen.getByText('Model')
         const permission = screen.getByText('Permission Mode')
         expect(model.compareDocumentPosition(permission) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
         expect(screen.getByText('Effort')).toBeTruthy()
+    })
+
+    it('expands an anchored sheet to the full sheet when the gear is clicked', () => {
+        renderComposer('claude')
+        fireEvent.click(screen.getByRole('button', { name: 'Sonnet 4' }))
+        expect(screen.queryByText('Effort')).toBeNull()
+        fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+        expect(screen.getByText('Model')).toBeTruthy()
+        expect(screen.getByText('Effort')).toBeTruthy()
+        expect(screen.getByText('Permission Mode')).toBeTruthy()
     })
 
     it('shows generic value buttons for Pi with the provider-qualified model label', () => {
@@ -203,7 +239,8 @@ describe('HappyComposer generic model/effort value buttons', () => {
         // The value button label and the matching sheet row share the model name.
         expect(screen.getAllByText('Gemini 2.5 Pro').length).toBeGreaterThan(1)
         expect(screen.getByText('Vertex Gemini 2.5 Pro')).toBeTruthy()
-        expect(screen.getByText('Effort')).toBeTruthy()
+        // Anchored open from the model button: the Effort section stays collapsed.
+        expect(screen.queryByText('Effort')).toBeNull()
     })
 
     it('keeps the gear reachable on narrow viewports even when the toolbar layout hides it', () => {

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -525,6 +525,9 @@ export function HappyComposer(props: {
     const lastSendAcceptanceRef = useRef(props.sendAcceptance)
     const pendingSendAttemptIdRef = useRef<string | null>(null)
     const [showSettings, setShowSettings] = useState(false)
+    // Anchored settings sheet: the model/effort value buttons open only their
+    // own section; the gear (null) opens the full sheet.
+    const [settingsSection, setSettingsSection] = useState<'model' | 'effort' | null>(null)
     const [isAborting, setIsAborting] = useState(false)
     const [isSwitching, setIsSwitching] = useState(false)
     const [showContinueHint, setShowContinueHint] = useState(false)
@@ -1394,16 +1397,27 @@ export function HappyComposer(props: {
         }
     }, [api, pendingSchedule])
 
-    const handleSettingsToggle = useCallback(() => {
+    // Opens (or closes) the settings sheet. `section` anchors the sheet to a
+    // single section ('model' / 'effort'); the gear passes nothing = full sheet.
+    // Re-clicking with a different anchor while open switches the anchor
+    // instead of closing, so model->effort moves between sections directly.
+    const handleSettingsToggle = useCallback((section: 'model' | 'effort' | null = null) => {
         haptic('light')
-        setShowSettings((prev) => {
-            if (prev) {
-                setCursorDrillDownBase(null)
-                setCursorDrillDownDefaultVariant(null)
-            }
-            return !prev
-        })
-    }, [haptic])
+        if (showSettings && section !== settingsSection) {
+            // Open with a different anchor: switch sections, keep the sheet up.
+            setSettingsSection(section)
+            return
+        }
+        if (showSettings) {
+            setCursorDrillDownBase(null)
+            setCursorDrillDownDefaultVariant(null)
+            setShowSettings(false)
+            setSettingsSection(null)
+            return
+        }
+        setSettingsSection(section)
+        setShowSettings(true)
+    }, [haptic, showSettings, settingsSection])
 
     const clearCursorDrillDown = useCallback(() => {
         setCursorDrillDownBase(null)
@@ -1413,6 +1427,7 @@ export function HappyComposer(props: {
     const dismissSettings = useCallback(() => {
         clearCursorDrillDown()
         setShowSettings(false)
+        setSettingsSection(null)
     }, [clearCursorDrillDown])
 
     const handleModelChange = useCallback((nextModel: { provider: string; modelId: string } | string | null) => {
@@ -1623,14 +1638,20 @@ export function HappyComposer(props: {
         return option?.label ?? (effort ? effort : undefined)
     }, [isNarrowViewport, onEffortChange, agentFlavor, selectedPiModel, effort, claudeEffortOptions])
 
+    // Wrapper for DOM onClick consumers: never leak the MouseEvent into the
+    // `section` parameter (the gear must always open the full sheet).
+    const handleGearToggle = useCallback(() => {
+        handleSettingsToggle(null)
+    }, [handleSettingsToggle])
+
     const handleModelValueToggle = useCallback(() => {
         if (modelEffortControlsDisabled) return
-        handleSettingsToggle()
+        handleSettingsToggle('model')
     }, [modelEffortControlsDisabled, handleSettingsToggle])
 
     const handleEffortValueToggle = useCallback(() => {
         if (modelEffortControlsDisabled) return
-        handleSettingsToggle()
+        handleSettingsToggle('effort')
     }, [modelEffortControlsDisabled, handleSettingsToggle])
 
     const overlayPositionClass = isExpanded
@@ -1639,11 +1660,26 @@ export function HappyComposer(props: {
 
     const overlays = useMemo(() => {
         // Unified settings sheet for every flavor (Pi included).
-        if (showSettings && (showCollaborationSettings || showCopilotAgentModeSettings || showPermissionSettings || showModelSettings || showModelEffortSettings || showModelReasoningEffortSettings || showEffortSettings || showFastModeSettings)) {
+        // Anchored open (settingsSection): a model/effort value button expands
+        // only its own area; the gear (null) expands the full sheet.
+        const sheetModelAreaOn = settingsSection !== 'effort'
+        const sheetEffortAreaOn = settingsSection !== 'model'
+        const sheetOthersOn = settingsSection === null
+        const sheetModelSettings = showModelSettings && sheetModelAreaOn
+        const sheetModelEffortSettings = showModelEffortSettings && sheetModelAreaOn
+        const sheetModelReasoningEffortSettings = showModelReasoningEffortSettings && sheetEffortAreaOn
+        const sheetEffortSettings = showEffortSettings && sheetEffortAreaOn
+        const sheetPermissionSettings = showPermissionSettings && sheetOthersOn
+        const sheetFastModeSettings = showFastModeSettings && sheetOthersOn
+        const sheetCollaborationSettings = showCollaborationSettings && sheetOthersOn
+        const sheetCopilotAgentModeSettings = showCopilotAgentModeSettings && sheetOthersOn
+        const sheetModelAreaSettings = sheetModelSettings || sheetModelEffortSettings || sheetModelReasoningEffortSettings || sheetEffortSettings
+        const sheetOtherSettings = sheetFastModeSettings || sheetCollaborationSettings || sheetCopilotAgentModeSettings
+        if (showSettings && (sheetCollaborationSettings || sheetCopilotAgentModeSettings || sheetPermissionSettings || sheetModelSettings || sheetModelEffortSettings || sheetModelReasoningEffortSettings || sheetEffortSettings || sheetFastModeSettings)) {
             return (
                 <div ref={settingsOverlayRef} className={`${overlayPositionClass} w-full`}>
                     <FloatingOverlay maxHeight={320}>
-                        {showModelSettings ? (
+                        {sheetModelSettings ? (
                             <div className="py-2">
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
                                     {t('misc.model')}
@@ -1734,11 +1770,11 @@ export function HappyComposer(props: {
                             </div>
                         ) : null}
 
-                        {showModelSettings && showModelEffortSettings ? (
+                        {sheetModelSettings && sheetModelEffortSettings ? (
                             <div className="mx-3 h-px bg-[var(--app-divider)]" />
                         ) : null}
 
-                        {showModelEffortSettings ? (
+                        {sheetModelEffortSettings ? (
                             <ModelEffortSettingsSection
                                 agentFlavor={agentFlavor}
                                 options={[...(visibleModelEffortOptions ?? [])]}
@@ -1757,11 +1793,11 @@ export function HappyComposer(props: {
                             />
                         ) : null}
 
-                        {(showModelSettings || showModelEffortSettings) && showModelReasoningEffortSettings ? (
+                        {(sheetModelSettings || sheetModelEffortSettings) && sheetModelReasoningEffortSettings ? (
                             <div className="mx-3 h-px bg-[var(--app-divider)]" />
                         ) : null}
 
-                        {showModelReasoningEffortSettings ? (
+                        {sheetModelReasoningEffortSettings ? (
                             <div className="py-2">
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
                                     {t('misc.reasoningEffort')}
@@ -1798,11 +1834,11 @@ export function HappyComposer(props: {
                             </div>
                         ) : null}
 
-                        {showModelReasoningEffortSettings && showEffortSettings ? (
+                        {sheetModelReasoningEffortSettings && sheetEffortSettings ? (
                             <div className="mx-3 h-px bg-[var(--app-divider)]" />
                         ) : null}
 
-                        {showEffortSettings ? (
+                        {sheetEffortSettings ? (
                             <div className="py-2">
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
                                     {t('misc.effort')}
@@ -1841,11 +1877,11 @@ export function HappyComposer(props: {
                             </div>
                         ) : null}
 
-                        {showModelAreaSettings && showPermissionSettings ? (
+                        {sheetModelAreaSettings && sheetPermissionSettings ? (
                             <div className="mx-3 h-px bg-[var(--app-divider)]" />
                         ) : null}
 
-                        {showPermissionSettings ? (
+                        {sheetPermissionSettings ? (
                             <div className="py-2">
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
                                     {t('misc.permissionMode')}
@@ -1882,11 +1918,11 @@ export function HappyComposer(props: {
                             </div>
                         ) : null}
 
-                        {(showPermissionSettings || showModelAreaSettings) && showOtherSettings ? (
+                        {(sheetPermissionSettings || sheetModelAreaSettings) && sheetOtherSettings ? (
                             <div className="mx-3 h-px bg-[var(--app-divider)]" />
                         ) : null}
 
-                        {showFastModeSettings ? (
+                        {sheetFastModeSettings ? (
                             <div className="py-2">
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
                                     {t('misc.fastMode')}
@@ -1923,11 +1959,11 @@ export function HappyComposer(props: {
                             </div>
                         ) : null}
 
-                        {showFastModeSettings && (showCollaborationSettings || showCopilotAgentModeSettings) ? (
+                        {sheetFastModeSettings && (sheetCollaborationSettings || sheetCopilotAgentModeSettings) ? (
                             <div className="mx-3 h-px bg-[var(--app-divider)]" />
                         ) : null}
 
-                        {showCollaborationSettings ? (
+                        {sheetCollaborationSettings ? (
                             <div className="py-2">
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
                                     {t('misc.collaborationMode')}
@@ -1964,7 +2000,7 @@ export function HappyComposer(props: {
                             </div>
                         ) : null}
 
-                        {showCopilotAgentModeSettings ? (
+                        {sheetCopilotAgentModeSettings ? (
                             <div className="py-2">
                                 <div className="px-3 pb-1 text-xs font-semibold text-[var(--app-hint)]">
                                     {t('misc.copilotAgentMode')}
@@ -2024,6 +2060,7 @@ export function HappyComposer(props: {
         return null
     }, [
         showSettings,
+        settingsSection,
         agentFlavor,
         piModels,
         piSelectedModel,
@@ -2266,7 +2303,7 @@ export function HappyComposer(props: {
                             settingsDisabled={modelEffortControlsDisabled}
                             modelValueButtonRef={modelValueButtonRef}
                             effortValueButtonRef={effortValueButtonRef}
-                            onSettingsToggle={handleSettingsToggle}
+                            onSettingsToggle={handleGearToggle}
                             expanded={isExpanded}
                             onExpandedToggle={handleExpandedToggle}
                             showTerminalButton={showTerminalButton}
@@ -2294,11 +2331,11 @@ export function HappyComposer(props: {
                             hasAttachments={blocksScheduling}
                             modelValueLabel={modelValueLabel}
                             modelValueDisabled={modelEffortControlsDisabled}
-                            modelValueOpen={showSettings}
+                            modelValueOpen={showSettings && settingsSection !== 'effort'}
                             onModelValueToggle={handleModelValueToggle}
                             effortValueLabel={effortValueLabel}
                             effortValueDisabled={modelEffortControlsDisabled}
-                            effortValueOpen={showSettings}
+                            effortValueOpen={showSettings && settingsSection !== 'model'}
                             onEffortValueToggle={handleEffortValueToggle}
                             scratchlistMode={props.scratchlistMode}
                             scratchlistCount={props.scratchlistCount}


### PR DESCRIPTION
## Problem

Since #1475 the composer shows `[model]` and `[effort]` value buttons whose captions are the current values. Clicking either one opened the *same* full settings sheet as the gear, always rendered from the top in the fixed order Model → Effort → Permission → other. So clicking **Effort** never took you to Effort — you landed on the Model section and had to scroll past every model row to reach the control you asked for. The label on the button promised a specific destination the sheet did not deliver.

## Changes

`HappyComposer` gains a `settingsSection` state (`'model' | 'effort' | null`) that anchors the open sheet:

- **model button** expands only the Model area (including the Cursor variant drill-down).
- **effort button** expands only the Effort / Reasoning-effort area.
- **gear** keeps the full sheet (`null` anchor).
- Clicking the other value button while the sheet is open **switches sections in place** rather than closing, so model → effort is one click.
- Clicking the gear over an anchored sheet **expands it to the full sheet**.
- Re-clicking the same trigger still closes, preserving the #1475 toggle-close behaviour.

Implementation notes:

- The section gating happens on sheet-local flags derived inside the `overlays` memo (`sheetModelSettings`, `sheetEffortSettings`, …), so the section-divider conditions keep working and a single visible area never renders a leading, trailing, or orphaned divider.
- `handleGearToggle` is a zero-arg wrapper for the DOM `onClick` consumer, so a `MouseEvent` can never leak into the `section` parameter.
- `modelValueOpen` / `effortValueOpen` now highlight only while their own area is expanded, instead of both lighting up whenever the sheet was open.
- `dismissSettings` clears the anchor along with the sheet and the Cursor drill-down, so no stale anchor can survive a dismissal.

Unchanged: the outside-click dismissal exemption for all three triggers, Pi's mid-turn control liveness (`configurationControlsDisabled`, #1442), the Cursor variant drill-down flow, and narrow-viewport behaviour (value buttons hidden, gear opens the full sheet).

## Testing

- `web`: 2558 tests pass, `bunx tsc --noEmit` clean.
- Updated `HappyComposer.modelEffortButtons` coverage: anchored open from each value button (asserting the other sections stay collapsed), in-place section switching, gear opening the full sheet, and the gear expanding an already-anchored sheet.
