### PR TITLE
fix(web): unify message action button styling

### DIFF
--- a/web/src/components/AssistantChat/messages/MessageActionButton.tsx
+++ b/web/src/components/AssistantChat/messages/MessageActionButton.tsx
@@ -1,0 +1,29 @@
+import type { ButtonHTMLAttributes } from 'react'
+import { cn } from '@/lib/utils'
+
+export const MESSAGE_ACTION_BUTTON_CLASS =
+    'flex h-5 w-5 items-center justify-center rounded text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]'
+
+type MessageActionButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label' | 'title'> & {
+    label: string
+}
+
+export function MessageActionButton({
+    label,
+    className,
+    children,
+    type = 'button',
+    ...props
+}: MessageActionButtonProps) {
+    return (
+        <button
+            {...props}
+            type={type}
+            title={label}
+            aria-label={label}
+            className={cn(MESSAGE_ACTION_BUTTON_CLASS, className)}
+        >
+            {children}
+        </button>
+    )
+}

--- a/web/src/components/AssistantChat/messages/MessageActions.test.tsx
+++ b/web/src/components/AssistantChat/messages/MessageActions.test.tsx
@@ -6,6 +6,7 @@ import {
     MessageActions,
     selectThreadIsRunning,
 } from './MessageActions'
+import { MESSAGE_ACTION_BUTTON_CLASS } from './MessageActionButton'
 
 const copy = vi.fn()
 const onShareTurn = vi.fn()
@@ -359,6 +360,45 @@ describe('MessageActions', () => {
             'Fork',
             'Copy'
         ])
+    })
+
+    it('uses the shared compact style and matching accessible hover labels', () => {
+        renderActions({
+            align: 'end',
+            copyText: 'body',
+            messageElementId: 'message-1',
+            showFork: true,
+            showRewind: true,
+            onFork: async () => {},
+            onRewind: async () => {}
+        })
+
+        const buttons = ['Share turn as image', 'Rewind', 'Fork', 'Copy'].map((name) =>
+            screen.getByRole('button', { name })
+        )
+        expect(new Set(buttons.map((button) => button.className))).toEqual(new Set([MESSAGE_ACTION_BUTTON_CLASS]))
+        for (const button of buttons) {
+            expect(button).toHaveAttribute('title', button.getAttribute('aria-label'))
+        }
+        expect(buttons[0].querySelector('svg')).toHaveAttribute('class', 'h-3.5 w-3.5')
+    })
+
+    it('localizes every message action hover label in Simplified Chinese', () => {
+        localStorage.setItem('hapi-lang', 'zh-CN')
+
+        renderActions({
+            align: 'end',
+            copyText: 'body',
+            messageElementId: 'message-1',
+            showFork: true,
+            showRewind: true,
+            onFork: async () => {},
+            onRewind: async () => {}
+        })
+
+        for (const name of ['将本轮对话分享为图片', '回退', '分叉', '复制']) {
+            expect(screen.getByRole('button', { name })).toHaveAttribute('title', name)
+        }
     })
 
     it('shows Fork confirm dialog and calls onFork only after confirm', async () => {

--- a/web/src/components/AssistantChat/messages/MessageActions.tsx
+++ b/web/src/components/AssistantChat/messages/MessageActions.tsx
@@ -8,6 +8,7 @@ import { MessageMetadata, buildMessageMetadataLabels, type MessageMetadataProps 
 import { MessageTimestamp } from './MessageTimestamp'
 import { cn } from '@/lib/utils'
 import { ShareTurnButton } from './ShareTurnButton'
+import { MessageActionButton } from './MessageActionButton'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 
 export type MessageHistoryAction = {
@@ -70,47 +71,37 @@ export function MessageActions({
         <ShareTurnButton
             messageElementId={messageElementId}
             fallbackText={copyText}
-            className="flex h-5 w-5 items-center justify-center rounded text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
         />
     ) : null
 
     const historyButtons = !actionsLocked ? (
         <>
             {showRewind && onRewind ? (
-                <button
-                    type="button"
-                    title={t('message.rewind')}
-                    aria-label={t('message.rewind')}
-                    className="flex h-5 w-5 items-center justify-center rounded text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
+                <MessageActionButton
+                    label={t('message.rewind')}
                     onClick={() => setRewindOpen(true)}
                 >
                     <RewindIcon className="h-3.5 w-3.5" />
-                </button>
+                </MessageActionButton>
             ) : null}
             {showFork && onFork ? (
-                <button
-                    type="button"
-                    title={t('message.fork')}
-                    aria-label={t('message.fork')}
-                    className="flex h-5 w-5 items-center justify-center rounded text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
+                <MessageActionButton
+                    label={t('message.fork')}
                     onClick={() => setForkOpen(true)}
                 >
                     <ForkIcon className="h-3.5 w-3.5" />
-                </button>
+                </MessageActionButton>
             ) : null}
         </>
     ) : null
 
     const copyButton = canCopy ? (
-        <button
-            type="button"
-            title={copied ? t('message.copied') : t('message.copy')}
-            aria-label={copied ? t('message.copied') : t('message.copy')}
-            className="flex h-5 w-5 items-center justify-center rounded text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)]"
+        <MessageActionButton
+            label={copied ? t('message.copied') : t('message.copy')}
             onClick={() => copy(copyText!)}
         >
             {copied ? <CheckIcon className="h-3.5 w-3.5 text-green-500" /> : <CopyIcon className="h-3.5 w-3.5" />}
-        </button>
+        </MessageActionButton>
     ) : null
 
     return (

--- a/web/src/components/AssistantChat/messages/ShareTurnButton.tsx
+++ b/web/src/components/AssistantChat/messages/ShareTurnButton.tsx
@@ -1,6 +1,7 @@
 import { useAuiState } from '@assistant-ui/react'
 import { useOptionalHappyChatContext } from '@/components/AssistantChat/context'
 import { useTranslation } from '@/lib/use-translation'
+import { MessageActionButton } from './MessageActionButton'
 
 function ShareIcon(props: { className?: string }) {
     return (
@@ -49,12 +50,10 @@ export function ShareTurnButton(props: {
     const fallbackText = props.fallbackText?.trim() ?? ''
 
     return (
-        <button
-            type="button"
+        <MessageActionButton
             data-hapi-share-action="true"
-            title={t('message.shareTurn')}
-            aria-label={t('message.shareTurn')}
-            className={props.className ?? 'rounded-md p-0.5 opacity-60 transition-[opacity,background-color] hover:bg-[var(--app-subtle-bg)] sm:opacity-0 sm:group-hover/msg:opacity-100'}
+            label={t('message.shareTurn')}
+            className={props.className}
             onClick={(event) => {
                 event.stopPropagation()
                 const messageElement = event.currentTarget.closest('[data-hapi-message-role]')
@@ -69,7 +68,7 @@ export function ShareTurnButton(props: {
                 )
             }}
         >
-            <ShareIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />
-        </button>
+            <ShareIcon className="h-3.5 w-3.5" />
+        </MessageActionButton>
     )
 }


### PR DESCRIPTION
Fixes #1586

## Summary
- share one compact message-action button primitive for copy, fork, rewind, and share
- keep localized native hover titles and accessible labels aligned in English and Simplified Chinese
- preserve existing action locking and confirmation behavior

## Testing
- `bun typecheck && bun run test`
- `git diff --check`