### PR TITLE
fix(pi): refresh context after compaction

### DIFF
--- a/cli/src/pi/piEventConverter.test.ts
+++ b/cli/src/pi/piEventConverter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { convertPiEvent, convertPiTurnUsage } from './piEventConverter';
+import { convertPiCompactionUsage, convertPiEvent, convertPiTurnUsage } from './piEventConverter';
 import type { PiAgentEvent } from './types';
 
 describe('convertPiEvent', () => {
@@ -181,6 +181,16 @@ describe('convertPiEvent', () => {
             totalTokens: 315,
             contextTokens: 315
         });
+    });
+
+    it('should build context-only usage from a compaction estimate', () => {
+        expect(convertPiCompactionUsage(120)).toEqual({
+            type: 'usage',
+            inputTokens: 0,
+            outputTokens: 0,
+            contextTokens: 120,
+        });
+        expect(convertPiCompactionUsage(undefined)).toBeNull();
     });
 
     it('should preserve prior usage when Pi explicitly reports unknown context', () => {

--- a/cli/src/pi/piEventConverter.ts
+++ b/cli/src/pi/piEventConverter.ts
@@ -30,6 +30,17 @@ export function convertPiTurnUsage(
     };
 }
 
+/** Builds a context-only usage update from Pi's post-compaction estimate. */
+export function convertPiCompactionUsage(estimatedTokensAfter: number | undefined): AgentMessage | null {
+    if (estimatedTokensAfter === undefined || !Number.isFinite(estimatedTokensAfter) || estimatedTokensAfter < 0) return null;
+    return {
+        type: 'usage',
+        inputTokens: 0,
+        outputTokens: 0,
+        contextTokens: estimatedTokensAfter,
+    };
+}
+
 /** Converts validated Pi lifecycle events to HAPI chat messages. */
 export function convertPiEvent(event: PiAgentEvent): AgentMessage[] {
     switch (event.type) {

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1264,6 +1264,7 @@ describe('Pi built-in slash commands', () => {
         harness.session.onUserMessage.mockReset();
         harness.session.onCancelQueuedMessage.mockReset();
         harness.session.emitMessagesConsumed.mockReset();
+        harness.session.sendAgentMessage.mockReset();
         harness.session.sendSessionEvent.mockReset();
         harness.session.updateMetadata.mockReset();
         harness.cleanupCount = 0;
@@ -1341,6 +1342,14 @@ describe('Pi built-in slash commands', () => {
             type: 'response', id: compact.id, command: 'compact', success: true,
             data: { summary: 'API design focused summary', tokensBefore: 1000, estimatedTokensAfter: 120 },
         });
+
+        await vi.waitFor(() => expect(harness.session.sendAgentMessage).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'token_count',
+            info: expect.objectContaining({
+                total: expect.objectContaining({ inputTokens: 0, outputTokens: 0 }),
+                contextTokens: 120,
+            }),
+        })));
 
         // The summary lands as a structured event (the web renders it as a
         // dedicated block), not as a plain status message. (The /compact row

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { logger } from '@/ui/logger';
+import { convertAgentMessage } from '@/agent/messageConverter';
 import { bootstrapExistingSession, bootstrapSession } from '@/agent/sessionFactory';
 import { registerKillSessionHandler } from '@/claude/registerKillSessionHandler';
 import { registerLocalHandoffHandler } from '@/agent/localHandoff';
@@ -9,6 +10,7 @@ import { PiTransport } from './piTransport';
 import { PiSession } from './session';
 import { PiConversationHistory, PiHistoryRestoreError } from './conversationHistory';
 import { parsePiModels, parsePiCommands, PiRpcTimeoutError, sendPiRpcAndWait, wireTransportEvents } from './loop';
+import { convertPiCompactionUsage } from './piEventConverter';
 import { PiThinkingLevelSchema, SetSessionConfigPayloadSchema, PiCompactResultSchema, PiFullSessionStatsSchema } from './schemas';
 import type { PiImageContent, PiThinkingLevel } from './types';
 import { parsePiSpecialCommand, parseLeadingSlashName, type PiSpecialCommand } from './specialCommands';
@@ -1059,6 +1061,13 @@ export async function runPi(opts: {
                         else delta.push('?');
                         sendEvent(`📦 Compaction completed (tokens: ${delta.join(' ')})`);
                     }
+                    // Pi reports unknown context stats until the next model
+                    // response; use the compact result's estimate as a
+                    // temporary context-only update, then let real usage
+                    // replace it on the next turn.
+                    const usage = convertPiCompactionUsage(result.estimatedTokensAfter);
+                    const convertedUsage = usage ? convertAgentMessage(usage, piSession.currentModel) : null;
+                    if (convertedUsage) piSession.sendAgentMessage(convertedUsage);
                 } catch (error) {
                     if (error instanceof PiRpcTimeoutError) {
                         // The runtime lease is deliberately retained on timeout


### PR DESCRIPTION
Fixes #1630

## Summary

- publish a context-only usage update immediately after successful Pi `/compact`
- use Pi's `estimatedTokensAfter` as a temporary UI estimate
- preserve the existing authoritative usage path for the next LLM response

Pi intentionally reports unknown context usage immediately after compaction. HAPI now avoids displaying the pre-compaction value while keeping the estimate separate from provider token accounting.

## Testing

- `bun typecheck`
- `bun run test`