### PR TITLE
feat(web): surface opencode /compact and /clear in the slash command menu

### DIFF
--- a/cli/src/modules/common/slashCommands.test.ts
+++ b/cli/src/modules/common/slashCommands.test.ts
@@ -197,11 +197,16 @@ describe('listSlashCommands', () => {
             'plan',
             'default',
             'init',
+            'compact',
+            'clear',
         ]))
-        // Anything covered by composer buttons, plus aliases and unsupported
-        // placeholders, must stay out of the autocomplete menu — the resolver
-        // still accepts them when typed manually.
-        for (const hidden of ['model', 'reasoning', 'effort', 'permissions', 'permission', 'clear', 'compact']) {
+        // model/reasoning/effort/permissions have dedicated composer buttons and
+        // permission is an alias of permissions, so they stay out of the
+        // autocomplete menu (the resolver still accepts them when typed
+        // manually). compact/clear have no composer button and are now fully
+        // supported (native compaction via the OpenCode REST bridge), so they
+        // are surfaced here.
+        for (const hidden of ['model', 'reasoning', 'effort', 'permissions', 'permission']) {
             expect(names).not.toContain(hidden)
         }
     })

--- a/shared/src/slashCommands.ts
+++ b/shared/src/slashCommands.ts
@@ -48,6 +48,8 @@ export const BUILTIN_SLASH_COMMANDS = {
         { name: 'plan', description: 'Enable plan mode; use /plan off to return to default', source: 'builtin' },
         { name: 'default', description: 'Return OpenCode permission mode to default', source: 'builtin' },
         { name: 'init', description: 'Generate or refresh AGENTS.md for this project', source: 'builtin' },
+        { name: 'compact', description: 'Compact (summarize) the OpenCode session context (remote sessions only)', source: 'builtin' },
+        { name: 'clear', description: 'Archive this HAPI session and open a fresh OpenCode session', source: 'builtin' },
     ],
     cursor: [
         { name: 'compress', description: 'Compress conversation context to free window space (pass-through to Cursor agent)', source: 'builtin' },

--- a/web/src/lib/codexSlashCommands.test.ts
+++ b/web/src/lib/codexSlashCommands.test.ts
@@ -34,6 +34,19 @@ describe('getBuiltinSlashCommands', () => {
         expect(commands.map((command) => command.name)).toContain('compact')
     })
 
+    it('exposes OpenCode compact and clear builtins for the remote web menu', () => {
+        const commands = getBuiltinSlashCommands('opencode')
+        expect(commands.map((command) => command.name)).toEqual(expect.arrayContaining([
+            'compact',
+            'clear',
+            'help',
+            'status',
+            'plan',
+            'default',
+            'init',
+        ]))
+    })
+
     it('does not fall back to Claude commands for kimi', () => {
         expect(getBuiltinSlashCommands('kimi')).toEqual([])
     })


### PR DESCRIPTION
## Motivation

On the remote web/phone UI, the opencode `/` autocomplete menu is built from `BUILTIN_SLASH_COMMANDS` in `shared/src/slashCommands.ts`. It exposes only `help / status / plan / default / init`, intentionally omitting `compact` and `clear`.

That omission traces back to #753, when the OpenCode ACP backend had **no** compaction RPC — `/compact` and `/clear` were unsupported placeholders, so hiding them from the menu made sense.

Since then, `compact` became fully supported via the native OpenCode compaction bridge (#1252, + retries in #1433) and `clear` is a real implementation, but the menu list and the CLI test that locks the "hidden" set were **never updated**. The rationale for hiding them is now stale:

- `compact`/`clear` have **no** composer button (unlike model/reasoning/permissions).
- They are no longer unsupported — they work when typed manually.

So they are being surfaced in the menu, matching other flavors (pi, codex, grok, claude already list `compact`).

## Change

- `shared/src/slashCommands.ts`: add `compact` and `clear` to the opencode builtin list.
- `cli/src/modules/common/slashCommands.test.ts`: move `compact`/`clear` from the "hidden" set into the expected opencode builtin list; keep model/reasoning/effort/permissions hidden (they have composer buttons / are aliases).
- `web/src/lib/codexSlashCommands.test.ts`: add a web-side assertion that opencode exposes `compact` and `clear`.

## Verification

- OpenCode resolver already handles `/compact` (`kind: 'compact'`) and `/clear` (`kind: 'clear'`); `/help` already lists `/compact`.
- Updated unit expectations across cli + web for the opencode builtin set.