### PR TITLE
feat(acp): re-enable change_title for ACP launchers with manual title precedence

### DIFF
--- a/cli/src/agent/acpSessionTitle.test.ts
+++ b/cli/src/agent/acpSessionTitle.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { Metadata } from '../api/types';
 import { createAcpSessionTitleSync, registerAcpSessionTitleSync } from './acpSessionTitle';
 import type { AcpSessionInfoUpdate } from './backends/acp/AcpSdkBackend';
+
+type TitleClient = Parameters<typeof createAcpSessionTitleSync>[0];
+
+function makeClient(metadata: Partial<Metadata> = {}) {
+    const state = { ...metadata } as Metadata;
+    const sendClaudeSessionMessage = vi.fn();
+    return {
+        client: {
+            getMetadata: () => ({ ...state }),
+            updateMetadata: (handler: (metadata: Metadata) => Metadata) => {
+                Object.assign(state, handler(state));
+            },
+            sendClaudeSessionMessage
+        } satisfies TitleClient,
+        sendClaudeSessionMessage,
+        state
+    };
+}
 
 describe('registerAcpSessionTitleSync', () => {
     it('forwards normalized unique ACP titles as HAPI summaries', () => {
@@ -10,9 +29,9 @@ describe('registerAcpSessionTitleSync', () => {
                 listener = next;
             }
         };
-        const sendClaudeSessionMessage = vi.fn();
+        const { client, sendClaudeSessionMessage } = makeClient();
 
-        registerAcpSessionTitleSync(backend, { sendClaudeSessionMessage });
+        registerAcpSessionTitleSync(backend, client);
 
         listener!({ sessionId: 'session-1', title: '  Native Cursor Title  ' });
         listener!({ sessionId: 'session-1', title: 'Native Cursor Title' });
@@ -31,8 +50,8 @@ describe('registerAcpSessionTitleSync', () => {
     });
 
     it('stops syncing native titles after a manual title is set', () => {
-        const sendClaudeSessionMessage = vi.fn();
-        const controller = createAcpSessionTitleSync({ sendClaudeSessionMessage });
+        const { client, sendClaudeSessionMessage } = makeClient();
+        const controller = createAcpSessionTitleSync(client);
 
         controller.syncNativeTitle('Native Title');
         controller.markManualTitle();
@@ -44,5 +63,20 @@ describe('registerAcpSessionTitleSync', () => {
             summary: 'Native Title',
             leafUuid: expect.any(String)
         });
+    });
+
+    it('persists manual precedence in metadata and honors it after controller recreation', () => {
+        const first = makeClient();
+        const firstController = createAcpSessionTitleSync(first.client);
+        firstController.syncNativeTitle('Native Title');
+        firstController.markManualTitle();
+
+        expect(first.state.acpManualTitle).toBe(true);
+
+        const second = makeClient(first.state);
+        const secondController = createAcpSessionTitleSync(second.client);
+        secondController.syncNativeTitle('Newer Native Title');
+
+        expect(second.sendClaudeSessionMessage).not.toHaveBeenCalled();
     });
 });

--- a/cli/src/agent/acpSessionTitle.test.ts
+++ b/cli/src/agent/acpSessionTitle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { registerAcpSessionTitleSync } from './acpSessionTitle';
+import { createAcpSessionTitleSync, registerAcpSessionTitleSync } from './acpSessionTitle';
 import type { AcpSessionInfoUpdate } from './backends/acp/AcpSdkBackend';
 
 describe('registerAcpSessionTitleSync', () => {
@@ -26,6 +26,22 @@ describe('registerAcpSessionTitleSync', () => {
         expect(sendClaudeSessionMessage).toHaveBeenCalledWith({
             type: 'summary',
             summary: 'Native Cursor Title',
+            leafUuid: expect.any(String)
+        });
+    });
+
+    it('stops syncing native titles after a manual title is set', () => {
+        const sendClaudeSessionMessage = vi.fn();
+        const controller = createAcpSessionTitleSync({ sendClaudeSessionMessage });
+
+        controller.syncNativeTitle('Native Title');
+        controller.markManualTitle();
+        controller.syncNativeTitle('Newer Native Title');
+
+        expect(sendClaudeSessionMessage).toHaveBeenCalledTimes(1);
+        expect(sendClaudeSessionMessage).toHaveBeenCalledWith({
+            type: 'summary',
+            summary: 'Native Title',
             leafUuid: expect.any(String)
         });
     });

--- a/cli/src/agent/acpSessionTitle.ts
+++ b/cli/src/agent/acpSessionTitle.ts
@@ -6,32 +6,47 @@ import { normalizeNativeSessionTitle } from '@/agent/nativeSessionTitle';
 type AcpSessionTitleBackend = Pick<AcpSdkBackend, 'setSessionInfoUpdateListener'>;
 type AcpSessionTitleClient = Pick<ApiSessionClient, 'sendClaudeSessionMessage'>;
 
-/** Creates a normalized, deduplicated native-title sink for a HAPI session. */
-function createSessionTitleSync(client: AcpSessionTitleClient): (title: unknown) => void {
-    let lastTitle: string | null = null;
+export interface AcpSessionTitleController {
+    syncNativeTitle: (title: unknown) => void;
+    markManualTitle: () => void;
+}
 
-    return (title) => {
-        const normalizedTitle = normalizeNativeSessionTitle(title);
-        if (!normalizedTitle || normalizedTitle === lastTitle) {
-            return;
+/** Creates a normalized, deduplicated native-title sink for a HAPI session. */
+export function createAcpSessionTitleSync(client: AcpSessionTitleClient): AcpSessionTitleController {
+    let lastTitle: string | null = null;
+    let manual = false;
+
+    return {
+        syncNativeTitle: (title) => {
+            if (manual) {
+                return;
+            }
+            const normalizedTitle = normalizeNativeSessionTitle(title);
+            if (!normalizedTitle || normalizedTitle === lastTitle) {
+                return;
+            }
+            lastTitle = normalizedTitle;
+            client.sendClaudeSessionMessage({
+                type: 'summary',
+                summary: normalizedTitle,
+                leafUuid: randomUUID()
+            });
+        },
+        markManualTitle: () => {
+            manual = true;
         }
-        lastTitle = normalizedTitle;
-        client.sendClaudeSessionMessage({
-            type: 'summary',
-            summary: normalizedTitle,
-            leafUuid: randomUUID()
-        });
     };
 }
 
 /** Syncs agent-generated ACP session titles into HAPI session metadata. */
 export function registerAcpSessionTitleSync(
     backend: AcpSessionTitleBackend,
-    client: AcpSessionTitleClient
+    client: AcpSessionTitleClient,
+    controller?: AcpSessionTitleController
 ): void {
-    const syncTitle = createSessionTitleSync(client);
+    const titleSync = controller ?? createAcpSessionTitleSync(client);
 
     backend.setSessionInfoUpdateListener(({ title }) => {
-        syncTitle(title);
+        titleSync.syncNativeTitle(title);
     });
 }

--- a/cli/src/agent/acpSessionTitle.ts
+++ b/cli/src/agent/acpSessionTitle.ts
@@ -4,7 +4,10 @@ import type { AcpSdkBackend } from '@/agent/backends/acp';
 import { normalizeNativeSessionTitle } from '@/agent/nativeSessionTitle';
 
 type AcpSessionTitleBackend = Pick<AcpSdkBackend, 'setSessionInfoUpdateListener'>;
-type AcpSessionTitleClient = Pick<ApiSessionClient, 'sendClaudeSessionMessage'>;
+type AcpSessionTitleClient = Pick<
+    ApiSessionClient,
+    'sendClaudeSessionMessage' | 'getMetadata' | 'updateMetadata'
+>;
 
 export interface AcpSessionTitleController {
     syncNativeTitle: (title: unknown) => void;
@@ -14,7 +17,9 @@ export interface AcpSessionTitleController {
 /** Creates a normalized, deduplicated native-title sink for a HAPI session. */
 export function createAcpSessionTitleSync(client: AcpSessionTitleClient): AcpSessionTitleController {
     let lastTitle: string | null = null;
-    let manual = false;
+    // Survives launcher recreation / session resume via session metadata, so a
+    // manual change_title rename is not overwritten by later native titles.
+    let manual = client.getMetadata()?.acpManualTitle === true;
 
     return {
         syncNativeTitle: (title) => {
@@ -33,7 +38,14 @@ export function createAcpSessionTitleSync(client: AcpSessionTitleClient): AcpSes
             });
         },
         markManualTitle: () => {
+            if (manual) {
+                return;
+            }
             manual = true;
+            client.updateMetadata((metadata) => ({
+                ...metadata,
+                acpManualTitle: true
+            }));
         }
     };
 }

--- a/cli/src/agent/sessionFactory.test.ts
+++ b/cli/src/agent/sessionFactory.test.ts
@@ -164,6 +164,7 @@ describe('bootstrapExistingSession', () => {
                 text: 'resume me',
                 updatedAt: 100
             },
+            acpManualTitle: true,
             tools: ['read_file'],
             slashCommands: ['/compact'],
             conversationHistoryPoints: { 'local-user-1': true },
@@ -188,6 +189,7 @@ describe('bootstrapExistingSession', () => {
         })
 
         expect(result.metadata).toEqual(expect.objectContaining({
+            acpManualTitle: true,
             claudeSessionId: 'claude-thread-1',
             codexSessionId: 'codex-thread-1',
             geminiSessionId: 'gemini-thread-1',
@@ -222,6 +224,7 @@ describe('bootstrapExistingSession', () => {
         expect(sessionClient.updateMetadata).toHaveBeenCalledOnce()
         const updateHandler = sessionClient.updateMetadata.mock.calls[0][0]
         expect(updateHandler(session.metadata)).toEqual(expect.objectContaining({
+            acpManualTitle: true,
             codexSessionId: 'codex-thread-1',
             grokSessionId: 'grok-thread-1',
             conversationHistoryEntryIds: { 'local-user-1': 'pi-entry-1' }
@@ -229,6 +232,7 @@ describe('bootstrapExistingSession', () => {
         expect(notifyRunnerSessionStartedMock).toHaveBeenCalledWith(
             'hapi-session-1',
             expect.objectContaining({
+                acpManualTitle: true,
                 codexSessionId: 'codex-thread-1',
                 grokSessionId: 'grok-thread-1',
                 conversationHistoryEntryIds: { 'local-user-1': 'pi-entry-1' }

--- a/cli/src/agent/sessionFactory.ts
+++ b/cli/src/agent/sessionFactory.ts
@@ -120,6 +120,7 @@ function pickExistingSessionMetadata(metadata: Metadata | null | undefined): Par
 
     if (metadata.name !== undefined) preserved.name = metadata.name
     if (metadata.summary !== undefined) preserved.summary = metadata.summary
+    if (metadata.acpManualTitle !== undefined) preserved.acpManualTitle = metadata.acpManualTitle
     if (metadata.claudeSessionId !== undefined) preserved.claudeSessionId = metadata.claudeSessionId
     if (metadata.codexSessionId !== undefined) preserved.codexSessionId = metadata.codexSessionId
     if (metadata.codexSourceSessionId !== undefined) preserved.codexSourceSessionId = metadata.codexSourceSessionId

--- a/cli/src/claude/utils/startHappyServer.test.ts
+++ b/cli/src/claude/utils/startHappyServer.test.ts
@@ -118,6 +118,28 @@ describe('startHappyServer skill_lookup', () => {
         ])
     })
 
+    it('invokes onChangeTitle when change_title succeeds', async () => {
+        sendAgentMessage = vi.fn()
+        const sessionClient = {
+            updateMetadata: vi.fn(),
+            sendAgentMessage,
+            sendClaudeSessionMessage: vi.fn()
+        } as unknown as ApiSessionClient
+        const onChangeTitle = vi.fn()
+        const server = await startHappyServer(sessionClient, { onChangeTitle })
+        stopServer = server.stop
+        const mcp = new Client({ name: 'hapi-test', version: '1.0.0' })
+        client = mcp
+        await mcp.connect(new StreamableHTTPClientTransport(new URL(server.url)))
+
+        await mcp.callTool({
+            name: 'change_title',
+            arguments: { title: 'Manual Title' }
+        })
+
+        expect(onChangeTitle).toHaveBeenCalledWith('Manual Title')
+    })
+
     it('describes display_image as user output rather than image input', async () => {
         const mcp = await connect(false)
         const tools = await mcp.listTools()

--- a/cli/src/claude/utils/startHappyServer.test.ts
+++ b/cli/src/claude/utils/startHappyServer.test.ts
@@ -140,6 +140,31 @@ describe('startHappyServer skill_lookup', () => {
         expect(onChangeTitle).toHaveBeenCalledWith('Manual Title')
     })
 
+    it('does not invoke onChangeTitle when the title send fails', async () => {
+        sendAgentMessage = vi.fn()
+        const sessionClient = {
+            updateMetadata: vi.fn(),
+            sendAgentMessage,
+            sendClaudeSessionMessage: vi.fn(() => {
+                throw new Error('send failed')
+            })
+        } as unknown as ApiSessionClient
+        const onChangeTitle = vi.fn()
+        const server = await startHappyServer(sessionClient, { onChangeTitle })
+        stopServer = server.stop
+        const mcp = new Client({ name: 'hapi-test', version: '1.0.0' })
+        client = mcp
+        await mcp.connect(new StreamableHTTPClientTransport(new URL(server.url)))
+
+        const result = await mcp.callTool({
+            name: 'change_title',
+            arguments: { title: 'Manual Title' }
+        }) as ToolResult
+
+        expect(result.isError).toBe(true)
+        expect(onChangeTitle).not.toHaveBeenCalled()
+    })
+
     it('describes display_image as user output rather than image input', async () => {
         const mcp = await connect(false)
         const tools = await mcp.listTools()

--- a/cli/src/claude/utils/startHappyServer.ts
+++ b/cli/src/claude/utils/startHappyServer.ts
@@ -31,6 +31,7 @@ import { PingPeerError, formatInspectPeerReport, formatPeerSessionsList, inspect
 type StartHappyServerOptions = {
     emitTitleSummary?: boolean;
     enableChangeTitle?: boolean;
+    onChangeTitle?: (title: string) => void;
     skillLookup?: {
         workingDirectory: string;
         flavor: string;
@@ -61,7 +62,8 @@ function createHapiMcpServer(
     client: ApiSessionClient,
     emitTitleSummary: boolean,
     enableChangeTitle: boolean,
-    skillLookup: StartHappyServerOptions['skillLookup']
+    skillLookup: StartHappyServerOptions['skillLookup'],
+    onChangeTitle?: StartHappyServerOptions['onChangeTitle']
 ): McpServer {
     const handler = async (title: string) => {
         logger.debug('[hapiMCP] Changing title to:', title);
@@ -73,6 +75,7 @@ function createHapiMcpServer(
                     leafUuid: randomUUID()
                 });
             }
+            onChangeTitle?.(title);
 
             return { success: true };
         } catch (error) {
@@ -479,7 +482,7 @@ export async function startHappyServer(client: ApiSessionClient, options: StartH
     const mcps = new Map<string, McpServer>();
 
     const createMcpTransport = () => {
-        const mcp = createHapiMcpServer(client, emitTitleSummary, enableChangeTitle, options.skillLookup);
+        const mcp = createHapiMcpServer(client, emitTitleSummary, enableChangeTitle, options.skillLookup, options.onChangeTitle);
         const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (sessionId) => {

--- a/cli/src/codex/utils/buildHapiMcpBridge.ts
+++ b/cli/src/codex/utils/buildHapiMcpBridge.ts
@@ -46,6 +46,7 @@ export interface HapiMcpBridge {
 export interface HapiMcpBridgeOptions {
     emitTitleSummary?: boolean;
     enableChangeTitle?: boolean;
+    onChangeTitle?: (title: string) => void;
     skillLookup?: {
         workingDirectory: string;
         flavor: string;
@@ -80,6 +81,7 @@ export async function buildHapiMcpBridge(
     const happyServer = await startHappyServer(client, {
         emitTitleSummary: options.emitTitleSummary,
         enableChangeTitle: options.enableChangeTitle,
+        onChangeTitle: options.onChangeTitle,
         skillLookup: options.skillLookup
     });
     const bridgeCommand = getHappyCliCommand([

--- a/cli/src/copilot/copilotRemoteLauncher.ts
+++ b/cli/src/copilot/copilotRemoteLauncher.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
+import { createAcpSessionTitleSync, registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
 import { logger } from '@/ui/logger';
 import { buildHapiMcpBridge } from '@/codex/utils/buildHapiMcpBridge';
 import { convertAgentMessage } from '@/agent/messageConverter';
@@ -58,8 +58,9 @@ export class CopilotRemoteLauncher extends RemoteLauncherBase {
         const session = this.session;
         const messageBuffer = this.messageBuffer;
 
+        const titleSync = createAcpSessionTitleSync(session.client);
         const { server: happyServer, mcpServers } = await buildHapiMcpBridge(session.client, {
-            enableChangeTitle: false,
+            onChangeTitle: () => titleSync.markManualTitle(),
             skillLookup: { workingDirectory: session.path, flavor: 'copilot' }
         });
         this.happyServer = happyServer;
@@ -69,7 +70,7 @@ export class CopilotRemoteLauncher extends RemoteLauncherBase {
         this.currentAgentMode = session.getAgentMode();
         const backend = createCopilotBackend({ agentMode: this.currentAgentMode });
         this.backend = backend;
-        registerAcpSessionTitleSync(backend, session.client);
+        registerAcpSessionTitleSync(backend, session.client, titleSync);
 
         backend.onStderrError((error) => {
             logger.debug('[copilot-remote] stderr error', error);

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -34,8 +34,30 @@ const harness = vi.hoisted(() => ({
     stderrErrorHandler: null as ((error: { type: string; message: string; raw?: string }) => void) | null,
     disconnectError: null as Error | null,
     overlayCleanup: null as ReturnType<typeof vi.fn> | null,
-    agentActivityListener: null as ((thinking: boolean) => void) | null
+    agentActivityListener: null as ((thinking: boolean) => void) | null,
+    titleSyncControllers: [] as unknown[],
+    titleSyncRegistered: [] as unknown[]
 }));
+
+vi.mock('@/agent/acpSessionTitle', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/agent/acpSessionTitle')>();
+    return {
+        ...actual,
+        createAcpSessionTitleSync: (...args: Parameters<typeof actual.createAcpSessionTitleSync>) => {
+            const controller = actual.createAcpSessionTitleSync(...args);
+            harness.titleSyncControllers.push(controller);
+            return controller;
+        },
+        registerAcpSessionTitleSync: (
+            backend: Parameters<typeof actual.registerAcpSessionTitleSync>[0],
+            client: Parameters<typeof actual.registerAcpSessionTitleSync>[1],
+            controller?: Parameters<typeof actual.registerAcpSessionTitleSync>[2]
+        ) => {
+            harness.titleSyncRegistered.push(controller ?? null);
+            return actual.registerAcpSessionTitleSync(backend, client, controller);
+        }
+    };
+});
 
 const legacyLauncher = vi.hoisted(() => vi.fn());
 
@@ -309,6 +331,8 @@ describe('cursorAcpRemoteLauncher', () => {
         harness.disconnectError = null;
         harness.overlayCleanup = null;
         harness.agentActivityListener = null;
+        harness.titleSyncControllers = [];
+        harness.titleSyncRegistered = [];
         legacyLauncher.mockClear();
         process.stdin.isTTY = false;
         process.stdout.isTTY = false;
@@ -594,6 +618,17 @@ describe('cursorAcpRemoteLauncher', () => {
         expect(createCursorAcpBackend).toHaveBeenCalled();
         expect(harness.backendArgs).toEqual({ command: 'agent', args: ['acp'] });
         expect(legacyLauncher).not.toHaveBeenCalled();
+    });
+
+    it('shares one title-sync controller across backend (re)creation paths', async () => {
+        const session = makeSession(null);
+        await cursorAcpRemoteLauncher(session);
+
+        expect(harness.titleSyncControllers).toHaveLength(1);
+        expect(harness.titleSyncRegistered.length).toBeGreaterThan(0);
+        for (const controller of harness.titleSyncRegistered) {
+            expect(controller).toBe(harness.titleSyncControllers[0]);
+        }
     });
 
     it('applies harness thinking transitions once per edge (#1470)', async () => {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -295,6 +295,7 @@ function makeClient() {
         emitSteerIndeterminate: vi.fn(),
         setSteerDeliveryState: vi.fn(async () => true),
         sendClaudeSessionMessage: vi.fn(),
+        getMetadata: vi.fn(() => null),
         keepAlive: vi.fn(),
         emitSessionReady: vi.fn()
     } as unknown as ApiSessionClient;
@@ -1034,6 +1035,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1122,6 +1124,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1173,6 +1176,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1386,6 +1390,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1432,6 +1437,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1478,6 +1484,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1527,6 +1534,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1573,6 +1581,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1631,6 +1640,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1674,6 +1684,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1721,6 +1732,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),
@@ -1763,6 +1775,7 @@ describe('cursorAcpRemoteLauncher', () => {
         const client = {
             rpcHandlerManager: { registerHandler: vi.fn() },
             updateMetadata: vi.fn(),
+            getMetadata: vi.fn(() => null),
             flushMetadata: vi.fn(async () => true),
             sendSessionEvent: vi.fn(),
             sendAgentMessage: vi.fn(),

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -35,7 +35,7 @@ import { readSharedCursorModelsCache } from '@/modules/common/cursorModelsShared
 import type { AcpSdkBackend } from '@/agent/backends/acp';
 import type { AcpStderrError } from '@/agent/backends/acp/AcpStdioTransport';
 import { isAcpIndeterminateError } from '@/agent/backends/acp/AcpStdioTransport';
-import { registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
+import { createAcpSessionTitleSync, registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 import {
     cursorHapiMcpServerId,
@@ -104,8 +104,9 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
         const messageBuffer = this.messageBuffer;
         session.client.updateAgentState?.((state) => ({ ...state, steeringActive: false }));
 
+        const titleSync = createAcpSessionTitleSync(session.client);
         const { server: happyServer, mcpServers } = await buildHapiMcpBridge(session.client, {
-            enableChangeTitle: false,
+            onChangeTitle: () => titleSync.markManualTitle(),
             skillLookup: { workingDirectory: session.path, flavor: 'cursor' }
         });
         this.happyServer = happyServer;
@@ -155,7 +156,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                 addDirs: session.cursorAddDirs
             });
             this.backend = backend;
-            registerAcpSessionTitleSync(backend, session.client);
+            registerAcpSessionTitleSync(backend, session.client, titleSync);
             this.recordCursorNativeWorktreeMetadata();
 
             backend.setUsageUpdateListener((message) => this.handleAgentMessage(message));
@@ -271,7 +272,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                             addDirs: session.cursorAddDirs
                         });
                         this.backend = backend;
-                        registerAcpSessionTitleSync(backend, session.client);
+                        registerAcpSessionTitleSync(backend, session.client, titleSync);
                         backend.setUsageUpdateListener((message) => this.handleAgentMessage(message));
                         this.wireAgentActivityThinking(backend, session);
                         recentStderrHint = null;
@@ -332,7 +333,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                             addDirs: session.cursorAddDirs
                         });
                         this.backend = backend;
-                        registerAcpSessionTitleSync(backend, session.client);
+                        registerAcpSessionTitleSync(backend, session.client, titleSync);
                         backend.setUsageUpdateListener((message) => this.handleAgentMessage(message));
                         this.wireAgentActivityThinking(backend, session);
                         recentStderrHint = null;

--- a/cli/src/kimi/kimiRemoteLauncher.test.ts
+++ b/cli/src/kimi/kimiRemoteLauncher.test.ts
@@ -57,6 +57,8 @@ function createSession() {
         client: {
             rpcHandlerManager: { registerHandler: vi.fn() },
             sendAgentMessage: vi.fn(),
+            getMetadata: vi.fn(() => null),
+            updateMetadata: vi.fn(),
             sendSessionEvent: vi.fn()
         },
         queue,

--- a/cli/src/kimi/kimiRemoteLauncher.ts
+++ b/cli/src/kimi/kimiRemoteLauncher.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
+import { createAcpSessionTitleSync, registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
 import { logger } from '@/ui/logger';
 import { buildHapiMcpBridge } from '@/codex/utils/buildHapiMcpBridge';
 import { convertAgentMessage } from '@/agent/messageConverter';
@@ -44,8 +44,9 @@ class KimiRemoteLauncher extends RemoteLauncherBase {
         const session = this.session;
         const messageBuffer = this.messageBuffer;
 
+        const titleSync = createAcpSessionTitleSync(session.client);
         const { server: happyServer, mcpServers } = await buildHapiMcpBridge(session.client, {
-            enableChangeTitle: false,
+            onChangeTitle: () => titleSync.markManualTitle(),
             skillLookup: { workingDirectory: session.path, flavor: 'kimi' }
         });
         this.happyServer = happyServer;
@@ -54,7 +55,7 @@ class KimiRemoteLauncher extends RemoteLauncherBase {
 
         const backend = createKimiBackend();
         this.backend = backend;
-        registerAcpSessionTitleSync(backend, session.client);
+        registerAcpSessionTitleSync(backend, session.client, titleSync);
 
         backend.onStderrError((error) => {
             logger.debug('[kimi-remote] stderr error', error);

--- a/cli/src/opencode/opencodeRemoteLauncher.test.ts
+++ b/cli/src/opencode/opencodeRemoteLauncher.test.ts
@@ -8,7 +8,7 @@ const harness = vi.hoisted(() => ({
     promptCount: 0,
     promptContents: [] as unknown[],
     refreshSessionInfoCalls: [] as Array<{ sessionId: string; cwd: string }>,
-    bridgeOptions: null as { enableChangeTitle?: boolean; skillLookup?: { workingDirectory: string; flavor: string } } | null,
+    bridgeOptions: null as { onChangeTitle?: () => void; skillLookup?: { workingDirectory: string; flavor: string } } | null,
     events: [] as string[],
     cleanupEvents: [] as string[],
     setModelImpl: null as null | ((sessionId: string, modelId: string) => Promise<void>),
@@ -150,7 +150,7 @@ vi.mock('./utils/opencodeBackend', () => ({
 }));
 
 vi.mock('@/codex/utils/buildHapiMcpBridge', () => ({
-    buildHapiMcpBridge: async (_client: unknown, options?: { enableChangeTitle?: boolean; skillLookup?: { workingDirectory: string; flavor: string } }) => {
+    buildHapiMcpBridge: async (_client: unknown, options?: { onChangeTitle?: () => void; skillLookup?: { workingDirectory: string; flavor: string } }) => {
         harness.bridgeOptions = options ?? null;
         return {
             server: { stop: () => { harness.cleanupEvents.push('cleanup:server-stop'); if (harness.serverStopError) throw harness.serverStopError; } },

--- a/cli/src/opencode/opencodeRemoteLauncher.test.ts
+++ b/cli/src/opencode/opencodeRemoteLauncher.test.ts
@@ -1628,7 +1628,7 @@ describe('opencodeRemoteLauncher inline model switch', () => {
         expect(JSON.stringify(harness.promptContents[0])).toContain('$name');
         expect(JSON.stringify(harness.promptContents[0])).toContain('skill_lookup');
         expect(JSON.stringify(harness.promptContents[0])).toContain('hapi_display_image');
-        expect(JSON.stringify(harness.promptContents[0])).not.toContain('hapi_change_title');
+        expect(JSON.stringify(harness.promptContents[0])).toContain('hapi_change_title');
         expect(JSON.stringify(harness.promptContents[1])).not.toContain('skill_lookup');
     });
 
@@ -1655,7 +1655,7 @@ describe('opencodeRemoteLauncher inline model switch', () => {
         await opencodeRemoteLauncher(session as never);
 
         expect(harness.bridgeOptions).toEqual({
-            enableChangeTitle: false,
+            onChangeTitle: expect.any(Function),
             skillLookup: { workingDirectory: '/tmp/hapi-opencode-test', flavor: 'opencode' }
         });
         expect(harness.refreshSessionInfoCalls).toEqual([
@@ -1873,7 +1873,7 @@ describe('opencodeRemoteLauncher inline model switch', () => {
         expect(content[0]?.text).toContain('You are in plan mode');
         expect(content[0]?.text).toContain('Do not execute tools');
         expect(content[0]?.text).toContain('design the fix');
-        expect(content[0]?.text).not.toContain('hapi_change_title');
+        expect(content[0]?.text).toContain('hapi_change_title');
     });
 
     it('registers a listOpencodeModels RPC handler that returns the backend cache', async () => {

--- a/cli/src/opencode/opencodeRemoteLauncher.test.ts
+++ b/cli/src/opencode/opencodeRemoteLauncher.test.ts
@@ -321,6 +321,10 @@ function createSessionStub(
             }
         },
         sendAgentMessage(_message: unknown) {},
+        getMetadata() {
+            return null;
+        },
+        updateMetadata(_handler: (metadata: unknown) => unknown) {},
         sendClaudeSessionMessage(message: unknown) {
             claudeSessionMessages.push(message);
         },

--- a/cli/src/opencode/opencodeRemoteLauncher.ts
+++ b/cli/src/opencode/opencodeRemoteLauncher.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { randomUUID } from 'node:crypto';
-import { registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
+import { createAcpSessionTitleSync, registerAcpSessionTitleSync } from '@/agent/acpSessionTitle';
 import { logger } from '@/ui/logger';
 import { buildHapiMcpBridge } from '@/codex/utils/buildHapiMcpBridge';
 import type { AcpStderrError } from '@/agent/backends/acp/AcpStdioTransport';
@@ -158,8 +158,9 @@ class OpencodeRemoteLauncher extends RemoteLauncherBase {
         const session = this.session;
         const messageBuffer = this.messageBuffer;
 
+        const titleSync = createAcpSessionTitleSync(session.client);
         const { server: happyServer, mcpServers } = await buildHapiMcpBridge(session.client, {
-            enableChangeTitle: false,
+            onChangeTitle: () => titleSync.markManualTitle(),
             skillLookup: { workingDirectory: session.path, flavor: 'opencode' }
         });
         this.happyServer = happyServer;
@@ -181,7 +182,7 @@ class OpencodeRemoteLauncher extends RemoteLauncherBase {
             hostname
         });
         this.backend = backend;
-        registerAcpSessionTitleSync(backend, session.client);
+        registerAcpSessionTitleSync(backend, session.client, titleSync);
 
         backend.onStderrError((error) => {
             this.handleAcpStderrError(error);

--- a/cli/src/opencode/utils/systemPrompt.ts
+++ b/cli/src/opencode/utils/systemPrompt.ts
@@ -7,7 +7,7 @@
 
 import { trimIdent } from '@/utils/trimIdent';
 import { buildSessionCitationSteerInstruction } from '@hapi/protocol/sessionCitation';
-import { HAPI_MCP_BRIDGE_PROMPT } from '@/modules/common/hapiMcpBridgePrompt';
+import { HAPI_MCP_BRIDGE_PROMPT, HAPI_MCP_TITLE_INSTRUCTION } from '@/modules/common/hapiMcpBridgePrompt';
 import {
     DISPLAY_IMAGE_PROMPT_HAPI_MCP,
     DISPLAY_MEDIA_PROMPT_HAPI_MCP,
@@ -34,10 +34,11 @@ export function getTitleInstruction(env: NodeJS.ProcessEnv = process.env): strin
 }
 
 /**
- * Tool instructions for native ACP sessions. Title updates come from ACP, so
- * advertise only the MCP tools that remain available to the model.
+ * Instruction prepended to native ACP session prompts. change_title rides the
+ * same MCP bridge; manual titles take precedence over native ACP title sync.
  */
 export const OPENCODE_NATIVE_TOOL_INSTRUCTION = trimIdent(`
+    ${HAPI_MCP_TITLE_INSTRUCTION}
     ${DISPLAY_IMAGE_PROMPT_HAPI_MCP}
     ${DISPLAY_VIDEO_PROMPT_HAPI_MCP}
     ${DISPLAY_MEDIA_PROMPT_HAPI_MCP}

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -57,6 +57,10 @@ export const MetadataSchema = z.object({
     version: z.string().optional(),
     name: z.string().optional(),
     os: z.string().optional(),
+    // Set when the title was chosen via the hapi change_title MCP tool. ACP
+    // native session-title sync must not overwrite it, including after
+    // launcher recreation or session resume.
+    acpManualTitle: z.boolean().optional(),
     summary: MetadataSummarySchema.optional(),
     machineId: z.string().optional(),
     claudeSessionId: z.string().optional(),


### PR DESCRIPTION
## Why

ACP-based launchers (opencode, cursor, kimi, copilot) disable the hapi `change_title` MCP tool (#1028) and rely solely on native ACP session-title sync. When the agent never generates a native title (e.g. short sessions), there is no way to set a title short of hub API calls.

## What

- Re-enable `change_title` on those four ACP launchers.
- Manual titles win over native sync: `change_title` marks a shared title-sync controller (`createAcpSessionTitleSync`), so later native `sessionInfoUpdate` titles no longer overwrite a manual rename. Cursor's three backend-(re)creation paths share one controller instance.
- Add the title-tool usage instruction back to the opencode prompt.

## Verification

- Unit: manual-precedence controller test, cursor controller-sharing test, `onChangeTitle` success/failure paths; full suites green (cli 2452 / web 2845 / shared / relay) + typecheck all packages.
- Isolated E2E: spawned an opencode session against an isolated hub+runner — the bridge process now advertises `change_title` in `--tools`, and the MCP server's `tools/list` exposes it.
