### PR TITLE
fix(web): improve generated media retry and sizing

### DIFF
--- a/web/src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx
@@ -54,7 +54,7 @@ function renderCard(options: {
     return { getGeneratedImageBlob }
 }
 
-describe('GeneratedImageCard video fetch', () => {
+describe('GeneratedImageCard media fetch', () => {
     it('labels displayed images in English without implying AI generation', () => {
         renderCard({ mimeType: 'image/png', locale: 'en' })
 
@@ -93,6 +93,50 @@ describe('GeneratedImageCard video fetch', () => {
         await waitFor(() => {
             expect(getGeneratedImageBlob).toHaveBeenCalledWith('session-1', 'img-1')
         })
+    })
+
+    it('keeps tiny image previews sized to their content instead of stretching the frame', async () => {
+        renderCard({ mimeType: 'image/png' })
+
+        const image = await screen.findByRole('img', { name: 'clip.mp4' })
+        const frame = image.parentElement?.parentElement
+        if (!frame) throw new Error('Expected generated image frame')
+        const card = frame.parentElement
+        if (!card) throw new Error('Expected generated image card')
+
+        expect(frame).toHaveClass('w-fit', 'max-w-full')
+        expect(frame).not.toHaveClass('min-h-32', 'min-w-[12rem]')
+        expect(card).toHaveClass('w-fit', 'max-w-[92%]')
+    })
+
+    it('shows a friendly error and retries a failed image load', async () => {
+        const getGeneratedImageBlob = vi.fn()
+            .mockRejectedValueOnce(new Error('HTTP 404'))
+            .mockResolvedValueOnce(new Blob(['x'], { type: 'image/png' }))
+        renderCard({ mimeType: 'image/png', locale: 'en', getGeneratedImageBlob })
+
+        await waitFor(() => {
+            expect(screen.getByText('Displayed image is currently unavailable.')).toBeInTheDocument()
+        })
+        expect(screen.queryByText('HTTP 404')).not.toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: /Displayed image is currently unavailable\. Retry/ }))
+
+        await waitFor(() => {
+            expect(getGeneratedImageBlob).toHaveBeenCalledTimes(2)
+            expect(screen.getByRole('img', { name: 'clip.mp4' })).toBeInTheDocument()
+        })
+    })
+
+    it('localizes the failed image retry state in Simplified Chinese', async () => {
+        const getGeneratedImageBlob = vi.fn().mockRejectedValue(new Error('HTTP 404'))
+        renderCard({ mimeType: 'image/png', locale: 'zh-CN', getGeneratedImageBlob })
+
+        await waitFor(() => {
+            expect(screen.getByText('展示图片暂不可用。')).toBeInTheDocument()
+            expect(screen.getByText('重新加载')).toBeInTheDocument()
+        })
+        expect(screen.queryByText('HTTP 404')).not.toBeInTheDocument()
     })
 
     it('loads audio on demand and renders controls', async () => {

--- a/web/src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { HappyChatProvider } from '@/components/AssistantChat/context'
-import { GeneratedImageCard } from '@/components/AssistantChat/messages/ToolMessage'
+import { computeTinyImageScale, GeneratedImageCard } from '@/components/AssistantChat/messages/ToolMessage'
 import { I18nProvider } from '@/lib/i18n-context'
 import type { ApiClient } from '@/api/client'
 import type { HappyChatContextValue } from '@/components/AssistantChat/context'
@@ -107,6 +107,33 @@ describe('GeneratedImageCard media fetch', () => {
         expect(frame).toHaveClass('w-fit', 'max-w-full')
         expect(frame).not.toHaveClass('min-h-32', 'min-w-[12rem]')
         expect(card).toHaveClass('w-fit', 'max-w-[92%]')
+    })
+
+    it('reserves layout space when scaling a skinny tiny image', async () => {
+        expect(computeTinyImageScale(16, 32)).toBe(2)
+
+        class MockImage {
+            naturalWidth = 16
+            naturalHeight = 32
+            onload: (() => void) | null = null
+
+            set src(_value: string) {
+                queueMicrotask(() => this.onload?.())
+            }
+        }
+
+        vi.stubGlobal('Image', MockImage)
+        try {
+            renderCard({ mimeType: 'image/png' })
+            const image = await screen.findByRole('img', { name: 'clip.mp4' })
+
+            await waitFor(() => {
+                expect(image).toHaveStyle({ width: '32px', height: '64px' })
+            })
+            expect(image).not.toHaveStyle({ transform: 'scale(2)' })
+        } finally {
+            vi.unstubAllGlobals()
+        }
     })
 
     it('shows a friendly error and retries a failed image load', async () => {

--- a/web/src/components/AssistantChat/messages/ToolMessage.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.tsx
@@ -121,7 +121,13 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
                     probe.onload = () => {
                         if (disposed) return
                         const scale = computeTinyImageScale(probe.naturalWidth, probe.naturalHeight)
-                        setImageStyle(scale === 1 ? undefined : { transform: `scale(${scale})` })
+                        setImageStyle(scale === 1 ? undefined : {
+                            // Keep the enlarged preview inside normal layout flow. CSS transforms
+                            // only change painting, so a w-fit card would reserve the tiny source
+                            // dimensions and could overlap adjacent chat content.
+                            width: probe.naturalWidth * scale,
+                            height: probe.naturalHeight * scale,
+                        })
                     }
                     probe.src = nextObjectUrl
                 }

--- a/web/src/components/AssistantChat/messages/ToolMessage.tsx
+++ b/web/src/components/AssistantChat/messages/ToolMessage.tsx
@@ -68,9 +68,10 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
     const ctx = useHappyChatContext()
     const { t } = useTranslation()
     const [objectUrl, setObjectUrl] = useState<string | null>(null)
-    const [error, setError] = useState<string | null>(null)
+    const [hasError, setHasError] = useState(false)
     const [imageStyle, setImageStyle] = useState<CSSProperties | undefined>(undefined)
     const [loadMedia, setLoadMedia] = useState(false)
+    const [loadRetryCount, setLoadRetryCount] = useState(0)
     const objectUrlRef = useRef<string | null>(null)
     const isVideo = isInlineVideoMimeType(props.block.mimeType)
     const isAudio = isInlineAudioMimeType(props.block.mimeType)
@@ -103,7 +104,7 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
         }
         setObjectUrl(null)
         setImageStyle(undefined)
-        setError(null)
+        setHasError(false)
 
         void ctx.api.getGeneratedImageBlob(ctx.sessionId, props.block.imageId)
             .then((blob) => {
@@ -125,18 +126,18 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
                     probe.src = nextObjectUrl
                 }
             })
-            .catch((err: unknown) => {
+            .catch(() => {
                 if (disposed) return
-                setError(err instanceof Error ? err.message : 'Failed to load inline media')
+                setHasError(true)
             })
 
         return () => {
             disposed = true
         }
-    }, [ctx.api, ctx.sessionId, props.block.imageId, isImage, shouldFetch])
+    }, [ctx.api, ctx.sessionId, props.block.imageId, isImage, shouldFetch, loadRetryCount])
 
     return (
-        <div className="max-w-[92%] rounded-2xl border border-[var(--app-border)] bg-[var(--app-tool-card-bg)] p-3">
+        <div className="w-fit max-w-[92%] rounded-2xl border border-[var(--app-border)] bg-[var(--app-tool-card-bg)] p-3">
             <div className="mb-2 min-w-0 truncate text-xs font-medium text-[var(--app-hint)]">
                 {mediaHeader}
             </div>
@@ -167,7 +168,7 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
                         <span className="min-w-0 truncate">Download {props.block.fileName}</span>
                     </a>
                 ) : (
-                    <div className="flex min-h-32 min-w-[12rem] items-center justify-center rounded-xl bg-[var(--app-subtle-bg)]">
+                    <div className="flex w-fit max-w-full items-center justify-center rounded-xl bg-[var(--app-subtle-bg)]">
                         <ImagePreview
                             src={objectUrl}
                             fileName={props.block.fileName}
@@ -178,10 +179,19 @@ export function GeneratedImageCard(props: { block: GeneratedImageBlock }) {
                         />
                     </div>
                 )
-            ) : error ? (
-                <div className="text-sm text-[var(--app-hint)]">
-                    {t('media.displayed.unavailable', { label: mediaLabel, error })}
-                </div>
+            ) : hasError ? (
+                <button
+                    type="button"
+                    onClick={() => setLoadRetryCount((count) => count + 1)}
+                    className="flex min-h-32 w-72 max-w-full min-w-[12rem] items-center justify-center rounded-xl border border-[var(--app-border)] bg-[var(--app-subtle-bg)] px-4 text-center text-sm text-[var(--app-hint)] transition-colors hover:text-[var(--app-fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
+                >
+                    <span className="flex flex-col gap-1">
+                        <span>{t('media.displayed.unavailable', { label: mediaLabel })}</span>
+                        <span className="text-xs font-medium text-[var(--app-fg)] underline underline-offset-2">
+                            {t('media.displayed.retry')}
+                        </span>
+                    </span>
+                </button>
             ) : !isImage && !loadMedia ? (
                 <button
                     type="button"

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -521,7 +521,8 @@ export default {
   'media.displayed.audio': 'Displayed audio',
   'media.displayed.file': 'Displayed file',
   'media.displayed.header': '{label}: {fileName}',
-  'media.displayed.unavailable': '{label} is unavailable. {error}',
+  'media.displayed.unavailable': '{label} is currently unavailable.',
+  'media.displayed.retry': 'Retry',
 
   // Tool card
   'tool.askQuestion': 'Other',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -520,7 +520,8 @@ export default {
   'media.displayed.audio': '展示音频',
   'media.displayed.file': '展示文件',
   'media.displayed.header': '{label}：{fileName}',
-  'media.displayed.unavailable': '{label}不可用：{error}',
+  'media.displayed.unavailable': '{label}暂不可用。',
+  'media.displayed.retry': '重新加载',
 
   // Tool card
   'tool.askQuestion': '其他',


### PR DESCRIPTION
## Summary

- Replace raw HTTP error text in generated media cards with localized, user-friendly unavailable states.
- Add an accessible retry action that re-fetches failed generated media.
- Make generated media cards and image frames size to their content while preserving maximum width constraints.
- Reserve layout space for scaled tiny previews so enlarged images do not overlap adjacent chat content.
- Add English and Simplified Chinese retry/unavailable labels.
- Add regression coverage for retry behavior, localized errors, and tiny image sizing.

No backend, API, RPC, persistence, database schema, dependency, or shared tool-card changes are included.

## Validation

- `bun typecheck`
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name display-image-retry-ux -Suite Root terminal-wrap-fidelity.spec.ts` — 2/2 passed
- `bun run test:web -- src/components/AssistantChat/messages/ToolMessage.generatedMedia.test.tsx src/lib/generatedInlineMedia.test.ts src/api/client.test.ts` — 3 files, 28 tests passed
- `bun run build` — passed
- Isolated live Web smoke test — passed; verified 64×64 generated images, content-sized media cards, and visibility of text, code-block, tool-call, and CLI-output bubbles
- Review follow-up: tiny-image layout regression test passed (16x32 scaled to 32x64 without CSS transform)
- `git diff --check`

## Related Issues

Refs #927

## AI Disclosure

OpenAI Codex (GPT-5.6) assisted with implementation, testing, validation, review follow-up, and PR drafting.