### PR TITLE
fix(claude): accept first fork child prompt on SessionStart:fork hook

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1118,8 +1118,6 @@
 
     "@twsxtd/hapi-linux-x64": ["@twsxtd/hapi-linux-x64@0.29.0", "", { "os": "linux", "cpu": "x64", "bin": { "hapi": "bin/hapi" } }, "sha512-KwCJhDN9H+QI0Xafj63CFqqPiv/dHv6WhSjWKFOIcT6sPwY8JcLUjDkp5a4NLG9DSzqOR9DB2ptA2l9GPFa1/A=="],
 
-    "@twsxtd/hapi-win32-x64": ["@twsxtd/hapi-win32-x64@0.29.0", "", { "os": "win32", "cpu": "x64", "bin": { "hapi": "bin/hapi.exe" } }, "sha512-HZ1oz+TU1Xc7Jaa29uj/65GaLqsOMeCKO1+bDHgYtcHQrBjSIba69Av3T8Yr4YMaJ+82jOfAGBibQ20FJoCRLg=="],
-
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],

--- a/bun.lock
+++ b/bun.lock
@@ -1118,6 +1118,8 @@
 
     "@twsxtd/hapi-linux-x64": ["@twsxtd/hapi-linux-x64@0.29.0", "", { "os": "linux", "cpu": "x64", "bin": { "hapi": "bin/hapi" } }, "sha512-KwCJhDN9H+QI0Xafj63CFqqPiv/dHv6WhSjWKFOIcT6sPwY8JcLUjDkp5a4NLG9DSzqOR9DB2ptA2l9GPFa1/A=="],
 
+    "@twsxtd/hapi-win32-x64": ["@twsxtd/hapi-win32-x64@0.29.0", "", { "os": "win32", "cpu": "x64", "bin": { "hapi": "bin/hapi.exe" } }, "sha512-HZ1oz+TU1Xc7Jaa29uj/65GaLqsOMeCKO1+bDHgYtcHQrBjSIba69Av3T8Yr4YMaJ+82jOfAGBibQ20FJoCRLg=="],
+
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],

--- a/cli/src/claude/claudeRemote.forkInit.test.ts
+++ b/cli/src/claude/claudeRemote.forkInit.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as claudeSdk from '@/claude/sdk';
+import type { SDKMessage } from '@/claude/sdk/types';
+
+vi.mock('@/claude/utils/claudeCheckSession', () => ({
+    claudeCheckSession: () => true
+}));
+
+vi.mock('@/modules/watcher/awaitFileExist', () => ({
+    awaitFileExist: async () => true
+}));
+
+vi.mock('@/claude/sdk/utils', () => ({
+    getDefaultClaudeCodePath: () => '/usr/bin/claude'
+}));
+
+const queryMock = vi.fn();
+
+async function waitFor(condition: () => boolean, timeoutMs = 2000, intervalMs = 10): Promise<void> {
+    const startedAt = Date.now();
+    while (!condition()) {
+        if (Date.now() - startedAt > timeoutMs) {
+            throw new Error('Timed out waiting for condition');
+        }
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+}
+
+describe('claudeRemote fork bootstrap', () => {
+    // A forked child starts query() before any prompt exists. Real SDK runs emit
+    // SessionStart hooks but no `init` until the first prompt is sent, so the
+    // child prompt must be accepted on the fork hook signal alone.
+    it('pushes the first child prompt after SessionStart:fork even when init never arrives', { timeout: 15_000 }, async () => {
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+
+        let receivedPrompt: unknown;
+        let promptClosed = false;
+
+        queryMock.mockImplementationOnce(({ prompt }: { prompt: AsyncIterable<unknown> }) => ({
+            async *[Symbol.asyncIterator]() {
+                const promptIterator = prompt[Symbol.asyncIterator]();
+
+                // Fork bootstrap: hooks arrive while no prompt has been pushed yet.
+                yield { type: 'system', subtype: 'hook_started' } as unknown as SDKMessage;
+                yield {
+                    type: 'system',
+                    subtype: 'hook_response',
+                    hook_name: 'SessionStart:fork',
+                    outcome: 'success'
+                } as unknown as SDKMessage;
+
+                // The fix must push the first child prompt here.
+                const next = await promptIterator.next();
+                receivedPrompt = next.value;
+                promptClosed = true;
+            }
+        }));
+
+        try {
+            await claudeRemote({
+                sessionId: null,
+                path: process.cwd(),
+                mcpServers: {},
+                claudeEnvVars: {},
+                claudeArgs: ['--resume', 'source-session-id', '--fork-session'],
+                allowedTools: [],
+                hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () =>
+                    { return { message: 'Reply with exactly: PONG2', mode: { permissionMode: 'bypassPermissions' } }; },
+                onReady: () => {},
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: () => {}
+            });
+
+            await waitFor(() => promptClosed);
+            expect(receivedPrompt).toMatchObject({
+                type: 'user',
+                message: { role: 'user', content: 'Reply with exactly: PONG2' }
+            });
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+    });
+});

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -293,6 +293,25 @@ export async function claudeRemote(opts: {
             opts.onMessage(message);
 
             // Handle special system messages
+            if (
+                message.type === 'system'
+                && message.subtype === 'hook_response'
+                && (message as { hook_name?: string }).hook_name === 'SessionStart:fork'
+                && awaitingForkInit
+            ) {
+                // A forked child starts query() before any prompt exists, and the
+                // SDK only emits `init` after the first prompt is sent. The fork
+                // itself materializes on the SessionStart:fork hook, so accept the
+                // first child prompt from that signal instead of deadlocking on
+                // an `init` that will not arrive until the prompt below is sent.
+                awaitingForkInit = false;
+                const first = await applyInitialTurn();
+                if (!first) {
+                    return;
+                }
+                initial = first;
+            }
+
             if (message.type === 'system' && message.subtype === 'init') {
                 // Start thinking when session initializes
                 updateThinking(true);


### PR DESCRIPTION
## Summary

Forking an active Claude conversation in HAPI creates the child HAPI session successfully, but the first message sent to the child never gets a response — the child CLI process sits idle forever.

The child is spawned with `claude --resume <source-id> --fork-session` and no initial prompt. `claudeRemote` starts the SDK `query()` immediately (so the native fork materializes at the clicked state) but defers pushing the first user prompt until a `system/init` message arrives (`awaitingForkInit`). The Claude Agent SDK, however, only emits `init` **after** it receives the first prompt. Neither side moves: hapi waits for `init`, the SDK waits for input. The hub's `waitForClaudeForkBound` only checks that the forked session file was created, so the hub reports success while the child is deadlocked.

## Fix

The native fork has already materialized by the time the `SessionStart:fork` hook response arrives on the stream (new session id + transcript are written at that point). So treat that hook as the fork-materialization signal and accept the first child prompt from it, instead of waiting for an `init` that cannot arrive until the prompt itself is sent:

- `cli/src/claude/claudeRemote.ts`: new trigger — when `awaitingForkInit` is set and a `system`/`hook_response` with `hook_name === 'SessionStart:fork'` arrives, clear the flag and run `applyInitialTurn()`. The existing `init`-based trigger is kept as-is, so whichever signal arrives first works; the flag guarantees single application.
- `cli/src/claude/claudeRemote.forkInit.test.ts`: regression test — stream emits SessionStart hooks but no `init`; asserts the first child prompt is pushed onto the SDK input iterable.

## Testing

- New unit test fails before the fix (input never pushed / timeout) and passes after.
- Full claude suite: 208 passed; `bun typecheck` clean.
- Verified end-to-end against a real Claude Code binary in an isolated hub+runner stack: source session answered "PONG1", fork returned 200, child session answered "PONG2" (before this change the child stayed silent indefinitely). Child log shows the fixed path: `hook_response (#4)` → `initial message acquired` → `init (#7)` → assistant response → result.