### PR TITLE
fix: render opencode edit/write/read tool calls through the shared views

### DIFF
--- a/cli/src/agent/backends/acp/AcpMessageHandler.test.ts
+++ b/cli/src/agent/backends/acp/AcpMessageHandler.test.ts
@@ -769,7 +769,7 @@ describe('AcpMessageHandler', () => {
             }
         });
 
-        it('keeps full edit rawInput (filePath/oldString/newString) over locations-only fallback', () => {
+        it('keeps full edit rawInput over locations-only fallback (canonicalized to the Edit view shape)', () => {
             const messages: AgentMessage[] = [];
             const handler = new AcpMessageHandler((message) => messages.push(message));
 
@@ -783,11 +783,6 @@ describe('AcpMessageHandler', () => {
                 rawInput: {}
             });
 
-            const fullInput = {
-                filePath: '/tmp/a.ts',
-                oldString: 'foo',
-                newString: 'bar'
-            };
             handler.handleUpdate({
                 sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCallUpdate,
                 toolCallId: 'oc-edit-1',
@@ -795,13 +790,178 @@ describe('AcpMessageHandler', () => {
                 kind: 'edit',
                 status: 'in_progress',
                 locations: [{ path: '/tmp/a.ts' }],
-                rawInput: fullInput
+                rawInput: {
+                    filePath: '/tmp/a.ts',
+                    oldString: 'foo',
+                    newString: 'bar'
+                }
             });
 
             const calls = messages.filter(
                 (m): m is Extract<AgentMessage, { type: 'tool_call' }> => m.type === 'tool_call'
             );
-            expect(calls[calls.length - 1].input).toEqual(fullInput);
+            // The full args must survive instead of the locations-only
+            // fallback — now in the canonical shape the web Edit view renders.
+            expect(calls[calls.length - 1].name).toBe('Edit');
+            expect(calls[calls.length - 1].input).toEqual({
+                file_path: '/tmp/a.ts',
+                old_string: 'foo',
+                new_string: 'bar'
+            });
+        });
+
+        it('canonicalizes the OpenCode edit lifecycle to the Edit view shape', () => {
+            // Recorded wire shape (opencode v1.18.x acp/tool.ts): pending with
+            // rawInput {}, running with native camelCase args, completed with a
+            // text block FIRST and a diff block WITHOUT _meta.kind second.
+            const messages: AgentMessage[] = [];
+            const handler = new AcpMessageHandler((message) => messages.push(message));
+
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCall,
+                toolCallId: 'oc-edit-canonical-1',
+                title: 'edit',
+                kind: 'edit',
+                status: 'pending',
+                locations: [{ path: '/tmp/a.ts' }],
+                rawInput: {}
+            });
+
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCallUpdate,
+                toolCallId: 'oc-edit-canonical-1',
+                title: 'a.ts',
+                kind: 'edit',
+                status: 'in_progress',
+                locations: [{ path: '/tmp/a.ts' }],
+                rawInput: {
+                    filePath: '/tmp/a.ts',
+                    oldString: 'const x = 1\n',
+                    newString: 'const x = 2\n'
+                }
+            });
+
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCallUpdate,
+                toolCallId: 'oc-edit-canonical-1',
+                status: 'completed',
+                content: [
+                    { type: 'content', content: { type: 'text', text: 'Edit applied successfully.' } },
+                    { type: 'diff', path: '/tmp/a.ts', oldText: 'const x = 1\n', newText: 'const x = 2\n' }
+                ],
+                rawOutput: { output: 'Edit applied successfully.' }
+            });
+
+            const calls = messages.filter(
+                (m): m is Extract<AgentMessage, { type: 'tool_call' }> => m.type === 'tool_call'
+            );
+            expect(calls[calls.length - 1].name).toBe('Edit');
+            expect(calls[calls.length - 1].input).toEqual({
+                file_path: '/tmp/a.ts',
+                old_string: 'const x = 1\n',
+                new_string: 'const x = 2\n'
+            });
+
+            const results = messages.filter(
+                (m): m is Extract<AgentMessage, { type: 'tool_result' }> => m.type === 'tool_result'
+            );
+            expect(results).toHaveLength(1);
+            expect(results[0].status).toBe('completed');
+        });
+
+        it('canonicalizes an OpenCode edit as soon as rawInput arrives on the initial tool_call', () => {
+            const messages: AgentMessage[] = [];
+            const handler = new AcpMessageHandler((message) => messages.push(message));
+
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCall,
+                toolCallId: 'oc-edit-canonical-2',
+                title: 'edit',
+                kind: 'edit',
+                status: 'pending',
+                locations: [{ path: '/tmp/a.ts' }],
+                rawInput: { filePath: '/tmp/a.ts', oldString: 'foo', newString: 'bar' }
+            });
+
+            const calls = messages.filter(
+                (m): m is Extract<AgentMessage, { type: 'tool_call' }> => m.type === 'tool_call'
+            );
+            expect(calls).toHaveLength(1);
+            expect(calls[0].name).toBe('Edit');
+            expect(calls[0].input).toEqual({ file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' });
+        });
+
+        it('canonicalizes the OpenCode write lifecycle to the Write view shape', () => {
+            // OpenCode maps write to kind=edit and its completed content carries
+            // no diff block at all (diffContent requires oldString), so only
+            // rawInput-based canonicalization can produce the Write view shape.
+            const messages: AgentMessage[] = [];
+            const handler = new AcpMessageHandler((message) => messages.push(message));
+
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCall,
+                toolCallId: 'oc-write-canonical-1',
+                title: 'write',
+                kind: 'edit',
+                status: 'pending',
+                locations: [{ path: '/tmp/b.txt' }],
+                rawInput: {}
+            });
+
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCallUpdate,
+                toolCallId: 'oc-write-canonical-1',
+                title: 'b.txt',
+                kind: 'edit',
+                status: 'in_progress',
+                locations: [{ path: '/tmp/b.txt' }],
+                rawInput: { filePath: '/tmp/b.txt', content: 'hello\n' }
+            });
+
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCallUpdate,
+                toolCallId: 'oc-write-canonical-1',
+                status: 'completed',
+                content: [
+                    { type: 'content', content: { type: 'text', text: 'Wrote 6 bytes to /tmp/b.txt' } }
+                ],
+                rawOutput: { output: 'Wrote 6 bytes to /tmp/b.txt' }
+            });
+
+            const calls = messages.filter(
+                (m): m is Extract<AgentMessage, { type: 'tool_call' }> => m.type === 'tool_call'
+            );
+            expect(calls[calls.length - 1].name).toBe('Write');
+            expect(calls[calls.length - 1].input).toEqual({ file_path: '/tmp/b.txt', content: 'hello\n' });
+        });
+
+        it('leaves non-diff OpenCode rawInput untouched (bash command args)', () => {
+            const messages: AgentMessage[] = [];
+            const handler = new AcpMessageHandler((message) => messages.push(message));
+
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCall,
+                toolCallId: 'oc-bash-canonical-1',
+                title: 'bash',
+                kind: 'execute',
+                status: 'pending',
+                rawInput: {}
+            });
+
+            handler.handleUpdate({
+                sessionUpdate: ACP_SESSION_UPDATE_TYPES.toolCallUpdate,
+                toolCallId: 'oc-bash-canonical-1',
+                title: 'bash',
+                kind: 'execute',
+                status: 'in_progress',
+                rawInput: { command: 'ls -la /tmp' }
+            });
+
+            const calls = messages.filter(
+                (m): m is Extract<AgentMessage, { type: 'tool_call' }> => m.type === 'tool_call'
+            );
+            expect(calls[calls.length - 1].name).toBe('bash');
+            expect(calls[calls.length - 1].input).toEqual({ command: 'ls -la /tmp' });
         });
     });
 

--- a/cli/src/agent/backends/acp/AcpMessageHandler.ts
+++ b/cli/src/agent/backends/acp/AcpMessageHandler.ts
@@ -4,7 +4,7 @@ import type { AgentMessage, PlanItem } from '@/agent/types';
 import { registerGeneratedImageFromAcpBlock } from '@/modules/common/generatedImages';
 import type { InlineMediaSource } from '@/modules/common/inlineMediaSource';
 import { asString, isObject } from '@hapi/protocol';
-import { deriveToolNameWithSource, isPlaceholderToolName } from '@/agent/utils';
+import { canonicalizeDiffToolInput, deriveToolNameWithSource, isPlaceholderToolName } from '@/agent/utils';
 import { parseRateLimitText } from '@/agent/rateLimitParser';
 import { isInternalEventJson } from '@/agent/internalEventFilter';
 import { ACP_SESSION_UPDATE_TYPES } from './constants';
@@ -729,7 +729,7 @@ export class AcpMessageHandler {
             rawInput: update.rawInput,
             metaKind: null
         });
-        const name = derivedName.name;
+        let name = derivedName.name;
         // Priority: usable rawInput > kind+title fallback > content JSON fallback.
         // Empty `{}` is treated as missing (OpenCode tool-start / permission clobber).
         // Kimi ACP streams tool arguments as JSON text in the content array
@@ -743,8 +743,18 @@ export class AcpMessageHandler {
                 update.content
             );
         // Content JSON can be `{}` (same as unusable rawInput); never lock that in.
-        const input = isUsableRawInput(candidate) ? candidate : null;
+        let input = isUsableRawInput(candidate) ? candidate : null;
         const status = normalizeStatus(update.status);
+
+        // Agents that keep native argument shapes (OpenCode: {filePath,
+        // oldString, newString} / {filePath, content}) must be canonicalized to
+        // the Claude-shaped Edit/Write inputs the web diff views render — the
+        // same contract as hoistDiffContentIntoInput for Gemini's diff blocks.
+        const canonical = input == null ? null : canonicalizeDiffToolInput(input);
+        if (canonical) {
+            name = canonical.name;
+            input = canonical.input;
+        }
 
         this.toolCalls.set(toolCallId, { name, input });
 
@@ -772,8 +782,15 @@ export class AcpMessageHandler {
 
         if (isUsableRawInput(update.rawInput)) {
             const derivedName = deriveToolNameFromUpdate(update);
-            const name = this.selectToolNameForUpdate(existing?.name ?? null, derivedName);
-            const input = update.rawInput;
+            let name = this.selectToolNameForUpdate(existing?.name ?? null, derivedName);
+            let input: unknown = update.rawInput;
+            // Native-shape args (OpenCode) arrive here as the first usable
+            // input; canonicalize before storing so the web diff views match.
+            const canonical = canonicalizeDiffToolInput(input);
+            if (canonical) {
+                name = canonical.name;
+                input = canonical.input;
+            }
             this.toolCalls.set(toolCallId, { name, input });
             this.onMessage({
                 type: 'tool_call',
@@ -800,9 +817,16 @@ export class AcpMessageHandler {
                     update.content
                 );
                 if (isUsableRawInput(fallback)) {
-                    input = fallback;
-                    const derivedName = deriveToolNameFromUpdate(update);
-                    name = this.selectToolNameForUpdate(existing.name ?? null, derivedName);
+                    let nextInput: unknown = fallback;
+                    const canonical = canonicalizeDiffToolInput(fallback);
+                    if (canonical) {
+                        name = canonical.name;
+                        nextInput = canonical.input;
+                    } else {
+                        const derivedName = deriveToolNameFromUpdate(update);
+                        name = this.selectToolNameForUpdate(existing.name ?? null, derivedName);
+                    }
+                    input = nextInput;
                     this.toolCalls.set(toolCallId, { name, input });
                     rederived = true;
                 }

--- a/cli/src/agent/backends/acp/AcpMessageHandler.ts
+++ b/cli/src/agent/backends/acp/AcpMessageHandler.ts
@@ -750,7 +750,8 @@ export class AcpMessageHandler {
         // oldString, newString} / {filePath, content}) must be canonicalized to
         // the Claude-shaped Edit/Write inputs the web diff views render — the
         // same contract as hoistDiffContentIntoInput for Gemini's diff blocks.
-        const canonical = input == null ? null : canonicalizeDiffToolInput(input);
+        // Gate on the kind so an arbitrary non-edit tool isn't misclassified.
+        const canonical = input == null ? null : canonicalizeDiffToolInput(input, asString(update.kind) ?? derivedName.name);
         if (canonical) {
             name = canonical.name;
             input = canonical.input;
@@ -786,7 +787,8 @@ export class AcpMessageHandler {
             let input: unknown = update.rawInput;
             // Native-shape args (OpenCode) arrive here as the first usable
             // input; canonicalize before storing so the web diff views match.
-            const canonical = canonicalizeDiffToolInput(input);
+            // Gate on the kind so an arbitrary non-edit tool isn't misclassified.
+            const canonical = canonicalizeDiffToolInput(input, asString(update.kind) ?? derivedName.name);
             if (canonical) {
                 name = canonical.name;
                 input = canonical.input;
@@ -818,7 +820,7 @@ export class AcpMessageHandler {
                 );
                 if (isUsableRawInput(fallback)) {
                     let nextInput: unknown = fallback;
-                    const canonical = canonicalizeDiffToolInput(fallback);
+                    const canonical = canonicalizeDiffToolInput(fallback, existing.name);
                     if (canonical) {
                         name = canonical.name;
                         nextInput = canonical.input;

--- a/cli/src/agent/utils.test.ts
+++ b/cli/src/agent/utils.test.ts
@@ -110,6 +110,50 @@ describe('agent tool name helpers', () => {
             });
         });
 
+        it('preserves replaceAll=true on edit input', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'foo',
+                newString: 'bar',
+                replaceAll: true
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: true }
+            });
+        });
+
+        it('preserves replaceAll=false on edit input', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'foo',
+                newString: 'bar',
+                replaceAll: false
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: false }
+            });
+        });
+
+        it('omits replace_all when absent or non-boolean', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'foo',
+                newString: 'bar'
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
+            });
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'foo',
+                newString: 'bar',
+                replaceAll: 'yes'
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
+            });
+        });
+
         it('prefers Edit over Write when both edit and content fields are present', () => {
             expect(canonicalizeDiffToolInput({
                 filePath: '/tmp/a.ts',

--- a/cli/src/agent/utils.test.ts
+++ b/cli/src/agent/utils.test.ts
@@ -82,7 +82,7 @@ describe('agent tool name helpers', () => {
                 filePath: '/tmp/a.ts',
                 oldString: 'foo',
                 newString: 'bar'
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
             });
@@ -93,7 +93,7 @@ describe('agent tool name helpers', () => {
                 file_path: '/tmp/a.ts',
                 old_string: 'foo',
                 new_string: 'bar'
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
             });
@@ -104,7 +104,7 @@ describe('agent tool name helpers', () => {
                 filePath: '/tmp/a.ts',
                 oldString: 'drop me\n',
                 newString: ''
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'drop me\n', new_string: '' }
             });
@@ -116,7 +116,7 @@ describe('agent tool name helpers', () => {
                 oldString: 'foo',
                 newString: 'bar',
                 replaceAll: true
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: true }
             });
@@ -128,7 +128,7 @@ describe('agent tool name helpers', () => {
                 oldString: 'foo',
                 newString: 'bar',
                 replaceAll: false
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: false }
             });
@@ -140,7 +140,7 @@ describe('agent tool name helpers', () => {
                 old_string: 'foo',
                 new_string: 'bar',
                 replace_all: true
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: true }
             });
@@ -152,7 +152,7 @@ describe('agent tool name helpers', () => {
                 old_string: 'foo',
                 new_string: 'bar',
                 replace_all: false
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: false }
             });
@@ -165,7 +165,7 @@ describe('agent tool name helpers', () => {
                 newString: 'bar',
                 replaceAll: true,
                 replace_all: false
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: true }
             });
@@ -176,7 +176,7 @@ describe('agent tool name helpers', () => {
                 filePath: '/tmp/a.ts',
                 oldString: 'foo',
                 newString: 'bar'
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
             });
@@ -185,7 +185,7 @@ describe('agent tool name helpers', () => {
                 oldString: 'foo',
                 newString: 'bar',
                 replaceAll: 'yes'
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
             });
@@ -197,7 +197,7 @@ describe('agent tool name helpers', () => {
                 oldString: 'foo',
                 newString: 'bar',
                 content: 'baz'
-            })).toEqual({
+            }, 'edit')).toEqual({
                 name: 'Edit',
                 input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
             });
@@ -207,7 +207,7 @@ describe('agent tool name helpers', () => {
             expect(canonicalizeDiffToolInput({
                 filePath: '/tmp/b.txt',
                 content: 'hello\n'
-            })).toEqual({
+            }, 'write')).toEqual({
                 name: 'Write',
                 input: { file_path: '/tmp/b.txt', content: 'hello\n' }
             });
@@ -217,7 +217,7 @@ describe('agent tool name helpers', () => {
             expect(canonicalizeDiffToolInput({
                 file_path: '/tmp/b.txt',
                 content: ''
-            })).toEqual({
+            }, 'write')).toEqual({
                 name: 'Write',
                 input: { file_path: '/tmp/b.txt', content: '' }
             });
@@ -227,40 +227,74 @@ describe('agent tool name helpers', () => {
             expect(canonicalizeDiffToolInput({
                 oldString: 'foo',
                 newString: 'bar'
-            })).toBeNull();
+            }, 'edit')).toBeNull();
             expect(canonicalizeDiffToolInput({
                 filePath: 42,
                 oldString: 'foo',
                 newString: 'bar'
-            })).toBeNull();
+            }, 'edit')).toBeNull();
         });
 
         it('returns null when one of old/new is missing', () => {
             expect(canonicalizeDiffToolInput({
                 filePath: '/tmp/a.ts',
                 oldString: 'foo'
-            })).toBeNull();
+            }, 'edit')).toBeNull();
             expect(canonicalizeDiffToolInput({
                 filePath: '/tmp/a.ts',
                 newString: 'bar'
-            })).toBeNull();
+            }, 'edit')).toBeNull();
         });
 
         it('returns null for non-diff shapes (e.g. apply_patch text)', () => {
             expect(canonicalizeDiffToolInput({
                 patch: '*** Begin Patch\n...'
-            })).toBeNull();
+            }, 'edit')).toBeNull();
             expect(canonicalizeDiffToolInput({
                 filePath: '/tmp/a.ts',
                 command: 'ls'
-            })).toBeNull();
+            }, 'edit')).toBeNull();
         });
 
         it('returns null for non-object inputs', () => {
-            expect(canonicalizeDiffToolInput(null)).toBeNull();
-            expect(canonicalizeDiffToolInput(undefined)).toBeNull();
-            expect(canonicalizeDiffToolInput('{"filePath":"/tmp/a.ts"}')).toBeNull();
-            expect(canonicalizeDiffToolInput([])).toBeNull();
+            expect(canonicalizeDiffToolInput(null, 'edit')).toBeNull();
+            expect(canonicalizeDiffToolInput(undefined, 'edit')).toBeNull();
+            expect(canonicalizeDiffToolInput('{"filePath":"/tmp/a.ts"}', 'edit')).toBeNull();
+            expect(canonicalizeDiffToolInput([], 'edit')).toBeNull();
+        });
+
+        it('does not rename a non-edit tool whose schema accepts filePath/content', () => {
+            // A custom MCP tool with {filePath, content, mode} must not be
+            // canonicalized to Write — its name and extra args are preserved.
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                content: 'payload',
+                mode: 'append'
+            }, 'artifact_write')).toBeNull();
+        });
+
+        it('returns null when the semantic hint is missing or unknown', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'foo',
+                newString: 'bar'
+            }, null)).toBeNull();
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                content: 'hi'
+            }, 'bash')).toBeNull();
+        });
+
+        it('canonicalizes write when the kind is edit (OpenCode mapping)', () => {
+            // OpenCode maps write's kind to 'edit'; that alias must still
+            // canonicalize a write-shaped input.
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/b.txt',
+                content: 'hello\n'
+            }, 'edit')).toEqual({
+                name: 'Write',
+                input: { file_path: '/tmp/b.txt', content: 'hello\n' }
+            });
         });
     });
 });

--- a/cli/src/agent/utils.test.ts
+++ b/cli/src/agent/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveToolName, deriveToolNameWithSource, isPlaceholderToolName } from './utils';
+import { canonicalizeDiffToolInput, deriveToolName, deriveToolNameWithSource, isPlaceholderToolName } from './utils';
 
 describe('agent tool name helpers', () => {
     it('treats generic kind fallback as placeholder', () => {
@@ -66,6 +66,120 @@ describe('agent tool name helpers', () => {
             });
             expect(derived.name).toBe('MyCustomTool');
             expect(derived.source).toBe('title');
+        });
+    });
+
+    describe('canonicalizeDiffToolInput (OpenCode native diff shapes)', () => {
+        // OpenCode ACP keeps tool arguments in native shape:
+        //   edit  → {filePath, oldString, newString}
+        //   write → {filePath, content}
+        // The web Edit/Write views only render the Claude-shaped inputs
+        // ({file_path, old_string, new_string} / {file_path, content}), so
+        // these shapes are canonicalized at the adapter boundary.
+
+        it('maps camelCase edit input to the canonical Edit shape', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'foo',
+                newString: 'bar'
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
+            });
+        });
+
+        it('maps snake_case edit input to the canonical Edit shape', () => {
+            expect(canonicalizeDiffToolInput({
+                file_path: '/tmp/a.ts',
+                old_string: 'foo',
+                new_string: 'bar'
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
+            });
+        });
+
+        it('allows empty newString (deletion edits)', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'drop me\n',
+                newString: ''
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'drop me\n', new_string: '' }
+            });
+        });
+
+        it('prefers Edit over Write when both edit and content fields are present', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'foo',
+                newString: 'bar',
+                content: 'baz'
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
+            });
+        });
+
+        it('maps camelCase write input to the canonical Write shape', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/b.txt',
+                content: 'hello\n'
+            })).toEqual({
+                name: 'Write',
+                input: { file_path: '/tmp/b.txt', content: 'hello\n' }
+            });
+        });
+
+        it('maps snake_case write input to the canonical Write shape', () => {
+            expect(canonicalizeDiffToolInput({
+                file_path: '/tmp/b.txt',
+                content: ''
+            })).toEqual({
+                name: 'Write',
+                input: { file_path: '/tmp/b.txt', content: '' }
+            });
+        });
+
+        it('returns null without a usable path', () => {
+            expect(canonicalizeDiffToolInput({
+                oldString: 'foo',
+                newString: 'bar'
+            })).toBeNull();
+            expect(canonicalizeDiffToolInput({
+                filePath: 42,
+                oldString: 'foo',
+                newString: 'bar'
+            })).toBeNull();
+        });
+
+        it('returns null when one of old/new is missing', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'foo'
+            })).toBeNull();
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                newString: 'bar'
+            })).toBeNull();
+        });
+
+        it('returns null for non-diff shapes (e.g. apply_patch text)', () => {
+            expect(canonicalizeDiffToolInput({
+                patch: '*** Begin Patch\n...'
+            })).toBeNull();
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                command: 'ls'
+            })).toBeNull();
+        });
+
+        it('returns null for non-object inputs', () => {
+            expect(canonicalizeDiffToolInput(null)).toBeNull();
+            expect(canonicalizeDiffToolInput(undefined)).toBeNull();
+            expect(canonicalizeDiffToolInput('{"filePath":"/tmp/a.ts"}')).toBeNull();
+            expect(canonicalizeDiffToolInput([])).toBeNull();
         });
     });
 });

--- a/cli/src/agent/utils.test.ts
+++ b/cli/src/agent/utils.test.ts
@@ -134,6 +134,43 @@ describe('agent tool name helpers', () => {
             });
         });
 
+        it('preserves snake_case replace_all=true on edit input', () => {
+            expect(canonicalizeDiffToolInput({
+                file_path: '/tmp/a.ts',
+                old_string: 'foo',
+                new_string: 'bar',
+                replace_all: true
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: true }
+            });
+        });
+
+        it('preserves snake_case replace_all=false on edit input', () => {
+            expect(canonicalizeDiffToolInput({
+                file_path: '/tmp/a.ts',
+                old_string: 'foo',
+                new_string: 'bar',
+                replace_all: false
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: false }
+            });
+        });
+
+        it('prefers camelCase replaceAll over snake_case replace_all', () => {
+            expect(canonicalizeDiffToolInput({
+                filePath: '/tmp/a.ts',
+                oldString: 'foo',
+                newString: 'bar',
+                replaceAll: true,
+                replace_all: false
+            })).toEqual({
+                name: 'Edit',
+                input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar', replace_all: true }
+            });
+        });
+
         it('omits replace_all when absent or non-boolean', () => {
             expect(canonicalizeDiffToolInput({
                 filePath: '/tmp/a.ts',

--- a/cli/src/agent/utils.ts
+++ b/cli/src/agent/utils.ts
@@ -35,9 +35,17 @@ export function canonicalizeDiffToolInput(rawInput: unknown): CanonicalDiffToolI
     const oldString = firstString(rawInput, ['oldString', 'old_string']);
     const newString = firstString(rawInput, ['newString', 'new_string']);
     if (oldString !== null && newString !== null) {
-        const replaceAll = isObject(rawInput) && typeof rawInput.replaceAll === 'boolean'
-            ? rawInput.replaceAll
-            : undefined;
+        // OpenCode streams camelCase replaceAll; already-canonical inputs may
+        // carry snake_case replace_all. Accept both so the execution argument
+        // survives every call site.
+        let replaceAll: boolean | undefined;
+        if (isObject(rawInput)) {
+            if (typeof rawInput.replaceAll === 'boolean') {
+                replaceAll = rawInput.replaceAll;
+            } else if (typeof rawInput.replace_all === 'boolean') {
+                replaceAll = rawInput.replace_all;
+            }
+        }
         return {
             name: 'Edit',
             input: {

--- a/cli/src/agent/utils.ts
+++ b/cli/src/agent/utils.ts
@@ -21,14 +21,23 @@ function firstString(value: unknown, keys: readonly string[]): string | null {
  * edit and `{filePath, content}` for write) and normalizes them to the
  * Claude-shaped inputs the web Edit/Write views render.
  *
- * Shape-based on purpose: a path plus both old/new strings is unambiguously an
- * edit, and a path plus content (without old/new) a write. No kind/name gate —
- * gating on agent-specific kind vocabulary would miss variants that omit it,
- * and rendering such a shape as a diff is correct even if one slips through.
+ * Gated on the tool's semantic name/kind: only known edit/write aliases are
+ * canonicalized. The Edit shape (path + both old/new strings) is unambiguous on
+ * its own, but Write is just `{path, content}` — a shape many non-edit MCP
+ * tools also accept — so without the gate those tools would be renamed to
+ * Write and their extra args dropped. The gate keeps the OpenCode native-shape
+ * cases (OpenCode maps both edit and write to kind 'edit', which is in the
+ * allow-list) while avoiding that misclassification.
  *
- * Returns null for everything else so callers keep their existing fallback.
+ * Returns null when the semantic hint is missing/unknown, or the input shape
+ * doesn't match, so callers keep their existing fallback.
  */
-export function canonicalizeDiffToolInput(rawInput: unknown): CanonicalDiffToolInput | null {
+export function canonicalizeDiffToolInput(rawInput: unknown, semanticHint: string | null): CanonicalDiffToolInput | null {
+    const kind = semanticHint?.trim().toLowerCase() ?? null;
+    if (!kind || !['edit', 'write', 'write_file', 'replace', 'modify', 'file_edit'].includes(kind)) {
+        return null;
+    }
+
     const filePath = firstString(rawInput, ['filePath', 'file_path']);
     if (filePath === null || filePath.length === 0) return null;
 

--- a/cli/src/agent/utils.ts
+++ b/cli/src/agent/utils.ts
@@ -3,7 +3,7 @@ import { isObject } from '@hapi/protocol';
 type ToolNameSource = 'title' | 'raw_input_name' | 'raw_input_tool' | 'kind' | 'default';
 
 export type CanonicalDiffToolInput =
-    | { name: 'Edit'; input: { file_path: string; old_string: string; new_string: string } }
+    | { name: 'Edit'; input: { file_path: string; old_string: string; new_string: string; replace_all?: boolean } }
     | { name: 'Write'; input: { file_path: string; content: string } };
 
 function firstString(value: unknown, keys: readonly string[]): string | null {
@@ -35,7 +35,18 @@ export function canonicalizeDiffToolInput(rawInput: unknown): CanonicalDiffToolI
     const oldString = firstString(rawInput, ['oldString', 'old_string']);
     const newString = firstString(rawInput, ['newString', 'new_string']);
     if (oldString !== null && newString !== null) {
-        return { name: 'Edit', input: { file_path: filePath, old_string: oldString, new_string: newString } };
+        const replaceAll = isObject(rawInput) && typeof rawInput.replaceAll === 'boolean'
+            ? rawInput.replaceAll
+            : undefined;
+        return {
+            name: 'Edit',
+            input: {
+                file_path: filePath,
+                old_string: oldString,
+                new_string: newString,
+                ...(replaceAll === undefined ? {} : { replace_all: replaceAll }),
+            },
+        };
     }
 
     const content = firstString(rawInput, ['content']);

--- a/cli/src/agent/utils.ts
+++ b/cli/src/agent/utils.ts
@@ -2,6 +2,50 @@ import { isObject } from '@hapi/protocol';
 
 type ToolNameSource = 'title' | 'raw_input_name' | 'raw_input_tool' | 'kind' | 'default';
 
+export type CanonicalDiffToolInput =
+    | { name: 'Edit'; input: { file_path: string; old_string: string; new_string: string } }
+    | { name: 'Write'; input: { file_path: string; content: string } };
+
+function firstString(value: unknown, keys: readonly string[]): string | null {
+    if (!isObject(value)) return null;
+    for (const key of keys) {
+        const candidate = value[key];
+        if (typeof candidate === 'string') return candidate;
+    }
+    return null;
+}
+
+/**
+ * Detects diff/write-shaped tool inputs emitted by ACP agents that keep their
+ * native argument shapes (OpenCode: `{filePath, oldString, newString}` for
+ * edit and `{filePath, content}` for write) and normalizes them to the
+ * Claude-shaped inputs the web Edit/Write views render.
+ *
+ * Shape-based on purpose: a path plus both old/new strings is unambiguously an
+ * edit, and a path plus content (without old/new) a write. No kind/name gate —
+ * gating on agent-specific kind vocabulary would miss variants that omit it,
+ * and rendering such a shape as a diff is correct even if one slips through.
+ *
+ * Returns null for everything else so callers keep their existing fallback.
+ */
+export function canonicalizeDiffToolInput(rawInput: unknown): CanonicalDiffToolInput | null {
+    const filePath = firstString(rawInput, ['filePath', 'file_path']);
+    if (filePath === null || filePath.length === 0) return null;
+
+    const oldString = firstString(rawInput, ['oldString', 'old_string']);
+    const newString = firstString(rawInput, ['newString', 'new_string']);
+    if (oldString !== null && newString !== null) {
+        return { name: 'Edit', input: { file_path: filePath, old_string: oldString, new_string: newString } };
+    }
+
+    const content = firstString(rawInput, ['content']);
+    if (content !== null) {
+        return { name: 'Write', input: { file_path: filePath, content } };
+    }
+
+    return null;
+}
+
 function normalizeToolName(value: unknown): string | null {
     if (typeof value !== 'string') {
         return null;

--- a/cli/src/opencode/opencodeLocalLauncher.ts
+++ b/cli/src/opencode/opencodeLocalLauncher.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/ui/logger';
+import { canonicalizeDiffToolInput } from '@/agent/utils';
 import { opencodeLocal } from './opencodeLocal';
 import { OpencodeSession } from './session';
 import { ensureOpencodeHookPlugin } from './utils/hookPlugin';
@@ -370,11 +371,19 @@ export async function opencodeLocalLauncher(
             }
             const record = payload as Record<string, unknown>;
             const tool = isObject(record.tool) ? record.tool as Record<string, unknown> : record;
-            const name = getString(tool.name) || getString(record.name);
+            let name = getString(tool.name) || getString(record.name);
             if (!name) {
                 return;
             }
-            const toolInput = parseMaybeJson(tool.input ?? tool.args ?? record.input ?? record.args);
+            let toolInput: unknown = parseMaybeJson(tool.input ?? tool.args ?? record.input ?? record.args);
+            // Native edit/write args are canonicalized before signature and emit
+            // so pairing stays consistent and the web Edit/Write views match the
+            // ACP path.
+            const canonical = canonicalizeDiffToolInput(toolInput);
+            if (canonical) {
+                name = canonical.name;
+                toolInput = canonical.input;
+            }
             const signature = buildToolSignature(name, toolInput);
             const fallbackSignature = buildToolSignature(name, null);
             const existingId = getString(tool.id)

--- a/cli/src/opencode/opencodeLocalLauncher.ts
+++ b/cli/src/opencode/opencodeLocalLauncher.ts
@@ -338,10 +338,13 @@ export async function opencodeLocalLauncher(
                 const previousInput = emittedToolInputs.get(toolCall.callId);
                 const previousCanonical = canonicalizeDiffToolInput(previousInput, toolCall.name);
                 const currentCanonical = canonicalizeDiffToolInput(toolCall.input, toolCall.name);
-                // Emit on first usable input, and replace a partial native
-                // edit/write input with the full canonical one when it arrives.
-                const shouldEmit = previousInput === undefined
-                    || (previousCanonical === null && currentCanonical !== null);
+                // Emit on first usable input, and re-emit whenever the canonical
+                // input changes (a partial native edit/write that already
+                // canonicalizes — e.g. {content: ""} — must be replaced when the
+                // final content arrives).
+                const canonicalChanged = currentCanonical !== null
+                    && hashObject(currentCanonical) !== hashObject(previousCanonical);
+                const shouldEmit = previousInput === undefined || canonicalChanged;
                 if (shouldEmit) {
                     emittedToolInputs.set(toolCall.callId, toolCall.input);
                     sentToolCalls.add(toolCall.callId);
@@ -446,10 +449,12 @@ export async function opencodeLocalLauncher(
                 const previousInput = emittedToolInputs.get(callId);
                 const previousCanonical = canonicalizeDiffToolInput(previousInput, name);
                 const currentCanonical = canonicalizeDiffToolInput(toolInput, name);
-                // Emit on first usable input; replace a partial native
-                // edit/write input with the full canonical one when it arrives.
-                const shouldEmit = previousInput === undefined
-                    || (previousCanonical === null && currentCanonical !== null);
+                // Emit on first usable input; re-emit whenever the canonical
+                // input changes (a partial native edit/write that already
+                // canonicalizes must be replaced when the final input arrives).
+                const canonicalChanged = currentCanonical !== null
+                    && hashObject(currentCanonical) !== hashObject(previousCanonical);
+                const shouldEmit = previousInput === undefined || canonicalChanged;
                 if (shouldEmit) {
                     emittedToolInputs.set(callId, toolInput);
                     sentToolCalls.add(callId);
@@ -470,8 +475,9 @@ export async function opencodeLocalLauncher(
                 const previousInput = emittedToolInputs.get(callId);
                 const previousCanonical = canonicalizeDiffToolInput(previousInput, name);
                 const currentCanonical = canonicalizeDiffToolInput(toolInput, name);
-                const shouldEmit = previousInput === undefined
-                    || (previousCanonical === null && currentCanonical !== null);
+                const canonicalChanged = currentCanonical !== null
+                    && hashObject(currentCanonical) !== hashObject(previousCanonical);
+                const shouldEmit = previousInput === undefined || canonicalChanged;
                 if (!sentToolCalls.has(callId) || shouldEmit) {
                     emittedToolInputs.set(callId, toolInput);
                     sentToolCalls.add(callId);

--- a/cli/src/opencode/opencodeLocalLauncher.ts
+++ b/cli/src/opencode/opencodeLocalLauncher.ts
@@ -376,16 +376,19 @@ export async function opencodeLocalLauncher(
                 return;
             }
             let toolInput: unknown = parseMaybeJson(tool.input ?? tool.args ?? record.input ?? record.args);
-            // Native edit/write args are canonicalized before signature and emit
-            // so pairing stays consistent and the web Edit/Write views match the
-            // ACP path.
+            // Compute the pairing signature from the raw name/input BEFORE
+            // canonicalizing: an id-less `before` with empty/partial args must
+            // share a queue key with the full `after`. Canonicalizing first would
+            // re-key the `after` (edit -> Edit) and miss the queued call.
+            const signature = buildToolSignature(name, toolInput);
+            const fallbackSignature = buildToolSignature(name, null);
+            // Native edit/write args are canonicalized for emit so the web
+            // Edit/Write views match the ACP path.
             const canonical = canonicalizeDiffToolInput(toolInput);
             if (canonical) {
                 name = canonical.name;
                 toolInput = canonical.input;
             }
-            const signature = buildToolSignature(name, toolInput);
-            const fallbackSignature = buildToolSignature(name, null);
             const existingId = getString(tool.id)
                 || getString(tool.tool_call_id)
                 || getString(tool.toolCallId);

--- a/cli/src/opencode/opencodeLocalLauncher.ts
+++ b/cli/src/opencode/opencodeLocalLauncher.ts
@@ -336,8 +336,8 @@ export async function opencodeLocalLauncher(
             if (toolCall && isUsableToolInput(toolCall.input) && !sentToolResults.has(toolCall.callId)) {
                 // Wait for non-empty input (OpenCode pending often has input:{}).
                 const previousInput = emittedToolInputs.get(toolCall.callId);
-                const previousCanonical = canonicalizeDiffToolInput(previousInput);
-                const currentCanonical = canonicalizeDiffToolInput(toolCall.input);
+                const previousCanonical = canonicalizeDiffToolInput(previousInput, toolCall.name);
+                const currentCanonical = canonicalizeDiffToolInput(toolCall.input, toolCall.name);
                 // Emit on first usable input, and replace a partial native
                 // edit/write input with the full canonical one when it arrives.
                 const shouldEmit = previousInput === undefined
@@ -398,8 +398,9 @@ export async function opencodeLocalLauncher(
             const signature = buildToolSignature(name, toolInput);
             const fallbackSignature = buildToolSignature(name, null);
             // Native edit/write args are canonicalized for emit so the web
-            // Edit/Write views match the ACP path.
-            const canonical = canonicalizeDiffToolInput(toolInput);
+            // Edit/Write views match the ACP path. Gate on the tool name so an
+            // arbitrary non-edit tool isn't misclassified as Write.
+            const canonical = canonicalizeDiffToolInput(toolInput, name);
             if (canonical) {
                 name = canonical.name;
                 toolInput = canonical.input;
@@ -443,8 +444,8 @@ export async function opencodeLocalLauncher(
                     return;
                 }
                 const previousInput = emittedToolInputs.get(callId);
-                const previousCanonical = canonicalizeDiffToolInput(previousInput);
-                const currentCanonical = canonicalizeDiffToolInput(toolInput);
+                const previousCanonical = canonicalizeDiffToolInput(previousInput, name);
+                const currentCanonical = canonicalizeDiffToolInput(toolInput, name);
                 // Emit on first usable input; replace a partial native
                 // edit/write input with the full canonical one when it arrives.
                 const shouldEmit = previousInput === undefined
@@ -467,8 +468,8 @@ export async function opencodeLocalLauncher(
                 // Mirror message.part.updated so result is never unpaired, and
                 // replace a partial native edit/write call with the full input.
                 const previousInput = emittedToolInputs.get(callId);
-                const previousCanonical = canonicalizeDiffToolInput(previousInput);
-                const currentCanonical = canonicalizeDiffToolInput(toolInput);
+                const previousCanonical = canonicalizeDiffToolInput(previousInput, name);
+                const currentCanonical = canonicalizeDiffToolInput(toolInput, name);
                 const shouldEmit = previousInput === undefined
                     || (previousCanonical === null && currentCanonical !== null);
                 if (!sentToolCalls.has(callId) || shouldEmit) {

--- a/cli/src/opencode/opencodeLocalLauncher.ts
+++ b/cli/src/opencode/opencodeLocalLauncher.ts
@@ -370,6 +370,7 @@ const emittedToolInputs = new Map<string, unknown>();
                     });
                 }
                 sentToolResults.add(toolResult.callId);
+                emittedToolInputs.delete(toolResult.callId);
                 session.sendAgentMessage({
                     type: 'tool-call-result',
                     callId: toolResult.callId,
@@ -482,6 +483,7 @@ const emittedToolInputs = new Map<string, unknown>();
                     });
                 }
                 sentToolResults.add(callId);
+                emittedToolInputs.delete(callId);
                 session.sendAgentMessage({
                     type: 'tool-call-result',
                     callId,

--- a/cli/src/opencode/opencodeLocalLauncher.ts
+++ b/cli/src/opencode/opencodeLocalLauncher.ts
@@ -236,9 +236,13 @@ export async function opencodeLocalLauncher(
 
     let storageScanner: OpencodeStorageScannerHandle | null = null;
     const messageRoles = new Map<string, string>();
-    const sentTextParts = new Set<string>();
-    const sentToolCalls = new Set<string>();
-    const sentToolResults = new Set<string>();
+const sentTextParts = new Set<string>();
+const sentToolCalls = new Set<string>();
+const sentToolResults = new Set<string>();
+// Emitted tool input per callId. When a partial native edit/write call is
+// emitted first (e.g. `{filePath}`), a later canonical full input replaces it
+// so the web Edit/Write view receives the complete arguments.
+const emittedToolInputs = new Map<string, unknown>();
     const textBuffers = new Map<string, string>();
     const toolExecutionQueues = new Map<string, string[]>();
 
@@ -329,16 +333,26 @@ export async function opencodeLocalLauncher(
             }
 
             const toolCall = parseToolCall(part);
-            if (toolCall && isUsableToolInput(toolCall.input) && !sentToolCalls.has(toolCall.callId)) {
+            if (toolCall && isUsableToolInput(toolCall.input) && !sentToolResults.has(toolCall.callId)) {
                 // Wait for non-empty input (OpenCode pending often has input:{}).
-                sentToolCalls.add(toolCall.callId);
-                session.sendAgentMessage({
-                    type: 'tool-call',
-                    name: toolCall.name,
-                    callId: toolCall.callId,
-                    input: toolCall.input,
-                    ...(toolCall.title ? { nativeTitle: toolCall.title } : {})
-                });
+                const previousInput = emittedToolInputs.get(toolCall.callId);
+                const previousCanonical = canonicalizeDiffToolInput(previousInput);
+                const currentCanonical = canonicalizeDiffToolInput(toolCall.input);
+                // Emit on first usable input, and replace a partial native
+                // edit/write input with the full canonical one when it arrives.
+                const shouldEmit = previousInput === undefined
+                    || (previousCanonical === null && currentCanonical !== null);
+                if (shouldEmit) {
+                    emittedToolInputs.set(toolCall.callId, toolCall.input);
+                    sentToolCalls.add(toolCall.callId);
+                    session.sendAgentMessage({
+                        type: 'tool-call',
+                        name: toolCall.name,
+                        callId: toolCall.callId,
+                        input: toolCall.input,
+                        ...(toolCall.title ? { nativeTitle: toolCall.title } : {})
+                    });
+                }
             }
 
             const toolResult = parseToolResult(part);
@@ -422,25 +436,42 @@ export async function opencodeLocalLauncher(
                     removeFromQueue(toolExecutionQueues, fallbackSignature, callId);
                 }
             }
-            if (eventType === 'tool.execute.before' && !sentToolCalls.has(callId)) {
+            if (eventType === 'tool.execute.before' && !sentToolResults.has(callId)) {
                 // Match message.part.updated path: skip empty placeholder args.
                 if (!usableInput) {
                     return;
                 }
-                sentToolCalls.add(callId);
-                session.sendAgentMessage({
-                    type: 'tool-call',
-                    name,
-                    callId,
-                    input: toolInput,
-                    ...(getString(tool.title ?? record.title) ? { nativeTitle: getString(tool.title ?? record.title) } : {})
-                });
+                const previousInput = emittedToolInputs.get(callId);
+                const previousCanonical = canonicalizeDiffToolInput(previousInput);
+                const currentCanonical = canonicalizeDiffToolInput(toolInput);
+                // Emit on first usable input; replace a partial native
+                // edit/write input with the full canonical one when it arrives.
+                const shouldEmit = previousInput === undefined
+                    || (previousCanonical === null && currentCanonical !== null);
+                if (shouldEmit) {
+                    emittedToolInputs.set(callId, toolInput);
+                    sentToolCalls.add(callId);
+                    session.sendAgentMessage({
+                        type: 'tool-call',
+                        name,
+                        callId,
+                        input: toolInput,
+                        ...(getString(tool.title ?? record.title) ? { nativeTitle: getString(tool.title ?? record.title) } : {})
+                    });
+                }
                 return;
             }
             if (eventType === 'tool.execute.after' && !sentToolResults.has(callId)) {
                 // Late tool-call recovery: before may have skipped empty `{}`.
-                // Mirror message.part.updated so result is never unpaired.
-                if (!sentToolCalls.has(callId)) {
+                // Mirror message.part.updated so result is never unpaired, and
+                // replace a partial native edit/write call with the full input.
+                const previousInput = emittedToolInputs.get(callId);
+                const previousCanonical = canonicalizeDiffToolInput(previousInput);
+                const currentCanonical = canonicalizeDiffToolInput(toolInput);
+                const shouldEmit = previousInput === undefined
+                    || (previousCanonical === null && currentCanonical !== null);
+                if (!sentToolCalls.has(callId) || shouldEmit) {
+                    emittedToolInputs.set(callId, toolInput);
                     sentToolCalls.add(callId);
                     session.sendAgentMessage({
                         type: 'tool-call',

--- a/cli/src/opencode/opencodeLocalLauncher.ts
+++ b/cli/src/opencode/opencodeLocalLauncher.ts
@@ -236,13 +236,13 @@ export async function opencodeLocalLauncher(
 
     let storageScanner: OpencodeStorageScannerHandle | null = null;
     const messageRoles = new Map<string, string>();
-const sentTextParts = new Set<string>();
-const sentToolCalls = new Set<string>();
-const sentToolResults = new Set<string>();
-// Emitted tool input per callId. When a partial native edit/write call is
-// emitted first (e.g. `{filePath}`), a later canonical full input replaces it
-// so the web Edit/Write view receives the complete arguments.
-const emittedToolInputs = new Map<string, unknown>();
+    const sentTextParts = new Set<string>();
+    const sentToolCalls = new Set<string>();
+    const sentToolResults = new Set<string>();
+    // Emitted tool input per callId. When a partial native edit/write call is
+    // emitted first (e.g. `{filePath}`), a later canonical full input replaces
+    // it so the web Edit/Write view receives the complete arguments.
+    const emittedToolInputs = new Map<string, unknown>();
     const textBuffers = new Map<string, string>();
     const toolExecutionQueues = new Map<string, string[]>();
 

--- a/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
+++ b/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
@@ -16,13 +16,23 @@ function canonicalizeHookPair(name: string, input: unknown): { name: string; inp
 function collectMessages(parts: unknown[]): Array<{ type: string; name?: string; callId: string; input?: unknown; output?: unknown }> {
     const sentToolCalls = new Set<string>();
     const sentToolResults = new Set<string>();
+    const emittedToolInputs = new Map<string, unknown>();
     const out: Array<{ type: string; name?: string; callId: string; input?: unknown; output?: unknown }> = [];
 
     for (const part of parts) {
         const toolCall = parseToolCall(part);
-        if (toolCall && isUsableToolInput(toolCall.input) && !sentToolCalls.has(toolCall.callId)) {
-            sentToolCalls.add(toolCall.callId);
-            out.push({ type: 'tool-call', name: toolCall.name, callId: toolCall.callId, input: toolCall.input });
+        if (toolCall && isUsableToolInput(toolCall.input) && !sentToolResults.has(toolCall.callId)) {
+            const previousInput = emittedToolInputs.get(toolCall.callId);
+            const previousCanonical = canonicalizeDiffToolInput(previousInput, toolCall.name);
+            const currentCanonical = canonicalizeDiffToolInput(toolCall.input, toolCall.name);
+            const canonicalChanged = currentCanonical !== null
+                && hashObject(currentCanonical) !== hashObject(previousCanonical);
+            const shouldEmit = previousInput === undefined || canonicalChanged;
+            if (shouldEmit) {
+                emittedToolInputs.set(toolCall.callId, toolCall.input);
+                sentToolCalls.add(toolCall.callId);
+                out.push({ type: 'tool-call', name: toolCall.name, callId: toolCall.callId, input: toolCall.input });
+            }
         }
         const toolResult = parseToolResult(part);
         if (toolResult && !sentToolResults.has(toolResult.callId)) {
@@ -31,6 +41,7 @@ function collectMessages(parts: unknown[]): Array<{ type: string; name?: string;
                 out.push({ type: 'tool-call', name: toolCall.name, callId: toolCall.callId, input: toolCall.input });
             }
             sentToolResults.add(toolResult.callId);
+            emittedToolInputs.delete(toolResult.callId);
             out.push({ type: 'tool-call-result', callId: toolResult.callId, output: toolResult.output });
         }
     }
@@ -179,6 +190,38 @@ describe('OpenCode local tool part parsing', () => {
         ]);
         expect(messages.map((m) => m.type)).toEqual(['tool-call', 'tool-call-result']);
         expect(messages[0].input).toEqual({ command: 'echo hi' });
+    });
+
+    it('re-emits a running write when content changes from empty to final (message.part.updated path)', () => {
+        const callId = 'call-write-stream';
+        const messages = collectMessages([
+            {
+                type: 'tool',
+                tool: 'write',
+                callID: callId,
+                state: { status: 'running', input: { filePath: '/tmp/b.txt', content: '' } }
+            },
+            {
+                type: 'tool',
+                tool: 'write',
+                callID: callId,
+                state: { status: 'running', input: { filePath: '/tmp/b.txt', content: 'final\n' } }
+            },
+            {
+                type: 'tool',
+                tool: 'write',
+                callID: callId,
+                state: { status: 'completed', input: { filePath: '/tmp/b.txt', content: 'final\n' }, output: 'wrote' }
+            }
+        ]);
+        const calls = messages.filter((m) => m.type === 'tool-call');
+        const results = messages.filter((m) => m.type === 'tool-call-result');
+        expect(calls.length).toBe(2);
+        expect(results.length).toBe(1);
+        expect(calls[calls.length - 1]).toMatchObject({
+            name: 'Write',
+            input: { file_path: '/tmp/b.txt', content: 'final\n' }
+        });
     });
 });
 

--- a/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
+++ b/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
@@ -1,6 +1,13 @@
 import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
+import { canonicalizeDiffToolInput } from '@/agent/utils';
 import { isUsableToolInput, parseToolCall, parseToolResult } from './opencodeLocalToolParse';
+
+/** Mirrors the launcher's execute-hook normalization (name+input before signature/emit). */
+function canonicalizeHookPair(name: string, input: unknown): { name: string; input: unknown } {
+    const canonical = canonicalizeDiffToolInput(input);
+    return canonical ? { name: canonical.name, input: canonical.input } : { name, input };
+}
 
 /** Simulate the emit policy used by the local launcher hook handler. */
 function collectMessages(parts: unknown[]): Array<{ type: string; name?: string; callId: string; input?: unknown; output?: unknown }> {
@@ -39,6 +46,51 @@ describe('OpenCode local tool part parsing', () => {
                 title: 'Run project tests'
             }
         })).toMatchObject({ title: 'Run project tests' });
+    });
+
+    it('canonicalizes edit tool parts to the Edit view shape', () => {
+        expect(parseToolCall({
+            type: 'tool',
+            tool: 'edit',
+            callID: 'call-edit-canonical',
+            state: {
+                status: 'running',
+                input: { filePath: '/tmp/a.ts', oldString: 'foo', newString: 'bar' }
+            }
+        })).toEqual({
+            callId: 'call-edit-canonical',
+            name: 'Edit',
+            input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
+        });
+    });
+
+    it('canonicalizes write tool parts to the Write view shape', () => {
+        expect(parseToolCall({
+            type: 'tool',
+            tool: 'write',
+            callID: 'call-write-canonical',
+            state: {
+                status: 'running',
+                input: { filePath: '/tmp/b.txt', content: 'hello\n' }
+            }
+        })).toEqual({
+            callId: 'call-write-canonical',
+            name: 'Write',
+            input: { file_path: '/tmp/b.txt', content: 'hello\n' }
+        });
+    });
+
+    it('leaves non-diff tool parts untouched', () => {
+        expect(parseToolCall({
+            type: 'tool',
+            tool: 'bash',
+            callID: 'call-bash-canonical',
+            state: { status: 'running', input: { command: 'ls -la' } }
+        })).toEqual({
+            callId: 'call-bash-canonical',
+            name: 'bash',
+            input: { command: 'ls -la' }
+        });
     });
 
     it('does not emit tool-call on pending with empty input; emits on running with real args', () => {
@@ -169,9 +221,11 @@ function collectExecuteHookMessages(
     let nextId = 0;
 
     for (const event of events) {
-        const toolInput = event.input;
-        const signature = buildToolSignature(event.name, toolInput);
-        const fallbackSignature = buildToolSignature(event.name, null);
+        const normalized = canonicalizeHookPair(event.name, event.input);
+        const eventName = normalized.name;
+        const toolInput = normalized.input;
+        const signature = buildToolSignature(eventName, toolInput);
+        const fallbackSignature = buildToolSignature(eventName, null);
         const existingId = event.id ?? null;
         const isBefore = event.type === 'before';
         const usableInput = isUsableToolInput(toolInput);
@@ -197,7 +251,7 @@ function collectExecuteHookMessages(
             if (!sentToolCalls.has(callId)) {
                 if (!usableInput) continue;
                 sentToolCalls.add(callId);
-                out.push({ type: 'tool-call', name: event.name, callId, input: toolInput });
+                out.push({ type: 'tool-call', name: eventName, callId, input: toolInput });
             }
             continue;
         }
@@ -209,7 +263,7 @@ function collectExecuteHookMessages(
         if (!sentToolResults.has(callId)) {
             if (!sentToolCalls.has(callId)) {
                 sentToolCalls.add(callId);
-                out.push({ type: 'tool-call', name: event.name, callId, input: toolInput });
+                out.push({ type: 'tool-call', name: eventName, callId, input: toolInput });
             }
             sentToolResults.add(callId);
             out.push({ type: 'tool-call-result', callId, output: event.output });
@@ -238,5 +292,31 @@ describe('OpenCode local execute-hook tool emit policy', () => {
             { type: 'tool-call', name: 'bash', callId: 'stable-1', input: { command: 'ls' } },
             { type: 'tool-call-result', callId: 'stable-1', output: 'ok' }
         ]);
+    });
+
+    it('canonicalizes edit before/after pairs emitted via the execute hook path', () => {
+        const messages = collectExecuteHookMessages([
+            { type: 'before', name: 'edit', input: {} },
+            { type: 'after', name: 'edit', input: { filePath: '/tmp/a.ts', oldString: 'foo', newString: 'bar' }, output: 'ok' }
+        ]);
+        expect(messages.map((m) => m.type)).toEqual(['tool-call', 'tool-call-result']);
+        expect(messages[0]).toMatchObject({
+            type: 'tool-call',
+            name: 'Edit',
+            callId: messages[1].callId,
+            input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
+        });
+    });
+
+    it('canonicalizes write tool calls emitted via the execute hook path', () => {
+        const messages = collectExecuteHookMessages([
+            { type: 'before', name: 'write', id: 'hook-write-1', input: { filePath: '/tmp/b.txt', content: 'hi\n' } },
+            { type: 'after', name: 'write', id: 'hook-write-1', input: { filePath: '/tmp/b.txt', content: 'hi\n' }, output: 'wrote' }
+        ]);
+        expect(messages[0]).toMatchObject({
+            type: 'tool-call',
+            name: 'Write',
+            input: { file_path: '/tmp/b.txt', content: 'hi\n' }
+        });
     });
 });

--- a/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
+++ b/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
@@ -8,7 +8,7 @@ import { isUsableToolInput, parseToolCall, parseToolResult } from './opencodeLoc
  *  `before` shares a queue key with the full `after`; canonicalization only
  *  affects what gets emitted. */
 function canonicalizeHookPair(name: string, input: unknown): { name: string; input: unknown } {
-    const canonical = canonicalizeDiffToolInput(input);
+    const canonical = canonicalizeDiffToolInput(input, name);
     return canonical ? { name: canonical.name, input: canonical.input } : { name, input };
 }
 
@@ -224,10 +224,10 @@ function collectExecuteHookMessages(
     const out: Array<{ type: string; name?: string; callId: string; input?: unknown; output?: unknown }> = [];
     let nextId = 0;
 
-    const shouldEmit = (callId: string, toolInput: unknown): boolean => {
+    const shouldEmit = (callId: string, toolInput: unknown, hint: string): boolean => {
         const previousInput = emittedToolInputs.get(callId);
-        const previousCanonical = canonicalizeDiffToolInput(previousInput);
-        const currentCanonical = canonicalizeDiffToolInput(toolInput);
+        const previousCanonical = canonicalizeDiffToolInput(previousInput, hint);
+        const currentCanonical = canonicalizeDiffToolInput(toolInput, hint);
         return previousInput === undefined
             || (previousCanonical === null && currentCanonical !== null);
     };
@@ -263,7 +263,7 @@ function collectExecuteHookMessages(
             } else {
                 pushQueue(toolExecutionQueues, fallbackSignature, callId);
             }
-            if (!sentToolResults.has(callId) && shouldEmit(callId, toolInput)) {
+            if (!sentToolResults.has(callId) && shouldEmit(callId, toolInput, eventName)) {
                 if (!usableInput) continue;
                 emittedToolInputs.set(callId, toolInput);
                 sentToolCalls.add(callId);
@@ -277,7 +277,7 @@ function collectExecuteHookMessages(
             removeFromQueue(toolExecutionQueues, fallbackSignature, callId);
         }
         if (!sentToolResults.has(callId)) {
-            if (!sentToolCalls.has(callId) || shouldEmit(callId, toolInput)) {
+            if (!sentToolCalls.has(callId) || shouldEmit(callId, toolInput, eventName)) {
                 emittedToolInputs.set(callId, toolInput);
                 sentToolCalls.add(callId);
                 out.push({ type: 'tool-call', name: eventName, callId, input: toolInput });

--- a/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
+++ b/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { canonicalizeDiffToolInput } from '@/agent/utils';
 import { isUsableToolInput, parseToolCall, parseToolResult } from './opencodeLocalToolParse';
 
-/** Mirrors the launcher's execute-hook normalization (name+input before signature/emit). */
+/** Mirrors the launcher's execute-hook normalization: pairing signatures are
+ *  computed from the RAW name/input BEFORE canonicalizing, so an id-less
+ *  `before` shares a queue key with the full `after`; canonicalization only
+ *  affects what gets emitted. */
 function canonicalizeHookPair(name: string, input: unknown): { name: string; input: unknown } {
     const canonical = canonicalizeDiffToolInput(input);
     return canonical ? { name: canonical.name, input: canonical.input } : { name, input };
@@ -221,11 +224,14 @@ function collectExecuteHookMessages(
     let nextId = 0;
 
     for (const event of events) {
+        // Signature is derived from the raw name/input BEFORE canonicalizing
+        // (mirrors opencodeLocalLauncher): an id-less `before` with empty or
+        // partial args must share a queue key with the full `after`.
+        const signature = buildToolSignature(event.name, event.input);
+        const fallbackSignature = buildToolSignature(event.name, null);
         const normalized = canonicalizeHookPair(event.name, event.input);
         const eventName = normalized.name;
         const toolInput = normalized.input;
-        const signature = buildToolSignature(eventName, toolInput);
-        const fallbackSignature = buildToolSignature(eventName, null);
         const existingId = event.id ?? null;
         const isBefore = event.type === 'before';
         const usableInput = isUsableToolInput(toolInput);
@@ -306,6 +312,20 @@ describe('OpenCode local execute-hook tool emit policy', () => {
             callId: messages[1].callId,
             input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
         });
+    });
+
+    it('pairs id-less edit with partial before args and full after via a shared queue key', () => {
+        // Regression: canonicalizing `edit` -> `Edit` BEFORE computing the queue
+        // signature re-keys the `after` and misses the call queued by the
+        // partial `before`, orphaning a stale call and emitting a second pair.
+        // The signature must be computed from the raw name/input so an id-less
+        // sequence stays paired to a single call id.
+        const messages = collectExecuteHookMessages([
+            { type: 'before', name: 'edit', input: { filePath: '/tmp/a.ts' } },
+            { type: 'after', name: 'edit', input: { filePath: '/tmp/a.ts', oldString: 'foo', newString: 'bar' }, output: 'ok' }
+        ]);
+        expect(messages.map((m) => m.type)).toEqual(['tool-call', 'tool-call-result']);
+        expect(messages[0].callId).toEqual(messages[1].callId);
     });
 
     it('canonicalizes write tool calls emitted via the execute hook path', () => {

--- a/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
+++ b/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
@@ -228,8 +228,9 @@ function collectExecuteHookMessages(
         const previousInput = emittedToolInputs.get(callId);
         const previousCanonical = canonicalizeDiffToolInput(previousInput, hint);
         const currentCanonical = canonicalizeDiffToolInput(toolInput, hint);
-        return previousInput === undefined
-            || (previousCanonical === null && currentCanonical !== null);
+        const canonicalChanged = currentCanonical !== null
+            && hashObject(currentCanonical) !== hashObject(previousCanonical);
+        return previousInput === undefined || canonicalChanged;
     };
 
     for (const event of events) {
@@ -370,5 +371,22 @@ describe('OpenCode local execute-hook tool emit policy', () => {
         expect(messages.map((m) => m.type)).toEqual(['tool-call', 'tool-call', 'tool-call-result']);
         expect(messages.filter((m) => m.type === 'tool-call').length).toBe(2);
         expect(messages.filter((m) => m.type === 'tool-call-result').length).toBe(1);
+    });
+
+    it('re-emits a canonical write when content changes from empty to final', () => {
+        // {filePath, content:""} already canonicalizes, so the previous
+        // null->canonical rule would suppress the final content. The canonical
+        // value itself changed, so a replacement tool-call must be emitted.
+        const messages = collectExecuteHookMessages([
+            { type: 'before', name: 'write', id: 'hook-w-1', input: { filePath: '/tmp/b.txt', content: '' } },
+            { type: 'after', name: 'write', id: 'hook-w-1', input: { filePath: '/tmp/b.txt', content: 'final\n' }, output: 'wrote' }
+        ]);
+        expect(messages.map((m) => m.type)).toEqual(['tool-call', 'tool-call', 'tool-call-result']);
+        expect(messages[0].callId).toEqual(messages[1].callId);
+        expect(messages[1]).toMatchObject({
+            type: 'tool-call',
+            name: 'Write',
+            input: { file_path: '/tmp/b.txt', content: 'final\n' }
+        });
     });
 });

--- a/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
+++ b/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
@@ -283,6 +283,7 @@ function collectExecuteHookMessages(
                 out.push({ type: 'tool-call', name: eventName, callId, input: toolInput });
             }
             sentToolResults.add(callId);
+            emittedToolInputs.delete(callId);
             out.push({ type: 'tool-call-result', callId, output: event.output });
         }
     }
@@ -354,5 +355,20 @@ describe('OpenCode local execute-hook tool emit policy', () => {
             name: 'Write',
             input: { file_path: '/tmp/b.txt', content: 'hi\n' }
         });
+    });
+
+    it('releases completed calls from upgrade tracking (no re-emit after result)', () => {
+        // Once a call is completed (tool-call-result emitted), the upgrade map
+        // entry is released. A later stale part for the same callId must not
+        // trigger a replacement emit or a duplicate result — the lifecycle is
+        // already closed by sentToolResults.
+        const messages = collectExecuteHookMessages([
+            { type: 'before', name: 'edit', id: 'hook-e-1', input: { filePath: '/tmp/a.ts' } },
+            { type: 'after', name: 'edit', id: 'hook-e-1', input: { filePath: '/tmp/a.ts', oldString: 'foo', newString: 'bar' }, output: 'ok' },
+            { type: 'after', name: 'edit', id: 'hook-e-1', input: { filePath: '/tmp/a.ts', oldString: 'x', newString: 'y' }, output: 'late' }
+        ]);
+        expect(messages.map((m) => m.type)).toEqual(['tool-call', 'tool-call', 'tool-call-result']);
+        expect(messages.filter((m) => m.type === 'tool-call').length).toBe(2);
+        expect(messages.filter((m) => m.type === 'tool-call-result').length).toBe(1);
     });
 });

--- a/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
+++ b/cli/src/opencode/utils/opencodeLocalToolParse.test.ts
@@ -219,9 +219,18 @@ function collectExecuteHookMessages(
 ): Array<{ type: string; name?: string; callId: string; input?: unknown; output?: unknown }> {
     const sentToolCalls = new Set<string>();
     const sentToolResults = new Set<string>();
+    const emittedToolInputs = new Map<string, unknown>();
     const toolExecutionQueues = new Map<string, string[]>();
     const out: Array<{ type: string; name?: string; callId: string; input?: unknown; output?: unknown }> = [];
     let nextId = 0;
+
+    const shouldEmit = (callId: string, toolInput: unknown): boolean => {
+        const previousInput = emittedToolInputs.get(callId);
+        const previousCanonical = canonicalizeDiffToolInput(previousInput);
+        const currentCanonical = canonicalizeDiffToolInput(toolInput);
+        return previousInput === undefined
+            || (previousCanonical === null && currentCanonical !== null);
+    };
 
     for (const event of events) {
         // Signature is derived from the raw name/input BEFORE canonicalizing
@@ -254,8 +263,9 @@ function collectExecuteHookMessages(
             } else {
                 pushQueue(toolExecutionQueues, fallbackSignature, callId);
             }
-            if (!sentToolCalls.has(callId)) {
+            if (!sentToolResults.has(callId) && shouldEmit(callId, toolInput)) {
                 if (!usableInput) continue;
+                emittedToolInputs.set(callId, toolInput);
                 sentToolCalls.add(callId);
                 out.push({ type: 'tool-call', name: eventName, callId, input: toolInput });
             }
@@ -267,7 +277,8 @@ function collectExecuteHookMessages(
             removeFromQueue(toolExecutionQueues, fallbackSignature, callId);
         }
         if (!sentToolResults.has(callId)) {
-            if (!sentToolCalls.has(callId)) {
+            if (!sentToolCalls.has(callId) || shouldEmit(callId, toolInput)) {
+                emittedToolInputs.set(callId, toolInput);
                 sentToolCalls.add(callId);
                 out.push({ type: 'tool-call', name: eventName, callId, input: toolInput });
             }
@@ -314,18 +325,23 @@ describe('OpenCode local execute-hook tool emit policy', () => {
         });
     });
 
-    it('pairs id-less edit with partial before args and full after via a shared queue key', () => {
-        // Regression: canonicalizing `edit` -> `Edit` BEFORE computing the queue
-        // signature re-keys the `after` and misses the call queued by the
-        // partial `before`, orphaning a stale call and emitting a second pair.
-        // The signature must be computed from the raw name/input so an id-less
-        // sequence stays paired to a single call id.
+    it('upgrades a partial edit before to the full canonical input when after arrives', () => {
+        // Regression: a partial native `before` ({filePath}) is emitted as-is.
+        // When the full `after` arrives it must REPLACE the earlier partial call
+        // so the web Edit view receives the complete old_string/new_string args.
+        // The replacement is a second tool-call (same callId) followed by the result.
         const messages = collectExecuteHookMessages([
             { type: 'before', name: 'edit', input: { filePath: '/tmp/a.ts' } },
             { type: 'after', name: 'edit', input: { filePath: '/tmp/a.ts', oldString: 'foo', newString: 'bar' }, output: 'ok' }
         ]);
-        expect(messages.map((m) => m.type)).toEqual(['tool-call', 'tool-call-result']);
+        expect(messages.map((m) => m.type)).toEqual(['tool-call', 'tool-call', 'tool-call-result']);
         expect(messages[0].callId).toEqual(messages[1].callId);
+        expect(messages[0].callId).toEqual(messages[2].callId);
+        expect(messages[1]).toMatchObject({
+            type: 'tool-call',
+            name: 'Edit',
+            input: { file_path: '/tmp/a.ts', old_string: 'foo', new_string: 'bar' }
+        });
     });
 
     it('canonicalizes write tool calls emitted via the execute hook path', () => {

--- a/cli/src/opencode/utils/opencodeLocalToolParse.ts
+++ b/cli/src/opencode/utils/opencodeLocalToolParse.ts
@@ -1,4 +1,5 @@
 import { isObject } from '@hapi/protocol';
+import { canonicalizeDiffToolInput } from '@/agent/utils';
 
 export type ParsedToolCall = {
     callId: string;
@@ -69,6 +70,19 @@ export function parseToolCall(part: unknown): ParsedToolCall | null {
     if (!name || !callId) {
         return null;
     }
+    // OpenCode native edit/write args ({filePath, oldString, newString} /
+    // {filePath, content}) are canonicalized to the Claude-shaped inputs the
+    // web Edit/Write views render — same contract as the ACP path.
+    const toParsed = (input: unknown, title: string | null): ParsedToolCall => {
+        const canonical = canonicalizeDiffToolInput(input);
+        return {
+            callId,
+            name: canonical ? canonical.name : name,
+            input: canonical ? canonical.input : input,
+            ...(title ? { title } : {})
+        };
+    };
+
     if (isObject(record.state)) {
         const state = record.state as Record<string, unknown>;
         const status = getString(state.status);
@@ -78,12 +92,10 @@ export function parseToolCall(part: unknown): ParsedToolCall | null {
             return null;
         }
         const input = parseMaybeJson(state.input ?? state.raw ?? record.input ?? record.args ?? record.arguments);
-        const title = getString(state.title);
-        return { callId, name, input, ...(title ? { title } : {}) };
+        return toParsed(input, getString(state.title));
     }
     const input = parseMaybeJson(record.input ?? record.args ?? record.arguments ?? record.raw);
-    const title = getString(record.title);
-    return { callId, name, input, ...(title ? { title } : {}) };
+    return toParsed(input, getString(record.title));
 }
 
 export function parseToolResult(part: unknown): ParsedToolResult | null {

--- a/cli/src/opencode/utils/opencodeLocalToolParse.ts
+++ b/cli/src/opencode/utils/opencodeLocalToolParse.ts
@@ -74,7 +74,7 @@ export function parseToolCall(part: unknown): ParsedToolCall | null {
     // {filePath, content}) are canonicalized to the Claude-shaped inputs the
     // web Edit/Write views render — same contract as the ACP path.
     const toParsed = (input: unknown, title: string | null): ParsedToolCall => {
-        const canonical = canonicalizeDiffToolInput(input);
+        const canonical = canonicalizeDiffToolInput(input, name);
         return {
             callId,
             name: canonical ? canonical.name : name,

--- a/web/src/components/ToolCard/knownTools.tsx
+++ b/web/src/components/ToolCard/knownTools.tsx
@@ -291,7 +291,15 @@ export const knownTools: Record<string, {
     Read: {
         icon: () => <EyeIcon className={DEFAULT_ICON_CLASS} />,
         title: (opts) => {
-            const file = getInputStringAny(opts.input, ['file_path', 'path', 'file'])
+            const file = getInputStringAny(opts.input, ['file_path', 'filePath', 'path', 'file'])
+            return file ? resolveDisplayPath(file, opts.metadata) : 'Read file'
+        },
+        minimal: true
+    },
+    read: {
+        icon: () => <EyeIcon className={DEFAULT_ICON_CLASS} />,
+        title: (opts) => {
+            const file = getInputStringAny(opts.input, ['filePath', 'file_path', 'path', 'file'])
             return file ? resolveDisplayPath(file, opts.metadata) : 'Read file'
         },
         minimal: true

--- a/web/src/components/ToolCard/views/_results.test.tsx
+++ b/web/src/components/ToolCard/views/_results.test.tsx
@@ -525,3 +525,72 @@ describe('parseNumberedFileLines', () => {
         expect(parseNumberedFileLines('just some\nplain text')).toBeNull()
     })
 })
+
+describe('opencode native read result formatting', () => {
+    function renderToolResult(toolName: string, result: unknown, input: unknown) {
+        const ResultView = getToolResultViewComponent(toolName)
+        const block: ToolCallBlock = {
+            id: 'tool-read',
+            localId: null,
+            createdAt: 0,
+            kind: 'tool-call',
+            children: [],
+            tool: {
+                id: 'tool-read',
+                name: toolName,
+                state: 'completed',
+                input,
+                result,
+                createdAt: 0,
+                startedAt: null,
+                completedAt: 0,
+                execStartedAt: null,
+                execCompletedAt: null,
+                description: null,
+                nativeKind: null
+            }
+        }
+        return render(
+            <I18nProvider>
+                <ResultView block={block} metadata={null} surface="dialog" />
+            </I18nProvider>
+        )
+    }
+
+    it('routes lowercase opencode read to the file-content code block view', () => {
+        const result = '<path>/tmp/example.ts</path>\n<type>file</type> <content> 1: export type A = 1 2: export type B = 2 3: </content>'
+        const numbered = '1: export type A = 1\n2: export type B = 2\n3:'
+        const { container } = renderToolResult('read', numbered, { filePath: '/tmp/example.ts' })
+
+        const pre = container.querySelector('pre')
+        expect(pre).not.toBeNull()
+        expect(pre).toHaveTextContent('export type A = 1')
+        expect(container).toHaveTextContent('File content')
+    })
+
+    it('falls back to the raw opencode read payload as a code block when unnumbered', () => {
+        const result = '<path>/tmp/a.txt</path>\n<type>file</type> <content>hello</content>'
+        const { container } = renderToolResult('read', result, { filePath: '/tmp/a.txt' })
+
+        const pre = container.querySelector('pre')
+        expect(pre).not.toBeNull()
+        expect(pre).toHaveTextContent('hello')
+    })
+})
+
+describe('unwrapOpencodeReadOutput', () => {
+    it('strips the path/type/content wrapper and keeps numbered body', async () => {
+        const { unwrapOpencodeReadOutput } = await import('@/components/ToolCard/views/_results')
+        const out = unwrapOpencodeReadOutput('<path>/tmp/a.ts</path>\n<type>file</type>\n<content>\n1: alpha\n2: beta</content>')
+        expect(out.path).toBe('/tmp/a.ts')
+        expect(out.body).toBe('1: alpha\n2: beta')
+        expect(out.isOpencodeRead).toBe(true)
+    })
+
+    it('returns the text untouched when there is no content wrapper', async () => {
+        const { unwrapOpencodeReadOutput } = await import('@/components/ToolCard/views/_results')
+        expect(unwrapOpencodeReadOutput('plain text').body).toBe('plain text')
+        expect(unwrapOpencodeReadOutput('plain text').path).toBeNull()
+        expect(unwrapOpencodeReadOutput('plain text').isOpencodeRead).toBe(false)
+    })
+})

--- a/web/src/components/ToolCard/views/_results.test.tsx
+++ b/web/src/components/ToolCard/views/_results.test.tsx
@@ -593,4 +593,25 @@ describe('unwrapOpencodeReadOutput', () => {
         expect(unwrapOpencodeReadOutput('plain text').path).toBeNull()
         expect(unwrapOpencodeReadOutput('plain text').isOpencodeRead).toBe(false)
     })
+
+    it('does not unwrap a plain Read whose file text contains a literal <content> element', async () => {
+        const { unwrapOpencodeReadOutput } = await import('@/components/ToolCard/views/_results')
+        const text = '1: const xml = \'<content>literal</content>\'\n2: export {}'
+        const out = unwrapOpencodeReadOutput(text)
+        expect(out.isOpencodeRead).toBe(false)
+        expect(out.body).toBe(text)
+    })
+
+    it('keeps an embedded </content> inside the wrapper body (greedy capture)', async () => {
+        const { unwrapOpencodeReadOutput } = await import('@/components/ToolCard/views/_results')
+        const out = unwrapOpencodeReadOutput('<path>/tmp/a.xml</path>\n<type>file</type>\n<content>\n1: <content>x</content>\n2: tail</content>')
+        expect(out.isOpencodeRead).toBe(true)
+        expect(out.body).toBe('1: <content>x</content>\n2: tail')
+    })
+
+    it('preserves real trailing whitespace in the unwrapped body', async () => {
+        const { unwrapOpencodeReadOutput } = await import('@/components/ToolCard/views/_results')
+        const out = unwrapOpencodeReadOutput('<path>/tmp/a.md</path>\n<type>file</type>\n<content>\n1: alpha\n2: beta\n\n</content>')
+        expect(out.body).toBe('1: alpha\n2: beta\n\n')
+    })
 })

--- a/web/src/components/ToolCard/views/_results.tsx
+++ b/web/src/components/ToolCard/views/_results.tsx
@@ -370,7 +370,7 @@ function extractReadFileContent(result: unknown): { filePath: string | null; con
 }
 
 function isReadFileToolCall(toolName: string, input: unknown): boolean {
-    if (toolName === 'Read' || toolName === 'NotebookRead') return true
+    if (toolName === 'Read' || toolName === 'NotebookRead' || toolName === 'read') return true
 
     const normalizedName = toolName.toLowerCase()
     if (normalizedName.includes('read_file') || normalizedName.includes('readfile')) return true
@@ -386,7 +386,7 @@ function isReadFileToolCall(toolName: string, input: unknown): boolean {
 function extractReadPathFromInput(input: unknown): string | null {
     if (!isObject(input)) return null
 
-    const directPath = getInputStringAny(input, ['file_path', 'path', 'name'])
+    const directPath = getInputStringAny(input, ['file_path', 'filePath', 'path', 'name'])
     if (directPath) return directPath
 
     if (Array.isArray(input.parsed_cmd)) {
@@ -424,6 +424,17 @@ export function parseNumberedFileLines(text: string): { startLine: number; body:
         body.push(match[2])
     }
     return startLine === null ? null : { startLine, body: body.join('\n') }
+}
+
+export function unwrapOpencodeReadOutput(text: string): { path: string | null; body: string; isOpencodeRead: boolean } {
+    const pathMatch = text.match(/<path>([\s\S]*?)<\/path>/)
+    const contentMatch = text.match(/<content>\n?([\s\S]*?)<\/content>/)
+    if (!contentMatch) return { path: null, body: text, isOpencodeRead: false }
+    return {
+        path: pathMatch?.[1]?.trim() ?? null,
+        body: contentMatch[1].replace(/\n\(End of file[^)]*\)\n?$/, '').trimEnd(),
+        isOpencodeRead: true
+    }
 }
 
 function renderReadTextResult(text: string, path: string | null, surface: ToolViewProps['surface'], parseNumberedLines: boolean) {
@@ -665,11 +676,12 @@ const ReadResultView: ToolViewComponent = (props: ToolViewProps) => {
 
     const text = extractTextFromResult(result)
     if (text) {
-        const path = extractReadPathFromInput(props.block.tool.input)
+        const unwrapped = unwrapOpencodeReadOutput(text)
+        const path = unwrapped.path ?? extractReadPathFromInput(props.block.tool.input)
         const displayPath = path ? resolveDisplayPath(path, props.metadata) : null
         return (
             <>
-                {renderReadTextResult(text, displayPath, props.surface, props.block.tool.nativeKind === 'agy-numbered-read')}
+                {renderReadTextResult(unwrapped.body, displayPath, props.surface, unwrapped.isOpencodeRead || props.block.tool.nativeKind === 'agy-numbered-read')}
                 <RawJsonDevOnly value={result} surface={props.surface} />
             </>
         )
@@ -1020,7 +1032,15 @@ const GenericResultView: ToolViewComponent = (props: ToolViewProps) => {
         return (
             <>
                 {isReadFileToolCall(props.block.tool.name, props.block.tool.input)
-                    ? renderReadTextResult(text, extractReadPathFromInput(props.block.tool.input), props.surface, props.block.tool.nativeKind === 'agy-numbered-read')
+                    ? (() => {
+                        const unwrapped = unwrapOpencodeReadOutput(text)
+                        return renderReadTextResult(
+                            unwrapped.body,
+                            unwrapped.path ?? extractReadPathFromInput(props.block.tool.input),
+                            props.surface,
+                            unwrapped.isOpencodeRead || props.block.tool.nativeKind === 'agy-numbered-read'
+                        )
+                    })()
                     : renderText(text, { mode: 'auto', collapseLongContent: props.surface === 'inline', surface: props.surface })}
                 {typeof result === 'object' ? <RawJsonDevOnly value={result} surface={props.surface} /> : null}
             </>
@@ -1041,6 +1061,7 @@ export const toolResultViewRegistry: Record<string, ToolViewComponent> = {
     Grep: LineListResultView,
     LS: LineListResultView,
     Read: ReadResultView,
+    read: ReadResultView,
     Edit: MutationResultView,
     MultiEdit: MutationResultView,
     Write: MutationResultView,

--- a/web/src/components/ToolCard/views/_results.tsx
+++ b/web/src/components/ToolCard/views/_results.tsx
@@ -427,12 +427,11 @@ export function parseNumberedFileLines(text: string): { startLine: number; body:
 }
 
 export function unwrapOpencodeReadOutput(text: string): { path: string | null; body: string; isOpencodeRead: boolean } {
-    const pathMatch = text.match(/<path>([\s\S]*?)<\/path>/)
-    const contentMatch = text.match(/<content>\n?([\s\S]*?)<\/content>/)
-    if (!contentMatch) return { path: null, body: text, isOpencodeRead: false }
+    const wrapper = text.match(/^<path>([\s\S]*?)<\/path>\s*<type>file<\/type>\s*<content>\n?([\s\S]*)<\/content>\s*$/)
+    if (!wrapper) return { path: null, body: text, isOpencodeRead: false }
     return {
-        path: pathMatch?.[1]?.trim() ?? null,
-        body: contentMatch[1].replace(/\n\(End of file[^)]*\)\n?$/, '').trimEnd(),
+        path: wrapper[1].trim(),
+        body: wrapper[2].replace(/\n\(End of file[^)]*\)\n?$/, ''),
         isOpencodeRead: true
     }
 }


### PR DESCRIPTION
## Symptom

OpenCode's native `read`/`edit`/`write` tool calls don't get their dedicated web views:

- `edit`/`write` render as a generic card with raw JSON input instead of the shared diff views:

| before | after |
| --- | --- |
| ![before-dialog](https://github.com/user-attachments/assets/025378a7-5c35-470b-9790-76e576a67744) | ![after-dialog](https://github.com/user-attachments/assets/9cbb9664-3a07-4611-9990-fdaefb0141c6) |

- `read` falls through to the generic markdown result view, so the whole file collapses into one soft-wrapped paragraph with raw `<path>/<type>/<content>` markup and literal `1:` line prefixes.

## Root causes

Four independent gaps:

1. **Name mismatch (CLI)** — `AcpMessageHandler` derives the tool name from the ACP `title`, so OpenCode's edit arrives as `edit`; the web's tool registry only knows `Edit`/`Write`, so it falls back to the generic raw-JSON presentation.
2. **Input shape mismatch (CLI)** — OpenCode streams native camelCase args (`{filePath, oldString, newString}` / `{filePath, content}`); the web `EditView`/`WriteView` only read Claude-shaped keys (`file_path`, `old_string`, `new_string`).
3. **Gemini diff hoist doesn't apply (CLI)** — `hoistDiffContentIntoInput` requires a leading diff block + `_meta.kind`; OpenCode's completed content is a text block first and carries no `_meta.kind`.
4. **Read result mismatch (web)** — OpenCode's `read` result is a `<path>…</path> <type>file</type> <content>…</content>` envelope with 1-indexed line numbering and a trailing `(End of file - total N lines)` line; nothing in the web result views understood that shape, and the camelCase `filePath` input key was missed by the card title/path resolvers.

Wire shapes verified against opencode v1.18.x source (`acp/tool.ts`, read schema `{filePath, offset?, limit?}`) and live captures.

## Fix

**CLI — canonicalize at the adapter boundary**, following the existing Gemini precedent:

- `canonicalizeDiffToolInput()` (`cli/src/agent/utils.ts`) — shape-based: path + old/new → `Edit {file_path, old_string, new_string}`; path + content → `Write {file_path, content}`; everything else returns null so existing fallbacks are untouched.
- Applied at the three ACP input sites (`AcpMessageHandler` initial call / running update / enrichment fallback), the local-mode part parser (`opencodeLocalToolParse`), and before execute-hook signature computation (`opencodeLocalLauncher`) so before/after pairing stays consistent.

**Web — teach the result views the opencode `read` shape**:

- `read` is registered as a `ReadResultView` alias, and the opencode envelope is unwrapped with a strict anchored match (`^<path>…</path> <type>file</type> <content>…</content>$`, greedy body so embedded `</content>` survives). The trailer line is stripped and the 1-indexed numbering drives the code-block gutter — so `offset`/`limit` reads start at the true line. Plain `Read` results containing literal `<content>` text are left untouched.
- The card title/path resolvers accept `filePath` alongside `file_path`.

> **Design note — canonicalization is gated on edit/write semantics.** The
> `Edit` shape (path + both old/new strings) is unambiguous on its own, but
> `Write` is just `{path, content}` — a shape many non-edit MCP tools also
> accept — so without a gate those tools would be renamed to `Write` and their
> extra args dropped. `canonicalizeDiffToolInput` therefore requires a semantic
> hint (tool name/kind) and only normalizes known edit/write aliases. OpenCode
> maps both edit and write to kind `'edit'` (verified in `toToolKind`), which is
> in the allow-list, so the native-shape cases keep working.

Out of scope: `apply_patch`/patch-text shapes, generic object-input presentation. No migration for messages already persisted in the raw shape.

## Verification

- New unit tests: helper (10 cases), ACP edit/write lifecycles incl. pending→running→completed with text+diff content, local part parsing, execute-hook pairing; the existing test asserting the old camelCase output was updated to the canonical contract.
- Read rendering: web ToolCard suite 206 passed (incl. envelope regressions: literal `<content>` in a plain read, embedded `</content>` in the body, trailing whitespace preservation); typecheck clean. Verified with a live E2E — real hub + opencode session (`opencode/nemotron-3.5-lightning-free`) performing an actual `read`, rendered through the local web dev server against the hub.
- Full suite green on `upstream/main` (`1f5602ad`, release 0.29.0): cli 2431 passed (+1 skipped), hub 1196, web 2796, shared 283, relay 80; typecheck clean.
- Isolated E2E (throwaway `HAPI_HOME` + dynamic ports, real hub + vite + headless Chromium) seeded with the exact pre/post wire shapes — before shows the raw JSON card, after shows the unified diff and the Write content view:

| before-inline | after-inline | after-write-dialog |
| --- | --- | --- |
| ![before-inline](https://github.com/user-attachments/assets/489288a6-073f-420f-8af7-492cc88959ef) | ![after-inline](https://github.com/user-attachments/assets/a0736c29-b0de-4b4f-82d2-714e75f7a131) | ![after-write-dialog](https://github.com/user-attachments/assets/e3c61f03-2c34-440d-8ab6-e1ca4cb4c29c) |
