### PR TITLE
fix(web): keep machine health visible for single-machine layouts

### DIFF
--- a/web/src/components/MachineFilterBar.test.tsx
+++ b/web/src/components/MachineFilterBar.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import { MachineFilterBar, MachineFilterMenu, getMachineFilterMenuClampStyle } from './MachineFilterBar'
+import { MachineFilterBar, MachineFilterMenu, MachineSummaryRow, getMachineFilterMenuClampStyle } from './MachineFilterBar'
 import { I18nProvider } from '@/lib/i18n-context'
 
 const defaultMachines: Parameters<typeof MachineFilterBar>[0]['machines'] = [
@@ -117,6 +117,62 @@ describe('MachineFilterBar', () => {
         renderBar()
 
         expect(screen.getByRole('group', { name: 'Filter sessions by machine' }).className).toContain('max-md:hidden')
+    })
+})
+
+describe('MachineSummaryRow', () => {
+    function renderSummary(machine: Parameters<typeof MachineSummaryRow>[0]['machine']) {
+        return render(
+            <I18nProvider>
+                <MachineSummaryRow machine={machine} />
+            </I18nProvider>
+        )
+    }
+
+    it('renders the machine, session count, and inline health without any filter button', () => {
+        renderSummary(defaultMachines[1])
+
+        expect(screen.getByText('Teemo')).toBeTruthy()
+        expect(screen.getByText('(2)')).toBeTruthy()
+        // Health is inline — no hover needed — so touch layouts see it too.
+        expect(screen.getByText('CPU 12% · RAM 88%')).toBeTruthy()
+        // Not a filter control: the inline row has no button (the only button
+        // anywhere is the tooltip body's "?" help toggle).
+        const content = screen.getByText('Teemo').parentElement!
+        expect(within(content).queryByRole('button')).toBeNull()
+    })
+
+    it('keeps full capacity details in a hover popup like the filter chips', () => {
+        renderSummary(defaultMachines[1])
+
+        const content = screen.getByText('Teemo').parentElement!
+        const describedBy = content.getAttribute('aria-describedby')
+        expect(describedBy).toBeTruthy()
+
+        const tooltip = document.getElementById(describedBy!)
+        expect(tooltip).toBeTruthy()
+        expect(tooltip!.getAttribute('role')).toBe('tooltip')
+        expect(tooltip!.textContent).toContain('Machine capacity')
+        expect(tooltip!.textContent).toContain('12%')
+        // The inline metrics cover touch layouts; the popup itself is desktop-only
+        expect(tooltip!.className).toContain('max-md:hidden')
+        // A pseudo-element bridges the mt-1 gap so the popup stays open while entered
+        expect(tooltip!.className).toContain('before:-top-1')
+    })
+
+    it('stays visible below the md breakpoint (health must not be desktop-only)', () => {
+        const { container } = renderSummary(defaultMachines[1])
+
+        expect(container.firstElementChild!.className).not.toContain('max-md:hidden')
+    })
+
+    it('renders label and count only when the machine reports no metrics', () => {
+        renderSummary(defaultMachines[0])
+
+        expect(screen.getByText('Mint')).toBeTruthy()
+        expect(screen.getByText('(3)')).toBeTruthy()
+        expect(screen.queryByText(/CPU/)).toBeNull()
+        expect(screen.queryByText(/RAM/)).toBeNull()
     })
 })
 

--- a/web/src/components/MachineFilterBar.tsx
+++ b/web/src/components/MachineFilterBar.tsx
@@ -128,6 +128,51 @@ export function MachineFilterBar(props: {
     )
 }
 
+// Single-machine counterpart of MachineFilterBar: with nothing to filter,
+// chips would be meaningless, but the machine's health and session count
+// still belong in the sidebar. Renders a compact non-interactive row —
+// health metrics are inline so touch layouts need no hover, and pointer
+// users get the same capacity popup as the filter chips.
+export function MachineSummaryRow(props: { machine: MachineFilterItem }) {
+    const tooltipId = useId()
+    const hasHealth = Boolean(props.machine.healthPresentation?.metrics.length)
+
+    const content = (
+        <span
+            className="flex min-w-0 items-center gap-1.5"
+            aria-describedby={hasHealth ? tooltipId : undefined}
+        >
+            <span className="max-w-32 truncate text-[var(--app-fg)]">{props.machine.label}</span>
+            <span className="shrink-0 tabular-nums text-[var(--app-hint)]">({props.machine.sessionCount})</span>
+            {hasHealth ? (
+                <span className="min-w-0 truncate tabular-nums text-[var(--app-hint)]">
+                    {props.machine.healthPresentation!.metrics
+                        .map((metric) => `${metric.shortLabel} ${metric.percent}%`)
+                        .join(' · ')}
+                </span>
+            ) : null}
+        </span>
+    )
+
+    return (
+        <div className="flex items-center px-2 pb-2 text-xs">
+            {hasHealth ? (
+                // Same popup treatment as the filter chips: hidden below md
+                // (the inline metrics above already cover touch layouts).
+                <HoverTooltip
+                    id={tooltipId}
+                    target={content}
+                    side="bottom"
+                    align="start"
+                    tooltipClassName="pointer-events-auto before:absolute before:inset-x-0 before:-top-1 before:h-1 before:content-[''] px-3 py-2 min-w-[16rem] max-md:hidden"
+                >
+                    <MachineHealthTooltipBody presentation={props.machine.healthPresentation!} />
+                </HoverTooltip>
+            ) : content}
+        </div>
+    )
+}
+
 function MachineFilterMenuRow(props: {
     label: string
     count: number

--- a/web/src/components/SessionList.machine-filter.test.tsx
+++ b/web/src/components/SessionList.machine-filter.test.tsx
@@ -144,6 +144,24 @@ describe('SessionList machine filter', () => {
         expect(screen.getByText('CPU 12% · RAM 88%')).toBeTruthy()
     })
 
+    it('shows the summary row for a sole machine with no visible sessions', () => {
+        // Fresh install / "active only" filtering: zero session groups, but the
+        // sole machine is online and its health must stay visible.
+        renderSessionList(
+            [],
+            {
+                'machine-1': makeMachine({
+                    id: 'machine-1',
+                    health: { collectedAt: 100, cpuPercent: 12, memoryPercent: 88 }
+                })
+            }
+        )
+
+        const summary = screen.getByText('Mint').parentElement!
+        expect(within(summary).getByText('(0)')).toBeTruthy()
+        expect(screen.getByText('CPU 12% · RAM 88%')).toBeTruthy()
+    })
+
     it('shows the filter bar and machine-suffixed group titles with multiple machines', () => {
         renderSessionList(multiMachineSessions)
 

--- a/web/src/components/SessionList.machine-filter.test.tsx
+++ b/web/src/components/SessionList.machine-filter.test.tsx
@@ -1,8 +1,8 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
-import type { SessionSummary } from '@/types/api'
+import type { SessionSummary, Machine } from '@/types/api'
 import { I18nProvider } from '@/lib/i18n-context'
 import { ToastProvider } from '@/lib/toast-context'
 import { SessionList } from './SessionList'
@@ -54,7 +54,24 @@ function renderWithProviders(children: ReactNode) {
     )
 }
 
-function renderSessionList(sessions: SessionSummary[]) {
+function makeMachine(overrides: Partial<Machine> & { id: string }): Machine {
+    return {
+        namespace: 'default',
+        seq: 1,
+        createdAt: 0,
+        updatedAt: 0,
+        active: true,
+        activeAt: 0,
+        metadata: null,
+        metadataVersion: 0,
+        runnerState: null,
+        runnerStateVersion: 0,
+        health: null,
+        ...overrides
+    }
+}
+
+function renderSessionList(sessions: SessionSummary[], machinesById?: Record<string, Machine>) {
     return renderWithProviders(
         <SessionList
             sessions={sessions}
@@ -66,6 +83,7 @@ function renderSessionList(sessions: SessionSummary[]) {
             renderHeader={false}
             api={null}
             machineLabelsById={{ 'machine-1': 'Mint', 'machine-2': 'Teemo' }}
+            machinesById={machinesById}
         />
     )
 }
@@ -88,7 +106,7 @@ describe('SessionList machine filter', () => {
         window.localStorage.clear()
     })
 
-    it('hides the filter bar when all sessions are on a single machine', () => {
+    it('shows a compact summary row instead of filter chips on a single machine', () => {
         renderSessionList([
             makeSession({
                 id: 'session-1',
@@ -97,9 +115,33 @@ describe('SessionList machine filter', () => {
             })
         ])
 
+        // One machine has nothing to filter — no bar, no mobile filter menu.
         expect(screen.queryByRole('group', { name: 'Filter sessions by machine' })).toBeNull()
         expect(screen.queryByRole('button', { name: 'Filter sessions by machine' })).toBeNull()
+        // The machine label and session count stay visible.
+        const summary = screen.getByText('Mint').parentElement!
+        expect(within(summary).getByText('(1)')).toBeTruthy()
         expect(screen.getByTitle('/work/hapi')).toBeTruthy()
+    })
+
+    it('shows machine health inline on the single-machine summary row', () => {
+        renderSessionList(
+            [
+                makeSession({
+                    id: 'session-1',
+                    updatedAt: 100,
+                    metadata: { path: '/work/hapi', machineId: 'machine-1', agentSessionId: 'thread-1' }
+                })
+            ],
+            {
+                'machine-1': makeMachine({
+                    id: 'machine-1',
+                    health: { collectedAt: 100, cpuPercent: 12, memoryPercent: 88 }
+                })
+            }
+        )
+
+        expect(screen.getByText('CPU 12% · RAM 88%')).toBeTruthy()
     })
 
     it('shows the filter bar and machine-suffixed group titles with multiple machines', () => {

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -43,7 +43,7 @@ import { getWorktreeSessionLabel } from '@/lib/sessionWorktreeLabel'
 import { retargetSharePendingTransfer } from '@/lib/sharePendingState'
 import type { Machine } from '@/types/api'
 import { getMachinePlatform, presentMachineHealth } from '@/lib/machineHealth'
-import { MachineFilterBar, MachineFilterMenu } from '@/components/MachineFilterBar'
+import { MachineFilterBar, MachineFilterMenu, MachineSummaryRow } from '@/components/MachineFilterBar'
 import { useSessionListMachineFilter } from '@/hooks/useSessionListMachineFilter'
 import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStatus'
 import { SessionRowSummary } from '@/components/SessionRowSummary'
@@ -1286,6 +1286,10 @@ export function SessionList(props: {
         [machineFilters, machinesById]
     )
     const showMachineFilterBar = machineFilters.length >= 2
+    // With a single machine there is nothing to filter, but health and the
+    // session count still belong in the sidebar: render a compact summary
+    // row instead of the filter bar.
+    const singleMachineItem = machineFilters.length === 1 ? machineFilterItems[0] : null
     // A persisted filter whose machine no longer has sessions falls back to
     // "All"; with at most one machine the bar is hidden and never filters.
     const activeMachineFilter = showMachineFilterBar && machineFilter !== null
@@ -1946,6 +1950,8 @@ export function SessionList(props: {
                     value={activeMachineFilter}
                     onChange={setMachineFilter}
                 />
+            ) : singleMachineItem ? (
+                <MachineSummaryRow machine={singleMachineItem} />
             ) : null}
             </div>
 

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1288,8 +1288,26 @@ export function SessionList(props: {
     const showMachineFilterBar = machineFilters.length >= 2
     // With a single machine there is nothing to filter, but health and the
     // session count still belong in the sidebar: render a compact summary
-    // row instead of the filter bar.
-    const singleMachineItem = machineFilters.length === 1 ? machineFilterItems[0] : null
+    // row instead of the filter bar. The row is derived from session groups,
+    // but those disappear when the sole machine has no visible sessions
+    // (fresh install, or "active only" filtering); fall back to the machines
+    // list so its health stays visible (#1259).
+    const soleRegisteredMachine = machineFilters.length === 0 && Object.keys(machinesById).length === 1
+        ? Object.values(machinesById)[0]
+        : null
+    const singleMachineItem = machineFilters.length === 1
+        ? machineFilterItems[0]
+        : soleRegisteredMachine
+            ? {
+                id: soleRegisteredMachine.id,
+                label: resolveMachineLabel(soleRegisteredMachine.id),
+                sessionCount: 0,
+                healthPresentation: presentMachineHealth(
+                    soleRegisteredMachine.health,
+                    getMachinePlatform(soleRegisteredMachine)
+                )
+            }
+            : null
     // A persisted filter whose machine no longer has sessions falls back to
     // "All"; with at most one machine the bar is hidden and never filters.
     const activeMachineFilter = showMachineFilterBar && machineFilter !== null


### PR DESCRIPTION
## Problem

Since the v0.25.0 sidebar redesign, the machine filter bar is the only path for
machine CPU/RAM health and session counts into the UI, and it only renders with
2+ machines. On a single-machine setup (e.g. one VM accessed from both phone and
desktop, as in #1259) that means:

- No CPU/RAM health anywhere, desktop or mobile
- No per-machine/total session counts

Fixes #1259

## Change

With exactly one machine there is nothing to filter, so chips would be
meaningless. This renders a compact, non-interactive `MachineSummaryRow` in the
filter bar's slot instead:

- Machine label + session count, visible on all breakpoints
- Inline `CPU 12% · RAM 88%` metrics (same inline format as the mobile filter
  menu) — no hover needed, so touch layouts are covered
- Pointer users additionally get the full capacity popup
  (`MachineHealthTooltipBody`), same as the multi-machine filter chips

Multi-machine behavior is unchanged.

## Testing

- `SessionList.machine-filter.test.tsx`: the single-machine case now asserts the
  summary row (label, count, and inline health via `machinesById`) renders with
  no filter UI
- `MachineFilterBar.test.tsx`: new `MachineSummaryRow` block — inline health,
  no filter button, hover popup parity with chips, stays visible below `md`
- `bun run test` (2836 tests) and `bun run typecheck` pass
