### PR TITLE
fix(codex): let forked sessions resume while source stays active

### DIFF
--- a/cli/src/codex/codexAppServerClient.test.ts
+++ b/cli/src/codex/codexAppServerClient.test.ts
@@ -21,6 +21,8 @@ vi.mock('node:fs', async () => {
 });
 
 vi.mock('@/utils/process', () => ({
+    STRICT_PROCESS_OWNERSHIP_ENV: 'HAPI_STRICT_PROCESS_OWNERSHIP_TOKEN',
+    getProcessStartMarker: vi.fn(() => 'spawn-marker'),
     killProcessByChildProcess: vi.fn(async () => true)
 }));
 
@@ -29,14 +31,18 @@ vi.mock('@/ui/logger', () => ({
 }));
 
 import { CodexAppServerClient, isIndeterminateError } from './codexAppServerClient';
+import { getProcessStartMarker, killProcessByChildProcess } from '@/utils/process';
+
+const strictOwnershipEnv = 'HAPI_STRICT_PROCESS_OWNERSHIP_TOKEN';
 
 function fakeStream(): EventEmitter & { setEncoding: ReturnType<typeof vi.fn> } {
     return Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
 }
 
-function fakeChild() {
+function fakeChild(options?: { pid?: number; stdinEnd?: () => void }) {
     return Object.assign(new EventEmitter(), {
-        stdin: { end: vi.fn(), write: vi.fn() },
+        pid: options?.pid ?? 123,
+        stdin: { destroy: vi.fn(), end: vi.fn(options?.stdinEnd), write: vi.fn() },
         stdout: fakeStream(),
         stderr: fakeStream()
     });
@@ -46,6 +52,10 @@ describe('CodexAppServerClient process cwd', () => {
     beforeEach(() => {
         execFileSyncMock.mockClear();
         spawnMock.mockReset();
+        vi.mocked(getProcessStartMarker).mockReset();
+        vi.mocked(getProcessStartMarker).mockReturnValue('spawn-marker');
+        vi.mocked(killProcessByChildProcess).mockReset();
+        vi.mocked(killProcessByChildProcess).mockResolvedValue(true);
     });
 
     it('passes an explicit neutral cwd to the app-server process', async () => {
@@ -59,6 +69,703 @@ describe('CodexAppServerClient process cwd', () => {
             ['app-server'],
             expect.objectContaining({ cwd: '/neutral-home' })
         );
+        await client.disconnect();
+    });
+
+    it('captures and forwards the immutable Windows process marker for a strict client', async () => {
+        const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+        Object.defineProperty(process, 'platform', {
+            ...platformDescriptor,
+            value: 'win32'
+        });
+        const child = fakeChild({ pid: 321 });
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        try {
+            await client.connect({ requireVerifiedProcessIdentity: true });
+            expect(getProcessStartMarker).toHaveBeenNthCalledWith(1, process.pid);
+            expect(getProcessStartMarker).toHaveBeenNthCalledWith(2, 321);
+            vi.mocked(getProcessStartMarker).mockReturnValue('replacement-marker');
+
+            await client.disconnect({ deadline: 12_345 });
+
+            expect(killProcessByChildProcess).toHaveBeenCalledWith(
+                child,
+                false,
+                'spawn-marker',
+                12_345
+            );
+        } finally {
+            Object.defineProperty(process, 'platform', platformDescriptor);
+        }
+    });
+
+    it('uses legacy Windows teardown and reconnects when marker probing is unavailable', async () => {
+        const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+        Object.defineProperty(process, 'platform', {
+            ...platformDescriptor,
+            value: 'win32'
+        });
+        vi.mocked(getProcessStartMarker).mockImplementation(() => {
+            throw new Error('marker probe unavailable');
+        });
+        const originalChild = fakeChild();
+        const replacementChild = fakeChild({ pid: 456 });
+        spawnMock
+            .mockReturnValueOnce(originalChild)
+            .mockReturnValueOnce(replacementChild);
+        vi.mocked(killProcessByChildProcess)
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(true);
+        const client = new CodexAppServerClient();
+
+        try {
+            await client.connect();
+            await expect(client.disconnect()).rejects.toThrow('could not be terminated');
+            await client.connect();
+            await client.disconnect();
+
+            expect(getProcessStartMarker).not.toHaveBeenCalled();
+            expect(killProcessByChildProcess).toHaveBeenNthCalledWith(
+                1,
+                originalChild,
+                false,
+                undefined,
+                undefined
+            );
+            expect(killProcessByChildProcess).toHaveBeenNthCalledWith(
+                2,
+                replacementChild,
+                false,
+                undefined,
+                undefined
+            );
+            expect(spawnMock).toHaveBeenCalledTimes(2);
+        } finally {
+            Object.defineProperty(process, 'platform', platformDescriptor);
+        }
+    });
+
+    it('rejects a strict Windows connection before spawn when marker preflight fails', async () => {
+        const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+        Object.defineProperty(process, 'platform', {
+            ...platformDescriptor,
+            value: 'win32'
+        });
+        vi.mocked(getProcessStartMarker).mockReturnValue(null);
+        spawnMock.mockReturnValue(fakeChild());
+        const client = new CodexAppServerClient();
+
+        try {
+            await expect(client.connect({
+                requireVerifiedProcessIdentity: true
+            })).rejects.toThrow('process identity could not be verified');
+            expect(client.isConnected()).toBe(false);
+            expect(getProcessStartMarker).toHaveBeenCalledWith(process.pid);
+            expect(spawnMock).not.toHaveBeenCalled();
+        } finally {
+            Object.defineProperty(process, 'platform', platformDescriptor);
+        }
+    });
+
+    it('fails closed with a null marker when disconnect races strict Windows marker capture', async () => {
+        vi.useFakeTimers();
+        const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+        Object.defineProperty(process, 'platform', {
+            ...platformDescriptor,
+            value: 'win32'
+        });
+        const child = fakeChild({ pid: 321 });
+        vi.mocked(getProcessStartMarker)
+            .mockReturnValueOnce('node-marker')
+            .mockReturnValue(null);
+        vi.mocked(killProcessByChildProcess).mockResolvedValue(false);
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        try {
+            const connecting = client.connect({ requireVerifiedProcessIdentity: true });
+            const connectionError = connecting.then(() => null, (error: unknown) => error);
+            await Promise.resolve();
+
+            await expect(client.disconnect()).rejects.toThrow('could not be terminated');
+            expect(killProcessByChildProcess).toHaveBeenNthCalledWith(
+                1,
+                child,
+                false,
+                null,
+                undefined
+            );
+
+            await vi.advanceTimersByTimeAsync(1_000);
+            const error = await connectionError;
+
+            expect(error).toBeInstanceOf(Error);
+            expect((error as Error).message).toContain('process identity could not be verified');
+            expect(getProcessStartMarker).toHaveBeenNthCalledWith(1, process.pid);
+            expect(vi.mocked(getProcessStartMarker).mock.calls.length).toBeGreaterThan(2);
+            expect(client.isConnected()).toBe(false);
+            expect(client.isInitialized()).toBe(false);
+            expect(child.stdin.write).not.toHaveBeenCalled();
+            expect(vi.mocked(killProcessByChildProcess).mock.calls.every((call) => (
+                call[1] === false && call[2] === null
+            ))).toBe(true);
+            await expect(client.connect({
+                requireVerifiedProcessIdentity: true
+            })).rejects.toThrow('termination is unconfirmed');
+            expect(spawnMock).toHaveBeenCalledOnce();
+        } finally {
+            Object.defineProperty(process, 'platform', platformDescriptor);
+            vi.useRealTimers();
+        }
+    });
+
+    it('rejects strict Windows connect when the child exits during marker capture', async () => {
+        vi.useFakeTimers();
+        const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+        Object.defineProperty(process, 'platform', {
+            ...platformDescriptor,
+            value: 'win32'
+        });
+        const child = fakeChild({ pid: 321 });
+        vi.mocked(getProcessStartMarker)
+            .mockReturnValueOnce('node-marker')
+            .mockReturnValueOnce(null)
+            .mockReturnValueOnce('reused-marker');
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        try {
+            const connecting = client.connect({ requireVerifiedProcessIdentity: true });
+            const connectionError = connecting.then(() => null, (error: unknown) => error);
+            child.emit('exit', 0, null);
+
+            await vi.advanceTimersByTimeAsync(20);
+            const error = await connectionError;
+
+            expect(error).toBeInstanceOf(Error);
+            expect((error as Error).message).toContain(
+                'process identity could not be verified'
+            );
+            expect(getProcessStartMarker).toHaveBeenNthCalledWith(1, process.pid);
+            expect(getProcessStartMarker).toHaveBeenNthCalledWith(2, 321);
+            expect(getProcessStartMarker).toHaveBeenNthCalledWith(3, 321);
+            expect(client.isConnected()).toBe(false);
+            expect(client.isInitialized()).toBe(false);
+            expect(killProcessByChildProcess).not.toHaveBeenCalled();
+            await expect(client.connect({
+                requireVerifiedProcessIdentity: true
+            })).rejects.toThrow('termination is unconfirmed');
+            expect(spawnMock).toHaveBeenCalledOnce();
+        } finally {
+            Object.defineProperty(process, 'platform', platformDescriptor);
+            vi.useRealTimers();
+        }
+    });
+
+    it('detaches and terminates the strict POSIX client as a process group', async () => {
+        const child = fakeChild({ pid: 321 });
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        await client.connect({ requireVerifiedProcessIdentity: true });
+        const spawnOptions = spawnMock.mock.calls[0]?.[2] as {
+            env: Record<string, string>;
+        };
+        const ownershipToken = spawnOptions.env[strictOwnershipEnv];
+        await client.disconnect({ deadline: 12_345 });
+
+        expect(ownershipToken).toEqual(expect.any(String));
+        expect(spawnMock).toHaveBeenCalledWith(
+            'codex',
+            ['app-server'],
+            expect.objectContaining({ detached: true })
+        );
+        expect(killProcessByChildProcess).toHaveBeenCalledWith(
+            child,
+            false,
+            'spawn-marker',
+            12_345,
+            true,
+            ownershipToken
+        );
+    });
+
+    it('rejects a strict POSIX connection when the root marker cannot be captured', async () => {
+        vi.mocked(getProcessStartMarker).mockReturnValue(null);
+        const child = fakeChild({ pid: 321 });
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        await expect(client.connect({
+            requireVerifiedProcessIdentity: true
+        })).rejects.toThrow('process identity could not be verified');
+
+        expect(getProcessStartMarker).toHaveBeenCalledWith(321);
+        expect(killProcessByChildProcess).toHaveBeenCalledWith(
+            child,
+            false,
+            null,
+            undefined,
+            true,
+            expect.any(String)
+        );
+        expect(client.isConnected()).toBe(false);
+    });
+
+    it('keeps the legacy process path off Windows', async () => {
+        const child = fakeChild();
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        await client.connect();
+        await client.disconnect();
+
+        expect(getProcessStartMarker).not.toHaveBeenCalled();
+        expect(killProcessByChildProcess).toHaveBeenCalledWith(
+            child,
+            false,
+            undefined,
+            undefined
+        );
+    });
+
+    it('invalidates a reconnect when shutdown joins its controlled disconnect', async () => {
+        let finishTermination!: (terminated: boolean) => void;
+        vi.mocked(killProcessByChildProcess).mockReturnValue(new Promise<boolean>((resolve) => {
+            finishTermination = resolve;
+        }));
+        spawnMock.mockReturnValue(fakeChild());
+        const client = new CodexAppServerClient();
+
+        await client.connect();
+        const teardown = client.disconnect();
+        const reconnect = client.connect();
+        const reconnectError = reconnect.then(() => null, (error: unknown) => error);
+        await Promise.resolve();
+        const shutdown = client.disconnect();
+        finishTermination(true);
+
+        await teardown;
+        await shutdown;
+        const error = await reconnectError;
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain('superseded');
+        expect(spawnMock).toHaveBeenCalledOnce();
+    });
+
+    it('does not report a controlled disconnect as transport abandonment on child exit', async () => {
+        let finishTermination!: (terminated: boolean) => void;
+        vi.mocked(killProcessByChildProcess).mockReturnValue(new Promise<boolean>((resolve) => {
+            finishTermination = resolve;
+        }));
+        const child = fakeChild();
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+        const transportAbandonedHandler = vi.fn();
+        client.setTransportAbandonedHandler(transportAbandonedHandler);
+
+        await client.connect();
+        const disconnect = client.disconnect();
+        child.emit('exit', 0, null);
+
+        expect(transportAbandonedHandler).not.toHaveBeenCalled();
+        finishTermination(true);
+        await disconnect;
+    });
+
+    it('reports transport abandonment once when the child exits during abandoned teardown', async () => {
+        let finishTermination!: (terminated: boolean) => void;
+        vi.mocked(killProcessByChildProcess).mockReturnValue(new Promise<boolean>((resolve) => {
+            finishTermination = resolve;
+        }));
+        const child = fakeChild();
+        child.stdin.write = vi.fn(() => true);
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+        const transportAbandonedHandler = vi.fn();
+        const abortController = new AbortController();
+        client.setTransportAbandonedHandler(transportAbandonedHandler);
+
+        await client.connect();
+        const fork = client.forkThread(
+            { threadId: 'thread-1' },
+            { signal: abortController.signal }
+        );
+        await Promise.resolve();
+        abortController.abort();
+        await expect(fork).rejects.toThrow('Request aborted');
+        child.emit('exit', 0, null);
+
+        expect(transportAbandonedHandler).toHaveBeenCalledOnce();
+        finishTermination(true);
+        await client.disconnect();
+    });
+
+    it('allows the default client to reconnect after an unexpected process exit', async () => {
+        const originalChild = fakeChild();
+        const replacementChild = fakeChild({ pid: 456 });
+        spawnMock
+            .mockReturnValueOnce(originalChild)
+            .mockReturnValueOnce(replacementChild);
+        const client = new CodexAppServerClient();
+        const transportAbandonedHandler = vi.fn();
+        client.setTransportAbandonedHandler(transportAbandonedHandler);
+
+        await client.connect();
+        originalChild.emit('exit', 1, null);
+
+        expect(transportAbandonedHandler).toHaveBeenCalledOnce();
+        await client.connect();
+        expect(spawnMock).toHaveBeenCalledTimes(2);
+        await client.disconnect();
+    });
+
+    it('starts strict POSIX process-group cleanup immediately after leader exit', async () => {
+        let finishTermination!: (terminated: boolean) => void;
+        vi.mocked(killProcessByChildProcess).mockReturnValue(new Promise<boolean>((resolve) => {
+            finishTermination = resolve;
+        }));
+        const child = fakeChild({ pid: 321 });
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        await client.connect({ requireVerifiedProcessIdentity: true });
+        const spawnOptions = spawnMock.mock.calls[0]?.[2] as {
+            env: Record<string, string>;
+        };
+        const ownershipToken = spawnOptions.env[strictOwnershipEnv];
+        child.emit('exit', 1, null);
+
+        expect(killProcessByChildProcess).toHaveBeenCalledWith(
+            child,
+            false,
+            'spawn-marker',
+            undefined,
+            true,
+            ownershipToken
+        );
+
+        const disconnect = client.disconnect({ deadline: 12_345 });
+        expect(killProcessByChildProcess).toHaveBeenCalledOnce();
+        finishTermination(true);
+
+        await disconnect;
+        expect(killProcessByChildProcess).toHaveBeenCalledOnce();
+        expect(client.isConnected()).toBe(false);
+    });
+
+    it('surfaces failed background POSIX cleanup and allows an explicit retry', async () => {
+        let rejectTermination!: (error: Error) => void;
+        vi.mocked(killProcessByChildProcess)
+            .mockReturnValueOnce(new Promise<boolean>((_resolve, reject) => {
+                rejectTermination = reject;
+            }))
+            .mockResolvedValueOnce(true);
+        const child = fakeChild({ pid: 321 });
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+        const unhandledRejections: unknown[] = [];
+        const onUnhandledRejection = (reason: unknown) => {
+            unhandledRejections.push(reason);
+        };
+        process.on('unhandledRejection', onUnhandledRejection);
+
+        try {
+            await client.connect({ requireVerifiedProcessIdentity: true });
+            const spawnOptions = spawnMock.mock.calls[0]?.[2] as {
+                env: Record<string, string>;
+            };
+            const ownershipToken = spawnOptions.env[strictOwnershipEnv];
+            child.emit('exit', 1, null);
+
+            expect(killProcessByChildProcess).toHaveBeenCalledOnce();
+            expect(killProcessByChildProcess).toHaveBeenNthCalledWith(
+                1,
+                child,
+                false,
+                'spawn-marker',
+                undefined,
+                true,
+                ownershipToken
+            );
+            rejectTermination(new Error('tree kill failed'));
+            await new Promise<void>((resolve) => setImmediate(resolve));
+
+            expect(unhandledRejections).toEqual([]);
+            await expect(client.disconnect()).rejects.toThrow('tree kill failed');
+
+            await client.disconnect();
+            expect(killProcessByChildProcess).toHaveBeenCalledTimes(2);
+            expect(killProcessByChildProcess).toHaveBeenNthCalledWith(
+                2,
+                child,
+                false,
+                'spawn-marker',
+                undefined,
+                true,
+                ownershipToken
+            );
+        } finally {
+            process.off('unhandledRejection', onUnhandledRejection);
+        }
+    });
+
+    it('keeps strict Windows teardown fail-closed after its leader exits', async () => {
+        const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+        Object.defineProperty(process, 'platform', {
+            ...platformDescriptor,
+            value: 'win32'
+        });
+        const child = fakeChild({ pid: 321 });
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        try {
+            await client.connect({ requireVerifiedProcessIdentity: true });
+            child.emit('exit', 0, null);
+
+            await expect(client.disconnect()).rejects.toThrow('termination is unconfirmed');
+
+            expect(killProcessByChildProcess).not.toHaveBeenCalled();
+        } finally {
+            Object.defineProperty(process, 'platform', platformDescriptor);
+        }
+    });
+
+    it('retains process ownership when process-tree termination is unconfirmed', async () => {
+        const originalChild = fakeChild();
+        const replacementChild = fakeChild({ pid: 456 });
+        spawnMock
+            .mockReturnValueOnce(originalChild)
+            .mockReturnValueOnce(replacementChild);
+        vi.mocked(killProcessByChildProcess).mockResolvedValue(false);
+        const client = new CodexAppServerClient();
+
+        await client.connect({ requireVerifiedProcessIdentity: true });
+        const spawnOptions = spawnMock.mock.calls[0]?.[2] as {
+            env: Record<string, string>;
+        };
+        const ownershipToken = spawnOptions.env[strictOwnershipEnv];
+
+        await expect(client.disconnect()).rejects.toThrow('could not be terminated');
+        expect(killProcessByChildProcess).toHaveBeenCalledOnce();
+
+        await expect(client.connect({
+            requireVerifiedProcessIdentity: true
+        })).rejects.toThrow('termination is unconfirmed');
+        expect(spawnMock).toHaveBeenCalledOnce();
+
+        vi.mocked(killProcessByChildProcess).mockResolvedValue(true);
+        await client.disconnect();
+        expect(killProcessByChildProcess).toHaveBeenNthCalledWith(
+            2,
+            originalChild,
+            false,
+            'spawn-marker',
+            undefined,
+            true,
+            ownershipToken
+        );
+        await client.connect({ requireVerifiedProcessIdentity: true });
+        expect(spawnMock).toHaveBeenCalledTimes(2);
+        await client.disconnect();
+    });
+
+    it('rejects disconnect when process-tree termination throws', async () => {
+        spawnMock.mockReturnValue(fakeChild());
+        vi.mocked(killProcessByChildProcess).mockRejectedValue(new Error('tree kill failed'));
+        const client = new CodexAppServerClient();
+
+        await client.connect({ requireVerifiedProcessIdentity: true });
+
+        await expect(client.disconnect()).rejects.toThrow('tree kill failed');
+        expect(killProcessByChildProcess).toHaveBeenCalledOnce();
+        await expect(client.connect({
+            requireVerifiedProcessIdentity: true
+        })).rejects.toThrow('termination is unconfirmed');
+        expect(spawnMock).toHaveBeenCalledOnce();
+
+        vi.mocked(killProcessByChildProcess).mockResolvedValue(true);
+        await client.disconnect();
+    });
+
+    it('does not treat root exit as confirmation that the process tree terminated', async () => {
+        let finishTermination!: (terminated: boolean) => void;
+        vi.mocked(killProcessByChildProcess).mockReturnValue(new Promise<boolean>((resolve) => {
+            finishTermination = resolve;
+        }));
+        const child = fakeChild();
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        await client.connect({ requireVerifiedProcessIdentity: true });
+        const disconnect = client.disconnect();
+        await Promise.resolve();
+        child.emit('exit', 0, null);
+        finishTermination(false);
+
+        await expect(disconnect).rejects.toThrow('could not be terminated');
+        await expect(client.connect({
+            requireVerifiedProcessIdentity: true
+        })).rejects.toThrow('termination is unconfirmed');
+        expect(spawnMock).toHaveBeenCalledOnce();
+    });
+
+    it('does not treat a child-process error as confirmation that the process tree terminated', async () => {
+        let finishTermination!: (terminated: boolean) => void;
+        vi.mocked(killProcessByChildProcess).mockReturnValue(new Promise<boolean>((resolve) => {
+            finishTermination = resolve;
+        }));
+        const child = fakeChild();
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+
+        await client.connect({ requireVerifiedProcessIdentity: true });
+        const disconnect = client.disconnect();
+        await Promise.resolve();
+        child.emit('error', new Error('transport failed'));
+        finishTermination(false);
+
+        await expect(disconnect).rejects.toThrow('could not be terminated');
+        await expect(client.connect({
+            requireVerifiedProcessIdentity: true
+        })).rejects.toThrow('termination is unconfirmed');
+        expect(spawnMock).toHaveBeenCalledOnce();
+    });
+
+    it('ignores buffered stdout after process teardown starts', async () => {
+        let finishTermination!: (terminated: boolean) => void;
+        vi.mocked(killProcessByChildProcess).mockReturnValue(new Promise<boolean>((resolve) => {
+            finishTermination = resolve;
+        }));
+        const child = fakeChild();
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+        const notificationHandler = vi.fn();
+        client.setNotificationHandler(notificationHandler);
+
+        await client.connect();
+        const disconnect = client.disconnect();
+        await Promise.resolve();
+        child.stdout.emit('data', Buffer.from(`${JSON.stringify({
+            method: 'thread/status/changed',
+            params: { threadId: 'stale-thread' }
+        })}\n`));
+
+        expect(notificationHandler).not.toHaveBeenCalled();
+        finishTermination(true);
+        await disconnect;
+    });
+
+    it('allows reconnect when only stdin closing fails after confirmed termination', async () => {
+        const originalChild = fakeChild({
+            stdinEnd: () => {
+                throw new Error('stdin close failed');
+            }
+        });
+        const replacementChild = fakeChild({ pid: 456 });
+        spawnMock
+            .mockReturnValueOnce(originalChild)
+            .mockReturnValueOnce(replacementChild);
+        const client = new CodexAppServerClient();
+
+        await client.connect();
+        await expect(client.disconnect()).rejects.toThrow('stdin close failed');
+
+        await client.connect();
+        expect(spawnMock).toHaveBeenCalledTimes(2);
+        await client.disconnect();
+    });
+
+    it('starts process-tree termination before closing stdin', async () => {
+        const calls: string[] = [];
+        vi.mocked(killProcessByChildProcess).mockImplementation(async () => {
+            calls.push('terminate');
+            return true;
+        });
+        spawnMock.mockReturnValue(fakeChild({
+            stdinEnd: () => calls.push('stdin.end')
+        }));
+        const client = new CodexAppServerClient();
+
+        await client.connect();
+        await client.disconnect();
+
+        expect(calls).toEqual(['terminate', 'stdin.end']);
+    });
+
+    it('awaits and propagates process-tree termination when closing stdin throws', async () => {
+        let rejectTermination!: (error: Error) => void;
+        vi.mocked(killProcessByChildProcess).mockReturnValue(new Promise<boolean>((_resolve, reject) => {
+            rejectTermination = reject;
+        }));
+        spawnMock.mockReturnValue(fakeChild({
+            stdinEnd: () => {
+                throw new Error('stdin close failed');
+            }
+        }));
+        const client = new CodexAppServerClient();
+
+        await client.connect();
+
+        let settled = false;
+        const disconnect = client.disconnect().finally(() => {
+            settled = true;
+        });
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        rejectTermination(new Error('tree kill failed'));
+        await expect(disconnect).rejects.toThrow('tree kill failed');
+        expect(killProcessByChildProcess).toHaveBeenCalledOnce();
+    });
+
+    it('terminates the process tree when aborting an unconfirmed stdin dispatch', async () => {
+        const child = fakeChild();
+        child.stdin.write = vi.fn(() => true);
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+        const abortController = new AbortController();
+
+        await client.connect();
+        const fork = client.forkThread(
+            { threadId: 'thread-1' },
+            { signal: abortController.signal }
+        );
+        await Promise.resolve();
+        abortController.abort();
+
+        await expect(fork).rejects.toThrow('Request aborted');
+        await client.disconnect();
+        expect(killProcessByChildProcess).toHaveBeenCalledOnce();
+    });
+
+    it('propagates abandoned transport termination failure to disconnect', async () => {
+        vi.mocked(killProcessByChildProcess).mockResolvedValue(false);
+        const child = fakeChild();
+        child.stdin.write = vi.fn(() => true);
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient();
+        const abortController = new AbortController();
+
+        await client.connect({ requireVerifiedProcessIdentity: true });
+        const fork = client.forkThread(
+            { threadId: 'thread-1' },
+            { signal: abortController.signal }
+        );
+        await Promise.resolve();
+        abortController.abort();
+
+        await expect(fork).rejects.toThrow('Request aborted');
+        await expect(client.disconnect()).rejects.toThrow('could not be terminated');
+        await expect(client.connect({
+            requireVerifiedProcessIdentity: true
+        })).rejects.toThrow('termination is unconfirmed');
+        expect(spawnMock).toHaveBeenCalledOnce();
+
+        vi.mocked(killProcessByChildProcess).mockResolvedValue(true);
         await client.disconnect();
     });
 

--- a/cli/src/codex/codexAppServerClient.ts
+++ b/cli/src/codex/codexAppServerClient.ts
@@ -1,8 +1,13 @@
 import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { logger } from '@/ui/logger';
 import { JsonLineParser } from '@/utils/jsonLineParser';
-import { killProcessByChildProcess } from '@/utils/process';
+import {
+    getProcessStartMarker,
+    killProcessByChildProcess,
+    STRICT_PROCESS_OWNERSHIP_ENV
+} from '@/utils/process';
 import type {
     CollaborationModeListResponse,
     InitializeParams,
@@ -172,8 +177,27 @@ function resolveCodexAppServerCommand(): string {
     return best.command;
 }
 
+async function captureProcessStartMarker(pid: number): Promise<string | null> {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+        const marker = getProcessStartMarker(pid);
+        if (marker !== null) return marker;
+        if (attempt < 2) {
+            await new Promise<void>((resolve) => setTimeout(resolve, 20));
+        }
+    }
+    return null;
+}
+
 export class CodexAppServerClient extends JsonLineParser {
     private process: ChildProcessWithoutNullStreams | null = null;
+    private processStartMarker: string | null | undefined;
+    private processOwnershipToken: string | undefined;
+    private processExited = false;
+    private terminationUnconfirmed = false;
+    private requireConfirmedTermination = false;
+    private disconnecting: Promise<void> | null = null;
+    private retainDisconnecting = false;
+    private lifecycleGeneration = 0;
     private connected = false;
     private initialized = false;
 
@@ -204,34 +228,75 @@ export class CodexAppServerClient extends JsonLineParser {
         this.stderrHandler = handler;
     }
 
-    async connect(): Promise<void> {
+    async connect(options?: { requireVerifiedProcessIdentity?: boolean }): Promise<void> {
+        const lifecycleGeneration = this.lifecycleGeneration;
+        if (this.disconnecting) {
+            const disconnecting = this.disconnecting;
+            this.retainDisconnecting = false;
+            try {
+                await disconnecting;
+            } finally {
+                if (this.disconnecting === disconnecting) this.disconnecting = null;
+            }
+        }
+        this.assertConnectIsCurrent(lifecycleGeneration);
         if (this.connected) {
             return;
+        }
+        if (this.process) {
+            throw new Error(
+                'Cannot connect while previous Codex app-server process termination is unconfirmed'
+            );
+        }
+        const requireVerifiedProcessIdentity = options?.requireVerifiedProcessIdentity === true;
+        if (requireVerifiedProcessIdentity
+            && process.platform === 'win32'
+            && getProcessStartMarker(process.pid) === null) {
+            throw new Error('Codex app-server process identity could not be verified');
         }
 
         const codexCommand = resolveCodexAppServerCommand();
         logger.debug(`[CodexAppServer] Starting ${codexCommand} app-server`);
+        this.assertConnectIsCurrent(lifecycleGeneration);
+        const processOwnershipToken = requireVerifiedProcessIdentity
+            && process.platform !== 'win32'
+            ? randomUUID()
+            : undefined;
+        const childEnv = Object.keys(process.env).reduce((acc, key) => {
+            const value = process.env[key];
+            if (typeof value === 'string') acc[key] = value;
+            return acc;
+        }, {} as Record<string, string>);
+        if (processOwnershipToken) {
+            childEnv[STRICT_PROCESS_OWNERSHIP_ENV] = processOwnershipToken;
+        }
         const child = spawn(codexCommand, ['app-server'], {
             cwd: this.options.cwd,
-            env: Object.keys(process.env).reduce((acc, key) => {
-                const value = process.env[key];
-                if (typeof value === 'string') acc[key] = value;
-                return acc;
-            }, {} as Record<string, string>),
+            env: childEnv,
             stdio: ['pipe', 'pipe', 'pipe'],
             shell: process.platform === 'win32',
-            windowsHide: process.platform === 'win32'
+            windowsHide: process.platform === 'win32',
+            ...(requireVerifiedProcessIdentity && process.platform !== 'win32'
+                ? { detached: true }
+                : {})
         });
         this.process = child;
+        this.processStartMarker = requireVerifiedProcessIdentity
+            ? null
+            : undefined;
+        this.processOwnershipToken = processOwnershipToken;
+        this.processExited = false;
+        this.terminationUnconfirmed = false;
+        this.requireConfirmedTermination = requireVerifiedProcessIdentity;
 
         child.stdout.setEncoding('utf8');
         child.stdout.on('data', (chunk) => {
-            if (this.process === child) this.feed(chunk);
+            if (this.process === child && this.connected) this.feed(chunk);
         });
 
         child.stderr.setEncoding('utf8');
         child.stderr.on('data', (chunk) => {
-            if (this.process !== child) return;
+            if (this.process !== child || !this.connected) return;
             const text = chunk.toString().trim();
             if (text.length > 0) {
                 logger.debug(`[CodexAppServer][stderr] ${text}`);
@@ -241,18 +306,39 @@ export class CodexAppServerClient extends JsonLineParser {
 
         child.on('exit', (code, signal) => {
             if (this.process !== child) return;
+            const wasConnected = this.connected;
             const message = `Codex app-server exited (code=${code ?? 'null'}, signal=${signal ?? 'null'})`;
             logger.debug(message);
             this.rejectAllPending(new Error(message));
             this.connected = false;
             this.initialized = false;
             this.resetParserState();
-            this.process = null;
-            this.transportAbandonedHandler?.();
+            if (this.requireConfirmedTermination) {
+                this.processExited = true;
+                this.terminationUnconfirmed = true;
+                if (process.platform !== 'win32') {
+                    const disconnecting = this.startDisconnect(undefined, true);
+                    void disconnecting.catch((error) => {
+                        logger.debug(
+                            '[CodexAppServer] Error terminating process group after exit',
+                            error
+                        );
+                    });
+                }
+            } else {
+                this.process = null;
+                this.processStartMarker = undefined;
+                this.processOwnershipToken = undefined;
+                this.processExited = false;
+                this.terminationUnconfirmed = false;
+                this.requireConfirmedTermination = false;
+            }
+            if (wasConnected) this.transportAbandonedHandler?.();
         });
 
         child.on('error', (error) => {
             if (this.process !== child) return;
+            const wasConnected = this.connected;
             logger.debug('[CodexAppServer] Process error', error);
             const message = error instanceof Error ? error.message : String(error);
             this.rejectAllPending(new Error(
@@ -260,13 +346,52 @@ export class CodexAppServerClient extends JsonLineParser {
                 { cause: error }
             ));
             this.connected = false;
+            this.initialized = false;
             this.resetParserState();
-            this.process = null;
-            this.transportAbandonedHandler?.();
+            if (!this.requireConfirmedTermination || !child.pid) {
+                this.process = null;
+                this.processStartMarker = undefined;
+                this.processOwnershipToken = undefined;
+                this.processExited = false;
+                this.terminationUnconfirmed = false;
+                this.requireConfirmedTermination = false;
+            } else {
+                this.terminationUnconfirmed = true;
+            }
+            if (wasConnected) this.transportAbandonedHandler?.();
         });
 
+        if (requireVerifiedProcessIdentity) {
+            const processStartMarker = child.pid
+                ? await captureProcessStartMarker(child.pid)
+                : null;
+            if (processStartMarker === null
+                || this.process !== child
+                || this.processExited
+                || this.terminationUnconfirmed) {
+                this.processStartMarker = null;
+                const identityError = new Error(
+                    'Codex app-server process identity could not be verified'
+                );
+                try {
+                    await this.startDisconnect(undefined, false);
+                } catch (error) {
+                    logger.debug('[CodexAppServer] Error cleaning up unverified process', error);
+                }
+                throw identityError;
+            }
+            this.processStartMarker = processStartMarker;
+        }
+
+        this.assertConnectIsCurrent(lifecycleGeneration);
         this.connected = true;
         logger.debug('[CodexAppServer] Connected');
+    }
+
+    private assertConnectIsCurrent(lifecycleGeneration: number): void {
+        if (lifecycleGeneration !== this.lifecycleGeneration) {
+            throw new Error('Codex app-server connection was superseded by disconnect');
+        }
     }
 
     setNotificationHandler(handler: ((method: string, params: unknown) => void) | null): void {
@@ -450,26 +575,140 @@ export class CodexAppServerClient extends JsonLineParser {
         return response as ThreadGoalClearResponse;
     }
 
-    async disconnect(): Promise<void> {
-        if (!this.connected) {
+    disconnect(options?: { deadline?: number }): Promise<void> {
+        return this.startDisconnect(options, false);
+    }
+
+    private startDisconnect(
+        options: { deadline?: number } | undefined,
+        retainUntilObserved: boolean
+    ): Promise<void> {
+        this.lifecycleGeneration += 1;
+        const activeDisconnect = this.disconnecting;
+        if (activeDisconnect) {
+            if (!retainUntilObserved) {
+                this.retainDisconnecting = false;
+                const clear = () => {
+                    if (this.disconnecting === activeDisconnect) this.disconnecting = null;
+                };
+                void activeDisconnect.then(clear, clear);
+            }
+            return activeDisconnect;
+        }
+        const disconnecting = this.disconnectProcess(options);
+        this.disconnecting = disconnecting;
+        this.retainDisconnecting = retainUntilObserved;
+        const clear = () => {
+            if (this.disconnecting === disconnecting && !this.retainDisconnecting) {
+                this.disconnecting = null;
+            }
+        };
+        void disconnecting.then(clear, clear);
+        return disconnecting;
+    }
+
+    private async disconnectProcess(options?: { deadline?: number }): Promise<void> {
+        if (!this.connected && !this.process) {
             return;
         }
 
         const child = this.process;
-        this.process = null;
+        const processStartMarker = this.processStartMarker;
+        const processOwnershipToken = this.processOwnershipToken;
+        const requireConfirmedTermination = this.requireConfirmedTermination;
+        const canVerifyProcessGroup = requireConfirmedTermination && process.platform !== 'win32';
+        this.connected = false;
+        this.initialized = false;
+        let stdinError: unknown = null;
+        let terminationError: unknown = null;
+        let termination: Promise<boolean> | null = null;
+        let terminationConfirmed = child === null;
 
         try {
-            child?.stdin.end();
             if (child) {
-                await killProcessByChildProcess(child);
+                if (this.processExited && this.terminationUnconfirmed && !canVerifyProcessGroup) {
+                    terminationError = new Error('Codex app-server process tree termination is unconfirmed');
+                } else {
+                    try {
+                        termination = canVerifyProcessGroup
+                            ? killProcessByChildProcess(
+                                child,
+                                false,
+                                processStartMarker,
+                                options?.deadline,
+                                true,
+                                processOwnershipToken
+                            )
+                            : killProcessByChildProcess(
+                                child,
+                                false,
+                                processStartMarker,
+                                options?.deadline
+                            );
+                    } catch (error) {
+                        terminationError = error;
+                    }
+                }
             }
-        } catch (error) {
-            logger.debug('[CodexAppServer] Error while stopping process', error);
+
+            try {
+                child?.stdin.end();
+            } catch (error) {
+                stdinError = error;
+            }
+
+            if (termination) {
+                try {
+                    const terminated = await termination;
+                    if (terminated) {
+                        terminationConfirmed = true;
+                    } else {
+                        terminationError = new Error('Codex app-server process could not be terminated');
+                    }
+                } catch (error) {
+                    terminationError = error;
+                }
+            }
         } finally {
             this.rejectAllPending(new Error('Codex app-server disconnected'));
             this.connected = false;
             this.initialized = false;
             this.resetParserState();
+        }
+
+        if (child && terminationConfirmed) {
+            terminationError = null;
+            if (this.process === child) {
+                this.process = null;
+                this.processStartMarker = undefined;
+                this.processOwnershipToken = undefined;
+                this.requireConfirmedTermination = false;
+            }
+            this.processExited = false;
+            this.terminationUnconfirmed = false;
+        } else if (!child) {
+            this.processStartMarker = undefined;
+            this.processOwnershipToken = undefined;
+            this.processExited = false;
+            this.terminationUnconfirmed = false;
+            this.requireConfirmedTermination = false;
+        } else if (terminationError) {
+            if (requireConfirmedTermination) {
+                this.terminationUnconfirmed = true;
+            } else if (this.process === child) {
+                this.process = null;
+                this.processStartMarker = undefined;
+                this.processOwnershipToken = undefined;
+                this.processExited = false;
+                this.terminationUnconfirmed = false;
+                this.requireConfirmedTermination = false;
+            }
+        }
+
+        const teardownError = terminationError ?? stdinError;
+        if (teardownError) {
+            logger.debug('[CodexAppServer] Error while stopping process', teardownError);
+            throw teardownError;
         }
 
         logger.debug('[CodexAppServer] Disconnected');
@@ -541,7 +780,7 @@ export class CodexAppServerClient extends JsonLineParser {
 
         const abandonUnconfirmedDispatch = (error: Error) => {
             const child = this.process;
-            this.process = null;
+            const disconnecting = this.startDisconnect(undefined, true);
             this.connected = false;
             this.initialized = false;
             try {
@@ -552,6 +791,9 @@ export class CodexAppServerClient extends JsonLineParser {
             this.rejectAllPending(error);
             this.resetParserState();
             this.transportAbandonedHandler?.();
+            void disconnecting.catch((disconnectError) => {
+                logger.debug('[CodexAppServer] Error terminating abandoned transport', disconnectError);
+            });
         };
 
         const failRequest = (error: Error, abandon = false) => {

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -2,12 +2,30 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MessageQueue2 } from '@/utils/MessageQueue2';
 import type { EnhancedMode } from './loop';
 
+type MockAppServerClientState = {
+    connectCalls: number;
+    connected: boolean;
+    connectImplementation: (() => Promise<void>) | null;
+    disconnectCalls: number;
+    disconnectImplementation: (() => Promise<void>) | null;
+    interruptImplementation: (() => Promise<void>) | null;
+    initializeImplementation: (() => Promise<void>) | null;
+    rollbackImplementation: (() => Promise<void>) | null;
+    isConnectedError: Error | null;
+    lifecycleGeneration: number;
+};
+
 const harness = vi.hoisted(() => ({
+    appServerClients: [] as MockAppServerClientState[],
+    happyServerStopCalls: 0,
     notifications: [] as Array<{ method: string; params: unknown }>,
     dispatchNotification: null as ((method: string, params: unknown) => void) | null,
     registerRequestCalls: [] as string[],
     requestHandlers: new Map<string, (params: unknown) => Promise<unknown> | unknown>(),
     initializeCalls: [] as unknown[],
+    initializeImplementations: [] as Array<(() => Promise<void>) | null>,
+    supportsMethodCalls: [] as string[],
+    supportsMethodImplementation: null as ((method: string) => Promise<boolean>) | null,
     setFeatureEnablementCalls: [] as unknown[],
     failSetFeatureEnablement: false,
     listCollaborationModeCalls: 0,
@@ -52,6 +70,7 @@ const harness = vi.hoisted(() => ({
     safetyBufferingFasterModel: null as string | null,
     emitModelSafetyNotices: false,
     startTurnMessages: [] as string[],
+    forkThreadParams: [] as Array<Record<string, unknown>>,
     failResumeThreadIds: [] as string[],
     nextThreadSystemErrorMessage: null as string | null,
     failNextCompact: false,
@@ -100,20 +119,55 @@ vi.mock('./codexAppServerClient', () => {
     class MockCodexAppServerClient {
         private notificationHandler: ((method: string, params: unknown) => void) | null = null;
         private stderrHandler: ((text: string) => void) | null = null;
+        private readonly state: MockAppServerClientState;
 
-        async connect(): Promise<void> {}
+        constructor() {
+            const clientIndex = harness.appServerClients.length;
+            this.state = {
+                connectCalls: 0,
+                connected: false,
+                connectImplementation: null,
+                disconnectCalls: 0,
+                disconnectImplementation: null,
+                interruptImplementation: null,
+                initializeImplementation: harness.initializeImplementations[clientIndex] ?? null,
+                rollbackImplementation: null,
+                isConnectedError: null,
+                lifecycleGeneration: 0
+            };
+            harness.appServerClients.push(this.state);
+        }
+
+        async connect(): Promise<void> {
+            const lifecycleGeneration = this.state.lifecycleGeneration;
+            this.state.connectCalls += 1;
+            await this.state.connectImplementation?.();
+            if (lifecycleGeneration !== this.state.lifecycleGeneration) {
+                throw new Error('Codex app-server connection was superseded by disconnect');
+            }
+            this.state.connected = true;
+        }
 
         isConnected(): boolean {
-            return true;
+            if (this.state.isConnectedError) {
+                throw this.state.isConnectedError;
+            }
+            return this.state.connected;
         }
 
         isInitialized(): boolean {
-            return true;
+            return this.state.connected;
         }
 
         async initialize(params: unknown): Promise<{ protocolVersion: number }> {
             harness.initializeCalls.push(params);
+            await this.state.initializeImplementation?.();
             return { protocolVersion: 1 };
+        }
+
+        async supportsMethod(method: string): Promise<boolean> {
+            harness.supportsMethodCalls.push(method);
+            return await (harness.supportsMethodImplementation?.(method) ?? Promise.resolve(true));
         }
 
         setNotificationHandler(handler: ((method: string, params: unknown) => void) | null): void {
@@ -168,6 +222,11 @@ vi.mock('./codexAppServerClient', () => {
                 throw new Error('resume failed');
             }
             return { thread: { id }, model: 'gpt-5.4' };
+        }
+
+        async forkThread(params?: Record<string, unknown>): Promise<{ thread: { id: string }; model: string }> {
+            harness.forkThreadParams.push(params ?? {});
+            return { thread: { id: 'forked-thread' }, model: 'gpt-5.4' };
         }
 
         async compactThread(params?: { threadId?: string }): Promise<Record<string, never>> {
@@ -1042,6 +1101,7 @@ vi.mock('./codexAppServerClient', () => {
             const threadId = params?.threadId ?? 'thread-unknown';
             const turnId = params?.turnId ?? 'turn-unknown';
             harness.interruptedTurns.push({ threadId, turnId });
+            await this.state.interruptImplementation?.();
             const error = harness.interruptErrors.shift();
             if (error) {
                 throw error;
@@ -1062,6 +1122,7 @@ vi.mock('./codexAppServerClient', () => {
         async rollbackThread(params?: { threadId?: string; numTurns?: number }): Promise<{ thread: { id: string } }> {
             const threadId = params?.threadId ?? 'thread-unknown';
             harness.rollbackCalls.push({ threadId, numTurns: params?.numTurns ?? 0 });
+            await this.state.rollbackImplementation?.();
             const error = harness.rollbackErrors.shift();
             if (error) {
                 throw error;
@@ -1069,7 +1130,12 @@ vi.mock('./codexAppServerClient', () => {
             return { thread: { id: threadId } };
         }
 
-        async disconnect(): Promise<void> {}
+        async disconnect(): Promise<void> {
+            this.state.lifecycleGeneration += 1;
+            this.state.disconnectCalls += 1;
+            this.state.connected = false;
+            await this.state.disconnectImplementation?.();
+        }
     }
 
     return {
@@ -1086,16 +1152,42 @@ vi.mock('./utils/buildHapiMcpBridge', () => ({
         harness.bridgeOptions.push(options);
         return {
         server: {
-            stop: () => {}
+            stop: () => {
+                harness.happyServerStopCalls += 1;
+            }
         },
         mcpServers: {}
         };
     }
 }));
 
-import { codexRemoteLauncher, isCurrentSteerHandler } from './codexRemoteLauncher';
+import {
+    codexRemoteLauncher,
+    isCurrentSteerHandler,
+    waitForSourceLeaseAcquisition
+} from './codexRemoteLauncher';
 import { INDETERMINATE_SYMBOL } from './codexAppServerClient';
+import { CodexConversationHistory } from './conversationHistory';
+import { logger } from '@/ui/logger';
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
+
+function createDeferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+function getSourceClientState(): MockAppServerClientState {
+    const state = harness.appServerClients[0];
+    if (!state) {
+        throw new Error('Expected the source Codex app-server client to exist');
+    }
+    return state;
+}
 
 type FakeAgentState = {
     requests: Record<string, unknown>;
@@ -1245,7 +1337,490 @@ function createSessionStub(
     };
 }
 
+async function finishActiveLauncher(
+    session: ReturnType<typeof createSessionStub>['session'],
+    running: Promise<'switch' | 'exit'>
+): Promise<void> {
+    harness.dispatchNotification?.('turn/completed', {
+        status: 'Completed',
+        turn: { id: 'turn-1' }
+    });
+    session.queue.close();
+    await expect(running).resolves.toBe('exit');
+}
+
+describe('waitForSourceLeaseAcquisition', () => {
+    it('aborts a signaled waiter without delaying an earlier no-signal waiter', async () => {
+        const acquisition = createDeferred<void>();
+        const abortController = new AbortController();
+        const noSignalWaiter = waitForSourceLeaseAcquisition(acquisition.promise);
+        const signaledWaiter = waitForSourceLeaseAcquisition(
+            acquisition.promise,
+            abortController.signal
+        );
+
+        abortController.abort(new Error('waiter aborted'));
+
+        await expect(signaledWaiter).rejects.toThrow('waiter aborted');
+        let noSignalSettled = false;
+        void noSignalWaiter.finally(() => {
+            noSignalSettled = true;
+        });
+        await Promise.resolve();
+        expect(noSignalSettled).toBe(false);
+
+        acquisition.resolve();
+        await expect(noSignalWaiter).resolves.toBeUndefined();
+    });
+
+    it('does not cross-cancel a no-signal waiter when an earlier signaled waiter aborts', async () => {
+        const acquisition = createDeferred<void>();
+        const abortController = new AbortController();
+        const signaledWaiter = waitForSourceLeaseAcquisition(
+            acquisition.promise,
+            abortController.signal
+        );
+        const noSignalWaiter = waitForSourceLeaseAcquisition(acquisition.promise);
+
+        abortController.abort(new Error('waiter aborted'));
+
+        await expect(signaledWaiter).rejects.toThrow('waiter aborted');
+        acquisition.resolve();
+        await expect(noSignalWaiter).resolves.toBeUndefined();
+    });
+});
+
 describe('codexRemoteLauncher', () => {
+    it('keeps history mutations blocked until the source capability probe settles', async () => {
+        const probeGate = createDeferred<boolean>();
+        harness.supportsMethodImplementation = () => probeGate.promise;
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => expect(harness.supportsMethodCalls).toEqual(['thread/fork']));
+        await vi.waitFor(() => expect(harness.startTurnMessages).toEqual(['first']));
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        await expect(
+            rpcHandlers.get(RPC_METHODS.ForkConversation)!({})
+        ).rejects.toThrow('Session is busy');
+        expect(harness.appServerClients).toHaveLength(1);
+
+        probeGate.resolve(true);
+        await vi.waitFor(() => expect(harness.supportsMethodCalls).toEqual([
+            'thread/fork',
+            'thread/rollback'
+        ]));
+        await expect(
+            rpcHandlers.get(RPC_METHODS.ForkConversation)!({})
+        ).resolves.toEqual({ nativeSessionId: 'forked-thread' });
+        expect(harness.appServerClients).toHaveLength(2);
+
+        session.queue.close();
+        await expect(running).resolves.toBe('exit');
+    });
+
+    it('waits for temporary fork initialization and cleanup before starting queued source work', async () => {
+        const initializeGate = createDeferred<void>();
+        const disconnectGate = createDeferred<void>();
+        harness.initializeImplementations = [null, () => initializeGate.promise];
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => expect(harness.startTurnMessages).toEqual(['first']));
+
+        const fork = Promise.resolve(rpcHandlers.get(RPC_METHODS.ForkConversation)!({}));
+        await vi.waitFor(() => expect(harness.appServerClients).toHaveLength(2));
+        const temporaryClient = harness.appServerClients[1]!;
+        temporaryClient.disconnectImplementation = () => disconnectGate.promise;
+
+        session.queue.push('second', createMode());
+        await vi.waitFor(() => expect(session.queue.size()).toBe(0));
+        expect(harness.startTurnMessages).toEqual(['first']);
+
+        initializeGate.resolve();
+        await vi.waitFor(() => expect(temporaryClient.disconnectCalls).toBe(1));
+        expect(harness.startTurnMessages).toEqual(['first']);
+
+        disconnectGate.resolve();
+        await expect(fork).resolves.toEqual({ nativeSessionId: 'forked-thread' });
+        await vi.waitFor(() => expect(harness.startTurnMessages).toEqual(['first', 'second']));
+        session.queue.close();
+        await expect(running).resolves.toBe('exit');
+    });
+
+    it('waits for temporary fork cleanup before compacting the source thread', async () => {
+        const initializeGate = createDeferred<void>();
+        const disconnectGate = createDeferred<void>();
+        harness.initializeImplementations = [null, () => initializeGate.promise];
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => expect(harness.startTurnMessages).toEqual(['first']));
+
+        const fork = Promise.resolve(rpcHandlers.get(RPC_METHODS.ForkConversation)!({}));
+        await vi.waitFor(() => expect(harness.appServerClients).toHaveLength(2));
+        const temporaryClient = harness.appServerClients[1]!;
+        temporaryClient.disconnectImplementation = () => disconnectGate.promise;
+
+        session.queue.push('/compact', createMode());
+        await vi.waitFor(() => expect(session.queue.size()).toBe(0));
+        expect(harness.compactThreadIds).toEqual([]);
+
+        initializeGate.resolve();
+        await vi.waitFor(() => expect(temporaryClient.disconnectCalls).toBe(1));
+        expect(harness.compactThreadIds).toEqual([]);
+
+        disconnectGate.resolve();
+        await expect(fork).resolves.toEqual({ nativeSessionId: 'forked-thread' });
+        await vi.waitFor(() => expect(harness.compactThreadIds).toEqual(['thread-1']));
+        session.queue.close();
+        await expect(running).resolves.toBe('exit');
+    });
+
+    it('keeps the source lease while an active turn is interrupted for compaction', async () => {
+        harness.suppressTurnCompletion = true;
+        harness.deferCompactCompletion = true;
+        const { session, rpcHandlers } = createSessionStub(
+            ['first', '/compact'],
+            createMode(),
+            true
+        );
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => expect(harness.compactThreadIds).toEqual(['thread-1']));
+
+        await expect(
+            rpcHandlers.get(RPC_METHODS.ForkConversation)!({})
+        ).rejects.toThrow('Session is busy');
+        expect(harness.appServerClients).toHaveLength(1);
+
+        harness.dispatchNotification?.('item/completed', {
+            threadId: 'thread-1',
+            turnId: 'compact-1',
+            item: { id: 'compact-item-1', type: 'contextCompaction' }
+        });
+        harness.dispatchNotification?.('turn/completed', {
+            threadId: 'thread-1',
+            turn: { id: 'compact-1', status: 'completed' }
+        });
+        await expect(running).resolves.toBe('exit');
+    });
+
+    it('keeps the source lease until an abort interrupt request settles', async () => {
+        harness.suppressTurnCompletion = true;
+        const interruptGate = createDeferred<void>();
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        const sourceClient = getSourceClientState();
+        await vi.waitFor(() => expect(harness.startTurnThreadIds).toEqual(['thread-1']));
+        sourceClient.interruptImplementation = () => interruptGate.promise;
+
+        const abort = Promise.resolve(rpcHandlers.get('abort')!({}));
+        await vi.waitFor(() => expect(harness.interruptedTurns).toEqual([
+            { threadId: 'thread-1', turnId: 'turn-1' }
+        ]));
+        harness.dispatchNotification?.('turn/completed', {
+            threadId: 'thread-1',
+            turnId: 'turn-1',
+            turn: { id: 'turn-1', status: 'interrupted' }
+        });
+
+        await expect(
+            rpcHandlers.get(RPC_METHODS.ForkConversation)!({})
+        ).rejects.toThrow('Session is busy');
+        expect(harness.appServerClients).toHaveLength(1);
+
+        interruptGate.resolve();
+        await abort;
+        session.queue.close();
+        await expect(running).resolves.toBe('exit');
+    });
+
+    it('retries retained fork cleanup before starting queued source work', async () => {
+        const initializeGate = createDeferred<void>();
+        const retryCleanupGate = createDeferred<void>();
+        const cleanupError = new Error('temporary app-server teardown failed');
+        harness.initializeImplementations = [null, () => initializeGate.promise];
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => expect(harness.startTurnMessages).toEqual(['first']));
+
+        const fork = Promise.resolve(rpcHandlers.get(RPC_METHODS.ForkConversation)!({}));
+        await vi.waitFor(() => expect(harness.appServerClients).toHaveLength(2));
+        const temporaryClient = harness.appServerClients[1]!;
+        temporaryClient.disconnectImplementation = async () => {
+            if (temporaryClient.disconnectCalls === 1) throw cleanupError;
+            await retryCleanupGate.promise;
+        };
+        initializeGate.resolve();
+        await expect(fork).rejects.toBe(cleanupError);
+
+        session.queue.push('second', createMode());
+        await vi.waitFor(() => expect(session.queue.size()).toBe(0));
+        await vi.waitFor(() => expect(temporaryClient.disconnectCalls).toBe(2));
+        expect(harness.startTurnMessages).toEqual(['first']);
+
+        retryCleanupGate.resolve();
+        await vi.waitFor(() => expect(harness.startTurnMessages).toEqual(['first', 'second']));
+        session.queue.close();
+        await expect(running).resolves.toBe('exit');
+    });
+
+    it('does not start queued source work when aborted during retained fork cleanup', async () => {
+        const initializeGate = createDeferred<void>();
+        const retryCleanupGate = createDeferred<void>();
+        const cleanupError = new Error('temporary app-server teardown failed');
+        harness.initializeImplementations = [null, () => initializeGate.promise];
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => expect(harness.startTurnMessages).toEqual(['first']));
+
+        const fork = Promise.resolve(rpcHandlers.get(RPC_METHODS.ForkConversation)!({}));
+        await vi.waitFor(() => expect(harness.appServerClients).toHaveLength(2));
+        const temporaryClient = harness.appServerClients[1]!;
+        temporaryClient.disconnectImplementation = async () => {
+            if (temporaryClient.disconnectCalls === 1) throw cleanupError;
+            await retryCleanupGate.promise;
+        };
+        initializeGate.resolve();
+        await expect(fork).rejects.toBe(cleanupError);
+
+        session.queue.push('second', createMode());
+        await vi.waitFor(() => expect(session.queue.size()).toBe(0));
+        await vi.waitFor(() => expect(temporaryClient.disconnectCalls).toBe(2));
+
+        await rpcHandlers.get('abort')?.({});
+        retryCleanupGate.resolve();
+        session.queue.close();
+        await expect(running).resolves.toBe('exit');
+
+        expect(harness.startTurnMessages).toEqual(['first']);
+    });
+
+    it('waits for a temporary fork before reconnecting to reconcile an indeterminate steer', async () => {
+        harness.suppressTurnCompletion = true;
+        const initializeGate = createDeferred<void>();
+        harness.initializeImplementations = [null, () => initializeGate.promise];
+        const indeterminate = new Error('Codex app-server disconnected');
+        Object.defineProperty(indeterminate, INDETERMINATE_SYMBOL, { value: true });
+        harness.steerCompletionError = indeterminate;
+        harness.readThreadError = new Error('thread temporarily unreadable');
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        const sourceClient = getSourceClientState();
+        await vi.waitFor(() => expect(harness.startTurnThreadIds).toEqual(['thread-1']));
+
+        session.queue.push('steer me', createMode(), 'local-1');
+        await expect(rpcHandlers.get(RPC_METHODS.SteerQueuedMessage)!({ localId: 'local-1' })).resolves.toEqual({
+            steered: false,
+            error: 'Steer outcome is being reconciled'
+        });
+        harness.dispatchNotification?.('turn/completed', {
+            threadId: 'thread-1',
+            turnId: 'turn-1',
+            turn: { id: 'turn-1', status: 'completed' }
+        });
+        await vi.waitFor(() => expect(harness.readThreadParams).toHaveLength(1), { timeout: 5_000 });
+
+        const fork = Promise.resolve(rpcHandlers.get(RPC_METHODS.ForkConversation)!({}));
+        await vi.waitFor(() => expect(harness.appServerClients).toHaveLength(2));
+        harness.readThreadError = null;
+        harness.readThreadResponse = {
+            thread: {
+                turns: [{
+                    items: [{ type: 'userMessage', clientId: 'local-1', text: 'steer me' }]
+                }]
+            }
+        };
+        sourceClient.connected = false;
+
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+        expect(sourceClient.connectCalls).toBe(1);
+        expect(harness.readThreadParams).toHaveLength(1);
+
+        initializeGate.resolve();
+        await expect(fork).resolves.toEqual({ nativeSessionId: 'forked-thread' });
+        await vi.waitFor(() => {
+            expect(sourceClient.connectCalls).toBe(2);
+            expect(harness.readThreadParams).toHaveLength(2);
+        }, { timeout: 5_000 });
+
+        session.queue.close();
+        await expect(running).resolves.toBe('exit');
+    }, 10_000);
+
+    it('starts history cleanup and source disconnect before awaiting either', async () => {
+        const historyGate = createDeferred<void>();
+        const disconnectGate = createDeferred<void>();
+        const originalHistoryCleanup = CodexConversationHistory.prototype.cleanup;
+        const historyCleanupStarted = vi.fn();
+        vi.spyOn(CodexConversationHistory.prototype, 'cleanup').mockImplementation(async function (this: CodexConversationHistory) {
+            historyCleanupStarted();
+            await originalHistoryCleanup.call(this);
+            await historyGate.promise;
+        });
+        const { session } = createSessionStub();
+        const running = codexRemoteLauncher(session as never);
+        const sourceClient = getSourceClientState();
+        sourceClient.disconnectImplementation = () => disconnectGate.promise;
+        let settled = false;
+        void running.then(() => {
+            settled = true;
+        }, () => {
+            settled = true;
+        });
+
+        await vi.waitFor(() => {
+            expect(historyCleanupStarted).toHaveBeenCalledOnce();
+            expect(sourceClient.disconnectCalls).toBe(1);
+        });
+        expect(settled).toBe(false);
+
+        historyGate.resolve();
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        disconnectGate.resolve();
+        await expect(running).resolves.toBe('exit');
+    });
+
+    it('disconnects the source before awaiting pending reconciliation on a normal switch exit', async () => {
+        harness.suppressTurnCompletion = true;
+        const indeterminate = new Error('Codex app-server disconnected');
+        Object.defineProperty(indeterminate, INDETERMINATE_SYMBOL, { value: true });
+        harness.steerCompletionError = indeterminate;
+        const reconnectGate = createDeferred<void>();
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        const sourceClient = getSourceClientState();
+        await vi.waitFor(() => expect(harness.startTurnThreadIds).toEqual(['thread-1']));
+
+        session.queue.push('steer me', createMode(), 'local-1');
+        const steerHandler = rpcHandlers.get(RPC_METHODS.SteerQueuedMessage)!;
+        await expect(steerHandler({ localId: 'local-1' })).resolves.toEqual({
+            steered: false,
+            error: 'Steer outcome is being reconciled'
+        });
+
+        sourceClient.connected = false;
+        sourceClient.connectImplementation = () => reconnectGate.promise;
+        await vi.waitFor(() => expect(sourceClient.connectCalls).toBe(2), { timeout: 5_000 });
+
+        const switchRequest = Promise.resolve(rpcHandlers.get(RPC_METHODS.Switch)!({}));
+        try {
+            await vi.waitFor(() => expect(sourceClient.disconnectCalls).toBe(1), { timeout: 250 });
+        } finally {
+            reconnectGate.resolve();
+            await switchRequest;
+            await running;
+        }
+
+        expect(sourceClient.connected).toBe(false);
+    }, 10_000);
+
+    it('stops reconciliation before a deliberate switch awaits interrupt', async () => {
+        harness.suppressTurnCompletion = true;
+        const indeterminate = new Error('Codex app-server disconnected');
+        Object.defineProperty(indeterminate, INDETERMINATE_SYMBOL, { value: true });
+        harness.steerCompletionError = indeterminate;
+        const interruptGate = createDeferred<void>();
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        const sourceClient = getSourceClientState();
+        await vi.waitFor(() => expect(harness.startTurnThreadIds).toEqual(['thread-1']));
+
+        vi.useFakeTimers();
+        session.queue.push('steer me', createMode(), 'local-1');
+        const steerHandler = rpcHandlers.get(RPC_METHODS.SteerQueuedMessage)!;
+        await expect(steerHandler({ localId: 'local-1' })).resolves.toEqual({
+            steered: false,
+            error: 'Steer outcome is being reconciled'
+        });
+        sourceClient.connected = false;
+        sourceClient.interruptImplementation = () => interruptGate.promise;
+
+        const switchRequest = Promise.resolve(rpcHandlers.get(RPC_METHODS.Switch)!({}));
+        try {
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(harness.interruptedTurns).toEqual([{ threadId: 'thread-1', turnId: 'turn-1' }]);
+            await vi.advanceTimersByTimeAsync(1_100);
+            expect(sourceClient.connectCalls).toBe(1);
+        } finally {
+            interruptGate.resolve();
+            await switchRequest;
+            vi.useRealTimers();
+            await running;
+        }
+    });
+
+    it('stops and awaits in-flight steer reconciliation after an abnormal main-loop exit', async () => {
+        harness.suppressTurnCompletion = true;
+        const indeterminate = new Error('Codex app-server disconnected');
+        Object.defineProperty(indeterminate, INDETERMINATE_SYMBOL, { value: true });
+        harness.steerCompletionError = indeterminate;
+        const reconnectGate = createDeferred<void>();
+        const { session, rpcHandlers } = createSessionStub(['first'], createMode(), false, false);
+        const running = codexRemoteLauncher(session as never);
+        const sourceClient = getSourceClientState();
+        let settled = false;
+        void running.then(() => {
+            settled = true;
+        }, () => {
+            settled = true;
+        });
+        await vi.waitFor(() => expect(harness.startTurnThreadIds).toEqual(['thread-1']));
+
+        session.queue.push('steer me', createMode(), 'local-1');
+        const handler = rpcHandlers.get(RPC_METHODS.SteerQueuedMessage)!;
+        await expect(handler({ localId: 'local-1' })).resolves.toEqual({
+            steered: false,
+            error: 'Steer outcome is being reconciled'
+        });
+
+        sourceClient.connected = false;
+        sourceClient.connectImplementation = () => reconnectGate.promise;
+        await vi.waitFor(() => expect(sourceClient.connectCalls).toBe(2), { timeout: 5_000 });
+
+        sourceClient.isConnectedError = new Error('main loop failed');
+        harness.dispatchNotification?.('turn/completed', {
+            status: 'Completed',
+            turn: { id: 'turn-1' }
+        });
+
+        await vi.waitFor(() => {
+            expect(sourceClient.disconnectCalls).toBe(1);
+        });
+        expect(settled).toBe(false);
+
+        reconnectGate.resolve();
+        await expect(running).rejects.toThrow('main loop failed');
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+        expect(sourceClient.connectCalls).toBe(2);
+        expect(sourceClient.connected).toBe(false);
+    }, 10_000);
+
+    it('logs cleanup failures and continues cleaning later resources', async () => {
+        const historyError = new Error('history cleanup failed');
+        const disconnectError = new Error('source disconnect failed');
+        vi.spyOn(CodexConversationHistory.prototype, 'cleanup').mockRejectedValue(historyError);
+        const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+        const { session } = createSessionStub();
+        const running = codexRemoteLauncher(session as never);
+        getSourceClientState().disconnectImplementation = async () => {
+            throw disconnectError;
+        };
+
+        await expect(running).resolves.toBe('exit');
+
+        expect(debugSpy).toHaveBeenCalledWith(
+            '[codex-remote]: Error disconnecting fork client',
+            historyError
+        );
+        expect(debugSpy).toHaveBeenCalledWith(
+            '[codex-remote]: Error disconnecting client',
+            disconnectError
+        );
+        expect(harness.happyServerStopCalls).toBe(1);
+    });
+
     it('invalidates queued steer handlers after abort or cleanup', () => {
         expect(isCurrentSteerHandler(3, 3, false)).toBe(true);
         expect(isCurrentSteerHandler(4, 3, false)).toBe(false);
@@ -1269,9 +1844,7 @@ describe('codexRemoteLauncher', () => {
             clientUserMessageId: 'local-1'
         });
         await vi.waitFor(() => expect(emitMessagesConsumed).toHaveBeenCalledWith(['local-1'], { steered: true }));
-        // The suppressed turn never completes, so the launcher stays busy;
-        // close the queue and leave the run promise unawaited.
-        session.queue.close();
+        await finishActiveLauncher(session, runPromise);
     });
 
     it('restores the row when the app-server explicitly rejects after dispatch', async () => {
@@ -1292,7 +1865,7 @@ describe('codexRemoteLauncher', () => {
         expect(result).toEqual({ steered: false, error: 'turn/steer not allowed here' });
         await vi.waitFor(() => expect(session.queue.cancelByLocalId('local-1')).toBe(true));
         expect(emitMessagesConsumed).not.toHaveBeenCalledWith(['local-1'], { steered: true });
-        session.queue.close();
+        await finishActiveLauncher(session, runPromise);
     });
 
     it('holds an indeterminate steer for explicit retry or cancel', async () => {
@@ -1317,7 +1890,7 @@ describe('codexRemoteLauncher', () => {
         expect(emitSteerIndeterminate).toHaveBeenCalledWith(['local-1']);
         expect(session.queue.cancelByLocalId('local-1')).toBe(true);
         expect(emitMessagesConsumed).not.toHaveBeenCalledWith(['local-1'], { steered: true });
-        session.queue.close();
+        await finishActiveLauncher(session, runPromise);
     });
 
     it('reconciles an indeterminate steer to accepted once the thread shows the message', async () => {
@@ -1347,7 +1920,7 @@ describe('codexRemoteLauncher', () => {
         await vi.waitFor(() => expect(emitMessagesConsumed).toHaveBeenCalledWith(['local-1'], { steered: true }), { timeout: 5_000 });
         // Row committed and consumed — the tombstone blocks a stale retry.
         expect(session.queue.cancelByLocalId('local-1')).toBe('consumed');
-        session.queue.close();
+        await finishActiveLauncher(session, runPromise);
     });
 
     it('reconciles when stdin dispatch fails indeterminately', async () => {
@@ -1368,7 +1941,7 @@ describe('codexRemoteLauncher', () => {
         expect(emitSteerIndeterminate).toHaveBeenCalledWith(['local-1']);
         expect(session.queue.cancelByLocalId('local-1')).toBe(true);
         expect(emitMessagesConsumed).not.toHaveBeenCalledWith(['local-1'], { steered: true });
-        session.queue.close();
+        await finishActiveLauncher(session, runPromise);
     });
 
     it('restores the queued row when stdin dispatch fails', async () => {
@@ -1385,14 +1958,21 @@ describe('codexRemoteLauncher', () => {
         expect(result).toEqual({ steered: false, error: 'stdin closed' });
         await vi.waitFor(() => expect(session.queue.cancelByLocalId('local-1')).toBe(true));
         expect(emitMessagesConsumed).not.toHaveBeenCalledWith(['local-1'], { steered: true });
-        session.queue.close();
+        await finishActiveLauncher(session, runPromise);
     });
     afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        harness.appServerClients = [];
+        harness.happyServerStopCalls = 0;
         harness.notifications = [];
         harness.dispatchNotification = null;
         harness.registerRequestCalls = [];
         harness.requestHandlers = new Map();
         harness.initializeCalls = [];
+        harness.initializeImplementations = [];
+        harness.supportsMethodCalls = [];
+        harness.supportsMethodImplementation = null;
         harness.setFeatureEnablementCalls = [];
         harness.failSetFeatureEnablement = false;
         harness.listCollaborationModeCalls = 0;
@@ -1436,6 +2016,7 @@ describe('codexRemoteLauncher', () => {
         harness.safetyBufferingFasterModel = null;
         harness.emitModelSafetyNotices = false;
         harness.startTurnMessages = [];
+        harness.forkThreadParams = [];
         harness.failResumeThreadIds = [];
         harness.remainingThreadSystemErrors = 0;
         harness.nextThreadSystemErrorMessage = null;
@@ -2187,6 +2768,47 @@ describe('codexRemoteLauncher', () => {
         expect(getModelReasoningEffort()).toBe('low');
     });
 
+    it('keeps the source lease while a safety-buffered turn rolls back after its terminal event', async () => {
+        harness.emitSafetyBuffering = true;
+        harness.safetyBufferingFasterModel = 'gpt-5.4-mini';
+        harness.emitTurnAbortedOnInterrupt = true;
+        const rollbackGate = createDeferred<void>();
+        const { session, rpcHandlers, getAgentState } = createSessionStub(['first message']);
+        const running = codexRemoteLauncher(session as never);
+        const sourceClient = getSourceClientState();
+        sourceClient.rollbackImplementation = () => rollbackGate.promise;
+
+        await vi.waitFor(() => {
+            expect(Object.values(getAgentState().requests)).toContainEqual(expect.objectContaining({
+                tool: 'request_user_input'
+            }));
+        });
+        const requestId = Object.keys(getAgentState().requests)[0];
+        const permissionResponse = Promise.resolve(rpcHandlers.get('permission')?.({
+            id: requestId,
+            approved: true,
+            answers: {
+                safety_buffering_action: {
+                    answers: ['Retry with a faster model']
+                }
+            }
+        }));
+
+        await vi.waitFor(() => expect(harness.rollbackCalls).toEqual([
+            { threadId: 'thread-1', numTurns: 1 }
+        ]));
+        try {
+            await expect(
+                rpcHandlers.get(RPC_METHODS.ForkConversation)!({})
+            ).rejects.toThrow('Session is busy');
+            expect(harness.appServerClients).toHaveLength(1);
+        } finally {
+            rollbackGate.resolve();
+            await permissionResponse;
+            await running;
+        }
+    });
+
     it('keeps the original safety-buffered turn running when the user dismisses the retry', async () => {
         harness.emitSafetyBuffering = true;
         harness.safetyBufferingFasterModel = 'gpt-5.4-mini';
@@ -2498,6 +3120,27 @@ describe('codexRemoteLauncher', () => {
             message: "Task failed: Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying."
         });
         expect(session.thinking).toBe(false);
+    });
+
+    it('keeps the source lease until automatic compact recovery completes', async () => {
+        harness.remainingThreadSystemErrors = 1;
+        harness.deferCompactCompletion = true;
+        harness.nextThreadSystemErrorMessage = "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.";
+        const { session, rpcHandlers } = createSessionStub(['first message']);
+        const running = codexRemoteLauncher(session as never);
+        await vi.waitFor(() => expect(harness.compactThreadIds).toEqual(['thread-1']));
+
+        await expect(
+            rpcHandlers.get(RPC_METHODS.ForkConversation)!({})
+        ).rejects.toThrow('Session is busy');
+        expect(harness.appServerClients).toHaveLength(1);
+
+        harness.dispatchNotification?.('thread/compacted', {
+            threadId: 'thread-1',
+            turnId: 'compact-1'
+        });
+        await expect(running).resolves.toBe('exit');
+        expect(harness.startTurnMessages).toEqual(['first message', 'first message']);
     });
 
     it('does not create a new thread when same-conversation compact fails', async () => {

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -221,6 +221,29 @@ export function isCurrentSteerHandler(
     return currentEpoch === handlerEpoch && !shouldExit;
 }
 
+export async function waitForSourceLeaseAcquisition(
+    acquisition: Promise<void>,
+    signal?: AbortSignal
+): Promise<void> {
+    if (!signal) {
+        await acquisition;
+        return;
+    }
+    if (signal.aborted) throw signal.reason;
+
+    let onAbort!: () => void;
+    const aborted = new Promise<never>((_, reject) => {
+        onAbort = () => reject(signal.reason);
+        signal.addEventListener('abort', onAbort, { once: true });
+    });
+    try {
+        await Promise.race([acquisition, aborted]);
+    } finally {
+        signal.removeEventListener('abort', onAbort);
+    }
+    if (signal.aborted) throw signal.reason;
+}
+
 class CodexRemoteLauncher extends RemoteLauncherBase {
     private readonly session: CodexSession;
     private readonly appServerClient: CodexAppServerClient;
@@ -236,6 +259,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
     private currentTurnId: string | null = null;
     private readonly activeChildTurns = new Map<string, string>();
     readonly conversationHistory = new CodexConversationHistory(() => this.appServerClient);
+    private releaseConversationHistorySourceLease: (() => void) | null = null;
+    private beginConversationHistorySourceOperation: (() => Promise<() => void>) | null = null;
+    private stopSteerReconciliation: () => Promise<void> = async () => {};
 
     constructor(session: CodexSession) {
         super(process.env.DEBUG ? session.logPath : undefined);
@@ -291,7 +317,11 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         this.abortInProgress = true;
         this.steerEpoch++;
         logger.debug('[Codex] Abort requested - stopping current task');
+        let releaseSourceOperation: (() => void) | null = null;
         try {
+            if ((this.currentThreadId && this.currentTurnId) || this.activeChildTurns.size > 0) {
+                releaseSourceOperation = await this.beginConversationHistorySourceOperation?.() ?? null;
+            }
             await this.interruptActiveTurns('abort');
             this.currentTurnId = null;
 
@@ -306,6 +336,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         } catch (error) {
             logger.debug('[Codex] Error during abort:', error);
         } finally {
+            releaseSourceOperation?.();
             this.abortController = new AbortController();
             this.abortInProgress = false;
         }
@@ -315,6 +346,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         logger.debug('[codex-remote]: Exiting agent via Ctrl-C');
         this.exitReason = 'exit';
         this.shouldExit = true;
+        void this.stopSteerReconciliation();
         await this.handleAbort();
     }
 
@@ -322,12 +354,14 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         logger.debug('[codex-remote]: Switching to local mode via double space');
         this.exitReason = 'switch';
         this.shouldExit = true;
+        void this.stopSteerReconciliation();
         await this.handleAbort();
     }
 
     private async handleSwitchRequest(): Promise<void> {
         this.exitReason = 'switch';
         this.shouldExit = true;
+        void this.stopSteerReconciliation();
         await this.handleAbort();
     }
 
@@ -688,8 +722,73 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         let scheduleReadyAfterTurn: (() => void) | null = null;
         let clearReadyAfterTurnTimer: (() => void) | null = null;
         let turnInFlight = false;
+        let sourceOperationRefs = 0;
+        let turnOwnsSourceLease = false;
+        let sourceLeaseAcquisitionInFlight: Promise<void> | null = null;
+        const releaseSourceLease = () => {
+            const release = this.releaseConversationHistorySourceLease;
+            this.releaseConversationHistorySourceLease = null;
+            release?.();
+        };
+        const maybeReleaseSourceLease = () => {
+            if (sourceOperationRefs === 0 && !turnOwnsSourceLease) {
+                releaseSourceLease();
+            }
+        };
+        const ensureSourceLease = async (signal?: AbortSignal): Promise<void> => {
+            if (!this.releaseConversationHistorySourceLease) {
+                if (!sourceLeaseAcquisitionInFlight) {
+                    const acquisition = this.conversationHistory.acquireSourceLease().then((release) => {
+                        this.releaseConversationHistorySourceLease = release;
+                        maybeReleaseSourceLease();
+                    });
+                    sourceLeaseAcquisitionInFlight = acquisition;
+                    const clearAcquisition = () => {
+                        if (sourceLeaseAcquisitionInFlight === acquisition) {
+                            sourceLeaseAcquisitionInFlight = null;
+                        }
+                    };
+                    void acquisition.then(clearAcquisition, clearAcquisition);
+                }
+                await waitForSourceLeaseAcquisition(sourceLeaseAcquisitionInFlight, signal);
+            }
+            if (signal?.aborted) throw signal.reason;
+        };
+        const beginSourceOperation = async (signal?: AbortSignal): Promise<() => void> => {
+            sourceOperationRefs += 1;
+            let released = false;
+            const releaseOperation = () => {
+                if (released) return;
+                released = true;
+                sourceOperationRefs -= 1;
+                maybeReleaseSourceLease();
+            };
+            try {
+                await ensureSourceLease(signal);
+                return releaseOperation;
+            } catch (error) {
+                releaseOperation();
+                throw error;
+            }
+        };
+        const probeConversationHistoryCapabilities = (): void => {
+            void beginSourceOperation()
+                .then(async (releaseSourceOperation) => {
+                    try {
+                        await this.conversationHistory.probeCapabilities();
+                    } finally {
+                        releaseSourceOperation();
+                    }
+                })
+                .catch((error) => {
+                    logger.debug(`[Codex] Failed to probe conversation history capabilities: ${errorMessage(error)}`);
+                });
+        };
+        this.beginConversationHistorySourceOperation = () => beginSourceOperation();
         const setTurnInFlight = (value: boolean) => {
             turnInFlight = value;
+            turnOwnsSourceLease = value && this.releaseConversationHistorySourceLease !== null;
+            maybeReleaseSourceLease();
             session.client.updateAgentState((state) => ({ ...state, steeringActive: value }));
         };
         setTurnInFlight(false);
@@ -1875,6 +1974,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             threadId: string;
             message: QueuedMessage;
             timeout: ReturnType<typeof setTimeout> | null;
+            releaseSourceOperation: (() => void) | null;
         } | null = null;
         let manualCompact: {
             threadId: string;
@@ -1901,7 +2001,6 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             // The old process is gone; its foreground turn cannot deliver more
             // notifications. Let the loop recover on a fresh app-server.
             setTurnInFlight(false);
-            this.conversationHistory.setBusy(false);
             if (session.thinking) session.onThinkingChange(false);
             recoveryInFlight = false;
             activeMessage = null;
@@ -1940,6 +2039,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         }>();
         let steerReconcileTimer: ReturnType<typeof setTimeout> | null = null;
         let steerReconcileInProgress = false;
+        let steerReconcileInFlight: Promise<void> | null = null;
         let shuttingDown = false;
 
         const settleReconcileEntry = (localId: string, entry: { taken: QueueReservation<EnhancedMode>; batch: QueuedMessage }): void => {
@@ -1972,6 +2072,11 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 return;
             }
             steerReconcileInProgress = true;
+            let resolveInFlight!: () => void;
+            const inFlight = new Promise<void>((resolve) => {
+                resolveInFlight = resolve;
+            });
+            steerReconcileInFlight = inFlight;
             try {
                 for (const [localId, entry] of Array.from(pendingSteerReconciliations.entries())) {
                     if (pendingSteerReconciliations.get(localId) !== entry) continue;
@@ -2002,6 +2107,10 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     }, 1_000);
                     steerReconcileTimer.unref?.();
                 }
+                resolveInFlight();
+                if (steerReconcileInFlight === inFlight) {
+                    steerReconcileInFlight = null;
+                }
             }
         };
 
@@ -2017,6 +2126,16 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 void runSteerReconciliation();
             }, 1_000);
             steerReconcileTimer.unref?.();
+        };
+
+        this.stopSteerReconciliation = () => {
+            shuttingDown = true;
+            if (steerReconcileTimer) {
+                clearTimeout(steerReconcileTimer);
+                steerReconcileTimer = null;
+            }
+            pendingSteerReconciliations.clear();
+            return steerReconcileInFlight ?? Promise.resolve();
         };
 
         // thread/read auto-connects after a disconnect, but a freshly spawned
@@ -2043,7 +2162,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         // (client ids are not guaranteed durable), so anything unreadable or
         // unmatched stays 'unknown' and is retried.
         const reconcileSteerByClientId = async (threadId: string, localId: string): Promise<'accepted' | 'unknown'> => {
+            let releaseSourceOperation: (() => void) | null = null;
             try {
+                releaseSourceOperation = await beginSourceOperation();
                 await ensureAppServerInitialized();
                 const response = await appServerClient.readThread(
                     { threadId, includeTurns: true },
@@ -2065,6 +2186,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             } catch (error) {
                 logger.debug(`[Codex] steer reconcile unavailable (${error instanceof Error ? error.message : String(error)})`);
                 return 'unknown';
+            } finally {
+                releaseSourceOperation?.();
             }
         };
 
@@ -2247,6 +2370,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             if (compactRecovery === recovery) {
                 compactRecovery = null;
             }
+            recovery.releaseSourceOperation?.();
+            recovery.releaseSourceOperation = null;
             recoveryInFlight = false;
             wakeLoop();
         };
@@ -2286,7 +2411,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             const recovery = {
                 threadId,
                 message: messageToRetry,
-                timeout: null as ReturnType<typeof setTimeout> | null
+                timeout: null as ReturnType<typeof setTimeout> | null,
+                releaseSourceOperation: null as (() => void) | null
             };
             compactRecovery = recovery;
             recovery.timeout = setTimeout(() => {
@@ -2301,7 +2427,15 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 `[Codex] Compacting retryable context failure on same thread ` +
                 `(attempt ${sameThreadCompactAttempt}/${SAME_THREAD_MAX_COMPACT_RETRIES}): ${error ?? 'unknown error'}`
             );
-            void appServerClient.compactThread({ threadId }, { signal: this.abortController.signal })
+            void beginSourceOperation(this.abortController.signal)
+                .then(async (releaseSourceOperation) => {
+                    if (compactRecovery !== recovery) {
+                        releaseSourceOperation();
+                        return;
+                    }
+                    recovery.releaseSourceOperation = releaseSourceOperation;
+                    await appServerClient.compactThread({ threadId }, { signal: this.abortController.signal });
+                })
                 .catch((compactError) => {
                     logger.warn('[Codex] Failed to start app-server thread compact before retry:', compactError);
                     failCompactRecovery(
@@ -2530,7 +2664,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             suppressReadyForInterruptedTurn(request.turnId);
             clearReadyAfterTurnTimer?.();
             let interrupted = false;
+            let releaseSourceOperation: (() => void) | null = null;
             try {
+                releaseSourceOperation = await beginSourceOperation();
                 await appServerClient.interruptTurn({
                     threadId: request.threadId,
                     turnId: request.turnId
@@ -2577,6 +2713,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 session.sendSessionEvent({ type: 'message', message });
             } finally {
                 recoveryInFlight = false;
+                releaseSourceOperation?.();
                 wakeLoop();
                 if (interrupted && !pending) {
                     scheduleReadyAfterTurn?.();
@@ -2704,7 +2841,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     if (!this.currentThreadId || this.currentThreadId === threadId) {
                         this.currentThreadId = threadId;
                         this.conversationHistory.setThreadId(threadId);
-                        void this.conversationHistory.probeCapabilities().catch(() => {});
+                        probeConversationHistoryCapabilities();
                         session.onSessionFound(threadId);
                     } else {
                         logger.debug(
@@ -3101,7 +3238,6 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             }
             if (isTerminalEvent) {
                 setTurnInFlight(false);
-                this.conversationHistory.setBusy(false);
                 allowAnonymousTerminalEvent = false;
                 if (session.thinking) {
                     logger.debug('thinking completed');
@@ -3732,7 +3868,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 applyResolvedModel(resumeRecord?.model);
                 this.currentThreadId = threadId;
                 this.conversationHistory.setThreadId(threadId);
-                void this.conversationHistory.probeCapabilities().catch(() => {});
+                probeConversationHistoryCapabilities();
                 session.onSessionFound(threadId);
                 hasThread = true;
                 logger.debug(`[Codex] Resumed app-server thread ${threadId} for /compact`);
@@ -3796,7 +3932,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     applyResolvedModel(resumeRecord?.model);
                     this.currentThreadId = threadId;
                     this.conversationHistory.setThreadId(threadId);
-                    void this.conversationHistory.probeCapabilities().catch(() => {});
+                    probeConversationHistoryCapabilities();
                     session.onSessionFound(threadId);
                     hasThread = true;
                     return threadId;
@@ -3829,7 +3965,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 }
                 this.currentThreadId = threadId;
                 this.conversationHistory.setThreadId(threadId);
-                void this.conversationHistory.probeCapabilities().catch(() => {});
+                probeConversationHistoryCapabilities();
                 session.onSessionFound(threadId);
                 hasThread = true;
                 return threadId;
@@ -3990,8 +4126,15 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
 
         while (!this.shouldExit) {
             logActiveHandles('loop-top');
-            if (!appServerClient.isConnected() || !appServerClient.isInitialized()) {
-                await ensureAppServerInitialized();
+            const appServerReady = appServerClient.isConnected() && appServerClient.isInitialized();
+            if (!appServerReady && pendingSteerReconciliations.size === 0) {
+                let releaseReconnectSourceOperation: (() => void) | null = null;
+                try {
+                    releaseReconnectSourceOperation = await beginSourceOperation(this.abortController.signal);
+                    await ensureAppServerInitialized();
+                } finally {
+                    releaseReconnectSourceOperation?.();
+                }
             }
             if (pendingSteerReconciliations.size > 0) {
                 await runSteerReconciliation();
@@ -4049,7 +4192,11 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 clearReadyAfterTurnTimer?.();
             }
 
+            let releaseMessageSourceOperation: (() => void) | null = null;
             try {
+                releaseMessageSourceOperation = await beginSourceOperation(this.abortController.signal);
+                await ensureAppServerInitialized();
+
                 if (await handleGoalCommand(message)) {
                     continue;
                 }
@@ -4128,7 +4275,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
 
                     this.currentThreadId = threadId;
                     this.conversationHistory.setThreadId(threadId);
-                    void this.conversationHistory.probeCapabilities().catch(() => {});
+                    probeConversationHistoryCapabilities();
                     session.onSessionFound(threadId);
                     hasThread = true;
                 } else {
@@ -4141,7 +4288,6 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 }
 
                 setTurnInFlight(true);
-                this.conversationHistory.setBusy(true);
                 allowAnonymousTerminalEvent = false;
                 const mode = {
                     ...message.mode,
@@ -4221,7 +4367,6 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 logger.warn('Error in codex session:', error);
                 const isAbortError = error instanceof Error && error.name === 'AbortError';
                 setTurnInFlight(false);
-                this.conversationHistory.setBusy(false);
                 allowAnonymousTerminalEvent = false;
                 this.currentTurnId = null;
 
@@ -4240,6 +4385,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     hasThread = false;
                 }
             } finally {
+                releaseMessageSourceOperation?.();
                 if (!turnInFlight) {
                     permissionHandler.reset();
                     reasoningProcessor.abort();
@@ -4272,24 +4418,33 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         clearDeferredThreadStatusFailure();
         cancelSafetyBufferingRequest('Session ended');
         cancelAllPendingThrottledAgentRunUpdates();
-        // Stop reconciliation: the launcher is leaving; no pending steer may
-        // spawn a fresh app-server after cleanup.
-        shuttingDown = true;
-        if (steerReconcileTimer) {
-            clearTimeout(steerReconcileTimer);
-            steerReconcileTimer = null;
-        }
-        pendingSteerReconciliations.clear();
+        void this.stopSteerReconciliation();
     }
 
     protected async cleanup(): Promise<void> {
         logger.debug('[codex-remote]: cleanup start');
+        this.beginConversationHistorySourceOperation = null;
+        const releaseSourceLease = this.releaseConversationHistorySourceLease;
+        this.releaseConversationHistorySourceLease = null;
+        releaseSourceLease?.();
         this.appServerClient.setTransportAbandonedHandler(null);
         this.appServerClient.setStderrHandler(null);
-        try {
-            await this.appServerClient.disconnect();
-        } catch (error) {
-            logger.debug('[codex-remote]: Error disconnecting client', error);
+        const reconciliationCleanup = this.stopSteerReconciliation();
+        const historyCleanup = this.conversationHistory.cleanup();
+        const sourceDisconnect = this.appServerClient.disconnect();
+        const [reconciliationResult, historyResult, sourceResult] = await Promise.allSettled([
+            reconciliationCleanup,
+            historyCleanup,
+            sourceDisconnect
+        ]);
+        if (reconciliationResult.status === 'rejected') {
+            logger.debug('[codex-remote]: Error stopping steer reconciliation', reconciliationResult.reason);
+        }
+        if (historyResult.status === 'rejected') {
+            logger.debug('[codex-remote]: Error disconnecting fork client', historyResult.reason);
+        }
+        if (sourceResult.status === 'rejected') {
+            logger.debug('[codex-remote]: Error disconnecting client', sourceResult.reason);
         }
 
         this.clearAbortHandlers(this.session.client.rpcHandlerManager);

--- a/cli/src/codex/conversationHistory.test.ts
+++ b/cli/src/codex/conversationHistory.test.ts
@@ -2,11 +2,20 @@ import { describe, expect, it, vi } from 'vitest'
 import { CodexConversationHistory } from './conversationHistory'
 
 function createClient(overrides?: {
-    fork?: (params: Record<string, unknown>) => Promise<{ thread: { id: string } }>
+    fork?: (
+        params: Record<string, unknown>,
+        options?: { signal?: AbortSignal }
+    ) => Promise<{ thread: { id: string } }>
     rollback?: (params: { threadId: string; numTurns: number }) => Promise<unknown>
-    read?: () => Promise<{ thread: { id: string; turns: Array<Record<string, unknown>> } }>
+    read?: (
+        params?: Record<string, unknown>,
+        options?: { signal?: AbortSignal }
+    ) => Promise<{ thread: { id: string; turns: Array<Record<string, unknown>> } }>
 }) {
     return {
+        connect: async () => {},
+        initialize: async () => ({ protocolVersion: 1 }),
+        disconnect: async () => {},
         supportsMethod: async () => true,
         forkThread: overrides?.fork ?? (async () => ({ thread: { id: 'forked-1' } })),
         rollbackThread: overrides?.rollback ?? (async () => ({ thread: { id: 'thread-1' } })),
@@ -23,13 +32,17 @@ function createClient(overrides?: {
     }
 }
 
+function createHistory(getClient: () => unknown): CodexConversationHistory {
+    return new CodexConversationHistory(getClient as never, () => getClient() as never)
+}
+
 describe('CodexConversationHistory', () => {
     it('only publishes methods confirmed by the app server', async () => {
         const supportsMethod = vi.fn(async (method: string) => method === 'thread/fork')
-        const history = new CodexConversationHistory(() => ({
+        const history = createHistory(() => ({
             ...createClient(),
             supportsMethod
-        }) as never)
+        }))
         history.setThreadId('thread-1')
         await history.probeCapabilities()
         expect(history.getCapabilitiesForMetadata()?.conversationHistory).toEqual({
@@ -38,16 +51,935 @@ describe('CodexConversationHistory', () => {
         })
     })
 
+    it('coalesces concurrent capability probes', async () => {
+        let firstCall = true
+        let finishFirstProbe!: (supported: boolean) => void
+        const supportsMethod = vi.fn(() => {
+            if (firstCall) {
+                firstCall = false
+                return new Promise<boolean>((resolve) => {
+                    finishFirstProbe = resolve
+                })
+            }
+            return Promise.resolve(true)
+        })
+        const history = createHistory(() => ({
+            ...createClient(),
+            supportsMethod
+        }))
+        history.setThreadId('thread-1')
+        const firstProbe = history.probeCapabilities()
+        await vi.waitFor(() => expect(supportsMethod).toHaveBeenCalledOnce())
+
+        const secondProbe = history.probeCapabilities()
+        const reusedPromise = secondProbe === firstProbe
+        finishFirstProbe(true)
+        await Promise.all([firstProbe, secondProbe])
+
+        expect(reusedPromise).toBe(true)
+        expect(supportsMethod).toHaveBeenCalledTimes(2)
+    })
+
+    it('waits for a pending capability probe and prevents client access after shutdown', async () => {
+        let finishFirstProbe!: (supported: boolean) => void
+        const supportsMethod = vi.fn((method: string) => {
+            if (method === 'thread/fork') {
+                return new Promise<boolean>((resolve) => {
+                    finishFirstProbe = resolve
+                })
+            }
+            return Promise.resolve(true)
+        })
+        const client = {
+            ...createClient(),
+            supportsMethod
+        }
+        const getClient = vi.fn(() => client)
+        const publishCapabilities = vi.fn(async () => {})
+        const history = createHistory(getClient)
+        history.setPublishCapabilities(publishCapabilities)
+        history.setThreadId('thread-1')
+        const probe = history.probeCapabilities()
+        await vi.waitFor(() => expect(supportsMethod).toHaveBeenCalledOnce())
+
+        let cleanupSettled = false
+        const cleanup = history.cleanup().finally(() => {
+            cleanupSettled = true
+        })
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        const cleanupSettledWhileProbePending = cleanupSettled
+
+        finishFirstProbe(true)
+        await Promise.all([probe, cleanup])
+        expect(cleanupSettledWhileProbePending).toBe(false)
+        expect(supportsMethod).toHaveBeenCalledOnce()
+        expect(publishCapabilities).not.toHaveBeenCalled()
+
+        getClient.mockClear()
+        await history.probeCapabilities()
+        expect(getClient).not.toHaveBeenCalled()
+        expect(publishCapabilities).not.toHaveBeenCalled()
+    })
+
+    it('does not mutate rewind capability after shutdown starts during its probe', async () => {
+        let finishRollbackProbe!: (supported: boolean) => void
+        const supportsMethod = vi.fn((method: string) => {
+            if (method === 'thread/fork') return Promise.resolve(true)
+            if (method === 'thread/rollback') {
+                return new Promise<boolean>((resolve) => {
+                    finishRollbackProbe = resolve
+                })
+            }
+            throw new Error(`Unexpected capability probe: ${method}`)
+        })
+        const client = {
+            ...createClient(),
+            supportsMethod
+        }
+        const getClient = vi.fn(() => client)
+        const publishCapabilities = vi.fn(async () => {})
+        const history = createHistory(getClient)
+        history.setPublishCapabilities(publishCapabilities)
+        history.setThreadId('thread-1')
+        const probe = history.probeCapabilities()
+        await vi.waitFor(() => {
+            expect(supportsMethod).toHaveBeenNthCalledWith(2, 'thread/rollback')
+        })
+
+        let cleanupSettled = false
+        const cleanup = history.cleanup().finally(() => {
+            cleanupSettled = true
+        })
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        const cleanupSettledWhileProbePending = cleanupSettled
+
+        finishRollbackProbe(true)
+        await Promise.all([probe, cleanup])
+        expect(cleanupSettledWhileProbePending).toBe(false)
+        expect(history.getCapabilityStates().rewindToMessage).toBe('unknown')
+        expect(supportsMethod).toHaveBeenCalledTimes(2)
+        expect(publishCapabilities).not.toHaveBeenCalled()
+
+        getClient.mockClear()
+        await history.probeCapabilities()
+        expect(getClient).not.toHaveBeenCalled()
+        expect(supportsMethod).toHaveBeenCalledTimes(2)
+        expect(publishCapabilities).not.toHaveBeenCalled()
+    })
+
     it('forks current without a turn boundary', async () => {
         const fork = vi.fn(async (params: Record<string, unknown>) => {
             expect(params.beforeTurnId).toBeUndefined()
             return { thread: { id: 'forked-current' } }
         })
-        const history = new CodexConversationHistory(() => createClient({ fork }) as never)
+        const history = createHistory(() => createClient({ fork }))
         history.setThreadId('thread-1')
         const result = await history.fork()
         expect(result).toEqual({ nativeSessionId: 'forked-current' })
         expect(fork).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects history mutations while the source lease is active', async () => {
+        const rollback = vi.fn(async () => ({ thread: { id: 'thread-1' } }))
+        const createForkClient = vi.fn(() => createClient())
+        const history = new CodexConversationHistory(
+            () => createClient({ rollback }) as never,
+            createForkClient as never
+        )
+        history.setThreadId('thread-1')
+        const release = await history.acquireSourceLease()
+
+        try {
+            await expect(history.fork()).rejects.toThrow('Session is busy')
+            await expect(history.rewind('local-b')).rejects.toThrow('Session is busy')
+            expect(createForkClient).not.toHaveBeenCalled()
+            expect(rollback).not.toHaveBeenCalled()
+        } finally {
+            release()
+        }
+    })
+
+    it('forks through a disconnected temporary app server', async () => {
+        const activeFork = vi.fn(async () => ({ thread: { id: 'forked-active' } }))
+        const activeClient = createClient({ fork: activeFork })
+        const calls: string[] = []
+        let finishDisconnect: (() => void) | undefined
+        const temporaryClient = {
+            connect: vi.fn(async () => {
+                calls.push('connect')
+            }),
+            initialize: vi.fn(async (params: Record<string, unknown>) => {
+                calls.push('initialize')
+                expect(params).toMatchObject({ capabilities: { experimentalApi: true } })
+                return { protocolVersion: 1 }
+            }),
+            forkThread: vi.fn(async (params: Record<string, unknown>) => {
+                calls.push('fork')
+                expect(params).toEqual({ threadId: 'thread-1' })
+                return { thread: { id: 'forked-temporary' } }
+            }),
+            disconnect: vi.fn(() => new Promise<void>((resolve) => {
+                calls.push('disconnect')
+                finishDisconnect = resolve
+            }))
+        }
+        const history = new CodexConversationHistory(
+            () => activeClient as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        const fork = history.fork()
+        await vi.waitFor(() => expect(temporaryClient.disconnect).toHaveBeenCalledOnce())
+        expect(activeFork).not.toHaveBeenCalled()
+
+        let settled = false
+        void fork.then(() => {
+            settled = true
+        })
+        await Promise.resolve()
+        expect(settled).toBe(false)
+        expect(finishDisconnect).toBeDefined()
+        finishDisconnect!()
+
+        await expect(fork).resolves.toEqual({ nativeSessionId: 'forked-temporary' })
+        expect(calls).toEqual(['connect', 'initialize', 'fork', 'disconnect'])
+    })
+
+    it('rejects fork when temporary app-server disconnect fails', async () => {
+        const disconnectError = new Error('temporary app-server teardown failed')
+        const activeFork = vi.fn(async () => ({ thread: { id: 'forked-active' } }))
+        const temporaryFork = vi.fn(async () => ({ thread: { id: 'forked-temporary' } }))
+        const temporaryClient = {
+            ...createClient({ fork: temporaryFork }),
+            disconnect: vi.fn(async () => {
+                throw disconnectError
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient({ fork: activeFork }) as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        await expect(history.fork()).rejects.toBe(disconnectError)
+        expect(temporaryFork).toHaveBeenCalledWith(
+            { threadId: 'thread-1' },
+            expect.objectContaining({ signal: expect.any(AbortSignal) })
+        )
+        expect(activeFork).not.toHaveBeenCalled()
+    })
+
+    it('retries failed temporary cleanup before starting another fork client', async () => {
+        const cleanupError = new Error('temporary app-server teardown failed')
+        const firstClient = {
+            ...createClient(),
+            disconnect: vi.fn(async () => {
+                throw cleanupError
+            })
+        }
+        const secondClient = {
+            ...createClient(),
+            connect: vi.fn(async () => {})
+        }
+        const createForkClient = vi.fn()
+            .mockReturnValueOnce(firstClient)
+            .mockReturnValueOnce(secondClient)
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            createForkClient as never
+        )
+        history.setThreadId('thread-1')
+
+        await expect(history.fork()).rejects.toBe(cleanupError)
+        await expect(history.fork()).rejects.toBe(cleanupError)
+
+        expect(firstClient.disconnect).toHaveBeenCalledTimes(2)
+        expect(createForkClient).toHaveBeenCalledOnce()
+        expect(secondClient.connect).not.toHaveBeenCalled()
+    })
+
+    it('retries failed temporary cleanup before dispatching rewind', async () => {
+        const cleanupError = new Error('temporary app-server teardown failed')
+        let finishCleanup!: () => void
+        const cleanupGate = new Promise<void>((resolve) => {
+            finishCleanup = resolve
+        })
+        const rollback = vi.fn(async () => ({ thread: { id: 'thread-1' } }))
+        const sourceClient = createClient({ rollback })
+        const temporaryClient = {
+            ...createClient(),
+            disconnect: vi.fn()
+                .mockRejectedValueOnce(cleanupError)
+                .mockImplementationOnce(() => cleanupGate)
+        }
+        const history = new CodexConversationHistory(
+            () => sourceClient as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        await expect(history.fork()).rejects.toBe(cleanupError)
+        const rewind = history.rewind('local-b')
+        await vi.waitFor(() => expect(temporaryClient.disconnect).toHaveBeenCalledTimes(2))
+        expect(rollback).not.toHaveBeenCalled()
+
+        finishCleanup()
+        await expect(rewind).resolves.toEqual({
+            success: true,
+            truncateFromLocalId: 'local-b',
+            messages: []
+        })
+        expect(rollback).toHaveBeenCalledOnce()
+    })
+
+    it('retries failed temporary cleanup during history shutdown', async () => {
+        const cleanupError = new Error('temporary app-server teardown failed')
+        const temporaryClient = {
+            ...createClient(),
+            disconnect: vi.fn()
+                .mockRejectedValueOnce(cleanupError)
+                .mockResolvedValueOnce(undefined)
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        await expect(history.fork()).rejects.toBe(cleanupError)
+        await history.cleanup()
+
+        expect(temporaryClient.disconnect).toHaveBeenCalledTimes(2)
+    })
+
+    it('disconnects an active temporary client when shutdown races a pending fork', async () => {
+        const interrupted = new Error('temporary client disconnected')
+        let forkSignal: AbortSignal | undefined
+        let rejectFork!: (error: Error) => void
+        const pendingFork = vi.fn((_params: Record<string, unknown>, options?: { signal?: AbortSignal }) => new Promise<{ thread: { id: string } }>((_resolve, reject) => {
+            forkSignal = options?.signal
+            rejectFork = reject
+        }))
+        const temporaryClient = {
+            ...createClient({ fork: pendingFork }),
+            disconnect: vi.fn(async () => {
+                rejectFork(interrupted)
+            })
+        }
+        const activeClient = createClient()
+        const readThread = vi.spyOn(activeClient, 'readThread')
+        const history = new CodexConversationHistory(
+            () => activeClient as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+        const fork = history.fork().catch((error) => error)
+        await vi.waitFor(() => expect(pendingFork).toHaveBeenCalledOnce())
+
+        const cleanup = history.cleanup()
+        try {
+            await Promise.resolve()
+            expect(forkSignal?.aborted).toBe(true)
+            expect(temporaryClient.disconnect).toHaveBeenCalled()
+            await cleanup
+        } finally {
+            rejectFork(interrupted)
+            await fork
+        }
+
+        await expect(fork).resolves.toBe(interrupted)
+        await expect(history.fork()).rejects.toThrow('shutting down')
+        await expect(history.rewind('local-a')).rejects.toThrow('shutting down')
+        await expect(history.acquireSourceLease()).rejects.toThrow('shutting down')
+        expect(readThread).not.toHaveBeenCalled()
+    })
+
+    it('disconnects an active temporary client before waiting for a pending probe', async () => {
+        let finishProbe!: (supported: boolean) => void
+        const supportsMethod = vi.fn(() => new Promise<boolean>((resolve) => {
+            finishProbe = resolve
+        }))
+        const activeClient = {
+            ...createClient(),
+            supportsMethod
+        }
+        const interrupted = new Error('temporary client disconnected')
+        let rejectFork!: (error: Error) => void
+        const pendingFork = vi.fn(() => new Promise<{ thread: { id: string } }>((_resolve, reject) => {
+            rejectFork = reject
+        }))
+        const temporaryClient = {
+            ...createClient({ fork: pendingFork }),
+            disconnect: vi.fn(async () => {
+                rejectFork(interrupted)
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => activeClient as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+        const probe = history.probeCapabilities()
+        await vi.waitFor(() => expect(supportsMethod).toHaveBeenCalledOnce())
+        const fork = history.fork().catch((error) => error)
+        await vi.waitFor(() => expect(pendingFork).toHaveBeenCalledOnce())
+
+        const cleanup = history.cleanup()
+        await Promise.resolve()
+        const disconnectStartedWhileProbePending = temporaryClient.disconnect.mock.calls.length > 0
+
+        finishProbe(true)
+        await Promise.all([probe, fork, cleanup])
+        expect(disconnectStartedWhileProbePending).toBe(true)
+    })
+
+    it('does not initialize or reconnect when shutdown follows temporary connect', async () => {
+        let finishConnect: (() => void) | undefined
+        let connected = false
+        const connect = vi.fn(() => {
+            if (connect.mock.calls.length === 1) {
+                return new Promise<void>((resolve) => {
+                    finishConnect = () => {
+                        connected = true
+                        resolve()
+                    }
+                })
+            }
+            connected = true
+            return Promise.resolve()
+        })
+        const initialize = vi.fn(async () => {
+            if (!connected) await connect()
+            return { protocolVersion: 1 }
+        })
+        const nativeFork = vi.fn(async () => ({ thread: { id: 'forked-temporary' } }))
+        const temporaryClient = {
+            ...createClient({ fork: nativeFork }),
+            connect,
+            initialize,
+            disconnect: vi.fn(async () => {
+                connected = false
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+        const fork = history.fork().catch((error) => error)
+        await vi.waitFor(() => expect(connect).toHaveBeenCalledOnce())
+
+        finishConnect!()
+        const cleanup = history.cleanup()
+        const [forkError] = await Promise.all([fork, cleanup])
+
+        expect(forkError).toEqual(new Error('Codex conversation history is shutting down'))
+        expect(connect).toHaveBeenCalledOnce()
+        expect(initialize).not.toHaveBeenCalled()
+        expect(nativeFork).not.toHaveBeenCalled()
+    })
+
+    it('rejects rewind while a fork mutation is in progress', async () => {
+        const interrupted = new Error('fork interrupted')
+        let rejectFork: ((error: Error) => void) | undefined
+        const pendingFork = vi.fn(() => new Promise<{ thread: { id: string } }>((_resolve, reject) => {
+            rejectFork = reject
+        }))
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => createClient({ fork: pendingFork }) as never
+        )
+        history.setThreadId('thread-1')
+        const fork = history.fork().catch((error) => error)
+        await vi.waitFor(() => expect(pendingFork).toHaveBeenCalledOnce())
+
+        try {
+            await expect(history.rewind('local-a')).rejects.toThrow('mutation is already in progress')
+        } finally {
+            rejectFork!(interrupted)
+            await fork
+        }
+    })
+
+    it('requires verified temporary process identity before native fork', async () => {
+        const identityError = new Error('temporary process identity could not be verified')
+        const fork = vi.fn(async () => ({ thread: { id: 'forked-temporary' } }))
+        const temporaryClient = {
+            ...createClient({ fork }),
+            connect: vi.fn(async (options?: { requireVerifiedProcessIdentity?: boolean }) => {
+                if (options?.requireVerifiedProcessIdentity) throw identityError
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        await expect(history.fork()).rejects.toBe(identityError)
+        expect(temporaryClient.connect).toHaveBeenCalledWith({
+            requireVerifiedProcessIdentity: true
+        })
+        expect(fork).not.toHaveBeenCalled()
+    })
+
+    it('preserves the fork error when temporary cleanup also fails', async () => {
+        const forkError = new Error('thread/fork is unsupported')
+        const cleanupError = new Error('temporary cleanup failed')
+        const temporaryClient = {
+            ...createClient({
+                fork: async () => {
+                    throw forkError
+                }
+            }),
+            disconnect: vi.fn(async () => {
+                throw cleanupError
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        const error = await history.fork().catch((caught) => caught)
+        expect(error).toBeInstanceOf(AggregateError)
+        expect(error.errors).toEqual([forkError, cleanupError])
+        expect(error.message).toContain(forkError.message)
+        expect(history.getCapabilityStates().forkCurrent).toBe('unsupported')
+    })
+
+    it('preserves the direct fork error when capability publishing and cleanup fail', async () => {
+        const forkError = new Error('thread/fork is unsupported')
+        const publishError = new Error('capability publish failed')
+        const cleanupError = new Error('temporary cleanup failed')
+        const temporaryClient = {
+            ...createClient({
+                fork: async () => {
+                    throw forkError
+                }
+            }),
+            disconnect: vi.fn(async () => {
+                throw cleanupError
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        const publishCapabilities = vi.fn(async () => {
+            throw publishError
+        })
+        history.setPublishCapabilities(publishCapabilities)
+        history.setThreadId('thread-1')
+
+        const error = await history.fork().catch((caught) => caught)
+        expect(error).toBeInstanceOf(AggregateError)
+        expect(error.errors).toEqual([forkError, cleanupError])
+        expect(history.getCapabilityStates().forkCurrent).toBe('unsupported')
+        expect(publishCapabilities).toHaveBeenCalledOnce()
+    })
+
+    it('does not publish fork capability after shutdown begins during temporary cleanup', async () => {
+        const forkError = new Error('thread/fork method not found')
+        let finishDisconnect!: () => void
+        const pendingDisconnect = new Promise<void>((resolve) => {
+            finishDisconnect = resolve
+        })
+        const temporaryClient = {
+            ...createClient({
+                fork: async () => {
+                    throw forkError
+                }
+            }),
+            disconnect: vi.fn(() => pendingDisconnect)
+        }
+        const publishCapabilities = vi.fn(async () => {})
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setPublishCapabilities(publishCapabilities)
+        history.setThreadId('thread-1')
+        const fork = history.fork().catch((error) => error)
+        await vi.waitFor(() => expect(temporaryClient.disconnect).toHaveBeenCalledOnce())
+
+        const cleanup = history.cleanup()
+        await vi.waitFor(() => expect(temporaryClient.disconnect).toHaveBeenCalledTimes(2))
+        finishDisconnect()
+        const [result] = await Promise.all([fork, cleanup])
+
+        expect(result).toBe(forkError)
+        expect(history.getCapabilityStates().forkCurrent).toBe('unsupported')
+        expect(publishCapabilities).not.toHaveBeenCalled()
+    })
+
+    it('does not mark fork unsupported when only cleanup reports unsupported', async () => {
+        const temporaryClient = {
+            ...createClient({
+                fork: async () => {
+                    throw new Error('fork request failed')
+                }
+            }),
+            disconnect: vi.fn(async () => {
+                throw new Error('temporary cleanup is unsupported')
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        await expect(history.fork()).rejects.toBeInstanceOf(AggregateError)
+        expect(history.getCapabilityStates().forkCurrent).toBe('unknown')
+    })
+
+    it('does not mark fork unsupported when successful fork cleanup reports unsupported', async () => {
+        const cleanupError = new Error('temporary cleanup is unsupported')
+        const temporaryClient = {
+            ...createClient({
+                fork: async () => ({ thread: { id: 'forked-temporary' } })
+            }),
+            disconnect: vi.fn(async () => {
+                throw cleanupError
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        await expect(history.fork()).rejects.toBe(cleanupError)
+        expect(history.getCapabilityStates().forkCurrent).toBe('unknown')
+    })
+
+    it('does not mark fork unsupported when initialize reports unsupported', async () => {
+        const initializeError = new Error('experimental API is unsupported')
+        const fork = vi.fn(async () => ({ thread: { id: 'forked-temporary' } }))
+        const temporaryClient = {
+            ...createClient({ fork }),
+            initialize: vi.fn(async () => {
+                throw initializeError
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        await expect(history.fork()).rejects.toBe(initializeError)
+        expect(history.getCapabilityStates().forkCurrent).toBe('unknown')
+        expect(fork).not.toHaveBeenCalled()
+    })
+
+    it('reserves cleanup time when the temporary fork stalls', async () => {
+        vi.useFakeTimers()
+        let forkSignal: AbortSignal | undefined
+        const temporaryClient = {
+            ...createClient({
+                fork: (_params, options) => new Promise((_resolve, reject) => {
+                    forkSignal = options?.signal
+                    forkSignal?.addEventListener('abort', () => {
+                        reject(new Error('fork aborted'))
+                    }, { once: true })
+                })
+            }),
+            disconnect: vi.fn(async () => {})
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+        const fork = history.fork()
+        const outcome = fork.then(
+            (value) => ({ type: 'resolved' as const, value }),
+            (error: unknown) => ({ type: 'rejected' as const, error })
+        )
+
+        try {
+            await vi.advanceTimersByTimeAsync(79_999)
+            expect(temporaryClient.disconnect).not.toHaveBeenCalled()
+            expect(forkSignal?.aborted).toBe(false)
+            await vi.advanceTimersByTimeAsync(1)
+            expect(forkSignal?.aborted).toBe(true)
+            expect(temporaryClient.disconnect).toHaveBeenCalledOnce()
+            const result = await outcome
+            expect(result.type).toBe('rejected')
+            if (result.type === 'rejected') {
+                expect(result.error).toEqual(new Error('Codex fork timed out after 80000ms'))
+            }
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('reports a stalled fork and cleanup failure together', async () => {
+        vi.useFakeTimers()
+        let finishFork: ((value: { thread: { id: string } }) => void) | undefined
+        const cleanupError = new Error('temporary cleanup failed')
+        const temporaryClient = {
+            ...createClient({
+                fork: () => new Promise((resolve) => {
+                    finishFork = resolve
+                })
+            }),
+            disconnect: vi.fn(async () => {
+                throw cleanupError
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+        const outcome = history.fork().catch((error) => error)
+
+        try {
+            await vi.advanceTimersByTimeAsync(80_000)
+            const error = await outcome
+            expect(error).toBeInstanceOf(AggregateError)
+            expect(error.errors).toEqual([
+                new Error('Codex fork timed out after 80000ms'),
+                cleanupError
+            ])
+        } finally {
+            finishFork?.({ thread: { id: 'forked-late' } })
+            await Promise.resolve()
+            vi.useRealTimers()
+        }
+    })
+
+    it('applies the total fork deadline to stalled cleanup', async () => {
+        vi.useFakeTimers()
+        const temporaryClient = {
+            ...createClient({
+                fork: async () => ({ thread: { id: 'forked-temporary' } })
+            }),
+            disconnect: vi.fn(() => new Promise<void>(() => {}))
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+        const outcome = history.fork().catch((error) => error)
+
+        try {
+            await vi.advanceTimersByTimeAsync(89_999)
+            expect(temporaryClient.disconnect).toHaveBeenCalledOnce()
+            await vi.advanceTimersByTimeAsync(1)
+            await expect(outcome).resolves.toEqual(
+                new Error('Codex fork cleanup timed out after 90000ms total')
+            )
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('rejects a successful fork when cleanup crosses the total deadline', async () => {
+        vi.useFakeTimers()
+        const startedAt = Date.now()
+        const temporaryClient = {
+            ...createClient({
+                fork: async () => ({ thread: { id: 'forked-too-late' } })
+            }),
+            disconnect: vi.fn(async () => {
+                vi.setSystemTime(startedAt + 90_001)
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        try {
+            await expect(history.fork()).rejects.toEqual(
+                new Error('Codex fork cleanup timed out after 90000ms total')
+            )
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('reports the deadline when failed cleanup crosses the total deadline', async () => {
+        vi.useFakeTimers()
+        const startedAt = Date.now()
+        const cleanupError = new Error('temporary cleanup failed too late')
+        const temporaryClient = {
+            ...createClient({
+                fork: async () => ({ thread: { id: 'forked-too-late' } })
+            }),
+            disconnect: vi.fn(async () => {
+                vi.setSystemTime(startedAt + 90_001)
+                throw cleanupError
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        try {
+            await expect(history.fork()).rejects.toEqual(
+                new Error('Codex fork cleanup timed out after 90000ms total')
+            )
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('reserves cleanup time while historical turn reads stall', async () => {
+        vi.useFakeTimers()
+        let readSignal: AbortSignal | undefined
+        let finishRead: ((value: { thread: { id: string; turns: Array<Record<string, unknown>> } }) => void) | undefined
+        const activeClient = createClient({
+            read: (_params, options) => new Promise((resolve) => {
+                readSignal = options?.signal
+                finishRead = resolve
+            })
+        })
+        const createTemporaryClient = vi.fn(() => createClient())
+        const history = new CodexConversationHistory(
+            () => activeClient as never,
+            () => createTemporaryClient() as never
+        )
+        history.setThreadId('thread-1')
+        const outcome = history.fork('local-a').catch((error) => error)
+
+        try {
+            await vi.advanceTimersByTimeAsync(80_000)
+            expect(readSignal?.aborted).toBe(true)
+            await expect(outcome).resolves.toEqual(
+                new Error('Codex fork timed out after 80000ms')
+            )
+            expect(createTemporaryClient).not.toHaveBeenCalled()
+        } finally {
+            finishRead?.({ thread: { id: 'thread-1', turns: [] } })
+            await Promise.resolve()
+            vi.useRealTimers()
+        }
+    })
+
+    it('does not connect a temporary client after a historical read exhausts the operation deadline', async () => {
+        vi.useFakeTimers()
+        const startedAt = Date.now()
+        const activeClient = createClient({
+            read: async () => {
+                vi.setSystemTime(startedAt + 81_000)
+                return {
+                    thread: {
+                        id: 'thread-1',
+                        turns: [
+                            { id: 'turn-a', items: [{ type: 'userMessage', clientId: 'local-a' }] }
+                        ]
+                    }
+                }
+            }
+        })
+        const temporaryClient = {
+            ...createClient(),
+            connect: vi.fn(async () => {})
+        }
+        const history = new CodexConversationHistory(
+            () => activeClient as never,
+            () => temporaryClient as never
+        )
+        history.setThreadId('thread-1')
+
+        try {
+            await expect(history.fork('local-a')).rejects.toEqual(
+                new Error('Codex fork timed out after 80000ms')
+            )
+            expect(temporaryClient.connect).not.toHaveBeenCalled()
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('does not start capability publishing after the total fork deadline expires', async () => {
+        vi.useFakeTimers()
+        const startedAt = Date.now()
+        const forkError = new Error('thread/fork method not found')
+        const publishCapabilities = vi.fn(async () => {})
+        const temporaryClient = {
+            ...createClient({
+                fork: async () => {
+                    throw forkError
+                }
+            }),
+            disconnect: vi.fn(async () => {
+                vi.setSystemTime(startedAt + 90_001)
+            })
+        }
+        const history = new CodexConversationHistory(
+            () => createClient() as never,
+            () => temporaryClient as never
+        )
+        history.setPublishCapabilities(publishCapabilities)
+        history.setThreadId('thread-1')
+
+        try {
+            const error = await history.fork().catch((caught) => caught)
+            expect(error).toBeInstanceOf(AggregateError)
+            expect(error.errors).toEqual([
+                forkError,
+                new Error('Codex fork cleanup timed out after 90000ms total')
+            ])
+            expect(publishCapabilities).not.toHaveBeenCalled()
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('applies the total fork deadline to capability publishing', async () => {
+        vi.useFakeTimers()
+        let finishPublish: (() => void) | undefined
+        const history = createHistory(() => createClient())
+        history.setPublishCapabilities(() => new Promise<void>((resolve) => {
+            finishPublish = resolve
+        }))
+        history.setThreadId('thread-1')
+        let settled = false
+        const outcome = history.fork().then(
+            (value) => ({ type: 'resolved' as const, value }),
+            (error: unknown) => ({ type: 'rejected' as const, error })
+        ).finally(() => {
+            settled = true
+        })
+
+        try {
+            await vi.advanceTimersByTimeAsync(90_000)
+            expect(settled).toBe(true)
+            await expect(outcome).resolves.toEqual({
+                type: 'rejected',
+                error: new Error('Codex fork timed out after 90000ms total')
+            })
+        } finally {
+            finishPublish?.()
+            await Promise.resolve()
+            vi.useRealTimers()
+        }
+    })
+
+    it('marks only historical fork unsupported on direct method-not-found', async () => {
+        const forkError = new Error('thread/fork method not found')
+        const history = createHistory(() => createClient({
+            fork: async () => {
+                throw forkError
+            }
+        }))
+        history.setThreadId('thread-1')
+
+        await expect(history.fork('local-b')).rejects.toBe(forkError)
+        expect(history.getCapabilityStates().forkAtMessage).toBe('unsupported')
+        expect(history.getCapabilityStates().forkCurrent).toBe('unknown')
     })
 
     it('historical fork passes lastTurnId of the previous turn', async () => {
@@ -56,7 +988,7 @@ describe('CodexConversationHistory', () => {
             expect(params.beforeTurnId).toBeUndefined()
             return { thread: { id: 'forked-hist' } }
         })
-        const history = new CodexConversationHistory(() => createClient({ fork }) as never)
+        const history = createHistory(() => createClient({ fork }))
         history.setThreadId('thread-1')
         const result = await history.fork('local-b')
         expect(result.nativeSessionId).toBe('forked-hist')
@@ -68,7 +1000,7 @@ describe('CodexConversationHistory', () => {
             expect(params.lastTurnId).toBeUndefined()
             return { thread: { id: 'forked-first' } }
         })
-        const history = new CodexConversationHistory(() => createClient({ fork }) as never)
+        const history = createHistory(() => createClient({ fork }))
         history.setThreadId('thread-1')
         const result = await history.fork('local-a')
         expect(result.nativeSessionId).toBe('forked-first')
@@ -79,7 +1011,7 @@ describe('CodexConversationHistory', () => {
             expect(params).toEqual({ threadId: 'thread-1', numTurns: 2 })
             return { thread: { id: 'thread-1' } }
         })
-        const history = new CodexConversationHistory(() => createClient({ rollback }) as never)
+        const history = createHistory(() => createClient({ rollback }))
         history.setThreadId('thread-1')
         const result = await history.rewind('local-b')
         expect(result).toEqual({
@@ -90,12 +1022,266 @@ describe('CodexConversationHistory', () => {
         expect(rollback).toHaveBeenCalledTimes(1)
     })
 
+    it('does not classify an unsupported capability publish error as rollback failure', async () => {
+        const publishError = new Error('capability publishing is unsupported')
+        const rollback = vi.fn(async () => ({ thread: { id: 'thread-1' } }))
+        const publishCapabilities = vi.fn(async () => {
+            throw publishError
+        })
+        const history = createHistory(() => createClient({ rollback }))
+        history.setPublishCapabilities(publishCapabilities)
+        history.setThreadId('thread-1')
+
+        await expect(history.rewind('local-b')).rejects.toBe(publishError)
+        expect(history.getCapabilityStates().rewindToMessage).toBe('supported')
+        expect(publishCapabilities).toHaveBeenCalledOnce()
+    })
+
+    it('aborts a timed-out rewind read and never rolls back when it resolves late', async () => {
+        vi.useFakeTimers()
+        let readSignal: AbortSignal | undefined
+        let finishRead: ((value: { thread: { id: string; turns: Array<Record<string, unknown>> } }) => void) | undefined
+        const read = vi.fn((_params?: Record<string, unknown>, options?: { signal?: AbortSignal }) => new Promise<{ thread: { id: string; turns: Array<Record<string, unknown>> } }>((resolve) => {
+            readSignal = options?.signal
+            finishRead = resolve
+        }))
+        const rollback = vi.fn(async () => ({ thread: { id: 'thread-1' } }))
+        const history = createHistory(() => createClient({ read, rollback }))
+        history.setThreadId('thread-1')
+        const outcome = history.rewind('local-b').catch((error) => error)
+
+        try {
+            await vi.advanceTimersByTimeAsync(90_000)
+            finishRead!({
+                thread: {
+                    id: 'thread-1',
+                    turns: [
+                        { id: 'turn-a', items: [{ type: 'userMessage', clientId: 'local-a' }] },
+                        { id: 'turn-b', items: [{ type: 'userMessage', clientId: 'local-b' }] }
+                    ]
+                }
+            })
+            await expect(outcome).resolves.toEqual(
+                new Error('Codex rewind timed out after 90000ms total')
+            )
+            expect(readSignal?.aborted).toBe(true)
+            expect(rollback).not.toHaveBeenCalled()
+        } finally {
+            finishRead?.({ thread: { id: 'thread-1', turns: [] } })
+            await outcome
+            vi.useRealTimers()
+        }
+    })
+
+    it('does not roll back when the session becomes busy during the turn read', async () => {
+        let finishRead: ((value: { thread: { id: string; turns: Array<Record<string, unknown>> } }) => void) | undefined
+        const read = vi.fn(() => new Promise<{ thread: { id: string; turns: Array<Record<string, unknown>> } }>((resolve) => {
+            finishRead = resolve
+        }))
+        const rollback = vi.fn(async () => ({ thread: { id: 'thread-1' } }))
+        const history = createHistory(() => createClient({ read, rollback }))
+        history.setThreadId('thread-1')
+        const rewind = history.rewind('local-b')
+        await vi.waitFor(() => expect(read).toHaveBeenCalledOnce())
+
+        history.setBusy(true)
+        finishRead!({
+            thread: {
+                id: 'thread-1',
+                turns: [
+                    { id: 'turn-a', items: [{ type: 'userMessage', clientId: 'local-a' }] },
+                    { id: 'turn-b', items: [{ type: 'userMessage', clientId: 'local-b' }] }
+                ]
+            }
+        })
+
+        await expect(rewind).rejects.toThrow('Session is busy')
+        expect(rollback).not.toHaveBeenCalled()
+    })
+
+    it('retains a timed-out rollback as an active mutation until it settles', async () => {
+        vi.useFakeTimers()
+        let rejectRollback: ((error: Error) => void) | undefined
+        let settled = false
+        const rollback = vi.fn()
+            .mockImplementationOnce(() => new Promise<{ thread: { id: string } }>((_resolve, reject) => {
+                rejectRollback = reject
+            }))
+            .mockResolvedValue({ thread: { id: 'thread-1' } })
+        const publishCapabilities = vi.fn(async () => {})
+        const history = createHistory(() => createClient({ rollback }))
+        history.setPublishCapabilities(publishCapabilities)
+        history.setThreadId('thread-1')
+        const outcome = history.rewind('local-b').then(
+            (value) => ({ type: 'resolved' as const, value }),
+            (error: unknown) => ({ type: 'rejected' as const, error })
+        ).finally(() => {
+            settled = true
+        })
+        let cleanup: Promise<void> | undefined
+
+        try {
+            await vi.advanceTimersByTimeAsync(90_000)
+            expect(settled).toBe(true)
+            await expect(outcome).resolves.toEqual({
+                type: 'rejected',
+                error: new Error('Codex rewind timed out after 90000ms total')
+            })
+            expect(publishCapabilities).not.toHaveBeenCalled()
+
+            await expect(history.fork()).rejects.toThrow('mutation is already in progress')
+            await expect(history.rewind('local-b')).rejects.toThrow('mutation is already in progress')
+
+            let cleanupSettled = false
+            cleanup = history.cleanup().finally(() => {
+                cleanupSettled = true
+            })
+            await vi.advanceTimersByTimeAsync(0)
+            expect(cleanupSettled).toBe(false)
+        } finally {
+            rejectRollback?.(new Error('rollback settled late'))
+            await outcome
+            await cleanup
+            vi.useRealTimers()
+        }
+    })
+
+    it('keeps source work queued until a timed-out rollback settles', async () => {
+        vi.useFakeTimers()
+        let rejectRollback!: (error: Error) => void
+        const rollback = vi.fn(() => new Promise<{ thread: { id: string } }>((_resolve, reject) => {
+            rejectRollback = reject
+        }))
+        const history = createHistory(() => createClient({ rollback }))
+        history.setThreadId('thread-1')
+        const rewind = history.rewind('local-b').catch((error) => error)
+
+        try {
+            await vi.advanceTimersByTimeAsync(90_000)
+            await expect(rewind).resolves.toEqual(
+                new Error('Codex rewind timed out after 90000ms total')
+            )
+
+            let sourceLeaseAcquired = false
+            const sourceLease = history.acquireSourceLease().then((release) => {
+                sourceLeaseAcquired = true
+                return release
+            })
+            await vi.advanceTimersByTimeAsync(0)
+            expect(sourceLeaseAcquired).toBe(false)
+
+            rejectRollback(new Error('rollback settled late'))
+            const release = await sourceLease
+            expect(sourceLeaseAcquired).toBe(true)
+            release()
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+
+    it('applies the total rewind deadline to capability publishing', async () => {
+        vi.useFakeTimers()
+        let finishPublish: (() => void) | undefined
+        let settled = false
+        const history = createHistory(() => createClient())
+        history.setPublishCapabilities(() => new Promise<void>((resolve) => {
+            finishPublish = resolve
+        }))
+        history.setThreadId('thread-1')
+        const outcome = history.rewind('local-b').then(
+            (value) => ({ type: 'resolved' as const, value }),
+            (error: unknown) => ({ type: 'rejected' as const, error })
+        ).finally(() => {
+            settled = true
+        })
+
+        try {
+            await vi.advanceTimersByTimeAsync(90_000)
+            expect(settled).toBe(true)
+            await expect(outcome).resolves.toEqual({
+                type: 'rejected',
+                error: new Error('Codex rewind timed out after 90000ms total')
+            })
+        } finally {
+            finishPublish?.()
+            await outcome
+            vi.useRealTimers()
+        }
+    })
+
+    it('does not start rollback when shutdown follows the turn read', async () => {
+        let finishRead: ((value: { thread: { id: string; turns: Array<Record<string, unknown>> } }) => void) | undefined
+        const read = vi.fn(() => new Promise<{ thread: { id: string; turns: Array<Record<string, unknown>> } }>((resolve) => {
+            finishRead = resolve
+        }))
+        const rollback = vi.fn(async () => ({ thread: { id: 'thread-1' } }))
+        const history = createHistory(() => createClient({ read, rollback }))
+        history.setThreadId('thread-1')
+        const rewind = history.rewind('local-b').catch((error) => error)
+        await vi.waitFor(() => expect(read).toHaveBeenCalledOnce())
+
+        finishRead!({
+            thread: {
+                id: 'thread-1',
+                turns: [
+                    { id: 'turn-a', items: [{ type: 'userMessage', clientId: 'local-a' }] },
+                    { id: 'turn-b', items: [{ type: 'userMessage', clientId: 'local-b' }] }
+                ]
+            }
+        })
+        const cleanup = history.cleanup()
+        const [rewindError] = await Promise.all([rewind, cleanup])
+
+        expect(rewindError).toEqual(new Error('Codex conversation history is shutting down'))
+        expect(rollback).not.toHaveBeenCalled()
+    })
+
+    it('waits for an active rollback during shutdown', async () => {
+        let finishRollback: (() => void) | undefined
+        const rollback = vi.fn(() => new Promise<{ thread: { id: string } }>((resolve) => {
+            finishRollback = () => resolve({ thread: { id: 'thread-1' } })
+        }))
+        const history = createHistory(() => createClient({ rollback }))
+        history.setThreadId('thread-1')
+        const rewind = history.rewind('local-b').catch((error) => error)
+        await vi.waitFor(() => expect(rollback).toHaveBeenCalledOnce())
+
+        let cleanupSettled = false
+        const cleanup = history.cleanup().finally(() => {
+            cleanupSettled = true
+        })
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        expect(cleanupSettled).toBe(false)
+
+        finishRollback!()
+        const [rewindError] = await Promise.all([rewind, cleanup])
+        expect(rewindError).toEqual(new Error('Codex conversation history is shutting down'))
+    })
+
+    it('rejects fork while a rewind mutation is in progress', async () => {
+        let finishRollback: (() => void) | undefined
+        const rollback = vi.fn(() => new Promise<{ thread: { id: string } }>((resolve) => {
+            finishRollback = () => resolve({ thread: { id: 'thread-1' } })
+        }))
+        const history = createHistory(() => createClient({ rollback }))
+        history.setThreadId('thread-1')
+        const rewind = history.rewind('local-b')
+        await vi.waitFor(() => expect(rollback).toHaveBeenCalledOnce())
+
+        try {
+            await expect(history.fork()).rejects.toThrow('mutation is already in progress')
+        } finally {
+            finishRollback!()
+            await rewind
+        }
+    })
+
     it('marks rewind unsupported on method-not-found without affecting fork', async () => {
         const rollback = vi.fn(async () => {
             throw new Error('thread/rollback is unsupported')
         })
         const fork = vi.fn(async () => ({ thread: { id: 'forked-ok' } }))
-        const history = new CodexConversationHistory(() => createClient({ rollback, fork }) as never)
+        const history = createHistory(() => createClient({ rollback, fork }))
         history.setThreadId('thread-1')
         await expect(history.rewind('local-a')).rejects.toThrow(/unsupported/)
         const caps = history.getCapabilitiesForMetadata()?.conversationHistory
@@ -106,10 +1292,10 @@ describe('CodexConversationHistory', () => {
 
     it('does not call native fork when selected turn is missing', async () => {
         const fork = vi.fn(async () => ({ thread: { id: 'x' } }))
-        const history = new CodexConversationHistory(() => createClient({
+        const history = createHistory(() => createClient({
             fork,
             read: async () => ({ thread: { id: 'thread-1', turns: [] } })
-        }) as never)
+        }))
         history.setThreadId('thread-1')
         await expect(history.fork('missing-local')).rejects.toThrow(/No native history point/)
         expect(fork).not.toHaveBeenCalled()
@@ -121,7 +1307,7 @@ describe('CodexConversationHistory', () => {
             expect(params.beforeTurnId).toBeUndefined()
             return { thread: { id: 'forked-restored' } }
         })
-        const history = new CodexConversationHistory(() => createClient({
+        const history = createHistory(() => createClient({
             fork,
             // Simulate a relaunch where thread/read no longer exposes clientIds.
             read: async () => ({
@@ -133,7 +1319,7 @@ describe('CodexConversationHistory', () => {
                     ]
                 }
             })
-        }) as never)
+        }))
         history.setThreadId('thread-1')
         history.restoreTurns({ 'local-b': 'turn-b' })
         const result = await history.fork('local-b')

--- a/cli/src/codex/conversationHistory.ts
+++ b/cli/src/codex/conversationHistory.ts
@@ -1,4 +1,4 @@
-import type { CodexAppServerClient } from './codexAppServerClient'
+import { CodexAppServerClient } from './codexAppServerClient'
 import type { Metadata } from '@/api/types'
 import {
     CODEX_CONVERSATION_HISTORY_INITIAL,
@@ -28,10 +28,68 @@ function isMethodNotFound(error: unknown): boolean {
     return /method not found|unknown method|unsupported/i.test(message)
 }
 
+async function withDeadline<T>(
+    operation: () => Promise<T>,
+    deadline: number,
+    timeoutError: Error,
+    onTimeout?: () => void
+): Promise<T> {
+    let timeoutTriggered = false
+    const triggerTimeout = () => {
+        if (timeoutTriggered) return
+        timeoutTriggered = true
+        onTimeout?.()
+    }
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) {
+        triggerTimeout()
+        throw timeoutError
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    const timedOut = new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+            triggerTimeout()
+            reject(timeoutError)
+        }, remaining)
+        timeout.unref()
+    })
+    try {
+        let result: T
+        try {
+            result = await Promise.race([operation(), timedOut])
+        } catch (error) {
+            if (timeoutTriggered || Date.now() >= deadline) {
+                triggerTimeout()
+                throw timeoutError
+            }
+            throw error
+        }
+        if (timeoutTriggered || Date.now() >= deadline) {
+            triggerTimeout()
+            throw timeoutError
+        }
+        return result
+    } finally {
+        if (timeout) clearTimeout(timeout)
+    }
+}
+
 type TurnInfo = {
     id: string
     status?: string
     clientIds: string[]
+}
+
+type ForkClient = Pick<CodexAppServerClient, 'connect' | 'initialize' | 'forkThread' | 'disconnect'>
+const HISTORY_OPERATION_TIMEOUT_MS = 90_000
+const FORK_CLEANUP_RESERVE_MS = 10_000
+type ForkCapability = 'forkCurrent' | 'forkAtMessage'
+type SourceLeaseWaiter = {
+    signal?: AbortSignal
+    resolve: (release: () => void) => void
+    reject: (error: unknown) => void
+    onAbort?: () => void
 }
 
 export class CodexConversationHistory {
@@ -40,8 +98,20 @@ export class CodexConversationHistory {
     private readonly turnByLocalId = new Map<string, string>()
     private busy = false
     private publishCapabilities: (() => Promise<void>) | null = null
+    private failedForkClient: ForkClient | null = null
+    private activeForkClient: ForkClient | null = null
+    private activeForkAbortController: AbortController | null = null
+    private mutationInFlight: Promise<unknown> | null = null
+    private rawRollbackInFlight: Promise<unknown> | null = null
+    private probeInFlight: Promise<void> | null = null
+    private closing = false
+    private leaseOwner: symbol | null = null
+    private readonly sourceLeaseWaiters: SourceLeaseWaiter[] = []
 
-    constructor(private readonly getClient: () => CodexAppServerClient | null) {}
+    constructor(
+        private readonly getClient: () => CodexAppServerClient | null,
+        private readonly createForkClient: () => ForkClient = () => new CodexAppServerClient()
+    ) {}
 
     setPublishCapabilities(fn: () => Promise<void>): void {
         this.publishCapabilities = fn
@@ -49,6 +119,21 @@ export class CodexConversationHistory {
 
     setBusy(busy: boolean): void {
         this.busy = busy
+    }
+
+    async acquireSourceLease(signal?: AbortSignal): Promise<() => void> {
+        const release = await this.waitForSourceLease(signal)
+        try {
+            this.throwIfClosing()
+            if (signal?.aborted) throw signal.reason
+            await this.retryFailedForkCleanupBy(Date.now() + HISTORY_OPERATION_TIMEOUT_MS)
+            this.throwIfClosing()
+            if (signal?.aborted) throw signal.reason
+            return release
+        } catch (error) {
+            release()
+            throw error
+        }
     }
 
     setThreadId(threadId: string | null): void {
@@ -80,14 +165,86 @@ export class CodexConversationHistory {
         return conversationHistory ? { conversationHistory } : undefined
     }
 
+    async cleanup(): Promise<void> {
+        this.closing = true
+        this.rejectSourceLeaseWaiters(new Error('Codex conversation history is shutting down'))
+        this.activeForkAbortController?.abort()
+        const deadline = Date.now() + HISTORY_OPERATION_TIMEOUT_MS
+        const activeClient = this.activeForkClient
+        if (activeClient) {
+            try {
+                await withDeadline(
+                    () => activeClient.disconnect({ deadline }),
+                    deadline,
+                    new Error(`Codex fork cleanup timed out after ${HISTORY_OPERATION_TIMEOUT_MS}ms total`)
+                )
+            } catch {
+                this.failedForkClient = activeClient
+            }
+        }
+
+        const probeInFlight = this.probeInFlight
+        if (probeInFlight) {
+            try {
+                await withDeadline(
+                    () => probeInFlight,
+                    deadline,
+                    new Error(`Codex fork cleanup timed out after ${HISTORY_OPERATION_TIMEOUT_MS}ms total`)
+                )
+            } catch {
+                // Probe errors do not prevent the existing shutdown sequence.
+            }
+        }
+
+        const inFlight = this.mutationInFlight
+        if (inFlight) {
+            try {
+                await withDeadline(
+                    () => inFlight,
+                    deadline,
+                    new Error(`Codex fork cleanup timed out after ${HISTORY_OPERATION_TIMEOUT_MS}ms total`)
+                )
+            } catch {
+                // Mutation errors are expected during teardown; retained cleanup is retried below.
+            }
+        }
+
+        const rawRollback = this.rawRollbackInFlight
+        if (rawRollback) {
+            try {
+                await withDeadline(
+                    () => rawRollback,
+                    deadline,
+                    new Error(`Codex rollback cleanup timed out after ${HISTORY_OPERATION_TIMEOUT_MS}ms total`)
+                )
+            } catch {
+                // Rollback failures are already reported to the mutation caller.
+            }
+        }
+        await this.retryFailedForkCleanupBy(deadline)
+    }
+
     /** Probe fork/rollback once thread is live. Never optimistic. */
-    async probeCapabilities(): Promise<void> {
+    probeCapabilities(): Promise<void> {
+        if (this.closing) return Promise.resolve()
+        if (this.probeInFlight) return this.probeInFlight
+
+        const inFlight = this.runCapabilityProbe().finally(() => {
+            if (this.probeInFlight === inFlight) this.probeInFlight = null
+        })
+        this.probeInFlight = inFlight
+        return inFlight
+    }
+
+    private async runCapabilityProbe(): Promise<void> {
         const client = this.getClient()
         const threadId = this.threadId
         if (!client || !threadId) return
 
         if (this.states.forkCurrent === 'unknown' || this.states.forkAtMessage === 'unknown') {
-            if (await client.supportsMethod('thread/fork')) {
+            const forkSupported = await client.supportsMethod('thread/fork')
+            if (this.closing) return
+            if (forkSupported) {
                 this.states = markSupported(this.states, 'forkCurrent')
                 this.states = markSupported(this.states, 'forkAtMessage')
             } else {
@@ -97,19 +254,72 @@ export class CodexConversationHistory {
         }
 
         if (this.states.rewindToMessage === 'unknown') {
-            this.states = await client.supportsMethod('thread/rollback')
+            const rewindSupported = await client.supportsMethod('thread/rollback')
+            if (this.closing) return
+            this.states = rewindSupported
                 ? markSupported(this.states, 'rewindToMessage')
                 : markUnsupported(this.states, 'rewindToMessage')
         }
 
         await this.publishCapabilities?.()
+        if (this.closing) return
     }
 
     async fork(messageLocalId?: string): Promise<ForkConversationRpcResult> {
+        const abortController = new AbortController()
+        return this.runMutation(async (deadline) => {
+            this.activeForkAbortController = abortController
+            try {
+                return await this.performFork(messageLocalId, deadline, abortController)
+            } finally {
+                if (this.activeForkAbortController === abortController) {
+                    this.activeForkAbortController = null
+                }
+            }
+        })
+    }
+
+    private async runMutation<T>(operation: (deadline: number) => Promise<T>): Promise<T> {
+        if (this.closing) throw new Error('Codex conversation history is shutting down')
+        if (this.busy) throw new Error('Session is busy')
+        if (this.mutationInFlight || this.rawRollbackInFlight) {
+            throw new Error('Codex conversation history mutation is already in progress')
+        }
+        const releaseLease = this.acquireMutationLease()
+        const deadline = Date.now() + HISTORY_OPERATION_TIMEOUT_MS
+        const inFlight = (async () => {
+            await this.retryFailedForkCleanupBy(deadline)
+            this.throwIfClosing()
+            return await operation(deadline)
+        })()
+        this.mutationInFlight = inFlight
+        try {
+            return await inFlight
+        } finally {
+            if (this.mutationInFlight === inFlight) this.mutationInFlight = null
+            this.releaseMutationLeaseAfterRollback(releaseLease)
+        }
+    }
+
+    private releaseMutationLeaseAfterRollback(releaseLease: () => void): void {
+        const rawRollback = this.rawRollbackInFlight
+        if (rawRollback) {
+            void rawRollback.then(releaseLease, releaseLease)
+        } else {
+            releaseLease()
+        }
+    }
+
+    private async performFork(
+        messageLocalId: string | undefined,
+        deadline: number,
+        abortController: AbortController
+    ): Promise<ForkConversationRpcResult> {
         if (this.busy) throw new Error('Session is busy')
         const client = this.getClient()
         const threadId = this.threadId
         if (!client || !threadId) throw new Error('Codex thread is not ready')
+        this.throwIfForkStopped(abortController.signal)
 
         if (messageLocalId) {
             if (this.states.forkAtMessage === 'unsupported') {
@@ -118,8 +328,18 @@ export class CodexConversationHistory {
             // HAPI historical fork excludes the selected boundary turn. Prefer the
             // stable inclusive `lastTurnId` of the previous turn over experimental
             // `beforeTurnId`, so native context matches the hydrated transcript.
-            const turns = await this.listTurns()
+            const operationTimeout = new Error(
+                `Codex fork timed out after ${HISTORY_OPERATION_TIMEOUT_MS - FORK_CLEANUP_RESERVE_MS}ms`
+            )
+            const turns = await withDeadline(
+                () => this.listTurns(abortController.signal),
+                deadline - FORK_CLEANUP_RESERVE_MS,
+                operationTimeout,
+                () => abortController.abort()
+            )
+            this.throwIfForkStopped(abortController.signal)
             const selectedTurnId = await this.resolveTurnId(messageLocalId, turns)
+            this.throwIfForkStopped(abortController.signal)
             const selectedIndex = turns.findIndex((turn) => turn.id === selectedTurnId)
             if (selectedIndex < 0) {
                 throw new Error('Selected turn not found')
@@ -130,46 +350,50 @@ export class CodexConversationHistory {
             const boundary = selectedIndex === 0
                 ? { beforeTurnId: selectedTurnId }
                 : { lastTurnId: turns[selectedIndex - 1]!.id }
-            try {
-                const response = await client.forkThread({
-                    threadId,
-                    ...boundary
-                })
-                const nativeSessionId = asString(asRecord(response.thread)?.id)
-                if (!nativeSessionId) throw new Error('thread/fork did not return thread.id')
-                this.states = markSupported(this.states, 'forkAtMessage')
-                this.states = markSupported(this.states, 'forkCurrent')
-                await this.publishCapabilities?.()
-                return { nativeSessionId }
-            } catch (error) {
-                if (isMethodNotFound(error)) {
-                    this.states = markUnsupported(this.states, 'forkAtMessage')
-                    await this.publishCapabilities?.()
-                }
-                throw error
-            }
+            const response = await this.forkThread({
+                threadId,
+                ...boundary
+            }, 'forkAtMessage', deadline, abortController)
+            this.throwIfForkStopped(abortController.signal)
+            const nativeSessionId = asString(asRecord(response.thread)?.id)
+            if (!nativeSessionId) throw new Error('thread/fork did not return thread.id')
+            this.states = markSupported(this.states, 'forkAtMessage')
+            this.states = markSupported(this.states, 'forkCurrent')
+            await this.publishCapabilitiesBy(deadline)
+            this.throwIfForkStopped(abortController.signal)
+            return { nativeSessionId }
         }
 
         if (this.states.forkCurrent === 'unsupported') {
             throw new Error('Fork current is not supported')
         }
-        try {
-            const response = await client.forkThread({ threadId })
-            const nativeSessionId = asString(asRecord(response.thread)?.id)
-            if (!nativeSessionId) throw new Error('thread/fork did not return thread.id')
-            this.states = markSupported(this.states, 'forkCurrent')
-            await this.publishCapabilities?.()
-            return { nativeSessionId }
-        } catch (error) {
-            if (isMethodNotFound(error)) {
-                this.states = markUnsupported(this.states, 'forkCurrent')
-                await this.publishCapabilities?.()
-            }
-            throw error
-        }
+        const response = await this.forkThread(
+            { threadId },
+            'forkCurrent',
+            deadline,
+            abortController
+        )
+        this.throwIfForkStopped(abortController.signal)
+        const nativeSessionId = asString(asRecord(response.thread)?.id)
+        if (!nativeSessionId) throw new Error('thread/fork did not return thread.id')
+        this.states = markSupported(this.states, 'forkCurrent')
+        await this.publishCapabilitiesBy(deadline)
+        this.throwIfForkStopped(abortController.signal)
+        return { nativeSessionId }
     }
 
     async rewind(messageLocalId: string): Promise<RewindConversationRpcResult> {
+        return this.runMutation((deadline) => this.performRewind(messageLocalId, deadline))
+    }
+
+    private async performRewind(
+        messageLocalId: string,
+        deadline: number
+    ): Promise<RewindConversationRpcResult> {
+        const timeoutError = new Error(
+            `Codex rewind timed out after ${HISTORY_OPERATION_TIMEOUT_MS}ms total`
+        )
+        const abortController = new AbortController()
         if (this.busy) throw new Error('Session is busy')
         const client = this.getClient()
         const threadId = this.threadId
@@ -178,8 +402,15 @@ export class CodexConversationHistory {
             throw new Error('Rewind is not supported')
         }
 
-        const turns = await this.listTurns()
+        const turns = await withDeadline(
+            () => this.listTurns(abortController.signal),
+            deadline,
+            timeoutError,
+            () => abortController.abort()
+        )
+        this.throwIfRewindStopped(deadline, timeoutError)
         const turnId = await this.resolveTurnId(messageLocalId, turns)
+        this.throwIfRewindStopped(deadline, timeoutError)
         const index = turns.findIndex((turn) => turn.id === turnId)
         if (index < 0) throw new Error('Selected turn not found')
         if (turns[index]?.status === 'inProgress' || turns[index]?.status === 'in_progress') {
@@ -188,18 +419,36 @@ export class CodexConversationHistory {
         const numTurns = turns.length - index
         if (numTurns <= 0) throw new Error('Invalid rewind count')
 
+        this.throwIfRewindStopped(deadline, timeoutError)
+        if (this.busy) throw new Error('Session is busy')
         try {
-            await client.rollbackThread({ threadId, numTurns })
-            this.states = markSupported(this.states, 'rewindToMessage')
-            await this.publishCapabilities?.()
+            const rawRollback = client.rollbackThread({ threadId, numTurns })
+            this.rawRollbackInFlight = rawRollback
+            const clearRawRollback = () => {
+                if (this.rawRollbackInFlight === rawRollback) {
+                    this.rawRollbackInFlight = null
+                }
+            }
+            void rawRollback.then(clearRawRollback, clearRawRollback)
+            await withDeadline(
+                () => rawRollback,
+                deadline,
+                timeoutError
+            )
         } catch (error) {
+            this.throwIfRewindStopped(deadline, timeoutError)
             if (isMethodNotFound(error)) {
                 this.states = markUnsupported(this.states, 'rewindToMessage')
-                await this.publishCapabilities?.()
+                await this.publishCapabilitiesBy(deadline, timeoutError)
+                this.throwIfRewindStopped(deadline, timeoutError)
                 throw new Error('thread/rollback is unsupported')
             }
             throw error
         }
+        this.throwIfRewindStopped(deadline, timeoutError)
+        this.states = markSupported(this.states, 'rewindToMessage')
+        await this.publishCapabilitiesBy(deadline, timeoutError)
+        this.throwIfRewindStopped(deadline, timeoutError)
 
         // Re-read remaining turns for hydrate; return empty messages so hub truncates
         // and child clients reset via epoch. Native history is source of truth on resume.
@@ -224,13 +473,259 @@ export class CodexConversationHistory {
         throw new Error(`No native history point for message ${localId}`)
     }
 
-    private async listTurns(): Promise<TurnInfo[]> {
+    private async forkThread(
+        params: Parameters<CodexAppServerClient['forkThread']>[0],
+        capability: ForkCapability,
+        deadline: number,
+        abortController: AbortController
+    ) {
+        this.throwIfForkStopped(abortController.signal)
+        const client = this.createForkClient()
+        this.activeForkClient = client
+        try {
+            return await this.forkThreadWithClient(
+                client,
+                params,
+                capability,
+                deadline,
+                abortController
+            )
+        } finally {
+            if (this.activeForkClient === client) this.activeForkClient = null
+        }
+    }
+
+    private async forkThreadWithClient(
+        client: ForkClient,
+        params: Parameters<CodexAppServerClient['forkThread']>[0],
+        capability: ForkCapability,
+        deadline: number,
+        abortController: AbortController
+    ) {
+        const operationDeadline = deadline - FORK_CLEANUP_RESERVE_MS
+        let methodUnsupported = false
+        let operationFailed = false
+        let operationError: unknown = null
+        let response: Awaited<ReturnType<ForkClient['forkThread']>> | null = null
+
+        try {
+            const operationTimeout = new Error(
+                `Codex fork timed out after ${HISTORY_OPERATION_TIMEOUT_MS - FORK_CLEANUP_RESERVE_MS}ms`
+            )
+            response = await withDeadline(async () => {
+                this.throwIfForkStopped(abortController.signal)
+                await client.connect({ requireVerifiedProcessIdentity: true })
+                this.throwIfForkStopped(abortController.signal)
+                await client.initialize({
+                    clientInfo: {
+                        name: 'hapi-codex-client',
+                        version: '1.0.0'
+                    },
+                    capabilities: {
+                        experimentalApi: true
+                    }
+                })
+                this.throwIfForkStopped(abortController.signal)
+                try {
+                    const forked = await client.forkThread(params, {
+                        signal: abortController.signal
+                    })
+                    this.throwIfForkStopped(abortController.signal)
+                    return forked
+                } catch (error) {
+                    if (!abortController.signal.aborted && isMethodNotFound(error)) {
+                        this.states = markUnsupported(this.states, capability)
+                        methodUnsupported = true
+                    }
+                    throw error
+                }
+            }, operationDeadline, operationTimeout, () => abortController.abort())
+        } catch (error) {
+            operationFailed = true
+            operationError = error
+        }
+
+        let cleanupFailed = false
+        let cleanupError: unknown = null
+        try {
+            await withDeadline(
+                () => client.disconnect({ deadline }),
+                deadline,
+                new Error(`Codex fork cleanup timed out after ${HISTORY_OPERATION_TIMEOUT_MS}ms total`)
+            )
+        } catch (error) {
+            this.failedForkClient = client
+            cleanupFailed = true
+            cleanupError = error
+        }
+
+        if (!operationFailed) {
+            try {
+                this.throwIfForkStopped(abortController.signal)
+            } catch (error) {
+                operationFailed = true
+                operationError = error
+            }
+        }
+
+        if (methodUnsupported && !this.closing && !abortController.signal.aborted) {
+            try {
+                await this.publishCapabilitiesBy(deadline)
+            } catch (error) {
+                logger.debug(
+                    `[Codex] Failed to publish fork capability update: ${error instanceof Error ? error.message : String(error)}`
+                )
+            }
+        }
+
+        if (operationFailed && cleanupFailed) {
+            const operationMessage = operationError instanceof Error
+                ? operationError.message
+                : String(operationError)
+            const cleanupMessage = cleanupError instanceof Error
+                ? cleanupError.message
+                : String(cleanupError)
+            throw new AggregateError(
+                [operationError, cleanupError],
+                `${operationMessage}; temporary app-server cleanup failed: ${cleanupMessage}`
+            )
+        }
+        if (operationFailed) throw operationError
+        if (cleanupFailed) throw cleanupError
+        return response!
+    }
+
+    private throwIfClosing(): void {
+        if (this.closing) throw new Error('Codex conversation history is shutting down')
+    }
+
+    private acquireMutationLease(): () => void {
+        this.throwIfClosing()
+        if (this.busy) throw new Error('Session is busy')
+        if (this.leaseOwner) {
+            throw new Error('Codex conversation history mutation is already in progress')
+        }
+        const token = Symbol('codex-history-mutation')
+        this.leaseOwner = token
+        return this.createLeaseRelease(token)
+    }
+
+    private waitForSourceLease(signal?: AbortSignal): Promise<() => void> {
+        try {
+            this.throwIfClosing()
+        } catch (error) {
+            return Promise.reject(error)
+        }
+        if (signal?.aborted) return Promise.reject(signal.reason)
+        if (!this.leaseOwner) {
+            const token = Symbol('codex-source')
+            this.leaseOwner = token
+            this.busy = true
+            return Promise.resolve(this.createLeaseRelease(token))
+        }
+
+        return new Promise<() => void>((resolve, reject) => {
+            const waiter: SourceLeaseWaiter = { signal, resolve, reject }
+            if (signal) {
+                waiter.onAbort = () => {
+                    const index = this.sourceLeaseWaiters.indexOf(waiter)
+                    if (index >= 0) this.sourceLeaseWaiters.splice(index, 1)
+                    reject(signal.reason)
+                }
+                signal.addEventListener('abort', waiter.onAbort, { once: true })
+            }
+            this.sourceLeaseWaiters.push(waiter)
+        })
+    }
+
+    private createLeaseRelease(token: symbol): () => void {
+        let released = false
+        return () => {
+            if (released) return
+            released = true
+            if (this.leaseOwner !== token) return
+            this.leaseOwner = null
+            this.busy = false
+            this.grantNextSourceLease()
+        }
+    }
+
+    private grantNextSourceLease(): void {
+        while (!this.leaseOwner) {
+            const waiter = this.sourceLeaseWaiters.shift()
+            if (!waiter) return
+            if (waiter.onAbort && waiter.signal) {
+                waiter.signal.removeEventListener('abort', waiter.onAbort)
+            }
+            if (this.closing) {
+                waiter.reject(new Error('Codex conversation history is shutting down'))
+                continue
+            }
+            if (waiter.signal?.aborted) {
+                waiter.reject(waiter.signal.reason)
+                continue
+            }
+            const token = Symbol('codex-source')
+            this.leaseOwner = token
+            this.busy = true
+            waiter.resolve(this.createLeaseRelease(token))
+        }
+    }
+
+    private rejectSourceLeaseWaiters(error: Error): void {
+        for (const waiter of this.sourceLeaseWaiters.splice(0)) {
+            if (waiter.onAbort && waiter.signal) {
+                waiter.signal.removeEventListener('abort', waiter.onAbort)
+            }
+            waiter.reject(error)
+        }
+    }
+
+    private throwIfForkStopped(signal: AbortSignal): void {
+        this.throwIfClosing()
+        if (signal.aborted) throw new Error('Codex fork was aborted')
+    }
+
+    private throwIfRewindStopped(deadline: number, timeoutError: Error): void {
+        this.throwIfClosing()
+        if (Date.now() >= deadline) throw timeoutError
+    }
+
+    private async retryFailedForkCleanupBy(deadline: number): Promise<void> {
+        const client = this.failedForkClient
+        if (!client) return
+        await withDeadline(
+            () => client.disconnect({ deadline }),
+            deadline,
+            new Error(`Codex fork cleanup timed out after ${HISTORY_OPERATION_TIMEOUT_MS}ms total`)
+        )
+        if (this.failedForkClient === client) this.failedForkClient = null
+    }
+
+    private async publishCapabilitiesBy(
+        deadline: number,
+        timeoutError = new Error(
+            `Codex fork timed out after ${HISTORY_OPERATION_TIMEOUT_MS}ms total`
+        )
+    ): Promise<void> {
+        if (!this.publishCapabilities) return
+        await withDeadline(
+            () => this.publishCapabilities!(),
+            deadline,
+            timeoutError
+        )
+    }
+
+    private async listTurns(signal?: AbortSignal): Promise<TurnInfo[]> {
         const client = this.getClient()
         const threadId = this.threadId
         if (!client || !threadId) return []
 
         try {
-            const response = await client.readThread({ threadId, includeTurns: true })
+            const response = await client.readThread(
+                { threadId, includeTurns: true },
+                { signal }
+            )
             const thread = asRecord(response.thread)
             const turns = Array.isArray(thread?.turns) ? thread.turns : []
             return turns.flatMap((entry) => {
@@ -254,6 +749,7 @@ export class CodexConversationHistory {
                 }]
             })
         } catch (error) {
+            if (signal?.aborted) throw error
             logger.debug(`[Codex] thread/read failed: ${error instanceof Error ? error.message : String(error)}`)
             // Fall back to in-memory mapping only
             return Array.from(this.turnByLocalId.entries()).map(([localId, id]) => ({

--- a/cli/src/utils/process.test.ts
+++ b/cli/src/utils/process.test.ts
@@ -1,0 +1,2186 @@
+import { spawn as spawnChild, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fsOverrides, spawnSyncMock } = vi.hoisted(() => ({
+    fsOverrides: {
+        readdirSync: null as ((...args: unknown[]) => unknown) | null,
+        readFileSync: null as ((...args: unknown[]) => unknown) | null,
+        statSync: null as ((...args: unknown[]) => unknown) | null
+    },
+    spawnSyncMock: vi.fn()
+}));
+
+vi.mock('node:fs', async () => {
+    const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+    return {
+        ...actual,
+        readdirSync: (...args: Parameters<typeof actual.readdirSync>) => (
+            fsOverrides.readdirSync
+                ? fsOverrides.readdirSync(...args)
+                : actual.readdirSync(...args)
+        ),
+        readFileSync: (...args: Parameters<typeof actual.readFileSync>) => (
+            fsOverrides.readFileSync
+                ? fsOverrides.readFileSync(...args)
+                : actual.readFileSync(...args)
+        ),
+        statSync: (...args: Parameters<typeof actual.statSync>) => (
+            fsOverrides.statSync
+                ? fsOverrides.statSync(...args)
+                : actual.statSync(...args)
+        )
+    };
+});
+
+vi.mock('cross-spawn', () => ({
+    default: Object.assign(vi.fn(), { sync: spawnSyncMock })
+}));
+
+import {
+    getProcessStartMarker,
+    isProcessAlive,
+    killProcess,
+    killProcessByChildProcess
+} from './process';
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+const rootMarker = '2026-08-20T08:00:00.1234560Z';
+const childMarker = '2026-08-20T08:00:01.1234560Z';
+const strictOwnershipEnv = 'HAPI_STRICT_PROCESS_OWNERSHIP_TOKEN';
+
+function powershellScript(args: unknown): string {
+    return Array.isArray(args) ? String(args.at(-1) ?? '') : '';
+}
+
+function processTable(rows: Array<{ pid: number; parentPid: number; marker: string }>): Buffer {
+    return Buffer.from(rows.map((row) => (
+        `${row.pid}|${row.parentPid}|${row.marker}`
+    )).join('\n'));
+}
+
+function rootProcessTableResult(args: unknown): { status: number; stdout: Buffer } | null {
+    if (!powershellScript(args).includes('ParentProcessId')) return null;
+    return {
+        status: 0,
+        stdout: processTable([{ pid: 123, parentPid: 1, marker: rootMarker }])
+    };
+}
+
+function wmicProcessTable(rows: Array<{
+    pid: number;
+    parentPid: number;
+    creationDate: string;
+}>): Buffer {
+    return Buffer.from(rows.map((row) => [
+        `CreationDate=${row.creationDate}`,
+        `ParentProcessId=${row.parentPid}`,
+        `ProcessId=${row.pid}`
+    ].join('\r\n')).join('\r\n\r\n'));
+}
+
+function processExited(): never {
+    throw Object.assign(new Error('process exited'), { code: 'ESRCH' });
+}
+
+function requireProcessStartMarker(pid: number): string {
+    const marker = getProcessStartMarker(pid);
+    if (marker === null) throw new Error(`Could not capture process marker for PID ${pid}`);
+    return marker;
+}
+
+function taskkillCalls(): unknown[][] {
+    return spawnSyncMock.mock.calls.filter(([command]) => command === 'taskkill');
+}
+
+describe('killProcess on Windows', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        Object.defineProperty(process, 'platform', {
+            ...platformDescriptor,
+            value: 'win32'
+        });
+        spawnSyncMock.mockReset();
+        spawnSyncMock.mockImplementation((command: string, args: unknown) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return {
+                        status: 0,
+                        stdout: processTable([{ pid: 123, parentPid: 1, marker: rootMarker }])
+                    };
+                }
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            return { status: 0 };
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('keeps the legacy taskkill tree path when no marker is supplied', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+
+        await expect(killProcess(123)).resolves.toBe(true);
+
+        expect(taskkillCalls()).toHaveLength(1);
+        expect(taskkillCalls()[0]?.[1]).toEqual(expect.arrayContaining(['/T', '/PID', '123']));
+        expect(taskkillCalls()[0]?.[2]).not.toHaveProperty('timeout');
+        expect(spawnSyncMock.mock.calls.some(([command]) => command === 'powershell')).toBe(false);
+    });
+
+    it('bounds legacy taskkill when the caller supplies a deadline', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+
+        await expect(
+            killProcess(123, false, undefined, Date.now() + 100)
+        ).resolves.toBe(true);
+
+        expect(taskkillCalls()).toHaveLength(1);
+        expect(taskkillCalls()[0]?.[2]).toHaveProperty('timeout');
+        expect((taskkillCalls()[0]?.[2] as { timeout: number }).timeout).toBeLessThanOrEqual(100);
+    });
+
+    it('fails closed without taskkill when marker capture failed', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+
+        await expect(killProcess(123, false, null)).resolves.toBe(false);
+
+        expect(spawnSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a PID generation captured after spawn', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: unknown) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return {
+                        status: 0,
+                        stdout: processTable([{ pid: 123, parentPid: 1, marker: childMarker }])
+                    };
+                }
+                return { status: 0, stdout: Buffer.from(`${childMarker}\n`) };
+            }
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        await expect(result).resolves.toBe(false);
+
+        expect(taskkillCalls()).toHaveLength(0);
+    });
+
+    it('waits for the expected process generation to exit', async () => {
+        let alive = true;
+        vi.spyOn(process, 'kill').mockImplementation((() => {
+            if (alive) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: unknown) => {
+            if (command === 'powershell') {
+                const table = rootProcessTableResult(args);
+                if (table) return table;
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            alive = false;
+            return { status: 0 };
+        });
+
+        await expect(killProcess(123, false, rootMarker)).resolves.toBe(true);
+
+        expect(taskkillCalls()).toHaveLength(1);
+        expect(taskkillCalls()[0]?.[1]).toEqual(expect.arrayContaining(['/T', '/PID', '123']));
+        expect(taskkillCalls()[0]?.[2]).toHaveProperty('timeout');
+    });
+
+    it('returns false when the root exits but a tracked descendant generation remains', async () => {
+        const alive = new Set([123, 456]);
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+            if (alive.has(pid)) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return {
+                        status: 0,
+                        stdout: processTable([
+                            { pid: 123, parentPid: 1, marker: rootMarker },
+                            { pid: 456, parentPid: 123, marker: childMarker }
+                        ])
+                    };
+                }
+                const pid = powershellScript(args).includes('456') ? 456 : 123;
+                const marker = pid === 456 ? childMarker : rootMarker;
+                return { status: 0, stdout: Buffer.from(`${marker}\n`) };
+            }
+            alive.delete(123);
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        await expect(result).resolves.toBe(false);
+        expect(alive.has(456)).toBe(true);
+    });
+
+    it('returns true only after the root and tracked descendant generations exit', async () => {
+        const alive = new Set([123, 456]);
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+            if (alive.has(pid)) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return {
+                        status: 0,
+                        stdout: processTable([
+                            { pid: 123, parentPid: 1, marker: rootMarker },
+                            { pid: 456, parentPid: 123, marker: childMarker }
+                        ])
+                    };
+                }
+                const pid = powershellScript(args).includes('456') ? 456 : 123;
+                const marker = pid === 456 ? childMarker : rootMarker;
+                return { status: 0, stdout: Buffer.from(`${marker}\n`) };
+            }
+            alive.delete(123);
+            setTimeout(() => alive.delete(456), 100);
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(100);
+
+        await expect(result).resolves.toBe(true);
+    });
+
+    it('tracks a descendant generation that appears after taskkill starts', async () => {
+        const alive = new Set([123, 456]);
+        let tableReads = 0;
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+            if (alive.has(pid)) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    tableReads += 1;
+                    return {
+                        status: 0,
+                        stdout: processTable([
+                            { pid: 123, parentPid: 1, marker: rootMarker },
+                            ...(tableReads >= 3
+                                ? [{ pid: 456, parentPid: 123, marker: childMarker }]
+                                : [])
+                        ])
+                    };
+                }
+                const marker = powershellScript(args).includes('456')
+                    ? childMarker
+                    : rootMarker;
+                return { status: 0, stdout: Buffer.from(`${marker}\n`) };
+            }
+            alive.delete(123);
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        await expect(result).resolves.toBe(false);
+        expect(alive.has(456)).toBe(true);
+        expect(tableReads).toBeGreaterThanOrEqual(3);
+    });
+
+    it('does not count a newly discovered but already exited descendant as an empty scan', async () => {
+        const handoffMarker = '2026-08-20T08:00:02.1234560Z';
+        const alive = new Set([123, 789]);
+        let tableReads = 0;
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+            if (alive.has(pid)) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    tableReads += 1;
+                    return {
+                        status: 0,
+                        stdout: processTable([
+                            { pid: 123, parentPid: 1, marker: rootMarker },
+                            ...(tableReads >= 3
+                                ? [{ pid: 456, parentPid: 123, marker: childMarker }]
+                                : []),
+                            ...(tableReads >= 4
+                                ? [{ pid: 789, parentPid: 456, marker: handoffMarker }]
+                                : [])
+                        ])
+                    };
+                }
+                const script = powershellScript(args);
+                const marker = script.includes('789')
+                    ? handoffMarker
+                    : script.includes('456') ? childMarker : rootMarker;
+                return { status: 0, stdout: Buffer.from(`${marker}\n`) };
+            }
+            alive.delete(123);
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        await expect(result).resolves.toBe(false);
+        expect(alive.has(789)).toBe(true);
+        expect(tableReads).toBeGreaterThanOrEqual(4);
+    });
+
+    it('fails closed when a same-millisecond child predates its parent', async () => {
+        const newerRootMarker = '2026-08-20T08:00:00.1239000Z';
+        const olderChildMarker = '2026-08-20T08:00:00.1231000Z';
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return {
+                        status: 0,
+                        stdout: processTable([
+                            { pid: 123, parentPid: 1, marker: newerRootMarker },
+                            { pid: 456, parentPid: 123, marker: olderChildMarker }
+                        ])
+                    };
+                }
+                const marker = powershellScript(args).includes('456')
+                    ? olderChildMarker
+                    : newerRootMarker;
+                return { status: 0, stdout: Buffer.from(`${marker}\n`) };
+            }
+            return { status: 1 };
+        });
+
+        await expect(killProcess(123, false, newerRootMarker)).resolves.toBe(false);
+
+        expect(taskkillCalls()).toHaveLength(0);
+    });
+
+    it('fails closed when a Windows descendant marker is not canonical', async () => {
+        const malformedChildMarker = '2026-08-20T08:00:01.123Z';
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return {
+                        status: 0,
+                        stdout: processTable([
+                            { pid: 123, parentPid: 1, marker: rootMarker },
+                            { pid: 456, parentPid: 123, marker: malformedChildMarker }
+                        ])
+                    };
+                }
+                const marker = powershellScript(args).includes('456')
+                    ? malformedChildMarker
+                    : rootMarker;
+                return { status: 0, stdout: Buffer.from(`${marker}\n`) };
+            }
+            return { status: 1 };
+        });
+
+        await expect(killProcess(123, false, rootMarker)).resolves.toBe(false);
+
+        expect(taskkillCalls()).toHaveLength(0);
+    });
+
+    it('fails closed when the complete Windows process tree cannot be enumerated', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return { status: 1, stdout: Buffer.alloc(0) };
+                }
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            if (command === 'wmic') return { status: 1, stdout: Buffer.alloc(0) };
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        await expect(result).resolves.toBe(false);
+
+        expect(taskkillCalls()).toHaveLength(0);
+    });
+
+    it('uses the WMIC process-table fallback with valid system PID zero records', async () => {
+        const alive = new Set([123]);
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+            if (alive.has(pid)) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return { status: 1, stdout: Buffer.alloc(0) };
+                }
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            if (command === 'wmic') {
+                return {
+                    status: 0,
+                    stdout: wmicProcessTable([
+                        {
+                            pid: 0,
+                            parentPid: 0,
+                            creationDate: '20260820070000.123456+000'
+                        },
+                        {
+                            pid: 123,
+                            parentPid: 1,
+                            creationDate: '20260820080000.123456+000'
+                        }
+                    ])
+                };
+            }
+            alive.delete(123);
+            return { status: 0 };
+        });
+
+        await expect(killProcess(123, false, rootMarker)).resolves.toBe(true);
+
+        expect(taskkillCalls()).toHaveLength(1);
+        expect(spawnSyncMock.mock.calls.some(([command]) => command === 'wmic')).toBe(true);
+    });
+
+    it.each(['powershell', 'wmic'] as const)(
+        'ignores an unrelated %s process whose creation marker is unavailable',
+        async (source) => {
+            const alive = new Set([123]);
+            vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+                if (alive.has(pid)) return true;
+                return processExited();
+            }) as typeof process.kill);
+            spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+                if (command === 'powershell') {
+                    if (powershellScript(args).includes('ParentProcessId')) {
+                        if (source === 'wmic') return { status: 1, stdout: Buffer.alloc(0) };
+                        return {
+                            status: 0,
+                            stdout: processTable([
+                                { pid: 123, parentPid: 1, marker: rootMarker },
+                                { pid: 999, parentPid: 1, marker: '' }
+                            ])
+                        };
+                    }
+                    return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+                }
+                if (command === 'wmic') {
+                    return {
+                        status: 0,
+                        stdout: wmicProcessTable([
+                            {
+                                pid: 123,
+                                parentPid: 1,
+                                creationDate: '20260820080000.123456+000'
+                            },
+                            { pid: 999, parentPid: 1, creationDate: '' }
+                        ])
+                    };
+                }
+                alive.delete(123);
+                return { status: 0 };
+            });
+
+            await expect(killProcess(123, false, rootMarker)).resolves.toBe(true);
+
+            expect(taskkillCalls()).toHaveLength(1);
+        }
+    );
+
+    it.each(['powershell', 'wmic'] as const)(
+        'fails closed when a %s descendant creation marker is unavailable',
+        async (source) => {
+            vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+            spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+                if (command === 'powershell') {
+                    if (powershellScript(args).includes('ParentProcessId')) {
+                        if (source === 'wmic') return { status: 1, stdout: Buffer.alloc(0) };
+                        return {
+                            status: 0,
+                            stdout: processTable([
+                                { pid: 123, parentPid: 1, marker: rootMarker },
+                                { pid: 456, parentPid: 123, marker: '' }
+                            ])
+                        };
+                    }
+                    return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+                }
+                if (command === 'wmic') {
+                    return {
+                        status: 0,
+                        stdout: wmicProcessTable([
+                            {
+                                pid: 123,
+                                parentPid: 1,
+                                creationDate: '20260820080000.123456+000'
+                            },
+                            { pid: 456, parentPid: 123, creationDate: '' }
+                        ])
+                    };
+                }
+                return { status: 0 };
+            });
+
+            await expect(killProcess(123, false, rootMarker)).resolves.toBe(false);
+
+            expect(taskkillCalls()).toHaveLength(0);
+            if (source === 'powershell') {
+                expect(spawnSyncMock.mock.calls.some(([command]) => command === 'wmic')).toBe(false);
+            }
+        }
+    );
+
+    it('fails closed when a WMIC descendant row has incomplete topology', async () => {
+        const alive = new Set([123]);
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+            if (alive.has(pid)) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return { status: 1, stdout: Buffer.alloc(0) };
+                }
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            if (command === 'wmic') {
+                return {
+                    status: 0,
+                    stdout: Buffer.from([
+                        'CreationDate=20260820080000.123456+000',
+                        'ParentProcessId=1',
+                        'ProcessId=123',
+                        '',
+                        'CreationDate=20260820080001.123456+000',
+                        'ParentProcessId=123'
+                    ].join('\r\n'))
+                };
+            }
+            alive.delete(123);
+            return { status: 0 };
+        });
+
+        await expect(killProcess(123, false, rootMarker)).resolves.toBe(false);
+
+        expect(taskkillCalls()).toHaveLength(0);
+    });
+
+    it('fails closed when the expected generation exits before taskkill starts', async () => {
+        let aliveChecks = 0;
+        vi.spyOn(process, 'kill').mockImplementation((() => {
+            aliveChecks += 1;
+            if (aliveChecks < 4) return true;
+            return processExited();
+        }) as typeof process.kill);
+
+        await expect(killProcess(123, false, rootMarker)).resolves.toBe(false);
+
+        expect(taskkillCalls()).toHaveLength(0);
+    });
+
+    it('fails closed when taskkill returns nonzero and the root PID disappears', async () => {
+        let alive = true;
+        vi.spyOn(process, 'kill').mockImplementation((() => {
+            if (alive) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: unknown) => {
+            if (command === 'powershell') {
+                const table = rootProcessTableResult(args);
+                if (table) return table;
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            alive = false;
+            return { status: 1 };
+        });
+
+        await expect(killProcess(123, false, rootMarker)).resolves.toBe(false);
+
+        expect(taskkillCalls()).toHaveLength(1);
+    });
+
+    it('fails closed when taskkill errors and the root PID disappears', async () => {
+        let alive = true;
+        vi.spyOn(process, 'kill').mockImplementation((() => {
+            if (alive) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: unknown) => {
+            if (command === 'powershell') {
+                const table = rootProcessTableResult(args);
+                if (table) return table;
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            alive = false;
+            return { status: null, error: new Error('taskkill failed') };
+        });
+
+        await expect(killProcess(123, false, rootMarker)).resolves.toBe(false);
+
+        expect(taskkillCalls()).toHaveLength(1);
+    });
+
+    it('force-kills the same generation when graceful taskkill stalls', async () => {
+        let alive = true;
+        vi.spyOn(process, 'kill').mockImplementation((() => {
+            if (alive) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                const table = rootProcessTableResult(args);
+                if (table) return table;
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            if (args.includes('/F')) alive = false;
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        await expect(result).resolves.toBe(true);
+        expect(taskkillCalls()).toHaveLength(2);
+        expect(taskkillCalls()[1]?.[1]).toEqual(
+            expect.arrayContaining(['/F', '/T', '/PID', '123'])
+        );
+    });
+
+    it('returns false when successful graceful and forced taskkill leave the generation alive', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        await expect(result).resolves.toBe(false);
+        expect(taskkillCalls()).toHaveLength(2);
+        expect(taskkillCalls()[1]?.[1]).toContain('/F');
+    });
+
+    it('fails closed when forced taskkill fails and the root PID disappears', async () => {
+        let alive = true;
+        vi.spyOn(process, 'kill').mockImplementation((() => {
+            if (alive) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                const table = rootProcessTableResult(args);
+                if (table) return table;
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            if (args.includes('/F')) {
+                alive = false;
+                return { status: 1 };
+            }
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        await expect(result).resolves.toBe(false);
+        expect(taskkillCalls()).toHaveLength(2);
+        expect(taskkillCalls()[1]?.[1]).toContain('/F');
+    });
+
+    it('does not force-kill a reused PID', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+        let markerReads = 0;
+        spawnSyncMock.mockImplementation((command: string, args: unknown) => {
+            if (command === 'powershell') {
+                const table = rootProcessTableResult(args);
+                if (table) return table;
+                markerReads += 1;
+                return {
+                    status: 0,
+                    stdout: Buffer.from(markerReads === 1
+                        ? `${rootMarker}\n`
+                        : `${childMarker}\n`)
+                };
+            }
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(2_000);
+
+        await expect(result).resolves.toBe(true);
+        expect(taskkillCalls()).toHaveLength(1);
+    });
+
+    it('fails closed when the current generation cannot be read', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+        spawnSyncMock.mockReturnValue({ status: 1, stdout: Buffer.alloc(0) });
+
+        await expect(killProcess(123, false, rootMarker)).resolves.toBe(false);
+
+        expect(taskkillCalls()).toHaveLength(0);
+    });
+
+    it('does not taskkill when a tracked descendant liveness probe is unknown', async () => {
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+            if (pid === 456) {
+                throw Object.assign(new Error('access denied'), { code: 'EPERM' });
+            }
+            return true;
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'powershell') {
+                if (powershellScript(args).includes('ParentProcessId')) {
+                    return {
+                        status: 0,
+                        stdout: processTable([
+                            { pid: 123, parentPid: 1, marker: rootMarker },
+                            { pid: 456, parentPid: 123, marker: childMarker }
+                        ])
+                    };
+                }
+                const marker = powershellScript(args).includes('456')
+                    ? childMarker
+                    : rootMarker;
+                return { status: 0, stdout: Buffer.from(`${marker}\n`) };
+            }
+            return { status: 0 };
+        });
+
+        const result = killProcess(123, false, rootMarker);
+        await vi.advanceTimersByTimeAsync(3_000);
+
+        await expect(result).resolves.toBe(false);
+        expect(taskkillCalls()).toHaveLength(0);
+    });
+
+    it('bounds Windows commands by the caller deadline', async () => {
+        const alive = new Set([123]);
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+            if (alive.has(pid)) return true;
+            return processExited();
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: unknown) => {
+            if (command === 'powershell') {
+                const table = rootProcessTableResult(args);
+                if (table) return table;
+                return { status: 0, stdout: Buffer.from(`${rootMarker}\n`) };
+            }
+            alive.delete(123);
+            return { status: 0 };
+        });
+
+        await expect(
+            killProcess(123, false, rootMarker, Date.now() + 100)
+        ).resolves.toBe(true);
+
+        const windowsCalls = spawnSyncMock.mock.calls.filter(([command]) => (
+            command === 'powershell' || command === 'taskkill'
+        ));
+        for (const [, , options] of windowsCalls) {
+            expect((options as { timeout: number }).timeout).toBeLessThanOrEqual(100);
+        }
+    });
+
+    it('forwards the generation marker and deadline from a child process', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string) => {
+            if (command === 'powershell') {
+                return { status: 0, stdout: Buffer.from('replacement-marker\n') };
+            }
+            return { status: 0 };
+        });
+        const child = { pid: 123 } as ChildProcess;
+
+        await expect(
+            killProcessByChildProcess(child, false, rootMarker, Date.now() + 100)
+        ).resolves.toBe(false);
+
+        const powershellCall = spawnSyncMock.mock.calls.find(([command]) => command === 'powershell');
+        expect((powershellCall?.[2] as { timeout: number }).timeout).toBeLessThanOrEqual(100);
+        expect(taskkillCalls()).toHaveLength(0);
+    });
+
+    it('normalizes a WMIC fallback marker to the PowerShell format', () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string) => {
+            if (command === 'powershell') {
+                return { status: 1, stdout: Buffer.alloc(0) };
+            }
+            return {
+                status: 0,
+                stdout: Buffer.from('CreationDate=20260820080000.123456+000\r\n')
+            };
+        });
+
+        expect(getProcessStartMarker(123)).toBe(rootMarker);
+    });
+
+    it('fails closed when the expected generation is already absent', async () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => processExited()) as typeof process.kill);
+
+        await expect(killProcess(123, false, rootMarker)).resolves.toBe(false);
+        expect(spawnSyncMock).not.toHaveBeenCalled();
+    });
+});
+
+describe.skipIf(process.platform === 'win32')('strict POSIX token ownership', () => {
+    const originalMarker = 'Thu Aug 20 08:00:00 2026';
+    const replacementMarker = 'Thu Aug 20 08:00:01 2026';
+    const psColumns = 'pid=,uid=,ppid=,pgid=,lstart=,command=';
+    const uid = process.getuid?.() ?? 1_000;
+    let tokenSequence = 0;
+    let ownershipToken: string;
+    let child: ChildProcess;
+
+    function ownershipTable(options?: {
+        command?: string;
+        marker?: string;
+        processGroupId?: number;
+        token?: string;
+        uid?: number;
+    }): Buffer {
+        const environment = options?.token
+            ? ` ${strictOwnershipEnv}=${options.token}`
+            : '';
+        return Buffer.from(
+            `456 ${options?.uid ?? uid} 1 ${options?.processGroupId ?? 123} `
+                + `${options?.marker ?? originalMarker} `
+                + `${options?.command ?? 'node app.js'}${environment}\n`
+        );
+    }
+
+    function isPsTable(args: string[], modifier: 'axeww' | 'axww'): boolean {
+        return args.length === 3
+            && args[0] === modifier
+            && args[1] === '-o'
+            && args[2] === psColumns;
+    }
+
+    function installProcessSignalMock(options?: { exitOnDirectSignal?: boolean }): string[] {
+        let ownedProcessAlive = true;
+        const signals: string[] = [];
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123) return processExited();
+                if (pid === 456 && !ownedProcessAlive) return processExited();
+                return true;
+            }
+            signals.push(`${pid}:${String(signal)}`);
+            if (pid === 456 && options?.exitOnDirectSignal) ownedProcessAlive = false;
+            return true;
+        }) as typeof process.kill);
+        return signals;
+    }
+
+    beforeEach(() => {
+        Object.defineProperty(process, 'platform', {
+            ...platformDescriptor,
+            value: 'darwin'
+        });
+        tokenSequence += 1;
+        ownershipToken = `strict-token-${tokenSequence}`;
+        child = { pid: 123 } as ChildProcess;
+        spawnSyncMock.mockReset();
+    });
+
+    afterEach(() => {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+        vi.restoreAllMocks();
+    });
+
+    it('signals only a same-UID token found in the enriched command suffix', async () => {
+        const signals = installProcessSignalMock({ exitOnDirectSignal: true });
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command !== 'ps') return { status: 1, stdout: Buffer.alloc(0) };
+            if (args[0] === '-p') {
+                return { status: 0, stdout: Buffer.from(`${originalMarker}\n`) };
+            }
+            if (isPsTable(args, 'axeww')) {
+                return { status: 0, stdout: ownershipTable({ token: ownershipToken }) };
+            }
+            if (isPsTable(args, 'axww')) {
+                return { status: 0, stdout: ownershipTable() };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toEqual(['-123:SIGTERM', '456:SIGTERM']);
+        expect(spawnSyncMock).toHaveBeenCalledWith(
+            'ps',
+            ['axeww', '-o', psColumns],
+            expect.objectContaining({ stdio: 'pipe' })
+        );
+        expect(spawnSyncMock).toHaveBeenCalledWith(
+            'ps',
+            ['axww', '-o', psColumns],
+            expect.objectContaining({ stdio: 'pipe' })
+        );
+    });
+
+    const rejectedOwnershipCases: Array<[
+        string,
+        () => { token: string; uid?: number }
+    ]> = [
+        ['wrong token', () => ({ token: `${ownershipToken}-wrong` })],
+        ['different UID', () => ({ token: ownershipToken, uid: uid + 1 })]
+    ];
+
+    it.each(rejectedOwnershipCases)('leaves a %s process untouched', async (
+        _case,
+        enrichedOptions
+    ) => {
+        const signals = installProcessSignalMock();
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command !== 'ps') return { status: 1, stdout: Buffer.alloc(0) };
+            if (isPsTable(args, 'axeww')) {
+                return { status: 0, stdout: ownershipTable(enrichedOptions()) };
+            }
+            if (isPsTable(args, 'axww')) {
+                const options = enrichedOptions();
+                return { status: 0, stdout: ownershipTable({ uid: options.uid }) };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('does not treat a token appearing only in argv as ownership', async () => {
+        const signals = installProcessSignalMock();
+        const commandLine = `node app.js ${strictOwnershipEnv}=${ownershipToken}`;
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command !== 'ps') return { status: 1, stdout: Buffer.alloc(0) };
+            if (isPsTable(args, 'axeww') || isPsTable(args, 'axww')) {
+                return {
+                    status: 0,
+                    stdout: ownershipTable({ command: commandLine })
+                };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('does not signal a replaced token-owned PID generation', async () => {
+        const signals = installProcessSignalMock();
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'ps' && args.includes('-p')) {
+                return { status: 0, stdout: Buffer.from(`${replacementMarker}\n`) };
+            }
+            if (command === 'ps' && isPsTable(args, 'axeww')) {
+                return { status: 0, stdout: ownershipTable({ token: ownershipToken }) };
+            }
+            if (command === 'ps' && isPsTable(args, 'axww')) {
+                return { status: 0, stdout: ownershipTable() };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 100,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('does not signal a same-marker replacement missing the ownership token', async () => {
+        const signals = installProcessSignalMock();
+        let includeToken = true;
+        let markerReads = 0;
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command !== 'ps') return { status: 1, stdout: Buffer.alloc(0) };
+            if (args[0] === '-p') {
+                markerReads += 1;
+                if (markerReads === 2) includeToken = false;
+                return { status: 0, stdout: Buffer.from(`${originalMarker}\n`) };
+            }
+            if (isPsTable(args, 'axeww')) {
+                return {
+                    status: 0,
+                    stdout: ownershipTable({
+                        processGroupId: 789,
+                        ...(includeToken ? { token: ownershipToken } : {})
+                    })
+                };
+            }
+            if (isPsTable(args, 'axww')) {
+                return {
+                    status: 0,
+                    stdout: ownershipTable({ processGroupId: 789 })
+                };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('revalidates the current process group before group signaling', async () => {
+        const signals = installProcessSignalMock({ exitOnDirectSignal: true });
+        let processGroupId = 123;
+        let markerReads = 0;
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command !== 'ps') return { status: 1, stdout: Buffer.alloc(0) };
+            if (args[0] === '-p') {
+                markerReads += 1;
+                if (markerReads === 2) processGroupId = 789;
+                return { status: 0, stdout: Buffer.from(`${originalMarker}\n`) };
+            }
+            if (isPsTable(args, 'axeww')) {
+                return {
+                    status: 0,
+                    stdout: ownershipTable({ processGroupId, token: ownershipToken })
+                };
+            }
+            if (isPsTable(args, 'axww')) {
+                return { status: 0, stdout: ownershipTable({ processGroupId }) };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toEqual(['456:SIGTERM']);
+    });
+
+    it('fails closed before signaling when a token-owned identity is unknown', async () => {
+        const signals = installProcessSignalMock();
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'ps' && args.includes('-p')) {
+                return { status: 1, stdout: Buffer.alloc(0) };
+            }
+            if (command === 'ps' && isPsTable(args, 'axeww')) {
+                return { status: 0, stdout: ownershipTable({ token: ownershipToken }) };
+            }
+            if (command === 'ps' && isPsTable(args, 'axww')) {
+                return { status: 0, stdout: ownershipTable() };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 100,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('retains a known generation across cleanup retries', async () => {
+        const signals = installProcessSignalMock();
+        let includeToken = true;
+        let markerAvailable = false;
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command !== 'ps') return { status: 1, stdout: Buffer.alloc(0) };
+            if (args[0] === '-p') {
+                return markerAvailable
+                    ? { status: 0, stdout: Buffer.from(`${originalMarker}\n`) }
+                    : { status: 1, stdout: Buffer.alloc(0) };
+            }
+            if (isPsTable(args, 'axeww')) {
+                return {
+                    status: 0,
+                    stdout: ownershipTable(includeToken ? { token: ownershipToken } : undefined)
+                };
+            }
+            if (isPsTable(args, 'axww')) {
+                return { status: 0, stdout: ownershipTable() };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        includeToken = false;
+        markerAvailable = true;
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('does not count an observed generation that exits during identity handoff as empty', async () => {
+        const signals: string[] = [];
+        let tableScan = 0;
+        const table = (pid: number, includeToken: boolean): Buffer => Buffer.from(
+            `${pid} ${uid} 1 123 ${originalMarker} node app.js`
+                + `${includeToken ? ` ${strictOwnershipEnv}=${ownershipToken}` : ''}\n`
+        );
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123) return processExited();
+                if (pid === 789) {
+                    throw Object.assign(new Error('identity denied'), { code: 'EACCES' });
+                }
+                return true;
+            }
+            signals.push(`${pid}:${String(signal)}`);
+            return true;
+        }) as typeof process.kill);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command !== 'ps') return { status: 1, stdout: Buffer.alloc(0) };
+            if (args[0] === '-p') {
+                return { status: 0, stdout: Buffer.from(`${replacementMarker}\n`) };
+            }
+            if (isPsTable(args, 'axeww')) {
+                tableScan += 1;
+                if (tableScan <= 2) return { status: 0, stdout: table(456, false) };
+                if (tableScan === 3) return { status: 0, stdout: table(456, true) };
+                return { status: 0, stdout: table(789, true) };
+            }
+            if (isPsTable(args, 'axww')) {
+                return { status: 0, stdout: table(tableScan >= 4 ? 789 : 456, false) };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 300,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(tableScan).toBeGreaterThanOrEqual(4);
+        expect(signals).toEqual([]);
+    });
+
+    it('rejects a different token on a retry for the same child', async () => {
+        const signals = installProcessSignalMock();
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command !== 'ps') return { status: 1, stdout: Buffer.alloc(0) };
+            if (args[0] === '-p') return { status: 1, stdout: Buffer.alloc(0) };
+            if (isPsTable(args, 'axeww')) {
+                return { status: 0, stdout: ownershipTable({ token: ownershipToken }) };
+            }
+            if (isPsTable(args, 'axww')) {
+                return { status: 0, stdout: ownershipTable() };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+        spawnSyncMock.mockClear();
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            `${ownershipToken}-replacement`
+        )).resolves.toBe(false);
+
+        expect(spawnSyncMock).not.toHaveBeenCalled();
+        expect(signals).toEqual([]);
+    });
+
+    it('does not signal a recycled process group with no token-owned generation', async () => {
+        const signals = installProcessSignalMock();
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'ps' && (isPsTable(args, 'axeww') || isPsTable(args, 'axww'))) {
+                return { status: 0, stdout: ownershipTable() };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 100,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('fails closed when ownership enumeration fails', async () => {
+        const signals = installProcessSignalMock();
+        spawnSyncMock.mockReturnValue({ status: 1, stdout: Buffer.alloc(0) });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('does not enumerate or signal after the caller deadline', async () => {
+        const signals = installProcessSignalMock();
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() - 1,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(spawnSyncMock).not.toHaveBeenCalled();
+        expect(signals).toEqual([]);
+    });
+
+    it.each([
+        ['process group', 123],
+        ['individual process', 789]
+    ])('does not signal a %s when its final identity probe consumes the deadline', async (
+        _case,
+        processGroupId
+    ) => {
+        const signals = installProcessSignalMock();
+        const deadline = 10_100;
+        let now = 10_000;
+        let markerReads = 0;
+        vi.spyOn(Date, 'now').mockImplementation(() => now);
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command !== 'ps') return { status: 1, stdout: Buffer.alloc(0) };
+            if (args[0] === '-p') {
+                markerReads += 1;
+                if (markerReads === 2) now = deadline;
+                return { status: 0, stdout: Buffer.from(`${originalMarker}\n`) };
+            }
+            if (isPsTable(args, 'axeww')) {
+                return {
+                    status: 0,
+                    stdout: ownershipTable({ processGroupId, token: ownershipToken })
+                };
+            }
+            if (isPsTable(args, 'axww')) {
+                return { status: 0, stdout: ownershipTable({ processGroupId }) };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            deadline,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('bounds ownership enumeration by the caller deadline', async () => {
+        installProcessSignalMock();
+        spawnSyncMock.mockImplementation((command: string, args: string[]) => {
+            if (command === 'ps' && (isPsTable(args, 'axeww') || isPsTable(args, 'axww'))) {
+                return { status: 0, stdout: ownershipTable() };
+            }
+            return { status: 1, stdout: Buffer.alloc(0) };
+        });
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            originalMarker,
+            Date.now() + 100,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        const enumerationCalls = spawnSyncMock.mock.calls.filter(([, args]) => (
+            Array.isArray(args) && (isPsTable(args, 'axeww') || isPsTable(args, 'axww'))
+        ));
+        expect(enumerationCalls.length).toBeGreaterThanOrEqual(4);
+        expect(enumerationCalls.every(([, , options]) => (
+            (options as { timeout: number }).timeout > 0
+                && (options as { timeout: number }).timeout <= 100
+        ))).toBe(true);
+    });
+});
+
+describe.skipIf(process.platform !== 'linux')('strict Linux token ownership', () => {
+    const rootStartMarker = 'linux:4000';
+    const uid = process.getuid?.() ?? 1_000;
+    let tokenSequence = 0;
+
+    function linuxStat(pid: number, processGroupId: number, startTime: string): string {
+        const fields = Array.from({ length: 20 }, () => '0');
+        fields[0] = 'S';
+        fields[1] = '1';
+        fields[2] = String(processGroupId);
+        fields[19] = startTime;
+        return `${pid} (node) ${fields.join(' ')}`;
+    }
+
+    function installProcMock(options: {
+        environment: () => Buffer;
+        pid: number;
+        processGroupId: number;
+        startTime?: string;
+    }): void {
+        fsOverrides.readdirSync = (path) => {
+            expect(path).toBe('/proc');
+            return [String(options.pid)];
+        };
+        fsOverrides.statSync = (path) => {
+            expect(path).toBe(`/proc/${options.pid}`);
+            return { uid };
+        };
+        fsOverrides.readFileSync = (path) => {
+            if (path === `/proc/${options.pid}/stat`) {
+                return linuxStat(
+                    options.pid,
+                    options.processGroupId,
+                    options.startTime ?? '4242'
+                );
+            }
+            if (path === `/proc/${options.pid}/environ`) {
+                return options.environment();
+            }
+            throw new Error(`Unexpected proc read: ${String(path)}`);
+        };
+    }
+
+    beforeEach(() => {
+        fsOverrides.readdirSync = null;
+        fsOverrides.readFileSync = null;
+        fsOverrides.statSync = null;
+        spawnSyncMock.mockReset();
+    });
+
+    afterEach(() => {
+        fsOverrides.readdirSync = null;
+        fsOverrides.readFileSync = null;
+        fsOverrides.statSync = null;
+        vi.restoreAllMocks();
+    });
+
+    it('reads the precise Linux process start time from procfs', () => {
+        installProcMock({
+            environment: () => Buffer.alloc(0),
+            pid: 123,
+            processGroupId: 123,
+            startTime: '7777'
+        });
+        vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+        spawnSyncMock.mockReturnValue({
+            status: 0,
+            stdout: Buffer.from('Thu Aug 20 08:00:00 2026\n')
+        });
+
+        expect(getProcessStartMarker(123)).toBe('linux:7777');
+        expect(spawnSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when a known owned generation makes its environment unreadable', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-known-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        let environmentReadable = true;
+        let identityKnown = false;
+        let ownedProcessAlive = true;
+        const signals: string[] = [];
+        installProcMock({
+            environment: () => {
+                if (!environmentReadable) {
+                    throw Object.assign(new Error('environment denied'), { code: 'EACCES' });
+                }
+                return Buffer.from(`${strictOwnershipEnv}=${ownershipToken}\0`);
+            },
+            pid: 456,
+            processGroupId: 123
+        });
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123) return processExited();
+                if (!ownedProcessAlive) return processExited();
+                if (pid === 456 && !identityKnown) {
+                    throw Object.assign(new Error('identity denied'), { code: 'EACCES' });
+                }
+                return true;
+            }
+            signals.push(`${pid}:${String(signal)}`);
+            ownedProcessAlive = false;
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        environmentReadable = false;
+        identityKnown = true;
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('retries a transiently unreadable new owned generation before failing closed', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-transient-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        let environmentReads = 0;
+        let ownedProcessAlive = true;
+        const signals: string[] = [];
+        installProcMock({
+            environment: () => {
+                environmentReads += 1;
+                if (environmentReads === 1) {
+                    throw Object.assign(new Error('environment denied'), { code: 'EACCES' });
+                }
+                return Buffer.from(`${strictOwnershipEnv}=${ownershipToken}\0`);
+            },
+            pid: 456,
+            processGroupId: 123
+        });
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123 || (pid === 456 && !ownedProcessAlive)) return processExited();
+                return true;
+            }
+            signals.push(`${pid}:${String(signal)}`);
+            if (pid === 456) ownedProcessAlive = false;
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 300,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(environmentReads).toBeGreaterThan(1);
+        expect(signals).toContain('456:SIGTERM');
+    });
+
+    it('does not lose a descendant spawned during Linux snapshot handoff', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-handoff-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        let scan = 0;
+        let handoffRecordReads = 0;
+        const signals: string[] = [];
+        fsOverrides.readdirSync = () => {
+            scan += 1;
+            if (scan === 1) return ['999'];
+            if (scan === 2) return ['456'];
+            return ['789'];
+        };
+        fsOverrides.statSync = () => ({ uid });
+        fsOverrides.readFileSync = (path) => {
+            if (path === '/proc/999/stat') return linuxStat(999, 999, '3000');
+            if (path === '/proc/999/environ') return Buffer.alloc(0);
+            if (path === '/proc/456/stat') {
+                handoffRecordReads += 1;
+                if (handoffRecordReads > 1) {
+                    throw Object.assign(new Error('process exited'), { code: 'ENOENT' });
+                }
+                return linuxStat(456, 123, '4242');
+            }
+            if (path === '/proc/456/environ') {
+                return Buffer.from(`${strictOwnershipEnv}=${ownershipToken}\0`);
+            }
+            if (path === '/proc/789/stat') return linuxStat(789, 789, '4243');
+            if (path === '/proc/789/environ') {
+                return Buffer.from(`${strictOwnershipEnv}=${ownershipToken}\0`);
+            }
+            throw new Error(`Unexpected proc read: ${String(path)}`);
+        };
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123 || pid === 456) return processExited();
+                if (pid === 789) {
+                    throw Object.assign(new Error('identity denied'), { code: 'EACCES' });
+                }
+                return true;
+            }
+            signals.push(`${pid}:${String(signal)}`);
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(scan).toBeGreaterThanOrEqual(3);
+        expect(signals).toEqual([]);
+    });
+
+    it('does not signal a stale process group after a known process moves groups', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-moved-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        let includeToken = true;
+        let identityKnown = false;
+        let ownedProcessAlive = true;
+        let processGroupId = 123;
+        const signals: string[] = [];
+        installProcMock({
+            environment: () => Buffer.from(includeToken
+                ? `${strictOwnershipEnv}=${ownershipToken}\0`
+                : ''),
+            pid: 456,
+            get processGroupId() {
+                return processGroupId;
+            }
+        });
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123) return processExited();
+                if (!ownedProcessAlive) return processExited();
+                if (pid === 456 && !identityKnown) {
+                    throw Object.assign(new Error('identity denied'), { code: 'EACCES' });
+                }
+                return true;
+            }
+            signals.push(`${pid}:${String(signal)}`);
+            if (pid === 456) ownedProcessAlive = false;
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        includeToken = false;
+        identityKnown = true;
+        processGroupId = 789;
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toEqual(['456:SIGTERM']);
+    });
+
+    it('fails closed when the strict root environment is unreadable', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-root-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        const signals: string[] = [];
+        installProcMock({
+            environment: () => {
+                throw Object.assign(new Error('environment denied'), { code: 'EACCES' });
+            },
+            pid: 123,
+            processGroupId: 123,
+            startTime: '4000'
+        });
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) return true;
+            signals.push(`${pid}:${String(signal)}`);
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('ignores an unreadable unrelated same-UID environment', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-unrelated-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        const signals: string[] = [];
+        installProcMock({
+            environment: () => {
+                throw Object.assign(new Error('environment denied'), { code: 'EACCES' });
+            },
+            pid: 999,
+            processGroupId: 999,
+            startTime: '3000'
+        });
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123) return processExited();
+                return true;
+            }
+            signals.push(`${pid}:${String(signal)}`);
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('fails closed when an unreadable older PID changes generation during inspection', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-raced-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        let environmentReads = 0;
+        let statReads = 0;
+        installProcMock({
+            environment: () => {
+                environmentReads += 1;
+                if (environmentReads === 1) {
+                    throw Object.assign(new Error('environment denied'), { code: 'EACCES' });
+                }
+                return Buffer.alloc(0);
+            },
+            pid: 999,
+            processGroupId: 999,
+            get startTime() {
+                statReads += 1;
+                return statReads === 1 ? '3000' : '5000';
+            }
+        });
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123) return processExited();
+                return true;
+            }
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+    });
+});
+
+describe.skipIf(process.platform === 'win32')('strict POSIX process-group termination', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('does not resolve until the detached parent and descendant are both gone', async () => {
+        const ownershipToken = `group-tree-${process.pid}-${Date.now()}`;
+        const parent = spawnChild(process.execPath, ['-e', [
+            "const { spawn } = require('node:child_process')",
+            "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' })",
+            'console.log(child.pid)',
+            'setInterval(() => {}, 1000)'
+        ].join(';')], {
+            detached: true,
+            env: { ...process.env, [strictOwnershipEnv]: ownershipToken },
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const rootStartMarker = requireProcessStartMarker(parent.pid!);
+        try {
+            const output = await once(parent.stdout!, 'data');
+            const childPid = Number(output[0].toString().trim());
+
+            await expect(killProcessByChildProcess(
+                parent,
+                false,
+                rootStartMarker,
+                Date.now() + 5_000,
+                true,
+                ownershipToken
+            )).resolves.toBe(true);
+
+            expect(isProcessAlive(parent.pid!)).toBe(false);
+            expect(isProcessAlive(childPid)).toBe(false);
+        } finally {
+            try {
+                process.kill(-parent.pid!, 'SIGKILL');
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+            }
+            if (parent.exitCode === null && parent.signalCode === null) {
+                await once(parent, 'exit');
+            }
+        }
+    });
+
+    it('terminates a token-owned setsid child while its parent is still alive', async () => {
+        const ownershipToken = `setsid-live-root-${process.pid}-${Date.now()}`;
+        const parent = spawnChild(process.execPath, ['-e', [
+            "const { spawn } = require('node:child_process')",
+            "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' })",
+            'child.unref()',
+            'console.log(child.pid)',
+            'setInterval(() => {}, 1000)'
+        ].join(';')], {
+            detached: true,
+            env: { ...process.env, [strictOwnershipEnv]: ownershipToken },
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const rootStartMarker = requireProcessStartMarker(parent.pid!);
+        let childPid: number | null = null;
+
+        try {
+            const output = await once(parent.stdout!, 'data');
+            childPid = Number(output[0].toString().trim());
+
+            await expect(killProcessByChildProcess(
+                parent,
+                false,
+                rootStartMarker,
+                Date.now() + 5_000,
+                true,
+                ownershipToken
+            )).resolves.toBe(true);
+
+            expect(isProcessAlive(parent.pid!)).toBe(false);
+            expect(isProcessAlive(childPid)).toBe(false);
+        } finally {
+            for (const processGroupId of [parent.pid!, childPid]) {
+                if (processGroupId === null) continue;
+                try {
+                    process.kill(-processGroupId, 'SIGKILL');
+                } catch (error) {
+                    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+                }
+            }
+            if (parent.exitCode === null && parent.signalCode === null) {
+                await once(parent, 'exit');
+            }
+        }
+    });
+
+    it('terminates a surviving process group after its detached leader exits', async () => {
+        const ownershipToken = `group-reparent-${process.pid}-${Date.now()}`;
+        const parent = spawnChild(process.execPath, ['-e', [
+            "const { spawn } = require('node:child_process')",
+            "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' })",
+            'child.unref()',
+            'console.log(child.pid)'
+        ].join(';')], {
+            detached: true,
+            env: { ...process.env, [strictOwnershipEnv]: ownershipToken },
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const rootStartMarker = requireProcessStartMarker(parent.pid!);
+        try {
+            const output = await once(parent.stdout!, 'data');
+            const childPid = Number(output[0].toString().trim());
+            if (parent.exitCode === null && parent.signalCode === null) {
+                await once(parent, 'exit');
+            }
+            expect(isProcessAlive(parent.pid!)).toBe(false);
+            expect(isProcessAlive(childPid)).toBe(true);
+
+            await expect(killProcessByChildProcess(
+                parent,
+                false,
+                rootStartMarker,
+                Date.now() + 5_000,
+                true,
+                ownershipToken
+            )).resolves.toBe(true);
+
+            expect(isProcessAlive(childPid)).toBe(false);
+        } finally {
+            try {
+                process.kill(-parent.pid!, 'SIGKILL');
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+            }
+            if (parent.exitCode === null && parent.signalCode === null) {
+                await once(parent, 'exit');
+            }
+        }
+    });
+
+    it('terminates a token-owned setsid child after its parent is reparented', async () => {
+        const ownershipToken = `setsid-reparent-${process.pid}-${Date.now()}`;
+        const parent = spawnChild(process.execPath, ['-e', [
+            "const { spawn } = require('node:child_process')",
+            "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' })",
+            'child.unref()',
+            'console.log(child.pid)'
+        ].join(';')], {
+            detached: true,
+            env: { ...process.env, [strictOwnershipEnv]: ownershipToken },
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const rootStartMarker = requireProcessStartMarker(parent.pid!);
+        let childPid: number | null = null;
+
+        try {
+            const output = await once(parent.stdout!, 'data');
+            childPid = Number(output[0].toString().trim());
+            if (parent.exitCode === null && parent.signalCode === null) {
+                await once(parent, 'exit');
+            }
+            expect(isProcessAlive(parent.pid!)).toBe(false);
+            expect(isProcessAlive(childPid)).toBe(true);
+
+            await expect(killProcessByChildProcess(
+                parent,
+                false,
+                rootStartMarker,
+                Date.now() + 5_000,
+                true,
+                ownershipToken
+            )).resolves.toBe(true);
+
+            expect(isProcessAlive(childPid)).toBe(false);
+        } finally {
+            if (childPid !== null) {
+                try {
+                    process.kill(-childPid, 'SIGKILL');
+                } catch (error) {
+                    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+                }
+            }
+            if (parent.exitCode === null && parent.signalCode === null) {
+                await once(parent, 'exit');
+            }
+        }
+    });
+
+    it('terminates a detached helper spawned by the root SIGTERM handler', async () => {
+        const ownershipToken = `signal-helper-${process.pid}-${Date.now()}`;
+        const parent = spawnChild(process.execPath, ['-e', [
+            "const { spawn } = require('node:child_process')",
+            'let handling = false',
+            "process.on('SIGTERM', () => {",
+            'if (handling) return',
+            'handling = true',
+            "const helper = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' })",
+            'helper.unref()',
+            'console.log(helper.pid)',
+            'setTimeout(() => process.exit(0), 50)',
+            '})',
+            "console.log('ready')",
+            'setInterval(() => {}, 1000)'
+        ].join(';')], {
+            detached: true,
+            env: { ...process.env, [strictOwnershipEnv]: ownershipToken },
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const rootStartMarker = requireProcessStartMarker(parent.pid!);
+        let helperPid: number | null = null;
+
+        try {
+            await once(parent.stdout!, 'data');
+            const helperOutput = once(parent.stdout!, 'data');
+            const termination = killProcessByChildProcess(
+                parent,
+                false,
+                rootStartMarker,
+                Date.now() + 5_000,
+                true,
+                ownershipToken
+            );
+            const output = await helperOutput;
+            helperPid = Number(output[0].toString().trim());
+
+            await expect(termination).resolves.toBe(true);
+            expect(isProcessAlive(helperPid)).toBe(false);
+        } finally {
+            for (const processGroupId of [parent.pid!, helperPid]) {
+                if (processGroupId === null) continue;
+                try {
+                    process.kill(-processGroupId, 'SIGKILL');
+                } catch (error) {
+                    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+                }
+            }
+            if (parent.exitCode === null && parent.signalCode === null) {
+                await once(parent, 'exit');
+            }
+        }
+    });
+
+    it('leaves a same-UID process with a different ownership token alive', async () => {
+        const ownershipToken = `owned-${process.pid}-${Date.now()}`;
+        const otherToken = `other-${process.pid}-${Date.now()}`;
+        const owned = spawnChild(process.execPath, ['-e', [
+            "process.stdout.write('ready')",
+            'setInterval(() => {}, 1000)'
+        ].join(';')], {
+            detached: true,
+            env: { ...process.env, [strictOwnershipEnv]: ownershipToken },
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const other = spawnChild(process.execPath, ['-e', [
+            "process.stdout.write('ready')",
+            'setInterval(() => {}, 1000)'
+        ].join(';')], {
+            detached: true,
+            env: { ...process.env, [strictOwnershipEnv]: otherToken },
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const rootStartMarker = requireProcessStartMarker(owned.pid!);
+
+        try {
+            await Promise.all([once(owned.stdout!, 'data'), once(other.stdout!, 'data')]);
+
+            await expect(killProcessByChildProcess(
+                owned,
+                false,
+                rootStartMarker,
+                Date.now() + 5_000,
+                true,
+                ownershipToken
+            )).resolves.toBe(true);
+
+            expect(isProcessAlive(owned.pid!)).toBe(false);
+            expect(isProcessAlive(other.pid!)).toBe(true);
+        } finally {
+            for (const processGroupId of [owned.pid!, other.pid!]) {
+                try {
+                    process.kill(-processGroupId, 'SIGKILL');
+                } catch (error) {
+                    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+                }
+            }
+            for (const child of [owned, other]) {
+                if (child.exitCode === null && child.signalCode === null) {
+                    await once(child, 'exit');
+                }
+            }
+        }
+    });
+
+    it.skipIf(process.platform !== 'linux')(
+        'fails closed for a newer nondumpable setsid helper after the root exits',
+        async () => {
+            const ownershipToken = `nondumpable-helper-${process.pid}-${Date.now()}`;
+            const helperScript = [
+                'import ctypes',
+                'import time',
+                'ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)',
+                "print('ready', flush=True)",
+                'time.sleep(60)'
+            ].join(';');
+            const parent = spawnChild(process.execPath, ['-e', [
+                "const { spawn } = require('node:child_process')",
+                "console.log('ready')",
+                "process.stdin.once('data', () => {",
+                `const helper = spawn('python3', ['-c', ${JSON.stringify(helperScript)}], { detached: true, stdio: ['ignore', 'pipe', 'ignore'] })`,
+                "helper.stdout.once('data', () => { console.log(helper.pid); helper.unref(); process.exit(0) })",
+                '})',
+                'process.stdin.resume()'
+            ].join(';')], {
+                detached: true,
+                env: { ...process.env, [strictOwnershipEnv]: ownershipToken },
+                stdio: ['pipe', 'pipe', 'ignore']
+            });
+            const rootStartMarker = requireProcessStartMarker(parent.pid!);
+            let helperPid: number | null = null;
+
+            try {
+                await once(parent.stdout!, 'data');
+                const helperOutput = once(parent.stdout!, 'data');
+                parent.stdin!.write('spawn');
+                const output = await helperOutput;
+                helperPid = Number(output[0].toString().trim());
+                if (parent.exitCode === null && parent.signalCode === null) {
+                    await once(parent, 'exit');
+                }
+                expect(isProcessAlive(helperPid)).toBe(true);
+
+                await expect(killProcessByChildProcess(
+                    parent,
+                    false,
+                    rootStartMarker,
+                    Date.now() + 5_000,
+                    true,
+                    ownershipToken
+                )).resolves.toBe(false);
+
+                expect(isProcessAlive(helperPid)).toBe(true);
+            } finally {
+                if (helperPid !== null) {
+                    try {
+                        process.kill(-helperPid, 'SIGKILL');
+                    } catch (error) {
+                        if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+                    }
+                }
+                if (parent.exitCode === null && parent.signalCode === null) {
+                    await once(parent, 'exit');
+                }
+            }
+        }
+    );
+
+    it('fails without signaling the process group after its deadline', async () => {
+        const ownershipToken = `expired-deadline-${process.pid}-${Date.now()}`;
+        const parent = spawnChild(process.execPath, ['-e', [
+            "process.stdout.write('ready')",
+            'setInterval(() => {}, 1000)'
+        ].join(';')], {
+            detached: true,
+            env: { ...process.env, [strictOwnershipEnv]: ownershipToken },
+            stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const rootStartMarker = requireProcessStartMarker(parent.pid!);
+
+        try {
+            await once(parent.stdout!, 'data');
+
+            await expect(killProcessByChildProcess(
+                parent,
+                false,
+                rootStartMarker,
+                Date.now() - 1,
+                true,
+                ownershipToken
+            )).resolves.toBe(false);
+            expect(isProcessAlive(parent.pid!)).toBe(true);
+        } finally {
+            try {
+                process.kill(-parent.pid!, 'SIGKILL');
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+            }
+            if (parent.exitCode === null && parent.signalCode === null) {
+                await once(parent, 'exit');
+            }
+        }
+    });
+});
+
+describe('isProcessAlive', () => {
+    it('returns false for ESRCH', () => {
+        vi.spyOn(process, 'kill').mockImplementation((() => {
+            throw Object.assign(new Error('missing'), { code: 'ESRCH' });
+        }) as typeof process.kill);
+
+        expect(isProcessAlive(123)).toBe(false);
+    });
+
+    it.each(['EPERM', 'EACCES', undefined])('returns false for %s probe failure', (code) => {
+        vi.spyOn(process, 'kill').mockImplementation((() => {
+            throw Object.assign(new Error('probe failed'), { code });
+        }) as typeof process.kill);
+
+        expect(isProcessAlive(123)).toBe(false);
+    });
+});

--- a/cli/src/utils/process.test.ts
+++ b/cli/src/utils/process.test.ts
@@ -1395,10 +1395,15 @@ describe.skipIf(process.platform !== 'linux')('strict Linux token ownership', ()
     const uid = process.getuid?.() ?? 1_000;
     let tokenSequence = 0;
 
-    function linuxStat(pid: number, processGroupId: number, startTime: string): string {
+    function linuxStat(
+        pid: number,
+        processGroupId: number,
+        startTime: string,
+        parentPid = 1
+    ): string {
         const fields = Array.from({ length: 20 }, () => '0');
         fields[0] = 'S';
-        fields[1] = '1';
+        fields[1] = String(parentPid);
         fields[2] = String(processGroupId);
         fields[19] = startTime;
         return `${pid} (node) ${fields.join(' ')}`;
@@ -1409,6 +1414,7 @@ describe.skipIf(process.platform !== 'linux')('strict Linux token ownership', ()
         pid: number;
         processGroupId: number;
         startTime?: string;
+        parentPid?: number;
     }): void {
         fsOverrides.readdirSync = (path) => {
             expect(path).toBe('/proc');
@@ -1423,7 +1429,8 @@ describe.skipIf(process.platform !== 'linux')('strict Linux token ownership', ()
                 return linuxStat(
                     options.pid,
                     options.processGroupId,
-                    options.startTime ?? '4242'
+                    options.startTime ?? '4242',
+                    options.parentPid
                 );
             }
             if (path === `/proc/${options.pid}/environ`) {
@@ -1723,6 +1730,133 @@ describe.skipIf(process.platform !== 'linux')('strict Linux token ownership', ()
                 if (pid === 123) return processExited();
                 return true;
             }
+            signals.push(`${pid}:${String(signal)}`);
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('ignores a newer unreadable unrelated same-UID environment', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-newer-unrelated-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        let rootAlive = true;
+        const signals: string[] = [];
+        fsOverrides.readdirSync = () => ['999', '123'];
+        fsOverrides.statSync = (path) => {
+            if (path === '/proc/123' && !rootAlive) {
+                throw Object.assign(new Error('root exited'), { code: 'ENOENT' });
+            }
+            return { uid };
+        };
+        fsOverrides.readFileSync = (path) => {
+            if (path === '/proc/999/stat') return linuxStat(999, 999, '5000');
+            if (path === '/proc/999/environ') {
+                throw Object.assign(new Error('environment denied'), { code: 'EACCES' });
+            }
+            if (path === '/proc/123/stat') {
+                if (!rootAlive) {
+                    throw Object.assign(new Error('root exited'), { code: 'ENOENT' });
+                }
+                return linuxStat(123, 123, '4000');
+            }
+            if (path === '/proc/123/environ') {
+                return Buffer.from(`${strictOwnershipEnv}=${ownershipToken}\0`);
+            }
+            throw new Error(`Unexpected proc read: ${String(path)}`);
+        };
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123 && !rootAlive) return processExited();
+                return true;
+            }
+            signals.push(`${pid}:${String(signal)}`);
+            if (pid === -123 || pid === 123) rootAlive = false;
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(true);
+
+        expect(signals).toContain('-123:SIGTERM');
+        expect(signals.some((entry) => entry.startsWith('999:'))).toBe(false);
+    });
+
+    it('fails closed for an unreadable direct child outside the root process group', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-direct-child-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        const signals: string[] = [];
+        fsOverrides.readdirSync = () => ['456', '123'];
+        fsOverrides.statSync = () => ({ uid });
+        fsOverrides.readFileSync = (path) => {
+            if (path === '/proc/456/stat') return linuxStat(456, 456, '5000', 123);
+            if (path === '/proc/456/environ') {
+                throw Object.assign(new Error('environment denied'), { code: 'EACCES' });
+            }
+            if (path === '/proc/123/stat') return linuxStat(123, 123, '4000');
+            if (path === '/proc/123/environ') {
+                return Buffer.from(`${strictOwnershipEnv}=${ownershipToken}\0`);
+            }
+            throw new Error(`Unexpected proc read: ${String(path)}`);
+        };
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) {
+                if (pid === 123) return processExited();
+                return true;
+            }
+            signals.push(`${pid}:${String(signal)}`);
+            return true;
+        }) as typeof process.kill);
+
+        await expect(killProcessByChildProcess(
+            child,
+            false,
+            rootStartMarker,
+            Date.now() + 200,
+            true,
+            ownershipToken
+        )).resolves.toBe(false);
+
+        expect(signals).toEqual([]);
+    });
+
+    it('does not trust an unreadable child after its parent PID is reused', async () => {
+        tokenSequence += 1;
+        const ownershipToken = `linux-reused-parent-token-${tokenSequence}`;
+        const child = { pid: 123 } as ChildProcess;
+        const signals: string[] = [];
+        fsOverrides.readdirSync = () => ['456'];
+        fsOverrides.statSync = (path) => {
+            expect(path).toBe('/proc/456');
+            return { uid };
+        };
+        fsOverrides.readFileSync = (path) => {
+            if (path === '/proc/456/stat') return linuxStat(456, 456, '5000', 123);
+            if (path === '/proc/456/environ') {
+                throw Object.assign(new Error('environment denied'), { code: 'EACCES' });
+            }
+            if (path === '/proc/123/stat') return linuxStat(123, 123, '6000');
+            throw new Error(`Unexpected proc read: ${String(path)}`);
+        };
+        vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+            if (signal === 0) return true;
             signals.push(`${pid}:${String(signal)}`);
             return true;
         }) as typeof process.kill);
@@ -2068,7 +2202,7 @@ describe.skipIf(process.platform === 'win32')('strict POSIX process-group termin
     });
 
     it.skipIf(process.platform !== 'linux')(
-        'fails closed for a newer nondumpable setsid helper after the root exits',
+        'ignores an unobserved nondumpable setsid helper after the root exits',
         async () => {
             const ownershipToken = `nondumpable-helper-${process.pid}-${Date.now()}`;
             const helperScript = [
@@ -2112,7 +2246,7 @@ describe.skipIf(process.platform === 'win32')('strict POSIX process-group termin
                     Date.now() + 5_000,
                     true,
                     ownershipToken
-                )).resolves.toBe(false);
+                )).resolves.toBe(true);
 
                 expect(isProcessAlive(helperPid)).toBe(true);
             } finally {

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -710,12 +710,21 @@ function listLinuxOwnedProcessGenerations(
       if (isMissingProcessError(error)) continue;
       if (isUnreadableProcessEnvironment(error)) {
         const key = processGenerationKey(recordBefore.value);
-        const candidateStartTime = linuxStartTime(recordBefore.value.startMarker);
-        if (candidateStartTime === null) return null;
-        if ((pid === rootPid
+        const hasPotentialOwnedParent = Array.from(knownOwned.values()).some((record) => (
+          record.pid === recordBefore.value.parentPid
+        ));
+        let hasKnownOwnedParent = false;
+        if (hasPotentialOwnedParent) {
+          const parentRecord = readLinuxProcessRecord(recordBefore.value.parentPid);
+          if (parentRecord.kind === 'unknown') return null;
+          hasKnownOwnedParent = parentRecord.kind === 'ok'
+            && knownOwned.has(processGenerationKey(parentRecord.value));
+        }
+        const plausiblyOwned = pid === rootPid
           || knownOwned.has(key)
-          || candidateStartTime >= rootStartTime)
-          && !confirmedExited.has(key)) {
+          || recordBefore.value.processGroupId === rootPid
+          || hasKnownOwnedParent;
+        if (plausiblyOwned && !confirmedExited.has(key)) {
           return 'retryable';
         }
         const recordAfter = readLinuxProcessRecord(pid);

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -1,46 +1,266 @@
 import type { ChildProcess } from 'node:child_process';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import spawn from 'cross-spawn';
+
+const WINDOWS_COMMAND_TIMEOUT_MS = 3_000;
+const WINDOWS_TREE_KILL_TIMEOUT_MS = 10_000;
+const POSIX_PROCESS_GROUP_KILL_TIMEOUT_MS = 3_000;
+const PROCESS_POLL_INTERVAL_MS = 20;
+const WINDOWS_START_MARKER_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z$/;
+
+export const STRICT_PROCESS_OWNERSHIP_ENV = 'HAPI_STRICT_PROCESS_OWNERSHIP_TOKEN';
 
 export const isWindows = (): boolean => process.platform === 'win32';
 
-export function isProcessAlive(pid: number): boolean {
+type ProcessLiveness = 'alive' | 'exited' | 'unknown';
+
+function probeProcessLiveness(pid: number): ProcessLiveness {
   if (!Number.isFinite(pid) || pid <= 0) {
-    return false;
+    return 'exited';
   }
 
   try {
     process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
+    return 'alive';
+  } catch (error) {
+    if (error && typeof error === 'object'
+      && (error as NodeJS.ErrnoException).code === 'ESRCH') {
+      return 'exited';
+    }
+    return 'unknown';
   }
 }
 
+export function isProcessAlive(pid: number): boolean {
+  return probeProcessLiveness(pid) === 'alive';
+}
+
 /** Stable marker for one OS PID generation; null means the platform probe failed. */
-export function getProcessStartMarker(pid: number): string | null {
+export function getProcessStartMarker(pid: number, deadline?: number): string | null {
   if (!isProcessAlive(pid)) return null;
   if (isWindows()) {
-    const powershell = spawn.sync('powershell', [
-      '-NoProfile', '-NonInteractive', '-Command',
-      `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CreationDate`
-    ], { stdio: 'pipe', windowsHide: true });
-    if (!powershell.error && powershell.status === 0) {
-      const marker = powershell.stdout?.toString().trim();
-      if (marker) return marker;
-    }
+    const marker = readWindowsProcessStartMarker(pid, deadline);
+    if (marker) return marker;
+    const timeout = getWindowsCommandTimeout(deadline);
+    if (timeout === null) return null;
     const result = spawn.sync('wmic', [
       'process', 'where', `ProcessId=${pid}`, 'get', 'CreationDate', '/value'
-    ], { stdio: 'pipe', windowsHide: true });
+    ], { stdio: 'pipe', windowsHide: true, timeout });
     if (result.error || result.status !== 0) return null;
     const match = (result.stdout?.toString() ?? '').match(/CreationDate=([^\r\n]+)/);
-    return match?.[1]?.trim() || null;
+    return normalizeWindowsWmicStartMarker(match?.[1]?.trim() ?? '');
   }
+  if (process.platform === 'linux') {
+    if (deadline !== undefined && Date.now() >= deadline) return null;
+    const record = readLinuxProcessRecord(pid);
+    if (deadline !== undefined && Date.now() >= deadline) return null;
+    return record.kind === 'ok' ? record.value.startMarker : null;
+  }
+  const timeout = deadline === undefined ? undefined : getPosixCommandTimeout(deadline);
+  if (timeout === null) return null;
   const result = spawn.sync('ps', ['-p', String(pid), '-o', 'lstart='], {
     stdio: 'pipe',
-    env: { ...process.env, LC_ALL: 'C', TZ: 'UTC' }
+    env: { ...process.env, LC_ALL: 'C', TZ: 'UTC' },
+    ...(timeout === undefined ? {} : { timeout })
   });
   if (result.error || result.status !== 0) return null;
   return result.stdout?.toString().trim() || null;
+}
+
+function normalizeWindowsWmicStartMarker(marker: string): string | null {
+  const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\.(\d{6})([+-])(\d{3})$/.exec(marker);
+  if (!match) return null;
+  const [, year, month, day, hour, minute, second, fraction, sign, offset] = match;
+  const localTime = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second)
+  );
+  if (!Number.isFinite(localTime)) return null;
+  const offsetMs = Number(offset) * 60_000 * (sign === '+' ? 1 : -1);
+  const utc = new Date(localTime - offsetMs);
+  const normalized = `${utc.toISOString().slice(0, 19)}.${fraction}0Z`;
+  return isCanonicalWindowsStartMarker(normalized) ? normalized : null;
+}
+
+function isCanonicalWindowsStartMarker(marker: string): boolean {
+  return WINDOWS_START_MARKER_PATTERN.test(marker)
+    && Number.isFinite(Date.parse(marker));
+}
+
+function getWindowsCommandTimeout(deadline?: number): number | null {
+  if (deadline === undefined) return WINDOWS_COMMAND_TIMEOUT_MS;
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return null;
+  return Math.max(1, Math.min(WINDOWS_COMMAND_TIMEOUT_MS, Math.ceil(remaining)));
+}
+
+function getPosixCommandTimeout(deadline: number): number | null {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return null;
+  return Math.max(1, Math.min(
+    POSIX_PROCESS_GROUP_KILL_TIMEOUT_MS,
+    Math.ceil(remaining)
+  ));
+}
+
+function readWindowsProcessStartMarker(pid: number, deadline?: number): string | null {
+  const timeout = getWindowsCommandTimeout(deadline);
+  if (timeout === null) return null;
+  try {
+    const powershell = spawn.sync('powershell', [
+      '-NoProfile', '-NonInteractive', '-Command',
+      `$process = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; `
+        + `if ($null -ne $process -and $null -ne $process.CreationDate) { `
+        + `$process.CreationDate.ToUniversalTime()`
+        + `.ToString('yyyy-MM-ddTHH:mm:ss.fffffffZ') }`
+    ], { stdio: 'pipe', windowsHide: true, timeout });
+    if (powershell.error || powershell.status !== 0) return null;
+    const marker = powershell.stdout?.toString().trim() ?? '';
+    return isCanonicalWindowsStartMarker(marker) ? marker : null;
+  } catch {
+    return null;
+  }
+}
+
+type WindowsProcessRecord = {
+  pid: number;
+  parentPid: number;
+  startMarker: string | null;
+};
+
+function parseWindowsProcessRecord(
+  pidText: string,
+  parentPidText: string,
+  startMarker: string
+): WindowsProcessRecord | null {
+  if (!pidText.trim() || !parentPidText.trim()) return null;
+  const pid = Number(pidText);
+  const parentPid = Number(parentPidText);
+  if (!Number.isInteger(pid) || pid < 0
+    || !Number.isInteger(parentPid) || parentPid < 0) {
+    return null;
+  }
+  const marker = startMarker && isCanonicalWindowsStartMarker(startMarker)
+    ? startMarker
+    : null;
+  return { pid, parentPid, startMarker: marker };
+}
+
+function parsePowerShellProcessTable(output: string): WindowsProcessRecord[] | null {
+  const records: WindowsProcessRecord[] = [];
+  const lines = output.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  if (lines.length === 0) return null;
+  for (const line of lines) {
+    const fields = line.split('|');
+    if (fields.length !== 3) return null;
+    const record = parseWindowsProcessRecord(fields[0], fields[1], fields[2]);
+    if (!record) return null;
+    records.push(record);
+  }
+  return records;
+}
+
+function parseWmicProcessTable(output: string): WindowsProcessRecord[] | null {
+  const records: WindowsProcessRecord[] = [];
+  let fields: Partial<Record<'CreationDate' | 'ParentProcessId' | 'ProcessId', string>> = {};
+  const finishRecord = (): boolean => {
+    if (Object.keys(fields).length === 0) return true;
+    const marker = normalizeWindowsWmicStartMarker(fields.CreationDate ?? '');
+    const record = parseWindowsProcessRecord(
+      fields.ProcessId ?? '',
+      fields.ParentProcessId ?? '',
+      marker ?? ''
+    );
+    fields = {};
+    if (!record) return false;
+    records.push(record);
+    return true;
+  };
+
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      if (!finishRecord()) return null;
+      continue;
+    }
+    const separator = trimmed.indexOf('=');
+    if (separator <= 0) return null;
+    const key = trimmed.slice(0, separator);
+    if (key !== 'CreationDate' && key !== 'ParentProcessId' && key !== 'ProcessId') return null;
+    fields[key] = trimmed.slice(separator + 1).trim();
+  }
+  if (!finishRecord() || records.length === 0) return null;
+  return records;
+}
+
+function readWindowsProcessTable(deadline: number): WindowsProcessRecord[] | null {
+  let timeout = getWindowsCommandTimeout(deadline);
+  if (timeout === null) return null;
+  try {
+    const powershell = spawn.sync('powershell', [
+      '-NoProfile', '-NonInteractive', '-Command',
+      `Get-CimInstance Win32_Process | ForEach-Object { `
+        + `$creation = if ($null -eq $_.CreationDate) { '' } else { `
+        + `$_.CreationDate.ToUniversalTime()`
+        + `.ToString('yyyy-MM-ddTHH:mm:ss.fffffffZ') }; `
+        + `'{0}|{1}|{2}' -f $_.ProcessId, $_.ParentProcessId, $creation }`
+    ], { stdio: 'pipe', windowsHide: true, timeout });
+    if (!powershell.error && powershell.status === 0) {
+      const records = parsePowerShellProcessTable(powershell.stdout?.toString() ?? '');
+      if (records) return records;
+    }
+  } catch {
+    // Fall through to WMIC on Windows installations without usable PowerShell CIM.
+  }
+
+  timeout = getWindowsCommandTimeout(deadline);
+  if (timeout === null) return null;
+  try {
+    const wmic = spawn.sync('wmic', [
+      'process', 'get', 'ProcessId,ParentProcessId,CreationDate', '/format:list'
+    ], { stdio: 'pipe', windowsHide: true, timeout });
+    if (wmic.error || wmic.status !== 0) return null;
+    return parseWmicProcessTable(wmic.stdout?.toString() ?? '');
+  } catch {
+    return null;
+  }
+}
+
+function captureWindowsProcessTree(
+  rootPid: number,
+  rootStartMarker: string,
+  deadline: number
+): WindowsProcessRecord[] | null {
+  const records = readWindowsProcessTable(deadline);
+  if (!records) return null;
+
+  const byPid = new Map<number, WindowsProcessRecord>();
+  for (const record of records) {
+    if (byPid.has(record.pid)) return null;
+    byPid.set(record.pid, record);
+  }
+  const root = byPid.get(rootPid);
+  if (!root || root.startMarker !== rootStartMarker) return null;
+
+  const tree: WindowsProcessRecord[] = [root];
+  const included = new Set([rootPid]);
+  for (let index = 0; index < tree.length; index += 1) {
+    const parent = tree[index];
+    const parentStartMarker = parent.startMarker;
+    if (!parentStartMarker) return null;
+    for (const candidate of records) {
+      if (candidate.parentPid !== parent.pid || included.has(candidate.pid)) continue;
+      if (!candidate.startMarker) return null;
+      if (candidate.startMarker < parentStartMarker) return null;
+      included.add(candidate.pid);
+      tree.push(candidate);
+    }
+  }
+  return tree;
 }
 
 // ponytail: ps -p is cheap and avoids PID-reuse false positives after OS upgrades/reboots
@@ -69,19 +289,28 @@ export function isHapiRunnerProcess(pid: number): boolean {
   return isRunnerCommand(result.stdout?.toString() ?? '');
 }
 
-function killProcessWindows(pid: number, force: boolean): boolean {
+function killProcessWindows(
+  pid: number,
+  force: boolean,
+  tree: boolean = true,
+  deadline?: number,
+  allowMissingAfterFailure: boolean = true
+): boolean {
   if (!isProcessAlive(pid)) {
-    return true;
+    return allowMissingAfterFailure;
   }
 
-  const args = ['/T', '/PID', pid.toString()];
+  const timeout = deadline === undefined ? undefined : getWindowsCommandTimeout(deadline);
+  if (timeout === null) return false;
+  const args = tree ? ['/T', '/PID', pid.toString()] : ['/PID', pid.toString()];
   if (force) {
     args.unshift('/F');
   }
   try {
     const result = spawn.sync('taskkill', args, {
       stdio: 'pipe',
-      windowsHide: true
+      windowsHide: true,
+      ...(timeout === undefined ? {} : { timeout })
     });
     if (result.error) {
       return false;
@@ -94,19 +323,163 @@ function killProcessWindows(pid: number, force: boolean): boolean {
     // Process teardown on Windows is racy: by the time taskkill runs, the target
     // may already be gone, which commonly surfaces as non-zero exit codes
     // (including 128 in some shells). Treat this as success if PID is no longer alive.
-    return !isProcessAlive(pid);
+    return allowMissingAfterFailure && !isProcessAlive(pid);
   } catch {
     return false;
   }
 }
 
-export async function killProcess(pid: number, force: boolean = false): Promise<boolean> {
+type ProcessIdentity = 'same' | 'exited' | 'unknown';
+
+function getProcessIdentity(
+  pid: number,
+  startMarker: string | null,
+  deadline: number
+): ProcessIdentity {
+  const liveness = probeProcessLiveness(pid);
+  if (liveness === 'exited') return 'exited';
+  if (liveness === 'unknown') return 'unknown';
+  if (startMarker === null) return 'unknown';
+  const currentMarker = getProcessStartMarker(pid, deadline);
+  if (!currentMarker) return 'unknown';
+  return currentMarker === startMarker ? 'same' : 'exited';
+}
+
+async function waitForWindowsProcessTreeExit(
+  tree: WindowsProcessRecord[],
+  maxWait: number,
+  deadline: number
+): Promise<boolean> {
+  const waitDeadline = Math.min(Date.now() + maxWait, deadline);
+  const knownGenerations = new Map(tree.map((record) => [
+    `${record.pid}:${record.startMarker}`,
+    record
+  ]));
+  let emptyScans = 0;
+  while (Date.now() <= waitDeadline) {
+    const currentTable = readWindowsProcessTable(deadline);
+    if (!currentTable) return false;
+    const currentByPid = new Map<number, WindowsProcessRecord>();
+    for (const record of currentTable) {
+      if (currentByPid.has(record.pid)) return false;
+      currentByPid.set(record.pid, record);
+    }
+
+    let discovered = true;
+    let discoveredThisScan = false;
+    while (discovered) {
+      discovered = false;
+      for (const candidate of currentTable) {
+        if (candidate.startMarker
+          && knownGenerations.has(`${candidate.pid}:${candidate.startMarker}`)) {
+          continue;
+        }
+        const parent = [...knownGenerations.values()].find((record) => (
+          record.pid === candidate.parentPid
+        ));
+        if (!parent) continue;
+        if (!parent.startMarker
+          || !candidate.startMarker
+          || candidate.startMarker < parent.startMarker) {
+          return false;
+        }
+        knownGenerations.set(`${candidate.pid}:${candidate.startMarker}`, candidate);
+        tree.push(candidate);
+        discovered = true;
+        discoveredThisScan = true;
+      }
+    }
+
+    let allExited = true;
+    for (const processRecord of tree) {
+      const identity = getProcessIdentity(
+        processRecord.pid,
+        processRecord.startMarker,
+        deadline
+      );
+      if (identity === 'unknown') return false;
+      if (identity === 'same') allExited = false;
+    }
+    if (allExited) {
+      if (discoveredThisScan) {
+        emptyScans = 0;
+        await Promise.resolve();
+        continue;
+      }
+      emptyScans += 1;
+      if (emptyScans >= 2) return true;
+      await Promise.resolve();
+      continue;
+    }
+    emptyScans = 0;
+    if (Date.now() >= waitDeadline) return false;
+    const delay = Math.min(PROCESS_POLL_INTERVAL_MS, waitDeadline - Date.now());
+    await new Promise(resolve => setTimeout(resolve, delay));
+  }
+  return false;
+}
+
+async function killWindowsProcessGeneration(
+  pid: number,
+  force: boolean,
+  expectedStartMarker: string | null,
+  deadline: number
+): Promise<boolean> {
+  if (!isProcessAlive(pid)) return false;
+  if (expectedStartMarker === null || Date.now() >= deadline) return false;
+  const processTree = captureWindowsProcessTree(pid, expectedStartMarker, deadline);
+  if (!processTree) return false;
+  for (const processRecord of processTree) {
+    const identity = getProcessIdentity(
+      processRecord.pid,
+      processRecord.startMarker,
+      deadline
+    );
+    if (identity === 'unknown' || (processRecord.pid === pid && identity !== 'same')) {
+      return false;
+    }
+  }
+
+  const requested = killProcessWindows(pid, force, true, deadline, false);
+  if (!requested) return false;
+  if (await waitForWindowsProcessTreeExit(
+    processTree,
+    force ? 1_000 : 2_000,
+    deadline
+  )) return true;
+
+  const identity = getProcessIdentity(pid, expectedStartMarker, deadline);
+  if (force || identity !== 'same') return false;
+
+  const forced = killProcessWindows(pid, true, true, deadline, false);
+  if (!forced) return false;
+  return waitForWindowsProcessTreeExit(processTree, 1_000, deadline);
+}
+
+export async function killProcess(
+  pid: number,
+  force: boolean = false,
+  expectedStartMarker?: string | null,
+  deadline?: number
+): Promise<boolean> {
   if (!Number.isFinite(pid) || pid <= 0) {
     return false;
   }
 
   if (isWindows()) {
-    return killProcessWindows(pid, force);
+    if (expectedStartMarker === undefined) {
+      return killProcessWindows(pid, force, true, deadline);
+    }
+    const teardownDeadline = Math.min(
+      deadline ?? Number.POSITIVE_INFINITY,
+      Date.now() + WINDOWS_TREE_KILL_TIMEOUT_MS
+    );
+    return killWindowsProcessGeneration(
+      pid,
+      force,
+      expectedStartMarker,
+      teardownDeadline
+    );
   }
 
   try {
@@ -203,9 +576,538 @@ async function waitForProcessToDie(pid: number, force: boolean): Promise<void> {
   }
 }
 
+type PosixMarkerSource = 'linux-proc' | 'ps';
+
+type PosixOwnedProcessRecord = {
+  pid: number;
+  parentPid: number;
+  processGroupId: number;
+  startMarker: string;
+  markerSource: PosixMarkerSource;
+};
+
+type StrictPosixOwnershipState = {
+  ownershipToken: string;
+  rootStartMarker: string;
+  knownGenerations: Map<string, PosixOwnedProcessRecord>;
+};
+
+const strictPosixOwnershipByChild = new WeakMap<ChildProcess, StrictPosixOwnershipState>();
+
+function linuxStartTime(startMarker: string): bigint | null {
+  const match = /^linux:(\d+)$/.exec(startMarker);
+  if (!match) return null;
+  try {
+    return BigInt(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+type ProcessReadResult<T> =
+  | { kind: 'ok'; value: T }
+  | { kind: 'exited' }
+  | { kind: 'unknown' };
+
+type OwnedProcessScanResult = PosixOwnedProcessRecord[] | 'retryable' | null;
+
+function isMissingProcessError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'ENOENT' || code === 'ESRCH';
+}
+
+function isUnreadableProcessEnvironment(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'EACCES' || code === 'EPERM';
+}
+
+function readLinuxProcessRecord(pid: number): ProcessReadResult<PosixOwnedProcessRecord> {
+  let output: string;
+  try {
+    output = readFileSync(`/proc/${pid}/stat`, 'utf8');
+  } catch (error) {
+    return isMissingProcessError(error) ? { kind: 'exited' } : { kind: 'unknown' };
+  }
+
+  const commandEnd = output.lastIndexOf(')');
+  const commandStart = output.indexOf('(');
+  if (commandStart <= 0 || commandEnd <= commandStart) return { kind: 'unknown' };
+  const parsedPid = Number(output.slice(0, commandStart).trim());
+  const fields = output.slice(commandEnd + 1).trim().split(/\s+/);
+  const parentPid = Number(fields[1]);
+  const processGroupId = Number(fields[2]);
+  const startTime = fields[19];
+  if (parsedPid !== pid
+    || !Number.isInteger(parentPid) || parentPid < 0
+    || !Number.isInteger(processGroupId) || processGroupId < 0
+    || !startTime || !/^\d+$/.test(startTime)) {
+    return { kind: 'unknown' };
+  }
+  return {
+    kind: 'ok',
+    value: {
+      pid,
+      parentPid,
+      processGroupId,
+      startMarker: `linux:${startTime}`,
+      markerSource: 'linux-proc'
+    }
+  };
+}
+
+function readProcessUid(pid: number): ProcessReadResult<number> {
+  try {
+    return { kind: 'ok', value: statSync(`/proc/${pid}`).uid };
+  } catch (error) {
+    return isMissingProcessError(error) ? { kind: 'exited' } : { kind: 'unknown' };
+  }
+}
+
+function hasOwnershipToken(environment: Buffer, ownershipToken: string): boolean {
+  const expected = `${STRICT_PROCESS_OWNERSHIP_ENV}=${ownershipToken}`;
+  return environment.toString().split('\0').includes(expected);
+}
+
+function listLinuxOwnedProcessGenerations(
+  ownershipToken: string,
+  deadline: number,
+  rootPid: number,
+  rootStartMarker: string,
+  knownOwned: Map<string, PosixOwnedProcessRecord>,
+  confirmedExited: Set<string>
+): OwnedProcessScanResult {
+  if (typeof process.getuid !== 'function') return null;
+  const rootStartTime = linuxStartTime(rootStartMarker);
+  if (rootStartTime === null) return null;
+  const uid = process.getuid();
+  let entries: string[];
+  try {
+    entries = readdirSync('/proc');
+  } catch {
+    return null;
+  }
+
+  const records: PosixOwnedProcessRecord[] = [];
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+    if (Date.now() >= deadline) return null;
+    const pid = Number(entry);
+    const uidBefore = readProcessUid(pid);
+    if (uidBefore.kind === 'exited') continue;
+    if (uidBefore.kind === 'unknown') return null;
+    if (uidBefore.value !== uid) continue;
+
+    const recordBefore = readLinuxProcessRecord(pid);
+    if (recordBefore.kind === 'exited') continue;
+    if (recordBefore.kind === 'unknown') return null;
+
+    let environment: Buffer;
+    try {
+      environment = readFileSync(`/proc/${pid}/environ`);
+    } catch (error) {
+      if (isMissingProcessError(error)) continue;
+      if (isUnreadableProcessEnvironment(error)) {
+        const key = processGenerationKey(recordBefore.value);
+        const candidateStartTime = linuxStartTime(recordBefore.value.startMarker);
+        if (candidateStartTime === null) return null;
+        if ((pid === rootPid
+          || knownOwned.has(key)
+          || candidateStartTime >= rootStartTime)
+          && !confirmedExited.has(key)) {
+          return 'retryable';
+        }
+        const recordAfter = readLinuxProcessRecord(pid);
+        const uidAfter = readProcessUid(pid);
+        if (recordAfter.kind === 'exited' || uidAfter.kind === 'exited') continue;
+        if (recordAfter.kind === 'unknown'
+          || uidAfter.kind === 'unknown'
+          || uidAfter.value !== uid
+          || recordAfter.value.startMarker !== recordBefore.value.startMarker) {
+          return null;
+        }
+        continue;
+      }
+      return null;
+    }
+    if (!hasOwnershipToken(environment, ownershipToken)) continue;
+
+    const recordAfter = readLinuxProcessRecord(pid);
+    const uidAfter = readProcessUid(pid);
+    if (recordAfter.kind === 'exited' || uidAfter.kind === 'exited') {
+      records.push(recordBefore.value);
+      continue;
+    }
+    if (recordAfter.kind === 'unknown' || uidAfter.kind === 'unknown') return null;
+    if (uidAfter.value !== uid
+      || recordAfter.value.startMarker !== recordBefore.value.startMarker) {
+      continue;
+    }
+    records.push(recordAfter.value);
+  }
+  return Date.now() >= deadline ? null : records;
+}
+
+type PsProcessRecord = PosixOwnedProcessRecord & {
+  uid: number;
+  command: string;
+};
+
+function readPsProcessTable(
+  includeEnvironment: boolean,
+  deadline: number
+): PsProcessRecord[] | null {
+  const timeout = getPosixCommandTimeout(deadline);
+  if (timeout === null) return null;
+  const result = spawn.sync('ps', [
+    includeEnvironment ? 'axeww' : 'axww',
+    '-o',
+    'pid=,uid=,ppid=,pgid=,lstart=,command='
+  ], {
+    stdio: 'pipe',
+    env: { ...process.env, LC_ALL: 'C', TZ: 'UTC' },
+    timeout
+  });
+  if (result.error || result.status !== 0 || Date.now() >= deadline) return null;
+
+  const records: PsProcessRecord[] = [];
+  const lines = (result.stdout?.toString() ?? '').split(/\r?\n/).filter(Boolean);
+  if (lines.length === 0) return null;
+  for (const line of lines) {
+    const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\S+\s+\S+\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+(.*)$/.exec(line);
+    if (!match) return null;
+    const [, pidText, uidText, parentPidText, processGroupIdText, marker, command] = match;
+    const pid = Number(pidText);
+    const uid = Number(uidText);
+    const parentPid = Number(parentPidText);
+    const processGroupId = Number(processGroupIdText);
+    if (!Number.isInteger(pid) || pid <= 0
+      || !Number.isInteger(uid) || uid < 0
+      || !Number.isInteger(parentPid) || parentPid < 0
+      || !Number.isInteger(processGroupId) || processGroupId < 0) {
+      return null;
+    }
+    records.push({
+      pid,
+      uid,
+      parentPid,
+      processGroupId,
+      startMarker: marker,
+      markerSource: 'ps',
+      command
+    });
+  }
+  return records;
+}
+
+function listPsOwnedProcessGenerations(
+  ownershipToken: string,
+  deadline: number
+): PosixOwnedProcessRecord[] | null {
+  if (typeof process.getuid !== 'function') return null;
+  const enrichedRecords = readPsProcessTable(true, deadline);
+  if (enrichedRecords === null) return null;
+  const plainRecords = readPsProcessTable(false, deadline);
+  if (plainRecords === null) return null;
+
+  const plainByPid = new Map<number, PsProcessRecord>();
+  for (const record of plainRecords) {
+    if (plainByPid.has(record.pid)) return null;
+    plainByPid.set(record.pid, record);
+  }
+
+  const uid = process.getuid();
+  const expectedToken = `${STRICT_PROCESS_OWNERSHIP_ENV}=${ownershipToken}`;
+  const owned: PosixOwnedProcessRecord[] = [];
+  for (const enriched of enrichedRecords) {
+    if (enriched.pid <= 0) return null;
+    const plain = plainByPid.get(enriched.pid);
+    if (!plain
+      || plain.startMarker !== enriched.startMarker
+      || plain.parentPid !== enriched.parentPid
+      || plain.processGroupId !== enriched.processGroupId) {
+      continue;
+    }
+    if (plain.uid !== uid || enriched.uid !== uid) continue;
+    const prefix = `${plain.command} `;
+    if (!enriched.command.startsWith(prefix)) continue;
+    const environment = enriched.command.slice(prefix.length);
+    if (!environment.split(/\s+/).includes(expectedToken)) continue;
+    owned.push({
+      pid: enriched.pid,
+      parentPid: enriched.parentPid,
+      processGroupId: enriched.processGroupId,
+      startMarker: enriched.startMarker,
+      markerSource: 'ps'
+    });
+  }
+  return owned;
+}
+
+function listOwnedProcessGenerations(
+  ownershipToken: string,
+  deadline: number,
+  rootPid: number,
+  rootStartMarker: string,
+  knownOwned: Map<string, PosixOwnedProcessRecord>,
+  confirmedExited: Set<string>
+): OwnedProcessScanResult {
+  if (!ownershipToken) return null;
+  return process.platform === 'linux'
+    ? listLinuxOwnedProcessGenerations(
+      ownershipToken,
+      deadline,
+      rootPid,
+      rootStartMarker,
+      knownOwned,
+      confirmedExited
+    )
+    : listPsOwnedProcessGenerations(ownershipToken, deadline);
+}
+
+function getPosixOwnedProcessIdentity(
+  record: PosixOwnedProcessRecord,
+  deadline: number
+): ProcessIdentity {
+  if (Date.now() >= deadline) return 'unknown';
+  const liveness = probeProcessLiveness(record.pid);
+  if (liveness !== 'alive') return liveness === 'exited' ? 'exited' : 'unknown';
+
+  if (record.markerSource === 'linux-proc') {
+    const current = readLinuxProcessRecord(record.pid);
+    if (current.kind !== 'ok') {
+      return current.kind === 'exited' ? 'exited' : 'unknown';
+    }
+    return current.value.startMarker === record.startMarker ? 'same' : 'exited';
+  }
+
+  const currentMarker = getProcessStartMarker(record.pid, deadline);
+  if (currentMarker !== null) {
+    return currentMarker === record.startMarker ? 'same' : 'exited';
+  }
+  return probeProcessLiveness(record.pid) === 'exited' ? 'exited' : 'unknown';
+}
+
+function revalidateOwnedProcessGeneration(
+  record: PosixOwnedProcessRecord,
+  ownershipToken: string,
+  deadline: number
+): ProcessReadResult<PosixOwnedProcessRecord> {
+  if (Date.now() >= deadline) return { kind: 'unknown' };
+  if (record.markerSource === 'linux-proc') {
+    const current = readLinuxProcessRecord(record.pid);
+    if (Date.now() >= deadline) return { kind: 'unknown' };
+    if (current.kind !== 'ok') return current;
+    return current.value.startMarker === record.startMarker
+      ? current
+      : { kind: 'exited' };
+  }
+
+  const currentRecords = listPsOwnedProcessGenerations(ownershipToken, deadline);
+  if (currentRecords === null) return { kind: 'unknown' };
+  const current = currentRecords.find((candidate) => (
+    processGenerationKey(candidate) === processGenerationKey(record)
+  ));
+  if (current) return { kind: 'ok', value: current };
+  const identity = getPosixOwnedProcessIdentity(record, deadline);
+  return identity === 'exited' ? { kind: 'exited' } : { kind: 'unknown' };
+}
+
+function signalProcess(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch (error) {
+    return isMissingProcessError(error);
+  }
+}
+
+function processGenerationKey(record: PosixOwnedProcessRecord): string {
+  return `${record.pid}:${record.markerSource}:${record.startMarker}`;
+}
+
+async function killProcessGroup(
+  processGroupId: number,
+  force: boolean,
+  deadline: number | undefined,
+  ownershipToken: string,
+  rootStartMarker: string,
+  knownOwned: Map<string, PosixOwnedProcessRecord>
+): Promise<boolean> {
+  const teardownDeadline = Math.min(
+    deadline ?? Number.POSITIVE_INFINITY,
+    Date.now() + POSIX_PROCESS_GROUP_KILL_TIMEOUT_MS
+  );
+  const gracefulDeadline = force
+    ? teardownDeadline
+    : Math.min(teardownDeadline, Date.now() + 2_000);
+  const termSignaled = new Set<string>();
+  const killSignaled = new Set<string>();
+  const exitedGenerations = new Set<string>();
+  let termGroupSignaled = false;
+  let killGroupSignaled = false;
+  let emptyScans = 0;
+
+  while (Date.now() < teardownDeadline) {
+    const records = listOwnedProcessGenerations(
+      ownershipToken,
+      teardownDeadline,
+      processGroupId,
+      rootStartMarker,
+      knownOwned,
+      exitedGenerations
+    );
+    if (records === null) return false;
+    if (records === 'retryable') {
+      const delay = Math.min(
+        PROCESS_POLL_INTERVAL_MS,
+        teardownDeadline - Date.now()
+      );
+      if (delay <= 0) return false;
+      await new Promise(resolve => setTimeout(resolve, delay));
+      continue;
+    }
+    const scannedGenerations = new Set<string>();
+    let observedNewGeneration = false;
+    for (const record of records) {
+      const key = processGenerationKey(record);
+      scannedGenerations.add(key);
+      if (exitedGenerations.has(key)) continue;
+      if (!knownOwned.has(key)) observedNewGeneration = true;
+      knownOwned.set(key, record);
+    }
+
+    const currentRecords: PosixOwnedProcessRecord[] = [];
+    let generationExitedDuringScan = false;
+    for (const [key, record] of knownOwned) {
+      const identity = getPosixOwnedProcessIdentity(record, teardownDeadline);
+      if (identity === 'unknown') return false;
+      if (identity === 'same') {
+        if (record.markerSource === 'ps' && !scannedGenerations.has(key)) {
+          return false;
+        }
+        currentRecords.push(record);
+      } else {
+        knownOwned.delete(key);
+        if (!exitedGenerations.has(key)) generationExitedDuringScan = true;
+        exitedGenerations.add(key);
+      }
+    }
+    if (currentRecords.length === 0) {
+      if (observedNewGeneration || generationExitedDuringScan) {
+        emptyScans = 0;
+        const delay = Math.min(
+          PROCESS_POLL_INTERVAL_MS,
+          teardownDeadline - Date.now()
+        );
+        if (delay <= 0) return false;
+        await new Promise(resolve => setTimeout(resolve, delay));
+        continue;
+      }
+      emptyScans += 1;
+      if (emptyScans >= 2) return true;
+      const delay = Math.min(
+        PROCESS_POLL_INTERVAL_MS,
+        teardownDeadline - Date.now()
+      );
+      if (delay <= 0) return false;
+      await new Promise(resolve => setTimeout(resolve, delay));
+      continue;
+    }
+    emptyScans = 0;
+
+    const useForce = force || Date.now() >= gracefulDeadline;
+    const signal: NodeJS.Signals = useForce ? 'SIGKILL' : 'SIGTERM';
+    const signaled = useForce ? killSignaled : termSignaled;
+    const groupAlreadySignaled = useForce ? killGroupSignaled : termGroupSignaled;
+    const groupRecord = currentRecords.find((record) => (
+      record.processGroupId === processGroupId
+    ));
+    if (groupRecord && !groupAlreadySignaled) {
+      const identity = getPosixOwnedProcessIdentity(groupRecord, teardownDeadline);
+      if (identity === 'unknown') return false;
+      if (identity === 'same') {
+        const current = revalidateOwnedProcessGeneration(
+          groupRecord,
+          ownershipToken,
+          teardownDeadline
+        );
+        if (current.kind === 'unknown') return false;
+        if (Date.now() >= teardownDeadline) return false;
+        if (current.kind === 'ok'
+          && current.value.processGroupId === processGroupId
+          && !signalProcess(-processGroupId, signal)) {
+          return false;
+        }
+      }
+      if (useForce) killGroupSignaled = true;
+      else termGroupSignaled = true;
+    }
+
+    for (const record of currentRecords) {
+      const key = processGenerationKey(record);
+      if (signaled.has(key)) continue;
+      const identity = getPosixOwnedProcessIdentity(record, teardownDeadline);
+      if (identity === 'unknown') return false;
+      if (identity === 'same') {
+        const current = revalidateOwnedProcessGeneration(
+          record,
+          ownershipToken,
+          teardownDeadline
+        );
+        if (current.kind === 'unknown') return false;
+        if (Date.now() >= teardownDeadline) return false;
+        if (current.kind === 'ok' && !signalProcess(current.value.pid, signal)) return false;
+      }
+      signaled.add(key);
+    }
+
+    const phaseDeadline = useForce ? teardownDeadline : gracefulDeadline;
+    const delay = Math.min(
+      PROCESS_POLL_INTERVAL_MS,
+      phaseDeadline - Date.now(),
+      teardownDeadline - Date.now()
+    );
+    if (delay > 0) {
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+  return false;
+}
+
+function createStrictPosixOwnershipState(
+  rootPid: number,
+  ownershipToken: string,
+  rootStartMarker: string
+): StrictPosixOwnershipState | null {
+  const markerSource: PosixMarkerSource = process.platform === 'linux'
+    ? 'linux-proc'
+    : 'ps';
+  if (markerSource === 'linux-proc' && linuxStartTime(rootStartMarker) === null) {
+    return null;
+  }
+  const rootRecord: PosixOwnedProcessRecord = {
+    pid: rootPid,
+    parentPid: 0,
+    processGroupId: rootPid,
+    startMarker: rootStartMarker,
+    markerSource
+  };
+  return {
+    ownershipToken,
+    rootStartMarker,
+    knownGenerations: new Map([[processGenerationKey(rootRecord), rootRecord]])
+  };
+}
+
 export async function killProcessByChildProcess(
   child: ChildProcess,
-  force: boolean = false
+  force: boolean = false,
+  expectedStartMarker?: string | null,
+  deadline?: number,
+  useProcessGroup: boolean = false,
+  ownershipToken?: string
 ): Promise<boolean> {
   const pid = child.pid;
   if (!pid) {
@@ -213,8 +1115,34 @@ export async function killProcessByChildProcess(
   }
 
   if (isWindows()) {
-    // Windows taskkill /T already kills the entire process tree
-    return killProcess(pid, force);
+    return killProcess(pid, force, expectedStartMarker, deadline);
+  }
+
+  if (useProcessGroup) {
+    if (!ownershipToken || !expectedStartMarker) return false;
+    const existingOwnership = strictPosixOwnershipByChild.get(child);
+    if (existingOwnership
+      && (existingOwnership.ownershipToken !== ownershipToken
+        || existingOwnership.rootStartMarker !== expectedStartMarker)) {
+      return false;
+    }
+    const ownership = existingOwnership ?? createStrictPosixOwnershipState(
+      pid,
+      ownershipToken,
+      expectedStartMarker
+    );
+    if (!ownership) return false;
+    if (!existingOwnership) strictPosixOwnershipByChild.set(child, ownership);
+    const terminated = await killProcessGroup(
+      pid,
+      force,
+      deadline,
+      ownershipToken,
+      ownership.rootStartMarker,
+      ownership.knownGenerations
+    );
+    if (terminated) strictPosixOwnershipByChild.delete(child);
+    return terminated;
   }
 
   // Kill entire process tree on Unix to prevent orphan processes


### PR DESCRIPTION
## Summary

- Fork Codex threads through a dedicated temporary app-server and verify its writer process tree has exited before returning the child thread.
- Serialize source-thread RPCs against fork and rewind with a reentrant, abort-aware source-operation lease.
- Harden strict temporary process teardown across Windows, Linux, and Darwin, including PID reuse, detached descendants, handoff races, and bounded cleanup.

## Testing

- `bun run typecheck`
- `bun run test`
  - CLI: 2,584 passed, 1 skipped
  - Hub: 1,203 passed, 3 skipped; 2 existing cross-file FCM environment-leak failures
  - Isolated `hub/src/fcm/fcmConfig.test.ts`: 5 passed
  - Web: 2,831 passed
  - Shared: 294 passed
  - Relay: 80 passed
- `bun run test:cli:integration`: 13 passed, 1 skipped
- Codex CLI 0.148.0 lifecycle probe: baseline active-writer reproduced and fixed path passed 3/3 on the final pre-rebase tree

Fixes #1555

AI-assisted with OpenAI Codex (GPT-5 / GPT-5.6-sol).
