### PR TITLE
docs(macOS): set launchd runner file limit

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -203,6 +203,11 @@ Create plist files for automatic startup on macOS.
         <key>HAPI_RUNNER_SUPERVISED</key>
         <string>1</string>
     </dict>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>65536</integer>
+    </dict>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>


### PR DESCRIPTION
## Summary

- Document `SoftResourceLimits.NumberOfFiles=65536` in the macOS runner LaunchAgent example.
- Prevent the documented runner setup from inheriting a low soft `maxfiles` limit that can make detached session children exit before reporting their startup webhook.

The current launchd example lives in `docs/guide/deployment.md` (the issue's former installation path now links there).

## Validation

- `TMPDIR=<isolated temp dir> bun typecheck`
- `TMPDIR=<isolated temp dir> bun run test` — 6,764 passed, 4 skipped, 0 failed
- Both launchd plist examples parse as XML; runner limit assertion passed.
- `git diff --check`

No macOS runtime validation was possible in this Linux worktree; the issue report includes a macOS reproduction and verified canary spawn after applying this setting.

AI-generated code: this documentation change was prepared with AI assistance and reviewed against the current source and Apple launchd documentation.

Fixes #1174
