### PR TITLE
ci: drop the codex-home config seed that breaks TOML parsing

### DIFF
--- a/.github/workflows/codex-mention-response.yml
+++ b/.github/workflows/codex-mention-response.yml
@@ -114,18 +114,9 @@ jobs:
         if: steps.check_skip.outputs.should_skip != 'true'
         run: git fetch --all
 
-      - name: Seed stream retry tuning in codex-home
-        run: |
-          mkdir -p "$RUNNER_TEMP/codex-home"
-          cat > "$RUNNER_TEMP/codex-home/config.toml" <<'TOML'
-          [model_providers.codex-action-responses-proxy]
-          stream_max_retries = 10
-          stream_idle_timeout_ms = 600000
-          TOML
-
       - name: Run Codex for Mention Response
         if: steps.check_skip.outputs.should_skip != 'true'
-        uses: openai/codex-action@v1.12
+        uses: openai/codex-action@v1.11
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -134,11 +125,12 @@ jobs:
           EVENT_TYPE: ${{ steps.check_skip.outputs.event_type }}
           IS_PR: ${{ steps.check_skip.outputs.is_pr }}
         with:
-          codex-home: ${{ runner.temp }}/codex-home
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL }}
           model: ${{ vars.OPENAI_MODEL || 'gpt-5.4' }}
           effort: ${{ vars.OPENAI_EFFORT || 'high' }}
+          # Tolerate flaky relay streams: more reconnects, longer idle timeout
+          codex-args: '-c model_providers.codex-action-responses-proxy.stream_max_retries=10 -c model_providers.codex-action-responses-proxy.stream_idle_timeout_ms=600000'
           sandbox: danger-full-access
           safety-strategy: drop-sudo
           prompt-file: .github/prompts/codex-mention-response.md

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -103,19 +103,10 @@ jobs:
             ${{ github.event.pull_request.base.ref }} \
             +refs/pull/${{ github.event.pull_request.number }}/head
 
-      - name: Seed stream retry tuning in codex-home
-        run: |
-          mkdir -p "$RUNNER_TEMP/codex-home"
-          cat > "$RUNNER_TEMP/codex-home/config.toml" <<'TOML'
-          [model_providers.codex-action-responses-proxy]
-          stream_max_retries = 10
-          stream_idle_timeout_ms = 600000
-          TOML
-
       - name: Run Codex for PR Review
         id: run_codex
         if: steps.check_bot.outputs.has_review_for_current_head != 'true'
-        uses: openai/codex-action@v1.12
+        uses: openai/codex-action@v1.11
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -124,11 +115,12 @@ jobs:
           LATEST_BOT_REVIEW_COMMIT: ${{ steps.check_bot.outputs.latest_bot_review_commit }}
           IS_FOLLOW_UP_REVIEW: ${{ steps.check_bot.outputs.is_follow_up_review }}
         with:
-          codex-home: ${{ runner.temp }}/codex-home
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL }}
           model: ${{ vars.OPENAI_MODEL || 'gpt-5.2-codex' }}
           effort: ${{ vars.OPENAI_EFFORT || 'high' }}
+          # Tolerate flaky relay streams: more reconnects, longer idle timeout
+          codex-args: '-c model_providers.codex-action-responses-proxy.stream_max_retries=10 -c model_providers.codex-action-responses-proxy.stream_idle_timeout_ms=600000'
           sandbox: danger-full-access
           safety-strategy: drop-sudo
           prompt-file: .github/prompts/codex-pr-review.md

--- a/.github/workflows/issue-auto-response.yml
+++ b/.github/workflows/issue-auto-response.yml
@@ -64,27 +64,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Seed stream retry tuning in codex-home
-        run: |
-          mkdir -p "$RUNNER_TEMP/codex-home"
-          cat > "$RUNNER_TEMP/codex-home/config.toml" <<'TOML'
-          [model_providers.codex-action-responses-proxy]
-          stream_max_retries = 10
-          stream_idle_timeout_ms = 600000
-          TOML
-
       - name: Run Codex for Issue Auto Response
         if: steps.check_bot.outputs.has_bot != 'true'
-        uses: openai/codex-action@v1.12
+        uses: openai/codex-action@v1.11
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          codex-home: ${{ runner.temp }}/codex-home
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL }}
           model: ${{ vars.OPENAI_MODEL || 'gpt-5.4' }}
           effort: ${{ vars.OPENAI_EFFORT || 'high' }}
+          # Tolerate flaky relay streams: more reconnects, longer idle timeout
+          codex-args: '-c model_providers.codex-action-responses-proxy.stream_max_retries=10 -c model_providers.codex-action-responses-proxy.stream_idle_timeout_ms=600000'
           sandbox: danger-full-access
           safety-strategy: drop-sudo
           prompt-file: .github/prompts/issue-auto-response.md


### PR DESCRIPTION
Follow-up to #1667: its codex-home config seed doesn't work — the action appends its own `[model_providers.codex-action-responses-proxy]` table to `config.toml` instead of merging, so every Codex workflow fails with a TOML duplicate key error (verified on an external PR run). And since v1.12 rejects the flaky-relay retry overrides in `codex-args`, the tuning cannot be expressed on v1.12 at all.

This pins all three workflows to v1.11, the last release that accepts those deliberate overrides under `drop-sudo`, and drops the seed — restoring the original behavior fully intact. Once the action either merges existing config or exposes first-class inputs for proxy tuning (same root cause as openai/codex-action#80), upgrading should be straightforward.
