### PR TITLE
feat(web): add mark unread session action

### DIFF
--- a/web/src/components/SessionActionMenu.test.tsx
+++ b/web/src/components/SessionActionMenu.test.tsx
@@ -74,6 +74,25 @@ describe('SessionActionMenu - Pin action', () => {
     })
 })
 
+describe('SessionActionMenu - Mark unread action', () => {
+    it('fires the mark-unread handler and closes the menu', () => {
+        const onMarkUnread = vi.fn()
+        const onClose = vi.fn()
+        renderMenu({ onMarkUnread, onClose })
+
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Mark as unread' }))
+
+        expect(onMarkUnread).toHaveBeenCalledTimes(1)
+        expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not render the action when no handler is provided', () => {
+        renderMenu()
+
+        expect(screen.queryByRole('menuitem', { name: 'Mark as unread' })).toBeNull()
+    })
+})
+
 describe('SessionActionMenu - positioning', () => {
     it('centers the menu on the supplied anchor', () => {
         const originalInnerWidth = window.innerWidth

--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -25,6 +25,7 @@ type SessionActionMenuProps = {
     sessionGlobalPinned?: boolean
     onSetPinMode?: (mode: 'none' | 'project' | 'global') => void
     onExport?: () => void
+    onMarkUnread?: () => void
     onSyncCodex?: () => void
     onSyncPi?: () => void
     onArchive: () => void
@@ -53,6 +54,21 @@ function EditIcon(props: { className?: string }) {
         >
             <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
             <path d="m15 5 4 4" />
+        </svg>
+    )
+}
+
+function UnreadIcon(props: { className?: string }) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            className={props.className}
+        >
+            <circle cx="12" cy="12" r="4" fill="currentColor" />
         </svg>
     )
 }
@@ -196,6 +212,7 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         sessionGlobalPinned = false,
         onSetPinMode,
         onExport,
+        onMarkUnread,
         onSyncCodex,
         onSyncPi,
         onArchive,
@@ -245,6 +262,11 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
     const handleExport = () => {
         onClose()
         onExport?.()
+    }
+
+    const handleMarkUnread = () => {
+        onClose()
+        onMarkUnread?.()
     }
 
     const handleSyncCodex = () => {
@@ -390,6 +412,18 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
                     <CopyIcon className="h-[18px] w-[18px] text-[var(--app-hint)]" />
                     {t('session.action.copyReference')}
                 </button>
+
+                {onMarkUnread ? (
+                    <button
+                        type="button"
+                        role="menuitem"
+                        className={`${baseItemClassName} hover:bg-[var(--app-subtle-bg)]`}
+                        onClick={handleMarkUnread}
+                    >
+                        <UnreadIcon className="text-[var(--app-hint)]" />
+                        {t('session.action.markUnread')}
+                    </button>
+                ) : null}
 
                 {onSetPinMode ? (
                     <>

--- a/web/src/components/SessionHeader.tsx
+++ b/web/src/components/SessionHeader.tsx
@@ -27,6 +27,7 @@ import { useSessionHeaderMetadata } from '@/hooks/useSessionHeaderMetadata'
 import { formatSessionHeaderTimestamp } from '@/lib/sessionHeaderTimestamp'
 import { selectMobileSessionHeaderSecondary } from '@/lib/sessionHeaderMobileMetadata'
 import { useMinuteTick } from '@/hooks/useMinuteTick'
+import { markSessionUnread } from '@/lib/sessionLastSeen'
 
 /** Same preference order as session-list chips: display label → host → short id. */
 export function resolveSessionHeaderMachineLabel(
@@ -519,6 +520,7 @@ export function SessionHeader(props: {
                 sessionPinned={Boolean(session.pinned)}
                 sessionGlobalPinned={Boolean(session.globalPinned)}
                 onRename={() => setRenameOpen(true)}
+                onMarkUnread={() => markSessionUnread(session.id, session.updatedAt)}
                 onSetPinMode={api ? (mode) => void handleSetPinMode(mode) : undefined}
                 onExport={() => setExportOpen(true)}
                 onSyncCodex={api && codexSessionId ? handleSyncCodex : undefined}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -30,6 +30,7 @@ import { classifySessionAttention, sessionIsUnread } from '@/lib/sessionAttentio
 import {
     getSessionLastSeenAt,
     getSessionLastSeenSnapshot,
+    getSessionManualUnreadAt,
     markSessionUnread,
     useSessionLastSeenVersion
 } from '@/lib/sessionLastSeen'
@@ -1017,7 +1018,8 @@ function SessionItem(props: {
         () => showDetailedStatus
             ? classifySessionAttention(s, {
                 selected,
-                lastSeenAt: getSessionLastSeenAt(s.id)
+                lastSeenAt: getSessionLastSeenAt(s.id),
+                manualUnreadAt: getSessionManualUnreadAt(s.id)
             })
             : null,
         [s, selected, showDetailedStatus, lastSeenVersion]

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -27,7 +27,12 @@ import { useSessionListStatusMode } from '@/hooks/useSessionListStatusMode'
 import { useShowActiveSessionsOnly } from '@/hooks/useShowActiveSessionsOnly'
 import { usePinInProgressSessions } from '@/hooks/usePinInProgressSessions'
 import { classifySessionAttention, sessionIsUnread } from '@/lib/sessionAttention'
-import { getSessionLastSeenAt, getSessionLastSeenSnapshot } from '@/lib/sessionLastSeen'
+import {
+    getSessionLastSeenAt,
+    getSessionLastSeenSnapshot,
+    markSessionUnread,
+    useSessionLastSeenVersion
+} from '@/lib/sessionLastSeen'
 import { useSessionRowTooltipIds } from '@/components/HoverTooltip'
 import { subscribeCodexImportedSessions } from '@/lib/codexImportedSessions'
 import { formatReopenError } from '@/lib/reopenError'
@@ -905,6 +910,7 @@ function SessionItem(props: {
     inRunningSection?: boolean
     projectLabel?: string
     machineLabel?: string
+    lastSeenVersion: number
 }) {
     const { t } = useTranslation()
     const { addToast } = useToast()
@@ -918,7 +924,8 @@ function SessionItem(props: {
         showDetailedStatus = false,
         inRunningSection = false,
         projectLabel,
-        machineLabel
+        machineLabel,
+        lastSeenVersion
     } = props
     const { haptic } = usePlatform()
     const [menuOpen, setMenuOpen] = useState(false)
@@ -1013,7 +1020,7 @@ function SessionItem(props: {
                 lastSeenAt: getSessionLastSeenAt(s.id)
             })
             : null,
-        [s, selected, showDetailedStatus]
+        [s, selected, showDetailedStatus, lastSeenVersion]
     )
     const hasScheduleTooltip = showDetailedStatus && s.futureScheduledMessageCount > 0
     const { attentionId, scheduleId, describedBy } = useSessionRowTooltipIds(
@@ -1037,6 +1044,7 @@ function SessionItem(props: {
                     selected={selected}
                     nestedTooltips
                     attentionTooltipId={attentionId}
+                    lastSeenVersion={lastSeenVersion}
                     scheduleTooltipId={scheduleId}
                     inRunningSection={inRunningSection}
                     projectLabel={projectLabel}
@@ -1055,6 +1063,7 @@ function SessionItem(props: {
                 onSetPinMode={(mode) => void handleSetPinMode(mode)}
                 onRename={() => setRenameOpen(true)}
                 onExport={() => setExportOpen(true)}
+                onMarkUnread={() => markSessionUnread(s.id, s.updatedAt)}
                 onArchive={() => setArchiveOpen(true)}
                 onReopen={cursorReopenDisabledReason ? undefined : handleReopen}
                 reopenDisabledReason={cursorReopenDisabledReason}
@@ -1193,6 +1202,7 @@ export function SessionList(props: {
     const { sessionPreviewLimit } = useSessionPreviewLimit()
     const { sessionListStatusMode } = useSessionListStatusMode()
     const { showActiveSessionsOnly } = useShowActiveSessionsOnly()
+    const lastSeenVersion = useSessionLastSeenVersion()
     // Transient unread lens — not a Settings preference. Cleared on reload; rows drop as they're seen.
     const [showUnreadOnly, setShowUnreadOnly] = useState(false)
     const { pinInProgressSessions } = usePinInProgressSessions()
@@ -1291,7 +1301,7 @@ export function SessionList(props: {
             selectedSessionId,
             id => lastSeenById[id] ?? 0
         )
-    }, [visibleSessions, selectedSessionId, showUnreadOnly])
+    }, [lastSeenVersion, visibleSessions, selectedSessionId, showUnreadOnly])
     const machineFilteredSessions = useMemo(
         () => activeMachineFilter === null
             ? unreadFilteredSessions
@@ -1524,6 +1534,7 @@ export function SessionList(props: {
                                             inRunningSection
                                             projectLabel={getGroupDisplayName(s.metadata?.worktree?.basePath ?? s.metadata?.path ?? 'Other')}
                                             machineLabel={resolveMachineLabel(s.metadata?.machineId ?? null)}
+                                            lastSeenVersion={lastSeenVersion}
                                         />
                                     ))}
                                 </div>
@@ -1650,6 +1661,7 @@ export function SessionList(props: {
                                     titleSuggestionAvailable={titleSuggestionAvailable}
                                     selected={s.id === selectedSessionId}
                                     showDetailedStatus={showDetailedStatus}
+                                    lastSeenVersion={lastSeenVersion}
                                 />
                             </div>
                         ))}
@@ -2015,6 +2027,7 @@ export function SessionList(props: {
                                             inRunningSection
                                             projectLabel={getGroupDisplayName(s.metadata?.worktree?.basePath ?? s.metadata?.path ?? 'Other')}
                                             machineLabel={resolveMachineLabel(s.metadata?.machineId ?? null)}
+                                            lastSeenVersion={lastSeenVersion}
                                         />
                                     ))}
                                 </div>

--- a/web/src/components/SessionRowSummary.test.tsx
+++ b/web/src/components/SessionRowSummary.test.tsx
@@ -61,4 +61,37 @@ describe('SessionRowSummary background status', () => {
         expect(tooltip).toHaveTextContent('Background tasks running')
         expect(tooltip).toHaveTextContent('2 tasks running')
     })
+
+    it('refreshes unread attention when the local watermark version changes', () => {
+        const session = makeSummary({
+            active: false,
+            backgroundTaskCount: 0,
+            updatedAt: 2_000,
+        })
+        localStorage.setItem('hapi.sessionLastSeen.v1', JSON.stringify({ [session.id]: 2_000 }))
+        const view = render(
+            <I18nProvider>
+                <SessionRowSummary
+                    session={session}
+                    showDetailedStatus={true}
+                    lastSeenVersion={0}
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument()
+
+        localStorage.setItem('hapi.sessionLastSeen.v1', JSON.stringify({ [session.id]: 1_999 }))
+        view.rerender(
+            <I18nProvider>
+                <SessionRowSummary
+                    session={session}
+                    showDetailedStatus={true}
+                    lastSeenVersion={1}
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('New activity')
+    })
 })

--- a/web/src/components/SessionRowSummary.test.tsx
+++ b/web/src/components/SessionRowSummary.test.tsx
@@ -131,4 +131,27 @@ describe('SessionRowSummary background status', () => {
 
         expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument()
     })
+
+    it('shows an explicit unread dot before the thinking spinner', () => {
+        const session = makeSummary({
+            id: 'selected-thinking-unread',
+            thinking: true,
+            updatedAt: 2_000,
+        })
+        localStorage.setItem('hapi.sessionLastSeen.v1', JSON.stringify({ [session.id]: 2_000 }))
+        localStorage.setItem('hapi.sessionManualUnread.v1', JSON.stringify({ [session.id]: 2_000 }))
+
+        render(
+            <I18nProvider>
+                <SessionRowSummary
+                    session={session}
+                    selected={true}
+                    showDetailedStatus={true}
+                    lastSeenVersion={0}
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('New activity')
+    })
 })

--- a/web/src/components/SessionRowSummary.test.tsx
+++ b/web/src/components/SessionRowSummary.test.tsx
@@ -94,4 +94,41 @@ describe('SessionRowSummary background status', () => {
 
         expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('New activity')
     })
+
+    it('shows an explicit unread dot for the selected session only', () => {
+        const session = makeSummary({
+            id: 'selected-unread',
+            active: false,
+            backgroundTaskCount: 0,
+            updatedAt: 2_000,
+        })
+        localStorage.setItem('hapi.sessionLastSeen.v1', JSON.stringify({ [session.id]: 2_000 }))
+        localStorage.setItem('hapi.sessionManualUnread.v1', JSON.stringify({ [session.id]: 2_000 }))
+
+        const view = render(
+            <I18nProvider>
+                <SessionRowSummary
+                    session={session}
+                    selected={true}
+                    showDetailedStatus={true}
+                    lastSeenVersion={0}
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('New activity')
+
+        view.rerender(
+            <I18nProvider>
+                <SessionRowSummary
+                    session={{ ...session, updatedAt: 2_001 }}
+                    selected={true}
+                    showDetailedStatus={true}
+                    lastSeenVersion={1}
+                />
+            </I18nProvider>
+        )
+
+        expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument()
+    })
 })

--- a/web/src/components/SessionRowSummary.tsx
+++ b/web/src/components/SessionRowSummary.tsx
@@ -109,6 +109,8 @@ export function SessionRowSummary(props: {
     nestedTooltips?: boolean
     /** Pass from parent when the parent owns `aria-describedby` (session list). */
     attentionTooltipId?: string
+    /** Recompute local unread attention when the session-list watermark changes. */
+    lastSeenVersion?: number
     scheduleTooltipId?: string
     className?: string
     /** Rows inside the pinned "in progress" section skip the text label (dot only). */
@@ -125,6 +127,7 @@ export function SessionRowSummary(props: {
         selected = false,
         nestedTooltips = true,
         attentionTooltipId: attentionTooltipIdProp,
+        lastSeenVersion,
         scheduleTooltipId: scheduleTooltipIdProp,
         className,
         inRunningSection = false,
@@ -142,7 +145,7 @@ export function SessionRowSummary(props: {
                 lastSeenAt: getSessionLastSeenAt(s.id),
             })
             : null,
-        [s, selected, showDetailedStatus]
+        [s, selected, showDetailedStatus, lastSeenVersion]
     )
     const attentionLabel = attention ? getAttentionLabel(attention, t) : null
     const urgentAttention = attention !== null

--- a/web/src/components/SessionRowSummary.tsx
+++ b/web/src/components/SessionRowSummary.tsx
@@ -174,7 +174,20 @@ export function SessionRowSummary(props: {
                     >
                         {sessionName}
                     </div>
-                    {s.active && s.thinking ? (
+                    {attention?.kind === 'unread' && nestedTooltips && attentionId ? (
+                        <SessionAttentionIndicator
+                            attention={attention}
+                            summary={s}
+                            label={attentionLabel ?? ''}
+                            tooltipId={attentionId}
+                        />
+                    ) : attention?.kind === 'unread' ? (
+                        <span
+                            className={`inline-flex h-2 w-2 shrink-0 rounded-full ${ATTENTION_DOT_CLASS.unread}`}
+                            title={attentionLabel ?? undefined}
+                            aria-label={attentionLabel ?? undefined}
+                        />
+                    ) : s.active && s.thinking ? (
                         <LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin-slow text-[var(--app-badge-success-text)]" />
                     ) : urgentAttention && nestedTooltips && attentionId ? (
                         <SessionAttentionIndicator

--- a/web/src/components/SessionRowSummary.tsx
+++ b/web/src/components/SessionRowSummary.tsx
@@ -5,7 +5,7 @@ import { ScheduleIcon } from '@/components/icons'
 import { HoverTooltip, SESSION_ROW_TOOLTIP_FOCUS_CLASS, useSessionRowTooltipIds } from '@/components/HoverTooltip'
 import { getAttentionLabel, SessionAttentionIndicator } from '@/components/SessionAttentionIndicator'
 import { classifySessionAttention } from '@/lib/sessionAttention'
-import { getSessionLastSeenAt } from '@/lib/sessionLastSeen'
+import { getSessionLastSeenAt, getSessionManualUnreadAt } from '@/lib/sessionLastSeen'
 import { formatRelativeTime } from '@/lib/relativeTime'
 import { formatScheduledTooltipDetail } from '@/lib/scheduledTime'
 import { getCodexImportedAt } from '@/lib/codexImportedSessions'
@@ -143,6 +143,7 @@ export function SessionRowSummary(props: {
             ? classifySessionAttention(s, {
                 selected,
                 lastSeenAt: getSessionLastSeenAt(s.id),
+                manualUnreadAt: getSessionManualUnreadAt(s.id),
             })
             : null,
         [s, selected, showDetailedStatus, lastSeenVersion]

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -237,6 +237,7 @@ export default {
   'session.action.pinFailed': 'Could not update pin',
   'sessions.pinnedSection': 'Pinned sessions',
   'session.action.export': 'Export conversation',
+  'session.action.markUnread': 'Mark as unread',
   'session.action.syncCodex': 'Sync Codex',
   'session.action.syncPi': 'Sync Pi history',
   'session.action.archive': 'Archive',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -237,6 +237,7 @@ export default {
   'session.action.pinFailed': '无法更新置顶状态',
   'sessions.pinnedSection': '置顶会话',
   'session.action.export': '导出对话',
+  'session.action.markUnread': '标为未读',
   'session.action.syncCodex': '同步 Codex',
   'session.action.syncPi': '同步 Pi 历史',
   'session.action.archive': '归档',

--- a/web/src/lib/sessionAttention.test.ts
+++ b/web/src/lib/sessionAttention.test.ts
@@ -45,6 +45,14 @@ describe('classifySessionAttention', () => {
         expect(attention).toEqual({ kind: 'unread' })
     })
 
+    it('keeps an explicitly marked unread dot while the selected session is thinking', () => {
+        const attention = classifySessionAttention(
+            makeSummary({ id: 'a', thinking: true, updatedAt: 5000 }),
+            { selected: true, lastSeenAt: 5000, manualUnreadAt: 5000 }
+        )
+        expect(attention).toEqual({ kind: 'unread' })
+    })
+
     it('does not show selected-session attention for ordinary new activity', () => {
         const attention = classifySessionAttention(
             makeSummary({ id: 'a', updatedAt: 5000 }),

--- a/web/src/lib/sessionAttention.test.ts
+++ b/web/src/lib/sessionAttention.test.ts
@@ -37,6 +37,30 @@ describe('classifySessionAttention', () => {
         expect(attention).toBeNull()
     })
 
+    it('shows an explicitly marked unread dot for the selected session', () => {
+        const attention = classifySessionAttention(
+            makeSummary({ id: 'a', updatedAt: 5000 }),
+            { selected: true, lastSeenAt: 5000, manualUnreadAt: 5000 }
+        )
+        expect(attention).toEqual({ kind: 'unread' })
+    })
+
+    it('does not show selected-session attention for ordinary new activity', () => {
+        const attention = classifySessionAttention(
+            makeSummary({ id: 'a', updatedAt: 5000 }),
+            { selected: true, lastSeenAt: 1000 }
+        )
+        expect(attention).toBeNull()
+    })
+
+    it('does not carry an explicit unread dot across newer activity', () => {
+        const attention = classifySessionAttention(
+            makeSummary({ id: 'a', updatedAt: 6000 }),
+            { selected: true, lastSeenAt: 5000, manualUnreadAt: 5000 }
+        )
+        expect(attention).toBeNull()
+    })
+
     it('prioritizes permission over unread activity', () => {
         const attention = classifySessionAttention(
             makeSummary({

--- a/web/src/lib/sessionAttention.ts
+++ b/web/src/lib/sessionAttention.ts
@@ -16,10 +16,16 @@ export function sessionIsUnread(
 
 export function classifySessionAttention(
     summary: SessionSummary,
-    options: { selected: boolean; lastSeenAt: number }
+    options: { selected: boolean; lastSeenAt: number; manualUnreadAt?: number | null }
 ): SessionAttention | null {
-    if (options.selected || summary.thinking) {
+    if (summary.thinking) {
         return null
+    }
+
+    if (options.selected) {
+        return options.manualUnreadAt === summary.updatedAt
+            ? { kind: 'unread' }
+            : null
     }
 
     const pendingRequestKinds = Array.isArray(summary.pendingRequestKinds)

--- a/web/src/lib/sessionAttention.ts
+++ b/web/src/lib/sessionAttention.ts
@@ -18,14 +18,14 @@ export function classifySessionAttention(
     summary: SessionSummary,
     options: { selected: boolean; lastSeenAt: number; manualUnreadAt?: number | null }
 ): SessionAttention | null {
-    if (summary.thinking) {
-        return null
-    }
-
     if (options.selected) {
         return options.manualUnreadAt === summary.updatedAt
             ? { kind: 'unread' }
             : null
+    }
+
+    if (summary.thinking) {
+        return null
     }
 
     const pendingRequestKinds = Array.isArray(summary.pendingRequestKinds)

--- a/web/src/lib/sessionLastSeen.test.ts
+++ b/web/src/lib/sessionLastSeen.test.ts
@@ -80,6 +80,21 @@ describe('sessionLastSeen', () => {
         expect(view.getByTestId('last-seen-version')).toHaveTextContent(String(initialVersion + 1))
     })
 
+    it('notifies consumers when either read-state key changes in another tab', () => {
+        const view = render(createElement(SessionLastSeenVersionProbe))
+        const initialVersion = Number(view.getByTestId('last-seen-version').textContent)
+
+        act(() => {
+            window.dispatchEvent(new StorageEvent('storage', { key: 'hapi.sessionLastSeen.v1' }))
+        })
+        expect(view.getByTestId('last-seen-version')).toHaveTextContent(String(initialVersion + 1))
+
+        act(() => {
+            window.dispatchEvent(new StorageEvent('storage', { key: 'hapi.sessionManualUnread.v1' }))
+        })
+        expect(view.getByTestId('last-seen-version')).toHaveTextContent(String(initialVersion + 2))
+    })
+
     it('uses the first session list as the unread baseline', () => {
         initializeSessionLastSeen('hub-a', [
             { id: 'session-a', updatedAt: 1000 },

--- a/web/src/lib/sessionLastSeen.test.ts
+++ b/web/src/lib/sessionLastSeen.test.ts
@@ -1,10 +1,19 @@
+import { createElement } from 'react'
+import { act, render } from '@testing-library/react'
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import {
     getSessionLastSeenAt,
     getSessionLastSeenSnapshot,
     initializeSessionLastSeen,
+    markSessionUnread,
     markSessionSeen,
+    useSessionLastSeenVersion,
 } from './sessionLastSeen'
+
+function SessionLastSeenVersionProbe() {
+    const version = useSessionLastSeenVersion()
+    return createElement('output', { 'data-testid': 'last-seen-version' }, version)
+}
 
 describe('sessionLastSeen', () => {
     beforeEach(() => {
@@ -30,6 +39,33 @@ describe('sessionLastSeen', () => {
         markSessionSeen('session-a', 5000)
         markSessionSeen('session-a', 2000)
         expect(getSessionLastSeenAt('session-a')).toBe(5000)
+    })
+
+    it('moves the watermark behind the current activity when marking unread', () => {
+        markSessionSeen('session-a', 5000)
+
+        markSessionUnread('session-a', 5000)
+
+        expect(getSessionLastSeenAt('session-a')).toBe(4999)
+    })
+
+    it('does not change an already-unread watermark when marking unread', () => {
+        markSessionSeen('session-a', 1000)
+
+        markSessionUnread('session-a', 5000)
+
+        expect(getSessionLastSeenAt('session-a')).toBe(1000)
+    })
+
+    it('notifies same-tab consumers when the watermark changes', () => {
+        const view = render(createElement(SessionLastSeenVersionProbe))
+        const initialVersion = Number(view.getByTestId('last-seen-version').textContent)
+
+        act(() => {
+            markSessionUnread('session-a', 5000)
+        })
+
+        expect(view.getByTestId('last-seen-version')).toHaveTextContent(String(initialVersion + 1))
     })
 
     it('uses the first session list as the unread baseline', () => {

--- a/web/src/lib/sessionLastSeen.test.ts
+++ b/web/src/lib/sessionLastSeen.test.ts
@@ -69,6 +69,15 @@ describe('sessionLastSeen', () => {
         expect(getSessionManualUnreadAt('session-a')).toBeNull()
     })
 
+    it('preserves an explicit unread marker when a stale seen timestamp arrives', () => {
+        markSessionUnread('session-a', 5000)
+
+        markSessionSeen('session-a', 4000)
+
+        expect(getSessionLastSeenAt('session-a')).toBe(4999)
+        expect(getSessionManualUnreadAt('session-a')).toBe(5000)
+    })
+
     it('notifies same-tab consumers when the watermark changes', () => {
         const view = render(createElement(SessionLastSeenVersionProbe))
         const initialVersion = Number(view.getByTestId('last-seen-version').textContent)

--- a/web/src/lib/sessionLastSeen.test.ts
+++ b/web/src/lib/sessionLastSeen.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest'
 import {
     getSessionLastSeenAt,
     getSessionLastSeenSnapshot,
+    getSessionManualUnreadAt,
     initializeSessionLastSeen,
     markSessionUnread,
     markSessionSeen,
@@ -47,6 +48,7 @@ describe('sessionLastSeen', () => {
         markSessionUnread('session-a', 5000)
 
         expect(getSessionLastSeenAt('session-a')).toBe(4999)
+        expect(getSessionManualUnreadAt('session-a')).toBe(5000)
     })
 
     it('does not change an already-unread watermark when marking unread', () => {
@@ -55,6 +57,16 @@ describe('sessionLastSeen', () => {
         markSessionUnread('session-a', 5000)
 
         expect(getSessionLastSeenAt('session-a')).toBe(1000)
+        expect(getSessionManualUnreadAt('session-a')).toBe(5000)
+    })
+
+    it('clears the explicit unread marker when the session is seen', () => {
+        markSessionUnread('session-a', 5000)
+        expect(getSessionManualUnreadAt('session-a')).toBe(5000)
+
+        markSessionSeen('session-a', 5000)
+
+        expect(getSessionManualUnreadAt('session-a')).toBeNull()
     })
 
     it('notifies same-tab consumers when the watermark changes', () => {

--- a/web/src/lib/sessionLastSeen.ts
+++ b/web/src/lib/sessionLastSeen.ts
@@ -1,12 +1,14 @@
 import { useSyncExternalStore } from 'react'
 
 const STORAGE_KEY = 'hapi.sessionLastSeen.v1'
+const MANUAL_UNREAD_KEY = 'hapi.sessionManualUnread.v1'
 const BASELINE_KEY = 'hapi.sessionLastSeenBaseline.v1'
 const CHANGE_EVENT = 'hapi.sessionLastSeen.changed'
 
 let changeVersion = 0
 
 type LastSeenStore = Record<string, number>
+type ManualUnreadStore = Record<string, number>
 
 function getLocalStorage(): Storage | null {
     if (typeof window === 'undefined') {
@@ -40,6 +42,27 @@ function readStore(): LastSeenStore {
     }
 }
 
+function readManualUnreadStore(): ManualUnreadStore {
+    const storage = getLocalStorage()
+    if (!storage) {
+        return {}
+    }
+
+    try {
+        const raw = storage.getItem(MANUAL_UNREAD_KEY)
+        if (!raw) {
+            return {}
+        }
+        const parsed: unknown = JSON.parse(raw)
+        if (!parsed || typeof parsed !== 'object') {
+            return {}
+        }
+        return parsed as ManualUnreadStore
+    } catch {
+        return {}
+    }
+}
+
 function writeStore(store: LastSeenStore): boolean {
     const storage = getLocalStorage()
     if (!storage) {
@@ -47,6 +70,20 @@ function writeStore(store: LastSeenStore): boolean {
     }
     try {
         storage.setItem(STORAGE_KEY, JSON.stringify(store))
+        return true
+    } catch {
+        // Ignore storage errors
+        return false
+    }
+}
+
+function writeManualUnreadStore(store: ManualUnreadStore): boolean {
+    const storage = getLocalStorage()
+    if (!storage) {
+        return false
+    }
+    try {
+        storage.setItem(MANUAL_UNREAD_KEY, JSON.stringify(store))
         return true
     } catch {
         // Ignore storage errors
@@ -73,7 +110,7 @@ function getStoreChangeVersion(): number {
     return changeVersion
 }
 
-/** Re-render consumers when a same-tab read watermark changes. */
+/** Re-render consumers when same-tab read-state changes. */
 export function useSessionLastSeenVersion(): number {
     return useSyncExternalStore(
         subscribeToStoreChanges,
@@ -84,6 +121,12 @@ export function useSessionLastSeenVersion(): number {
 
 export function getSessionLastSeenAt(sessionId: string): number {
     return readStore()[sessionId] ?? 0
+}
+
+/** Timestamp of the activity the operator explicitly marked unread, if any. */
+export function getSessionManualUnreadAt(sessionId: string): number | null {
+    const value = readManualUnreadStore()[sessionId]
+    return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
 /** One localStorage read/parse for bulk filters (e.g. unread-only lens). */
@@ -118,31 +161,54 @@ export function markSessionSeen(sessionId: string, seenAt: number): void {
         return
     }
     const store = readStore()
+    const manualUnreadStore = readManualUnreadStore()
     const nextSeenAt = Math.max(store[sessionId] ?? 0, seenAt)
-    if (store[sessionId] === nextSeenAt) {
+    const seenChanged = store[sessionId] !== nextSeenAt
+    const manualUnreadChanged = Object.prototype.hasOwnProperty.call(manualUnreadStore, sessionId)
+    if (!seenChanged && !manualUnreadChanged) {
         return
     }
-    store[sessionId] = nextSeenAt
-    if (writeStore(store)) {
+
+    if (seenChanged) {
+        store[sessionId] = nextSeenAt
+    }
+    if (manualUnreadChanged) {
+        delete manualUnreadStore[sessionId]
+    }
+
+    const seenWritten = !seenChanged || writeStore(store)
+    const manualUnreadWritten = !manualUnreadChanged || writeManualUnreadStore(manualUnreadStore)
+    if (seenWritten || manualUnreadWritten) {
         notifyStoreChanged()
     }
 }
 
-/** Move the local watermark just behind the current activity. */
+/** Move the local watermark just behind the current activity and remember the explicit action. */
 export function markSessionUnread(sessionId: string, updatedAt: number): void {
     if (!sessionId || !Number.isFinite(updatedAt)) {
         return
     }
 
     const store = readStore()
+    const manualUnreadStore = readManualUnreadStore()
     const unreadBefore = updatedAt - 1
     const currentSeenAt = store[sessionId]
-    if (typeof currentSeenAt === 'number' && currentSeenAt <= unreadBefore) {
+    const seenChanged = !(typeof currentSeenAt === 'number' && currentSeenAt <= unreadBefore)
+    const manualUnreadChanged = manualUnreadStore[sessionId] !== updatedAt
+    if (!seenChanged && !manualUnreadChanged) {
         return
     }
 
-    store[sessionId] = unreadBefore
-    if (writeStore(store)) {
+    if (seenChanged) {
+        store[sessionId] = unreadBefore
+    }
+    if (manualUnreadChanged) {
+        manualUnreadStore[sessionId] = updatedAt
+    }
+
+    const seenWritten = !seenChanged || writeStore(store)
+    const manualUnreadWritten = !manualUnreadChanged || writeManualUnreadStore(manualUnreadStore)
+    if (seenWritten || manualUnreadWritten) {
         notifyStoreChanged()
     }
 }

--- a/web/src/lib/sessionLastSeen.ts
+++ b/web/src/lib/sessionLastSeen.ts
@@ -102,8 +102,21 @@ function subscribeToStoreChanges(listener: () => void): () => void {
     if (typeof window === 'undefined') {
         return () => {}
     }
+
+    const handleStorage = (event: StorageEvent) => {
+        if (event.key !== STORAGE_KEY && event.key !== MANUAL_UNREAD_KEY) {
+            return
+        }
+        changeVersion += 1
+        listener()
+    }
+
     window.addEventListener(CHANGE_EVENT, listener)
-    return () => window.removeEventListener(CHANGE_EVENT, listener)
+    window.addEventListener('storage', handleStorage)
+    return () => {
+        window.removeEventListener(CHANGE_EVENT, listener)
+        window.removeEventListener('storage', handleStorage)
+    }
 }
 
 function getStoreChangeVersion(): number {

--- a/web/src/lib/sessionLastSeen.ts
+++ b/web/src/lib/sessionLastSeen.ts
@@ -177,7 +177,10 @@ export function markSessionSeen(sessionId: string, seenAt: number): void {
     const manualUnreadStore = readManualUnreadStore()
     const nextSeenAt = Math.max(store[sessionId] ?? 0, seenAt)
     const seenChanged = store[sessionId] !== nextSeenAt
-    const manualUnreadChanged = Object.prototype.hasOwnProperty.call(manualUnreadStore, sessionId)
+    const manualUnreadAt = manualUnreadStore[sessionId]
+    const manualUnreadChanged = typeof manualUnreadAt === 'number'
+        && Number.isFinite(manualUnreadAt)
+        && nextSeenAt >= manualUnreadAt
     if (!seenChanged && !manualUnreadChanged) {
         return
     }

--- a/web/src/lib/sessionLastSeen.ts
+++ b/web/src/lib/sessionLastSeen.ts
@@ -1,5 +1,10 @@
+import { useSyncExternalStore } from 'react'
+
 const STORAGE_KEY = 'hapi.sessionLastSeen.v1'
 const BASELINE_KEY = 'hapi.sessionLastSeenBaseline.v1'
+const CHANGE_EVENT = 'hapi.sessionLastSeen.changed'
+
+let changeVersion = 0
 
 type LastSeenStore = Record<string, number>
 
@@ -35,16 +40,46 @@ function readStore(): LastSeenStore {
     }
 }
 
-function writeStore(store: LastSeenStore): void {
+function writeStore(store: LastSeenStore): boolean {
     const storage = getLocalStorage()
     if (!storage) {
-        return
+        return false
     }
     try {
         storage.setItem(STORAGE_KEY, JSON.stringify(store))
+        return true
     } catch {
         // Ignore storage errors
+        return false
     }
+}
+
+function notifyStoreChanged(): void {
+    changeVersion += 1
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new Event(CHANGE_EVENT))
+    }
+}
+
+function subscribeToStoreChanges(listener: () => void): () => void {
+    if (typeof window === 'undefined') {
+        return () => {}
+    }
+    window.addEventListener(CHANGE_EVENT, listener)
+    return () => window.removeEventListener(CHANGE_EVENT, listener)
+}
+
+function getStoreChangeVersion(): number {
+    return changeVersion
+}
+
+/** Re-render consumers when a same-tab read watermark changes. */
+export function useSessionLastSeenVersion(): number {
+    return useSyncExternalStore(
+        subscribeToStoreChanges,
+        getStoreChangeVersion,
+        () => 0
+    )
 }
 
 export function getSessionLastSeenAt(sessionId: string): number {
@@ -83,6 +118,31 @@ export function markSessionSeen(sessionId: string, seenAt: number): void {
         return
     }
     const store = readStore()
-    store[sessionId] = Math.max(store[sessionId] ?? 0, seenAt)
-    writeStore(store)
+    const nextSeenAt = Math.max(store[sessionId] ?? 0, seenAt)
+    if (store[sessionId] === nextSeenAt) {
+        return
+    }
+    store[sessionId] = nextSeenAt
+    if (writeStore(store)) {
+        notifyStoreChanged()
+    }
+}
+
+/** Move the local watermark just behind the current activity. */
+export function markSessionUnread(sessionId: string, updatedAt: number): void {
+    if (!sessionId || !Number.isFinite(updatedAt)) {
+        return
+    }
+
+    const store = readStore()
+    const unreadBefore = updatedAt - 1
+    const currentSeenAt = store[sessionId]
+    if (typeof currentSeenAt === 'number' && currentSeenAt <= unreadBefore) {
+        return
+    }
+
+    store[sessionId] = unreadBefore
+    if (writeStore(store)) {
+        notifyStoreChanged()
+    }
 }


### PR DESCRIPTION
## Problem / Motivation

The session list did not provide a way to explicitly mark a session as unread. Selected sessions intentionally suppress ordinary new-activity indicators, so marking the currently open session needs to be distinguishable from a normal AI update and provide immediate visual feedback.

## Summary

- Add a “Mark as unread” action to session action menus.
- Persist an explicit unread marker alongside the existing local last-seen watermark.
- Refresh session-list attention indicators immediately after the action.
- Show the unread dot for an explicitly marked selected session, including while it is thinking.
- Keep ordinary newer activity hidden for the selected session.
- Clear the explicit unread marker when the session is seen.
- Synchronize read-state changes across open browser tabs.
- Preserve newer explicit-unread markers when a stale seen timestamp arrives.
- Add English and Simplified Chinese translations and regression coverage.

## Validation

- `bun typecheck`
- `bun run test:e2e -- terminal-wrap-fidelity.spec.ts` — 2/2 passed
- `bun run build`
- Focused Web tests — 5 files, 101 tests passed
- Live Playwright validation — 2/2 passed against seeded archived sessions
- `git diff --check`

## Risk / Migration

No API, database, or migration changes. Read-state markers are stored in versioned browser localStorage keys.

## Related Issues

None

## AI Disclosure

Implemented with assistance from OpenAI Codex (GPT-5.6).