### PR TITLE
fix(agy): report the failure reason instead of echoing the answer

### DIFF
--- a/cli/src/agy/headless/agyHeadlessDriver.test.ts
+++ b/cli/src/agy/headless/agyHeadlessDriver.test.ts
@@ -344,6 +344,76 @@ describe('AgyHeadlessDriver', () => {
         );
     });
 
+    it('reports the failure reason instead of echoing the answer', async () => {
+        const { session, queue, client } = createSession();
+        // A failed envelope still carries the answer in `response` (agy fills it
+        // from the completed buffer). Surfacing that as the failure text repeats
+        // the whole answer in the chat; the reason lives in `error`.
+        const stream = [
+            '{"event":"init","conversation_id":"c-e","init":{}}',
+            '{"event":"step_update","step_update":{"conversation_id":"c-e","step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"the answer"}}',
+            '{"event":"step_update","step_update":{"conversation_id":"c-e","step_index":2,"state":"DONE","step_type":"agent_response","text_delta":""}}',
+            '{"event":"result","result":{"conversation_id":"c-e","status":"ERROR","response":"the answer","error":"quota exceeded"}}',
+        ];
+        const driver = new AgyHeadlessDriver({ session, spawnAgy: () => fakeAgyProcess(stream) });
+
+        queue.push('hello', { permissionMode: 'request-review' }, 'local-1');
+        const launchPromise = driver.launch();
+        await new Promise((r) => setTimeout(r, 500));
+        queue.close();
+        session.stopKeepAlive();
+        await launchPromise;
+
+        expect(client.sendSessionEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'error', message: 'quota exceeded' })
+        );
+        const echoed = client.sendSessionEvent.mock.calls
+            .filter(([e]) => e.type === 'error' && typeof e.message === 'string' && e.message.includes('the answer'));
+        expect(echoed).toHaveLength(0);
+    });
+
+    it('falls back to the status when a failed envelope carries no reason', async () => {
+        const { session, queue, client } = createSession();
+        const stream = [
+            '{"event":"init","conversation_id":"c-n","init":{}}',
+            '{"event":"step_update","step_update":{"conversation_id":"c-n","step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"the answer"}}',
+            '{"event":"step_update","step_update":{"conversation_id":"c-n","step_index":2,"state":"DONE","step_type":"agent_response","text_delta":""}}',
+            '{"event":"result","result":{"conversation_id":"c-n","status":"ERROR","response":"the answer"}}',
+        ];
+        const driver = new AgyHeadlessDriver({ session, spawnAgy: () => fakeAgyProcess(stream) });
+
+        queue.push('hello', { permissionMode: 'request-review' }, 'local-1');
+        const launchPromise = driver.launch();
+        await new Promise((r) => setTimeout(r, 500));
+        queue.close();
+        session.stopKeepAlive();
+        await launchPromise;
+
+        expect(client.sendSessionEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'error', message: 'agy turn failed: ERROR' })
+        );
+    });
+
+    it('surfaces a timeout reason from a failed envelope', async () => {
+        const { session, queue, client } = createSession();
+        const stream = [
+            '{"event":"init","conversation_id":"c-t","init":{}}',
+            '{"event":"result","result":{"conversation_id":"c-t","status":"ERROR","response":"","error":"timeout waiting for response"}}',
+        ];
+        const driver = new AgyHeadlessDriver({ session, spawnAgy: () => fakeAgyProcess(stream) });
+
+        queue.push('hello', { permissionMode: 'request-review' }, 'local-1');
+        const launchPromise = driver.launch();
+        await new Promise((r) => setTimeout(r, 500));
+        queue.close();
+        session.stopKeepAlive();
+        await launchPromise;
+
+        expect(client.sendSessionEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'error', message: 'timeout waiting for response' })
+        );
+    });
+
     it('does NOT ack the delivery when the turn fails before accepting the prompt', async () => {
         const { session, queue, client } = createSession();
         // Exit non-zero with no user_input step and no result: the prompt was

--- a/cli/src/agy/headless/agyHeadlessDriver.ts
+++ b/cli/src/agy/headless/agyHeadlessDriver.ts
@@ -627,7 +627,11 @@ export class AgyHeadlessDriver extends RemoteLauncherBase {
                                 // A FAILURE envelope proves the prompt ran but the
                                 // turn failed; surface it (exit code may still be 0).
                                 if (event.status !== 'SUCCESS') {
-                                    resultFailure = event.response?.trim()
+                                    // The reason lives in `error`; `response` is the
+                                    // answer field and stays filled on a failed turn,
+                                    // so reading it here repeated the whole answer in
+                                    // the chat as if it were the failure text.
+                                    resultFailure = event.error?.trim()
                                         || `agy turn failed: ${event.status}`;
                                 } else if (event.response?.trim()) {
                                     const response = event.response.trim();

--- a/cli/src/agy/headless/agyNdjsonParser.test.ts
+++ b/cli/src/agy/headless/agyNdjsonParser.test.ts
@@ -42,7 +42,20 @@ describe('parseAgyNdjsonLine', () => {
 
     it('parses a FAILURE result envelope', () => {
         const event = parseAgyNdjsonLine('{"event":"result","result":{"conversation_id":"abc","status":"FAILURE","response":""}}');
-        expect(event).toEqual({ kind: 'result', conversationId: 'abc', status: 'FAILURE', response: '' });
+        expect(event).toEqual({ kind: 'result', conversationId: 'abc', status: 'FAILURE', response: '', error: null });
+    });
+
+    it('carries the failure reason from a failed envelope', () => {
+        // agy reports why the turn failed in `error`; `response` stays the
+        // answer field (empty here, since the turn produced no answer).
+        const event = parseAgyNdjsonLine('{"event":"result","result":{"conversation_id":"abc","status":"ERROR","response":"","error":"timeout waiting for response","duration_seconds":2.4}}');
+        expect(event).toEqual({
+            kind: 'result',
+            conversationId: 'abc',
+            status: 'ERROR',
+            response: '',
+            error: 'timeout waiting for response',
+        });
     });
 
     it('parses the result envelope', () => {
@@ -52,6 +65,7 @@ describe('parseAgyNdjsonLine', () => {
             conversationId: 'abc',
             status: 'SUCCESS',
             response: 'OK\n',
+            error: null,
         });
     });
 

--- a/cli/src/agy/headless/agyNdjsonParser.ts
+++ b/cli/src/agy/headless/agyNdjsonParser.ts
@@ -12,6 +12,7 @@ import type { AgyTranscriptEntry, AgyToolCall } from '../utils/agyTranscriptType
  *   {"event":"step_update","step_update":{"conversation_id":"...","step_index":3,"state":"DONE","step_type":"tool","tool_name":"run_command","duration_seconds":0.2,"tool_info":{"name":"run_command","parameters":{...},"output":"hi\r\n"}}}
  *   {"event":"step_update","step_update":{"conversation_id":"...","step_index":4,"state":"DONE","step_type":"checkpoint","duration_seconds":0.7,"usage":{...}}}
  *   {"event":"result","result":{"conversation_id":"...","status":"SUCCESS","response":"OK\n","duration_seconds":3.4,"num_turns":1,"usage":{...}}}
+ *   {"event":"result","result":{"conversation_id":"...","status":"ERROR","response":"","error":"timeout waiting for response","duration_seconds":2.4,"num_turns":1,"usage":{...}}}
  *
  * Mapping to the existing transcript-entry channel (sendAgySessionMessage):
  *   - init        → conversation id becomes known immediately (no hook needed)
@@ -31,7 +32,7 @@ export type AgyStreamEvent =
     | { kind: 'planner-delta'; stepIndex: number; delta: string; isDone: boolean; conversationId?: string }
     | { kind: 'tool'; entry: AgyTranscriptEntry; toolCall: AgyToolCall; isDone: boolean; conversationId?: string }
     | { kind: 'checkpoint'; stepIndex: number; conversationId?: string }
-    | { kind: 'result'; conversationId: string; status: string; response: string | null }
+    | { kind: 'result'; conversationId: string; status: string; response: string | null; error: string | null }
     | { kind: 'ignored'; reason: string };
 
 type StepUpdate = {
@@ -52,6 +53,7 @@ type ResultEnvelope = {
     conversation_id?: string;
     status?: string;
     response?: string;
+    error?: string;
 };
 
 /** agy tool ids are snake_case (run_command, view_file, …); transcript entry types are SCREAMING_SNAKE (RUN_COMMAND, VIEW_FILE, …). */
@@ -102,6 +104,7 @@ export function parseAgyNdjsonLine(rawLine: string): AgyStreamEvent {
             conversationId: typeof result.conversation_id === 'string' ? result.conversation_id : '',
             status: result.status,
             response: typeof result.response === 'string' ? result.response : null,
+            error: typeof result.error === 'string' ? result.error : null,
         };
     }
 


### PR DESCRIPTION
## Problem

On an `agy` session, a turn that ends with a non-SUCCESS `result` envelope delivers its answer twice: once as the streamed `agy_message`, then again as an error event right below it — the whole answer rendered as plain text with a ⚠ prefix.

The driver takes the failure text from `response`:

```ts
if (event.status !== 'SUCCESS') {
    resultFailure = event.response?.trim()
        || `agy turn failed: ${event.status}`;
}
```

But `response` is the *answer* field. agy fills it from the completed buffer regardless of status, so on a failed turn it holds the same answer that already went out through the delta stream. The reason for the failure is reported separately, in `error`, which the parser did not read at all.

Measured on agy 1.1.13 (`--print-timeout 15s` against a long prompt):

```json
{"event":"result","result":{"conversation_id":"…","status":"ERROR","response":"","error":"timeout waiting for response","duration_seconds":2.4,…}}
```

`response` is empty and the reason lives in `error`. On a turn that produced text before failing, `response` carries that text instead — which is what ends up duplicated in the chat.

## Change

- `agyNdjsonParser.ts`: carry `error` through the `result` envelope (added to `ResultEnvelope` and to the `result` stream event; `null` when absent).
- `agyHeadlessDriver.ts`: read the failure text from `error` rather than `response`. The existing `agy turn failed: <status>` fallback still applies when the envelope carries no reason, so a failed turn stays visible.

The SUCCESS branch is untouched.

## Tests

- parser: an envelope with `error` surfaces it; the existing SUCCESS/FAILURE cases now assert `error: null`.
- driver: a failed envelope whose `response` holds the answer reports the `error` text and never emits the answer as an error; a failed envelope with no `error` falls back to the status; a timeout envelope surfaces `timeout waiting for response`.

`bun run test:cli` and `bun run typecheck:cli` pass.

## Note

#1629 fixes the same duplication on the SUCCESS path (where the guard comparing the streamed text with the envelope misfires on mangled deltas). This one is the failure path, which that guard never reaches. The two touch adjacent hunks of the same file but do not depend on each other in either order.

AI disclosure per CONTRIBUTING: written with Claude Code (Opus 5).