### PR TITLE
feat(web): expose opencode /compact and /clear builtin slash commands

### DIFF
--- a/shared/src/slashCommands.ts
+++ b/shared/src/slashCommands.ts
@@ -48,6 +48,8 @@ export const BUILTIN_SLASH_COMMANDS = {
         { name: 'plan', description: 'Enable plan mode; use /plan off to return to default', source: 'builtin' },
         { name: 'default', description: 'Return OpenCode permission mode to default', source: 'builtin' },
         { name: 'init', description: 'Generate or refresh AGENTS.md for this project', source: 'builtin' },
+        { name: 'compact', description: 'Compact (summarize) the OpenCode session context (remote sessions only)', source: 'builtin' },
+        { name: 'clear', description: 'Archive this HAPI session and open a fresh OpenCode session', source: 'builtin' },
     ],
     cursor: [
         { name: 'compress', description: 'Compress conversation context to free window space (pass-through to Cursor agent)', source: 'builtin' },

--- a/web/src/lib/codexSlashCommands.test.ts
+++ b/web/src/lib/codexSlashCommands.test.ts
@@ -34,6 +34,19 @@ describe('getBuiltinSlashCommands', () => {
         expect(commands.map((command) => command.name)).toContain('compact')
     })
 
+    it('exposes OpenCode compact and clear builtins for the remote web menu', () => {
+        const commands = getBuiltinSlashCommands('opencode')
+        expect(commands.map((command) => command.name)).toEqual(expect.arrayContaining([
+            'compact',
+            'clear',
+            'help',
+            'status',
+            'plan',
+            'default',
+            'init',
+        ]))
+    })
+
     it('does not fall back to Claude commands for kimi', () => {
         expect(getBuiltinSlashCommands('kimi')).toEqual([])
     })


### PR DESCRIPTION
## Problem

On the hapi **remote web/phone** UI, the `/` slash-command menu is built from `BUILTIN_SLASH_COMMANDS` in `shared/src/slashCommands.ts`. The `opencode` builtin list omits `compact` (and `clear`), so `/compact` never appears in the mobile `/` menu — even though the parsing layer (`resolveOpencodeSlashCommand` in `cli/src/opencode/utils/slashCommands.ts`) already resolves `/compact` to `{ kind: 'compact' }` and triggers native OpenCode compaction, and `/clear` to `{ kind: 'clear' }`.

By contrast, `pi`, `codex`, `grok`, and `claude` all list `compact` in their builtin commands, which is why `/compact` shows up there but not for opencode.

## Change

- Add `compact` and `clear` to `BUILTIN_SLASH_COMMANDS.opencode`.
- Add a web test asserting opencode exposes `compact`, `clear`, `help`, `status`, `plan`, `default`, `init`.

## Verification

Manually confirmed the opencode builtin list now includes `compact` and `clear`. Test added in `web/src/lib/codexSlashCommands.test.ts`.