### PR TITLE
fix(cli): preserve source extensions for generated media downloads

### DIFF
--- a/cli/src/claude/utils/startHappyServer.test.ts
+++ b/cli/src/claude/utils/startHappyServer.test.ts
@@ -148,6 +148,26 @@ describe('startHappyServer skill_lookup', () => {
         }))
     })
 
+    it('preserves the source extension when display_media title omits one', async () => {
+        const path = join(sandboxDir, 'plan-a.zip')
+        await writeFile(path, Buffer.from([0x50, 0x4b, 0x03, 0x04]))
+        const mcp = await connect(false)
+
+        const result = await mcp.callTool({
+            name: 'display_media',
+            arguments: { path, title: 'Cursor Plan A Markdown 导出' }
+        }) as ToolResult
+
+        expect(result.isError).toBe(false)
+        expect(result.content?.[0]?.text).toContain('Displayed media: Cursor Plan A Markdown 导出.zip')
+        expect(sendAgentMessage).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'generated-image',
+            fileName: 'Cursor Plan A Markdown 导出.zip',
+            mimeType: 'application/octet-stream',
+            source: { ingress: 'mcp', toolName: 'display_media' }
+        }))
+    })
+
     it('does not expose change_title when native ACP titles are enabled', async () => {
         const sessionClient = {
             updateMetadata: vi.fn(),

--- a/cli/src/modules/common/generatedImages.test.ts
+++ b/cli/src/modules/common/generatedImages.test.ts
@@ -116,6 +116,19 @@ describe('generatedImages', () => {
         clearGeneratedImages()
     })
 
+    it('preserves the source extension when a custom file name omits one', () => {
+        const file = registerGeneratedImage({
+            id: 'test-zip-with-title',
+            path: '/tmp/plan-a.zip',
+            fileName: 'Cursor Plan A Markdown 导出',
+            mimeType: 'application/octet-stream',
+            bytes: Buffer.from('PK\\x03\\x04')
+        })
+
+        expect(file.fileName).toBe('Cursor Plan A Markdown 导出.zip')
+        clearGeneratedImages()
+    })
+
     it('snapshots image bytes at registration time', () => {
         const source = Buffer.from('original image bytes')
         const image = registerGeneratedImage({

--- a/cli/src/modules/common/generatedImages.ts
+++ b/cli/src/modules/common/generatedImages.ts
@@ -1,4 +1,4 @@
-import { basename } from 'node:path'
+import { basename, extname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { open } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
@@ -277,6 +277,14 @@ export function isInlineMediaMimeType(mimeType: string): boolean {
     return mimeType.startsWith('image/') || mimeType.startsWith('video/') || mimeType.startsWith('audio/')
 }
 
+function preserveSourceExtension(fileName: string, path: string): string {
+    const sourceExtension = extname(basename(path))
+    if (!sourceExtension || extname(fileName)) {
+        return fileName
+    }
+    return `${fileName}${sourceExtension}`
+}
+
 export function detectDisplayMediaMimeType(bytes: Uint8Array): string {
     const imageMimeType = detectImageMimeType(bytes)
     if (imageMimeType) return imageMimeType
@@ -312,9 +320,10 @@ export function registerGeneratedImage(args: { id: string; path: string; mimeTyp
         generatedImageBytes -= previous.content.byteLength
     }
 
+    const fallbackFileName = basename(args.path) || `${args.id}.png`
     const metadata: GeneratedImageMetadata = {
         id: args.id,
-        fileName: args.fileName || basename(args.path) || `${args.id}.png`,
+        fileName: preserveSourceExtension(args.fileName || fallbackFileName, args.path),
         content,
         mimeType: args.mimeType,
         createdAt: Date.now()


### PR DESCRIPTION
## Summary

- Preserve the source file extension when `display_media` supplies a custom title without one.
- Keep explicit custom extensions unchanged and preserve existing fallback behavior.
- Add regression coverage for generated-media registration and the `display_media` MCP flow.

## Problem / Motivation

When `display_media` was called with a custom title such as `Cursor Plan A Markdown 导出` for a ZIP source, HAPI used the title verbatim as the download filename. The downloaded bytes were valid, but the filename had no `.zip` suffix, so the operating system and archive tools could not identify it automatically.

The fix appends the source extension only when the custom filename omits an extension.

## Validation

- `bun typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name media-download-extension -Suite Root terminal-wrap-fidelity.spec.ts` — passed (2/2).
- Generated-media extension regression test — passed (1/1).
- `startHappyServer.test.ts` — passed (8/8).
- Generated media web component test — passed (7/7).
- `bun run test:shared` — passed (279/279).
- `bun run build` — passed.
- Live browser acceptance — passed (1/1).
- Public generated-media smoke test — passed: HTTP 200, `Content-Disposition` included `Cursor Plan A Markdown 导出.zip`, and the 22-byte response opened as a ZIP archive.

## Related Issues

None

## AI Assistance

This change was implemented and tested with OpenAI Codex (GPT-5.6).
