### PR TITLE
fix: warn before large session exports

### DIFF
--- a/hub/src/sync/messageService.test.ts
+++ b/hub/src/sync/messageService.test.ts
@@ -175,7 +175,7 @@ describe('MessageService goal status filtering', () => {
         expect(result.payload.messages.map((message) => message.id)).toEqual([normal.id, scheduled.id])
     })
 
-    it('returns too-large instead of truncating an export over the cap', () => {
+    it('returns a warning instead of truncating an export over the threshold', () => {
         const store = makeStore()
         const session = makeSession(store, 'session-export-cap')
 
@@ -183,13 +183,30 @@ describe('MessageService goal status filtering', () => {
         store.messages.addMessage(session.id, { role: 'agent', content: 'Two' })
 
         const service = new MessageService(store, makeIo(() => {}), makePublisher() as any)
-        const result = service.getSessionExport(session.id, toProtocolSession(session), 1)
+        const result = service.getSessionExport(session.id, toProtocolSession(session), { limit: 1 })
 
-        expect(result).toEqual({
-            type: 'too-large',
+        expect(result).toMatchObject({
+            type: 'warning',
             count: 2,
             limit: 1
         })
+        if (result.type !== 'warning') throw new Error('Expected export warning')
+        expect(result.sizeBytes).toBeGreaterThan(0)
+    })
+
+    it('returns the full export after the warning is explicitly confirmed', () => {
+        const store = makeStore()
+        const session = makeSession(store, 'session-export-confirmed')
+
+        store.messages.addMessage(session.id, { role: 'user', content: 'One' })
+        store.messages.addMessage(session.id, { role: 'agent', content: 'Two' })
+
+        const service = new MessageService(store, makeIo(() => {}), makePublisher() as any)
+        const result = service.getSessionExport(session.id, toProtocolSession(session), { limit: 1, allowLarge: true })
+
+        expect(result.type).toBe('success')
+        if (result.type !== 'success') throw new Error('Expected confirmed export')
+        expect(result.payload.messages).toHaveLength(2)
     })
 
     it('includes scratchlist text and attachment metadata in chronological order (tiann/hapi#1235)', () => {

--- a/hub/src/sync/messageService.test.ts
+++ b/hub/src/sync/messageService.test.ts
@@ -209,6 +209,34 @@ describe('MessageService goal status filtering', () => {
         expect(result.payload.messages).toHaveLength(2)
     })
 
+    it('counts UTF-8 bytes without requiring TextEncoder for multibyte export data', () => {
+        const store = makeStore()
+        const session = makeSession(store, 'session-export-utf8-size')
+        store.messages.addMessage(session.id, { role: 'user', content: '你好' })
+
+        const textEncoderDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'TextEncoder')
+        const dateNow = Date.now
+        Object.defineProperty(globalThis, 'TextEncoder', { value: undefined, configurable: true, writable: true })
+        Date.now = () => 1_762_000_000_000
+        try {
+            const service = new MessageService(store, makeIo(() => {}), makePublisher() as any)
+            const result = service.getSessionExport(session.id, toProtocolSession(session), { limit: 0 })
+            const confirmed = service.getSessionExport(session.id, toProtocolSession(session), { allowLarge: true })
+
+            expect(result.type).toBe('warning')
+            expect(confirmed.type).toBe('success')
+            if (result.type !== 'warning' || confirmed.type !== 'success') throw new Error('Expected export results')
+            expect(result.sizeBytes).toBe(Buffer.byteLength(`${JSON.stringify(confirmed.payload, null, 2)}\n`, 'utf8'))
+        } finally {
+            Date.now = dateNow
+            if (textEncoderDescriptor) {
+                Object.defineProperty(globalThis, 'TextEncoder', textEncoderDescriptor)
+            } else {
+                Reflect.deleteProperty(globalThis, 'TextEncoder')
+            }
+        }
+    })
+
     it('includes scratchlist text and attachment metadata in chronological order (tiann/hapi#1235)', () => {
         const store = makeStore()
         const session = makeSession(store, 'session-export-scratchlist')

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -1,6 +1,8 @@
 import {
     HAPI_SESSION_EXPORT_SCHEMA_VERSION,
+    SESSION_EXPORT_MAX_BYTES,
     SESSION_EXPORT_MESSAGE_LIMIT,
+    type HapiSessionExport,
     type HapiSessionExportResult
 } from '@hapi/protocol/sessionExport'
 import type { AttachmentMetadata, DecryptedMessage, Session } from '@hapi/protocol/types'
@@ -177,8 +179,9 @@ export class MessageService {
     getSessionExport(
         sessionId: string,
         session: Session,
-        limit: number = SESSION_EXPORT_MESSAGE_LIMIT
+        options: { limit?: number; allowLarge?: boolean } = {}
     ): HapiSessionExportResult {
+        const limit = options.limit ?? SESSION_EXPORT_MESSAGE_LIMIT
         const messages = this.store.messages.getAllMessages(sessionId)
             .filter(isExportVisibleStoredMessage)
             .sort((a, b) => {
@@ -187,14 +190,6 @@ export class MessageService {
                 return aAt !== bAt ? aAt - bAt : a.seq - b.seq
             })
             .map(toDecryptedMessage)
-
-        if (messages.length > limit) {
-            return {
-                type: 'too-large',
-                count: messages.length,
-                limit
-            }
-        }
 
         // Chronological ASC for archive readability (store list is DESC).
         const scratchlist = this.store.scratchlist.list(sessionId)
@@ -211,15 +206,35 @@ export class MessageService {
                 attachments: row.attachments
             }))
 
+        const payload: HapiSessionExport = {
+            schemaVersion: HAPI_SESSION_EXPORT_SCHEMA_VERSION,
+            exportedAt: Date.now(),
+            session,
+            messages,
+            scratchlist
+        }
+        const sizeBytes = new TextEncoder().encode(`${JSON.stringify(payload, null, 2)}\n`).byteLength
+        if (sizeBytes > SESSION_EXPORT_MAX_BYTES) {
+            return {
+                type: 'too-large',
+                count: messages.length,
+                limit,
+                sizeBytes,
+                maxBytes: SESSION_EXPORT_MAX_BYTES
+            }
+        }
+        if (!options.allowLarge && messages.length > limit) {
+            return {
+                type: 'warning',
+                count: messages.length,
+                limit,
+                sizeBytes
+            }
+        }
+
         return {
             type: 'success',
-            payload: {
-                schemaVersion: HAPI_SESSION_EXPORT_SCHEMA_VERSION,
-                exportedAt: Date.now(),
-                session,
-                messages,
-                scratchlist
-            }
+            payload
         }
     }
 

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -213,7 +213,8 @@ export class MessageService {
             messages,
             scratchlist
         }
-        const sizeBytes = new TextEncoder().encode(`${JSON.stringify(payload, null, 2)}\n`).byteLength
+        const serialized = `${JSON.stringify(payload, null, 2)}\n`
+        const sizeBytes = Buffer.byteLength(serialized, 'utf8')
         if (sizeBytes > SESSION_EXPORT_MAX_BYTES) {
             return {
                 type: 'too-large',

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -407,8 +407,8 @@ export class SyncEngine {
         return this.messageService.getQueuedState(sessionId, localIds)
     }
 
-    getSessionExport(sessionId: string, session: Session): HapiSessionExportResult {
-        return this.messageService.getSessionExport(sessionId, session)
+    getSessionExport(sessionId: string, session: Session, options?: { allowLarge?: boolean }): HapiSessionExportResult {
+        return this.messageService.getSessionExport(sessionId, session, options)
     }
 
     getDeliverableMessagesAfter(sessionId: string, options: { afterSeq: number; limit: number; now: number }): DecryptedMessage[] {

--- a/hub/src/web/routes/sessions.test.ts
+++ b/hub/src/web/routes/sessions.test.ts
@@ -60,7 +60,7 @@ function createApp(session: Session, opts?: {
     resumeSession?: (sessionId: string, namespace: string, resumeOpts?: { permissionMode?: string }) => Promise<{ type: string; sessionId?: string; message?: string; code?: string }>
     reopenSession?: (sessionId: string, namespace: string) => Promise<ReopenResultMock>
     listSlashCommands?: SyncEngine['listSlashCommands']
-    getSessionExport?: (sessionId: string, session: Session) => unknown
+    getSessionExport?: (sessionId: string, session: Session, options?: { allowLarge?: boolean }) => unknown
     sessionExists?: boolean
     archiveSession?: (sessionId: string) => Promise<void>
     getCursorChatStoreStatus?: SyncEngine['getCursorChatStoreStatus']
@@ -359,23 +359,74 @@ describe('sessions routes', () => {
         expect(body.messages.map((message) => message.id)).toEqual(['msg-1', 'msg-2'])
     })
 
-    it('returns 413 when the export exceeds the hard message cap', async () => {
+    it('returns export warning metadata when the export exceeds the message threshold', async () => {
         const session = createSession()
         const { app } = createApp(session, {
             getSessionExport: () => ({
-                type: 'too-large',
+                type: 'warning',
                 count: 20_001,
-                limit: 20_000
+                limit: 20_000,
+                sizeBytes: 12_345_678
             })
         })
 
         const response = await app.request('/api/sessions/session-1/export')
 
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+            type: 'warning',
+            count: 20_001,
+            limit: 20_000,
+            sizeBytes: 12_345_678
+        })
+    })
+
+    it('passes explicit large-export confirmation to the sync engine', async () => {
+        const session = createSession()
+        let allowLarge: boolean | undefined
+        const { app } = createApp(session, {
+            getSessionExport: (_sessionId, _session, options) => {
+                allowLarge = options?.allowLarge
+                return {
+                    type: 'success',
+                    payload: {
+                        schemaVersion: 2,
+                        exportedAt: 1_762_000_000_000,
+                        session,
+                        messages: [],
+                        scratchlist: []
+                    }
+                }
+            }
+        })
+
+        const response = await app.request('/api/sessions/session-1/export?confirmLarge=true')
+
+        expect(response.status).toBe(200)
+        expect(allowLarge).toBe(true)
+    })
+
+    it('returns 413 when the export exceeds the absolute resource limit', async () => {
+        const session = createSession()
+        const { app } = createApp(session, {
+            getSessionExport: () => ({
+                type: 'too-large',
+                count: 20_001,
+                limit: 20_000,
+                sizeBytes: 120_000_001,
+                maxBytes: 100_000_000
+            })
+        })
+
+        const response = await app.request('/api/sessions/session-1/export?confirmLarge=true')
+
         expect(response.status).toBe(413)
         expect(await response.json()).toEqual({
             error: 'Session export too large',
             count: 20_001,
-            limit: 20_000
+            limit: 20_000,
+            sizeBytes: 120_000_001,
+            maxBytes: 100_000_000
         })
     })
 

--- a/hub/src/web/routes/sessions.ts
+++ b/hub/src/web/routes/sessions.ts
@@ -139,12 +139,19 @@ export function createSessionsRoutes(getSyncEngine: () => SyncEngine | null): Ho
             return sessionResult
         }
 
-        const result = engine.getSessionExport(sessionResult.sessionId, sessionResult.session)
+        const result = engine.getSessionExport(sessionResult.sessionId, sessionResult.session, {
+            allowLarge: c.req.query('confirmLarge') === 'true'
+        })
+        if (result.type === 'warning') {
+            return c.json(result)
+        }
         if (result.type === 'too-large') {
             return c.json({
                 error: 'Session export too large',
                 count: result.count,
-                limit: result.limit
+                limit: result.limit,
+                sizeBytes: result.sizeBytes,
+                maxBytes: result.maxBytes
             }, 413)
         }
 

--- a/shared/src/sessionExport.ts
+++ b/shared/src/sessionExport.ts
@@ -12,6 +12,7 @@ import { DecryptedMessageSchema, ScratchlistEntrySchema, SessionSchema } from '.
  */
 export const HAPI_SESSION_EXPORT_SCHEMA_VERSION = 2
 export const SESSION_EXPORT_MESSAGE_LIMIT = 20_000
+export const SESSION_EXPORT_MAX_BYTES = 100 * 1024 * 1024
 
 export const HapiSessionExportSchema = z.object({
     schemaVersion: z.literal(HAPI_SESSION_EXPORT_SCHEMA_VERSION),
@@ -23,6 +24,22 @@ export const HapiSessionExportSchema = z.object({
 
 export type HapiSessionExport = z.infer<typeof HapiSessionExportSchema>
 
+export type HapiSessionExportWarning = {
+    type: 'warning'
+    count: number
+    limit: number
+    sizeBytes: number
+}
+
+export type HapiSessionExportTooLarge = {
+    type: 'too-large'
+    count: number
+    limit: number
+    sizeBytes: number
+    maxBytes: number
+}
+
 export type HapiSessionExportResult =
     | { type: 'success'; payload: HapiSessionExport }
-    | { type: 'too-large'; count: number; limit: number }
+    | HapiSessionExportWarning
+    | HapiSessionExportTooLarge

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -25,6 +25,7 @@ import type {
     SpawnResponse,
     VisibilityPayload,
     HapiSessionExport,
+    HapiSessionExportWarning,
     HubHealthResponse,
     SessionResponse,
     SessionTitleSuggestionResponse,
@@ -353,9 +354,13 @@ export class ApiClient {
         return await this.request<SessionResponse>(`/api/sessions/${encodeURIComponent(sessionId)}`)
     }
 
-    async getSessionExport(sessionId: string, options?: { signal?: AbortSignal }): Promise<HapiSessionExport> {
-        return await this.request<HapiSessionExport>(
-            `/api/sessions/${encodeURIComponent(sessionId)}/export`,
+    async getSessionExport(
+        sessionId: string,
+        options?: { signal?: AbortSignal; allowLarge?: boolean }
+    ): Promise<HapiSessionExport | HapiSessionExportWarning> {
+        const query = options?.allowLarge ? '?confirmLarge=true' : ''
+        return await this.request<HapiSessionExport | HapiSessionExportWarning>(
+            `/api/sessions/${encodeURIComponent(sessionId)}/export${query}`,
             { signal: options?.signal }
         )
     }

--- a/web/src/components/SessionExportDialog.test.tsx
+++ b/web/src/components/SessionExportDialog.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '@/api/client'
+import { I18nProvider } from '@/lib/i18n-context'
+import { ToastProvider } from '@/lib/toast-context'
+import { SessionExportDialog } from './SessionExportDialog'
+
+const downloadSessionExport = vi.hoisted(() => vi.fn())
+const readSessionExportFormat = vi.hoisted(() => vi.fn(() => 'json'))
+const writeSessionExportFormat = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/sessionExport/download', () => ({
+    downloadSessionExport,
+    readSessionExportFormat,
+    writeSessionExportFormat
+}))
+
+afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+})
+
+function renderDialog(onClose = vi.fn()) {
+    render(
+        <I18nProvider>
+            <ToastProvider>
+                <SessionExportDialog
+                    isOpen={true}
+                    onClose={onClose}
+                    sessionId="session-1"
+                    api={{} as ApiClient}
+                />
+            </ToastProvider>
+        </I18nProvider>
+    )
+    return onClose
+}
+
+const warning = {
+    type: 'warning' as const,
+    count: 20_001,
+    limit: 20_000,
+    sizeBytes: 12_345_678
+}
+
+describe('SessionExportDialog exports', () => {
+    it('downloads a normal export without a confirmation step', async () => {
+        downloadSessionExport.mockResolvedValueOnce({ type: 'download', filename: 'export', messageCount: 2 })
+        const onClose = renderDialog()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+
+        await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+        expect(downloadSessionExport).toHaveBeenCalledTimes(1)
+        expect(downloadSessionExport).toHaveBeenCalledWith(
+            expect.anything(),
+            'session-1',
+            'json',
+            expect.objectContaining({ allowLarge: false, signal: expect.any(AbortSignal) })
+        )
+    })
+
+    it('requires confirmation and does not download when cancelled', async () => {
+        downloadSessionExport.mockResolvedValueOnce(warning)
+        const onClose = renderDialog()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+
+        await waitFor(() => expect(screen.getByText(/20001/)).toBeInTheDocument())
+        expect(screen.getByRole('button', { name: 'Download anyway' })).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+        expect(onClose).toHaveBeenCalledTimes(1)
+        expect(downloadSessionExport).toHaveBeenCalledTimes(1)
+    })
+
+    it.each(['json', 'markdown'] as const)('downloads a large %s export after confirmation', async (format) => {
+        downloadSessionExport
+            .mockResolvedValueOnce(warning)
+            .mockResolvedValueOnce({ type: 'download', filename: 'export', messageCount: 20_001 })
+        const onClose = renderDialog()
+
+        if (format === 'markdown') {
+            fireEvent.click(screen.getByDisplayValue('markdown'))
+        }
+        fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Download anyway' })).toBeInTheDocument())
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download anyway' }))
+
+        await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+        expect(downloadSessionExport).toHaveBeenNthCalledWith(
+            2,
+            expect.anything(),
+            'session-1',
+            format,
+            expect.objectContaining({ allowLarge: true, signal: expect.any(AbortSignal) })
+        )
+    })
+})

--- a/web/src/components/SessionExportDialog.tsx
+++ b/web/src/components/SessionExportDialog.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/lib/sessionExport/download'
 import { useToast } from '@/lib/toast-context'
 import { useTranslation } from '@/lib/use-translation'
+import type { HapiSessionExportWarning } from '@/types/api'
 import { Button } from '@/components/ui/button'
 import {
     Dialog,
@@ -24,19 +25,34 @@ type SessionExportDialogProps = {
     api: ApiClient | null
 }
 
+function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`
+    const units = ['KiB', 'MiB', 'GiB']
+    let value = bytes
+    let unit = 'B'
+    for (const nextUnit of units) {
+        value /= 1024
+        unit = nextUnit
+        if (value < 1024 || nextUnit === units.at(-1)) break
+    }
+    return `${value.toFixed(value >= 10 ? 1 : 2)} ${unit}`
+}
+
 export function SessionExportDialog(props: SessionExportDialogProps) {
     const { t } = useTranslation()
     const toast = useToast()
     const [format, setFormat] = useState<SessionExportFormat>('json')
     const [isExporting, setIsExporting] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const [warning, setWarning] = useState<HapiSessionExportWarning | null>(null)
     const abortRef = useRef<AbortController | null>(null)
 
     useEffect(() => {
         if (!props.isOpen) return
         setFormat(readSessionExportFormat())
         setError(null)
-    }, [props.isOpen])
+        setWarning(null)
+    }, [props.isOpen, props.sessionId])
 
     useEffect(() => {
         return () => {
@@ -48,6 +64,7 @@ export function SessionExportDialog(props: SessionExportDialogProps) {
         abortRef.current?.abort()
         abortRef.current = null
         setIsExporting(false)
+        setWarning(null)
         props.onClose()
     }
 
@@ -65,8 +82,13 @@ export function SessionExportDialog(props: SessionExportDialogProps) {
 
         try {
             const result = await downloadSessionExport(props.api, props.sessionId, format, {
-                signal: controller.signal
+                signal: controller.signal,
+                allowLarge: warning !== null
             })
+            if (result.type === 'warning') {
+                setWarning(result)
+                return
+            }
             toast.addToast({
                 title: t('session.export.toast.success.title'),
                 body: t('session.export.toast.success.body', { filename: result.filename }),
@@ -147,12 +169,26 @@ export function SessionExportDialog(props: SessionExportDialogProps) {
                     </div>
                 ) : null}
 
+                {warning ? (
+                    <div role="alert" className="mt-3 rounded-md bg-amber-50 p-3 text-sm text-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+                        {t('session.export.warning', {
+                            count: warning.count,
+                            limit: warning.limit,
+                            size: formatBytes(warning.sizeBytes)
+                        })}
+                    </div>
+                ) : null}
+
                 <div className="mt-4 flex justify-end gap-2">
                     <Button type="button" variant="secondary" onClick={handleClose} disabled={isExporting}>
                         {t('button.cancel')}
                     </Button>
                     <Button type="button" onClick={handleDownload} disabled={isExporting}>
-                        {isExporting ? t('session.export.downloading') : t('session.export.download')}
+                        {isExporting
+                            ? t('session.export.downloading')
+                            : warning
+                                ? t('session.export.warning.confirm')
+                                : t('session.export.download')}
                     </Button>
                 </div>
             </DialogContent>

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -302,6 +302,8 @@ export default {
   'session.export.format.markdown': 'Markdown',
   'session.export.format.markdown.description': 'Readable view generated from the same export payload.',
   'session.export.download': 'Download',
+  'session.export.warning': 'This export contains {count} messages (about {size}) and exceeds the recommended {limit}-message threshold. Download anyway?',
+  'session.export.warning.confirm': 'Download anyway',
   'session.export.downloading': 'Exporting…',
   'session.export.error.noApi': 'Not connected to server',
   'session.export.error.default': 'Failed to export conversation',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -306,6 +306,8 @@ export default {
   'session.export.format.markdown': 'Markdown',
   'session.export.format.markdown.description': '从同一份导出载荷生成的可读视图。',
   'session.export.download': '下载',
+  'session.export.warning': '此导出包含 {count} 条消息（约 {size}），超过建议的 {limit} 条阈值。仍要下载吗？',
+  'session.export.warning.confirm': '仍要下载',
   'session.export.downloading': '导出中…',
   'session.export.error.noApi': '未连接到服务器',
   'session.export.error.default': '导出对话失败',

--- a/web/src/lib/sessionExport/download.test.ts
+++ b/web/src/lib/sessionExport/download.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '@/api/client'
+import type { HapiSessionExport } from '@hapi/protocol/sessionExport'
+import { downloadSessionExport } from './download'
+
+const warning = {
+    type: 'warning' as const,
+    count: 20_001,
+    limit: 20_000,
+    sizeBytes: 12_345_678
+}
+
+function makeExport(): HapiSessionExport {
+    return {
+        schemaVersion: 2,
+        exportedAt: 1_762_000_000_000,
+        session: {
+            id: 'abcdef123456',
+            metadata: { name: 'Export Demo' }
+        } as HapiSessionExport['session'],
+        messages: [],
+        scratchlist: []
+    }
+}
+
+afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+})
+
+describe('downloadSessionExport', () => {
+    it('returns the server warning without creating a download', async () => {
+        const getSessionExport = vi.fn().mockResolvedValue(warning)
+        const result = await downloadSessionExport(
+            { getSessionExport } as unknown as ApiClient,
+            'session-1',
+            'json'
+        )
+
+        expect(result).toEqual(warning)
+        expect(getSessionExport).toHaveBeenCalledWith('session-1', {
+            signal: undefined,
+            allowLarge: undefined
+        })
+    })
+
+    it('downloads the confirmed payload', async () => {
+        const getSessionExport = vi.fn().mockResolvedValue(makeExport())
+        const createObjectURL = vi.fn(() => 'blob:export')
+        const revokeObjectURL = vi.fn()
+        vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+        const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+        const result = await downloadSessionExport(
+            { getSessionExport } as unknown as ApiClient,
+            'session-1',
+            'json',
+            { allowLarge: true }
+        )
+
+        expect(result).toMatchObject({
+            type: 'download',
+            messageCount: 0
+        })
+        if (result.type !== 'download') throw new Error('Expected download result')
+        expect(result.filename).toMatch(/^export-demo-abcdef12-\d{4}-\d{2}-\d{2}\.json$/)
+        expect(getSessionExport).toHaveBeenCalledWith('session-1', {
+            signal: undefined,
+            allowLarge: true
+        })
+        expect(click).toHaveBeenCalledOnce()
+        expect(createObjectURL).toHaveBeenCalledOnce()
+    })
+})

--- a/web/src/lib/sessionExport/download.test.ts
+++ b/web/src/lib/sessionExport/download.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ApiClient } from '@/api/client'
-import type { HapiSessionExport } from '@hapi/protocol/sessionExport'
+import { SESSION_EXPORT_MAX_BYTES, type HapiSessionExport } from '@hapi/protocol/sessionExport'
 import { downloadSessionExport } from './download'
 
 const warning = {
@@ -10,13 +10,13 @@ const warning = {
     sizeBytes: 12_345_678
 }
 
-function makeExport(): HapiSessionExport {
+function makeExport(name = 'Export Demo'): HapiSessionExport {
     return {
         schemaVersion: 2,
         exportedAt: 1_762_000_000_000,
         session: {
             id: 'abcdef123456',
-            metadata: { name: 'Export Demo' }
+            metadata: { name }
         } as HapiSessionExport['session'],
         messages: [],
         scratchlist: []
@@ -70,5 +70,38 @@ describe('downloadSessionExport', () => {
         })
         expect(click).toHaveBeenCalledOnce()
         expect(createObjectURL).toHaveBeenCalledOnce()
+    })
+
+    it.each([
+        ['just below', SESSION_EXPORT_MAX_BYTES - 1, false],
+        ['just above', SESSION_EXPORT_MAX_BYTES + 1, true]
+    ] as const)('uses Blob byte size at the 100 MiB boundary (%s)', async (_label, blobSize, shouldReject) => {
+        class SizeReportingBlob {
+            readonly size = blobSize
+
+            constructor(_parts: BlobPart[], _options?: BlobPropertyBag) {}
+        }
+        const getSessionExport = vi.fn().mockResolvedValue(makeExport('导出 Demo'))
+        const createObjectURL = vi.fn(() => 'blob:export')
+        const revokeObjectURL = vi.fn()
+        vi.stubGlobal('Blob', SizeReportingBlob)
+        vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+        const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+        const result = downloadSessionExport(
+            { getSessionExport } as unknown as ApiClient,
+            'session-1',
+            'json',
+            { allowLarge: true }
+        )
+
+        if (shouldReject) {
+            await expect(result).rejects.toThrow('Session export exceeds')
+            expect(createObjectURL).not.toHaveBeenCalled()
+            return
+        }
+
+        await expect(result).resolves.toMatchObject({ type: 'download', messageCount: 0 })
+        expect(click).toHaveBeenCalledOnce()
     })
 })

--- a/web/src/lib/sessionExport/download.ts
+++ b/web/src/lib/sessionExport/download.ts
@@ -53,10 +53,10 @@ export function buildSessionExportFilename(payload: HapiSessionExport, format: S
 }
 
 function downloadTextFile(filename: string, text: string, mimeType: string): void {
-    if (new TextEncoder().encode(text).byteLength > SESSION_EXPORT_MAX_BYTES) {
+    const blob = new Blob([text], { type: mimeType })
+    if (blob.size > SESSION_EXPORT_MAX_BYTES) {
         throw new Error(`Session export exceeds ${SESSION_EXPORT_MAX_BYTES} bytes`)
     }
-    const blob = new Blob([text], { type: mimeType })
     const url = URL.createObjectURL(blob)
     const anchor = document.createElement('a')
     anchor.href = url

--- a/web/src/lib/sessionExport/download.ts
+++ b/web/src/lib/sessionExport/download.ts
@@ -1,10 +1,15 @@
 import type { ApiClient } from '@/api/client'
-import type { HapiSessionExport } from '@/types/api'
+import type { HapiSessionExport, HapiSessionExportWarning } from '@/types/api'
+import { SESSION_EXPORT_MAX_BYTES } from '@hapi/protocol/sessionExport'
 import { serializeSessionMarkdown } from './markdown'
 
 export type SessionExportFormat = 'json' | 'markdown'
 
 export const SESSION_EXPORT_FORMAT_STORAGE_KEY = 'hapi.sessionExportFormat'
+
+export type SessionExportDownloadResult =
+    | { type: 'download'; filename: string; messageCount: number }
+    | HapiSessionExportWarning
 
 export function readSessionExportFormat(): SessionExportFormat {
     if (typeof window === 'undefined') return 'json'
@@ -48,6 +53,9 @@ export function buildSessionExportFilename(payload: HapiSessionExport, format: S
 }
 
 function downloadTextFile(filename: string, text: string, mimeType: string): void {
+    if (new TextEncoder().encode(text).byteLength > SESSION_EXPORT_MAX_BYTES) {
+        throw new Error(`Session export exceeds ${SESSION_EXPORT_MAX_BYTES} bytes`)
+    }
     const blob = new Blob([text], { type: mimeType })
     const url = URL.createObjectURL(blob)
     const anchor = document.createElement('a')
@@ -64,14 +72,22 @@ export async function downloadSessionExport(
     api: ApiClient,
     sessionId: string,
     format: SessionExportFormat,
-    options?: { signal?: AbortSignal }
-): Promise<{ filename: string; messageCount: number }> {
-    const payload = await api.getSessionExport(sessionId, { signal: options?.signal })
+    options?: { signal?: AbortSignal; allowLarge?: boolean }
+): Promise<SessionExportDownloadResult> {
+    const response = await api.getSessionExport(sessionId, {
+        signal: options?.signal,
+        allowLarge: options?.allowLarge
+    })
+    if (!('schemaVersion' in response)) {
+        return response
+    }
+
+    const payload = response
     const filename = buildSessionExportFilename(payload, format)
     if (format === 'json') {
         downloadTextFile(filename, `${JSON.stringify(payload, null, 2)}\n`, 'application/json;charset=utf-8')
     } else {
         downloadTextFile(filename, serializeSessionMarkdown(payload), 'text/markdown;charset=utf-8')
     }
-    return { filename, messageCount: payload.messages.length }
+    return { type: 'download', filename, messageCount: payload.messages.length }
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -77,7 +77,10 @@ export type {
     WorktreeMetadata
 } from '@hapi/protocol/types'
 
-export type { HapiSessionExport } from '@hapi/protocol/sessionExport'
+export type {
+    HapiSessionExport,
+    HapiSessionExportWarning
+} from '@hapi/protocol/sessionExport'
 
 export type SessionMetadataSummary = {
     path: string


### PR DESCRIPTION
Closes #1641

## Summary

- Replace the 20,000-message export hard stop with a count/size warning and explicit confirmation.
- Preserve the absolute 100 MiB serialized-export safeguard.
- Support confirmed JSON and Markdown downloads with localized warning text.

## Tests

- `bun typecheck`
- `bun run test`
- `CI=1 PLAYWRIGHT_WEB_PORT=5180 bun run test:e2e -- terminal-wrap-fidelity.spec.ts composer-copy.spec.ts`

AI assistance: OpenAI GPT-5.6-luna via the pi coding agent.
