### PR TITLE
feat(web): show Claude round usage metadata

### DIFF
--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -109,6 +109,53 @@ describe('claudeRemote async message handling', () => {
         }
     });
 
+    it('waits for async onReady work before completing the result stream', async () => {
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        const releaseReady = deferred<void>();
+        queryMock.mockReturnValueOnce(createAsyncStream([
+            { type: 'result', subtype: 'success' } as unknown as SDKMessage
+        ]));
+
+        let nextCallCount = 0;
+        let readyStarted = false;
+        let settled = false;
+        try {
+            const runPromise = claudeRemote({
+                sessionId: 'session-1',
+                path: process.cwd(),
+                mcpServers: {},
+                claudeEnvVars: {},
+                claudeArgs: [],
+                allowedTools: [],
+                hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => nextCallCount++ === 0
+                    ? { message: 'Review this project', mode: { permissionMode: 'default' } }
+                    : null,
+                onReady: async () => {
+                    readyStarted = true;
+                    await releaseReady.promise;
+                },
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: () => {}
+            });
+            void runPromise.finally(() => { settled = true; });
+
+            await waitFor(() => readyStarted);
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(settled).toBe(false);
+
+            releaseReady.resolve();
+            await runPromise;
+        } finally {
+            releaseReady.resolve();
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+    });
+
     it('continues consuming assistant messages even when next user message is pending', async () => {
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');
@@ -363,7 +410,9 @@ describe('claudeRemote /compact result reporting', () => {
                     }
                     return null;
                 },
-                onReady: () => {},
+                onReady: (completionEvent) => {
+                    if (completionEvent) completionEvents.push(completionEvent);
+                },
                 isAborted: () => false,
                 onSessionFound: () => {},
                 onMessage: () => {},
@@ -421,5 +470,43 @@ describe('claudeRemote /compact result reporting', () => {
         ]);
 
         expect(completionEvents).toEqual(['Compaction started', 'Compaction completed']);
+    }, 15_000);
+
+    it('hands compact completion to the ready phase so the result carrier can flush first', async () => {
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        const wireOrder: string[] = [];
+        const queued: string[] = [];
+        queryMock.mockReturnValueOnce(createAsyncStream([resultMessage]));
+
+        let nextCallCount = 0;
+        try {
+            await claudeRemote({
+                sessionId: 'session-1', path: process.cwd(), mcpServers: {}, claudeEnvVars: {},
+                claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => nextCallCount++ === 0
+                    ? { message: '/compact', mode: { permissionMode: 'default' } }
+                    : null,
+                onReady: (completionEvent) => {
+                    wireOrder.push(...queued.splice(0));
+                    if (completionEvent) wireOrder.push(completionEvent);
+                    wireOrder.push('ready');
+                },
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: (message) => {
+                    if (message.type === 'result') queued.push('result');
+                },
+                onCompletionEvent: (message) => {
+                    if (message !== 'Compaction started') wireOrder.push(message);
+                }
+            });
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        expect(wireOrder).toEqual(['result', 'Compaction completed', 'ready']);
     }, 15_000);
 });

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -30,7 +30,7 @@ export async function claudeRemote(opts: {
 
     // Dynamic parameters
     nextMessage: () => Promise<{ message: string, mode: EnhancedMode } | null>,
-    onReady: () => void,
+    onReady: (completionEvent?: string) => void | Promise<void>,
     isAborted: (toolCallId: string) => boolean,
 
     // Callbacks
@@ -350,21 +350,18 @@ export async function claudeRemote(opts: {
                     opts.onFirstResult?.(initial.message);
                 }
 
-                // Send completion messages
+                let completionEvent: string | undefined;
                 if (isCompactCommand) {
-                    const completion = compactFailure
+                    completionEvent = compactFailure
                         ? `Compaction failed: ${compactFailure}`
                         : 'Compaction completed';
-                    logger.debug(`[claudeRemote] ${completion}`);
-                    if (opts.onCompletionEvent) {
-                        opts.onCompletionEvent(completion);
-                    }
+                    logger.debug(`[claudeRemote] ${completionEvent}`);
                     isCompactCommand = false;
                     compactFailure = null;
                 }
 
-                // Send ready event
-                opts.onReady();
+                // Flush the result carrier before completion, then announce ready.
+                await opts.onReady(completionEvent);
                 logger.debug(`${debugPrefix} onReady emitted for result #${resultSeq}`);
 
                 // Pull next user message without blocking response stream processing.

--- a/cli/src/claude/claudeRemoteLauncher.launchFailure.test.ts
+++ b/cli/src/claude/claudeRemoteLauncher.launchFailure.test.ts
@@ -141,6 +141,51 @@ describe('claudeRemoteLauncher launch-failure recovery', () => {
         expect(restoredMessageText).toBe('hello');
     });
 
+    it('sends the result carrier before compact completion and ready', async () => {
+        const queue = new MessageQueue2<EnhancedMode>((mode) => JSON.stringify(mode));
+        queue.push('/compact', { permissionMode: 'default' });
+
+        const client = makeClient();
+        const session = makeSession(queue, client);
+        const wireOrder: string[] = [];
+
+        client.sendClaudeSessionMessage.mockImplementation((logMessage: any) => {
+            if (logMessage.type === 'system' && logMessage.subtype === 'turn_duration') {
+                wireOrder.push('result');
+            }
+        });
+        client.sendSessionEvent.mockImplementation((event: any) => {
+            if (event?.type === 'message' && event.message === 'Compaction completed') {
+                wireOrder.push('completion');
+            }
+            if (event?.type === 'ready') {
+                wireOrder.push('ready');
+            }
+        });
+
+        claudeRemoteMock.mockImplementation(async (opts: any) => {
+            const input = await opts.nextMessage();
+            expect(input?.message).toBe('/compact');
+            opts.onMessage({
+                type: 'result',
+                subtype: 'success',
+                num_turns: 1,
+                total_cost_usd: 0,
+                duration_ms: 1,
+                duration_api_ms: 1,
+                is_error: false,
+                session_id: 's-1'
+            });
+            await opts.onReady('Compaction completed');
+            triggerSwitch(client);
+        });
+
+        const { claudeRemoteLauncher } = await import('./claudeRemoteLauncher');
+        await claudeRemoteLauncher(session);
+
+        expect(wireOrder).toEqual(['result', 'completion', 'ready']);
+    });
+
     it('restores a joined batch as separate items with each original localId and order preserved', async () => {
         // MessageQueue2.collectBatch() joins same-mode messages into a single
         // `message` string for the SDK (`sameModeMessages.join('\n')`), but

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -403,6 +403,9 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                             // to stamp invokedAt on the next user message before it stores the
                             // current turn's queued agent messages — making them sort permanently
                             // below the next user message.
+                            // The result summary is enqueued by onMessage immediately before onReady.
+                            // Drain it before ready so live clients receive the round metadata before
+                            // they close out the running turn.
                             await messageQueue.flush();
 
                             if (pending) {
@@ -504,13 +507,20 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                             // just asked to clear.
                             session.consumeOneTimeFlags();
                         },
-                        onReady: () => {
+                        onReady: async (completionEvent?: string) => {
                             // Reaching ready at all means this attempt is not an
                             // immediate/deterministic failure -- reset the
                             // respawn-storm guard. The turn that led here is no
                             // longer "in flight" either.
                             reachedReadyThisAttempt = true;
                             inFlightMessage = null;
+
+                            await messageQueue.flush();
+
+                            if (completionEvent) {
+                                logger.debug(`[remote]: Completion event: ${completionEvent}`);
+                                session.client.sendSessionEvent({ type: 'message', message: completionEvent });
+                            }
 
                             logger.debug(
                                 `[claudeRemoteLauncher][async-debug] onReady callback ` +

--- a/cli/src/claude/utils/OutgoingMessageQueue.test.ts
+++ b/cli/src/claude/utils/OutgoingMessageQueue.test.ts
@@ -22,13 +22,15 @@ describe('OutgoingMessageQueue message filtering', () => {
         expect(sent).toHaveLength(2)
     })
 
-    it('filters out system messages', async () => {
+    it('filters hidden system messages but sends visible system messages', async () => {
         queue.enqueue({ type: 'system', subtype: 'init', uuid: '1' })
-        queue.enqueue({ type: 'assistant', uuid: '2' })
+        queue.enqueue({ type: 'system', subtype: 'turn_duration', uuid: '2' })
+        queue.enqueue({ type: 'assistant', uuid: '3' })
         await queue.flush()
 
-        expect(sent).toHaveLength(1)
-        expect(sent[0]).toMatchObject({ type: 'assistant' })
+        expect(sent).toHaveLength(2)
+        expect(sent[0]).toMatchObject({ type: 'system', subtype: 'turn_duration' })
+        expect(sent[1]).toMatchObject({ type: 'assistant' })
     })
 
     it('filters out isMeta messages', async () => {

--- a/cli/src/claude/utils/OutgoingMessageQueue.ts
+++ b/cli/src/claude/utils/OutgoingMessageQueue.ts
@@ -6,6 +6,7 @@
  */
 
 import { AsyncLock } from '@/utils/lock';
+import { isClaudeChatVisibleMessage } from './chatVisibility';
 
 interface QueueItem {
     id: number;                    // Incremental ID for ordering
@@ -121,7 +122,7 @@ export class OutgoingMessageQueue {
             
             // Send if not already sent
             if (!item.sent) {
-                if (item.logMessage.type !== 'system' && !item.logMessage.isMeta && !item.logMessage.isCompactSummary) {
+                if (isClaudeChatVisibleMessage(item.logMessage) && !item.logMessage.isMeta && !item.logMessage.isCompactSummary) {
                     this.sendFunction(item.logMessage);
                 }
                 item.sent = true;

--- a/cli/src/claude/utils/sdkToLogConverter.test.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.test.ts
@@ -205,7 +205,11 @@ describe('SDKToLogConverter', () => {
     })
 
     describe('Result messages', () => {
-        it('should not convert result messages', () => {
+        it('converts successful results into a round-summary carrier without advancing the parent chain', () => {
+            const preceding = converter.convert({
+                type: 'user',
+                message: { role: 'user', content: 'first request' }
+            } as SDKUserMessage)
             const sdkMessage: SDKResultMessage = {
                 type: 'result',
                 subtype: 'success',
@@ -219,15 +223,41 @@ describe('SDKToLogConverter', () => {
                 duration_ms: 3000,
                 duration_api_ms: 2500,
                 is_error: false,
-                session_id: 'result-session'
+                session_id: 'result-session',
+                modelUsage: {
+                    'claude-opus-5': {
+                        inputTokens: 80,
+                        cacheCreationInputTokens: 20,
+                        cacheReadInputTokens: 100_000,
+                        outputTokens: 500
+                    }
+                }
             }
 
             const logMessage = converter.convert(sdkMessage)
 
-            expect(logMessage).toBeNull()
+            expect(logMessage).toMatchObject({
+                type: 'system',
+                subtype: 'turn_duration',
+                parentUuid: preceding?.uuid,
+                durationMs: 3000,
+                resultSummary: {
+                    usage: sdkMessage.usage,
+                    modelUsage: sdkMessage.modelUsage,
+                    total_cost_usd: 0.05,
+                    num_turns: 5,
+                    duration_ms: 3000
+                }
+            })
+
+            const following = converter.convert({
+                type: 'user',
+                message: { role: 'user', content: 'second request' }
+            } as SDKUserMessage)
+            expect(following?.parentUuid).toBe(preceding?.uuid)
         })
 
-        it('should not convert error results', () => {
+        it('converts error results into the same carrier shape', () => {
             const sdkMessage: SDKResultMessage = {
                 type: 'result',
                 subtype: 'error_max_turns',
@@ -241,8 +271,49 @@ describe('SDKToLogConverter', () => {
 
             const logMessage = converter.convert(sdkMessage)
 
-            // Error results are not converted to summaries
-            expect(logMessage).toBeFalsy()
+            expect(logMessage).toMatchObject({
+                type: 'system',
+                subtype: 'turn_duration',
+                durationMs: 5000,
+                resultSummary: {
+                    total_cost_usd: 0.1,
+                    num_turns: 10,
+                    duration_ms: 5000
+                }
+            })
+        })
+
+        it('does not let a sidechain result carrier advance the sidechain parent chain', () => {
+            const parentToolUseId = 'toolu_sidechain_result'
+            const firstSidechainAssistant = converter.convert({
+                type: 'assistant',
+                parent_tool_use_id: parentToolUseId,
+                message: { role: 'assistant', content: [{ type: 'text', text: 'working' }] }
+            } as unknown as SDKAssistantMessage)
+
+            const result = converter.convert({
+                type: 'result',
+                subtype: 'success',
+                parent_tool_use_id: parentToolUseId,
+                num_turns: 1,
+                total_cost_usd: 0,
+                duration_ms: 100,
+                duration_api_ms: 100,
+                is_error: false,
+                session_id: 'sidechain-result'
+            } as unknown as SDKResultMessage)
+
+            const followingSidechainAssistant = converter.convert({
+                type: 'assistant',
+                parent_tool_use_id: parentToolUseId,
+                message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] }
+            } as unknown as SDKAssistantMessage)
+
+            expect(result).toMatchObject({
+                isSidechain: true,
+                parentUuid: firstSidechainAssistant?.uuid
+            })
+            expect(followingSidechainAssistant?.parentUuid).toBe(firstSidechainAssistant?.uuid)
         })
     })
 

--- a/cli/src/claude/utils/sdkToLogConverter.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.ts
@@ -245,7 +245,9 @@ export class SDKToLogConverter {
             isSidechain = true;
             parentToolUseId = (sdkMessage as any).parent_tool_use_id;
             parentUuid = this.sidechainLastUUID.get((sdkMessage as any).parent_tool_use_id) ?? null;
-            this.sidechainLastUUID.set((sdkMessage as any).parent_tool_use_id!, uuid);
+            if (sdkMessage.type !== 'result') {
+                this.sidechainLastUUID.set((sdkMessage as any).parent_tool_use_id!, uuid);
+            }
         }
         const baseFields = {
             parentUuid: parentUuid,
@@ -389,11 +391,7 @@ export class SDKToLogConverter {
             }
 
             case 'result': {
-                // Result messages are not converted to log messages
-                // They're SDK-specific messages that indicate session completion
-                // Not part of the actual conversation log.
-                //
-                // But they carry the authoritative per-model contextWindow. modelUsage is
+                // Result messages carry the authoritative per-model contextWindow. modelUsage is
                 // keyed by the same raw model id the CLI reports on system/init, so the
                 // entry for the current session model is stored under resolvedContextWindowKey
                 // (which folds in the "[1m]" for fable), matching what assistant lookups use.
@@ -412,6 +410,19 @@ export class SDKToLogConverter {
                                 : model
                             this.modelContextWindows.set(key, cw)
                         }
+                    }
+                }
+                logMessage = {
+                    ...baseFields,
+                    type: 'system',
+                    subtype: 'turn_duration',
+                    durationMs: resultMsg.duration_ms,
+                    resultSummary: {
+                        usage: resultMsg.usage,
+                        modelUsage: resultMsg.modelUsage,
+                        total_cost_usd: resultMsg.total_cost_usd,
+                        num_turns: resultMsg.num_turns,
+                        duration_ms: resultMsg.duration_ms
                     }
                 }
                 break
@@ -456,7 +467,7 @@ export class SDKToLogConverter {
         }
 
         // Update last UUID for parent tracking
-        if (logMessage && logMessage.type !== 'summary') {
+        if (logMessage && logMessage.type !== 'summary' && sdkMessage.type !== 'result') {
             this.lastUuid = uuid
         }
 

--- a/web/src/chat/normalize.test.ts
+++ b/web/src/chat/normalize.test.ts
@@ -55,7 +55,16 @@ describe('normalizeDecryptedMessage', () => {
                     type: 'system',
                     subtype: 'turn_duration',
                     uuid: 'sys-2',
-                    durationMs: 1200
+                    isSidechain: true,
+                    parentToolUseId: 'toolu-agent-1',
+                    durationMs: 1200,
+                    resultSummary: {
+                        usage: { input_tokens: 10, output_tokens: 2 },
+                        modelUsage: { 'claude-opus-5': { inputTokens: 10, outputTokens: 2 } },
+                        total_cost_usd: 0.028029,
+                        num_turns: 9,
+                        duration_ms: 1200
+                    }
                 }
             }
         })
@@ -63,10 +72,99 @@ describe('normalizeDecryptedMessage', () => {
         expect(normalizeDecryptedMessage(message)).toMatchObject({
             id: 'msg-1',
             role: 'event',
-            isSidechain: false,
+            isSidechain: true,
+            parentToolUseId: 'toolu-agent-1',
             content: {
-                type: 'turn-duration',
-                durationMs: 1200
+                type: 'turn-summary',
+                summary: {
+                    usage: { input_tokens: 10, output_tokens: 2 },
+                    modelUsage: { 'claude-opus-5': { inputTokens: 10, outputTokens: 2 } },
+                    totalCostUsd: 0.028029,
+                    numTurns: 9,
+                    durationMs: 1200
+                }
+            }
+        })
+    })
+
+    it('falls back to aggregate usage and drops malformed or zero-only result fields', () => {
+        const message = makeMessage({
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: {
+                    type: 'system',
+                    subtype: 'turn_duration',
+                    uuid: 'sys-fallback',
+                    resultSummary: {
+                        usage: { input_tokens: 20, output_tokens: 4 },
+                        modelUsage: { 'claude-opus-5': { contextWindow: 200_000 } },
+                        total_cost_usd: 0,
+                        num_turns: 'bad',
+                        duration_ms: -1
+                    }
+                }
+            }
+        })
+
+        expect(normalizeDecryptedMessage(message)).toMatchObject({
+            role: 'event',
+            content: {
+                type: 'turn-summary',
+                summary: {
+                    usage: { input_tokens: 20, output_tokens: 4 },
+                    modelUsage: {},
+                    totalCostUsd: undefined,
+                    numTurns: undefined,
+                    durationMs: undefined
+                }
+            }
+        })
+    })
+
+    it('drops fractional and unsafe token counters and turn counts while retaining valid model fields', () => {
+        const message = makeMessage({
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: {
+                    type: 'system',
+                    subtype: 'turn_duration',
+                    uuid: 'sys-integers',
+                    resultSummary: {
+                        usage: { input_tokens: 20.5, output_tokens: 4 },
+                        modelUsage: {
+                            'claude-opus-5': {
+                                inputTokens: 100.5,
+                                outputTokens: 10,
+                                cacheReadInputTokens: 9_007_199_254_740_992
+                            },
+                            'claude-haiku-4-5': { inputTokens: 10, outputTokens: 4 },
+                            'claude-empty-5': { contextWindow: 200_000 }
+                        },
+                        total_cost_usd: 0.00002,
+                        num_turns: 1.5,
+                        duration_ms: 12.5
+                    }
+                }
+            }
+        })
+
+        expect(normalizeDecryptedMessage(message)).toMatchObject({
+            role: 'event',
+            content: {
+                type: 'turn-summary',
+                summary: {
+                    usage: undefined,
+                    modelUsage: {
+                        'claude-opus-5': { outputTokens: 10 },
+                        'claude-haiku-4-5': { inputTokens: 10, outputTokens: 4 },
+                        'claude-empty-5': {}
+                    },
+                    totalCostUsd: 0.00002,
+                    numTurns: undefined,
+                    durationMs: 12.5
+                }
             }
         })
     })

--- a/web/src/chat/normalizeAgent.ts
+++ b/web/src/chat/normalizeAgent.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent, CodexReview, CodexReviewFinding, NormalizedAgentContent, NormalizedMessage, ToolResultPermission } from '@/chat/types'
+import type { AgentEvent, CodexReview, CodexReviewFinding, NormalizedAgentContent, NormalizedMessage, RoundModelUsage, RoundSummary, ToolResultPermission, UsageData } from '@/chat/types'
 import { inlineMediaSourceFromWire } from '@/chat/inlineMediaSource'
 import { AGENT_MESSAGE_PAYLOAD_TYPE, asNumber, asString, isObject } from '@hapi/protocol'
 import { isClaudeChatVisibleMessage } from '@hapi/protocol/messages'
@@ -32,6 +32,66 @@ function normalizeToolResultPermissions(value: unknown): ToolResultPermission | 
 function normalizeAgentEvent(value: unknown): AgentEvent | null {
     if (!isObject(value) || typeof value.type !== 'string') return null
     return value as AgentEvent
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+    const number = asNumber(value)
+    return number !== null && Number.isFinite(number) && number >= 0 ? number : undefined
+}
+
+function nonNegativeSafeInteger(value: unknown): number | undefined {
+    const number = asNumber(value)
+    return number !== null && Number.isSafeInteger(number) && number >= 0 ? number : undefined
+}
+
+function normalizeResultUsage(value: unknown): UsageData | undefined {
+    if (!isObject(value)) return undefined
+    const inputTokens = nonNegativeSafeInteger(value.input_tokens)
+    const outputTokens = nonNegativeSafeInteger(value.output_tokens)
+    if (inputTokens === undefined || outputTokens === undefined) return undefined
+    return {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        cache_creation_input_tokens: nonNegativeSafeInteger(value.cache_creation_input_tokens),
+        cache_read_input_tokens: nonNegativeSafeInteger(value.cache_read_input_tokens)
+    }
+}
+
+function normalizeRoundSummary(value: unknown): RoundSummary | undefined {
+    if (!isObject(value)) return undefined
+
+    const parsedModelUsage: Array<[string, RoundModelUsage]> = []
+    if (isObject(value.modelUsage)) {
+        for (const [model, rawUsage] of Object.entries(value.modelUsage)) {
+            if (!isObject(rawUsage)) continue
+            const usage: RoundModelUsage = {
+                inputTokens: nonNegativeSafeInteger(rawUsage.inputTokens),
+                outputTokens: nonNegativeSafeInteger(rawUsage.outputTokens),
+                cacheReadInputTokens: nonNegativeSafeInteger(rawUsage.cacheReadInputTokens),
+                cacheCreationInputTokens: nonNegativeSafeInteger(rawUsage.cacheCreationInputTokens)
+            }
+            parsedModelUsage.push([model, usage])
+        }
+    }
+
+    const hasModelTokens = parsedModelUsage.some(([, usage]) => Object.values(usage).some(token => token !== undefined))
+    const modelUsage = hasModelTokens ? Object.fromEntries(parsedModelUsage) : {}
+
+    const usage = normalizeResultUsage(value.usage)
+    const totalCostUsd = nonNegativeNumber(value.total_cost_usd)
+    const numTurns = nonNegativeSafeInteger(value.num_turns)
+    const durationMs = nonNegativeNumber(value.duration_ms)
+    if (!usage && Object.keys(modelUsage).length === 0 && totalCostUsd === undefined && numTurns === undefined && durationMs === undefined) {
+        return undefined
+    }
+
+    return {
+        usage,
+        modelUsage,
+        totalCostUsd: totalCostUsd && totalCostUsd > 0 ? totalCostUsd : undefined,
+        numTurns: numTurns && numTurns > 0 ? numTurns : undefined,
+        durationMs
+    }
 }
 
 function normalizeThreadGoal(value: unknown) {
@@ -707,6 +767,21 @@ export function normalizeAgentRecord(
             }
         }
         if (data.type === 'system' && data.subtype === 'turn_duration') {
+            const summary = normalizeRoundSummary(data.resultSummary)
+            const isSidechain = Boolean(data.isSidechain)
+            const parentToolUseId = asString(data.parentToolUseId) ?? null
+            if (summary) {
+                return {
+                    id: messageId,
+                    localId,
+                    createdAt,
+                    role: 'event',
+                    content: { type: 'turn-summary', summary },
+                    isSidechain,
+                    parentToolUseId,
+                    meta
+                }
+            }
             return {
                 id: messageId,
                 localId,
@@ -717,7 +792,8 @@ export function normalizeAgentRecord(
                     durationMs: asNumber(data.durationMs) ?? 0,
                     targetMessageId: asString(data.messageId) ?? undefined
                 },
-                isSidechain: false,
+                isSidechain,
+                parentToolUseId,
                 meta
             }
         }

--- a/web/src/chat/reconcile.ts
+++ b/web/src/chat/reconcile.ts
@@ -10,6 +10,9 @@ import type {
     ToolCallBlock,
     ToolPermission,
     UserTextBlock,
+    RoundSummary,
+    RoundModelUsage,
+    UsageData,
 } from '@/chat/types'
 import { areInlineMediaSourcesEqual } from '@/chat/inlineMediaSource'
 
@@ -22,6 +25,41 @@ function indexBlocks(blocks: ChatBlock[], map: ChatBlocksById): void {
             indexBlocks(block.children, map)
         }
     }
+}
+
+function areUsageDataEqual(left?: UsageData, right?: UsageData): boolean {
+    if (left === right) return true
+    if (!left || !right) return false
+    return left.input_tokens === right.input_tokens
+        && left.output_tokens === right.output_tokens
+        && left.cache_creation_input_tokens === right.cache_creation_input_tokens
+        && left.cache_read_input_tokens === right.cache_read_input_tokens
+        && left.context_tokens === right.context_tokens
+        && left.context_window === right.context_window
+        && left.thread_id === right.thread_id
+        && left.scope_role === right.scope_role
+        && left.service_tier === right.service_tier
+}
+
+function areRoundModelUsagesEqual(left: RoundModelUsage, right: RoundModelUsage): boolean {
+    return left.inputTokens === right.inputTokens
+        && left.outputTokens === right.outputTokens
+        && left.cacheReadInputTokens === right.cacheReadInputTokens
+        && left.cacheCreationInputTokens === right.cacheCreationInputTokens
+}
+
+function areRoundSummariesEqual(left?: RoundSummary, right?: RoundSummary): boolean {
+    if (left === right) return true
+    if (!left || !right) return false
+    const leftModels = Object.keys(left.modelUsage)
+    const rightModels = Object.keys(right.modelUsage)
+    return left.totalCostUsd === right.totalCostUsd
+        && left.numTurns === right.numTurns
+        && left.durationMs === right.durationMs
+        && areUsageDataEqual(left.usage, right.usage)
+        && leftModels.length === rightModels.length
+        && leftModels.every(model => right.modelUsage[model] !== undefined
+            && areRoundModelUsagesEqual(left.modelUsage[model], right.modelUsage[model]))
 }
 
 function areStringArraysEqual(left?: string[] | null, right?: string[] | null): boolean {
@@ -121,6 +159,7 @@ function areAgentTextBlocksEqual(left: AgentTextBlock, right: AgentTextBlock): b
         && left.localId === right.localId
         && left.createdAt === right.createdAt
         && left.meta === right.meta
+        && areRoundSummariesEqual(left.roundSummary, right.roundSummary)
 }
 
 function areAgentReasoningBlocksEqual(left: AgentReasoningBlock, right: AgentReasoningBlock): boolean {
@@ -128,6 +167,7 @@ function areAgentReasoningBlocksEqual(left: AgentReasoningBlock, right: AgentRea
         && left.localId === right.localId
         && left.createdAt === right.createdAt
         && left.meta === right.meta
+        && areRoundSummariesEqual(left.roundSummary, right.roundSummary)
 }
 
 function areCliOutputBlocksEqual(left: CliOutputBlock, right: CliOutputBlock): boolean {
@@ -136,6 +176,7 @@ function areCliOutputBlocksEqual(left: CliOutputBlock, right: CliOutputBlock): b
         && left.createdAt === right.createdAt
         && left.source === right.source
         && left.meta === right.meta
+        && areRoundSummariesEqual(left.roundSummary, right.roundSummary)
 }
 
 function areGeneratedImageBlocksEqual(left: GeneratedImageBlock, right: GeneratedImageBlock): boolean {
@@ -146,6 +187,7 @@ function areGeneratedImageBlocksEqual(left: GeneratedImageBlock, right: Generate
         && left.mimeType === right.mimeType
         && areInlineMediaSourcesEqual(left.source, right.source)
         && left.meta === right.meta
+        && areRoundSummariesEqual(left.roundSummary, right.roundSummary)
 }
 
 function areCodexReviewBlocksEqual(left: CodexReviewBlock, right: CodexReviewBlock): boolean {
@@ -153,6 +195,7 @@ function areCodexReviewBlocksEqual(left: CodexReviewBlock, right: CodexReviewBlo
         && left.localId === right.localId
         && left.createdAt === right.createdAt
         && left.meta === right.meta
+        && areRoundSummariesEqual(left.roundSummary, right.roundSummary)
 }
 
 function areAgentEventBlocksEqual(left: AgentEventBlock, right: AgentEventBlock): boolean {
@@ -178,6 +221,7 @@ function areToolCallsEqual(left: ToolCallBlock, right: ToolCallBlock, childrenSa
         && left.tool.execStartedAt === right.tool.execStartedAt
         && left.tool.execCompletedAt === right.tool.execCompletedAt
         && arePermissionsEqual(left.tool.permission, right.tool.permission)
+        && areRoundSummariesEqual(left.roundSummary, right.roundSummary)
 }
 
 function reconcileBlockList(blocks: ChatBlock[], prevById: ChatBlocksById): ChatBlock[] {

--- a/web/src/chat/reducer.test.ts
+++ b/web/src/chat/reducer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { reduceChatBlocks } from './reducer'
+import { reconcileChatBlocks } from './reconcile'
 import { normalizeDecryptedMessage } from './normalize'
 import type { NormalizedMessage } from './types'
 import type { DecryptedMessage } from '@/types/api'
@@ -438,5 +439,109 @@ describe('reduceChatBlocks', () => {
         const block = reduced.blocks.find(b => b.kind === 'tool-call' && b.id === 'ask-pending')
         expect(block).toBeDefined()
         expect(block?.kind === 'tool-call' ? block.tool.permission?.status : null).toBe('pending')
+    })
+
+    it('attaches a result summary to the first block in the preceding contiguous assistant group', () => {
+        const summary = {
+            usage: { input_tokens: 100, output_tokens: 20 },
+            modelUsage: { 'claude-opus-5': { inputTokens: 100, outputTokens: 20 } },
+            totalCostUsd: 0.02,
+            numTurns: 2,
+            durationMs: 1500
+        }
+        const messages: NormalizedMessage[] = [
+            userMessage('u1', 'hello', 1),
+            {
+                id: 'a1', localId: 'turn-1', createdAt: 2, role: 'agent', isSidechain: false,
+                content: [{ type: 'text', text: 'thinking', uuid: 'a1', parentUUID: null }]
+            },
+            {
+                id: 'a2', localId: 'turn-2', createdAt: 3, role: 'agent', isSidechain: false,
+                content: [{ type: 'text', text: 'answer', uuid: 'a2', parentUUID: 'a1' }]
+            },
+            {
+                id: 'summary', localId: null, createdAt: 4, role: 'event', isSidechain: false,
+                content: { type: 'turn-summary', summary } as any
+            }
+        ]
+
+        const reduced = reduceChatBlocks(messages, null)
+        const firstAssistant = reduced.blocks.find(block => block.kind === 'agent-text' && block.id.startsWith('a1'))
+        expect((firstAssistant as any)?.roundSummary).toEqual(summary)
+        const secondAssistant = reduced.blocks.find(block => block.kind === 'agent-text' && block.id.startsWith('a2'))
+        expect((secondAssistant as any)?.roundSummary).toBeUndefined()
+    })
+
+    it('keeps a sidechain result summary on the subagent card instead of the next root response', () => {
+        const summary = {
+            modelUsage: { 'claude-opus-5': { inputTokens: 10, outputTokens: 2 } },
+            totalCostUsd: 0.01,
+            numTurns: 1,
+            durationMs: 800
+        }
+        const messages: NormalizedMessage[] = [
+            {
+                id: 'agent-tool', localId: null, createdAt: 1, role: 'agent', isSidechain: false,
+                content: [{
+                    type: 'tool-call', id: 'toolu-agent-1', name: 'Agent',
+                    input: { prompt: 'inspect the code', subagent_type: 'general-purpose' },
+                    description: null, uuid: 'root-1', parentUUID: null
+                }]
+            },
+            {
+                id: 'sidechain-answer', localId: null, createdAt: 2, role: 'agent', isSidechain: true,
+                parentToolUseId: 'toolu-agent-1',
+                content: [{ type: 'text', text: 'subagent answer', uuid: 'side-1', parentUUID: null }]
+            },
+            {
+                id: 'sidechain-summary', localId: null, createdAt: 3, role: 'event', isSidechain: true,
+                parentToolUseId: 'toolu-agent-1',
+                content: { type: 'turn-summary', summary } as any
+            },
+            {
+                id: 'root-answer', localId: null, createdAt: 4, role: 'agent', isSidechain: false,
+                content: [{ type: 'text', text: 'root answer', uuid: 'root-2', parentUUID: 'root-1' }]
+            }
+        ]
+
+        const reduced = reduceChatBlocks(messages, null)
+        const agentCard = reduced.blocks.find(block => block.kind === 'tool-call')
+        const sidechainAnswer = agentCard?.kind === 'tool-call'
+            ? agentCard.children.find(block => block.kind === 'agent-text')
+            : undefined
+        const rootAnswer = reduced.blocks.find(block => block.kind === 'agent-text')
+
+        expect(sidechainAnswer?.kind === 'agent-text' ? sidechainAnswer.roundSummary : undefined).toEqual(summary)
+        expect(rootAnswer?.kind === 'agent-text' ? rootAnswer.roundSummary : undefined).toBeUndefined()
+    })
+
+    it('keeps a late result summary when reconciling an existing assistant block', () => {
+        const summary = {
+            usage: { input_tokens: 10, output_tokens: 2 },
+            modelUsage: { 'claude-haiku-4-5': { inputTokens: 10, outputTokens: 2 } },
+            totalCostUsd: 0.02,
+            numTurns: 1,
+            durationMs: 1200
+        }
+        const baseMessages: NormalizedMessage[] = [
+            userMessage('u1', 'hello', 1),
+            {
+                id: 'a1', localId: 'turn-1', createdAt: 2, role: 'agent', isSidechain: false,
+                content: [{ type: 'text', text: 'answer', uuid: 'a1', parentUUID: null }]
+            }
+        ]
+        const before = reduceChatBlocks(baseMessages, null)
+        const previousById = new Map(before.blocks.map(block => [block.id, block]))
+        const after = reduceChatBlocks([
+            ...baseMessages,
+            {
+                id: 'summary', localId: null, createdAt: 3, role: 'event', isSidechain: false,
+                content: { type: 'turn-summary', summary } as any
+            }
+        ], null)
+
+        const reconciled = reconcileChatBlocks(after.blocks, previousById)
+        const assistant = reconciled.blocks.find(block => block.kind === 'agent-text')
+        expect(assistant?.kind === 'agent-text' ? assistant.roundSummary : undefined).toEqual(summary)
     })
 })

--- a/web/src/chat/reducerTimeline.ts
+++ b/web/src/chat/reducerTimeline.ts
@@ -1,4 +1,4 @@
-import type { AgentReasoningBlock, AgentTextBlock, ChatBlock, CliOutputBlock, CodexReviewBlock, ToolCallBlock, ToolPermission } from '@/chat/types'
+import type { AgentEventBlock, AgentReasoningBlock, AgentTextBlock, ChatBlock, CliOutputBlock, CodexReviewBlock, RoundSummary, ToolCallBlock, ToolPermission, UserTextBlock } from '@/chat/types'
 import type { TracedMessage } from '@/chat/tracer'
 import { createCliOutputBlock, isCliOutputText, mergeCliOutputBlocks } from '@/chat/reducerCliOutput'
 import { parseMessageAsEvent } from '@/chat/reducerEvents'
@@ -481,6 +481,26 @@ export function reduceTimeline(
             // abort-restore is a side-effect signal for the web composer,
             // not a visible chat event. Skip it in the timeline.
             if (msg.content.type === 'abort-restore') {
+                continue
+            }
+            if (msg.content.type === 'turn-summary') {
+                const summary = msg.content.summary as RoundSummary
+                type SummaryTargetBlock = Exclude<ChatBlock, UserTextBlock | AgentEventBlock>
+                const isSummaryTarget = (block: ChatBlock): block is SummaryTargetBlock =>
+                    block.kind !== 'user-text'
+                    && block.kind !== 'agent-event'
+                    && !(block.kind === 'cli-output' && block.source === 'user')
+                let firstIndex = -1
+                for (let index = blocks.length - 1; index >= 0; index -= 1) {
+                    if (!isSummaryTarget(blocks[index])) break
+                    firstIndex = index
+                }
+                if (firstIndex !== -1) {
+                    const firstBlock = blocks[firstIndex]
+                    if (isSummaryTarget(firstBlock)) {
+                        firstBlock.roundSummary = summary
+                    }
+                }
                 continue
             }
             if (msg.content.type === 'turn-duration') {

--- a/web/src/chat/toolGroups.ts
+++ b/web/src/chat/toolGroups.ts
@@ -1,4 +1,4 @@
-import type { ChatBlock, ToolCallBlock } from '@/chat/types'
+import type { ChatBlock, RoundSummary, ToolCallBlock } from '@/chat/types'
 import { getCodexCommandActions, isCodexExplorationTool } from '@/chat/codexCommandPresentation'
 import { isSubagentToolName } from '@/chat/subagentTool'
 import { isAskUserQuestionToolName } from '@/components/ToolCard/askUserQuestion'
@@ -33,6 +33,7 @@ export type ToolGroupBlock = {
     needsOlderHistory: boolean
     activityTitle?: string | null
     presentationMode?: 'default' | 'codex-exploration'
+    roundSummary?: RoundSummary
     summary: ToolGroupSummary
 }
 
@@ -314,6 +315,7 @@ export function buildVisibleChatBlocks(
             needsOlderHistory,
             activityTitle,
             presentationMode: groupingFamily,
+            roundSummary: tools[0].roundSummary,
             summary: summarizeToolGroup(tools)
         })
         index = cursor - 1

--- a/web/src/chat/tracer.test.ts
+++ b/web/src/chat/tracer.test.ts
@@ -156,6 +156,26 @@ function makeSidechainChildMsg(
 }
 
 describe('traceMessages — parentToolUseId direct grouping (broken subagent case)', () => {
+    it('groups a sidechain turn summary without an assistant-message uuid', () => {
+        const agentMsg = makeToolCallMsg('msg-agent', 'Agent', 'investigate background task')
+        const summary: NormalizedMessage = {
+            id: 'sc-summary',
+            localId: null,
+            createdAt: 1_700_000_003_000,
+            role: 'event',
+            isSidechain: true,
+            parentToolUseId: 'tc-msg-agent',
+            content: {
+                type: 'turn-summary',
+                summary: { modelUsage: { 'claude-opus-5': { inputTokens: 10, outputTokens: 2 } } }
+            }
+        } as NormalizedMessage
+
+        const result = traceMessages([agentMsg, summary])
+
+        expect(result.find(m => m.id === 'sc-summary')?.sidechainId).toBe('msg-agent')
+    })
+
     it('groups an orphaned sidechain child directly via parentToolUseId when no prompt-root sidechain message exists', () => {
         const agentMsg = makeToolCallMsg('msg-agent', 'Agent', 'investigate background task')
         // No sidechain root carrying the prompt — SDK dropped it as system/task_started

--- a/web/src/chat/tracer.ts
+++ b/web/src/chat/tracer.ts
@@ -30,7 +30,6 @@ function getParentUuid(message: NormalizedMessage): string | null {
 }
 
 function getParentToolUseId(message: NormalizedMessage): string | null {
-    if (message.role !== 'agent') return null
     return message.parentToolUseId ?? null
 }
 
@@ -111,10 +110,14 @@ export function traceMessages(messages: NormalizedMessage[]): TracedMessage[] {
             }
         }
 
-        if (sidechainId && uuid) {
-            state.uuidToSidechainId.set(uuid, sidechainId)
+        if (sidechainId) {
+            if (uuid) {
+                state.uuidToSidechainId.set(uuid, sidechainId)
+            }
             results.push({ ...message, sidechainId })
-            results.push(...processOrphans(state, uuid, sidechainId))
+            if (uuid) {
+                results.push(...processOrphans(state, uuid, sidechainId))
+            }
             continue
         }
 

--- a/web/src/chat/types.ts
+++ b/web/src/chat/types.ts
@@ -14,6 +14,21 @@ export type UsageData = {
     service_tier?: string
 }
 
+export type RoundModelUsage = {
+    inputTokens?: number
+    outputTokens?: number
+    cacheReadInputTokens?: number
+    cacheCreationInputTokens?: number
+}
+
+export type RoundSummary = {
+    usage?: UsageData
+    modelUsage: Record<string, RoundModelUsage>
+    totalCostUsd?: number
+    numTurns?: number
+    durationMs?: number
+}
+
 export type AgentEvent =
     | { type: 'switch'; mode: 'local' | 'remote' }
     | { type: 'message'; message: string }
@@ -24,6 +39,7 @@ export type AgentEvent =
     | { type: 'ready' }
     | { type: 'api-error'; retryAttempt: number; maxRetries: number; error: unknown }
     | { type: 'turn-duration'; durationMs: number; targetMessageId?: string }
+    | { type: 'turn-summary'; summary: RoundSummary }
     | { type: 'microcompact'; trigger: string; preTokens: number; tokensSaved: number }
     | { type: 'compact'; trigger: string; preTokens: number }
     // Structured result of Pi's compact RPC; rendered as a dedicated chat block.
@@ -222,6 +238,7 @@ export type AgentTextBlock = {
     durationMs?: number
     usage?: UsageData
     model?: string | null
+    roundSummary?: RoundSummary
     text: string
     meta?: unknown
 }
@@ -235,6 +252,7 @@ export type AgentReasoningBlock = {
     durationMs?: number
     usage?: UsageData
     model?: string | null
+    roundSummary?: RoundSummary
     text: string
     meta?: unknown
 }
@@ -248,6 +266,7 @@ export type CodexReviewBlock = {
     durationMs?: number
     usage?: UsageData
     model?: string | null
+    roundSummary?: RoundSummary
     review: CodexReview
     meta?: unknown
 }
@@ -261,6 +280,7 @@ export type CliOutputBlock = {
     durationMs?: number
     usage?: UsageData
     model?: string | null
+    roundSummary?: RoundSummary
     text: string
     source: 'user' | 'assistant'
     meta?: unknown
@@ -276,6 +296,7 @@ export type GeneratedImageBlock = {
     fileName: string
     mimeType: string | null
     source?: InlineMediaSource
+    roundSummary?: RoundSummary
     meta?: unknown
 }
 
@@ -298,6 +319,7 @@ export type ToolCallBlock = {
     durationMs?: number
     usage?: UsageData
     model?: string | null
+    roundSummary?: RoundSummary
     tool: ChatToolCall
     children: ChatBlock[]
     meta?: unknown

--- a/web/src/components/AssistantChat/messages/AssistantMessage.tsx
+++ b/web/src/components/AssistantChat/messages/AssistantMessage.tsx
@@ -56,8 +56,9 @@ export function HappyAssistantMessage() {
     const usage = useAuiState(({ message }) => (message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined)?.usage)
     const messageModel = useAuiState(({ message }) => (message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined)?.model)
     const turnCount = useAuiState(({ message }) => (message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined)?.turnCount)
+    const roundSummary = useAuiState(({ message }) => (message.metadata.custom as Partial<HappyChatMessageMetadata> | undefined)?.roundSummary)
 
-    const metadata = { durationMs, usage, model: messageModel ?? null, turnCount }
+    const metadata = { durationMs, usage, model: messageModel ?? null, turnCount, roundSummary }
 
     const history = ctx.metadata?.capabilities?.conversationHistory
     const showForkCurrent = Boolean(

--- a/web/src/components/AssistantChat/messages/MessageMetadata.test.ts
+++ b/web/src/components/AssistantChat/messages/MessageMetadata.test.ts
@@ -120,4 +120,63 @@ describe('buildMessageMetadataLabels', () => {
         })
         expect(parts.some(p => p.startsWith('Duration:'))).toBe(false)
     })
+
+    it('renders the exact Claude round summary hierarchy', () => {
+        const parts = buildMessageMetadataLabels({
+            model: 'derived-model-that-must-not-win',
+            usage: { input_tokens: 1, output_tokens: 1 },
+            roundSummary: {
+                modelUsage: {
+                    'claude-opus-5': {
+                        inputTokens: 80,
+                        cacheCreationInputTokens: 20,
+                        cacheReadInputTokens: 100_000,
+                        outputTokens: 500
+                    },
+                    'claude-haiku-4-5': {}
+                },
+                totalCostUsd: 0.028029,
+                numTurns: 9,
+                durationMs: 8163
+            }
+        } as any)
+
+        expect(parts).toEqual([
+            'Models: claude-opus-5, claude-haiku-4-5',
+            'Tokens: 100.6k (100.1k in · 500 out)',
+            'Cache read: 99.9% of input · API-rate est.: $0.028',
+            'Round: 8.2s · 9 internal turns'
+        ])
+    })
+
+    it('keeps the existing formatter byte-identical when no result summary is present', () => {
+        expect(buildMessageMetadataLabels({
+            durationMs: 1234,
+            model: 'claude-sonnet-4-6',
+            usage: { input_tokens: 3, output_tokens: 19, service_tier: 'standard' }
+        } as any)).toEqual([
+            'Duration: 1.2s',
+            'Model: claude-sonnet-4-6',
+            'Tokens: 22 total (3 in / 19 out)'
+        ])
+    })
+
+    it('uses the normalized valid model fields when other model counters are absent', () => {
+        expect(buildMessageMetadataLabels({
+            roundSummary: {
+                modelUsage: {
+                    'claude-opus-5': { outputTokens: 10 },
+                    'claude-haiku-4-5': { inputTokens: 10, outputTokens: 4 },
+                    'claude-empty-5': {}
+                },
+                totalCostUsd: 0.00002,
+                durationMs: 12.5
+            }
+        })).toEqual([
+            'Models: claude-opus-5, claude-haiku-4-5, claude-empty-5',
+            'Tokens: 24 (10 in · 14 out)',
+            'API-rate est.: <$0.0001',
+            'Round: 0.0s'
+        ])
+    })
 })

--- a/web/src/components/AssistantChat/messages/MessageMetadata.tsx
+++ b/web/src/components/AssistantChat/messages/MessageMetadata.tsx
@@ -1,4 +1,4 @@
-import type { UsageData } from '@/chat/types'
+import type { RoundModelUsage, RoundSummary, UsageData } from '@/chat/types'
 
 export type MessageMetadataProps = {
     durationMs?: number
@@ -9,10 +9,74 @@ export type MessageMetadataProps = {
      * footers pass `undefined` (or any value < 2).
      */
     turnCount?: number
+    roundSummary?: RoundSummary
     className?: string
 }
 
-export function buildMessageMetadataLabels({ durationMs, usage, model, turnCount }: Omit<MessageMetadataProps, 'className'>): string[] {
+function formatCompactTokenCount(value: number): string {
+    if (value < 1_000) return Math.round(value).toLocaleString()
+    const divisor = value >= 1_000_000 ? 1_000_000 : 1_000
+    const suffix = divisor === 1_000_000 ? 'm' : 'k'
+    return `${(Math.round((value / divisor) * 10) / 10).toString()}${suffix}`
+}
+
+function formatPercentage(value: number): string {
+    return (Math.round(value * 10) / 10).toString()
+}
+
+function formatUsd(value: number): string {
+    if (value < 0.0001) return '<$0.0001'
+    return value >= 0.01 ? `$${value.toFixed(3)}` : `$${value.toFixed(4)}`
+}
+
+function getRoundUsage(summary: RoundSummary): UsageData | undefined {
+    const entries = Object.values(summary.modelUsage)
+    const hasModelToken = entries.some((usage: RoundModelUsage) => Object.values(usage).some(token => typeof token === 'number'))
+    if (!hasModelToken) return summary.usage
+
+    return entries.reduce<UsageData>((total, usage) => ({
+        input_tokens: total.input_tokens + (usage.inputTokens ?? 0),
+        output_tokens: total.output_tokens + (usage.outputTokens ?? 0),
+        cache_creation_input_tokens: (total.cache_creation_input_tokens ?? 0) + (usage.cacheCreationInputTokens ?? 0),
+        cache_read_input_tokens: (total.cache_read_input_tokens ?? 0) + (usage.cacheReadInputTokens ?? 0)
+    }), { input_tokens: 0, output_tokens: 0 })
+}
+
+function buildRoundSummaryLabels(summary: RoundSummary, fallbackModel?: string | null): string[] {
+    const parts: string[] = []
+    const models = Object.keys(summary.modelUsage)
+    const model = models.length > 0 ? models.join(', ') : fallbackModel
+    if (model) parts.push(`${models.length > 1 ? 'Models' : 'Model'}: ${model}`)
+
+    const usage = getRoundUsage(summary)
+    if (usage) {
+        const input = usage.input_tokens
+            + (usage.cache_creation_input_tokens ?? 0)
+            + (usage.cache_read_input_tokens ?? 0)
+        const total = input + usage.output_tokens
+        parts.push(`Tokens: ${formatCompactTokenCount(total)} (${formatCompactTokenCount(input)} in · ${formatCompactTokenCount(usage.output_tokens)} out)`)
+
+        const economics: string[] = []
+        if (input > 0 && (usage.cache_read_input_tokens ?? 0) > 0) {
+            economics.push(`Cache read: ${formatPercentage(((usage.cache_read_input_tokens ?? 0) / input) * 100)}% of input`)
+        }
+        if (summary.totalCostUsd !== undefined && summary.totalCostUsd > 0) {
+            economics.push(`API-rate est.: ${formatUsd(summary.totalCostUsd)}`)
+        }
+        if (economics.length > 0) parts.push(economics.join(' · '))
+    } else if (summary.totalCostUsd !== undefined && summary.totalCostUsd > 0) {
+        parts.push(`API-rate est.: ${formatUsd(summary.totalCostUsd)}`)
+    }
+
+    const round: string[] = []
+    if (summary.durationMs !== undefined && summary.durationMs >= 0) round.push(`${(summary.durationMs / 1000).toFixed(1)}s`)
+    if (summary.numTurns !== undefined && summary.numTurns > 0) round.push(`${summary.numTurns} internal turn${summary.numTurns === 1 ? '' : 's'}`)
+    if (round.length > 0) parts.push(`Round: ${round.join(' · ')}`)
+    return parts
+}
+
+export function buildMessageMetadataLabels({ durationMs, usage, model, turnCount, roundSummary }: Omit<MessageMetadataProps, 'className'>): string[] {
+    if (roundSummary) return buildRoundSummaryLabels(roundSummary, model)
     const parts: string[] = []
     // Aggregated footers represent a response group with multiple distinct
     // turns. When the caller passes `turnCount >= 2` they have already
@@ -49,8 +113,8 @@ export function buildMessageMetadataLabels({ durationMs, usage, model, turnCount
     return parts
 }
 
-export function MessageMetadata({ durationMs, usage, model, turnCount, className }: MessageMetadataProps) {
-    const parts = buildMessageMetadataLabels({ durationMs, usage, model, turnCount })
+export function MessageMetadata({ durationMs, usage, model, turnCount, roundSummary, className }: MessageMetadataProps) {
+    const parts = buildMessageMetadataLabels({ durationMs, usage, model, turnCount, roundSummary })
     if (parts.length === 0) return null
 
     return (

--- a/web/src/lib/assistant-runtime.test.ts
+++ b/web/src/lib/assistant-runtime.test.ts
@@ -9,7 +9,7 @@ import {
     getResponseGroupTimestamps
 } from './assistant-runtime'
 import type { AgentEventBlock, AgentTextBlock, CliOutputBlock, ToolCallBlock, UserTextBlock } from '@/chat/types'
-import type { ToolGroupBlock, VisibleChatBlock } from '@/chat/toolGroups'
+import { buildVisibleChatBlocks, type ToolGroupBlock, type VisibleChatBlock } from '@/chat/toolGroups'
 
 // Minimal builders for VisibleChatBlock fixtures. Tests focus on metadata
 // aggregation behavior across response groups; non-metadata fields default to
@@ -802,5 +802,46 @@ describe('aggregateResponseGroups', () => {
         const meta = aggregates.get('a1')
         expect(meta?.usage?.cache_creation_input_tokens).toBe(300)
         expect(meta?.usage?.cache_read_input_tokens).toBe(100)
+    })
+
+    it('prefers a result summary for single-turn and tool-group response metadata', () => {
+        const summary = {
+            usage: { input_tokens: 100, output_tokens: 20 },
+            modelUsage: { 'claude-opus-5': { inputTokens: 100, outputTokens: 20 } },
+            totalCostUsd: 0.02,
+            numTurns: 2,
+            durationMs: 1500
+        }
+        const singleTurn = Object.assign(agentText('single', {
+            localId: 'L1', model: 'derived-model', usage: { input_tokens: 1, output_tokens: 1 }
+        }), { roundSummary: summary })
+        const groupedTurn = Object.assign(agentText('grouped', {
+            localId: 'L2', model: 'derived-model', usage: { input_tokens: 2, output_tokens: 2 }
+        }), { roundSummary: summary })
+        const tool = toolGroup('tool-group', [toolCall('tool', { localId: 'L2' })])
+
+        expect(aggregateResponseGroups([userText('u1'), singleTurn]).get('single')?.roundSummary).toEqual(summary)
+        expect(aggregateResponseGroups([userText('u2'), groupedTurn, tool]).get('grouped')?.roundSummary).toEqual(summary)
+    })
+
+    it('preserves a tool-only result summary through tool-call to tool-group conversion', () => {
+        const summary = {
+            usage: { input_tokens: 100, output_tokens: 20 },
+            modelUsage: { 'claude-opus-5': { inputTokens: 100, outputTokens: 20 } },
+            totalCostUsd: 0.02,
+            numTurns: 2,
+            durationMs: 1500
+        }
+        const firstTool = Object.assign(toolCall('read', { localId: 'L1' }), { roundSummary: summary })
+        const visible = buildVisibleChatBlocks([
+            userText('u1'),
+            firstTool,
+            toolCall('grep', { localId: 'L1' })
+        ], { hasMoreMessages: false })
+        const group = visible.find(block => block.kind === 'tool-group')
+        if (!group || group.kind !== 'tool-group') throw new Error('Expected tool group')
+
+        expect(group.roundSummary).toEqual(summary)
+        expect(aggregateResponseGroups(visible).get(group.id)?.roundSummary).toEqual(summary)
     })
 })

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -10,7 +10,7 @@ import {
 } from '@/lib/messageDelivery'
 import { safeStringify } from '@hapi/protocol'
 import { renderEventLabel } from '@/chat/presentation'
-import type { ChatBlock, CliOutputBlock, CodexReview, UsageData } from '@/chat/types'
+import type { ChatBlock, CliOutputBlock, CodexReview, RoundSummary, UsageData } from '@/chat/types'
 import type { AgentEvent, ToolCallBlock } from '@/chat/types'
 import type { ToolGroupBlock, VisibleChatBlock } from '@/chat/toolGroups'
 import { visibleBlockRole } from '@/chat/toolGroups'
@@ -27,6 +27,7 @@ export type AggregatedAssistantMeta = {
     invokedAt: number | null
     durationMs: undefined
     turnCount: number
+    roundSummary?: RoundSummary
 }
 
 export type HappyChatMessageMetadata = {
@@ -43,6 +44,7 @@ export type HappyChatMessageMetadata = {
     durationMs?: number
     usage?: UsageData
     model?: string | null
+    roundSummary?: RoundSummary
     review?: CodexReview
     /**
      * Distinct turn count when this block carries an aggregated response
@@ -256,16 +258,18 @@ export function aggregateResponseGroups(
     let groupInvokedAt: number | null = null
     let groupUsage: UsageData | undefined
     let groupTurnCount = 0
+    let groupRoundSummary: RoundSummary | undefined
 
     const flush = () => {
-        if (groupFirstBlockId !== null && groupTurnCount >= 2) {
+        if (groupFirstBlockId !== null && (groupTurnCount >= 2 || groupRoundSummary)) {
             const joinedModel = seenModels.length > 0 ? seenModels.join(', ') : null
             aggregates.set(groupFirstBlockId, {
                 usage: groupUsage,
                 model: joinedModel,
                 invokedAt: groupInvokedAt,
                 durationMs: undefined,
-                turnCount: groupTurnCount
+                turnCount: groupTurnCount,
+                roundSummary: groupRoundSummary
             })
         }
         groupFirstBlockId = null
@@ -274,6 +278,7 @@ export function aggregateResponseGroups(
         groupInvokedAt = null
         groupUsage = undefined
         groupTurnCount = 0
+        groupRoundSummary = undefined
     }
 
     for (const block of blocks) {
@@ -287,6 +292,13 @@ export function aggregateResponseGroups(
         if (groupFirstBlockId === null) {
             groupFirstBlockId = block.id
         }
+
+        const roundSummary = block.kind === 'tool-group'
+            ? block.roundSummary
+            : block.kind === 'user-text' || block.kind === 'agent-event'
+                ? undefined
+                : block.roundSummary
+        groupRoundSummary ??= roundSummary
 
         for (const turn of turnSourcesFromBlock(block)) {
             // Prefer the CLI-stamped `localId` when present. When it is null
@@ -890,7 +902,8 @@ export function useHappyRuntime(props: {
                         model: aggregate.model,
                         invokedAt: aggregate.invokedAt,
                         durationMs: aggregate.durationMs,
-                        turnCount: aggregate.turnCount
+                        turnCount: aggregate.turnCount,
+                        roundSummary: aggregate.roundSummary
                     } satisfies HappyChatMessageMetadata
                 }
             }


### PR DESCRIPTION

## Summary

This follows up on #637, which aggregated per-message metadata across a response group. Claude's final SDK result now lets the same surface show authoritative round-level usage, cost, duration, and turn count instead of deriving them from individual messages.

- preserve the Claude Agent SDK's final result as authoritative metadata for the preceding response round
- show models, processed tokens, cache-read share, API-rate estimate, elapsed round time, and internal turns in the message-details popover
- keep existing metadata labels unchanged when a round result is unavailable

## Details

Claude assistant messages expose per-message usage, while the SDK's final result contains the complete round-level usage, per-model breakdown, cost, duration, and turn count. The CLI now forwards that result through the existing `system/turn_duration` carrier without advancing the main or sidechain parent chain. The remote queue preserves visible system carriers and drains them before `ready`, while Web reconciliation retains late-arriving round summaries. The web app validates it at the normalization boundary, attaches it to the preceding contiguous assistant response group, and prefers it over derived per-message aggregates.

Malformed counters fail closed. Token and turn counts require non-negative safe integers, cost and duration require finite non-negative numbers, and a zero cost is omitted rather than presented as free usage.

## Test plan

- full CLI Vitest suite (2,439 passed, 1 skipped)
- full Hub suite (1,205 passed, 3 skipped)
- full Web Vitest suite (2,842 passed)
- full Shared and Relay suites (294 and 80 passed)
- CLI and Web typechecks
- Web production build
- isolated Hub + Vite + real Claude Haiku request + Playwright verification on desktop and iPhone 13, without a page reload

## Screenshots

| Desktop | Mobile |
| :---: | :---: |
| ![Claude round usage metadata on desktop](https://github.com/user-attachments/assets/7e12e091-3eb7-45b5-84f3-d1460e1da783) | ![Claude round usage metadata on mobile](https://github.com/user-attachments/assets/b7413a2f-b5fa-45ce-9b4c-f47bd3e9d55a) |
