### PR TITLE
fix(opencode): keep one stored message per reasoning stream

### DIFF
--- a/android/core/protocol/src/main/kotlin/app/hapi/protocol/window/MessageWindowLogic.kt
+++ b/android/core/protocol/src/main/kotlin/app/hapi/protocol/window/MessageWindowLogic.kt
@@ -106,12 +106,64 @@ object MessageWindowLogic {
     }
 
     /**
-     * Trim to [regularLimit] while never dropping queued rows: the regular
-     * budget shrinks by the queued count, `agent-run-*` rows trim against
-     * their own [AGENT_RUN_WINDOW_SIZE] bucket, and queued rows are re-merged
-     * afterwards (web `trimPreservingQueued`).
+     * Web `getReasoningStreamId`: the stream a reasoning row belongs to, or
+     * null for anything else. Unrecognised shapes read as null, which means
+     * "keep it".
      */
-    private fun trimPreservingQueued(messages: List<WindowMessage>, regularLimit: Int, mode: TrimMode): Trim {
+    private fun reasoningStreamId(message: WindowMessage): String? {
+        val outer = message.wire.content as? JsonObject ?: return null
+        if (outer["role"].stringOrNull != "agent") return null
+        val content = outer["content"] as? JsonObject ?: return null
+        if (content["type"].stringOrNull != "codex") return null
+        val data = content["data"] as? JsonObject ?: return null
+        if (data["type"].stringOrNull != "reasoning") return null
+        val id = data["id"].stringOrNull ?: return null
+        return id.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Web `dropSupersededReasoningSnapshots`: collapse a reasoning stream to
+     * the one snapshot that still says something. The CLI re-sends a growing
+     * buffer under a stable stream id every few hundred milliseconds and the
+     * timeline folds those rows into a single block, so spending window budget
+     * on the older ones is what pushes the surrounding conversation out of
+     * reach. Rows with no stream id are left alone.
+     */
+    private fun dropSupersededReasoningSnapshots(messages: List<WindowMessage>): List<WindowMessage> {
+        val newestByStream = LinkedHashMap<String, WindowMessage>()
+        for (message in messages) {
+            val streamId = reasoningStreamId(message) ?: continue
+            val incumbent = newestByStream[streamId]
+            if (incumbent == null) {
+                newestByStream[streamId] = message
+                continue
+            }
+            // Fall back to arrival order when either row predates seq
+            // numbering: `messages` is kept in display order, so later still
+            // means newer.
+            val challengerAt = messagePosition(message)
+            val incumbentAt = messagePosition(incumbent)
+            val newer = if (challengerAt != null && incumbentAt != null) {
+                challengerAt >= incumbentAt
+            } else {
+                true
+            }
+            if (newer) newestByStream[streamId] = message
+        }
+        if (newestByStream.isEmpty()) return messages
+        val survivors = newestByStream.values.mapTo(HashSet()) { it.id }
+        return messages.filter { reasoningStreamId(it) == null || it.id in survivors }
+    }
+
+    /**
+     * Trim to [regularLimit] while never dropping queued rows: superseded
+     * reasoning snapshots are collapsed first, the regular budget shrinks by
+     * the queued count, `agent-run-*` rows trim against their own
+     * [AGENT_RUN_WINDOW_SIZE] bucket, and queued rows are re-merged afterwards
+     * (web `trimPreservingQueued`).
+     */
+    private fun trimPreservingQueued(incoming: List<WindowMessage>, regularLimit: Int, mode: TrimMode): Trim {
+        val messages = dropSupersededReasoningSnapshots(incoming)
         val queued = messages.filter { it.isQueuedForInvocation }
         val queuedIds = queued.mapTo(HashSet()) { it.id }
         val nonQueued = messages.filter { it.id !in queuedIds }

--- a/cli/src/agent/messageConverter.test.ts
+++ b/cli/src/agent/messageConverter.test.ts
@@ -116,6 +116,32 @@ describe('convertAgentMessage', () => {
         });
     });
 
+    it('marks a live reasoning snapshot on the wire payload', () => {
+        const converted = convertAgentMessage({
+            type: 'reasoning',
+            text: 'thinking',
+            id: 'reasoning-stream-1',
+            live: true
+        });
+
+        expect(converted).toEqual({
+            type: 'reasoning',
+            message: 'thinking',
+            id: 'reasoning-stream-1',
+            live: true
+        });
+    });
+
+    it('omits the live marker from a settled reasoning payload', () => {
+        const converted = convertAgentMessage({
+            type: 'reasoning',
+            text: 'thinking',
+            id: 'reasoning-stream-1'
+        });
+
+        expect(converted !== null && 'live' in converted).toBe(false);
+    });
+
     it('converts error messages into codex error payloads', () => {
         const converted = convertAgentMessage({
             type: 'error',

--- a/cli/src/agent/messageConverter.ts
+++ b/cli/src/agent/messageConverter.ts
@@ -5,7 +5,7 @@ import type { InlineMediaSource } from '@/modules/common/inlineMediaSource';
 
 export type CodexMessage =
     | { type: 'message'; message: string; id?: string; streamSnapshot?: boolean }
-    | { type: 'reasoning'; message: string; id: string }
+    | { type: 'reasoning'; message: string; id: string; live?: boolean }
     | {
         type: 'token_count';
         model: string | null;
@@ -64,7 +64,17 @@ export function convertAgentMessage(message: AgentMessage, model?: string | null
             // AgentMessage uses `text` (consistent with the `text` variant);
             // the wire-level CodexMessage uses `message` to match the
             // existing reasoning format emitted by the Codex path.
-            return { type: 'reasoning', message: message.text, id: message.id ?? randomUUID() };
+            //
+            // `live` marks a throttled snapshot of a still-growing buffer, so
+            // the hub can keep just the newest one per stream instead of
+            // storing every intermediate. The settled message that closes a
+            // stream carries no marker, which is what makes it the survivor.
+            return {
+                type: 'reasoning',
+                message: message.text,
+                id: message.id ?? randomUUID(),
+                ...(message.live === true ? { live: true } : {})
+            };
         case 'usage':
             return {
                 type: 'token_count',

--- a/hub/src/socket/handlers/cli/sessionHandlers.test.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { AGENT_MESSAGE_PAYLOAD_TYPE } from '@hapi/protocol'
 import { Store, type StoredSession } from '../../../store'
 import type { SyncEvent } from '../../../sync/syncEngine'
 import type { CliSocketWithData } from '../../socketTypes'
@@ -37,6 +38,20 @@ function redundantGoalStatusContent(message: string): unknown {
     }
 }
 
+function reasoningContent(streamId: string, text: string, live: boolean): unknown {
+    return {
+        role: 'agent',
+        content: {
+            type: AGENT_MESSAGE_PAYLOAD_TYPE,
+            data: { type: 'reasoning', message: text, id: streamId, ...(live ? { live: true } : {}) }
+        }
+    }
+}
+
+function reasoningTextOf(message: { content: unknown }): string {
+    return (message.content as { content: { data: { message: string } } }).content.data.message
+}
+
 describe('cli session handlers', () => {
     it('preserves immediate queued rows for cleared handoff transfer', () => {
         const store = new Store(':memory:')
@@ -55,6 +70,52 @@ describe('cli session handlers', () => {
         expect(store.messages.getAllMessages(session.id)).toEqual([
             expect.objectContaining({ localId: 'held-local', invokedAt: null })
         ])
+    })
+
+    it('collapses a live reasoning stream into its settled message', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('reasoning-stream-session', {}, null, 'default')
+        const socket = new FakeSocket()
+
+        registerSessionHandlers(socket as unknown as CliSocketWithData, {
+            store,
+            resolveSessionAccess: () => ({ ok: true, value: session as StoredSession }),
+            emitAccessError: () => {
+                throw new Error('unexpected access error')
+            }
+        })
+
+        for (const text of ['th', 'thin', 'think']) {
+            socket.trigger('message', { sid: session.id, message: reasoningContent('stream-1', text, true) })
+        }
+        socket.trigger('message', { sid: session.id, message: reasoningContent('stream-1', 'thinking', false) })
+        // A second stream in the same turn must survive the first one's cleanup.
+        socket.trigger('message', { sid: session.id, message: reasoningContent('stream-2', 'more', true) })
+
+        expect(store.messages.getAllMessages(session.id).map(reasoningTextOf)).toEqual(['thinking', 'more'])
+    })
+
+    it('keeps every reasoning snapshot that carries no stream id', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('reasoning-idless-session', {}, null, 'default')
+        const socket = new FakeSocket()
+
+        registerSessionHandlers(socket as unknown as CliSocketWithData, {
+            store,
+            resolveSessionAccess: () => ({ ok: true, value: session as StoredSession }),
+            emitAccessError: () => {
+                throw new Error('unexpected access error')
+            }
+        })
+
+        for (const text of ['one', 'two']) {
+            socket.trigger('message', {
+                sid: session.id,
+                message: { role: 'agent', content: { type: AGENT_MESSAGE_PAYLOAD_TYPE, data: { type: 'reasoning', message: text } } }
+            })
+        }
+
+        expect(store.messages.getAllMessages(session.id)).toHaveLength(2)
     })
 
     it('drops redundant goal status events before persistence and broadcast', () => {

--- a/hub/src/socket/handlers/cli/sessionHandlers.ts
+++ b/hub/src/socket/handlers/cli/sessionHandlers.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { randomUUID } from 'node:crypto'
 import type { CopilotAgentMode } from '@hapi/protocol'
 import type { AgentState, CodexCollaborationMode, Metadata, PermissionMode } from '@hapi/protocol/types'
-import { isRedundantGoalStatusEventContent } from '@hapi/protocol/messages'
+import { getReasoningStreamId, isRedundantGoalStatusEventContent } from '@hapi/protocol/messages'
 import type { Store, StoredSession } from '../../../store'
 import type { SyncEvent } from '../../../sync/syncEngine'
 import { extractTodoWriteTodosFromMessageContent } from '../../../sync/todos'
@@ -134,6 +134,19 @@ export function registerSessionHandlers(socket: CliSocketWithData, deps: Session
         }
 
         const msg = store.messages.addMessage(sid, content, localId, undefined, createdAt)
+
+        // A reasoning stream arrives as a series of growing snapshots under one
+        // stable id, so a stream should cost one row rather than one per
+        // interval. Retire the earlier snapshots only once their replacement is
+        // stored: these are separate transactions, and clearing first would let
+        // a crash in between take the whole stream. Only rows marked live are
+        // eligible, so the settled message that closes a stream survives and
+        // also sweeps up its own leftovers.
+        const reasoningStreamId = getReasoningStreamId(content)
+        if (reasoningStreamId) {
+            store.messages.deleteLiveReasoningSnapshots(sid, reasoningStreamId, msg.id)
+        }
+
         if (shouldRecordSessionActivity(content)) {
             onSessionActivity?.(sid, msg.createdAt)
         }

--- a/hub/src/store/messageStore.ts
+++ b/hub/src/store/messageStore.ts
@@ -5,6 +5,7 @@ import {
     addMessage,
     addImportedMessage,
     cancelQueuedMessage,
+    deleteLiveReasoningSnapshots,
     deleteQueuedMessageById,
     claimIndeterminateMessage,
     lookupQueuedMessage,
@@ -52,6 +53,10 @@ export class MessageStore {
 
     addMessage(sessionId: string, content: unknown, localId?: string, scheduledAt?: number | null, createdAt?: number): StoredMessage {
         return addMessage(this.db, sessionId, content, localId, scheduledAt, createdAt)
+    }
+
+    deleteLiveReasoningSnapshots(sessionId: string, streamId: string, keepMessageId?: string): number {
+        return deleteLiveReasoningSnapshots(this.db, sessionId, streamId, keepMessageId)
     }
 
     addImportedMessage(sessionId: string, content: unknown, localId: string, createdAt: number): { message: StoredMessage; inserted: boolean } {

--- a/hub/src/store/messages.test.ts
+++ b/hub/src/store/messages.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'bun:test'
+import { AGENT_MESSAGE_PAYLOAD_TYPE } from '@hapi/protocol'
+import { getReasoningStreamId } from '@hapi/protocol/messages'
 import { Store } from './index'
 
 function makeStore(): Store {
@@ -594,5 +596,118 @@ describe('content codec integration', () => {
         const invokedAt = Date.now()
         expect(store.messages.markMessagesInvoked(session.id, ['lid-uncertain'], invokedAt)).toBe(1)
         expect(store.messages.getMessages(session.id)[0]).toMatchObject({ invokedAt })
+    })
+})
+
+describe('deleteLiveReasoningSnapshots', () => {
+    function reasoningMessage(streamId: string, text: string, live: boolean) {
+        return {
+            role: 'agent',
+            content: {
+                type: AGENT_MESSAGE_PAYLOAD_TYPE,
+                data: { type: 'reasoning', message: text, id: streamId, ...(live ? { live: true } : {}) }
+            }
+        }
+    }
+
+    function reasoningTexts(store: Store, sessionId: string): string[] {
+        return store.messages.getAllMessages(sessionId)
+            .map((message) => getReasoningStreamId(message.content) === null
+                ? null
+                : ((message.content as { content: { data: { message: string } } }).content.data.message))
+            .filter((text): text is string => text !== null)
+    }
+
+    it('keeps only the newest snapshot of a stream', () => {
+        const store = makeStore()
+        const session = makeSession(store, 'reasoning-collapse')
+
+        for (const text of ['a', 'ab', 'abc']) {
+            const stored = store.messages.addMessage(session.id, reasoningMessage('stream-1', text, true))
+            store.messages.deleteLiveReasoningSnapshots(session.id, 'stream-1', stored.id)
+        }
+
+        expect(reasoningTexts(store, session.id)).toEqual(['abc'])
+    })
+
+    it('lets a settled message supersede the snapshots of its own stream', () => {
+        const store = makeStore()
+        const session = makeSession(store, 'reasoning-settle')
+
+        store.messages.addMessage(session.id, reasoningMessage('stream-1', 'partial', true))
+        const settled = store.messages.addMessage(session.id, reasoningMessage('stream-1', 'final', false))
+        store.messages.deleteLiveReasoningSnapshots(session.id, 'stream-1', settled.id)
+
+        expect(reasoningTexts(store, session.id)).toEqual(['final'])
+    })
+
+    it('never removes a settled message', () => {
+        const store = makeStore()
+        const session = makeSession(store, 'reasoning-settled-kept')
+
+        store.messages.addMessage(session.id, reasoningMessage('stream-1', 'final', false))
+        const removed = store.messages.deleteLiveReasoningSnapshots(session.id, 'stream-1')
+
+        expect(removed).toBe(0)
+        expect(reasoningTexts(store, session.id)).toEqual(['final'])
+    })
+
+    it('leaves other streams alone', () => {
+        const store = makeStore()
+        const session = makeSession(store, 'reasoning-other-stream')
+
+        store.messages.addMessage(session.id, reasoningMessage('stream-1', 'first', true))
+        const other = store.messages.addMessage(session.id, reasoningMessage('stream-2', 'second', true))
+        store.messages.deleteLiveReasoningSnapshots(session.id, 'stream-2', other.id)
+
+        expect(reasoningTexts(store, session.id)).toEqual(['first', 'second'])
+    })
+
+    it('never crosses a session boundary', () => {
+        const store = makeStore()
+        const mine = makeSession(store, 'reasoning-mine')
+        const theirs = makeSession(store, 'reasoning-theirs')
+
+        store.messages.addMessage(theirs.id, reasoningMessage('stream-1', 'theirs', true))
+        store.messages.deleteLiveReasoningSnapshots(mine.id, 'stream-1')
+
+        expect(reasoningTexts(store, theirs.id)).toEqual(['theirs'])
+    })
+
+    it('spares the message that replaced the snapshots', () => {
+        const store = makeStore()
+        const session = makeSession(store, 'reasoning-keep-replacement')
+
+        const replacement = store.messages.addMessage(session.id, reasoningMessage('stream-1', 'newest', true))
+        const removed = store.messages.deleteLiveReasoningSnapshots(session.id, 'stream-1', replacement.id)
+
+        expect(removed).toBe(0)
+        expect(reasoningTexts(store, session.id)).toEqual(['newest'])
+    })
+
+    it('never lets a stream pass through zero rows', () => {
+        const store = makeStore()
+        const session = makeSession(store, 'reasoning-never-empty')
+
+        // Walk a stream the way the handler does — store, then sweep — and
+        // assert the stream is represented after every single step.
+        for (const text of ['a', 'ab', 'abc', 'abcd']) {
+            const stored = store.messages.addMessage(session.id, reasoningMessage('stream-1', text, true))
+            expect(reasoningTexts(store, session.id).length).toBeGreaterThan(0)
+            store.messages.deleteLiveReasoningSnapshots(session.id, 'stream-1', stored.id)
+            expect(reasoningTexts(store, session.id)).toEqual([text])
+        }
+    })
+
+    it('leaves unrelated messages untouched', () => {
+        const store = makeStore()
+        const session = makeSession(store, 'reasoning-unrelated')
+
+        store.messages.addMessage(session.id, { role: 'user', content: { type: 'text', text: 'hello' } })
+        store.messages.addMessage(session.id, reasoningMessage('stream-1', 'partial', true))
+        store.messages.deleteLiveReasoningSnapshots(session.id, 'stream-1')
+
+        expect(store.messages.getAllMessages(session.id)).toHaveLength(1)
+        expect(reasoningTexts(store, session.id)).toEqual([])
     })
 })

--- a/hub/src/store/messages.ts
+++ b/hub/src/store/messages.ts
@@ -2,6 +2,8 @@ import type { Database } from 'bun:sqlite'
 import { randomUUID } from 'node:crypto'
 import { isDeepStrictEqual } from 'node:util'
 
+import { getLiveReasoningStreamId } from '@hapi/protocol/messages'
+
 import type { StoredMessage } from './types'
 import { decodeMessageContent, encodeMessageContent, truncateOversizedMessageContent } from './contentCodec'
 
@@ -381,6 +383,49 @@ export function getDeliverableMessagesAfter(
     `).all(sessionId, safeAfterSeq, now, safeLimit) as DbMessageRow[]
 
     return rows.map(toStoredMessage)
+}
+
+/** How far back to look for a stream's replaceable snapshots.
+ *
+ *  The CLI re-sends a growing reasoning buffer every few hundred milliseconds,
+ *  so the previous snapshot of a stream is always among the newest rows of its
+ *  session. Scanning a bounded tail keeps this off the hot path on sessions
+ *  with tens of thousands of messages; anything older than the window is left
+ *  alone, which errs toward keeping data. */
+const REASONING_SNAPSHOT_LOOKBACK = 50
+
+/** Drop the replaceable snapshots of one reasoning stream.
+ *
+ *  Only messages explicitly marked live are eligible, and `keepMessageId` is
+ *  always spared. Callers run this *after* storing the message that supersedes
+ *  them, so the stream never passes through a moment with no row at all — the
+ *  two statements are separate transactions, and a crash between them must not
+ *  be able to take the whole stream with it. Returns how many rows were
+ *  removed. */
+export function deleteLiveReasoningSnapshots(
+    db: Database,
+    sessionId: string,
+    streamId: string,
+    keepMessageId?: string
+): number {
+    const rows = db.prepare(`
+        SELECT id, content FROM messages
+        WHERE session_id = ?
+        ORDER BY seq DESC
+        LIMIT ?
+    `).all(sessionId, REASONING_SNAPSHOT_LOOKBACK) as Array<Pick<DbMessageRow, 'id' | 'content'>>
+
+    const staleIds = rows
+        .filter((row) => row.id !== keepMessageId
+            && getLiveReasoningStreamId(decodeMessageContent(row.content)) === streamId)
+        .map((row) => row.id)
+    if (staleIds.length === 0) return 0
+
+    const placeholders = staleIds.map(() => '?').join(', ')
+    const result = db.prepare(
+        `DELETE FROM messages WHERE session_id = ? AND id IN (${placeholders})`
+    ).run(sessionId, ...staleIds)
+    return Number(result.changes)
 }
 
 /** Paginate messages by COALESCE(invoked_at, created_at) DESC, seq DESC.

--- a/ios/Packages/HapiKit/Sources/HapiProtocol/Window/MessageWindowLogic.swift
+++ b/ios/Packages/HapiKit/Sources/HapiProtocol/Window/MessageWindowLogic.swift
@@ -127,15 +127,66 @@ public enum MessageWindowLogic {
         return type == "agent-run-start" || type == "agent-run-update" || type == "agent-run-trace"
     }
 
-    /// Trim to `regularLimit` while never dropping queued rows: the regular
-    /// budget shrinks by the queued count, `agent-run-*` rows trim against
-    /// their own bucket (`agentRunWindowSize`), and queued rows are re-merged
-    /// afterwards (web `trimPreservingQueued`).
+    /// Web `getReasoningStreamId`: the stream a reasoning row belongs to, or
+    /// `nil` for anything else. Unrecognised shapes read as `nil`, which means
+    /// "keep it".
+    private static func reasoningStreamId(_ message: WindowMessage) -> String? {
+        guard let outer = message.content.objectValue,
+              outer["role"]?.stringValue == "agent",
+              let payload = outer["content"]?.objectValue,
+              payload["type"]?.stringValue == "codex",
+              let data = payload["data"]?.objectValue,
+              data["type"]?.stringValue == "reasoning",
+              let id = data["id"]?.stringValue,
+              !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return id
+    }
+
+    /// Web `dropSupersededReasoningSnapshots`: collapse a reasoning stream to
+    /// the one snapshot that still says something. The CLI re-sends a growing
+    /// buffer under a stable stream id every few hundred milliseconds and the
+    /// timeline folds those rows into a single block, so spending window
+    /// budget on the older ones is what pushes the surrounding conversation
+    /// out of reach. Rows with no stream id are left alone.
+    private static func dropSupersededReasoningSnapshots(
+        _ messages: [WindowMessage]
+    ) -> [WindowMessage] {
+        var newestByStream: [String: WindowMessage] = [:]
+        for message in messages {
+            guard let streamId = reasoningStreamId(message) else { continue }
+            guard let incumbent = newestByStream[streamId] else {
+                newestByStream[streamId] = message
+                continue
+            }
+            // Fall back to arrival order when either row predates seq
+            // numbering: `messages` is kept in display order, so later still
+            // means newer.
+            let newer: Bool
+            if let challengerAt = messagePosition(message),
+               let incumbentAt = messagePosition(incumbent) {
+                newer = !(challengerAt < incumbentAt)
+            } else {
+                newer = true
+            }
+            if newer { newestByStream[streamId] = message }
+        }
+        if newestByStream.isEmpty { return messages }
+        let survivors = Set(newestByStream.values.map(\.id))
+        return messages.filter { reasoningStreamId($0) == nil || survivors.contains($0.id) }
+    }
+
+    /// Trim to `regularLimit` while never dropping queued rows: superseded
+    /// reasoning snapshots are collapsed first, the regular budget shrinks by
+    /// the queued count, `agent-run-*` rows trim against their own bucket
+    /// (`agentRunWindowSize`), and queued rows are re-merged afterwards (web
+    /// `trimPreservingQueued`).
     private static func trimPreservingQueued(
-        _ messages: [WindowMessage],
+        _ incoming: [WindowMessage],
         regularLimit: Int,
         mode: TrimMode
     ) -> Trim {
+        let messages = dropSupersededReasoningSnapshots(incoming)
         let queued = messages.filter(\.isQueuedForInvocation)
         let queuedIds = Set(queued.map(\.id))
         let nonQueued = messages.filter { !queuedIds.contains($0.id) }

--- a/shared/fixtures/pagination/reasoning-snapshots-collapse-to-newest.json
+++ b/shared/fixtures/pagination/reasoning-snapshots-collapse-to-newest.json
@@ -1,0 +1,265 @@
+{
+    "description": "A reasoning stream arrives as repeated growing snapshots under one stream id. Only the newest snapshot of each stream survives the window (the timeline folds them into a single block anyway), streams collapse independently, the settled row that closes a stream supersedes its live snapshots, and rows without a stream id are untouched.",
+    "expectedState": {
+        "epoch": 0,
+        "hasMore": false,
+        "messages": [
+            {
+                "createdAt": 1000,
+                "id": "a-1",
+                "invokedAt": 1000,
+                "localId": null,
+                "optimistic": false,
+                "queued": false,
+                "seq": 1
+            },
+            {
+                "createdAt": 4000,
+                "id": "s-3",
+                "invokedAt": 4000,
+                "localId": null,
+                "optimistic": false,
+                "queued": false,
+                "seq": 4
+            },
+            {
+                "createdAt": 5000,
+                "id": "a-2",
+                "invokedAt": 5000,
+                "localId": null,
+                "optimistic": false,
+                "queued": false,
+                "seq": 5
+            },
+            {
+                "createdAt": 7000,
+                "id": "s-5",
+                "invokedAt": 7000,
+                "localId": null,
+                "optimistic": false,
+                "queued": false,
+                "seq": 7
+            },
+            {
+                "createdAt": 9000,
+                "id": "s-7",
+                "invokedAt": 9000,
+                "localId": null,
+                "optimistic": false,
+                "queued": false,
+                "seq": 9
+            }
+        ],
+        "newestCursor": {
+            "at": 9000,
+            "seq": 9
+        },
+        "olderCursor": {
+            "at": 1000,
+            "seq": 1
+        },
+        "viewMode": "tail"
+    },
+    "fixtureVersion": 1,
+    "name": "reasoning-snapshots-collapse-to-newest",
+    "ops": [
+        {
+            "expectedRequests": [
+                {
+                    "limit": 200
+                }
+            ],
+            "op": "sync-tail",
+            "responses": [
+                {
+                    "messages": [
+                        {
+                            "content": {
+                                "content": {
+                                    "data": {
+                                        "message": "a-1",
+                                        "type": "message"
+                                    },
+                                    "type": "codex"
+                                },
+                                "role": "agent"
+                            },
+                            "createdAt": 1000,
+                            "id": "a-1",
+                            "invokedAt": 1000,
+                            "localId": null,
+                            "seq": 1
+                        },
+                        {
+                            "content": {
+                                "content": {
+                                    "data": {
+                                        "id": "stream-a",
+                                        "live": true,
+                                        "message": "th",
+                                        "type": "reasoning"
+                                    },
+                                    "type": "codex"
+                                },
+                                "role": "agent"
+                            },
+                            "createdAt": 2000,
+                            "id": "s-1",
+                            "invokedAt": 2000,
+                            "localId": null,
+                            "seq": 2
+                        },
+                        {
+                            "content": {
+                                "content": {
+                                    "data": {
+                                        "id": "stream-a",
+                                        "live": true,
+                                        "message": "thin",
+                                        "type": "reasoning"
+                                    },
+                                    "type": "codex"
+                                },
+                                "role": "agent"
+                            },
+                            "createdAt": 3000,
+                            "id": "s-2",
+                            "invokedAt": 3000,
+                            "localId": null,
+                            "seq": 3
+                        },
+                        {
+                            "content": {
+                                "content": {
+                                    "data": {
+                                        "id": "stream-a",
+                                        "live": true,
+                                        "message": "thinking",
+                                        "type": "reasoning"
+                                    },
+                                    "type": "codex"
+                                },
+                                "role": "agent"
+                            },
+                            "createdAt": 4000,
+                            "id": "s-3",
+                            "invokedAt": 4000,
+                            "localId": null,
+                            "seq": 4
+                        },
+                        {
+                            "content": {
+                                "content": {
+                                    "data": {
+                                        "message": "a-2",
+                                        "type": "message"
+                                    },
+                                    "type": "codex"
+                                },
+                                "role": "agent"
+                            },
+                            "createdAt": 5000,
+                            "id": "a-2",
+                            "invokedAt": 5000,
+                            "localId": null,
+                            "seq": 5
+                        },
+                        {
+                            "content": {
+                                "content": {
+                                    "data": {
+                                        "id": "stream-b",
+                                        "live": true,
+                                        "message": "more",
+                                        "type": "reasoning"
+                                    },
+                                    "type": "codex"
+                                },
+                                "role": "agent"
+                            },
+                            "createdAt": 6000,
+                            "id": "s-4",
+                            "invokedAt": 6000,
+                            "localId": null,
+                            "seq": 6
+                        },
+                        {
+                            "content": {
+                                "content": {
+                                    "data": {
+                                        "id": "stream-b",
+                                        "message": "more still",
+                                        "type": "reasoning"
+                                    },
+                                    "type": "codex"
+                                },
+                                "role": "agent"
+                            },
+                            "createdAt": 7000,
+                            "id": "s-5",
+                            "invokedAt": 7000,
+                            "localId": null,
+                            "seq": 7
+                        }
+                    ],
+                    "page": {
+                        "direction": "latest",
+                        "epoch": 0,
+                        "hasMore": false,
+                        "limit": 200,
+                        "nextAfterAt": null,
+                        "nextAfterSeq": null,
+                        "nextBeforeAt": 1000,
+                        "nextBeforeSeq": 1,
+                        "reset": false,
+                        "snapshotHeadAt": 7000,
+                        "snapshotHeadSeq": 7
+                    }
+                }
+            ]
+        },
+        {
+            "messages": [
+                {
+                    "content": {
+                        "content": {
+                            "data": {
+                                "id": "stream-c",
+                                "live": true,
+                                "message": "later",
+                                "type": "reasoning"
+                            },
+                            "type": "codex"
+                        },
+                        "role": "agent"
+                    },
+                    "createdAt": 8000,
+                    "id": "s-6",
+                    "invokedAt": 8000,
+                    "localId": null,
+                    "seq": 8
+                },
+                {
+                    "content": {
+                        "content": {
+                            "data": {
+                                "id": "stream-c",
+                                "live": true,
+                                "message": "later still",
+                                "type": "reasoning"
+                            },
+                            "type": "codex"
+                        },
+                        "role": "agent"
+                    },
+                    "createdAt": 9000,
+                    "id": "s-7",
+                    "invokedAt": 9000,
+                    "localId": null,
+                    "seq": 9
+                }
+            ],
+            "op": "sse-messages"
+        }
+    ]
+}

--- a/shared/src/messages.test.ts
+++ b/shared/src/messages.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'bun:test'
+import { AGENT_MESSAGE_PAYLOAD_TYPE } from './modes'
 import {
     extractAssistantPlainText,
     extractNotifySummary,
+    getLiveReasoningStreamId,
+    getReasoningStreamId,
     isRedundantGoalStatusEventContent,
     splitNotifySummary,
     stripNotifySummaryFooter,
@@ -357,5 +360,44 @@ describe('isRedundantGoalStatusEventContent (regression-guard for messages.ts ed
             }
         }
         expect(isRedundantGoalStatusEventContent(value)).toBe(true)
+    })
+})
+
+describe('reasoning stream identity', () => {
+    function reasoningContent(overrides: Record<string, unknown> = {}) {
+        return {
+            role: 'agent',
+            content: {
+                type: AGENT_MESSAGE_PAYLOAD_TYPE,
+                data: { type: 'reasoning', message: 'thinking', id: 'stream-1', ...overrides }
+            }
+        }
+    }
+
+    test('reads the stream id from a live snapshot', () => {
+        expect(getReasoningStreamId(reasoningContent({ live: true }))).toBe('stream-1')
+        expect(getLiveReasoningStreamId(reasoningContent({ live: true }))).toBe('stream-1')
+    })
+
+    test('treats a settled reasoning message as part of the stream but not as live', () => {
+        expect(getReasoningStreamId(reasoningContent())).toBe('stream-1')
+        expect(getLiveReasoningStreamId(reasoningContent())).toBeNull()
+    })
+
+    test('does not treat a non-boolean live marker as live', () => {
+        expect(getLiveReasoningStreamId(reasoningContent({ live: 'yes' }))).toBeNull()
+    })
+
+    test.each([
+        ['a user-role envelope', { role: 'user', content: { type: AGENT_MESSAGE_PAYLOAD_TYPE, data: { type: 'reasoning', id: 'stream-1' } } }],
+        ['a different payload type', { role: 'agent', content: { type: 'event', data: { type: 'reasoning', id: 'stream-1' } } }],
+        ['a different data type', { role: 'agent', content: { type: AGENT_MESSAGE_PAYLOAD_TYPE, data: { type: 'message', id: 'stream-1' } } }],
+        ['a missing id', { role: 'agent', content: { type: AGENT_MESSAGE_PAYLOAD_TYPE, data: { type: 'reasoning' } } }],
+        ['a blank id', { role: 'agent', content: { type: AGENT_MESSAGE_PAYLOAD_TYPE, data: { type: 'reasoning', id: '   ' } } }],
+        ['a non-string id', { role: 'agent', content: { type: AGENT_MESSAGE_PAYLOAD_TYPE, data: { type: 'reasoning', id: 7 } } }],
+        ['a non-object value', 'reasoning']
+    ])('returns null for %s', (_label, value) => {
+        expect(getReasoningStreamId(value)).toBeNull()
+        expect(getLiveReasoningStreamId(value)).toBeNull()
     })
 })

--- a/shared/src/messages.ts
+++ b/shared/src/messages.ts
@@ -1,3 +1,4 @@
+import { AGENT_MESSAGE_PAYLOAD_TYPE } from './modes'
 import { isObject } from './utils'
 
 type RoleWrappedRecord = {
@@ -65,6 +66,48 @@ export function isRedundantGoalStatusMessageText(value: unknown): boolean {
     const message = value.trim()
     return message === 'Goal cleared'
         || /^Goal (active|paused|complete|blocked|limited by (?:budget|usage))(?:$|\s+·\s+)/.test(message)
+}
+
+/**
+ * ACP agents stream thoughts one token at a time, so the CLI coalesces them
+ * into a buffer and re-sends the whole buffer under a stable stream id every
+ * few hundred milliseconds. Every snapshot but the newest is dead weight: the
+ * buffer only ever grows, so an older snapshot is a strict prefix of a newer
+ * one and the timeline collapses them back into a single block anyway.
+ *
+ * These two readers let the hub and the web keep one message per stream
+ * instead of one per snapshot. They are deliberately separate:
+ *
+ *  - `getReasoningStreamId` answers "which stream does this belong to" and so
+ *    also matches the settled message that closes a stream. That message is
+ *    what triggers the final cleanup of its own leftovers.
+ *  - `getLiveReasoningStreamId` answers "is this a replaceable snapshot", and
+ *    so only ever matches something safe to drop.
+ *
+ * Anything unrecognised reads as `null`, which means "keep it".
+ */
+function readReasoningStreamId(value: unknown, liveOnly: boolean): string | null {
+    const record = unwrapRoleWrappedRecordEnvelope(value)
+    if (record?.role !== 'agent') return null
+
+    const content = record.content
+    if (!isObject(content) || content.type !== AGENT_MESSAGE_PAYLOAD_TYPE) return null
+
+    const data = isObject(content.data) ? content.data : null
+    if (!data || data.type !== 'reasoning') return null
+    if (liveOnly && data.live !== true) return null
+
+    const id = data.id
+    if (typeof id !== 'string' || id.trim().length === 0) return null
+    return id
+}
+
+export function getReasoningStreamId(value: unknown): string | null {
+    return readReasoningStreamId(value, false)
+}
+
+export function getLiveReasoningStreamId(value: unknown): string | null {
+    return readReasoningStreamId(value, true)
 }
 
 export function isRedundantGoalStatusEventContent(value: unknown): boolean {

--- a/web/scripts/fixtures/pagination/cases.ts
+++ b/web/scripts/fixtures/pagination/cases.ts
@@ -23,6 +23,39 @@ function agentMessage(init: { id: string; seq: number; at: number }): DecryptedM
     }
 }
 
+/** A throttled live snapshot of a reasoning stream: the CLI re-sends the
+ *  growing buffer under one stable stream id, so only the newest row of a
+ *  stream carries information. `live: false` marks the settled message that
+ *  closes the stream. */
+function reasoningSnapshot(init: {
+    id: string
+    seq: number
+    at: number
+    streamId: string
+    text: string
+    live?: boolean
+}): DecryptedMessage {
+    return {
+        id: init.id,
+        seq: init.seq,
+        localId: null,
+        content: {
+            role: 'agent',
+            content: {
+                type: 'codex',
+                data: {
+                    type: 'reasoning',
+                    message: init.text,
+                    id: init.streamId,
+                    ...(init.live === false ? {} : { live: true })
+                }
+            }
+        },
+        createdAt: init.at,
+        invokedAt: init.at
+    }
+}
+
 /** A row the chat pipeline hides (normalizes to null): meta system output. */
 function hiddenAgentMessage(init: { id: string; seq: number; at: number }): DecryptedMessage {
     return {
@@ -406,6 +439,39 @@ export const paginationFixtureCases: PaginationFixtureCase[] = [
             {
                 op: 'sse-messages',
                 messages: paddedAgentRun(201, 402)
+            }
+        ]
+    },
+    {
+        name: 'reasoning-snapshots-collapse-to-newest',
+        description: 'A reasoning stream arrives as repeated growing snapshots under one stream id. Only the newest snapshot of each stream survives the window (the timeline folds them into a single block anyway), streams collapse independently, the settled row that closes a stream supersedes its live snapshots, and rows without a stream id are untouched.',
+        ops: [
+            {
+                op: 'sync-tail',
+                responses: [
+                    pageResponse([
+                        agentMessage({ id: 'a-1', seq: 1, at: 1_000 }),
+                        reasoningSnapshot({ id: 's-1', seq: 2, at: 2_000, streamId: 'stream-a', text: 'th' }),
+                        reasoningSnapshot({ id: 's-2', seq: 3, at: 3_000, streamId: 'stream-a', text: 'thin' }),
+                        reasoningSnapshot({ id: 's-3', seq: 4, at: 4_000, streamId: 'stream-a', text: 'thinking' }),
+                        agentMessage({ id: 'a-2', seq: 5, at: 5_000 }),
+                        reasoningSnapshot({ id: 's-4', seq: 6, at: 6_000, streamId: 'stream-b', text: 'more' }),
+                        reasoningSnapshot({ id: 's-5', seq: 7, at: 7_000, streamId: 'stream-b', text: 'more still', live: false })
+                    ], {
+                        direction: 'latest',
+                        epoch: 0,
+                        hasMore: false,
+                        nextBefore: { at: 1_000, seq: 1 },
+                        snapshotHead: { at: 7_000, seq: 7 }
+                    })
+                ]
+            },
+            {
+                op: 'sse-messages',
+                messages: [
+                    reasoningSnapshot({ id: 's-6', seq: 8, at: 8_000, streamId: 'stream-c', text: 'later' }),
+                    reasoningSnapshot({ id: 's-7', seq: 9, at: 9_000, streamId: 'stream-c', text: 'later still' })
+                ]
             }
         ]
     },

--- a/web/src/lib/message-window-store.test.ts
+++ b/web/src/lib/message-window-store.test.ts
@@ -91,6 +91,23 @@ function makeHiddenAgentMessage(props: { id: string; seq: number; at: number }):
     } as DecryptedMessage
 }
 
+function makeReasoningMessage(id: string, streamId: string, seq: number, at: number, live = true): DecryptedMessage {
+    return {
+        id,
+        seq,
+        localId: null,
+        content: {
+            role: 'agent',
+            content: {
+                type: 'codex',
+                data: { type: 'reasoning', message: id, id: streamId, ...(live ? { live: true } : {}) }
+            }
+        },
+        createdAt: at,
+        invokedAt: at
+    } as DecryptedMessage
+}
+
 function makeAgentRunMessage(id: string, seq: number, at: number): DecryptedMessage {
     return {
         id,
@@ -1333,5 +1350,89 @@ describe('V2 persistence boundary', () => {
 
         expect(getMessageWindowState(id).messages[0]?.status).toBe('queued')
         expect(getQueuedReconcileCandidateLocalIds(id)).toEqual(['local-1'])
+    })
+})
+
+
+describe('reasoning snapshot compaction', () => {
+    it('keeps only the newest snapshot of each stream', () => {
+        const id = sessionId('reasoning-compaction')
+        const snapshots = Array.from({ length: 5 }, (_, index) =>
+            makeReasoningMessage(`snap-${index}`, 'stream-1', index + 1, index + 1)
+        )
+        const others = [
+            makeUserMessage({ id: 'user-1', seq: 10, invokedAt: 10, createdAt: 10 }),
+            makeUserMessage({ id: 'user-2', seq: 11, invokedAt: 11, createdAt: 11 })
+        ]
+        ingestIncomingMessages(id, [...snapshots, ...others])
+
+        expect(getMessageWindowState(id).messages.map((message) => message.id))
+            .toEqual(['snap-4', 'user-1', 'user-2'])
+    })
+
+    it('keeps the newest snapshot of every stream independently', () => {
+        const id = sessionId('reasoning-multi-stream')
+        ingestIncomingMessages(id, [
+            makeReasoningMessage('a-1', 'stream-a', 1, 1),
+            makeReasoningMessage('a-2', 'stream-a', 2, 2),
+            makeReasoningMessage('b-1', 'stream-b', 3, 3),
+            makeReasoningMessage('b-2', 'stream-b', 4, 4)
+        ])
+
+        expect(getMessageWindowState(id).messages.map((message) => message.id)).toEqual(['a-2', 'b-2'])
+    })
+
+    it('leaves messages without a reasoning stream untouched', () => {
+        const id = sessionId('reasoning-unrelated')
+        const messages = [
+            makeUserMessage({ id: 'user-1', seq: 1, invokedAt: 1, createdAt: 1 }),
+            makeAgentRunMessage('run-1', 2, 2),
+            makeAgentRunMessage('run-2', 3, 3)
+        ]
+        ingestIncomingMessages(id, messages)
+
+        expect(getMessageWindowState(id).messages).toHaveLength(3)
+    })
+
+    it('spends the window budget on conversation rather than duplicate snapshots', () => {
+        const id = sessionId('reasoning-window-budget')
+        // A session already carrying a flood of stored snapshots: without
+        // compaction they consume the whole window and the conversation that
+        // surrounds them falls out of it.
+        const flood = Array.from({ length: VISIBLE_WINDOW_SIZE }, (_, index) =>
+            makeReasoningMessage(`flood-${index}`, 'stream-1', index + 1, index + 1)
+        )
+        const conversation = Array.from({ length: 50 }, (_, index) =>
+            makeUserMessage({
+                id: `talk-${index}`,
+                seq: VISIBLE_WINDOW_SIZE + index + 1,
+                invokedAt: VISIBLE_WINDOW_SIZE + index + 1,
+                createdAt: VISIBLE_WINDOW_SIZE + index + 1
+            })
+        )
+        ingestIncomingMessages(id, [...flood, ...conversation])
+
+        const kept = getMessageWindowState(id).messages
+        for (const message of conversation) {
+            expect(kept.some((candidate) => candidate.id === message.id)).toBe(true)
+        }
+        expect(kept.filter((message) => message.id.startsWith('flood-'))).toHaveLength(1)
+    })
+
+    // The seq bounds are a view over what the window currently holds; the
+    // cursor that drives older-page requests is the server's own
+    // `nextBefore*`, which compaction never touches. Pinning the bounds keeps
+    // that distinction honest if the two are ever conflated.
+    it('derives its seq bounds from the surviving rows', () => {
+        const id = sessionId('reasoning-bounds')
+        ingestIncomingMessages(id, [
+            makeReasoningMessage('snap-1', 'stream-1', 1, 1),
+            makeReasoningMessage('snap-2', 'stream-1', 2, 2),
+            makeUserMessage({ id: 'user-1', seq: 3, invokedAt: 3, createdAt: 3 })
+        ])
+
+        const state = getMessageWindowState(id)
+        expect(state.oldestSeq).toBe(2)
+        expect(state.newestSeq).toBe(3)
     })
 })

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -1,3 +1,4 @@
+import { getReasoningStreamId } from '@hapi/protocol/messages'
 import type { ApiClient } from '@/api/client'
 import { normalizeDecryptedMessage } from '@/chat/normalize'
 import type { DecryptedMessage, MessageStatus, MessagesResponse } from '@/types/api'
@@ -443,11 +444,48 @@ function isCodexAgentRunMessage(message: DecryptedMessage): boolean {
     return type === 'agent-run-start' || type === 'agent-run-update' || type === 'agent-run-trace'
 }
 
+/** Collapse a reasoning stream down to the one snapshot that still says
+ *  something.
+ *
+ *  The CLI re-sends a growing reasoning buffer under a stable stream id every
+ *  few hundred milliseconds, and the timeline already folds those snapshots
+ *  into a single block by that id. Sessions recorded before the hub started
+ *  retiring them still carry every intermediate, and spending window budget on
+ *  rows that render as one block is what pushes the surrounding conversation
+ *  out of reach. Messages with no stream id are left alone. */
+function dropSupersededReasoningSnapshots(messages: DecryptedMessage[]): DecryptedMessage[] {
+    const newestByStream = new Map<string, DecryptedMessage>()
+    for (const message of messages) {
+        const streamId = getReasoningStreamId(message.content)
+        if (streamId === null) continue
+        const incumbent = newestByStream.get(streamId)
+        if (!incumbent) {
+            newestByStream.set(streamId, message)
+            continue
+        }
+        // Fall back to arrival order when either row predates seq numbering:
+        // `messages` is kept in display order, so later still means newer.
+        const challengerAt = messagePosition(message)
+        const incumbentAt = messagePosition(incumbent)
+        const newer = challengerAt && incumbentAt
+            ? comparePosition(challengerAt, incumbentAt) >= 0
+            : true
+        if (newer) newestByStream.set(streamId, message)
+    }
+    if (newestByStream.size === 0) return messages
+
+    const survivors = new Set<string>()
+    for (const message of newestByStream.values()) survivors.add(message.id)
+    return messages.filter((message) =>
+        getReasoningStreamId(message.content) === null || survivors.has(message.id))
+}
+
 function trimPreservingQueued(
-    messages: DecryptedMessage[],
+    incoming: DecryptedMessage[],
     regularLimit: number,
     mode: 'append' | 'prepend'
 ): { kept: DecryptedMessage[]; dropped: DecryptedMessage[] } {
+    const messages = dropSupersededReasoningSnapshots(incoming)
     const queued = messages.filter(isQueuedForInvocation)
     const queuedIds = new Set(queued.map((message) => message.id))
     const nonQueued = messages.filter((message) => !queuedIds.has(message.id))


### PR DESCRIPTION
## Problem

On a long OpenCode session, scrolling up through the conversation stops
getting anywhere and the thread flickers while reasoning streams.

ACP agents emit thoughts one token at a time, so `AcpMessageHandler`
coalesces them into a buffer and re-sends the whole buffer under a stable
stream id every 250ms (#661). That is what makes reasoning render live
instead of one row per token, and the web already folds those snapshots
back into a single block by their stream id.

What the snapshots also do is accumulate. Each one is stored as its own
message, so a stream that runs for a minute leaves ~240 rows behind where
the reader only ever sees one block. Measured on my own 26-hour session
(`sqlite3` on the hub's `hapi.db`):

| | |
|---|---|
| messages | 48,844 |
| stored bytes | 63 MB |
| newest 400 messages (`VISIBLE_WINDOW_SIZE`) span | **202 seconds** |

Across the same period, sessions on other agents held 30–1,541 messages;
the two largest sessions on the machine were both OpenCode. Because the
window budgets raw messages, those 400 slots bought about three minutes
of conversation out of twenty-six hours — paging up walks through
duplicate snapshots instead of history, and each 250ms snapshot appends a
row while trimming one off the far end, which is what shakes the scroll
anchor.

## Solution

Keep the streaming behaviour exactly as it is, and stop the snapshots
from piling up behind it.

- `cli`: the converter now forwards the `live` marker that says a payload
  is one of those throttled snapshots, mirroring how the text variant
  already forwards `streamSnapshot`. Settled messages carry no marker.
- `hub`: when a message belonging to a reasoning stream arrives, the
  stream's earlier *live* snapshots are retired. Only rows explicitly
  marked live are eligible, so the settled message that closes a stream is
  never removed and a stream always keeps its newest row. Lookups are
  bounded to the newest rows of the session, and anything unrecognised is
  left alone.
- `web`: sessions recorded before this still carry every snapshot, so the
  window now collapses each stream to its newest snapshot before trimming.
  Rendering is unchanged — the timeline already folds them by stream id.

No change to the snapshot interval, the payload contents, or what the web
receives while a turn is running.

## Tests

- `shared`: stream-id readers — live vs settled, and the null cases
  (wrong role, wrong payload type, wrong data type, missing/blank/non-string id).
- `hub`: store-level collapse, settled-supersedes-live, a settled message
  is never removed, other streams untouched, and **session boundaries are
  never crossed**; plus a socket-handler test over the real
  `message` → persist path.
- `web`: window compaction keeps the newest snapshot per stream, keeps
  streams independent, leaves non-reasoning rows alone, derives its seq
  bounds from the surviving rows, and a regression test that a flood of
  snapshots no longer evicts the surrounding conversation.

Manually verified end-to-end against a real `opencode` session on an
isolated hub — same prompt and model, `opencode/big-pickle`:

| | before | after |
|---|---|---|
| rows for the turn's reasoning stream | 40 | **1** |
| bytes stored for it | 25,477 | **431** |
| total messages stored for the turn | 46 | 6 |

## AI disclosure

Per CONTRIBUTING: written with Claude (Opus 5).
