### PR TITLE
feat(web): support composer attachment drag reordering

### DIFF
--- a/web/src/components/AssistantChat/AttachmentItem.test.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.test.tsx
@@ -33,6 +33,21 @@ function renderAttachment() {
     )
 }
 
+function renderAttachmentWithControls() {
+    return render(
+        <I18nProvider>
+            <AttachmentItem
+                dragHandleProps={{
+                    onPointerDown: vi.fn(),
+                    onKeyDown: vi.fn(),
+                    ariaLabel: 'Reorder attachment notes.txt',
+                    title: 'Drag to reorder attachment',
+                }}
+            />
+        </I18nProvider>
+    )
+}
+
 describe('AttachmentItem', () => {
     it('renders an image preview with its filename and an always-visible remove button', () => {
         mocks.attachment = {
@@ -89,6 +104,25 @@ describe('AttachmentItem', () => {
 
         expect(screen.queryByRole('img')).not.toBeInTheDocument()
         expect(screen.getByText('notes.txt')).toBeInTheDocument()
+    })
+
+    it('uses centered, unboxed controls for non-image attachments', () => {
+        mocks.attachment = {
+            name: 'notes.txt',
+            status: { type: 'requires-action', reason: 'composer-send' }
+        }
+
+        renderAttachmentWithControls()
+
+        const dragHandle = screen.getByTestId('attachment-drag-handle')
+        const removeButton = screen.getByRole('button', { name: 'Remove attachment' })
+        expect(dragHandle.parentElement).toHaveClass('gap-1.5', 'px-2')
+
+        for (const control of [dragHandle, removeButton]) {
+            expect(control).toHaveClass('hapi-composer-attachment-file-control', 'h-4', 'w-4', 'items-center')
+            expect(control).not.toHaveClass('absolute', 'top-1/2', '-translate-y-1/2')
+            expect(control.querySelector('span')).toBeNull()
+        }
     })
 
     it('keeps upload errors in the existing error layout', () => {

--- a/web/src/components/AssistantChat/AttachmentItem.test.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.test.tsx
@@ -119,7 +119,7 @@ describe('AttachmentItem', () => {
         expect(dragHandle.parentElement).toHaveClass('gap-1.5', 'px-2')
 
         for (const control of [dragHandle, removeButton]) {
-            expect(control).toHaveClass('hapi-composer-attachment-file-control', 'h-4', 'w-4', 'items-center')
+            expect(control).toHaveClass('hapi-composer-attachment-file-control', 'h-6', 'w-6', '-mx-1', 'items-center')
             expect(control).not.toHaveClass('absolute', 'top-1/2', '-translate-y-1/2')
             expect(control.querySelector('span')).toBeNull()
         }

--- a/web/src/components/AssistantChat/AttachmentItem.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.tsx
@@ -80,7 +80,7 @@ function DragHandle(props: AttachmentDragHandleProps & { isFile?: boolean }) {
             onPointerDown={props.onPointerDown}
             onKeyDown={props.onKeyDown}
             className={isFile
-                ? 'hapi-composer-attachment-control hapi-composer-attachment-file-control flex h-4 w-4 shrink-0 touch-none cursor-grab items-center justify-center rounded-md bg-transparent text-[var(--app-hint)] transition-colors hover:text-[var(--app-fg)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)] active:cursor-grabbing'
+                ? 'hapi-composer-attachment-control hapi-composer-attachment-file-control -mx-1 flex h-6 w-6 shrink-0 touch-none cursor-grab items-center justify-center rounded-md bg-transparent text-[var(--app-hint)] transition-colors hover:text-[var(--app-fg)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)] active:cursor-grabbing'
                 : 'hapi-composer-attachment-control absolute left-1 top-1 z-20 flex h-8 w-8 touch-none cursor-grab items-start justify-start rounded-md bg-transparent text-white/90 transition-colors hover:bg-black/15 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)] active:cursor-grabbing'}
         >
             {isFile ? (
@@ -172,7 +172,7 @@ export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandlePr
             {isError ? <span className="text-xs text-red-500 whitespace-nowrap">Upload failed</span> : null}
             {!isParking ? (
                 <AttachmentPrimitive.Remove
-                    className="hapi-composer-attachment-control hapi-composer-attachment-file-control flex h-4 w-4 shrink-0 items-center justify-center rounded-md bg-transparent text-[var(--app-hint)] transition-colors hover:text-[var(--app-fg)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)]"
+                    className="hapi-composer-attachment-control hapi-composer-attachment-file-control -mx-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-transparent text-[var(--app-hint)] transition-colors hover:text-[var(--app-fg)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)]"
                     aria-label="Remove attachment"
                     title="Remove attachment"
                 >

--- a/web/src/components/AssistantChat/AttachmentItem.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.tsx
@@ -1,11 +1,22 @@
 import { AttachmentPrimitive, useThreadComposerAttachment } from '@assistant-ui/react'
 import type { PendingAttachment } from '@assistant-ui/react'
+import type { KeyboardEventHandler, MouseEventHandler, PointerEventHandler, PointerEvent as ReactPointerEvent } from 'react'
 import { ImagePreview } from '@/components/ImagePreview'
 import { Spinner } from '@/components/Spinner'
 import { useComposerParking } from '@/components/AssistantChat/composerParkingContext'
 
 type ComposerAttachmentWithPreview = PendingAttachment & {
     previewUrl?: string
+}
+
+export type AttachmentDragHandleProps = {
+    onPointerDown: PointerEventHandler<HTMLButtonElement>
+    onKeyDown: KeyboardEventHandler<HTMLButtonElement>
+    ariaLabel: string
+    title: string
+    onSurfacePointerDown?: PointerEventHandler<HTMLElement>
+    onSurfaceContextMenu?: MouseEventHandler<HTMLElement>
+    onSurfaceClick?: MouseEventHandler<HTMLElement>
 }
 
 function ErrorIcon() {
@@ -37,28 +48,93 @@ function RemoveIcon() {
     )
 }
 
-export function AttachmentItem() {
+function DragHandleIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            viewBox="0 0 14 14"
+            fill="currentColor"
+        >
+            <circle cx="4" cy="3" r="1" />
+            <circle cx="10" cy="3" r="1" />
+            <circle cx="4" cy="7" r="1" />
+            <circle cx="10" cy="7" r="1" />
+            <circle cx="4" cy="11" r="1" />
+            <circle cx="10" cy="11" r="1" />
+        </svg>
+    )
+}
+
+function DragHandle(props: AttachmentDragHandleProps & { isFile?: boolean }) {
+    const isFile = props.isFile === true
+
+    return (
+        <button
+            type="button"
+            data-testid="attachment-drag-handle"
+            aria-label={props.ariaLabel}
+            title={props.title}
+            onPointerDown={props.onPointerDown}
+            onKeyDown={props.onKeyDown}
+            className={isFile
+                ? 'hapi-composer-attachment-control hapi-composer-attachment-file-control flex h-4 w-4 shrink-0 touch-none cursor-grab items-center justify-center rounded-md bg-transparent text-[var(--app-hint)] transition-colors hover:text-[var(--app-fg)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)] active:cursor-grabbing'
+                : 'hapi-composer-attachment-control absolute left-1 top-1 z-20 flex h-8 w-8 touch-none cursor-grab items-start justify-start rounded-md bg-transparent text-white/90 transition-colors hover:bg-black/15 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)] active:cursor-grabbing'}
+        >
+            {isFile ? (
+                <DragHandleIcon />
+            ) : (
+                <span className="flex h-5 w-5 items-center justify-center rounded bg-black/40 shadow-sm ring-1 ring-white/20">
+                    <DragHandleIcon />
+                </span>
+            )}
+        </button>
+    )
+}
+
+export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandleProps } = {}) {
     const { name, status, previewUrl } = useThreadComposerAttachment() as ComposerAttachmentWithPreview
     const isParking = useComposerParking()
     const isUploading = status.type === 'running'
     const isError = status.type === 'incomplete'
+    const surfacePointerDown = props.dragHandleProps?.onSurfacePointerDown
+        ? (event: ReactPointerEvent<HTMLElement>) => {
+            const target = event.target
+            if (target instanceof Element && target.closest('button, a, input, textarea, select, [role="button"]')) {
+                return
+            }
+            props.dragHandleProps?.onSurfacePointerDown?.(event)
+        }
+        : undefined
 
     if (previewUrl && !isError) {
         return (
-            <AttachmentPrimitive.Root className="group relative h-16 w-24 overflow-hidden rounded-lg bg-[var(--app-subtle-bg)]">
+            <AttachmentPrimitive.Root
+                className="group relative h-16 w-24 overflow-hidden rounded-lg bg-[var(--app-subtle-bg)]"
+                onPointerDown={surfacePointerDown}
+                onContextMenu={props.dragHandleProps?.onSurfaceContextMenu}
+            >
                 <ImagePreview
                     src={previewUrl}
                     fileName={name}
                     label={name}
                     galleryId="composer-attachments"
-                    buttonClassName="group h-full w-full cursor-zoom-in overflow-hidden rounded-lg text-left"
-                    imageClassName="h-full w-full object-cover transition-opacity group-hover:opacity-85"
+                    buttonClassName={`group h-full w-full cursor-zoom-in overflow-hidden rounded-lg text-left ${props.dragHandleProps ? 'touch-none' : ''}`}
+                    imageClassName="h-full w-full object-cover"
+                    onTriggerPointerDown={props.dragHandleProps?.onSurfacePointerDown}
+                    onTriggerContextMenu={props.dragHandleProps?.onSurfaceContextMenu}
+                    onTriggerClick={props.dragHandleProps?.onSurfaceClick}
                     caption={(
                         <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent px-1.5 pb-1 pt-3">
                             <span className="block truncate text-[10px] leading-tight text-white">{name}</span>
                         </div>
                     )}
                 />
+                {props.dragHandleProps ? (
+                    <DragHandle {...props.dragHandleProps} />
+                ) : null}
                 {isUploading ? (
                     <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40">
                         <Spinner size="sm" label={null} className="text-white" />
@@ -66,11 +142,13 @@ export function AttachmentItem() {
                 ) : null}
                 {!isParking ? (
                     <AttachmentPrimitive.Remove
-                        className="absolute right-1 top-1 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-black/65 text-white transition-colors hover:bg-black/85 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-white"
+                        className="hapi-composer-attachment-control absolute right-1 top-1 z-20 flex h-8 w-8 items-start justify-end rounded-md bg-transparent text-white transition-colors hover:bg-black/15 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-white"
                         aria-label="Remove attachment"
                         title="Remove attachment"
                     >
-                        <RemoveIcon />
+                        <span className="flex h-5 w-5 items-center justify-center rounded-md bg-black/40 shadow-sm ring-1 ring-white/20">
+                            <RemoveIcon />
+                        </span>
                     </AttachmentPrimitive.Remove>
                 ) : null}
             </AttachmentPrimitive.Root>
@@ -78,7 +156,12 @@ export function AttachmentItem() {
     }
 
     return (
-        <AttachmentPrimitive.Root className="flex items-center gap-2 rounded-lg bg-[var(--app-subtle-bg)] px-3 py-2 text-base text-[var(--app-fg)]">
+        <AttachmentPrimitive.Root
+            className="relative flex items-center gap-1.5 rounded-lg bg-[var(--app-subtle-bg)] px-2 py-2 text-base text-[var(--app-fg)]"
+            onPointerDown={surfacePointerDown}
+            onContextMenu={props.dragHandleProps?.onSurfaceContextMenu}
+        >
+            {props.dragHandleProps ? <DragHandle {...props.dragHandleProps} isFile /> : null}
             {isUploading ? <Spinner size="sm" label={null} className="text-[var(--app-hint)]" /> : null}
             {isError ? (
                 <span className="text-red-500">
@@ -89,7 +172,7 @@ export function AttachmentItem() {
             {isError ? <span className="text-xs text-red-500 whitespace-nowrap">Upload failed</span> : null}
             {!isParking ? (
                 <AttachmentPrimitive.Remove
-                    className="ml-auto flex h-5 w-5 items-center justify-center rounded text-[var(--app-hint)] transition-colors hover:text-[var(--app-fg)]"
+                    className="hapi-composer-attachment-control hapi-composer-attachment-file-control flex h-4 w-4 shrink-0 items-center justify-center rounded-md bg-transparent text-[var(--app-hint)] transition-colors hover:text-[var(--app-fg)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)]"
                     aria-label="Remove attachment"
                     title="Remove attachment"
                 >

--- a/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.sendError.test.tsx
@@ -108,6 +108,9 @@ vi.mock('@/hooks/useActiveSuggestions', () => ({ useActiveSuggestions: () => [[]
 vi.mock('@/components/ChatInput/FloatingOverlay', () => ({ FloatingOverlay: ({ children }: { children: ReactNode }) => <>{children}</> }))
 vi.mock('@/components/ChatInput/Autocomplete', () => ({ Autocomplete: () => null }))
 vi.mock('@/components/AssistantChat/StatusBar', () => ({ StatusBar: () => null }))
+vi.mock('@/components/AssistantChat/SortableComposerAttachments', () => ({
+    SortableComposerAttachments: () => null,
+}))
 vi.mock('@/components/AssistantChat/ComposerButtons', () => ({
     ComposerButtons: (props: {
         onSend: () => void

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -63,7 +63,7 @@ import { useVoiceInputPreferences } from '@/hooks/useVoiceInputPreferences'
 import { useDictation } from '@/hooks/useDictation'
 import type { ComposerSendIntent } from '@/lib/messageDelivery'
 import type { MessageDeliveryMode } from '@hapi/protocol'
-import { moveAttachmentId, orderItemsById, reconcileAttachmentOrder } from '@/lib/attachmentOrder'
+import { moveAttachmentId, orderItemsById, reconcileAttachmentOrder, type AttachmentDropPosition } from '@/lib/attachmentOrder'
 
 export interface TextInputState {
     text: string
@@ -469,9 +469,9 @@ export function HappyComposer(props: {
     const orderedAttachmentIds = reconcileAttachmentOrder(attachmentOrderRef.current, attachmentIds)
     attachmentOrderRef.current = orderedAttachmentIds
     const [, setAttachmentOrderRevision] = useState(0)
-    const handleAttachmentReorder = useCallback((activeId: string, targetId: string) => {
+    const handleAttachmentReorder = useCallback((activeId: string, targetId: string, position: AttachmentDropPosition) => {
         const currentOrder = reconcileAttachmentOrder(attachmentOrderRef.current, attachmentIds)
-        const nextOrder = moveAttachmentId(currentOrder, activeId, targetId)
+        const nextOrder = moveAttachmentId(currentOrder, activeId, targetId, position)
         if (nextOrder.every((id, index) => id === currentOrder[index])) return
         attachmentOrderRef.current = nextOrder
         setAttachmentOrderRevision((revision) => revision + 1)

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -48,7 +48,7 @@ import { Autocomplete } from '@/components/ChatInput/Autocomplete'
 import { StatusBar } from '@/components/AssistantChat/StatusBar'
 import { ComposerButtons } from '@/components/AssistantChat/ComposerButtons'
 import type { PendingSchedule } from '@/components/AssistantChat/ScheduleTimePicker'
-import { AttachmentItem } from '@/components/AssistantChat/AttachmentItem'
+import { SortableComposerAttachments } from '@/components/AssistantChat/SortableComposerAttachments'
 import { ComposerParkingContext } from '@/components/AssistantChat/composerParkingContext'
 import type { ScratchlistParkResult } from '@/lib/scratchlistAttachmentFlow'
 import { useTranslation } from '@/lib/use-translation'
@@ -63,6 +63,7 @@ import { useVoiceInputPreferences } from '@/hooks/useVoiceInputPreferences'
 import { useDictation } from '@/hooks/useDictation'
 import type { ComposerSendIntent } from '@/lib/messageDelivery'
 import type { MessageDeliveryMode } from '@hapi/protocol'
+import { moveAttachmentId, orderItemsById, reconcileAttachmentOrder } from '@/lib/attachmentOrder'
 
 export interface TextInputState {
     text: string
@@ -381,6 +382,8 @@ export function HappyComposer(props: {
      * queue request after a scratchlist/scheduled/failed early path.
      */
     pendingSendIntentRef?: MutableRefObject<ComposerSendIntent>
+    /** Shared order ref consumed by useHappyRuntime when the message is sent. */
+    attachmentOrderRef?: MutableRefObject<string[]>
     /** Chip hover / aria-label resolver (SessionChat → useSessions). */
     resolveSessionMentionTooltip?: (id: string, title: string) => SessionMentionResolveResult
 }) {
@@ -439,6 +442,7 @@ export function HappyComposer(props: {
         onClearSendError,
         onSuppressSendErrorRestore,
         pendingSendIntentRef,
+        attachmentOrderRef: externalAttachmentOrderRef,
         resolveSessionMentionTooltip,
     } = props
 
@@ -456,6 +460,23 @@ export function HappyComposer(props: {
     const { composerEnterBehavior } = useComposerEnterBehavior()
     const composerText = useAuiState((s) => s.composer.text)
     const attachments = useAuiState((s) => s.composer.attachments)
+    const localAttachmentOrderRef = useRef<string[]>([])
+    const attachmentOrderRef = externalAttachmentOrderRef ?? localAttachmentOrderRef
+    const attachmentIds = useMemo(
+        () => attachments.map((attachment) => attachment.id),
+        [attachments],
+    )
+    const orderedAttachmentIds = reconcileAttachmentOrder(attachmentOrderRef.current, attachmentIds)
+    attachmentOrderRef.current = orderedAttachmentIds
+    const [, setAttachmentOrderRevision] = useState(0)
+    const handleAttachmentReorder = useCallback((activeId: string, targetId: string) => {
+        const currentOrder = reconcileAttachmentOrder(attachmentOrderRef.current, attachmentIds)
+        const nextOrder = moveAttachmentId(currentOrder, activeId, targetId)
+        if (nextOrder.every((id, index) => id === currentOrder[index])) return
+        attachmentOrderRef.current = nextOrder
+        setAttachmentOrderRevision((revision) => revision + 1)
+    }, [attachmentIds, attachmentOrderRef])
+    const orderedAttachments = orderItemsById(attachments, orderedAttachmentIds)
     const threadIsRunning = useAuiState((s) => s.thread.isRunning)
     const threadIsDisabled = useAuiState((s) => s.thread.isDisabled)
     const composerTextRef = useRef(composerText)
@@ -621,7 +642,7 @@ export function HappyComposer(props: {
         onEdit: handleRichEdit,
     } = useRichComposerBridge(api, setInputState, sendError, onClearSendError, recordUserEdit)
 
-    const attachmentDrafts = attachments.flatMap((attachment) => {
+    const attachmentDrafts = orderedAttachments.flatMap((attachment) => {
         if (!attachment.file) return []
         const upload = attachment as typeof attachment & { path?: string; previewUrl?: string; uploadSessionId?: string }
         return [{
@@ -1139,7 +1160,7 @@ export function HappyComposer(props: {
                 const snapshot = api.composer().getState()
                 const prepared = await props.onParkScratchlist(
                     snapshot.text,
-                    snapshot.attachments,
+                    orderItemsById(snapshot.attachments, attachmentOrderRef.current),
                 )
                 if (!prepared) return
                 // Validate before irreversible add — otherwise a mid-flight
@@ -1213,6 +1234,7 @@ export function HappyComposer(props: {
         props.scratchlistMode,
         richMentionsEnabled,
         sendError,
+        attachmentOrderRef,
         pendingSendIntentRef,
         resetPendingSendIntent,
     ])
@@ -2204,7 +2226,12 @@ export function HappyComposer(props: {
                             <div className={`flex flex-wrap gap-2 px-4 pt-3 ${
                                 isExpanded ? 'max-h-[35%] shrink-0 overflow-y-auto' : ''
                             }`}>
-                                <ComposerPrimitive.Attachments components={{ Attachment: AttachmentItem }} />
+                                <SortableComposerAttachments
+                                    attachments={attachments}
+                                    orderedAttachmentIds={orderedAttachmentIds}
+                                    disabled={controlsDisabled}
+                                    onReorder={handleAttachmentReorder}
+                                />
                             </div>
                         ) : null}
 

--- a/web/src/components/AssistantChat/SortableComposerAttachments.test.tsx
+++ b/web/src/components/AssistantChat/SortableComposerAttachments.test.tsx
@@ -68,8 +68,8 @@ function Harness() {
         <SortableComposerAttachments
             attachments={attachments}
             orderedAttachmentIds={order}
-            onReorder={(activeId, targetId) => {
-                setOrder((current) => moveAttachmentId(current, activeId, targetId))
+            onReorder={(activeId, targetId, position) => {
+                setOrder((current) => moveAttachmentId(current, activeId, targetId, position))
             }}
         />
     )
@@ -106,6 +106,10 @@ describe('SortableComposerAttachments', () => {
         })
 
         const { container } = render(<Harness />)
+        vi.spyOn(
+            container.querySelector('[data-hapi-composer-attachment-id="c"]')!,
+            'getBoundingClientRect',
+        ).mockReturnValue({ left: 100, width: 100, right: 200, top: 0, bottom: 50, height: 50 } as DOMRect)
         const handle = screen.getByRole('button', { name: 'Reorder attachment a.png' })
 
         act(() => {
@@ -120,6 +124,33 @@ describe('SortableComposerAttachments', () => {
         ).map((element) => element.dataset.hapiComposerAttachmentId)).toEqual(['b', 'a', 'c'])
     })
 
+    it('moves the first attachment after the second when dragged across its midpoint', () => {
+        const elementsFromPoint = vi.fn(() => [
+            document.querySelector('[data-hapi-composer-attachment-id="b"]')!,
+        ])
+        Object.defineProperty(document, 'elementsFromPoint', {
+            configurable: true,
+            value: elementsFromPoint,
+        })
+
+        const { container } = render(<Harness />)
+        vi.spyOn(
+            container.querySelector('[data-hapi-composer-attachment-id="b"]')!,
+            'getBoundingClientRect',
+        ).mockReturnValue({ left: 0, width: 100, right: 100, top: 0, bottom: 50, height: 50 } as DOMRect)
+        const handle = screen.getByRole('button', { name: 'Reorder attachment a.png' })
+
+        act(() => {
+            dispatchPointerEvent(handle, 'pointerdown', { button: 0, pointerId: 3, clientX: 0, clientY: 0 })
+            dispatchPointerEvent(handle, 'pointermove', { pointerId: 3, clientX: 80, clientY: 0 })
+            dispatchPointerEvent(handle, 'pointerup', { pointerId: 3, clientX: 80, clientY: 0 })
+        })
+
+        expect(Array.from(
+            container.querySelectorAll<HTMLElement>('[data-hapi-composer-attachment-id]'),
+        ).map((element) => element.dataset.hapiComposerAttachmentId)).toEqual(['b', 'a', 'c'])
+    })
+
     it('supports keyboard movement through the same ordering path', () => {
         const { container } = render(<Harness />)
         fireEvent.keyDown(screen.getByRole('button', { name: 'Reorder attachment b.txt' }), { key: 'ArrowLeft' })
@@ -127,6 +158,15 @@ describe('SortableComposerAttachments', () => {
         expect(Array.from(
             container.querySelectorAll<HTMLElement>('[data-hapi-composer-attachment-id]'),
         ).map((element) => element.dataset.hapiComposerAttachmentId)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('moves an attachment right with the keyboard', () => {
+        const { container } = render(<Harness />)
+        fireEvent.keyDown(screen.getByRole('button', { name: 'Reorder attachment b.txt' }), { key: 'ArrowRight' })
+
+        expect(Array.from(
+            container.querySelectorAll<HTMLElement>('[data-hapi-composer-attachment-id]'),
+        ).map((element) => element.dataset.hapiComposerAttachmentId)).toEqual(['a', 'c', 'b'])
     })
 
     it('starts a drag from an image surface and suppresses its long-press menu', () => {
@@ -139,6 +179,10 @@ describe('SortableComposerAttachments', () => {
         })
 
         const { container } = render(<Harness />)
+        vi.spyOn(
+            container.querySelector('[data-hapi-composer-attachment-id="c"]')!,
+            'getBoundingClientRect',
+        ).mockReturnValue({ left: 100, width: 100, right: 200, top: 0, bottom: 50, height: 50 } as DOMRect)
         const surface = screen.getAllByTestId('attachment-surface')[0]!
         const contextMenu = new Event('contextmenu', { bubbles: true, cancelable: true })
 

--- a/web/src/components/AssistantChat/SortableComposerAttachments.test.tsx
+++ b/web/src/components/AssistantChat/SortableComposerAttachments.test.tsx
@@ -1,0 +1,160 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useState } from 'react'
+import type React from 'react'
+import { moveAttachmentId } from '@/lib/attachmentOrder'
+
+vi.mock('@assistant-ui/react', async () => {
+    const React = await import('react')
+    return {
+        ComposerPrimitive: {
+            AttachmentByIndex: (props: {
+                index: number
+                components?: { Attachment?: React.ComponentType }
+            }) => {
+                const Component = props.components?.Attachment
+                return (
+                    <div data-testid={`attachment-index-${props.index}`}>
+                        {Component ? <Component /> : null}
+                    </div>
+                )
+            },
+        },
+    }
+})
+
+vi.mock('./AttachmentItem', () => ({
+    AttachmentItem: (props: {
+        dragHandleProps?: {
+            onPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => void
+            onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void
+            ariaLabel: string
+            title: string
+            onSurfacePointerDown?: (event: React.PointerEvent<HTMLElement>) => void
+            onSurfaceContextMenu?: (event: React.MouseEvent<HTMLElement>) => void
+            onSurfaceClick?: (event: React.MouseEvent<HTMLElement>) => void
+        }
+    }) => props.dragHandleProps ? (
+        <>
+            <button
+                type="button"
+                data-testid="attachment-drag-handle"
+                aria-label={props.dragHandleProps.ariaLabel}
+                title={props.dragHandleProps.title}
+                onPointerDown={props.dragHandleProps.onPointerDown}
+                onKeyDown={props.dragHandleProps.onKeyDown}
+            />
+            <div
+                data-testid="attachment-surface"
+                onPointerDown={props.dragHandleProps.onSurfacePointerDown}
+                onContextMenu={props.dragHandleProps.onSurfaceContextMenu}
+                onClick={props.dragHandleProps.onSurfaceClick}
+            />
+        </>
+    ) : null,
+}))
+
+import { SortableComposerAttachments } from './SortableComposerAttachments'
+
+const attachments = [
+    { id: 'a', name: 'a.png', type: 'file', contentType: 'image/png' },
+    { id: 'b', name: 'b.txt', type: 'file', contentType: 'text/plain' },
+    { id: 'c', name: 'c.png', type: 'file', contentType: 'image/png' },
+] as never[]
+
+function Harness() {
+    const [order, setOrder] = useState(['a', 'b', 'c'])
+    return (
+        <SortableComposerAttachments
+            attachments={attachments}
+            orderedAttachmentIds={order}
+            onReorder={(activeId, targetId) => {
+                setOrder((current) => moveAttachmentId(current, activeId, targetId))
+            }}
+        />
+    )
+}
+
+function dispatchPointerEvent(
+    target: EventTarget,
+    type: string,
+    init: { button?: number; pointerId: number; clientX: number; clientY: number },
+): void {
+    const event = new Event(type, { bubbles: true, cancelable: true })
+    Object.defineProperties(event, {
+        button: { value: init.button ?? 0 },
+        pointerId: { value: init.pointerId },
+        clientX: { value: init.clientX },
+        clientY: { value: init.clientY },
+    })
+    target.dispatchEvent(event)
+}
+
+afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+})
+
+describe('SortableComposerAttachments', () => {
+    it('reorders an image or file when its drag handle crosses another attachment', () => {
+        const elementsFromPoint = vi.fn(() => [
+            document.querySelector('[data-hapi-composer-attachment-id="c"]')!,
+        ])
+        Object.defineProperty(document, 'elementsFromPoint', {
+            configurable: true,
+            value: elementsFromPoint,
+        })
+
+        const { container } = render(<Harness />)
+        const handle = screen.getByRole('button', { name: 'Reorder attachment a.png' })
+
+        act(() => {
+            dispatchPointerEvent(handle, 'pointerdown', { button: 0, pointerId: 1, clientX: 0, clientY: 0 })
+            dispatchPointerEvent(handle, 'pointermove', { pointerId: 1, clientX: 20, clientY: 0 })
+            dispatchPointerEvent(handle, 'pointerup', { pointerId: 1, clientX: 20, clientY: 0 })
+        })
+
+        expect(elementsFromPoint).toHaveBeenCalled()
+        expect(Array.from(
+            container.querySelectorAll<HTMLElement>('[data-hapi-composer-attachment-id]'),
+        ).map((element) => element.dataset.hapiComposerAttachmentId)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('supports keyboard movement through the same ordering path', () => {
+        const { container } = render(<Harness />)
+        fireEvent.keyDown(screen.getByRole('button', { name: 'Reorder attachment b.txt' }), { key: 'ArrowLeft' })
+
+        expect(Array.from(
+            container.querySelectorAll<HTMLElement>('[data-hapi-composer-attachment-id]'),
+        ).map((element) => element.dataset.hapiComposerAttachmentId)).toEqual(['b', 'a', 'c'])
+    })
+
+    it('starts a drag from an image surface and suppresses its long-press menu', () => {
+        const elementsFromPoint = vi.fn(() => [
+            document.querySelector('[data-hapi-composer-attachment-id="c"]')!,
+        ])
+        Object.defineProperty(document, 'elementsFromPoint', {
+            configurable: true,
+            value: elementsFromPoint,
+        })
+
+        const { container } = render(<Harness />)
+        const surface = screen.getAllByTestId('attachment-surface')[0]!
+        const contextMenu = new Event('contextmenu', { bubbles: true, cancelable: true })
+
+        act(() => {
+            dispatchPointerEvent(surface, 'pointerdown', { button: 0, pointerId: 2, clientX: 0, clientY: 0 })
+        })
+        surface.dispatchEvent(contextMenu)
+        expect(contextMenu.defaultPrevented).toBe(true)
+
+        act(() => {
+            dispatchPointerEvent(surface, 'pointermove', { pointerId: 2, clientX: 20, clientY: 0 })
+            dispatchPointerEvent(surface, 'pointerup', { pointerId: 2, clientX: 20, clientY: 0 })
+        })
+
+        expect(Array.from(
+            container.querySelectorAll<HTMLElement>('[data-hapi-composer-attachment-id]'),
+        ).map((element) => element.dataset.hapiComposerAttachmentId)).toEqual(['b', 'a', 'c'])
+    })
+})

--- a/web/src/components/AssistantChat/SortableComposerAttachments.tsx
+++ b/web/src/components/AssistantChat/SortableComposerAttachments.tsx
@@ -1,0 +1,262 @@
+import { ComposerPrimitive } from '@assistant-ui/react'
+import type { Attachment } from '@assistant-ui/react'
+import {
+    type KeyboardEvent as ReactKeyboardEvent,
+    type MouseEvent as ReactMouseEvent,
+    type PointerEvent as ReactPointerEvent,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react'
+import { AttachmentItem, type AttachmentDragHandleProps } from './AttachmentItem'
+
+const DRAG_START_DISTANCE_PX = 6
+
+type DragState = {
+    id: string
+    pointerId: number
+    startX: number
+    startY: number
+    started: boolean
+}
+
+type SortableComposerAttachmentProps = {
+    attachment: Attachment
+    index: number
+    isDragging: boolean
+    disabled: boolean
+    onPointerDown: (event: ReactPointerEvent<Element>, id: string, surface: boolean) => void
+    onKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>, id: string) => void
+    onContextMenu: (event: ReactMouseEvent<Element>, id: string) => void
+    onClick: (event: ReactMouseEvent<Element>, id: string) => void
+}
+
+function findAttachmentIdAtPoint(clientX: number, clientY: number): string | null {
+    if (typeof document.elementsFromPoint !== 'function') return null
+
+    for (const element of document.elementsFromPoint(clientX, clientY)) {
+        const target = element.closest<HTMLElement>('[data-hapi-composer-attachment-id]')
+        const id = target?.dataset.hapiComposerAttachmentId
+        if (id) return id
+    }
+    return null
+}
+
+function SortableComposerAttachment(props: SortableComposerAttachmentProps) {
+    const {
+        attachment,
+        index,
+        isDragging,
+        disabled,
+        onPointerDown,
+        onKeyDown,
+        onContextMenu,
+        onClick,
+    } = props
+    const handlePointerDown = useCallback(
+        (event: ReactPointerEvent<HTMLButtonElement>) => onPointerDown(event, attachment.id, false),
+        [attachment.id, onPointerDown],
+    )
+    const handleSurfacePointerDown = useCallback(
+        (event: ReactPointerEvent<HTMLElement>) => onPointerDown(event, attachment.id, true),
+        [attachment.id, onPointerDown],
+    )
+    const handleKeyDown = useCallback(
+        (event: ReactKeyboardEvent<HTMLButtonElement>) => onKeyDown(event, attachment.id),
+        [attachment.id, onKeyDown],
+    )
+    const handleContextMenu = useCallback(
+        (event: ReactMouseEvent<HTMLElement>) => onContextMenu(event, attachment.id),
+        [attachment.id, onContextMenu],
+    )
+    const handleClick = useCallback(
+        (event: ReactMouseEvent<HTMLElement>) => onClick(event, attachment.id),
+        [attachment.id, onClick],
+    )
+    const dragHandleProps = useMemo<AttachmentDragHandleProps | undefined>(
+        () => disabled
+            ? undefined
+            : {
+                onPointerDown: handlePointerDown,
+                onKeyDown: handleKeyDown,
+                ariaLabel: `Reorder attachment ${attachment.name}`,
+                title: 'Drag to reorder attachment',
+                onSurfacePointerDown: handleSurfacePointerDown,
+                onSurfaceContextMenu: handleContextMenu,
+                onSurfaceClick: handleClick,
+            },
+        [attachment.name, disabled, handleKeyDown, handlePointerDown],
+    )
+    const AttachmentWithHandle = useCallback(
+        () => <AttachmentItem dragHandleProps={dragHandleProps} />,
+        [dragHandleProps],
+    )
+
+    return (
+        <div
+            data-hapi-composer-attachment-id={attachment.id}
+            data-hapi-composer-attachment-dragging={isDragging || undefined}
+            className={isDragging ? 'opacity-60' : undefined}
+        >
+            <ComposerPrimitive.AttachmentByIndex
+                index={index}
+                components={{ Attachment: AttachmentWithHandle }}
+            />
+        </div>
+    )
+}
+
+export function SortableComposerAttachments(props: {
+    attachments: readonly Attachment[]
+    orderedAttachmentIds: readonly string[]
+    disabled?: boolean
+    onReorder: (activeId: string, targetId: string) => void
+}) {
+    const { attachments, orderedAttachmentIds, onReorder, disabled = false } = props
+    const [draggingId, setDraggingId] = useState<string | null>(null)
+    const dragRef = useRef<DragState | null>(null)
+    const suppressClickIdRef = useRef<string | null>(null)
+
+    useEffect(() => {
+        const handlePointerMove = (event: PointerEvent) => {
+            const drag = dragRef.current
+            if (!drag || drag.pointerId !== event.pointerId) return
+
+            if (!drag.started) {
+                const distance = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY)
+                if (distance < DRAG_START_DISTANCE_PX) return
+                drag.started = true
+                event.preventDefault()
+                setDraggingId(drag.id)
+            }
+
+            const targetId = findAttachmentIdAtPoint(event.clientX, event.clientY)
+            if (targetId && targetId !== drag.id) {
+                onReorder(drag.id, targetId)
+            }
+        }
+
+        const finishDrag = (event: PointerEvent) => {
+            const drag = dragRef.current
+            if (!drag || drag.pointerId !== event.pointerId) return
+            if (drag.started) {
+                suppressClickIdRef.current = drag.id
+            }
+            dragRef.current = null
+            setDraggingId(null)
+        }
+
+        document.addEventListener('pointermove', handlePointerMove)
+        document.addEventListener('pointerup', finishDrag)
+        document.addEventListener('pointercancel', finishDrag)
+        return () => {
+            document.removeEventListener('pointermove', handlePointerMove)
+            document.removeEventListener('pointerup', finishDrag)
+            document.removeEventListener('pointercancel', finishDrag)
+        }
+    }, [onReorder])
+
+    const handlePointerDown = useCallback(
+        (event: ReactPointerEvent<Element>, id: string, surface: boolean) => {
+            if (disabled || event.button !== 0) return
+            if (!surface) {
+                event.preventDefault()
+                event.stopPropagation()
+            }
+            if (typeof event.currentTarget.setPointerCapture === 'function') {
+                event.currentTarget.setPointerCapture(event.pointerId)
+            }
+            dragRef.current = {
+                id,
+                pointerId: event.pointerId,
+                startX: event.clientX,
+                startY: event.clientY,
+                started: false,
+            }
+        },
+        [disabled],
+    )
+
+    const handleContextMenu = useCallback(
+        (event: ReactMouseEvent<Element>, id: string) => {
+            if (dragRef.current?.id !== id && suppressClickIdRef.current !== id) return
+            event.preventDefault()
+            event.stopPropagation()
+        },
+        [],
+    )
+
+    const handleClick = useCallback(
+        (event: ReactMouseEvent<Element>, id: string) => {
+            if (suppressClickIdRef.current !== id) return
+            event.preventDefault()
+            event.stopPropagation()
+            suppressClickIdRef.current = null
+        },
+        [],
+    )
+
+    const handleKeyDown = useCallback(
+        (event: ReactKeyboardEvent<HTMLButtonElement>, id: string) => {
+            if (disabled) return
+
+            const currentIndex = orderedAttachmentIds.indexOf(id)
+            if (currentIndex < 0) return
+
+            let targetIndex: number | null = null
+            if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+                targetIndex = currentIndex - 1
+            } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+                targetIndex = currentIndex + 1
+            } else if (event.key === 'Home') {
+                targetIndex = 0
+            } else if (event.key === 'End') {
+                targetIndex = orderedAttachmentIds.length - 1
+            }
+
+            if (
+                targetIndex === null
+                || targetIndex < 0
+                || targetIndex >= orderedAttachmentIds.length
+                || targetIndex === currentIndex
+            ) {
+                return
+            }
+
+            event.preventDefault()
+            onReorder(id, orderedAttachmentIds[targetIndex]!)
+        },
+        [disabled, onReorder, orderedAttachmentIds],
+    )
+
+    const attachmentById = useMemo(
+        () => new Map(attachments.map((attachment) => [attachment.id, attachment])),
+        [attachments],
+    )
+
+    return (
+        <>
+            {orderedAttachmentIds.map((id) => {
+                const attachment = attachmentById.get(id)
+                if (!attachment) return null
+                const index = attachments.findIndex((item) => item.id === id)
+                if (index < 0) return null
+                return (
+                    <SortableComposerAttachment
+                        key={id}
+                        attachment={attachment}
+                        index={index}
+                        isDragging={draggingId === id}
+                        disabled={disabled}
+                        onPointerDown={handlePointerDown}
+                        onKeyDown={handleKeyDown}
+                        onContextMenu={handleContextMenu}
+                        onClick={handleClick}
+                    />
+                )
+            })}
+        </>
+    )
+}

--- a/web/src/components/AssistantChat/SortableComposerAttachments.tsx
+++ b/web/src/components/AssistantChat/SortableComposerAttachments.tsx
@@ -10,6 +10,7 @@ import {
     useRef,
     useState,
 } from 'react'
+import { type AttachmentDropPosition } from '@/lib/attachmentOrder'
 import { AttachmentItem, type AttachmentDragHandleProps } from './AttachmentItem'
 
 const DRAG_START_DISTANCE_PX = 6
@@ -33,13 +34,22 @@ type SortableComposerAttachmentProps = {
     onClick: (event: ReactMouseEvent<Element>, id: string) => void
 }
 
-function findAttachmentIdAtPoint(clientX: number, clientY: number): string | null {
+type AttachmentDropTarget = {
+    id: string
+    position: AttachmentDropPosition
+}
+
+function findAttachmentDropTarget(clientX: number, clientY: number): AttachmentDropTarget | null {
     if (typeof document.elementsFromPoint !== 'function') return null
 
     for (const element of document.elementsFromPoint(clientX, clientY)) {
         const target = element.closest<HTMLElement>('[data-hapi-composer-attachment-id]')
         const id = target?.dataset.hapiComposerAttachmentId
-        if (id) return id
+        if (id && target) {
+            const rect = target.getBoundingClientRect()
+            const position = clientX >= rect.left + rect.width / 2 ? 'after' : 'before'
+            return { id, position }
+        }
     }
     return null
 }
@@ -112,7 +122,7 @@ export function SortableComposerAttachments(props: {
     attachments: readonly Attachment[]
     orderedAttachmentIds: readonly string[]
     disabled?: boolean
-    onReorder: (activeId: string, targetId: string) => void
+    onReorder: (activeId: string, targetId: string, position: AttachmentDropPosition) => void
 }) {
     const { attachments, orderedAttachmentIds, onReorder, disabled = false } = props
     const [draggingId, setDraggingId] = useState<string | null>(null)
@@ -132,9 +142,9 @@ export function SortableComposerAttachments(props: {
                 setDraggingId(drag.id)
             }
 
-            const targetId = findAttachmentIdAtPoint(event.clientX, event.clientY)
-            if (targetId && targetId !== drag.id) {
-                onReorder(drag.id, targetId)
+            const target = findAttachmentDropTarget(event.clientX, event.clientY)
+            if (target && target.id !== drag.id) {
+                onReorder(drag.id, target.id, target.position)
             }
         }
 
@@ -206,14 +216,17 @@ export function SortableComposerAttachments(props: {
             if (currentIndex < 0) return
 
             let targetIndex: number | null = null
+            let targetPosition: AttachmentDropPosition = 'before'
             if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
                 targetIndex = currentIndex - 1
             } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
                 targetIndex = currentIndex + 1
+                targetPosition = 'after'
             } else if (event.key === 'Home') {
                 targetIndex = 0
             } else if (event.key === 'End') {
                 targetIndex = orderedAttachmentIds.length - 1
+                targetPosition = 'after'
             }
 
             if (
@@ -226,7 +239,7 @@ export function SortableComposerAttachments(props: {
             }
 
             event.preventDefault()
-            onReorder(id, orderedAttachmentIds[targetIndex]!)
+            onReorder(id, orderedAttachmentIds[targetIndex]!, targetPosition)
         },
         [disabled, onReorder, orderedAttachmentIds],
     )

--- a/web/src/components/ImagePreview.test.tsx
+++ b/web/src/components/ImagePreview.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { ImagePreview } from './ImagePreview'
 
 function renderGallery() {
@@ -57,5 +57,32 @@ describe('ImagePreview gallery navigation', () => {
         fireEvent.click(within(dialog).getByRole('button', { name: 'Next image' }))
         expect(screen.getByRole('dialog', { name: 'Second draft' })).toBeInTheDocument()
         expect(within(screen.getByRole('dialog')).queryByRole('img', { name: 'Sent image' })).not.toBeInTheDocument()
+    })
+
+    it('exposes trigger pointer and context-menu hooks for sortable image attachments', () => {
+        const onTriggerPointerDown = vi.fn()
+        const onTriggerContextMenu = vi.fn()
+        const onTriggerClick = vi.fn()
+
+        render(
+            <ImagePreview
+                src="/drag.png"
+                fileName="drag.png"
+                label="Drag image"
+                onTriggerPointerDown={onTriggerPointerDown}
+                onTriggerContextMenu={onTriggerContextMenu}
+                onTriggerClick={onTriggerClick}
+            />
+        )
+
+        const trigger = screen.getByRole('button', { name: /drag image/i })
+        fireEvent.pointerDown(trigger)
+        fireEvent.contextMenu(trigger)
+        fireEvent.click(trigger)
+
+        expect(onTriggerPointerDown).toHaveBeenCalledTimes(1)
+        expect(onTriggerContextMenu).toHaveBeenCalledTimes(1)
+        expect(onTriggerClick).toHaveBeenCalledTimes(1)
+        expect(screen.getByRole('dialog', { name: 'Drag image' })).toBeInTheDocument()
     })
 })

--- a/web/src/components/ImagePreview.tsx
+++ b/web/src/components/ImagePreview.tsx
@@ -38,6 +38,9 @@ export function ImagePreview(props: {
     imageStyle?: CSSProperties
     caption?: ReactNode
     galleryId?: string
+    onTriggerPointerDown?: (event: PointerEvent<HTMLButtonElement>) => void
+    onTriggerContextMenu?: (event: MouseEvent<HTMLButtonElement>) => void
+    onTriggerClick?: (event: MouseEvent<HTMLButtonElement>) => void
 }) {
     const [viewerOpen, setViewerOpen] = useState(false)
     const [previewImages, setPreviewImages] = useState<PreviewImage[]>([])
@@ -75,6 +78,17 @@ export function ImagePreview(props: {
         setPreviewIndex(index >= 0 ? index : 0)
         setViewerOpen(true)
     }, [props.galleryId])
+
+    const handleTriggerPointerDown = useCallback((event: PointerEvent<HTMLButtonElement>) => {
+        props.onTriggerPointerDown?.(event)
+        stopEvent(event)
+    }, [props.onTriggerPointerDown, stopEvent])
+
+    const handleTriggerClick = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+        props.onTriggerClick?.(event)
+        if (event.defaultPrevented) return
+        openViewer(event)
+    }, [openViewer, props.onTriggerClick])
 
     const updateScale = useCallback((next: number | ((current: number) => number)) => {
         setScale((current) => {
@@ -259,10 +273,11 @@ export function ImagePreview(props: {
         <>
             <button
                 type="button"
-                onPointerDown={stopEvent}
+                onPointerDown={handleTriggerPointerDown}
                 onMouseDown={stopEvent}
                 onTouchStart={stopEvent}
-                onClick={openViewer}
+                onContextMenu={props.onTriggerContextMenu}
+                onClick={handleTriggerClick}
                 data-image-preview-trigger=""
                 data-image-preview-file-name={props.fileName}
                 data-image-preview-label={props.label}

--- a/web/src/components/SessionChat.test.ts
+++ b/web/src/components/SessionChat.test.ts
@@ -6,6 +6,7 @@ import {
     isScratchlistHotkeyBlockedTarget,
     isScratchlistToggleHotkey,
     isSelectAllTargetBlocked,
+    mergeStagedAttachmentsInOrder,
     resolvePiContextWindow,
     resolveLatestCompletedBoundaryIdForView,
     shouldAutoClearPendingSchedule,
@@ -238,6 +239,29 @@ describe('shouldRouteToScratchlist', () => {
         expect(routed).toBe(true)
         const shouldClearAfterAccepted = !routed
         expect(shouldClearAfterAccepted).toBe(false)
+    })
+})
+
+describe('mergeStagedAttachmentsInOrder', () => {
+    function attachment(id: string, path: string): AttachmentMetadata {
+        return {
+            id,
+            filename: `${id}.png`,
+            mimeType: 'image/png',
+            size: 1024,
+            path,
+        }
+    }
+
+    it('replaces staged hub attachments without changing mixed attachment order', () => {
+        const hubAttachment = attachment('hub-a', 'hapi-hub:scratchlist/default/session/hub-a.png')
+        const normalAttachment = attachment('normal-b', '/tmp/normal-b.png')
+        const stagedAttachment = attachment('hub-a', '/tmp/staged-hub-a.png')
+
+        expect(mergeStagedAttachmentsInOrder(
+            [hubAttachment, normalAttachment],
+            [stagedAttachment],
+        )).toEqual([stagedAttachment, normalAttachment])
     })
 })
 

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -313,6 +313,14 @@ export function shouldRouteToScratchlist(
     return (attachments ?? []).every((att) => isHubScratchlistAttachmentPath(att.path))
 }
 
+export function mergeStagedAttachmentsInOrder(
+    attachments: readonly AttachmentMetadata[],
+    staged: readonly AttachmentMetadata[],
+): AttachmentMetadata[] {
+    const stagedById = new Map(staged.map((attachment) => [attachment.id, attachment]))
+    return attachments.map((attachment) => stagedById.get(attachment.id) ?? attachment)
+}
+
 function isUninvokedScheduledMessage(message: DecryptedMessage): boolean {
     return message.invokedAt == null && message.scheduledAt != null
 }
@@ -825,15 +833,15 @@ function SessionChatInner(props: SessionChatProps) {
             const list = attachments ?? []
             const hubItems = list.filter((att) => isHubScratchlistAttachmentPath(att.path))
             if (hubItems.length > 0) {
-                const normalItems = list.filter((att) => !isHubScratchlistAttachmentPath(att.path))
                 const staged = await stageScratchlistAttachmentsForComposeSend(
                     props.api,
                     props.session.id,
                     hubItems,
                 )
+                const ordered = mergeStagedAttachmentsInOrder(list, staged)
                 const accepted = await props.onSend(
                     text,
-                    [...normalItems, ...staged],
+                    ordered,
                     scheduledAt,
                     deliveryMode,
                 )

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1564,6 +1564,7 @@ function SessionChatInner(props: SessionChatProps) {
     // turn, so explicit or retry-safe queue intents never stick to later
     // ordinary sends.
     const pendingSendIntentRef = useRef<ComposerSendIntent>('default')
+    const attachmentOrderRef = useRef<string[]>([])
     const restoredSendErrorIdRef = useRef<number | null>(null)
 
     useEffect(() => {
@@ -1706,6 +1707,7 @@ function SessionChatInner(props: SessionChatProps) {
         isSending: props.isSending,
         isRunning: props.session.thinking || hasRunningChildAgent,
         onSendMessage: handleSend,
+        attachmentOrderRef,
         onAbort: handleAbort,
         attachmentAdapter,
         allowSendWhenInactive: true,
@@ -1880,6 +1882,7 @@ function SessionChatInner(props: SessionChatProps) {
                         onUploadDraftSnapshot={(text, attachments) => {
                             uploadDraftSnapshotRef.current = { text, attachments }
                         }}
+                        attachmentOrderRef={attachmentOrderRef}
                         resolveSessionMentionTooltip={resolveSessionMentionTooltip}
                         disabled={props.isSending}
                         pendingSchedule={pendingSchedule}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -672,3 +672,26 @@ html[data-theme="oled"] .shiki span:not([data-line-number]) {
   bottom: 50% !important;
   transform: translateY(50%);
 }
+
+/* Composer attachment controls stay discoverable on touch, but stay quiet
+   until the attachment is targeted on mouse-driven layouts. */
+@media (hover: hover) and (pointer: fine) {
+  .hapi-composer-attachment-control {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 150ms ease;
+  }
+
+  [data-hapi-composer-attachment-id]:hover .hapi-composer-attachment-control,
+  [data-hapi-composer-attachment-id]:focus-within .hapi-composer-attachment-control,
+  [data-hapi-composer-attachment-dragging] .hapi-composer-attachment-control {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .hapi-composer-attachment-control.hapi-composer-attachment-file-control {
+    opacity: 1;
+    pointer-events: auto;
+    transition: none;
+  }
+}

--- a/web/src/lib/assistant-runtime.ts
+++ b/web/src/lib/assistant-runtime.ts
@@ -15,6 +15,7 @@ import type { AgentEvent, ToolCallBlock } from '@/chat/types'
 import type { ToolGroupBlock, VisibleChatBlock } from '@/chat/toolGroups'
 import { visibleBlockRole } from '@/chat/toolGroups'
 import type { AttachmentMetadata, MessageStatus as HappyMessageStatus, Session } from '@/types/api'
+import { orderItemsById } from '@/lib/attachmentOrder'
 
 /**
  * Aggregated metadata for a multi-turn response group, surfaced on the
@@ -749,6 +750,7 @@ export function useHappyRuntime(props: {
         scheduledAt?: number | null,
         intent?: ComposerSendIntent,
     ) => void
+    attachmentOrderRef?: React.MutableRefObject<string[]>
     onAbort: () => Promise<void>
     attachmentAdapter?: AttachmentAdapter
     allowSendWhenInactive?: boolean
@@ -925,14 +927,23 @@ export function useHappyRuntime(props: {
         // failure, or downstream exception cannot leak an explicit queue
         // gesture into the next ordinary send.
         const { text, attachments } = extractMessageContent(message)
-        if (!text && attachments.length === 0) return
+        const orderedAttachments = orderItemsById(
+            attachments,
+            props.attachmentOrderRef?.current ?? [],
+        )
+        if (!text && orderedAttachments.length === 0) return
         // Resolve pendingSchedule at send time (Date.now()) so preset-type schedules
         // ("5 minutes from now") are relative to the actual send action, not the
         // moment the user clicked the preset button.
         const sendNow = Date.now()
         const scheduledAt = resolvePendingSchedule(props.pendingScheduleRef?.current ?? null, sendNow)
-        props.onSendMessage(text, attachments.length > 0 ? attachments : undefined, scheduledAt, intent)
-    }, [props.onSendMessage, props.pendingScheduleRef, props.pendingSendIntentRef])
+        props.onSendMessage(
+            text,
+            orderedAttachments.length > 0 ? orderedAttachments : undefined,
+            scheduledAt,
+            intent,
+        )
+    }, [props.attachmentOrderRef, props.onSendMessage, props.pendingScheduleRef, props.pendingSendIntentRef])
 
     const onCancel = useCallback(async () => {
         await props.onAbort()

--- a/web/src/lib/attachmentOrder.test.ts
+++ b/web/src/lib/attachmentOrder.test.ts
@@ -9,6 +9,7 @@ describe('attachment order helpers', () => {
     it('moves an attachment immediately before the drop target', () => {
         expect(moveAttachmentId(['a', 'b', 'c'], 'a', 'c')).toEqual(['b', 'a', 'c'])
         expect(moveAttachmentId(['a', 'b', 'c'], 'c', 'a')).toEqual(['c', 'a', 'b'])
+        expect(moveAttachmentId(['a', 'b', 'c'], 'a', 'b', 'after')).toEqual(['b', 'a', 'c'])
     })
 
     it('orders objects without dropping ids unknown to the order list', () => {

--- a/web/src/lib/attachmentOrder.test.ts
+++ b/web/src/lib/attachmentOrder.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { moveAttachmentId, orderItemsById, reconcileAttachmentOrder } from './attachmentOrder'
+
+describe('attachment order helpers', () => {
+    it('keeps existing order while appending newly added attachments', () => {
+        expect(reconcileAttachmentOrder(['b', 'stale', 'a'], ['a', 'b', 'c'])).toEqual(['b', 'a', 'c'])
+    })
+
+    it('moves an attachment immediately before the drop target', () => {
+        expect(moveAttachmentId(['a', 'b', 'c'], 'a', 'c')).toEqual(['b', 'a', 'c'])
+        expect(moveAttachmentId(['a', 'b', 'c'], 'c', 'a')).toEqual(['c', 'a', 'b'])
+    })
+
+    it('orders objects without dropping ids unknown to the order list', () => {
+        const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+        expect(orderItemsById(items, ['c', 'a'])).toEqual([{ id: 'c' }, { id: 'a' }, { id: 'b' }])
+    })
+})

--- a/web/src/lib/attachmentOrder.ts
+++ b/web/src/lib/attachmentOrder.ts
@@ -21,22 +21,23 @@ export function reconcileAttachmentOrder(
     return next
 }
 
-/** Move an item immediately before the target item. */
+export type AttachmentDropPosition = 'before' | 'after'
+
 export function moveAttachmentId(
     order: readonly string[],
     activeId: string,
     targetId: string,
+    position: AttachmentDropPosition = 'before',
 ): string[] {
     if (activeId === targetId) return [...order]
 
     const next = [...order]
     const activeIndex = next.indexOf(activeId)
-    const targetIndex = next.indexOf(targetId)
-    if (activeIndex < 0 || targetIndex < 0) return next
+    if (activeIndex < 0 || next.indexOf(targetId) < 0) return next
 
     const [active] = next.splice(activeIndex, 1)
     const insertionIndex = next.indexOf(targetId)
-    next.splice(insertionIndex < 0 ? targetIndex : insertionIndex, 0, active!)
+    next.splice(insertionIndex + (position === 'after' ? 1 : 0), 0, active!)
     return next
 }
 

--- a/web/src/lib/attachmentOrder.ts
+++ b/web/src/lib/attachmentOrder.ts
@@ -1,0 +1,65 @@
+export function reconcileAttachmentOrder(
+    previous: readonly string[],
+    current: readonly string[],
+): string[] {
+    const currentIds = new Set(current)
+    const next: string[] = []
+    const seen = new Set<string>()
+
+    for (const id of previous) {
+        if (!currentIds.has(id) || seen.has(id)) continue
+        next.push(id)
+        seen.add(id)
+    }
+
+    for (const id of current) {
+        if (seen.has(id)) continue
+        next.push(id)
+        seen.add(id)
+    }
+
+    return next
+}
+
+/** Move an item immediately before the target item. */
+export function moveAttachmentId(
+    order: readonly string[],
+    activeId: string,
+    targetId: string,
+): string[] {
+    if (activeId === targetId) return [...order]
+
+    const next = [...order]
+    const activeIndex = next.indexOf(activeId)
+    const targetIndex = next.indexOf(targetId)
+    if (activeIndex < 0 || targetIndex < 0) return next
+
+    const [active] = next.splice(activeIndex, 1)
+    const insertionIndex = next.indexOf(targetId)
+    next.splice(insertionIndex < 0 ? targetIndex : insertionIndex, 0, active!)
+    return next
+}
+
+export function orderItemsById<T extends { id: string }>(
+    items: readonly T[],
+    order: readonly string[],
+): T[] {
+    const byId = new Map(items.map((item) => [item.id, item]))
+    const seen = new Set<string>()
+    const ordered: T[] = []
+
+    for (const id of order) {
+        const item = byId.get(id)
+        if (!item || seen.has(id)) continue
+        ordered.push(item)
+        seen.add(id)
+    }
+
+    for (const item of items) {
+        if (seen.has(item.id)) continue
+        ordered.push(item)
+        seen.add(item.id)
+    }
+
+    return ordered
+}


### PR DESCRIPTION
## Problem / Motivation

Composer attachments could not be reordered, so users had to remove and re-add files to control the order sent to the agent. Image attachments also needed drag gestures that would not accidentally open the preview or trigger a context menu.

## Summary

- Add pointer, touch, and keyboard reordering for image and non-image composer attachments.
- Determine whether to insert before or after the target based on the pointer position relative to the target midpoint, including forward adjacent moves.
- Align keyboard movement semantics for Arrow keys, Home, and End.
- Preserve the selected attachment order through draft snapshots, Scratchlist parking, and final outgoing message payloads.
- Keep image preview behavior intact while preventing drag gestures from opening previews or context menus.
- Add responsive attachment controls for desktop and touch layouts.
- Add regression coverage for ordering, pointer gestures, keyboard movement, image interactions, and attachment control layouts.
- No new dependencies, API changes, or database migrations.

## Validation

- `bun typecheck`
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name attachment-drag-order -Suite Root -TestArgs terminal-wrap-fidelity.spec.ts` — 2 passed
- `bun run test:web -- src/lib/attachmentOrder.test.ts src/components/AssistantChat/AttachmentItem.test.tsx src/components/AssistantChat/SortableComposerAttachments.test.tsx src/components/ImagePreview.test.tsx` — 18 passed
- `bun run build`
- Manual validation on the Full task environment confirmed image and non-image attachment reordering on desktop and touch layouts, including forward adjacent moves.

## Related Issues

None

## AI Assistance

- Implemented and validated with OpenAI Codex (GPT-5.6).