### PR TITLE
fix(web): prevent session navigation on right-click

### DIFF
--- a/web/src/hooks/useLongPress.test.tsx
+++ b/web/src/hooks/useLongPress.test.tsx
@@ -59,6 +59,21 @@ describe('useLongPress', () => {
         expect(onClick).toHaveBeenCalledTimes(1)
     })
 
+    it('does not fire onClick for a desktop right-click before opening the context menu', () => {
+        const onClick = vi.fn()
+        const onLongPress = vi.fn()
+        const { getByTestId } = render(<Probe onClick={onClick} onLongPress={onLongPress} />)
+        const row = getByTestId('row')
+
+        fireEvent.mouseDown(row, { button: 2, clientX: 10, clientY: 10 })
+        fireEvent.mouseUp(row, { button: 2, clientX: 10, clientY: 10 })
+        const contextMenuWasPrevented = !fireEvent.contextMenu(row, { clientX: 10, clientY: 10 })
+
+        expect(contextMenuWasPrevented).toBe(true)
+        expect(onClick).not.toHaveBeenCalled()
+        expect(onLongPress).toHaveBeenCalledOnce()
+    })
+
     it('fires onClick once for a touch tap (ignores the browser-synthesized mouse events that follow)', () => {
         // Real touch browsers (Android Chrome, etc.) emit a compatibility
         // mousedown/mouseup/click ~300ms after touchend for any touch the page

--- a/web/src/hooks/useLongPress.ts
+++ b/web/src/hooks/useLongPress.ts
@@ -135,7 +135,8 @@ export function useLongPress(options: UseLongPressOptions): UseLongPressHandlers
         startTimer(e.clientX, e.clientY)
     }, [startTimer, isGhostMouseEvent])
 
-    const onMouseUp = useCallback<React.MouseEventHandler>(() => {
+    const onMouseUp = useCallback<React.MouseEventHandler>((e) => {
+        if (e.button !== 0) return
         if (isGhostMouseEvent()) return
         handleEnd(!isLongPressRef.current)
     }, [handleEnd, isGhostMouseEvent])


### PR DESCRIPTION
## Problem / Motivation

A desktop right-click on a session row could trigger the row's click handler after the context-menu event, navigating to that session unexpectedly.

## Summary

- Ignore non-primary mouseup events in `useLongPress`.
- Preserve the existing custom context-menu behavior.
- Add a regression test covering desktop right-click behavior.

## Validation

- `bun run --cwd web test -- src/hooks/useLongPress.test.tsx` — 15 passed.
- `bun typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name session-right-click-navigation -Suite Root terminal-wrap-fidelity.spec.ts` — 2 passed.
- `bun run build` — passed.
- `bun run test:shared` — 279 passed.
- Web deployment smoke test — 4 seeded sessions loaded; right-click opened the context menu while keeping the `/sessions` URL unchanged.

## Related Issues

None

## AI Disclosure

OpenAI Codex (GPT-5.6) assisted with investigation, implementation, testing, and PR drafting.