### PR TITLE
fix(web): make composer session mention pills ellipsize

### DIFF
--- a/web/src/components/AssistantChat/RichComposerInput.test.tsx
+++ b/web/src/components/AssistantChat/RichComposerInput.test.tsx
@@ -72,6 +72,25 @@ function ProgrammaticEditHarness() {
     )
 }
 
+function MentionHarness() {
+    const [value, setValue] = useState('')
+    const ref = useRef<RichComposerInputHandle>(null)
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() =>
+                    ref.current?.insertSessionMention({ id: 'sid-1', title: '아주 긴 데모 세션 이름 예시 말줄임표 필요' })
+                }
+            >
+                Insert mention
+            </button>
+            <RichComposerInput ref={ref} value={value} onValueChange={setValue} onMirrorChange={() => {}} />
+        </>
+    )
+}
+
 function LineBreakDeletionHarness() {
     const [value, setValue] = useState('hello')
 
@@ -88,6 +107,22 @@ function LineBreakDeletionHarness() {
         </>
     )
 }
+
+describe('RichComposerInput session mention pill', () => {
+    it('renders the mention pill with working text ellipsis clipping', () => {
+        render(<MentionHarness />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Insert mention' }))
+
+        const pill = screen.getByText('@아주 긴 데모 세션 이름 예시 말줄임표 필요')
+        // Ellipsis lives on the inner label; the pill itself centers it vertically.
+        expect(pill.className).toContain('truncate')
+        expect(pill.parentElement?.dataset.composerMention).toBe('session')
+        expect(pill.parentElement?.className).toContain('inline-flex')
+        expect(pill.parentElement?.className).toContain('align-baseline')
+        expect(pill.parentElement?.className).not.toContain('overflow-hidden')
+    })
+})
 
 describe('RichComposerInput responsive placeholder', () => {
     it('calculates a smaller font that fits overflowing text', () => {

--- a/web/src/components/AssistantChat/RichComposerInput.tsx
+++ b/web/src/components/AssistantChat/RichComposerInput.tsx
@@ -97,8 +97,14 @@ function createMentionSpan(
     span.dataset.sessionTitle = title
     span.dataset.composerMention = 'session'
     span.className =
-        'mx-0.5 inline-flex max-w-[12rem] items-center truncate rounded-md bg-[var(--app-subtle-bg)] px-1.5 py-0.5 align-baseline text-[0.95em] font-medium text-[var(--app-link)]'
-    span.textContent = `@${title || id.slice(0, 8)}`
+        'mx-0.5 inline-flex max-w-[16rem] items-baseline rounded-md bg-[var(--app-subtle-bg)] px-1.5 py-0.5 align-baseline text-[0.95em] font-medium text-[var(--app-link)]'
+    const label = document.createElement('span')
+    label.textContent = `@${title || id.slice(0, 8)}`
+    // Truncation lives on the inner label so the pill's own baseline stays a
+    // text baseline (an overflow≠visible inline-block would align by its
+    // bottom edge instead).
+    label.className = 'min-w-0 truncate'
+    span.appendChild(label)
     const tip = resolveTooltip?.(id, title)?.model
         ?? formatSessionMentionTooltip(null, title, id)
     span.setAttribute('aria-label', tip.ariaLabel)


### PR DESCRIPTION
## Problem

In the rich composer, a long session mention pill is hard-clipped without any ellipsis:

![before](https://github.com/user-attachments/assets/e89e0610-a194-45a3-aca7-5be5f17f3b22)

The pill class uses `inline-flex ... truncate`, but `text-overflow: ellipsis` does not apply to a flex container itself (the text node becomes a flex item), so `overflow: hidden` just cuts the text mid-glyph. Additionally, an inline-block with non-visible overflow aligns by its bottom margin edge, so naive fixes break vertical alignment.

## Fix

Keep the pill as an inline-flex atom but move truncation to an inner label span: the outer pill stays `align-baseline` (its baseline remains the text baseline since it no longer clips), while the inner label carries `min-w-0 truncate` for working ellipsis. Cap relaxed from 12rem to 16rem for readability with longer (e.g. CJK) titles:

![after](https://github.com/user-attachments/assets/3463dc02-9581-47d7-a654-39c88a172441)

- `data-composer-*` attributes, tooltip aria-label, and segment parsing/caret logic are unchanged.
- Verified backspace deletion of a pill still removes exactly the atom.

## Testing

- Added a vitest case asserting the inner label is `truncate` and the pill keeps baseline alignment (RED before / GREEN after).
- `bun run typecheck` and full `bun run test` pass.
