### PR TITLE
fix(web): improve deferred generated-file download controls

### DIFF
--- a/cli/src/modules/common/handlers/files.test.ts
+++ b/cli/src/modules/common/handlers/files.test.ts
@@ -3,6 +3,7 @@ import { mkdir, rm, stat, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { RpcHandlerManager } from '../../../api/rpc/RpcHandlerManager'
+import { clearGeneratedImages, registerGeneratedImage } from '../generatedImages'
 import { registerFileHandlers } from './files'
 
 async function createTempDir(prefix: string): Promise<string> {
@@ -23,6 +24,7 @@ describe('file RPC handlers', () => {
 
     afterEach(async () => {
         await rm(rootDir, { recursive: true, force: true })
+        clearGeneratedImages()
     })
 
     it('returns file metadata alongside content', async () => {
@@ -45,5 +47,32 @@ describe('file RPC handlers', () => {
         expect(parsed.content).toBe(Buffer.from('# test').toString('base64'))
         expect(parsed.size).toBe(expectedStats.size)
         expect(parsed.modified).toBe(expectedStats.mtime.getTime())
+    })
+
+    it('returns generated image metadata without content when requested', async () => {
+        const bytes = Buffer.from('generated file')
+        registerGeneratedImage({
+            id: 'generated-metadata-test',
+            path: join(rootDir, 'archive.zip'),
+            mimeType: 'application/octet-stream',
+            bytes,
+            fileName: 'archive.zip'
+        })
+
+        const response = await rpc.handleRequest({
+            method: 'session-test:readGeneratedImage',
+            params: JSON.stringify({ id: 'generated-metadata-test', metadataOnly: true })
+        })
+        const parsed = JSON.parse(response) as {
+            success: boolean
+            content?: string
+            size?: number
+            fileName?: string
+        }
+
+        expect(parsed.success).toBe(true)
+        expect(parsed.content).toBeUndefined()
+        expect(parsed.size).toBe(bytes.byteLength)
+        expect(parsed.fileName).toBe('archive.zip')
     })
 })

--- a/cli/src/modules/common/handlers/files.ts
+++ b/cli/src/modules/common/handlers/files.ts
@@ -17,6 +17,7 @@ type ReadFileResponse = FileReadResponse
 
 interface ReadGeneratedImageRequest {
     id: string
+    metadataOnly?: boolean
 }
 
 type ReadGeneratedImageResponse = GeneratedImageResponse
@@ -70,7 +71,8 @@ export function registerFileHandlers(rpcHandlerManager: RpcHandlerManager, worki
         try {
             return {
                 success: true,
-                content: image.content.toString('base64'),
+                ...(data.metadataOnly ? {} : { content: image.content.toString('base64') }),
+                size: image.content.byteLength,
                 mimeType: image.mimeType,
                 fileName: image.fileName
             }

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -305,8 +305,11 @@ export class RpcGateway {
         return await this.sessionRpc(sessionId, RPC_METHODS.ReadFile, { path }) as RpcReadFileResponse
     }
 
-    async readGeneratedImage(sessionId: string, imageId: string): Promise<RpcGeneratedImageResponse> {
-        return await this.sessionRpc(sessionId, RPC_METHODS.ReadGeneratedImage, { id: imageId }) as RpcGeneratedImageResponse
+    async readGeneratedImage(sessionId: string, imageId: string, options?: { metadataOnly?: boolean }): Promise<RpcGeneratedImageResponse> {
+        return await this.sessionRpc(sessionId, RPC_METHODS.ReadGeneratedImage, {
+            id: imageId,
+            ...(options?.metadataOnly ? { metadataOnly: true } : {})
+        }) as RpcGeneratedImageResponse
     }
 
     async listDirectory(sessionId: string, path: string): Promise<RpcListDirectoryResponse> {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -3860,8 +3860,8 @@ export class SyncEngine {
         return await this.rpcGateway.readSessionFile(sessionId, path)
     }
 
-    async readGeneratedImage(sessionId: string, imageId: string): Promise<RpcGeneratedImageResponse> {
-        return await this.rpcGateway.readGeneratedImage(sessionId, imageId)
+    async readGeneratedImage(sessionId: string, imageId: string, options?: { metadataOnly?: boolean }): Promise<RpcGeneratedImageResponse> {
+        return await this.rpcGateway.readGeneratedImage(sessionId, imageId, options)
     }
 
     async listDirectory(sessionId: string, path: string): Promise<RpcListDirectoryResponse> {

--- a/hub/src/web/routes/git.test.ts
+++ b/hub/src/web/routes/git.test.ts
@@ -59,6 +59,34 @@ describe('generated images route', () => {
         expect(rpcCalls).toBe(0)
     })
 
+    it('serves generated image metadata without transferring the content', async () => {
+        const session = { id: 'session-1', namespace: 'default', active: true } as unknown as Session
+        let metadataOnly: boolean | undefined
+        const engine = {
+            resolveSessionAccess: () => ({ ok: true as const, sessionId: 'session-1', session }),
+            readGeneratedImage: async (_sessionId: string, _imageId: string, options?: { metadataOnly?: boolean }) => {
+                metadataOnly = options?.metadataOnly
+                return {
+                    success: true,
+                    size: 20 * 1024,
+                    mimeType: 'application/octet-stream',
+                    fileName: 'archive.zip'
+                }
+            }
+        } as unknown as Partial<SyncEngine>
+
+        const response = await buildApp(engine).request('/api/sessions/session-1/generated-images/img-1?metadata=1')
+
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+            success: true,
+            size: 20 * 1024,
+            mimeType: 'application/octet-stream',
+            fileName: 'archive.zip'
+        })
+        expect(metadataOnly).toBe(true)
+    })
+
     it('serves audio inline and generic files as downloads with nosniff', async () => {
         const session = { id: 'session-1', namespace: 'default', active: true } as unknown as Session
         let mimeType = 'audio/wav'

--- a/hub/src/web/routes/git.ts
+++ b/hub/src/web/routes/git.ts
@@ -178,16 +178,32 @@ export function createGitRoutes(getSyncEngine: () => SyncEngine | null): Hono<We
         // already holds it, answer 304 *before* the RPC so revalidation skips the CLI round-trip
         // entirely (and still works even if the image was evicted from CLI memory). Issue #927.
         const etag = `"${parsed.data.imageId}"`
-        if (ifNoneMatchMatches(c.req.header('if-none-match'), etag)) {
+        const metadataOnly = c.req.query('metadata') === '1'
+        if (!metadataOnly && ifNoneMatchMatches(c.req.header('if-none-match'), etag)) {
             return c.body(null, 304, {
                 'Cache-Control': GENERATED_IMAGE_CACHE_CONTROL,
                 ETag: etag
             })
         }
 
-        const result = await runRpc(() => engine.readGeneratedImage(sessionResult.sessionId, parsed.data.imageId))
-        if (!result.success || !result.content) {
+        const result = await runRpc(() => engine.readGeneratedImage(
+            sessionResult.sessionId,
+            parsed.data.imageId,
+            metadataOnly ? { metadataOnly: true } : undefined
+        ))
+        if (!result.success || (!metadataOnly && !result.content)) {
             return c.json({ success: false, error: result.error ?? 'Generated image not found' }, 404)
+        }
+        if (metadataOnly) {
+            return c.json({
+                success: true,
+                size: result.size ?? (result.content ? Buffer.byteLength(result.content, 'base64') : undefined),
+                mimeType: result.mimeType,
+                fileName: result.fileName
+            })
+        }
+        if (!result.content) {
+            return c.json({ success: false, error: 'Generated image not found' }, 404)
         }
 
         const bytes = Uint8Array.from(Buffer.from(result.content, 'base64'))

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -661,6 +661,7 @@ export type FileReadResponse = {
 export type GeneratedImageResponse = {
     success: boolean
     content?: string
+    size?: number
     mimeType?: string
     fileName?: string
     error?: string

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -39,6 +39,7 @@ import type {
     CursorModelsResponse,
     DeleteUploadResponse,
     FileReadResponse,
+    GeneratedImageResponse,
     GitCommandResponse,
     GrokModelsResponse,
     CopilotModelsResponse,
@@ -466,6 +467,13 @@ export class ApiClient {
             throw new ApiError(`HTTP ${res.status}`, res.status, undefined, await res.text().catch(() => undefined))
         }
         return await res.blob()
+    }
+
+    async getGeneratedImageMetadata(sessionId: string, imageId: string): Promise<GeneratedImageResponse> {
+        const params = new URLSearchParams({ metadata: '1' })
+        return await this.request<GeneratedImageResponse>(
+            `/api/sessions/${encodeURIComponent(sessionId)}/generated-images/${encodeURIComponent(imageId)}?${params.toString()}`
+        )
     }
 
     async readSessionFile(sessionId: string, path: string): Promise<FileReadResponse> {

--- a/web/src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx
@@ -10,6 +10,7 @@ function renderCard(options: {
     mimeType: string | null
     locale?: 'en' | 'zh-CN'
     getGeneratedImageBlob?: ReturnType<typeof vi.fn>
+    getGeneratedImageMetadata?: ReturnType<typeof vi.fn>
 }) {
     if (options.locale) {
         localStorage.setItem('hapi-lang', options.locale)
@@ -18,7 +19,8 @@ function renderCard(options: {
     }
 
     const getGeneratedImageBlob = options.getGeneratedImageBlob ?? vi.fn(async () => new Blob(['x'], { type: options.mimeType ?? 'image/png' }))
-    const api = { getGeneratedImageBlob } as unknown as ApiClient
+    const getGeneratedImageMetadata = options.getGeneratedImageMetadata ?? vi.fn(async () => ({ success: false }))
+    const api = { getGeneratedImageBlob, getGeneratedImageMetadata } as unknown as ApiClient
     const value: HappyChatContextValue = {
         api,
         sessionId: 'session-1',
@@ -51,7 +53,7 @@ function renderCard(options: {
         </I18nProvider>
     )
 
-    return { getGeneratedImageBlob }
+    return { getGeneratedImageBlob, getGeneratedImageMetadata }
 }
 
 describe('GeneratedImageCard video fetch', () => {
@@ -73,6 +75,7 @@ describe('GeneratedImageCard video fetch', () => {
         const { getGeneratedImageBlob } = renderCard({ mimeType: 'video/mp4' })
 
         expect(screen.getByRole('button', { name: 'Load video' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Load video' })).not.toHaveClass('h-48')
         await new Promise((resolve) => setTimeout(resolve, 20))
         expect(getGeneratedImageBlob).not.toHaveBeenCalled()
     })
@@ -96,9 +99,9 @@ describe('GeneratedImageCard video fetch', () => {
     })
 
     it('loads audio on demand and renders controls', async () => {
-        renderCard({ mimeType: 'audio/wav' })
+        renderCard({ mimeType: 'audio/wav', locale: 'zh-CN' })
 
-        fireEvent.click(screen.getByRole('button', { name: 'Load audio' }))
+        fireEvent.click(screen.getByRole('button', { name: '加载音频' }))
 
         await waitFor(() => {
             expect(document.querySelector('audio[controls]')).toBeInTheDocument()
@@ -106,12 +109,46 @@ describe('GeneratedImageCard video fetch', () => {
     })
 
     it('loads unknown files on demand and renders a download link', async () => {
-        renderCard({ mimeType: 'application/octet-stream' })
-
-        fireEvent.click(screen.getByRole('button', { name: 'Prepare download' }))
+        const getGeneratedImageBlob = vi.fn(async () => new Blob([new Uint8Array(20 * 1024)], { type: 'application/octet-stream' }))
+        const getGeneratedImageMetadata = vi.fn(async () => ({ success: true, size: 20 * 1024 }))
+        renderCard({ mimeType: 'application/octet-stream', getGeneratedImageBlob, getGeneratedImageMetadata })
 
         await waitFor(() => {
-            expect(screen.getByRole('link', { name: /Download clip\.mp4/ })).toHaveAttribute('download', 'clip.mp4')
+            expect(screen.getByRole('button', { name: 'Prepare download (20 KB)' })).toBeInTheDocument()
+        })
+        fireEvent.click(screen.getByRole('button', { name: 'Prepare download (20 KB)' }))
+
+        await waitFor(() => {
+            expect(screen.getByRole('link', { name: 'Download file clip.mp4 (20 KB)' })).toHaveAttribute('download', 'clip.mp4')
+            expect(screen.getByText('Download file (20 KB)')).toBeInTheDocument()
+        })
+    })
+
+    it('localizes deferred media actions in Chinese', () => {
+        renderCard({ mimeType: 'application/octet-stream', locale: 'zh-CN' })
+
+        expect(screen.getByRole('button', { name: '加载文件' })).toBeInTheDocument()
+    })
+
+    it('localizes the video loading action in Chinese', () => {
+        renderCard({ mimeType: 'video/mp4', locale: 'zh-CN' })
+
+        expect(screen.getByRole('button', { name: '加载视频' })).toBeInTheDocument()
+    })
+
+    it('shows the file size before loading and uses the file label in Chinese', async () => {
+        const getGeneratedImageBlob = vi.fn(async () => new Blob([new Uint8Array(20 * 1024)], { type: 'application/octet-stream' }))
+        const getGeneratedImageMetadata = vi.fn(async () => ({ success: true, size: 20 * 1024 }))
+        renderCard({ mimeType: 'application/octet-stream', locale: 'zh-CN', getGeneratedImageBlob, getGeneratedImageMetadata })
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: '加载文件（20 KB）' })).toBeInTheDocument()
+        })
+        fireEvent.click(screen.getByRole('button', { name: '加载文件（20 KB）' }))
+
+        await waitFor(() => {
+            expect(screen.getByRole('link', { name: '下载文件 clip.mp4（20 KB）' })).toBeInTheDocument()
+            expect(screen.getByText('下载文件（20 KB）')).toBeInTheDocument()
         })
     })
 })

--- a/web/src/components/AssistantChat/messages/ToolMessage.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.tsx
@@ -16,6 +16,7 @@ import { CliOutputBlock } from '@/components/CliOutputBlock'
 import { UserBubbleContent, getUserBubbleClassName, shouldShowMessageStatus } from '@/components/AssistantChat/messages/user-bubble'
 import { ImagePreview } from '@/components/ImagePreview'
 import { FileIcon } from '@/components/FileIcon'
+import { formatFileSize } from '@/lib/file-metadata'
 import { useTranslation } from '@/lib/use-translation'
 import { inlineMediaLabelKey, isInlineAudioMimeType, isInlineImageMimeType, isInlineVideoMimeType } from '@/lib/generatedInlineMedia'
 
@@ -53,6 +54,7 @@ function isGeneratedImageBlock(value: unknown): value is GeneratedImageBlock {
 }
 
 const MIN_INLINE_IMAGE_DIMENSION = 64
+const MEDIA_ACTION_CLASS_NAME = 'flex w-full items-center gap-3 rounded-xl border border-[var(--app-border)] bg-[var(--app-subtle-bg)] px-4 py-3 text-left text-sm font-medium text-[var(--app-fg)]'
 
 /** Scale tiny icons up for readability without exploding skinny/tall images. */
 export function computeTinyImageScale(width: number, height: number): number {
@@ -70,6 +72,7 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
     const [objectUrl, setObjectUrl] = useState<string | null>(null)
     const [error, setError] = useState<string | null>(null)
     const [imageStyle, setImageStyle] = useState<CSSProperties | undefined>(undefined)
+    const [fileSize, setFileSize] = useState<number | undefined>(undefined)
     const [loadMedia, setLoadMedia] = useState(false)
     const objectUrlRef = useRef<string | null>(null)
     const isVideo = isInlineVideoMimeType(props.block.mimeType)
@@ -78,6 +81,10 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
     const isFile = !isVideo && !isAudio && !isImage
     const mediaLabel = t(inlineMediaLabelKey(props.block.mimeType))
     const mediaHeader = t('media.displayed.header', { label: mediaLabel, fileName: props.block.fileName })
+    const formattedFileSize = formatFileSize(fileSize) ?? '0 B'
+    const prepareDownloadLabel = fileSize === undefined
+        ? t('media.displayed.prepareDownload')
+        : t('media.displayed.prepareDownloadWithSize', { size: formattedFileSize })
     // Non-image media can be tens of MB; wait for explicit user intent before downloading.
     const shouldFetch = isImage || loadMedia
 
@@ -89,6 +96,24 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
             }
         }
     }, [])
+
+    useEffect(() => {
+        if (!isFile) return
+
+        let disposed = false
+        void ctx.api.getGeneratedImageMetadata(ctx.sessionId, props.block.imageId)
+            .then((metadata) => {
+                if (disposed || !metadata.success || typeof metadata.size !== 'number') return
+                setFileSize(metadata.size)
+            })
+            .catch(() => {
+                // Metadata is an optional enhancement; keep the deferred action usable if it fails.
+            })
+
+        return () => {
+            disposed = true
+        }
+    }, [ctx.api, ctx.sessionId, isFile, props.block.imageId])
 
     useEffect(() => {
         if (!shouldFetch) {
@@ -103,6 +128,7 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
         }
         setObjectUrl(null)
         setImageStyle(undefined)
+        setFileSize(undefined)
         setError(null)
 
         void ctx.api.getGeneratedImageBlob(ctx.sessionId, props.block.imageId)
@@ -114,6 +140,7 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
                 }
                 objectUrlRef.current = nextObjectUrl
                 setObjectUrl(nextObjectUrl)
+                setFileSize(blob.size)
                 if (isImage) {
                     setImageStyle(undefined)
                     const probe = new Image()
@@ -161,10 +188,16 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
                     <a
                         href={objectUrl}
                         download={props.block.fileName}
-                        className="flex items-center gap-3 rounded-xl border border-[var(--app-border)] bg-[var(--app-subtle-bg)] px-4 py-3 text-sm font-medium text-[var(--app-fg)]"
+                        aria-label={t('media.displayed.downloadFile', {
+                            fileName: props.block.fileName,
+                            size: formattedFileSize,
+                        })}
+                        className={MEDIA_ACTION_CLASS_NAME}
                     >
                         <FileIcon fileName={props.block.fileName} size={24} />
-                        <span className="min-w-0 truncate">Download {props.block.fileName}</span>
+                        <span className="min-w-0 truncate">
+                            {t('media.displayed.download', { size: formattedFileSize })}
+                        </span>
                     </a>
                 ) : (
                     <div className="flex min-h-32 min-w-[12rem] items-center justify-center rounded-xl bg-[var(--app-subtle-bg)]">
@@ -186,12 +219,19 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
                 <button
                     type="button"
                     onClick={() => setLoadMedia(true)}
-                    className="flex h-48 w-72 max-w-full items-center justify-center rounded-xl border border-[var(--app-border)] bg-[var(--app-subtle-bg)] text-sm font-medium text-[var(--app-fg)]"
+                    className={MEDIA_ACTION_CLASS_NAME}
                 >
-                    {isVideo ? 'Load video' : isAudio ? 'Load audio' : 'Prepare download'}
+                    <FileIcon fileName={props.block.fileName} size={24} />
+                    <span className="min-w-0 truncate">
+                        {isVideo
+                            ? t('media.displayed.loadVideo')
+                            : isAudio
+                                ? t('media.displayed.loadAudio')
+                                : prepareDownloadLabel}
+                    </span>
                 </button>
             ) : (
-                <div className="h-48 w-72 max-w-full animate-pulse rounded-xl bg-[var(--app-subtle-bg)]" />
+                <div className="h-12 w-full max-w-full animate-pulse rounded-xl bg-[var(--app-subtle-bg)]" />
             )}
         </div>
     )

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -521,6 +521,12 @@ export default {
   'media.displayed.audio': 'Displayed audio',
   'media.displayed.file': 'Displayed file',
   'media.displayed.header': '{label}: {fileName}',
+  'media.displayed.loadVideo': 'Load video',
+  'media.displayed.loadAudio': 'Load audio',
+  'media.displayed.prepareDownload': 'Prepare download',
+  'media.displayed.prepareDownloadWithSize': 'Prepare download ({size})',
+  'media.displayed.download': 'Download file ({size})',
+  'media.displayed.downloadFile': 'Download file {fileName} ({size})',
   'media.displayed.unavailable': '{label} is unavailable. {error}',
 
   // Tool card

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -520,6 +520,12 @@ export default {
   'media.displayed.audio': '展示音频',
   'media.displayed.file': '展示文件',
   'media.displayed.header': '{label}：{fileName}',
+  'media.displayed.loadVideo': '加载视频',
+  'media.displayed.loadAudio': '加载音频',
+  'media.displayed.prepareDownload': '加载文件',
+  'media.displayed.prepareDownloadWithSize': '加载文件（{size}）',
+  'media.displayed.download': '下载文件（{size}）',
+  'media.displayed.downloadFile': '下载文件 {fileName}（{size}）',
   'media.displayed.unavailable': '{label}不可用：{error}',
 
   // Tool card


### PR DESCRIPTION
## Summary

- Fix the deferred generated-file download control by replacing the oversized placeholder with a compact action.
- Add a metadata-only generated-file request so the UI can show the file size without downloading the file contents.
- Localize deferred media actions and display the file size in both the prepare and final download states while preserving the original filename.
- Add regression coverage across the CLI handler, Hub route, shared API type, Web component, and live download flow.

## Validation

- `bun typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name web-media-download-ux -Suite Root -TestArgs terminal-wrap-fidelity.spec.ts` — 2 passed.
- Web generated-media tests — 10 passed.
- Hub generated-image route tests — 10 passed.
- CLI file-handler tests — 2 passed.
- Shared package tests — 294 passed.
- `bun run build` — passed.
- `git diff --check` — passed.
- Live Playwright download flow — 1 passed:
  - Verified `加载文件（20 KB）`.
  - Verified `下载文件（20 KB）`.
  - Verified the downloaded filename remains `Cursor Plan A Markdown 导出.zip`.
- Local and public health checks — HTTP 200.

## Related Issues

None

## AI Disclosure

Implemented and validated with OpenAI Codex (GPT-5.6).