### PR TITLE
feat(cli): show Claude compaction as a summary card with token delta

### DIFF
--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as claudeSdk from '@/claude/sdk';
 import type { SDKMessage } from '@/claude/sdk/types';
+import { join } from 'node:path';
+import { getProjectPath } from '@/claude/utils/path';
+
+vi.mock('@/claude/utils/compactSummaryLookup', () => ({
+    findLatestCompactSummary: vi.fn(async () => null)
+}));
+
+import { findLatestCompactSummary } from '@/claude/utils/compactSummaryLookup';
+const findLatestCompactSummaryMock = vi.mocked(findLatestCompactSummary);
 
 vi.mock('@/claude/utils/claudeCheckSession', () => ({
     claudeCheckSession: () => true
@@ -69,6 +78,10 @@ async function waitFor(condition: () => boolean, timeoutMs = 300, intervalMs = 1
 }
 
 describe('claudeRemote async message handling', () => {
+    beforeEach(() => {
+        findLatestCompactSummaryMock.mockReset();
+        findLatestCompactSummaryMock.mockImplementation(async () => null);
+    });
     // CI occasionally exceeds the default 5s under load (unrelated to job work).
     it('reports the initial normal message once after the first result', { timeout: 15_000 }, async () => {
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
@@ -374,6 +387,10 @@ describe('claudeRemote async message handling', () => {
 });
 
 describe('claudeRemote /compact result reporting', () => {
+    beforeEach(() => {
+        findLatestCompactSummaryMock.mockReset();
+        findLatestCompactSummaryMock.mockImplementation(async () => null);
+    });
     const resultMessage = {
         type: 'result',
         subtype: 'success',
@@ -530,5 +547,107 @@ describe('claudeRemote /compact result reporting', () => {
         }
 
         expect(wireOrder).toEqual(['result', '📦 Compacted', 'ready']);
+    }, 15_000);
+});
+
+describe('claudeRemote compact summary promotion', () => {
+    beforeEach(() => {
+        findLatestCompactSummaryMock.mockReset();
+        findLatestCompactSummaryMock.mockImplementation(async () => null);
+    });
+
+    const initMessage = {
+        type: 'system',
+        subtype: 'init',
+        session_id: 's-9'
+    } as unknown as SDKMessage;
+
+    const resultMessage = {
+        type: 'result',
+        subtype: 'success',
+        num_turns: 1,
+        total_cost_usd: 0,
+        duration_ms: 1,
+        duration_api_ms: 1,
+        is_error: false,
+        session_id: 's-9'
+    } as unknown as SDKMessage;
+
+    async function runCompactWithSummary(
+        mockSummary: string | null
+    ): Promise<{ completionEvents: string[]; readyPayloads: Array<Record<string, unknown> | undefined> }> {
+        findLatestCompactSummaryMock.mockImplementation(async () => mockSummary);
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        const completionEvents: string[] = [];
+        const readyPayloads: Array<Record<string, unknown> | undefined> = [];
+
+        queryMock.mockReturnValueOnce(createAsyncStream([
+            initMessage,
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'manual', pre_tokens: 34492, post_tokens: 2082 },
+                session_id: 's-9',
+                uuid: 'u-2'
+            } as unknown as SDKMessage,
+            resultMessage
+        ]));
+
+        let nextCallCount = 0;
+        try {
+            await claudeRemote({
+                sessionId: 's-9',
+                path: process.cwd(),
+                mcpServers: {},
+                claudeEnvVars: {},
+                claudeArgs: [],
+                allowedTools: [],
+                hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => {
+                    nextCallCount += 1;
+                    if (nextCallCount === 1) {
+                        return { message: '/compact', mode: { permissionMode: 'default' } };
+                    }
+                    return null;
+                },
+                onReady: (completionEvent, compactSummary) => {
+                    if (completionEvent) completionEvents.push(completionEvent);
+                    readyPayloads.push(compactSummary as Record<string, unknown> | undefined);
+                },
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: () => {},
+                onCompletionEvent: (message) => {
+                    completionEvents.push(message);
+                },
+                onSessionReset: () => {}
+            });
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        return { completionEvents, readyPayloads };
+    }
+
+    it('promotes the transcript summary into a structured compact-summary payload', async () => {
+        const { completionEvents, readyPayloads } = await runCompactWithSummary('The conversation was about X');
+
+        expect(findLatestCompactSummaryMock).toHaveBeenCalledWith(
+            expect.stringContaining(join(getProjectPath(process.cwd()), 's-9.jsonl').slice(-40))
+        );
+        expect(readyPayloads).toEqual([
+            { summary: 'The conversation was about X', tokensBefore: 34492, tokensAfter: 2082 }
+        ]);
+        expect(completionEvents).toEqual(['📦 Compaction started']);
+    }, 15_000);
+
+    it('keeps the token delta fallback line when the transcript never yields a summary', async () => {
+        const { completionEvents, readyPayloads } = await runCompactWithSummary(null);
+
+        expect(readyPayloads).toEqual([undefined]);
+        expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compacted (34492 → 2082 tokens)']);
     }, 15_000);
 });

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -402,10 +402,12 @@ describe('claudeRemote /compact result reporting', () => {
         session_id: 's-1'
     } as unknown as SDKMessage;
 
+    let lastForwarded: SDKMessage[] = [];
     async function runCompact(sdkMessages: SDKMessage[]): Promise<string[]> {
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');
         const completionEvents: string[] = [];
+        const forwarded: SDKMessage[] = [];
 
         queryMock.mockReturnValueOnce(createAsyncStream(sdkMessages));
 
@@ -432,7 +434,9 @@ describe('claudeRemote /compact result reporting', () => {
                 },
                 isAborted: () => false,
                 onSessionFound: () => {},
-                onMessage: () => {},
+                onMessage: (message) => {
+                    forwarded.push(message);
+                },
                 onCompletionEvent: (message) => {
                     completionEvents.push(message);
                 },
@@ -443,6 +447,7 @@ describe('claudeRemote /compact result reporting', () => {
             querySpy.mockRestore();
         }
 
+        lastForwarded = forwarded;
         return completionEvents;
     }
 
@@ -509,6 +514,33 @@ describe('claudeRemote /compact result reporting', () => {
         ]);
 
         expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compacted (34492 → 2082 tokens)']);
+    }, 15_000);
+
+    it('does not relay the compact_boundary system message during a manual /compact', async () => {
+        // The boundary is already surfaced by the completion output (summary
+        // card or token-delta line). Relaying it too renders a second
+        // "Conversation compacted" event line next to it in the web chat.
+        await runCompact([
+            {
+                type: 'system',
+                subtype: 'status',
+                status: 'compacting',
+                session_id: 's-1',
+                uuid: 'u-1'
+            } as unknown as SDKMessage,
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'manual', pre_tokens: 34492, post_tokens: 2082 },
+                session_id: 's-1',
+                uuid: 'u-2'
+            } as unknown as SDKMessage,
+            resultMessage
+        ]);
+
+        expect(
+            lastForwarded.some((m) => m.type === 'system' && (m as { subtype?: string }).subtype === 'compact_boundary')
+        ).toBe(false);
     }, 15_000);
 
     it('hands compact completion to the ready phase so the result carrier can flush first', async () => {

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -1112,14 +1112,9 @@ describe('claudeRemote compact summary promotion', () => {
         expect(wireOrder.slice(0, 3)).toEqual(['compact outcome', 'ready', 'next prompt consumed']);
     }, 15_000);
 
-    it('cancels deferred compact completion when the response stream fails', async () => {
-        findLatestCompactSummaryMock.mockImplementation(async (_path, opts) => {
-            if (opts?.signal?.aborted) return null;
-            await new Promise<void>((resolve) => {
-                opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
-            });
-            return null;
-        });
+    it('publishes deferred compact completion before propagating a later stream failure', async () => {
+        const summary = deferred<string | null>();
+        findLatestCompactSummaryMock.mockImplementation(() => summary.promise);
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');
         transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-failure-'));
@@ -1143,7 +1138,74 @@ describe('claudeRemote compact summary promotion', () => {
 
         let nextCallCount = 0;
         let readyCount = 0;
+        let acceptedCount = 0;
+        const readyEvents: Array<string | undefined> = [];
         const completionEvents: string[] = [];
+        const run = claudeRemote({
+            sessionId: 's-9', path: transcriptDir, mcpServers: {}, claudeEnvVars: {},
+            claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+            canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+            nextMessage: async () => {
+                nextCallCount += 1;
+                if (nextCallCount === 1) return { message: '/compact', mode: { permissionMode: 'default' } };
+                return { message: 'must stay queued', mode: { permissionMode: 'default' } };
+            },
+            onReady: (completionEvent) => {
+                readyCount += 1;
+                readyEvents.push(completionEvent);
+            },
+            onCompactResultAccepted: () => {
+                acceptedCount += 1;
+            },
+            isAborted: () => false,
+            onSessionFound: () => {},
+            onMessage: () => {},
+            onCompletionEvent: (message) => completionEvents.push(message),
+            onSessionReset: () => {}
+        });
+        try {
+            await vi.waitFor(() => expect(findLatestCompactSummaryMock).toHaveBeenCalled());
+            summary.resolve(null);
+            await expect(run).rejects.toThrow('stream failed');
+        } finally {
+            summary.resolve(null);
+            await run.catch(() => {});
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        expect(nextCallCount).toBe(1);
+        expect(readyCount).toBe(1);
+        expect(acceptedCount).toBe(1);
+        expect(readyEvents).toEqual(['📦 Compacted (100 → 10 tokens)']);
+        expect(completionEvents).toEqual(['📦 Compaction started']);
+    }, 15_000);
+
+    it('does not consume the next prompt when completion and stream failure settle together', async () => {
+        findLatestCompactSummaryMock.mockImplementation(async () => null);
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-failure-tie-'));
+        const projectDir = getProjectPath(transcriptDir);
+        await mkdir(projectDir, { recursive: true });
+        await writeFile(join(projectDir, 's-9.jsonl'), '');
+        queryMock.mockReturnValueOnce({
+            async *[Symbol.asyncIterator]() {
+                yield initMessage;
+                yield {
+                    type: 'system',
+                    subtype: 'compact_boundary',
+                    compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                    session_id: 's-9',
+                    uuid: 'u-boundary'
+                } as unknown as SDKMessage;
+                yield resultMessage;
+                throw new Error('stream failed in tie');
+            }
+        });
+
+        let nextCallCount = 0;
+        const readyEvents: Array<string | undefined> = [];
         try {
             await expect(claudeRemote({
                 sessionId: 's-9', path: transcriptDir, mcpServers: {}, claudeEnvVars: {},
@@ -1151,26 +1213,26 @@ describe('claudeRemote compact summary promotion', () => {
                 canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
                 nextMessage: async () => {
                     nextCallCount += 1;
-                    if (nextCallCount === 1) return { message: '/compact', mode: { permissionMode: 'default' } };
-                    return { message: 'must stay queued', mode: { permissionMode: 'default' } };
+                    return nextCallCount === 1
+                        ? { message: '/compact', mode: { permissionMode: 'default' } }
+                        : { message: 'must stay queued', mode: { permissionMode: 'default' } };
                 },
-                onReady: () => {
-                    readyCount += 1;
+                onReady: (completionEvent) => {
+                    readyEvents.push(completionEvent);
                 },
                 isAborted: () => false,
                 onSessionFound: () => {},
                 onMessage: () => {},
-                onCompletionEvent: (message) => completionEvents.push(message),
+                onCompletionEvent: () => {},
                 onSessionReset: () => {}
-            })).rejects.toThrow('stream failed');
+            })).rejects.toThrow('stream failed in tie');
         } finally {
             queryMock.mockReset();
             querySpy.mockRestore();
         }
 
+        expect(readyEvents).toEqual(['📦 Compacted (100 → 10 tokens)']);
         expect(nextCallCount).toBe(1);
-        expect(readyCount).toBe(0);
-        expect(completionEvents).toEqual(['📦 Compaction started']);
     }, 15_000);
 
     it('propagates a rejected compact onReady callback to the response attempt', async () => {

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -543,6 +543,54 @@ describe('claudeRemote /compact result reporting', () => {
         ).toBe(false);
     }, 15_000);
 
+    it('detects a /compact sent on a later turn, not just the initial one', async () => {
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        const completionEvents: string[] = [];
+        queryMock.mockReturnValueOnce(createAsyncStream([
+            resultMessage,
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                session_id: 's-1',
+                uuid: 'u-2'
+            } as unknown as SDKMessage,
+            resultMessage
+        ]));
+
+        let nextCallCount = 0;
+        try {
+            await claudeRemote({
+                sessionId: 'session-1', path: process.cwd(), mcpServers: {}, claudeEnvVars: {},
+                claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => {
+                    nextCallCount += 1;
+                    if (nextCallCount === 1) return { message: 'hi', mode: { permissionMode: 'default' } };
+                    if (nextCallCount === 2) return { message: '/compact', mode: { permissionMode: 'default' } };
+                    return null;
+                },
+                onReady: (completionEvent) => {
+                    if (completionEvent) completionEvents.push(completionEvent);
+                },
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: () => {},
+                onCompletionEvent: (message) => {
+                    completionEvents.push(message);
+                },
+                onSessionReset: () => {}
+            });
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        expect(completionEvents).toContain('📦 Compaction started');
+        expect(completionEvents).toContain('📦 Compacted (100 → 10 tokens)');
+    }, 15_000);
+
     it('hands compact completion to the ready phase so the result carrier can flush first', async () => {
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');
@@ -668,7 +716,8 @@ describe('claudeRemote compact summary promotion', () => {
         const { completionEvents, readyPayloads } = await runCompactWithSummary('The conversation was about X');
 
         expect(findLatestCompactSummaryMock).toHaveBeenCalledWith(
-            expect.stringContaining(join(getProjectPath(process.cwd()), 's-9.jsonl').slice(-40))
+            expect.stringContaining(join(getProjectPath(process.cwd()), 's-9.jsonl').slice(-40)),
+            expect.objectContaining({ minBytes: expect.any(Number) })
         );
         expect(readyPayloads).toEqual([
             { summary: 'The conversation was about X', tokensBefore: 34492, tokensAfter: 2082 }

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -666,12 +666,13 @@ describe('claudeRemote compact summary promotion', () => {
 
     async function runCompactWithSummary(
         mockSummary: string | null
-    ): Promise<{ completionEvents: string[]; readyPayloads: Array<Record<string, unknown> | undefined> }> {
+    ): Promise<{ completionEvents: string[]; readyPayloads: Array<Record<string, unknown> | undefined>; contextTokens: Array<number | undefined> }> {
         findLatestCompactSummaryMock.mockImplementation(async () => mockSummary);
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');
         const completionEvents: string[] = [];
         const readyPayloads: Array<Record<string, unknown> | undefined> = [];
+        const contextTokens: Array<number | undefined> = [];
 
         // The baseline capture stats the transcript at /compact detection; a
         // missing file makes the lookup skip promotion, so tests that exercise
@@ -711,9 +712,10 @@ describe('claudeRemote compact summary promotion', () => {
                     }
                     return null;
                 },
-                onReady: (completionEvent, compactSummary) => {
+                onReady: (completionEvent, compactSummary, compactContextTokens) => {
                     if (completionEvent) completionEvents.push(completionEvent);
                     readyPayloads.push(compactSummary as Record<string, unknown> | undefined);
+                    contextTokens.push(compactContextTokens);
                 },
                 isAborted: () => false,
                 onSessionFound: () => {},
@@ -728,11 +730,11 @@ describe('claudeRemote compact summary promotion', () => {
             querySpy.mockRestore();
         }
 
-        return { completionEvents, readyPayloads };
+        return { completionEvents, readyPayloads, contextTokens };
     }
 
     it('promotes the transcript summary into a structured compact-summary payload', async () => {
-        const { completionEvents, readyPayloads } = await runCompactWithSummary('The conversation was about X');
+        const { completionEvents, readyPayloads, contextTokens } = await runCompactWithSummary('The conversation was about X');
 
         expect(findLatestCompactSummaryMock).toHaveBeenCalledWith(
             expect.stringContaining(join(getProjectPath(transcriptDir!), 's-9.jsonl').slice(-40)),
@@ -741,6 +743,7 @@ describe('claudeRemote compact summary promotion', () => {
         expect(readyPayloads).toEqual([
             { summary: 'The conversation was about X', tokensBefore: 34492, tokensAfter: 2082 }
         ]);
+        expect(contextTokens).toEqual([2082]);
         expect(completionEvents).toEqual(['📦 Compaction started']);
     }, 15_000);
 
@@ -801,7 +804,7 @@ describe('claudeRemote compact summary promotion', () => {
     }, 15_000);
 
     it('keeps the token delta fallback line when the transcript never yields a summary', async () => {
-        const { completionEvents, readyPayloads } = await runCompactWithSummary(null);
+        const { completionEvents, readyPayloads, contextTokens } = await runCompactWithSummary(null);
 
         expect(readyPayloads).toEqual([undefined]);
         expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compacted (34492 → 2082 tokens)']);

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -452,9 +452,9 @@ describe('claudeRemote /compact result reporting', () => {
             resultMessage
         ]);
 
-        expect(completionEvents).toContain('Compaction started');
+        expect(completionEvents).toContain('📦 Compaction started');
         expect(completionEvents.some((event) => event.includes('Not enough messages to compact.'))).toBe(true);
-        expect(completionEvents).not.toContain('Compaction completed');
+        expect(completionEvents).not.toContain('📦 Compacted');
     }, 15_000);
 
     it('still reports success when no failure status arrives', async () => {
@@ -469,7 +469,29 @@ describe('claudeRemote /compact result reporting', () => {
             resultMessage
         ]);
 
-        expect(completionEvents).toEqual(['Compaction started', 'Compaction completed']);
+        expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compacted']);
+    }, 15_000);
+
+    it('reports the token delta from the compact_boundary metadata', async () => {
+        const completionEvents = await runCompact([
+            {
+                type: 'system',
+                subtype: 'status',
+                status: 'compacting',
+                session_id: 's-1',
+                uuid: 'u-1'
+            } as unknown as SDKMessage,
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'manual', pre_tokens: 34492, post_tokens: 2082 },
+                session_id: 's-1',
+                uuid: 'u-2'
+            } as unknown as SDKMessage,
+            resultMessage
+        ]);
+
+        expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compacted (34492 → 2082 tokens)']);
     }, 15_000);
 
     it('hands compact completion to the ready phase so the result carrier can flush first', async () => {
@@ -499,7 +521,7 @@ describe('claudeRemote /compact result reporting', () => {
                     if (message.type === 'result') queued.push('result');
                 },
                 onCompletionEvent: (message) => {
-                    if (message !== 'Compaction started') wireOrder.push(message);
+                    if (message !== '📦 Compaction started') wireOrder.push(message);
                 }
             });
         } finally {
@@ -507,6 +529,6 @@ describe('claudeRemote /compact result reporting', () => {
             querySpy.mockRestore();
         }
 
-        expect(wireOrder).toEqual(['result', 'Compaction completed', 'ready']);
+        expect(wireOrder).toEqual(['result', '📦 Compacted', 'ready']);
     }, 15_000);
 });

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -545,6 +545,78 @@ describe('claudeRemote /compact result reporting', () => {
         ).toBe(false);
     }, 15_000);
 
+    it('does not relay the Compacted stdout echo during a manual /compact', async () => {
+        // The stdout echo is CLI bookkeeping for the active compact only —
+        // scoping the suppression here (where the command state lives) keeps
+        // identical output from other slash commands visible.
+        await runCompact([
+            {
+                type: 'system',
+                subtype: 'status',
+                status: 'compacting',
+                session_id: 's-1',
+                uuid: 'u-1'
+            } as unknown as SDKMessage,
+            {
+                type: 'user',
+                message: { role: 'user', content: '<local-command-stdout>Compacted </local-command-stdout>' }
+            } as unknown as SDKMessage,
+            resultMessage
+        ]);
+
+        expect(
+            lastForwarded.some((m) =>
+                m.type === 'user' &&
+                (m as { message?: { content?: unknown } }).message?.content === '<local-command-stdout>Compacted </local-command-stdout>'
+            )
+        ).toBe(false);
+    }, 15_000);
+
+    it('keeps the Compacted stdout echo visible outside a compact turn', async () => {
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        const forwarded: SDKMessage[] = [];
+        queryMock.mockReturnValueOnce(createAsyncStream([
+            {
+                type: 'user',
+                message: { role: 'user', content: '<local-command-stdout>Compacted </local-command-stdout>' }
+            } as unknown as SDKMessage,
+            resultMessage
+        ]));
+
+        let nextCallCount = 0;
+        try {
+            await claudeRemote({
+                sessionId: 'session-1', path: process.cwd(), mcpServers: {}, claudeEnvVars: {},
+                claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => {
+                    nextCallCount += 1;
+                    if (nextCallCount === 1) return { message: 'hi', mode: { permissionMode: 'default' } };
+                    return null;
+                },
+                onReady: () => {},
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: (message) => {
+                    forwarded.push(message);
+                },
+                onCompletionEvent: () => {},
+                onSessionReset: () => {}
+            });
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        expect(
+            forwarded.some((m) =>
+                m.type === 'user' &&
+                (m as { message?: { content?: unknown } }).message?.content === '<local-command-stdout>Compacted </local-command-stdout>'
+            )
+        ).toBe(true);
+    }, 15_000);
+
     it('detects a /compact sent on a later turn, not just the initial one', async () => {
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -482,6 +482,29 @@ describe('claudeRemote /compact result reporting', () => {
         expect(completionEvents).not.toContain('📦 Compacted');
     }, 15_000);
 
+    it('reports a generic failure without duplicating the fallback text', async () => {
+        const completionEvents = await runCompact([
+            {
+                type: 'system',
+                subtype: 'status',
+                status: 'compacting',
+                session_id: 's-1',
+                uuid: 'u-1'
+            } as unknown as SDKMessage,
+            {
+                type: 'system',
+                subtype: 'status',
+                status: null,
+                compact_result: 'failed',
+                session_id: 's-1',
+                uuid: 'u-2'
+            } as unknown as SDKMessage,
+            resultMessage
+        ]);
+
+        expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compaction failed']);
+    }, 15_000);
+
     it('still reports success when no failure status arrives', async () => {
         const completionEvents = await runCompact([
             {
@@ -517,6 +540,29 @@ describe('claudeRemote /compact result reporting', () => {
         ]);
 
         expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compacted (34492 → 2082 tokens)']);
+    }, 15_000);
+
+    it('ignores an autonomous result until the compact stream signal arrives', async () => {
+        const completionEvents = await runCompact([
+            resultMessage,
+            {
+                type: 'system',
+                subtype: 'status',
+                status: 'compacting',
+                session_id: 's-1',
+                uuid: 'u-status'
+            } as unknown as SDKMessage,
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                session_id: 's-1',
+                uuid: 'u-boundary'
+            } as unknown as SDKMessage,
+            resultMessage
+        ]);
+
+        expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compacted (100 → 10 tokens)']);
     }, 15_000);
 
     it('does not relay the compact_boundary system message during a manual /compact', async () => {
@@ -710,7 +756,16 @@ describe('claudeRemote /compact result reporting', () => {
         const { claudeRemote } = await import('./claudeRemote');
         const wireOrder: string[] = [];
         const queued: string[] = [];
-        queryMock.mockReturnValueOnce(createAsyncStream([resultMessage]));
+        queryMock.mockReturnValueOnce(createAsyncStream([
+            {
+                type: 'system',
+                subtype: 'status',
+                status: 'compacting',
+                session_id: 's-1',
+                uuid: 'u-status'
+            } as unknown as SDKMessage,
+            resultMessage
+        ]));
 
         let nextCallCount = 0;
         try {
@@ -916,6 +971,76 @@ describe('claudeRemote compact summary promotion', () => {
             queryMock.mockReset();
             querySpy.mockRestore();
         }
+    }, 15_000);
+
+    it('does not publish a successful compact outcome when summary polling is aborted', async () => {
+        findLatestCompactSummaryMock.mockImplementation(async (_path, opts) => {
+            if (opts?.signal?.aborted) return null;
+            await new Promise<void>((resolve) => {
+                opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
+            });
+            return null;
+        });
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        const controller = new AbortController();
+        const completionEvents: string[] = [];
+        let readyCount = 0;
+        transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-signal-abort-'));
+        const projectDir = getProjectPath(transcriptDir);
+        await mkdir(projectDir, { recursive: true });
+        await writeFile(join(projectDir, 's-9.jsonl'), '');
+        queryMock.mockReturnValueOnce({
+            async *[Symbol.asyncIterator]() {
+                yield initMessage;
+                yield {
+                    type: 'system',
+                    subtype: 'compact_boundary',
+                    compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                    session_id: 's-9',
+                    uuid: 'u-boundary'
+                } as unknown as SDKMessage;
+                yield resultMessage;
+                await new Promise<never>(() => {});
+            }
+        });
+
+        let nextCallCount = 0;
+        const run = claudeRemote({
+            sessionId: 's-9', path: transcriptDir, mcpServers: {}, claudeEnvVars: {},
+            claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+            signal: controller.signal,
+            canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+            nextMessage: async () => {
+                nextCallCount += 1;
+                return nextCallCount === 1
+                    ? { message: '/compact', mode: { permissionMode: 'default' } }
+                    : { message: 'must stay queued', mode: { permissionMode: 'default' } };
+            },
+            onReady: () => {
+                readyCount += 1;
+            },
+            isAborted: () => false,
+            onSessionFound: () => {},
+            onMessage: () => {},
+            onCompletionEvent: (message) => completionEvents.push(message),
+            onSessionReset: () => {}
+        });
+
+        try {
+            await vi.waitFor(() => expect(findLatestCompactSummaryMock).toHaveBeenCalled());
+            controller.abort();
+            await run;
+        } finally {
+            controller.abort();
+            await run.catch(() => {});
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        expect(completionEvents).toEqual(['📦 Compaction started']);
+        expect(readyCount).toBe(0);
+        expect(nextCallCount).toBe(1);
     }, 15_000);
 
     it('publishes compact outcome before consuming an already queued next prompt', async () => {
@@ -1224,7 +1349,17 @@ describe('claudeRemote compact summary promotion', () => {
             const { claudeRemote } = await import('./claudeRemote');
             const completionEvents: string[] = [];
             const readyPayloads: Array<Record<string, unknown> | undefined> = [];
-            queryMock.mockReturnValueOnce(createAsyncStream([initMessage, resultMessage]));
+            queryMock.mockReturnValueOnce(createAsyncStream([
+                initMessage,
+                {
+                    type: 'system',
+                    subtype: 'status',
+                    status: 'compacting',
+                    session_id: 's-9',
+                    uuid: 'u-status'
+                } as unknown as SDKMessage,
+                resultMessage
+            ]));
 
             let nextCallCount = 0;
             try {

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -740,7 +740,7 @@ describe('claudeRemote /compact result reporting', () => {
             querySpy.mockRestore();
         }
 
-        expect(wireOrder).toEqual(['result', 'ready', '📦 Compacted']);
+        expect(wireOrder).toEqual(['result', '📦 Compacted', 'ready']);
     }, 15_000);
 });
 
@@ -824,12 +824,10 @@ describe('claudeRemote compact summary promotion', () => {
                     }
                     return null;
                 },
-                onReady: (completionEvent, _compactSummary, compactContextTokens) => {
+                onReady: (completionEvent, compactSummary, compactContextTokens) => {
                     if (completionEvent) completionEvents.push(completionEvent);
+                    if (compactSummary) compactSummaries.push(compactSummary);
                     contextTokens.push(compactContextTokens);
-                },
-                onCompactSummary: (compactSummary) => {
-                    compactSummaries.push(compactSummary);
                 },
                 isAborted: () => false,
                 onSessionFound: () => {},
@@ -918,6 +916,75 @@ describe('claudeRemote compact summary promotion', () => {
             queryMock.mockReset();
             querySpy.mockRestore();
         }
+    }, 15_000);
+
+    it('publishes compact outcome before consuming an already queued next prompt', async () => {
+        const summary = deferred<string | null>();
+        findLatestCompactSummaryMock.mockImplementation(() => summary.promise);
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        const wireOrder: string[] = [];
+        transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-order-'));
+        const projectDir = getProjectPath(transcriptDir);
+        await mkdir(projectDir, { recursive: true });
+        await writeFile(join(projectDir, 's-9.jsonl'), '');
+
+        queryMock.mockImplementationOnce(({ prompt }: { prompt: AsyncIterable<unknown> }) => ({
+            async *[Symbol.asyncIterator]() {
+                const promptIterator = prompt[Symbol.asyncIterator]();
+                await promptIterator.next();
+                yield initMessage;
+                yield {
+                    type: 'system',
+                    subtype: 'compact_boundary',
+                    compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                    session_id: 's-9',
+                    uuid: 'u-boundary'
+                } as unknown as SDKMessage;
+                yield resultMessage;
+                await promptIterator.next();
+                yield resultMessage;
+            }
+        }));
+
+        let nextCallCount = 0;
+        const run = claudeRemote({
+            sessionId: 's-9', path: transcriptDir, mcpServers: {}, claudeEnvVars: {},
+            claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+            canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+            nextMessage: async () => {
+                nextCallCount += 1;
+                if (nextCallCount === 1) return { message: '/compact', mode: { permissionMode: 'default' } };
+                if (nextCallCount === 2) {
+                    wireOrder.push('next prompt consumed');
+                    return { message: 'after compact', mode: { permissionMode: 'default' } };
+                }
+                return null;
+            },
+            onReady: (_completionEvent, compactSummary) => {
+                if (compactSummary) wireOrder.push('compact outcome');
+                wireOrder.push('ready');
+            },
+            isAborted: () => false,
+            onSessionFound: () => {},
+            onMessage: () => {},
+            onCompletionEvent: () => {},
+            onSessionReset: () => {}
+        });
+
+        try {
+            await vi.waitFor(() => expect(findLatestCompactSummaryMock).toHaveBeenCalled());
+            expect(nextCallCount).toBe(1);
+            summary.resolve('summary');
+            await run;
+        } finally {
+            summary.resolve(null);
+            await run.catch(() => {});
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        expect(wireOrder.slice(0, 3)).toEqual(['compact outcome', 'ready', 'next prompt consumed']);
     }, 15_000);
 
     it('skips summary promotion entirely when the transcript baseline cannot be established', async () => {

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as claudeSdk from '@/claude/sdk';
 import type { SDKMessage } from '@/claude/sdk/types';
 import { join } from 'node:path';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { getProjectPath } from '@/claude/utils/path';
 
 vi.mock('@/claude/utils/compactSummaryLookup', () => ({
@@ -653,6 +655,15 @@ describe('claudeRemote compact summary promotion', () => {
         session_id: 's-9'
     } as unknown as SDKMessage;
 
+    let transcriptDir: string | null = null;
+
+    afterEach(async () => {
+        if (transcriptDir) {
+            await rm(transcriptDir, { recursive: true, force: true });
+            transcriptDir = null;
+        }
+    });
+
     async function runCompactWithSummary(
         mockSummary: string | null
     ): Promise<{ completionEvents: string[]; readyPayloads: Array<Record<string, unknown> | undefined> }> {
@@ -661,6 +672,14 @@ describe('claudeRemote compact summary promotion', () => {
         const { claudeRemote } = await import('./claudeRemote');
         const completionEvents: string[] = [];
         const readyPayloads: Array<Record<string, unknown> | undefined> = [];
+
+        // The baseline capture stats the transcript at /compact detection; a
+        // missing file makes the lookup skip promotion, so tests that exercise
+        // promotion need a real (empty) transcript on disk.
+        transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-'));
+        const projectDir = getProjectPath(transcriptDir);
+        await mkdir(projectDir, { recursive: true });
+        await writeFile(join(projectDir, 's-9.jsonl'), '');
 
         queryMock.mockReturnValueOnce(createAsyncStream([
             initMessage,
@@ -678,7 +697,7 @@ describe('claudeRemote compact summary promotion', () => {
         try {
             await claudeRemote({
                 sessionId: 's-9',
-                path: process.cwd(),
+                path: transcriptDir,
                 mcpServers: {},
                 claudeEnvVars: {},
                 claudeArgs: [],
@@ -716,13 +735,69 @@ describe('claudeRemote compact summary promotion', () => {
         const { completionEvents, readyPayloads } = await runCompactWithSummary('The conversation was about X');
 
         expect(findLatestCompactSummaryMock).toHaveBeenCalledWith(
-            expect.stringContaining(join(getProjectPath(process.cwd()), 's-9.jsonl').slice(-40)),
+            expect.stringContaining(join(getProjectPath(transcriptDir!), 's-9.jsonl').slice(-40)),
             expect.objectContaining({ minBytes: expect.any(Number) })
         );
         expect(readyPayloads).toEqual([
             { summary: 'The conversation was about X', tokensBefore: 34492, tokensAfter: 2082 }
         ]);
         expect(completionEvents).toEqual(['📦 Compaction started']);
+    }, 15_000);
+
+    it('skips summary promotion entirely when the transcript baseline cannot be established', async () => {
+        // No transcript file on disk: stat fails, the baseline stays null, and
+        // reading from offset 0 could promote a previous compaction's summary
+        // row — so the lookup must not run at all.
+        findLatestCompactSummaryMock.mockImplementation(async () => 'stale summary');
+        const dir = await mkdtemp(join(tmpdir(), 'claude-compact-missing-'));
+        try {
+            const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+            const { claudeRemote } = await import('./claudeRemote');
+            const completionEvents: string[] = [];
+            const readyPayloads: Array<Record<string, unknown> | undefined> = [];
+            queryMock.mockReturnValueOnce(createAsyncStream([initMessage, resultMessage]));
+
+            let nextCallCount = 0;
+            try {
+                await claudeRemote({
+                    sessionId: 's-9',
+                    path: dir,
+                    mcpServers: {},
+                    claudeEnvVars: {},
+                    claudeArgs: [],
+                    allowedTools: [],
+                    hookSettingsPath: '/tmp/hook.json',
+                    canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                    nextMessage: async () => {
+                        nextCallCount += 1;
+                        if (nextCallCount === 1) {
+                            return { message: '/compact', mode: { permissionMode: 'default' } };
+                        }
+                        return null;
+                    },
+                    onReady: (completionEvent, compactSummary) => {
+                        if (completionEvent) completionEvents.push(completionEvent);
+                        readyPayloads.push(compactSummary as Record<string, unknown> | undefined);
+                    },
+                    isAborted: () => false,
+                    onSessionFound: () => {},
+                    onMessage: () => {},
+                    onCompletionEvent: (message) => {
+                        completionEvents.push(message);
+                    },
+                    onSessionReset: () => {}
+                });
+            } finally {
+                queryMock.mockReset();
+                querySpy.mockRestore();
+            }
+
+            expect(findLatestCompactSummaryMock).not.toHaveBeenCalled();
+            expect(readyPayloads).toEqual([undefined]);
+            expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compacted']);
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
     }, 15_000);
 
     it('keeps the token delta fallback line when the transcript never yields a summary', async () => {

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -987,6 +987,130 @@ describe('claudeRemote compact summary promotion', () => {
         expect(wireOrder.slice(0, 3)).toEqual(['compact outcome', 'ready', 'next prompt consumed']);
     }, 15_000);
 
+    it('cancels deferred compact completion when the response stream fails', async () => {
+        findLatestCompactSummaryMock.mockImplementation(async (_path, opts) => {
+            if (opts?.signal?.aborted) return null;
+            await new Promise<void>((resolve) => {
+                opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
+            });
+            return null;
+        });
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-failure-'));
+        const projectDir = getProjectPath(transcriptDir);
+        await mkdir(projectDir, { recursive: true });
+        await writeFile(join(projectDir, 's-9.jsonl'), '');
+        queryMock.mockReturnValueOnce({
+            async *[Symbol.asyncIterator]() {
+                yield initMessage;
+                yield {
+                    type: 'system',
+                    subtype: 'compact_boundary',
+                    compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                    session_id: 's-9',
+                    uuid: 'u-boundary'
+                } as unknown as SDKMessage;
+                yield resultMessage;
+                throw new Error('stream failed');
+            }
+        });
+
+        let nextCallCount = 0;
+        let readyCount = 0;
+        const completionEvents: string[] = [];
+        try {
+            await expect(claudeRemote({
+                sessionId: 's-9', path: transcriptDir, mcpServers: {}, claudeEnvVars: {},
+                claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => {
+                    nextCallCount += 1;
+                    if (nextCallCount === 1) return { message: '/compact', mode: { permissionMode: 'default' } };
+                    return { message: 'must stay queued', mode: { permissionMode: 'default' } };
+                },
+                onReady: () => {
+                    readyCount += 1;
+                },
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: () => {},
+                onCompletionEvent: (message) => completionEvents.push(message),
+                onSessionReset: () => {}
+            })).rejects.toThrow('stream failed');
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        expect(nextCallCount).toBe(1);
+        expect(readyCount).toBe(0);
+        expect(completionEvents).toEqual(['📦 Compaction started']);
+    }, 15_000);
+
+    it('cancels deferred compact completion when an aborted tool exits the stream loop', async () => {
+        findLatestCompactSummaryMock.mockImplementation(async (_path, opts) => {
+            if (opts?.signal?.aborted) return null;
+            await new Promise<void>((resolve) => {
+                opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
+            });
+            return null;
+        });
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-abort-'));
+        const projectDir = getProjectPath(transcriptDir);
+        await mkdir(projectDir, { recursive: true });
+        await writeFile(join(projectDir, 's-9.jsonl'), '');
+        queryMock.mockReturnValueOnce(createAsyncStream([
+            initMessage,
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                session_id: 's-9',
+                uuid: 'u-boundary'
+            } as unknown as SDKMessage,
+            resultMessage,
+            {
+                type: 'user',
+                message: {
+                    role: 'user',
+                    content: [{ type: 'tool_result', tool_use_id: 'tool-aborted', content: 'cancelled' }]
+                }
+            } as unknown as SDKMessage
+        ]));
+
+        let nextCallCount = 0;
+        let readyCount = 0;
+        try {
+            await claudeRemote({
+                sessionId: 's-9', path: transcriptDir, mcpServers: {}, claudeEnvVars: {},
+                claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => {
+                    nextCallCount += 1;
+                    if (nextCallCount === 1) return { message: '/compact', mode: { permissionMode: 'default' } };
+                    return { message: 'must stay queued', mode: { permissionMode: 'default' } };
+                },
+                onReady: () => {
+                    readyCount += 1;
+                },
+                isAborted: (toolCallId) => toolCallId === 'tool-aborted',
+                onSessionFound: () => {},
+                onMessage: () => {},
+                onCompletionEvent: () => {},
+                onSessionReset: () => {}
+            });
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        expect(nextCallCount).toBe(1);
+        expect(readyCount).toBe(0);
+    }, 15_000);
+
     it('skips summary promotion entirely when the transcript baseline cannot be established', async () => {
         // No transcript file on disk: stat fails, the baseline stays null, and
         // reading from offset 0 could promote a previous compaction's summary

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -1048,6 +1048,108 @@ describe('claudeRemote compact summary promotion', () => {
         expect(completionEvents).toEqual(['📦 Compaction started']);
     }, 15_000);
 
+    it('propagates a rejected compact onReady callback to the response attempt', async () => {
+        findLatestCompactSummaryMock.mockImplementation(async () => 'summary');
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-ready-error-'));
+        const projectDir = getProjectPath(transcriptDir);
+        await mkdir(projectDir, { recursive: true });
+        await writeFile(join(projectDir, 's-9.jsonl'), '');
+        queryMock.mockImplementationOnce(createQueryThatMirrorsPromptErrors([
+            initMessage,
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                session_id: 's-9',
+                uuid: 'u-boundary'
+            } as unknown as SDKMessage,
+            resultMessage
+        ]));
+
+        let nextCallCount = 0;
+        try {
+            await expect(claudeRemote({
+                sessionId: 's-9', path: transcriptDir, mcpServers: {}, claudeEnvVars: {},
+                claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => {
+                    nextCallCount += 1;
+                    if (nextCallCount === 1) return { message: '/compact', mode: { permissionMode: 'default' } };
+                    return { message: 'must stay queued', mode: { permissionMode: 'default' } };
+                },
+                onReady: async () => {
+                    throw new Error('ready failed');
+                },
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: () => {},
+                onCompletionEvent: () => {},
+                onSessionReset: () => {}
+            })).rejects.toThrow('ready failed');
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+
+        expect(nextCallCount).toBe(1);
+    }, 15_000);
+
+    it('propagates compact completion failure after the prompt iterable has ended', async () => {
+        findLatestCompactSummaryMock.mockImplementation(async () => 'summary');
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-ended-prompt-'));
+        const projectDir = getProjectPath(transcriptDir);
+        await mkdir(projectDir, { recursive: true });
+        await writeFile(join(projectDir, 's-9.jsonl'), '');
+
+        queryMock.mockImplementationOnce(({ prompt }: { prompt: AsyncIterable<unknown> }) => {
+            const responseError = deferred<never>();
+            return {
+                setError(error: Error) {
+                    responseError.reject(error);
+                },
+                async *[Symbol.asyncIterator]() {
+                    const promptIterator = prompt[Symbol.asyncIterator]();
+                    await promptIterator.next();
+                    await promptIterator.return?.();
+                    yield initMessage;
+                    yield {
+                        type: 'system',
+                        subtype: 'compact_boundary',
+                        compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                        session_id: 's-9',
+                        uuid: 'u-boundary'
+                    } as unknown as SDKMessage;
+                    yield resultMessage;
+                    await responseError.promise;
+                }
+            };
+        });
+
+        try {
+            await expect(claudeRemote({
+                sessionId: 's-9', path: transcriptDir, mcpServers: {}, claudeEnvVars: {},
+                claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+                canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+                nextMessage: async () => ({ message: '/compact', mode: { permissionMode: 'default' } }),
+                onReady: async () => {
+                    throw new Error('ready failed after prompt end');
+                },
+                isAborted: () => false,
+                onSessionFound: () => {},
+                onMessage: () => {},
+                onCompletionEvent: () => {},
+                onSessionReset: () => {}
+            })).rejects.toThrow('ready failed after prompt end');
+        } finally {
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
+    }, 15_000);
+
     it('cancels deferred compact completion when an aborted tool exits the stream loop', async () => {
         findLatestCompactSummaryMock.mockImplementation(async (_path, opts) => {
             if (opts?.signal?.aborted) return null;

--- a/cli/src/claude/claudeRemote.test.ts
+++ b/cli/src/claude/claudeRemote.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { getProjectPath } from '@/claude/utils/path';
+import type { CompactSummaryPayload } from './claudeRemote';
 
 vi.mock('@/claude/utils/compactSummaryLookup', () => ({
     findLatestCompactSummary: vi.fn(async () => null)
@@ -545,6 +546,38 @@ describe('claudeRemote /compact result reporting', () => {
         ).toBe(false);
     }, 15_000);
 
+    it('keeps an automatic boundary visible while a manual /compact is pending', async () => {
+        await runCompact([
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'auto', pre_tokens: 50000, post_tokens: 3000 },
+                session_id: 's-1',
+                uuid: 'u-auto'
+            } as unknown as SDKMessage,
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'manual', pre_tokens: 34000, post_tokens: 2000 },
+                session_id: 's-1',
+                uuid: 'u-manual'
+            } as unknown as SDKMessage,
+            resultMessage
+        ]);
+
+        expect(
+            lastForwarded.some((m) =>
+                m.type === 'system' &&
+                (m as { subtype?: string; compact_metadata?: { trigger?: string } }).subtype === 'compact_boundary' &&
+                (m as { compact_metadata?: { trigger?: string } }).compact_metadata?.trigger === 'auto'
+            )
+        ).toBe(true);
+        expect(lastForwarded.some((m) =>
+            m.type === 'system' &&
+            (m as { compact_metadata?: { trigger?: string } }).compact_metadata?.trigger === 'manual'
+        )).toBe(false);
+    }, 15_000);
+
     it('does not relay the Compacted stdout echo during a manual /compact', async () => {
         // The stdout echo is CLI bookkeeping for the active compact only —
         // scoping the suppression here (where the command state lives) keeps
@@ -621,17 +654,24 @@ describe('claudeRemote /compact result reporting', () => {
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');
         const completionEvents: string[] = [];
-        queryMock.mockReturnValueOnce(createAsyncStream([
-            resultMessage,
-            {
-                type: 'system',
-                subtype: 'compact_boundary',
-                compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
-                session_id: 's-1',
-                uuid: 'u-2'
-            } as unknown as SDKMessage,
-            resultMessage
-        ]));
+        queryMock.mockImplementationOnce(({ prompt }: { prompt: AsyncIterable<unknown> }) => ({
+            async *[Symbol.asyncIterator]() {
+                const promptIterator = prompt[Symbol.asyncIterator]();
+                await promptIterator.next();
+                yield resultMessage;
+                // A compact response cannot arrive until the later-turn
+                // command has actually entered the SDK prompt queue.
+                await promptIterator.next();
+                yield {
+                    type: 'system',
+                    subtype: 'compact_boundary',
+                    compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                    session_id: 's-1',
+                    uuid: 'u-2'
+                } as unknown as SDKMessage;
+                yield resultMessage;
+            }
+        }));
 
         let nextCallCount = 0;
         try {
@@ -665,7 +705,7 @@ describe('claudeRemote /compact result reporting', () => {
         expect(completionEvents).toContain('📦 Compacted (100 → 10 tokens)');
     }, 15_000);
 
-    it('hands compact completion to the ready phase so the result carrier can flush first', async () => {
+    it('flushes the result carrier before publishing compact completion', async () => {
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');
         const wireOrder: string[] = [];
@@ -700,7 +740,7 @@ describe('claudeRemote /compact result reporting', () => {
             querySpy.mockRestore();
         }
 
-        expect(wireOrder).toEqual(['result', '📦 Compacted', 'ready']);
+        expect(wireOrder).toEqual(['result', 'ready', '📦 Compacted']);
     }, 15_000);
 });
 
@@ -738,12 +778,12 @@ describe('claudeRemote compact summary promotion', () => {
 
     async function runCompactWithSummary(
         mockSummary: string | null
-    ): Promise<{ completionEvents: string[]; readyPayloads: Array<Record<string, unknown> | undefined>; contextTokens: Array<number | undefined> }> {
+    ): Promise<{ completionEvents: string[]; compactSummaries: CompactSummaryPayload[]; contextTokens: Array<number | undefined> }> {
         findLatestCompactSummaryMock.mockImplementation(async () => mockSummary);
         const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
         const { claudeRemote } = await import('./claudeRemote');
         const completionEvents: string[] = [];
-        const readyPayloads: Array<Record<string, unknown> | undefined> = [];
+        const compactSummaries: CompactSummaryPayload[] = [];
         const contextTokens: Array<number | undefined> = [];
 
         // The baseline capture stats the transcript at /compact detection; a
@@ -784,10 +824,12 @@ describe('claudeRemote compact summary promotion', () => {
                     }
                     return null;
                 },
-                onReady: (completionEvent, compactSummary, compactContextTokens) => {
+                onReady: (completionEvent, _compactSummary, compactContextTokens) => {
                     if (completionEvent) completionEvents.push(completionEvent);
-                    readyPayloads.push(compactSummary as Record<string, unknown> | undefined);
                     contextTokens.push(compactContextTokens);
+                },
+                onCompactSummary: (compactSummary) => {
+                    compactSummaries.push(compactSummary);
                 },
                 isAborted: () => false,
                 onSessionFound: () => {},
@@ -802,21 +844,80 @@ describe('claudeRemote compact summary promotion', () => {
             querySpy.mockRestore();
         }
 
-        return { completionEvents, readyPayloads, contextTokens };
+        return { completionEvents, compactSummaries, contextTokens };
     }
 
     it('promotes the transcript summary into a structured compact-summary payload', async () => {
-        const { completionEvents, readyPayloads, contextTokens } = await runCompactWithSummary('The conversation was about X');
+        const { completionEvents, compactSummaries, contextTokens } = await runCompactWithSummary('The conversation was about X');
 
         expect(findLatestCompactSummaryMock).toHaveBeenCalledWith(
             expect.stringContaining(join(getProjectPath(transcriptDir!), 's-9.jsonl').slice(-40)),
             expect.objectContaining({ minBytes: expect.any(Number) })
         );
-        expect(readyPayloads).toEqual([
+        expect(compactSummaries).toEqual([
             { summary: 'The conversation was about X', tokensBefore: 34492, tokensAfter: 2082 }
         ]);
         expect(contextTokens).toEqual([2082]);
         expect(completionEvents).toEqual(['📦 Compaction started']);
+    }, 15_000);
+
+    it('continues consuming SDK messages while the compact summary is pending', async () => {
+        const summary = deferred<string | null>();
+        findLatestCompactSummaryMock.mockImplementation(() => summary.promise);
+        const querySpy = vi.spyOn(claudeSdk, 'query').mockImplementation(queryMock as typeof claudeSdk.query);
+        const { claudeRemote } = await import('./claudeRemote');
+        const forwarded: SDKMessage[] = [];
+        transcriptDir = await mkdtemp(join(tmpdir(), 'claude-compact-stream-'));
+        const projectDir = getProjectPath(transcriptDir);
+        await mkdir(projectDir, { recursive: true });
+        await writeFile(join(projectDir, 's-9.jsonl'), '');
+        queryMock.mockReturnValueOnce(createAsyncStream([
+            initMessage,
+            {
+                type: 'system',
+                subtype: 'compact_boundary',
+                compact_metadata: { trigger: 'manual', pre_tokens: 100, post_tokens: 10 },
+                session_id: 's-9',
+                uuid: 'u-boundary'
+            } as unknown as SDKMessage,
+            resultMessage,
+            {
+                type: 'assistant',
+                message: { role: 'assistant', content: [{ type: 'text', text: 'autonomous' }] },
+                session_id: 's-9',
+                uuid: 'u-autonomous'
+            } as unknown as SDKMessage
+        ]));
+
+        let nextCallCount = 0;
+        const run = claudeRemote({
+            sessionId: 's-9', path: transcriptDir, mcpServers: {}, claudeEnvVars: {},
+            claudeArgs: [], allowedTools: [], hookSettingsPath: '/tmp/hook.json',
+            canCallTool: async () => ({ behavior: 'allow', updatedInput: {} }),
+            nextMessage: async () => nextCallCount++ === 0
+                ? { message: '/compact', mode: { permissionMode: 'default' } }
+                : null,
+            onReady: () => {},
+            isAborted: () => false,
+            onSessionFound: () => {},
+            onMessage: (message) => forwarded.push(message),
+            onCompletionEvent: () => {},
+            onSessionReset: () => {}
+        });
+
+        try {
+            await vi.waitFor(() => {
+                expect(findLatestCompactSummaryMock).toHaveBeenCalled();
+                expect(forwarded.some((message) => message.type === 'assistant')).toBe(true);
+            });
+            summary.resolve(null);
+            await run;
+        } finally {
+            summary.resolve(null);
+            await run.catch(() => {});
+            queryMock.mockReset();
+            querySpy.mockRestore();
+        }
     }, 15_000);
 
     it('skips summary promotion entirely when the transcript baseline cannot be established', async () => {
@@ -876,9 +977,10 @@ describe('claudeRemote compact summary promotion', () => {
     }, 15_000);
 
     it('keeps the token delta fallback line when the transcript never yields a summary', async () => {
-        const { completionEvents, readyPayloads, contextTokens } = await runCompactWithSummary(null);
+        const { completionEvents, compactSummaries, contextTokens } = await runCompactWithSummary(null);
 
-        expect(readyPayloads).toEqual([undefined]);
+        expect(compactSummaries).toEqual([]);
+        expect(contextTokens).toEqual([2082]);
         expect(completionEvents).toEqual(['📦 Compaction started', '📦 Compacted (34492 → 2082 tokens)']);
     }, 15_000);
 });

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -2,6 +2,7 @@ import { EnhancedMode, PermissionMode } from "./loop";
 import { query, type QueryOptions as Options, type SDKMessage, type SDKSystemMessage, AbortError, SDKUserMessage } from '@/claude/sdk'
 import { claudeCheckSession } from "./utils/claudeCheckSession";
 import { join } from 'node:path';
+import { stat } from 'node:fs/promises';
 import { parseSpecialCommand } from "@/parsers/specialCommands";
 import { logger } from "@/lib";
 import { PushableAsyncIterable } from "@/utils/PushableAsyncIterable";
@@ -115,6 +116,12 @@ export async function claudeRemote(opts: {
     // usage (measured), so the boundary metadata is the only real source.
     let compactTokensBefore: number | undefined;
     let compactTokensAfter: number | undefined;
+    // Transcript byte size recorded when the /compact command is detected.
+    // Summary rows below this offset belong to earlier turns (a previous
+    // compaction's summary survives in resumed / second-compact sessions) and
+    // must not satisfy the summary lookup while the fresh row is still being
+    // flushed to disk.
+    let compactTranscriptBaseline = 0;
     // The local transcript is keyed by the live session id (updated on init),
     // not opts.sessionId which can be stale for forked sessions.
     let currentSessionId = startFrom;
@@ -125,11 +132,31 @@ export async function claudeRemote(opts: {
     // Success-only: a failed compaction keeps its failure line, an unknown
     // session id or any transcript read problem falls back to the plain
     // completion line. Never propagates errors into the result flow.
+    const getTranscriptBytes = async (): Promise<number> => {
+        if (!currentSessionId) return 0;
+        try {
+            return (await stat(join(getProjectPath(opts.path), `${currentSessionId}.jsonl`))).size;
+        } catch {
+            return 0;
+        }
+    };
+    const beginCompactCommand = () => {
+        logger.debug('[claudeRemote] /compact command detected - will process as normal but with compaction behavior');
+        // Set the flag and emit synchronously: the boundary message and the
+        // result can arrive while the baseline stat below is still in flight.
+        isCompactCommand = true;
+        if (opts.onCompletionEvent) {
+            opts.onCompletionEvent('📦 Compaction started');
+        }
+        void getTranscriptBytes().then((bytes) => {
+            compactTranscriptBaseline = bytes;
+        });
+    };
     const lookupCompactSummary = async (failure: string | null): Promise<CompactSummaryPayload | undefined> => {
         if (failure !== null || !currentSessionId) return undefined;
         try {
             const transcriptPath = join(getProjectPath(opts.path), `${currentSessionId}.jsonl`);
-            const summary = await findLatestCompactSummary(transcriptPath);
+            const summary = await findLatestCompactSummary(transcriptPath, { minBytes: compactTranscriptBaseline });
             if (summary === null) return undefined;
             return { summary, tokensBefore: compactTokensBefore, tokensAfter: compactTokensAfter };
         } catch (e) {
@@ -169,11 +196,7 @@ export async function claudeRemote(opts: {
             return null;
         }
         if (specialCommand.type === 'compact') {
-            logger.debug('[claudeRemote] /compact command detected - will process as normal but with compaction behavior');
-            isCompactCommand = true;
-            if (opts.onCompletionEvent) {
-                opts.onCompletionEvent('📦 Compaction started');
-            }
+            beginCompactCommand();
         }
 
         mode = next.mode;
@@ -288,6 +311,13 @@ export async function claudeRemote(opts: {
                     return;
                 }
                 mode = next.mode;
+                specialCommand = parseSpecialCommand(next.message);
+                if (specialCommand.type === 'compact') {
+                    // /compact can arrive on any turn, not just the initial
+                    // one — arm the compaction tracking here too so later
+                    // turns get the same summary/token completion output.
+                    beginCompactCommand();
+                }
                 messages.push({ type: 'user', message: { role: 'user', content: next.message } });
                 logger.debug(
                     `${debugPrefix} nextMessage resolved fetchId=${fetchId} elapsedMs=${Date.now() - startedAt} ` +

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -121,7 +121,7 @@ export async function claudeRemote(opts: {
     // compaction's summary survives in resumed / second-compact sessions) and
     // must not satisfy the summary lookup while the fresh row is still being
     // flushed to disk.
-    let compactTranscriptBaseline = 0;
+    let compactTranscriptBaseline: number | null = null;
     // The local transcript is keyed by the live session id (updated on init),
     // not opts.sessionId which can be stale for forked sessions.
     let currentSessionId = startFrom;
@@ -132,28 +132,30 @@ export async function claudeRemote(opts: {
     // Success-only: a failed compaction keeps its failure line, an unknown
     // session id or any transcript read problem falls back to the plain
     // completion line. Never propagates errors into the result flow.
-    const getTranscriptBytes = async (): Promise<number> => {
-        if (!currentSessionId) return 0;
+    // Null means the baseline could not be established (unknown session id or
+    // unreadable transcript) — summary promotion is skipped entirely, because
+    // reading from offset 0 could promote a previous compaction's summary row.
+    const getTranscriptBytes = async (): Promise<number | null> => {
+        if (!currentSessionId) return null;
         try {
             return (await stat(join(getProjectPath(opts.path), `${currentSessionId}.jsonl`))).size;
         } catch {
-            return 0;
+            return null;
         }
     };
-    const beginCompactCommand = () => {
+    const beginCompactCommand = async () => {
         logger.debug('[claudeRemote] /compact command detected - will process as normal but with compaction behavior');
-        // Set the flag and emit synchronously: the boundary message and the
-        // result can arrive while the baseline stat below is still in flight.
+        // Flag and status line go out synchronously; only the baseline capture
+        // is awaited (and it must complete before the command is enqueued, so
+        // the result handler can never read a not-yet-established offset).
         isCompactCommand = true;
         if (opts.onCompletionEvent) {
             opts.onCompletionEvent('📦 Compaction started');
         }
-        void getTranscriptBytes().then((bytes) => {
-            compactTranscriptBaseline = bytes;
-        });
+        compactTranscriptBaseline = await getTranscriptBytes();
     };
     const lookupCompactSummary = async (failure: string | null): Promise<CompactSummaryPayload | undefined> => {
-        if (failure !== null || !currentSessionId) return undefined;
+        if (failure !== null || !currentSessionId || compactTranscriptBaseline === null) return undefined;
         try {
             const transcriptPath = join(getProjectPath(opts.path), `${currentSessionId}.jsonl`);
             const summary = await findLatestCompactSummary(transcriptPath, { minBytes: compactTranscriptBaseline });
@@ -196,7 +198,7 @@ export async function claudeRemote(opts: {
             return null;
         }
         if (specialCommand.type === 'compact') {
-            beginCompactCommand();
+            await beginCompactCommand();
         }
 
         mode = next.mode;
@@ -316,7 +318,7 @@ export async function claudeRemote(opts: {
                     // /compact can arrive on any turn, not just the initial
                     // one — arm the compaction tracking here too so later
                     // turns get the same summary/token completion output.
-                    beginCompactCommand();
+                    await beginCompactCommand();
                 }
                 messages.push({ type: 'user', message: { role: 'user', content: next.message } });
                 logger.debug(

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -2,7 +2,7 @@ import { EnhancedMode, PermissionMode } from "./loop";
 import { query, type QueryOptions as Options, type SDKMessage, type SDKSystemMessage, AbortError, SDKUserMessage } from '@/claude/sdk'
 import { claudeCheckSession } from "./utils/claudeCheckSession";
 import { join } from 'node:path';
-import { stat } from 'node:fs/promises';
+import { statSync } from 'node:fs';
 import { parseSpecialCommand } from "@/parsers/specialCommands";
 import { logger } from "@/lib";
 import { PushableAsyncIterable } from "@/utils/PushableAsyncIterable";
@@ -40,6 +40,7 @@ export async function claudeRemote(opts: {
     // Dynamic parameters
     nextMessage: () => Promise<{ message: string, mode: EnhancedMode } | null>,
     onReady: (completionEvent?: string, compactSummary?: CompactSummaryPayload, compactContextTokens?: number) => void | Promise<void>,
+    onCompactSummary?: (compactSummary: CompactSummaryPayload) => void,
     isAborted: (toolCallId: string) => boolean,
 
     // Callbacks
@@ -135,32 +136,38 @@ export async function claudeRemote(opts: {
     // Null means the baseline could not be established (unknown session id or
     // unreadable transcript) — summary promotion is skipped entirely, because
     // reading from offset 0 could promote a previous compaction's summary row.
-    const getTranscriptBytes = async (): Promise<number | null> => {
+    const getTranscriptBytes = (): number | null => {
         if (!currentSessionId) return null;
         try {
-            return (await stat(join(getProjectPath(opts.path), `${currentSessionId}.jsonl`))).size;
+            return statSync(join(getProjectPath(opts.path), `${currentSessionId}.jsonl`)).size;
         } catch {
             return null;
         }
     };
-    const beginCompactCommand = async () => {
+    const beginCompactCommand = () => {
         logger.debug('[claudeRemote] /compact command detected - will process as normal but with compaction behavior');
-        // Flag and status line go out synchronously; only the baseline capture
-        // is awaited (and it must complete before the command is enqueued, so
-        // the result handler can never read a not-yet-established offset).
+        // Keep baseline capture, state arming, and command enqueue in one event
+        // loop turn so an autonomous result cannot claim the pending compact.
+        const baseline = getTranscriptBytes();
+        compactTranscriptBaseline = baseline;
         isCompactCommand = true;
         if (opts.onCompletionEvent) {
             opts.onCompletionEvent('📦 Compaction started');
         }
-        compactTranscriptBaseline = await getTranscriptBytes();
     };
-    const lookupCompactSummary = async (failure: string | null): Promise<CompactSummaryPayload | undefined> => {
-        if (failure !== null || !currentSessionId || compactTranscriptBaseline === null) return undefined;
+    const lookupCompactSummary = async (
+        failure: string | null,
+        sessionId: string | null,
+        baseline: number | null,
+        tokensBefore: number | undefined,
+        tokensAfter: number | undefined
+    ): Promise<CompactSummaryPayload | undefined> => {
+        if (failure !== null || !sessionId || baseline === null) return undefined;
         try {
-            const transcriptPath = join(getProjectPath(opts.path), `${currentSessionId}.jsonl`);
-            const summary = await findLatestCompactSummary(transcriptPath, { minBytes: compactTranscriptBaseline });
+            const transcriptPath = join(getProjectPath(opts.path), `${sessionId}.jsonl`);
+            const summary = await findLatestCompactSummary(transcriptPath, { minBytes: baseline, signal: opts.signal });
             if (summary === null) return undefined;
-            return { summary, tokensBefore: compactTokensBefore, tokensAfter: compactTokensAfter };
+            return { summary, tokensBefore, tokensAfter };
         } catch (e) {
             logger.debug('[claudeRemote] compact summary lookup failed', e);
             return undefined;
@@ -198,7 +205,7 @@ export async function claudeRemote(opts: {
             return null;
         }
         if (specialCommand.type === 'compact') {
-            await beginCompactCommand();
+            beginCompactCommand();
         }
 
         mode = next.mode;
@@ -287,6 +294,7 @@ export async function claudeRemote(opts: {
     let nextMessageFetchSeq = 0;
     let streamMessageSeq = 0;
     let resultSeq = 0;
+    const pendingCompactCompletions = new Set<Promise<void>>();
 
     const scheduleNextMessage = () => {
         if (nextMessageFetchInFlight || inputEnded) {
@@ -312,14 +320,15 @@ export async function claudeRemote(opts: {
                     );
                     return;
                 }
-                mode = next.mode;
-                specialCommand = parseSpecialCommand(next.message);
-                if (specialCommand.type === 'compact') {
+                const nextSpecialCommand = parseSpecialCommand(next.message);
+                if (nextSpecialCommand.type === 'compact') {
                     // /compact can arrive on any turn, not just the initial
                     // one — arm the compaction tracking here too so later
                     // turns get the same summary/token completion output.
-                    await beginCompactCommand();
+                    beginCompactCommand();
                 }
+                mode = next.mode;
+                specialCommand = nextSpecialCommand;
                 messages.push({ type: 'user', message: { role: 'user', content: next.message } });
                 logger.debug(
                     `${debugPrefix} nextMessage resolved fetchId=${fetchId} elapsedMs=${Date.now() - startedAt} ` +
@@ -358,8 +367,12 @@ export async function claudeRemote(opts: {
             // "Conversation compacted" status line, which would duplicate the
             // completion output (summary card or token-delta line) right below
             // it. Auto-compact boundaries keep relaying as before.
+            const compactMetadata =
+                message.type === 'system' && message.subtype === 'compact_boundary'
+                    ? (message as any).compact_metadata
+                    : undefined;
             const isManualCompactBoundary =
-                isCompactCommand && message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary';
+                isCompactCommand && compactMetadata?.trigger === 'manual';
             // The stdout echo of the active /compact is CLI bookkeeping for
             // this turn — suppress it here where the command state lives, so
             // identical output from other slash commands stays visible.
@@ -422,10 +435,9 @@ export async function claudeRemote(opts: {
 
             // Capture the compaction token delta from the boundary metadata
             // (pre_tokens/post_tokens are the context sizes on each side).
-            if (message.type === 'system' && message.subtype === 'compact_boundary' && isCompactCommand) {
-                const metadata = (message as any).compact_metadata;
-                if (typeof metadata?.pre_tokens === 'number') compactTokensBefore = metadata.pre_tokens;
-                if (typeof metadata?.post_tokens === 'number') compactTokensAfter = metadata.post_tokens;
+            if (isManualCompactBoundary) {
+                if (typeof compactMetadata?.pre_tokens === 'number') compactTokensBefore = compactMetadata.pre_tokens;
+                if (typeof compactMetadata?.post_tokens === 'number') compactTokensAfter = compactMetadata.post_tokens;
                 logger.debug(`[claudeRemote] compact_boundary tokens: ${compactTokensBefore} -> ${compactTokensAfter}`);
             }
 
@@ -442,28 +454,60 @@ export async function claudeRemote(opts: {
                     opts.onFirstResult?.(initial.message);
                 }
 
-                let completionEvent: string | undefined;
-                let compactSummary: CompactSummaryPayload | undefined;
                 let compactContextTokens: number | undefined;
+                let releaseCompactCompletion: (() => void) | undefined;
                 if (isCompactCommand) {
-                    compactSummary = await lookupCompactSummary(compactFailure);
-                    if (!compactSummary) {
-                        completionEvent = buildCompactCompletionEvent(compactFailure, compactTokensBefore, compactTokensAfter);
-                    }
-                    logger.debug(`[claudeRemote] ${compactSummary ? `compact summary promoted (${compactSummary.summary.length} chars)` : completionEvent}`);
+                    const failure = compactFailure;
+                    const sessionId = currentSessionId;
+                    const baseline = compactTranscriptBaseline;
+                    const tokensBefore = compactTokensBefore;
+                    const tokensAfter = compactTokensAfter;
                     // Preserve the post-compaction context size even when no
                     // summary was found: the launcher refreshes the context
                     // bar with it, since the next real usage only arrives
                     // with the next model response.
-                    compactContextTokens = compactTokensAfter;
+                    compactContextTokens = tokensAfter;
                     isCompactCommand = false;
                     compactFailure = null;
                     compactTokensBefore = undefined;
                     compactTokensAfter = undefined;
+                    compactTranscriptBaseline = null;
+
+                    const readyFlushed = new Promise<void>((resolve) => {
+                        releaseCompactCompletion = resolve;
+                    });
+                    const completion = (async () => {
+                        const compactSummary = await lookupCompactSummary(
+                            failure,
+                            sessionId,
+                            baseline,
+                            tokensBefore,
+                            tokensAfter
+                        );
+                        await readyFlushed;
+                        if (opts.signal?.aborted) return;
+                        if (compactSummary) {
+                            logger.debug(`[claudeRemote] compact summary promoted (${compactSummary.summary.length} chars)`);
+                            opts.onCompactSummary?.(compactSummary);
+                            return;
+                        }
+                        const completionEvent = buildCompactCompletionEvent(failure, tokensBefore, tokensAfter);
+                        logger.debug(`[claudeRemote] ${completionEvent}`);
+                        opts.onCompletionEvent?.(completionEvent);
+                    })();
+                    pendingCompactCompletions.add(completion);
+                    void completion
+                        .finally(() => pendingCompactCompletions.delete(completion))
+                        .catch((error) => logger.debug('[claudeRemote] compact completion callback failed', error));
                 }
 
-                // Flush the result carrier before completion, then announce ready.
-                await opts.onReady(completionEvent, compactSummary, compactContextTokens);
+                // Flush the result carrier and announce ready without blocking
+                // response consumption on transcript-summary polling.
+                try {
+                    await opts.onReady(undefined, undefined, compactContextTokens);
+                } finally {
+                    releaseCompactCompletion?.();
+                }
                 logger.debug(`${debugPrefix} onReady emitted for result #${resultSeq}`);
 
                 // Pull next user message without blocking response stream processing.
@@ -487,6 +531,7 @@ export async function claudeRemote(opts: {
             }
         }
         logger.debug(`${debugPrefix} response stream exhausted`);
+        await Promise.allSettled(pendingCompactCompletions);
     } catch (e) {
         if (e instanceof AbortError) {
             logger.debug(`[claudeRemote] Aborted`);

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -61,6 +61,7 @@ export async function claudeRemote(opts: {
     onThinkingChange?: (thinking: boolean) => void,
     onMessage: (message: SDKMessage) => void,
     onFirstResult?: (initialMessage: string) => void,
+    onCompactResultAccepted?: () => void,
     onCompletionEvent?: (message: string) => void,
     onSessionReset?: () => void
 }) {
@@ -364,14 +365,47 @@ export async function claudeRemote(opts: {
 
         const responseIterator = response[Symbol.asyncIterator]();
         let pendingResponseNext: Promise<IteratorResult<SDKMessage>> | null = null;
+        let pendingResponseDone = false;
+        let pendingResponseError: unknown;
+        let hasPendingResponseError = false;
         while (true) {
-            pendingResponseNext ??= responseIterator.next();
+            if (!pendingResponseNext) {
+                pendingResponseDone = false;
+                pendingResponseError = undefined;
+                hasPendingResponseError = false;
+                pendingResponseNext = responseIterator.next().then(
+                    (result) => {
+                        pendingResponseDone = result.done === true;
+                        return result;
+                    },
+                    (error) => {
+                        pendingResponseError = error;
+                        hasPendingResponseError = true;
+                        throw error;
+                    }
+                );
+            }
             let message: SDKMessage;
             if (compactCompletion) {
                 const winner = await Promise.race([
                     compactCompletion.then((result) => ({ type: 'compact' as const, result })),
-                    pendingResponseNext.then((result) => ({ type: 'response' as const, result }))
+                    pendingResponseNext.then(
+                        (result) => ({ type: 'response' as const, result }),
+                        (error) => ({ type: 'response-error' as const, error })
+                    )
                 ]);
+                if (winner.type === 'response-error') {
+                    if (winner.error instanceof AbortError) throw winner.error;
+                    if (opts.signal?.aborted) throw new AbortError('Compaction completion aborted');
+                    const completion = await compactCompletion;
+                    compactCompletion = null;
+                    await opts.onReady(
+                        completion.completionEvent,
+                        completion.compactSummary,
+                        completion.contextTokens
+                    );
+                    throw winner.error;
+                }
                 if (winner.type === 'compact') {
                     compactCompletion = null;
                     await opts.onReady(
@@ -380,6 +414,11 @@ export async function claudeRemote(opts: {
                         winner.result.contextTokens
                     );
                     logger.debug(`${debugPrefix} compact completion published`);
+                    if (hasPendingResponseError) throw pendingResponseError;
+                    if (pendingResponseDone) {
+                        responseClosed = true;
+                        break;
+                    }
                     scheduleNextMessage();
                     continue;
                 }
@@ -521,6 +560,7 @@ export async function claudeRemote(opts: {
                     // bar with it, since the next real usage only arrives
                     // with the next model response.
                     compactState.active = null;
+                    opts.onCompactResultAccepted?.();
 
                     compactCompletion = (async () => {
                         const compactSummary = await lookupCompactSummary(

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -159,12 +159,13 @@ export async function claudeRemote(opts: {
         sessionId: string | null,
         baseline: number | null,
         tokensBefore: number | undefined,
-        tokensAfter: number | undefined
+        tokensAfter: number | undefined,
+        signal?: AbortSignal
     ): Promise<CompactSummaryPayload | undefined> => {
         if (failure !== null || !sessionId || baseline === null) return undefined;
         try {
             const transcriptPath = join(getProjectPath(opts.path), `${sessionId}.jsonl`);
-            const summary = await findLatestCompactSummary(transcriptPath, { minBytes: baseline, signal: opts.signal });
+            const summary = await findLatestCompactSummary(transcriptPath, { minBytes: baseline, signal });
             if (summary === null) return undefined;
             return { summary, tokensBefore, tokensAfter };
         } catch (e) {
@@ -294,12 +295,18 @@ export async function claudeRemote(opts: {
     let streamMessageSeq = 0;
     let resultSeq = 0;
     const pendingCompactCompletions = new Set<Promise<void>>();
+    const compactCompletionAbort = new AbortController();
+    let responseFailed = false;
+    let responseClosed = false;
+    const abortCompactCompletion = () => compactCompletionAbort.abort();
+    opts.signal?.addEventListener('abort', abortCompactCompletion, { once: true });
+    if (opts.signal?.aborted) compactCompletionAbort.abort();
 
     const scheduleNextMessage = () => {
-        if (nextMessageFetchInFlight || inputEnded) {
+        if (nextMessageFetchInFlight || inputEnded || responseClosed) {
             logger.debug(
                 `${debugPrefix} scheduleNextMessage skipped ` +
-                `(inFlight=${nextMessageFetchInFlight}, inputEnded=${inputEnded})`
+                `(inFlight=${nextMessageFetchInFlight}, inputEnded=${inputEnded}, responseClosed=${responseClosed})`
             );
             return;
         }
@@ -311,6 +318,7 @@ export async function claudeRemote(opts: {
         void (async () => {
             try {
                 const next = await opts.nextMessage();
+                if (responseClosed) return;
                 if (!next) {
                     inputEnded = true;
                     messages.end();
@@ -475,16 +483,19 @@ export async function claudeRemote(opts: {
                             sessionId,
                             baseline,
                             tokensBefore,
-                            tokensAfter
+                            tokensAfter,
+                            compactCompletionAbort.signal
                         );
-                        if (opts.signal?.aborted) return;
+                        if (responseFailed || compactCompletionAbort.signal.aborted) return;
                         const completionEvent = compactSummary
                             ? undefined
                             : buildCompactCompletionEvent(failure, tokensBefore, tokensAfter);
                         logger.debug(`[claudeRemote] ${compactSummary ? `compact summary promoted (${compactSummary.summary.length} chars)` : completionEvent}`);
                         await opts.onReady(completionEvent, compactSummary, tokensAfter);
                         logger.debug(`${debugPrefix} onReady emitted for compact result #${resultSeq}`);
-                        scheduleNextMessage();
+                        if (!responseClosed && !compactCompletionAbort.signal.aborted) {
+                            scheduleNextMessage();
+                        }
                     })();
                     pendingCompactCompletions.add(completion);
                     void completion
@@ -516,9 +527,14 @@ export async function claudeRemote(opts: {
                 }
             }
         }
+        responseClosed = true;
         logger.debug(`${debugPrefix} response stream exhausted`);
         await Promise.allSettled(pendingCompactCompletions);
     } catch (e) {
+        responseFailed = true;
+        responseClosed = true;
+        compactCompletionAbort.abort();
+        await Promise.allSettled(pendingCompactCompletions);
         if (e instanceof AbortError) {
             logger.debug(`[claudeRemote] Aborted`);
             // Ignore
@@ -527,6 +543,12 @@ export async function claudeRemote(opts: {
             throw e;
         }
     } finally {
+        responseClosed = true;
+        if (pendingCompactCompletions.size > 0) {
+            compactCompletionAbort.abort();
+            await Promise.allSettled(pendingCompactCompletions);
+        }
+        opts.signal?.removeEventListener('abort', abortCompactCompletion);
         logger.debug(
             `${debugPrefix} finally ` +
             `(streamMessages=${streamMessageSeq}, results=${resultSeq}, nextFetches=${nextMessageFetchSeq}, inputEnded=${inputEnded})`

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -360,7 +360,17 @@ export async function claudeRemote(opts: {
             // it. Auto-compact boundaries keep relaying as before.
             const isManualCompactBoundary =
                 isCompactCommand && message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary';
-            if (!isManualCompactBoundary) {
+            // The stdout echo of the active /compact is CLI bookkeeping for
+            // this turn — suppress it here where the command state lives, so
+            // identical output from other slash commands stays visible.
+            const echo = message.type === 'user'
+                ? (message as SDKUserMessage).message?.content
+                : undefined;
+            const isManualCompactBookkeeping =
+                isCompactCommand &&
+                typeof echo === 'string' &&
+                /^<local-command-stdout>\s*Compacted\s*<\/local-command-stdout>$/.test(echo.trim());
+            if (!isManualCompactBoundary && !isManualCompactBookkeeping) {
                 opts.onMessage(message);
             }
 

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -296,6 +296,7 @@ export async function claudeRemote(opts: {
     let resultSeq = 0;
     const pendingCompactCompletions = new Set<Promise<void>>();
     const compactCompletionAbort = new AbortController();
+    let compactCompletionError: Error | null = null;
     let responseFailed = false;
     let responseClosed = false;
     const abortCompactCompletion = () => compactCompletionAbort.abort();
@@ -478,23 +479,30 @@ export async function claudeRemote(opts: {
                     compactTranscriptBaseline = null;
 
                     const completion = (async () => {
-                        const compactSummary = await lookupCompactSummary(
-                            failure,
-                            sessionId,
-                            baseline,
-                            tokensBefore,
-                            tokensAfter,
-                            compactCompletionAbort.signal
-                        );
-                        if (responseFailed || compactCompletionAbort.signal.aborted) return;
-                        const completionEvent = compactSummary
-                            ? undefined
-                            : buildCompactCompletionEvent(failure, tokensBefore, tokensAfter);
-                        logger.debug(`[claudeRemote] ${compactSummary ? `compact summary promoted (${compactSummary.summary.length} chars)` : completionEvent}`);
-                        await opts.onReady(completionEvent, compactSummary, tokensAfter);
-                        logger.debug(`${debugPrefix} onReady emitted for compact result #${resultSeq}`);
-                        if (!responseClosed && !compactCompletionAbort.signal.aborted) {
-                            scheduleNextMessage();
+                        try {
+                            const compactSummary = await lookupCompactSummary(
+                                failure,
+                                sessionId,
+                                baseline,
+                                tokensBefore,
+                                tokensAfter,
+                                compactCompletionAbort.signal
+                            );
+                            if (responseFailed || compactCompletionAbort.signal.aborted) return;
+                            const completionEvent = compactSummary
+                                ? undefined
+                                : buildCompactCompletionEvent(failure, tokensBefore, tokensAfter);
+                            logger.debug(`[claudeRemote] ${compactSummary ? `compact summary promoted (${compactSummary.summary.length} chars)` : completionEvent}`);
+                            await opts.onReady(completionEvent, compactSummary, tokensAfter);
+                            logger.debug(`${debugPrefix} onReady emitted for compact result #${resultSeq}`);
+                            if (!responseClosed && !compactCompletionAbort.signal.aborted) {
+                                scheduleNextMessage();
+                            }
+                        } catch (error) {
+                            compactCompletionError = error instanceof Error ? error : new Error(String(error));
+                            messages.setError(compactCompletionError);
+                            (response as { setError?: (error: Error) => void }).setError?.(compactCompletionError);
+                            throw compactCompletionError;
                         }
                     })();
                     pendingCompactCompletions.add(completion);
@@ -530,6 +538,7 @@ export async function claudeRemote(opts: {
         responseClosed = true;
         logger.debug(`${debugPrefix} response stream exhausted`);
         await Promise.allSettled(pendingCompactCompletions);
+        if (compactCompletionError) throw compactCompletionError;
     } catch (e) {
         responseFailed = true;
         responseClosed = true;

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -40,7 +40,6 @@ export async function claudeRemote(opts: {
     // Dynamic parameters
     nextMessage: () => Promise<{ message: string, mode: EnhancedMode } | null>,
     onReady: (completionEvent?: string, compactSummary?: CompactSummaryPayload, compactContextTokens?: number) => void | Promise<void>,
-    onCompactSummary?: (compactSummary: CompactSummaryPayload) => void,
     isAborted: (toolCallId: string) => boolean,
 
     // Callbacks
@@ -454,8 +453,6 @@ export async function claudeRemote(opts: {
                     opts.onFirstResult?.(initial.message);
                 }
 
-                let compactContextTokens: number | undefined;
-                let releaseCompactCompletion: (() => void) | undefined;
                 if (isCompactCommand) {
                     const failure = compactFailure;
                     const sessionId = currentSessionId;
@@ -466,16 +463,12 @@ export async function claudeRemote(opts: {
                     // summary was found: the launcher refreshes the context
                     // bar with it, since the next real usage only arrives
                     // with the next model response.
-                    compactContextTokens = tokensAfter;
                     isCompactCommand = false;
                     compactFailure = null;
                     compactTokensBefore = undefined;
                     compactTokensAfter = undefined;
                     compactTranscriptBaseline = null;
 
-                    const readyFlushed = new Promise<void>((resolve) => {
-                        releaseCompactCompletion = resolve;
-                    });
                     const completion = (async () => {
                         const compactSummary = await lookupCompactSummary(
                             failure,
@@ -484,30 +477,23 @@ export async function claudeRemote(opts: {
                             tokensBefore,
                             tokensAfter
                         );
-                        await readyFlushed;
                         if (opts.signal?.aborted) return;
-                        if (compactSummary) {
-                            logger.debug(`[claudeRemote] compact summary promoted (${compactSummary.summary.length} chars)`);
-                            opts.onCompactSummary?.(compactSummary);
-                            return;
-                        }
-                        const completionEvent = buildCompactCompletionEvent(failure, tokensBefore, tokensAfter);
-                        logger.debug(`[claudeRemote] ${completionEvent}`);
-                        opts.onCompletionEvent?.(completionEvent);
+                        const completionEvent = compactSummary
+                            ? undefined
+                            : buildCompactCompletionEvent(failure, tokensBefore, tokensAfter);
+                        logger.debug(`[claudeRemote] ${compactSummary ? `compact summary promoted (${compactSummary.summary.length} chars)` : completionEvent}`);
+                        await opts.onReady(completionEvent, compactSummary, tokensAfter);
+                        logger.debug(`${debugPrefix} onReady emitted for compact result #${resultSeq}`);
+                        scheduleNextMessage();
                     })();
                     pendingCompactCompletions.add(completion);
                     void completion
                         .finally(() => pendingCompactCompletions.delete(completion))
                         .catch((error) => logger.debug('[claudeRemote] compact completion callback failed', error));
+                    continue;
                 }
 
-                // Flush the result carrier and announce ready without blocking
-                // response consumption on transcript-summary polling.
-                try {
-                    await opts.onReady(undefined, undefined, compactContextTokens);
-                } finally {
-                    releaseCompactCompletion?.();
-                }
+                await opts.onReady();
                 logger.debug(`${debugPrefix} onReady emitted for result #${resultSeq}`);
 
                 // Pull next user message without blocking response stream processing.

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -31,6 +31,7 @@ interface CompactCompletion {
 interface ActiveCompact {
     baseline: number | null;
     failure: string | null;
+    sawCompactSignal: boolean;
     tokensBefore?: number;
     tokensAfter?: number;
 }
@@ -148,7 +149,8 @@ export async function claudeRemote(opts: {
         // loop turn so an autonomous result cannot claim the pending compact.
         compactState.active = {
             baseline: getTranscriptBytes(),
-            failure: null
+            failure: null,
+            sawCompactSignal: false
         };
         if (opts.onCompletionEvent) {
             opts.onCompletionEvent('📦 Compaction started');
@@ -472,11 +474,14 @@ export async function claudeRemote(opts: {
             // we do not recognise cannot invent a failure.
             if (message.type === 'system' && message.subtype === 'status' && compactState.active) {
                 const systemStatus = message as SDKSystemMessage;
+                if (systemStatus.status === 'compacting' || systemStatus.compact_result !== undefined) {
+                    compactState.active.sawCompactSignal = true;
+                }
                 if (systemStatus.compact_result === 'failed') {
                     const reason = typeof systemStatus.compact_error === 'string'
                         ? systemStatus.compact_error.trim()
                         : '';
-                    compactState.active.failure = reason.length > 0 ? reason : 'Compaction failed';
+                    compactState.active.failure = reason;
                     logger.debug(`[claudeRemote] Compaction reported as failed: ${compactState.active.failure}`);
                 }
             }
@@ -484,6 +489,7 @@ export async function claudeRemote(opts: {
             // Capture the compaction token delta from the boundary metadata
             // (pre_tokens/post_tokens are the context sizes on each side).
             if (isManualCompactBoundary && compactState.active) {
+                compactState.active.sawCompactSignal = true;
                 if (typeof compactMetadata?.pre_tokens === 'number') compactState.active.tokensBefore = compactMetadata.pre_tokens;
                 if (typeof compactMetadata?.post_tokens === 'number') compactState.active.tokensAfter = compactMetadata.post_tokens;
                 logger.debug(`[claudeRemote] compact_boundary tokens: ${compactState.active.tokensBefore} -> ${compactState.active.tokensAfter}`);
@@ -503,6 +509,7 @@ export async function claudeRemote(opts: {
                 }
 
                 if (compactState.active) {
+                    if (!compactState.active.sawCompactSignal) continue;
                     const compact = compactState.active;
                     const sessionId = currentSessionId;
                     const baseline = compact.baseline;
@@ -524,6 +531,9 @@ export async function claudeRemote(opts: {
                             tokensAfter,
                             compactCompletionAbort.signal
                         );
+                        if (compactCompletionAbort.signal.aborted) {
+                            throw new AbortError('Compaction completion aborted');
+                        }
                         const completionEvent = compactSummary
                             ? undefined
                             : buildCompactCompletionEvent(failure, tokensBefore, tokensAfter);

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -321,8 +321,16 @@ export async function claudeRemote(opts: {
             );
             logger.debugLargeJson(`[claudeRemote] Message ${message.type}`, message);
 
-            // Handle messages
-            opts.onMessage(message);
+            // Handle messages. During a manual /compact the compact_boundary
+            // system message stays unrelayed: its only web rendering is a
+            // "Conversation compacted" status line, which would duplicate the
+            // completion output (summary card or token-delta line) right below
+            // it. Auto-compact boundaries keep relaying as before.
+            const isManualCompactBoundary =
+                isCompactCommand && message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary';
+            if (!isManualCompactBoundary) {
+                opts.onMessage(message);
+            }
 
             // Handle special system messages
             if (message.type === 'system' && message.subtype === 'init') {

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -12,6 +12,7 @@ import { PermissionResult } from "./sdk/types";
 import { getHapiBlobsDir } from "@/constants/uploadPaths";
 import { getDefaultClaudeCodePath } from "./sdk/utils";
 import { filterCatalogAffectingClaudeArgs } from "./sdk/metadataExtractor";
+import { buildCompactCompletionEvent } from "./utils/compactCompletion";
 
 export async function claudeRemote(opts: {
 
@@ -102,6 +103,11 @@ export async function claudeRemote(opts: {
     // reported, so an unseen or successful status keeps the success path.
     let isCompactCommand = false;
     let compactFailure: string | null = null;
+    // Token context size around the compaction, from the system/compact_boundary
+    // message's compact_metadata. The result that follows a compact reports all-zero
+    // usage (measured), so the boundary metadata is the only real source.
+    let compactTokensBefore: number | undefined;
+    let compactTokensAfter: number | undefined;
     let awaitingForkInit = forkSession;
 
     const messages = new PushableAsyncIterable<SDKUserMessage>();
@@ -140,7 +146,7 @@ export async function claudeRemote(opts: {
             logger.debug('[claudeRemote] /compact command detected - will process as normal but with compaction behavior');
             isCompactCommand = true;
             if (opts.onCompletionEvent) {
-                opts.onCompletionEvent('Compaction started');
+                opts.onCompletionEvent('📦 Compaction started');
             }
         }
 
@@ -337,6 +343,15 @@ export async function claudeRemote(opts: {
                 }
             }
 
+            // Capture the compaction token delta from the boundary metadata
+            // (pre_tokens/post_tokens are the context sizes on each side).
+            if (message.type === 'system' && message.subtype === 'compact_boundary' && isCompactCommand) {
+                const metadata = (message as any).compact_metadata;
+                if (typeof metadata?.pre_tokens === 'number') compactTokensBefore = metadata.pre_tokens;
+                if (typeof metadata?.post_tokens === 'number') compactTokensAfter = metadata.post_tokens;
+                logger.debug(`[claudeRemote] compact_boundary tokens: ${compactTokensBefore} -> ${compactTokensAfter}`);
+            }
+
             // Handle result messages
             if (message.type === 'result') {
                 resultSeq += 1;
@@ -352,12 +367,12 @@ export async function claudeRemote(opts: {
 
                 let completionEvent: string | undefined;
                 if (isCompactCommand) {
-                    completionEvent = compactFailure
-                        ? `Compaction failed: ${compactFailure}`
-                        : 'Compaction completed';
+                    completionEvent = buildCompactCompletionEvent(compactFailure, compactTokensBefore, compactTokensAfter);
                     logger.debug(`[claudeRemote] ${completionEvent}`);
                     isCompactCommand = false;
                     compactFailure = null;
+                    compactTokensBefore = undefined;
+                    compactTokensAfter = undefined;
                 }
 
                 // Flush the result carrier before completion, then announce ready.

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -39,7 +39,7 @@ export async function claudeRemote(opts: {
 
     // Dynamic parameters
     nextMessage: () => Promise<{ message: string, mode: EnhancedMode } | null>,
-    onReady: (completionEvent?: string, compactSummary?: CompactSummaryPayload) => void | Promise<void>,
+    onReady: (completionEvent?: string, compactSummary?: CompactSummaryPayload, compactContextTokens?: number) => void | Promise<void>,
     isAborted: (toolCallId: string) => boolean,
 
     // Callbacks
@@ -434,12 +434,18 @@ export async function claudeRemote(opts: {
 
                 let completionEvent: string | undefined;
                 let compactSummary: CompactSummaryPayload | undefined;
+                let compactContextTokens: number | undefined;
                 if (isCompactCommand) {
                     compactSummary = await lookupCompactSummary(compactFailure);
                     if (!compactSummary) {
                         completionEvent = buildCompactCompletionEvent(compactFailure, compactTokensBefore, compactTokensAfter);
                     }
                     logger.debug(`[claudeRemote] ${compactSummary ? `compact summary promoted (${compactSummary.summary.length} chars)` : completionEvent}`);
+                    // Preserve the post-compaction context size even when no
+                    // summary was found: the launcher refreshes the context
+                    // bar with it, since the next real usage only arrives
+                    // with the next model response.
+                    compactContextTokens = compactTokensAfter;
                     isCompactCommand = false;
                     compactFailure = null;
                     compactTokensBefore = undefined;
@@ -447,7 +453,7 @@ export async function claudeRemote(opts: {
                 }
 
                 // Flush the result carrier before completion, then announce ready.
-                await opts.onReady(completionEvent, compactSummary);
+                await opts.onReady(completionEvent, compactSummary, compactContextTokens);
                 logger.debug(`${debugPrefix} onReady emitted for result #${resultSeq}`);
 
                 // Pull next user message without blocking response stream processing.

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -22,6 +22,19 @@ export interface CompactSummaryPayload {
     tokensAfter?: number;
 }
 
+interface CompactCompletion {
+    completionEvent?: string;
+    compactSummary?: CompactSummaryPayload;
+    contextTokens?: number;
+}
+
+interface ActiveCompact {
+    baseline: number | null;
+    failure: string | null;
+    tokensBefore?: number;
+    tokensAfter?: number;
+}
+
 export async function claudeRemote(opts: {
 
     // Fixed parameters
@@ -105,23 +118,9 @@ export async function claudeRemote(opts: {
     let mode: EnhancedMode = bootstrapMode;
     let initial: { message: string; mode: EnhancedMode } | null = null;
     let specialCommand: ReturnType<typeof parseSpecialCommand> = { type: null };
-    // Claude reports the /compact outcome on a `system`/`status` message that
-    // arrives before the `result` message. Hold it here so the completion event
-    // can report what actually happened. Stays null unless a failure is
-    // reported, so an unseen or successful status keeps the success path.
-    let isCompactCommand = false;
-    let compactFailure: string | null = null;
-    // Token context size around the compaction, from the system/compact_boundary
-    // message's compact_metadata. The result that follows a compact reports all-zero
-    // usage (measured), so the boundary metadata is the only real source.
-    let compactTokensBefore: number | undefined;
-    let compactTokensAfter: number | undefined;
-    // Transcript byte size recorded when the /compact command is detected.
-    // Summary rows below this offset belong to earlier turns (a previous
-    // compaction's summary survives in resumed / second-compact sessions) and
-    // must not satisfy the summary lookup while the fresh row is still being
-    // flushed to disk.
-    let compactTranscriptBaseline: number | null = null;
+    // Owns all mutable state from command enqueue through its result. Null
+    // means no manual compact turn can claim stream status or boundaries.
+    const compactState: { active: ActiveCompact | null } = { active: null };
     // The local transcript is keyed by the live session id (updated on init),
     // not opts.sessionId which can be stale for forked sessions.
     let currentSessionId = startFrom;
@@ -147,9 +146,10 @@ export async function claudeRemote(opts: {
         logger.debug('[claudeRemote] /compact command detected - will process as normal but with compaction behavior');
         // Keep baseline capture, state arming, and command enqueue in one event
         // loop turn so an autonomous result cannot claim the pending compact.
-        const baseline = getTranscriptBytes();
-        compactTranscriptBaseline = baseline;
-        isCompactCommand = true;
+        compactState.active = {
+            baseline: getTranscriptBytes(),
+            failure: null
+        };
         if (opts.onCompletionEvent) {
             opts.onCompletionEvent('📦 Compaction started');
         }
@@ -294,11 +294,9 @@ export async function claudeRemote(opts: {
     let nextMessageFetchSeq = 0;
     let streamMessageSeq = 0;
     let resultSeq = 0;
-    const pendingCompactCompletions = new Set<Promise<void>>();
     const compactCompletionAbort = new AbortController();
-    let compactCompletionError: Error | null = null;
-    let responseFailed = false;
     let responseClosed = false;
+    let compactCompletion: Promise<CompactCompletion> | null = null;
     const abortCompactCompletion = () => compactCompletionAbort.abort();
     opts.signal?.addEventListener('abort', abortCompactCompletion, { once: true });
     if (opts.signal?.aborted) compactCompletionAbort.abort();
@@ -362,7 +360,49 @@ export async function claudeRemote(opts: {
     try {
         logger.debug(`[claudeRemote] Starting to iterate over response`);
 
-        for await (const message of response) {
+        const responseIterator = response[Symbol.asyncIterator]();
+        let pendingResponseNext: Promise<IteratorResult<SDKMessage>> | null = null;
+        while (true) {
+            pendingResponseNext ??= responseIterator.next();
+            let message: SDKMessage;
+            if (compactCompletion) {
+                const winner = await Promise.race([
+                    compactCompletion.then((result) => ({ type: 'compact' as const, result })),
+                    pendingResponseNext.then((result) => ({ type: 'response' as const, result }))
+                ]);
+                if (winner.type === 'compact') {
+                    compactCompletion = null;
+                    await opts.onReady(
+                        winner.result.completionEvent,
+                        winner.result.compactSummary,
+                        winner.result.contextTokens
+                    );
+                    logger.debug(`${debugPrefix} compact completion published`);
+                    scheduleNextMessage();
+                    continue;
+                }
+                pendingResponseNext = null;
+                if (winner.result.done) {
+                    responseClosed = true;
+                    const completion = await compactCompletion;
+                    compactCompletion = null;
+                    await opts.onReady(
+                        completion.completionEvent,
+                        completion.compactSummary,
+                        completion.contextTokens
+                    );
+                    break;
+                }
+                message = winner.result.value;
+            } else {
+                const next = await pendingResponseNext;
+                pendingResponseNext = null;
+                if (next.done) {
+                    responseClosed = true;
+                    break;
+                }
+                message = next.value;
+            }
             streamMessageSeq += 1;
             logger.debug(
                 `${debugPrefix} stream message #${streamMessageSeq} type=${message.type} ` +
@@ -380,7 +420,7 @@ export async function claudeRemote(opts: {
                     ? (message as any).compact_metadata
                     : undefined;
             const isManualCompactBoundary =
-                isCompactCommand && compactMetadata?.trigger === 'manual';
+                compactState.active !== null && compactMetadata?.trigger === 'manual';
             // The stdout echo of the active /compact is CLI bookkeeping for
             // this turn — suppress it here where the command state lives, so
             // identical output from other slash commands stays visible.
@@ -388,7 +428,7 @@ export async function claudeRemote(opts: {
                 ? (message as SDKUserMessage).message?.content
                 : undefined;
             const isManualCompactBookkeeping =
-                isCompactCommand &&
+                compactState.active !== null &&
                 typeof echo === 'string' &&
                 /^<local-command-stdout>\s*Compacted\s*<\/local-command-stdout>$/.test(echo.trim());
             if (!isManualCompactBoundary && !isManualCompactBookkeeping) {
@@ -430,23 +470,23 @@ export async function claudeRemote(opts: {
             // Capture the /compact outcome. Only a reported failure is recorded:
             // anything else leaves the success path untouched, so a status shape
             // we do not recognise cannot invent a failure.
-            if (message.type === 'system' && message.subtype === 'status' && isCompactCommand) {
+            if (message.type === 'system' && message.subtype === 'status' && compactState.active) {
                 const systemStatus = message as SDKSystemMessage;
                 if (systemStatus.compact_result === 'failed') {
                     const reason = typeof systemStatus.compact_error === 'string'
                         ? systemStatus.compact_error.trim()
                         : '';
-                    compactFailure = reason.length > 0 ? reason : 'Compaction failed';
-                    logger.debug(`[claudeRemote] Compaction reported as failed: ${compactFailure}`);
+                    compactState.active.failure = reason.length > 0 ? reason : 'Compaction failed';
+                    logger.debug(`[claudeRemote] Compaction reported as failed: ${compactState.active.failure}`);
                 }
             }
 
             // Capture the compaction token delta from the boundary metadata
             // (pre_tokens/post_tokens are the context sizes on each side).
-            if (isManualCompactBoundary) {
-                if (typeof compactMetadata?.pre_tokens === 'number') compactTokensBefore = compactMetadata.pre_tokens;
-                if (typeof compactMetadata?.post_tokens === 'number') compactTokensAfter = compactMetadata.post_tokens;
-                logger.debug(`[claudeRemote] compact_boundary tokens: ${compactTokensBefore} -> ${compactTokensAfter}`);
+            if (isManualCompactBoundary && compactState.active) {
+                if (typeof compactMetadata?.pre_tokens === 'number') compactState.active.tokensBefore = compactMetadata.pre_tokens;
+                if (typeof compactMetadata?.post_tokens === 'number') compactState.active.tokensAfter = compactMetadata.post_tokens;
+                logger.debug(`[claudeRemote] compact_boundary tokens: ${compactState.active.tokensBefore} -> ${compactState.active.tokensAfter}`);
             }
 
             // Handle result messages
@@ -462,55 +502,41 @@ export async function claudeRemote(opts: {
                     opts.onFirstResult?.(initial.message);
                 }
 
-                if (isCompactCommand) {
-                    const failure = compactFailure;
+                if (compactState.active) {
+                    const compact = compactState.active;
                     const sessionId = currentSessionId;
-                    const baseline = compactTranscriptBaseline;
-                    const tokensBefore = compactTokensBefore;
-                    const tokensAfter = compactTokensAfter;
+                    const baseline = compact.baseline;
+                    const failure = compact.failure;
+                    const tokensBefore = compact.tokensBefore;
+                    const tokensAfter = compact.tokensAfter;
                     // Preserve the post-compaction context size even when no
                     // summary was found: the launcher refreshes the context
                     // bar with it, since the next real usage only arrives
                     // with the next model response.
-                    isCompactCommand = false;
-                    compactFailure = null;
-                    compactTokensBefore = undefined;
-                    compactTokensAfter = undefined;
-                    compactTranscriptBaseline = null;
+                    compactState.active = null;
 
-                    const completion = (async () => {
-                        try {
-                            const compactSummary = await lookupCompactSummary(
-                                failure,
-                                sessionId,
-                                baseline,
-                                tokensBefore,
-                                tokensAfter,
-                                compactCompletionAbort.signal
-                            );
-                            if (responseFailed || compactCompletionAbort.signal.aborted) return;
-                            const completionEvent = compactSummary
-                                ? undefined
-                                : buildCompactCompletionEvent(failure, tokensBefore, tokensAfter);
-                            logger.debug(`[claudeRemote] ${compactSummary ? `compact summary promoted (${compactSummary.summary.length} chars)` : completionEvent}`);
-                            await opts.onReady(completionEvent, compactSummary, tokensAfter);
-                            logger.debug(`${debugPrefix} onReady emitted for compact result #${resultSeq}`);
-                            if (!responseClosed && !compactCompletionAbort.signal.aborted) {
-                                scheduleNextMessage();
-                            }
-                        } catch (error) {
-                            compactCompletionError = error instanceof Error ? error : new Error(String(error));
-                            messages.setError(compactCompletionError);
-                            (response as { setError?: (error: Error) => void }).setError?.(compactCompletionError);
-                            throw compactCompletionError;
-                        }
+                    compactCompletion = (async () => {
+                        const compactSummary = await lookupCompactSummary(
+                            failure,
+                            sessionId,
+                            baseline,
+                            tokensBefore,
+                            tokensAfter,
+                            compactCompletionAbort.signal
+                        );
+                        const completionEvent = compactSummary
+                            ? undefined
+                            : buildCompactCompletionEvent(failure, tokensBefore, tokensAfter);
+                        logger.debug(`[claudeRemote] ${compactSummary ? `compact summary promoted (${compactSummary.summary.length} chars)` : completionEvent}`);
+                        return { completionEvent, compactSummary, contextTokens: tokensAfter };
                     })();
-                    pendingCompactCompletions.add(completion);
-                    void completion
-                        .finally(() => pendingCompactCompletions.delete(completion))
-                        .catch((error) => logger.debug('[claudeRemote] compact completion callback failed', error));
                     continue;
                 }
+
+                // An autonomous result may arrive while transcript polling is
+                // pending. The coordinator keeps consuming it, but the compact
+                // outcome remains the sole owner of ready and the next prompt.
+                if (compactCompletion) continue;
 
                 await opts.onReady();
                 logger.debug(`${debugPrefix} onReady emitted for result #${resultSeq}`);
@@ -535,15 +561,11 @@ export async function claudeRemote(opts: {
                 }
             }
         }
-        responseClosed = true;
         logger.debug(`${debugPrefix} response stream exhausted`);
-        await Promise.allSettled(pendingCompactCompletions);
-        if (compactCompletionError) throw compactCompletionError;
     } catch (e) {
-        responseFailed = true;
         responseClosed = true;
         compactCompletionAbort.abort();
-        await Promise.allSettled(pendingCompactCompletions);
+        await Promise.allSettled(compactCompletion ? [compactCompletion] : []);
         if (e instanceof AbortError) {
             logger.debug(`[claudeRemote] Aborted`);
             // Ignore
@@ -553,9 +575,9 @@ export async function claudeRemote(opts: {
         }
     } finally {
         responseClosed = true;
-        if (pendingCompactCompletions.size > 0) {
+        if (compactCompletion) {
             compactCompletionAbort.abort();
-            await Promise.allSettled(pendingCompactCompletions);
+            await Promise.allSettled([compactCompletion]);
         }
         opts.signal?.removeEventListener('abort', abortCompactCompletion);
         logger.debug(

--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -13,6 +13,13 @@ import { getHapiBlobsDir } from "@/constants/uploadPaths";
 import { getDefaultClaudeCodePath } from "./sdk/utils";
 import { filterCatalogAffectingClaudeArgs } from "./sdk/metadataExtractor";
 import { buildCompactCompletionEvent } from "./utils/compactCompletion";
+import { findLatestCompactSummary } from "./utils/compactSummaryLookup";
+
+export interface CompactSummaryPayload {
+    summary: string;
+    tokensBefore?: number;
+    tokensAfter?: number;
+}
 
 export async function claudeRemote(opts: {
 
@@ -31,7 +38,7 @@ export async function claudeRemote(opts: {
 
     // Dynamic parameters
     nextMessage: () => Promise<{ message: string, mode: EnhancedMode } | null>,
-    onReady: (completionEvent?: string) => void | Promise<void>,
+    onReady: (completionEvent?: string, compactSummary?: CompactSummaryPayload) => void | Promise<void>,
     isAborted: (toolCallId: string) => boolean,
 
     // Callbacks
@@ -108,9 +115,28 @@ export async function claudeRemote(opts: {
     // usage (measured), so the boundary metadata is the only real source.
     let compactTokensBefore: number | undefined;
     let compactTokensAfter: number | undefined;
+    // The local transcript is keyed by the live session id (updated on init),
+    // not opts.sessionId which can be stale for forked sessions.
+    let currentSessionId = startFrom;
     let awaitingForkInit = forkSession;
 
     const messages = new PushableAsyncIterable<SDKUserMessage>();
+
+    // Success-only: a failed compaction keeps its failure line, an unknown
+    // session id or any transcript read problem falls back to the plain
+    // completion line. Never propagates errors into the result flow.
+    const lookupCompactSummary = async (failure: string | null): Promise<CompactSummaryPayload | undefined> => {
+        if (failure !== null || !currentSessionId) return undefined;
+        try {
+            const transcriptPath = join(getProjectPath(opts.path), `${currentSessionId}.jsonl`);
+            const summary = await findLatestCompactSummary(transcriptPath);
+            if (summary === null) return undefined;
+            return { summary, tokensBefore: compactTokensBefore, tokensAfter: compactTokensAfter };
+        } catch (e) {
+            logger.debug('[claudeRemote] compact summary lookup failed', e);
+            return undefined;
+        }
+    };
 
     const applyInitialTurn = async (): Promise<{ message: string; mode: EnhancedMode } | null> => {
         let next: { message: string; mode: EnhancedMode } | null;
@@ -308,6 +334,7 @@ export async function claudeRemote(opts: {
                 // Session id is still in memory, wait until session file is written to disk
                 // Start a watcher for to detect the session id
                 if (systemInit.session_id) {
+                    currentSessionId = systemInit.session_id;
                     logger.debug(`[claudeRemote] Waiting for session file to be written to disk: ${systemInit.session_id}`);
                     const projectDir = getProjectPath(opts.path);
                     const found = await awaitFileExist(join(projectDir, `${systemInit.session_id}.jsonl`));
@@ -366,9 +393,13 @@ export async function claudeRemote(opts: {
                 }
 
                 let completionEvent: string | undefined;
+                let compactSummary: CompactSummaryPayload | undefined;
                 if (isCompactCommand) {
-                    completionEvent = buildCompactCompletionEvent(compactFailure, compactTokensBefore, compactTokensAfter);
-                    logger.debug(`[claudeRemote] ${completionEvent}`);
+                    compactSummary = await lookupCompactSummary(compactFailure);
+                    if (!compactSummary) {
+                        completionEvent = buildCompactCompletionEvent(compactFailure, compactTokensBefore, compactTokensAfter);
+                    }
+                    logger.debug(`[claudeRemote] ${compactSummary ? `compact summary promoted (${compactSummary.summary.length} chars)` : completionEvent}`);
                     isCompactCommand = false;
                     compactFailure = null;
                     compactTokensBefore = undefined;
@@ -376,7 +407,7 @@ export async function claudeRemote(opts: {
                 }
 
                 // Flush the result carrier before completion, then announce ready.
-                await opts.onReady(completionEvent);
+                await opts.onReady(completionEvent, compactSummary);
                 logger.debug(`${debugPrefix} onReady emitted for result #${resultSeq}`);
 
                 // Pull next user message without blocking response stream processing.

--- a/cli/src/claude/claudeRemoteLauncher.launchFailure.test.ts
+++ b/cli/src/claude/claudeRemoteLauncher.launchFailure.test.ts
@@ -141,6 +141,36 @@ describe('claudeRemoteLauncher launch-failure recovery', () => {
         expect(restoredMessageText).toBe('hello');
     });
 
+    it('does not restore /compact after its SDK result was accepted', async () => {
+        const queue = new MessageQueue2<EnhancedMode>((mode) => JSON.stringify(mode));
+        queue.push('/compact', { permissionMode: 'default' });
+
+        const client = makeClient();
+        const session = makeSession(queue, client);
+        let callCount = 0;
+        let queueSizeOnSecondAttempt: number | undefined;
+
+        claudeRemoteMock.mockImplementation(async (opts: any) => {
+            callCount += 1;
+            if (callCount === 1) {
+                const msg = await opts.nextMessage();
+                expect(msg?.message).toBe('/compact');
+                opts.onCompactResultAccepted();
+                throw new Error('stream failed after compact result');
+            }
+
+            queueSizeOnSecondAttempt = session.queue.size();
+            triggerSwitch(client);
+            throw new Error('stop test');
+        });
+
+        const { claudeRemoteLauncher } = await import('./claudeRemoteLauncher');
+        await claudeRemoteLauncher(session);
+
+        expect(callCount).toBe(2);
+        expect(queueSizeOnSecondAttempt).toBe(0);
+    });
+
     it('sends the result carrier before compact completion and ready', async () => {
         const queue = new MessageQueue2<EnhancedMode>((mode) => JSON.stringify(mode));
         queue.push('/compact', { permissionMode: 'default' });

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -508,15 +508,6 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                             // just asked to clear.
                             session.consumeOneTimeFlags();
                         },
-                        onCompactSummary: (compactSummary: CompactSummaryPayload) => {
-                            logger.debug(`[remote]: Compact summary promoted (${compactSummary.summary.length} chars)`);
-                            session.client.sendSessionEvent({
-                                type: 'compact-summary',
-                                summary: compactSummary.summary,
-                                tokensBefore: compactSummary.tokensBefore,
-                                estimatedTokensAfter: compactSummary.tokensAfter
-                            });
-                        },
                         onReady: async (completionEvent?: string, compactSummary?: CompactSummaryPayload, compactContextTokens?: number) => {
                             // Reaching ready at all means this attempt is not an
                             // immediate/deterministic failure -- reset the

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -508,6 +508,15 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                             // just asked to clear.
                             session.consumeOneTimeFlags();
                         },
+                        onCompactSummary: (compactSummary: CompactSummaryPayload) => {
+                            logger.debug(`[remote]: Compact summary promoted (${compactSummary.summary.length} chars)`);
+                            session.client.sendSessionEvent({
+                                type: 'compact-summary',
+                                summary: compactSummary.summary,
+                                tokensBefore: compactSummary.tokensBefore,
+                                estimatedTokensAfter: compactSummary.tokensAfter
+                            });
+                        },
                         onReady: async (completionEvent?: string, compactSummary?: CompactSummaryPayload, compactContextTokens?: number) => {
                             // Reaching ready at all means this attempt is not an
                             // immediate/deterministic failure -- reset the

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -2,6 +2,7 @@ import React from "react";
 import { Session } from "./session";
 import { RemoteModeDisplay } from "@/ui/ink/RemoteModeDisplay";
 import { claudeRemote, type CompactSummaryPayload } from "./claudeRemote";
+import { convertAgentMessage } from "@/agent/messageConverter";
 import { PermissionHandler } from "./utils/permissionHandler";
 import { Future } from "@/utils/future";
 import { SDKAssistantMessage, SDKMessage, SDKUserMessage } from "./sdk";
@@ -507,7 +508,7 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                             // just asked to clear.
                             session.consumeOneTimeFlags();
                         },
-                        onReady: async (completionEvent?: string, compactSummary?: CompactSummaryPayload) => {
+                        onReady: async (completionEvent?: string, compactSummary?: CompactSummaryPayload, compactContextTokens?: number) => {
                             // Reaching ready at all means this attempt is not an
                             // immediate/deterministic failure -- reset the
                             // respawn-storm guard. The turn that led here is no
@@ -529,6 +530,17 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                                     tokensBefore: compactSummary.tokensBefore,
                                     estimatedTokensAfter: compactSummary.tokensAfter
                                 });
+                            }
+                            if (compactContextTokens !== undefined) {
+                                // The status bar keeps the last pre-compaction
+                                // usage until the next model response; refresh
+                                // it with the boundary's post-tokens the same
+                                // way the Pi launcher does.
+                                const convertedUsage = convertAgentMessage(
+                                    { type: 'usage', inputTokens: 0, outputTokens: 0, contextTokens: compactContextTokens },
+                                    session.getModel()
+                                );
+                                if (convertedUsage) session.client.sendAgentMessage(convertedUsage);
                             }
 
                             logger.debug(

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -493,6 +493,13 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                         onFirstResult: (initialMessage) => {
                             applySessionTitleFallback(session.client, initialMessage);
                         },
+                        onCompactResultAccepted: () => {
+                            // The command has completed at the SDK boundary even
+                            // if transcript summary lookup is still pending. A
+                            // later stream failure must not replay /compact.
+                            reachedReadyThisAttempt = true;
+                            inFlightMessage = null;
+                        },
                         onCompletionEvent: (message: string) => {
                             logger.debug(`[remote]: Completion event: ${message}`);
                             session.client.sendSessionEvent({ type: 'message', message });

--- a/cli/src/claude/claudeRemoteLauncher.ts
+++ b/cli/src/claude/claudeRemoteLauncher.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { Session } from "./session";
 import { RemoteModeDisplay } from "@/ui/ink/RemoteModeDisplay";
-import { claudeRemote } from "./claudeRemote";
+import { claudeRemote, type CompactSummaryPayload } from "./claudeRemote";
 import { PermissionHandler } from "./utils/permissionHandler";
 import { Future } from "@/utils/future";
 import { SDKAssistantMessage, SDKMessage, SDKUserMessage } from "./sdk";
@@ -507,7 +507,7 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                             // just asked to clear.
                             session.consumeOneTimeFlags();
                         },
-                        onReady: async (completionEvent?: string) => {
+                        onReady: async (completionEvent?: string, compactSummary?: CompactSummaryPayload) => {
                             // Reaching ready at all means this attempt is not an
                             // immediate/deterministic failure -- reset the
                             // respawn-storm guard. The turn that led here is no
@@ -520,6 +520,15 @@ class ClaudeRemoteLauncher extends RemoteLauncherBase {
                             if (completionEvent) {
                                 logger.debug(`[remote]: Completion event: ${completionEvent}`);
                                 session.client.sendSessionEvent({ type: 'message', message: completionEvent });
+                            }
+                            if (compactSummary) {
+                                logger.debug(`[remote]: Compact summary promoted (${compactSummary.summary.length} chars)`);
+                                session.client.sendSessionEvent({
+                                    type: 'compact-summary',
+                                    summary: compactSummary.summary,
+                                    tokensBefore: compactSummary.tokensBefore,
+                                    estimatedTokensAfter: compactSummary.tokensAfter
+                                });
                             }
 
                             logger.debug(

--- a/cli/src/claude/utils/compactCompletion.test.ts
+++ b/cli/src/claude/utils/compactCompletion.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tests for the claude /compact completion event builder
+ */
+
+import { describe, it, expect } from 'vitest'
+import { buildCompactCompletionEvent } from './compactCompletion'
+
+describe('buildCompactCompletionEvent', () => {
+    it('reports failure with its reason', () => {
+        expect(buildCompactCompletionEvent('context too large', undefined, undefined))
+            .toBe('📦 Compaction failed: context too large')
+    })
+
+    it('falls back to a generic failure message when no reason is available', () => {
+        expect(buildCompactCompletionEvent('', undefined, undefined))
+            .toBe('📦 Compaction failed')
+    })
+
+    it('emits a token delta line when both tokens are known', () => {
+        expect(buildCompactCompletionEvent(null, 34492, 2082))
+            .toBe('📦 Compacted (34492 → 2082 tokens)')
+    })
+
+    it('omits the delta when tokens are missing', () => {
+        expect(buildCompactCompletionEvent(null, undefined, 2082)).toBe('📦 Compacted')
+        expect(buildCompactCompletionEvent(null, 34492, undefined)).toBe('📦 Compacted')
+        expect(buildCompactCompletionEvent(null, undefined, undefined)).toBe('📦 Compacted')
+    })
+})

--- a/cli/src/claude/utils/compactCompletion.ts
+++ b/cli/src/claude/utils/compactCompletion.ts
@@ -1,0 +1,21 @@
+/**
+ * Builds the chat-visible completion line for a claude /compact turn.
+ *
+ * The SDK stream carries no summary body for compactions (measured: only a
+ * system/compact_boundary with token metadata arrives), so the completion
+ * event is the defensive fallback line — pi-style token delta when both
+ * numbers are known, bare acknowledgment otherwise.
+ */
+export function buildCompactCompletionEvent(
+    failure: string | null,
+    tokensBefore?: number,
+    tokensAfter?: number
+): string {
+    if (failure !== null) {
+        return failure.length > 0 ? `📦 Compaction failed: ${failure}` : '📦 Compaction failed'
+    }
+    if (typeof tokensBefore === 'number' && typeof tokensAfter === 'number') {
+        return `📦 Compacted (${tokensBefore} → ${tokensAfter} tokens)`
+    }
+    return '📦 Compacted'
+}

--- a/cli/src/claude/utils/compactSummaryLookup.test.ts
+++ b/cli/src/claude/utils/compactSummaryLookup.test.ts
@@ -48,6 +48,49 @@ describe('extractCompactSummaryFromTranscript', () => {
 });
 
 describe('findLatestCompactSummary', () => {
+    it('ignores summaries written before the baseline offset', async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'compact-summary-'));
+        try {
+            const filePath = join(dir, 's-1.jsonl');
+            const stale = entry('stale summary from a previous compaction') + '\n';
+            await writeFile(filePath, stale);
+            const baselineBytes = Buffer.byteLength(stale, 'utf8');
+            // A resumed or second-compact session already carries a summary row.
+            // With the baseline recorded before the new compaction started, the
+            // stale row must not satisfy the lookup while the new row is delayed.
+            const pending = findLatestCompactSummary(filePath, {
+                attempts: 3,
+                intervalMs: 5,
+                sleep: async () => {},
+                minBytes: baselineBytes
+            });
+            await new Promise((r) => setTimeout(r, 20));
+            expect(await pending).toBeNull();
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('returns only the summary written after the baseline offset', async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'compact-summary-'));
+        try {
+            const filePath = join(dir, 's-1.jsonl');
+            const stale = entry('stale summary') + '\n';
+            await writeFile(filePath, stale);
+            const baselineBytes = Buffer.byteLength(stale, 'utf8');
+            const pending = findLatestCompactSummary(filePath, {
+                attempts: 5,
+                intervalMs: 5,
+                sleep: async () => {},
+                minBytes: baselineBytes
+            });
+            await writeFile(filePath, stale + entry('fresh summary') + '\n');
+            await expect(pending).resolves.toBe('fresh summary');
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
+
     it('resolves the summary once the transcript contains an isCompactSummary entry', async () => {
         const dir = await mkdtemp(join(tmpdir(), 'compact-summary-'));
         try {

--- a/cli/src/claude/utils/compactSummaryLookup.test.ts
+++ b/cli/src/claude/utils/compactSummaryLookup.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { extractCompactSummaryFromTranscript, findLatestCompactSummary } from './compactSummaryLookup';
+
+function entry(text: string, isCompactSummary = true): string {
+    return JSON.stringify({
+        type: 'user',
+        uuid: `u-${Math.random().toString(36).slice(2)}`,
+        isCompactSummary,
+        message: { role: 'user', content: text },
+        sessionId: 's-1'
+    });
+}
+
+describe('extractCompactSummaryFromTranscript', () => {
+    it('returns the text of the last isCompactSummary entry', () => {
+        const content = [
+            entry('older summary'),
+            entry('not a summary', false),
+            entry('newer summary')
+        ].join('\n');
+
+        expect(extractCompactSummaryFromTranscript(content)).toBe('newer summary');
+    });
+
+    it('returns null when no entry carries isCompactSummary', () => {
+        const content = [entry('plain turn', false)].join('\n');
+        expect(extractCompactSummaryFromTranscript(content)).toBeNull();
+    });
+
+    it('returns null for empty or malformed lines without throwing', () => {
+        expect(extractCompactSummaryFromTranscript('')).toBeNull();
+        expect(extractCompactSummaryFromTranscript('{broken json\n[]\n')).toBeNull();
+    });
+
+    it('extracts joined text from array-style message content', () => {
+        const content = JSON.stringify({
+            type: 'user',
+            uuid: 'u-1',
+            isCompactSummary: true,
+            message: { role: 'user', content: [{ type: 'text', text: 'part one\n' }, { type: 'text', text: 'part two' }] }
+        });
+
+        expect(extractCompactSummaryFromTranscript(content)).toBe('part one\npart two');
+    });
+});
+
+describe('findLatestCompactSummary', () => {
+    it('resolves the summary once the transcript contains an isCompactSummary entry', async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'compact-summary-'));
+        try {
+            const filePath = join(dir, 's-1.jsonl');
+            const sleeps: number[] = [];
+            const pending = findLatestCompactSummary(filePath, {
+                attempts: 5,
+                intervalMs: 7,
+                sleep: async (ms) => { sleeps.push(ms); }
+            });
+            await writeFile(filePath, entry('late summary') + '\n');
+            await expect(pending).resolves.toBe('late summary');
+            expect(sleeps.length).toBeGreaterThan(0);
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('returns null after exhausting attempts when the entry never appears', async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'compact-summary-'));
+        try {
+            const filePath = join(dir, 'missing.jsonl');
+            const summary = await findLatestCompactSummary(filePath, {
+                attempts: 3,
+                intervalMs: 1,
+                sleep: async () => {}
+            });
+            expect(summary).toBeNull();
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
+});

--- a/cli/src/claude/utils/compactSummaryLookup.test.ts
+++ b/cli/src/claude/utils/compactSummaryLookup.test.ts
@@ -123,4 +123,20 @@ describe('findLatestCompactSummary', () => {
             await rm(dir, { recursive: true, force: true });
         }
     });
+
+    it('stops polling when aborted', async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'compact-summary-'));
+        try {
+            const controller = new AbortController();
+            const pending = findLatestCompactSummary(join(dir, 'missing.jsonl'), {
+                attempts: 10,
+                intervalMs: 10_000,
+                signal: controller.signal
+            });
+            controller.abort();
+            await expect(pending).resolves.toBeNull();
+        } finally {
+            await rm(dir, { recursive: true, force: true });
+        }
+    });
 });

--- a/cli/src/claude/utils/compactSummaryLookup.ts
+++ b/cli/src/claude/utils/compactSummaryLookup.ts
@@ -54,6 +54,7 @@ export async function findLatestCompactSummary(
         attempts?: number;
         intervalMs?: number;
         sleep?: (ms: number) => Promise<void>;
+        signal?: AbortSignal;
         // Byte offset recorded before the compaction started. Rows below it
         // belong to earlier turns (e.g. a previous compaction's summary in a
         // resumed or second-compact session) and must not satisfy this lookup
@@ -64,8 +65,24 @@ export async function findLatestCompactSummary(
     const attempts = opts?.attempts ?? 10;
     const intervalMs = opts?.intervalMs ?? 500;
     const minBytes = opts?.minBytes ?? 0;
-    const sleep = opts?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+    const signal = opts?.signal;
+    const sleep = opts?.sleep ?? ((ms: number) => new Promise<void>((resolve) => {
+        if (signal?.aborted) {
+            resolve();
+            return;
+        }
+        const onAbort = () => {
+            clearTimeout(timer);
+            resolve();
+        };
+        const timer = setTimeout(() => {
+            signal?.removeEventListener('abort', onAbort);
+            resolve();
+        }, ms);
+        signal?.addEventListener('abort', onAbort, { once: true });
+    }));
     for (let attempt = 0; attempt < attempts; attempt++) {
+        if (signal?.aborted) return null;
         let handle: FileHandle | undefined;
         try {
             // Range-read only the tail written after the baseline: the

--- a/cli/src/claude/utils/compactSummaryLookup.ts
+++ b/cli/src/claude/utils/compactSummaryLookup.ts
@@ -1,0 +1,73 @@
+import { readFile } from 'node:fs/promises';
+import { RawJSONLinesSchema } from '../types';
+
+/**
+ * Looks up the compact summary body Claude Code writes to the local session
+ * transcript (`<projectDir>/<sessionId>.jsonl`). The SDK stream carries only
+ * the boundary metadata, so the transcript is the sole source for the summary
+ * text. Claude Code may flush it slightly after the result arrives, hence the
+ * bounded polling.
+ */
+
+export function extractCompactSummaryFromTranscript(content: string): string | null {
+    let latest: string | null = null;
+    for (const line of content.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) continue;
+        let parsedJson: unknown;
+        try {
+            parsedJson = JSON.parse(trimmed);
+        } catch {
+            continue;
+        }
+        const parsed = RawJSONLinesSchema.safeParse(parsedJson);
+        if (!parsed.success || parsed.data.type !== 'user' || !parsed.data.isCompactSummary) {
+            continue;
+        }
+        const text = extractText((parsed.data.message as { content?: unknown } | undefined)?.content);
+        if (text !== null) latest = text;
+    }
+    return latest;
+}
+
+function extractText(content: unknown): string | null {
+    if (typeof content === 'string') {
+        const trimmed = content.trim();
+        return trimmed.length > 0 ? trimmed : null;
+    }
+    if (Array.isArray(content)) {
+        const joined = content
+            .filter((block): block is { type: 'text'; text: string } =>
+                typeof block === 'object' && block !== null &&
+                (block as any).type === 'text' && typeof (block as any).text === 'string')
+            .map((block) => block.text.trim())
+            .join('\n')
+            .trim();
+        return joined.length > 0 ? joined : null;
+    }
+    return null;
+}
+
+export async function findLatestCompactSummary(
+    transcriptPath: string,
+    opts?: {
+        attempts?: number;
+        intervalMs?: number;
+        sleep?: (ms: number) => Promise<void>;
+    }
+): Promise<string | null> {
+    const attempts = opts?.attempts ?? 10;
+    const intervalMs = opts?.intervalMs ?? 500;
+    const sleep = opts?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        try {
+            const content = await readFile(transcriptPath, 'utf8');
+            const summary = extractCompactSummaryFromTranscript(content);
+            if (summary !== null) return summary;
+        } catch {
+            // Missing or unreadable transcript: keep polling until attempts run out.
+        }
+        if (attempt < attempts - 1) await sleep(intervalMs);
+    }
+    return null;
+}

--- a/cli/src/claude/utils/compactSummaryLookup.ts
+++ b/cli/src/claude/utils/compactSummaryLookup.ts
@@ -54,14 +54,21 @@ export async function findLatestCompactSummary(
         attempts?: number;
         intervalMs?: number;
         sleep?: (ms: number) => Promise<void>;
+        // Byte offset recorded before the compaction started. Rows below it
+        // belong to earlier turns (e.g. a previous compaction's summary in a
+        // resumed or second-compact session) and must not satisfy this lookup
+        // while the fresh row is still being flushed.
+        minBytes?: number;
     }
 ): Promise<string | null> {
     const attempts = opts?.attempts ?? 10;
     const intervalMs = opts?.intervalMs ?? 500;
+    const minBytes = opts?.minBytes ?? 0;
     const sleep = opts?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
     for (let attempt = 0; attempt < attempts; attempt++) {
         try {
-            const content = await readFile(transcriptPath, 'utf8');
+            const buf = await readFile(transcriptPath);
+            const content = buf.subarray(minBytes).toString('utf8');
             const summary = extractCompactSummaryFromTranscript(content);
             if (summary !== null) return summary;
         } catch {

--- a/cli/src/claude/utils/compactSummaryLookup.ts
+++ b/cli/src/claude/utils/compactSummaryLookup.ts
@@ -75,7 +75,15 @@ export async function findLatestCompactSummary(
             const size = (await handle.stat()).size;
             if (size > minBytes) {
                 const buf = Buffer.alloc(size - minBytes);
-                await handle.read(buf, 0, buf.length, minBytes);
+                // FileHandle.read() may fulfill fewer bytes than requested —
+                // loop until the requested range is fully read (the session
+                // scanner's incremental reader follows the same contract).
+                let bytesRead = 0;
+                while (bytesRead < buf.length) {
+                    const result = await handle.read(buf, bytesRead, buf.length - bytesRead, minBytes + bytesRead);
+                    if (result.bytesRead === 0) break;
+                    bytesRead += result.bytesRead;
+                }
                 const summary = extractCompactSummaryFromTranscript(buf.toString('utf8'));
                 if (summary !== null) return summary;
             }

--- a/cli/src/claude/utils/compactSummaryLookup.ts
+++ b/cli/src/claude/utils/compactSummaryLookup.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { open, type FileHandle } from 'node:fs/promises';
 import { RawJSONLinesSchema } from '../types';
 
 /**
@@ -66,13 +66,23 @@ export async function findLatestCompactSummary(
     const minBytes = opts?.minBytes ?? 0;
     const sleep = opts?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
     for (let attempt = 0; attempt < attempts; attempt++) {
+        let handle: FileHandle | undefined;
         try {
-            const buf = await readFile(transcriptPath);
-            const content = buf.subarray(minBytes).toString('utf8');
-            const summary = extractCompactSummaryFromTranscript(content);
-            if (summary !== null) return summary;
+            // Range-read only the tail written after the baseline: the
+            // transcript is append-only and can be large, and this poll runs
+            // every attempt while the compaction result is already in flight.
+            handle = await open(transcriptPath, 'r');
+            const size = (await handle.stat()).size;
+            if (size > minBytes) {
+                const buf = Buffer.alloc(size - minBytes);
+                await handle.read(buf, 0, buf.length, minBytes);
+                const summary = extractCompactSummaryFromTranscript(buf.toString('utf8'));
+                if (summary !== null) return summary;
+            }
         } catch {
             // Missing or unreadable transcript: keep polling until attempts run out.
+        } finally {
+            await handle?.close().catch(() => {});
         }
         if (attempt < attempts - 1) await sleep(intervalMs);
     }

--- a/cli/src/claude/utils/sdkToLogConverter.test.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.test.ts
@@ -118,33 +118,14 @@ describe('SDKToLogConverter', () => {
 
         it.each([
             '<local-command-stdout>Compacted </local-command-stdout>',
-            '<local-command-stdout>Compacted</local-command-stdout>'
-        ])('should mark the compact stdout bookkeeping user message as meta (%s)', (content) => {
-            // Claude Code echoes the /compact result back over the SDK as a
-            // plain user-role message. It is CLI plumbing, not chat content,
-            // so it must ride the same isMeta filter as injected turns.
-            const sdkMessage: SDKUserMessage = {
-                type: 'user',
-                message: {
-                    role: 'user',
-                    content
-                }
-            }
-
-            const logMessage = converter.convert(sdkMessage)
-
-            expect(logMessage?.type).toBe('user')
-            expect(logMessage?.isMeta).toBe(true)
-        })
-
-        it.each([
             '<local-command-name>/context</local-command-name>',
             '<local-command-stdout>context window usage</local-command-stdout>',
             '<local-command-stderr>boom</local-command-stderr>'
         ])('keeps other local-command CLI output visible for the client contract (%s)', (content) => {
-            // Non-compaction slash-command output is rendered intentionally as a
-            // CLI-output block (docs/api/client-contract/messages.md) — only the
-            // compact stdout echo is bookkeeping.
+            // Local-command output is rendered intentionally as a CLI-output
+            // block (docs/api/client-contract/messages.md). The compact stdout
+            // echo is suppressed upstream, in claudeRemote's stream loop, where
+            // the active-command state lives.
             const sdkMessage: SDKUserMessage = {
                 type: 'user',
                 message: {

--- a/cli/src/claude/utils/sdkToLogConverter.test.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.test.ts
@@ -115,6 +115,28 @@ describe('SDKToLogConverter', () => {
 
             expect(converter.convert(sdkMessage)?.isMeta).toBeUndefined()
         })
+
+        it.each([
+            '<local-command-name>/compact</local-command-name>',
+            '<local-command-stdout>Compacted </local-command-stdout>',
+            '<local-command-stderr>boom</local-command-stderr>'
+        ])('should mark local-command tag user messages as meta (%s)', (content) => {
+            // Claude Code echoes slash-command bookkeeping back over the SDK as
+            // plain user-role messages. They are CLI plumbing, not chat content,
+            // so they must ride the same isMeta filter as injected turns.
+            const sdkMessage: SDKUserMessage = {
+                type: 'user',
+                message: {
+                    role: 'user',
+                    content
+                }
+            }
+
+            const logMessage = converter.convert(sdkMessage)
+
+            expect(logMessage?.type).toBe('user')
+            expect(logMessage?.isMeta).toBe(true)
+        })
     })
 
     describe('Assistant messages', () => {

--- a/cli/src/claude/utils/sdkToLogConverter.test.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.test.ts
@@ -117,13 +117,12 @@ describe('SDKToLogConverter', () => {
         })
 
         it.each([
-            '<local-command-name>/compact</local-command-name>',
             '<local-command-stdout>Compacted </local-command-stdout>',
-            '<local-command-stderr>boom</local-command-stderr>'
-        ])('should mark local-command tag user messages as meta (%s)', (content) => {
-            // Claude Code echoes slash-command bookkeeping back over the SDK as
-            // plain user-role messages. They are CLI plumbing, not chat content,
-            // so they must ride the same isMeta filter as injected turns.
+            '<local-command-stdout>Compacted</local-command-stdout>'
+        ])('should mark the compact stdout bookkeeping user message as meta (%s)', (content) => {
+            // Claude Code echoes the /compact result back over the SDK as a
+            // plain user-role message. It is CLI plumbing, not chat content,
+            // so it must ride the same isMeta filter as injected turns.
             const sdkMessage: SDKUserMessage = {
                 type: 'user',
                 message: {
@@ -136,6 +135,25 @@ describe('SDKToLogConverter', () => {
 
             expect(logMessage?.type).toBe('user')
             expect(logMessage?.isMeta).toBe(true)
+        })
+
+        it.each([
+            '<local-command-name>/context</local-command-name>',
+            '<local-command-stdout>context window usage</local-command-stdout>',
+            '<local-command-stderr>boom</local-command-stderr>'
+        ])('keeps other local-command CLI output visible for the client contract (%s)', (content) => {
+            // Non-compaction slash-command output is rendered intentionally as a
+            // CLI-output block (docs/api/client-contract/messages.md) — only the
+            // compact stdout echo is bookkeeping.
+            const sdkMessage: SDKUserMessage = {
+                type: 'user',
+                message: {
+                    role: 'user',
+                    content
+                }
+            }
+
+            expect(converter.convert(sdkMessage)?.isMeta).toBeUndefined()
         })
     })
 

--- a/cli/src/claude/utils/sdkToLogConverter.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.ts
@@ -283,12 +283,14 @@ export class SDKToLogConverter {
                     logMessage.isMeta = true
                 }
 
-                // Slash-command bookkeeping echoes back as plain user-role text
-                // tagged with <local-command-*> wrappers. They are CLI plumbing,
-                // not chat content — flag them meta so the same downstream
-                // filters hide them instead of leaking raw stdout into the UI.
+                // The /compact result echoes back as a plain user-role message
+                // wrapped in <local-command-stdout>Compacted</local-command-stdout>.
+                // That one echo is CLI plumbing — flag it meta so the downstream
+                // filters hide it. Other local-command output (e.g. /context)
+                // is rendered intentionally as a CLI-output block by the client
+                // contract and must stay visible.
                 const contentText = typeof userMsg.message.content === 'string' ? userMsg.message.content : null
-                if (contentText && contentText.startsWith('<local-command-')) {
+                if (contentText && /^<local-command-stdout>\s*Compacted\s*<\/local-command-stdout>$/.test(contentText.trim())) {
                     logMessage.isMeta = true
                 }
 

--- a/cli/src/claude/utils/sdkToLogConverter.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.ts
@@ -283,16 +283,6 @@ export class SDKToLogConverter {
                     logMessage.isMeta = true
                 }
 
-                // The /compact result echoes back as a plain user-role message
-                // wrapped in <local-command-stdout>Compacted</local-command-stdout>.
-                // That one echo is CLI plumbing — flag it meta so the downstream
-                // filters hide it. Other local-command output (e.g. /context)
-                // is rendered intentionally as a CLI-output block by the client
-                // contract and must stay visible.
-                const contentText = typeof userMsg.message.content === 'string' ? userMsg.message.content : null
-                if (contentText && /^<local-command-stdout>\s*Compacted\s*<\/local-command-stdout>$/.test(contentText.trim())) {
-                    logMessage.isMeta = true
-                }
 
                 // Check if this is a tool result and add mode if available
                 if (Array.isArray(userMsg.message.content)) {

--- a/cli/src/claude/utils/sdkToLogConverter.ts
+++ b/cli/src/claude/utils/sdkToLogConverter.ts
@@ -283,6 +283,15 @@ export class SDKToLogConverter {
                     logMessage.isMeta = true
                 }
 
+                // Slash-command bookkeeping echoes back as plain user-role text
+                // tagged with <local-command-*> wrappers. They are CLI plumbing,
+                // not chat content — flag them meta so the same downstream
+                // filters hide them instead of leaking raw stdout into the UI.
+                const contentText = typeof userMsg.message.content === 'string' ? userMsg.message.content : null
+                if (contentText && contentText.startsWith('<local-command-')) {
+                    logMessage.isMeta = true
+                }
+
                 // Check if this is a tool result and add mode if available
                 if (Array.isArray(userMsg.message.content)) {
                     for (const content of userMsg.message.content) {

--- a/web/src/components/AssistantChat/messages/SystemMessage.test.tsx
+++ b/web/src/components/AssistantChat/messages/SystemMessage.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CompactSummaryCard } from './SystemMessage'
+
+vi.mock('./MessageTimestamp', () => ({
+    MessageTimestamp: () => <time data-testid="timestamp">12:00</time>
+}))
+
+vi.mock('@/components/MarkdownRenderer', () => ({
+    MarkdownRenderer: ({ content }: { content: string }) => (
+        <div data-testid="compact-summary-body">{content}</div>
+    )
+}))
+
+describe('CompactSummaryCard', () => {
+    it('renders the header with token delta collapsed by default', () => {
+        render(<CompactSummaryCard delta="34,492 → 2,082 tokens" text="the summary body" />)
+
+        expect(screen.getByText('Context compacted')).toBeTruthy()
+        expect(screen.getByText(/34,492/)).toBeTruthy()
+        expect(screen.queryByTestId('compact-summary-body')).toBeNull()
+    })
+
+    it('shows the summary body when expanded', () => {
+        render(<CompactSummaryCard delta={null} text="the summary body" />)
+
+        const toggle = screen.getByRole('button')
+        expect(screen.queryByTestId('compact-summary-body')).toBeNull()
+
+        fireEvent.click(toggle)
+        expect(screen.getByTestId('compact-summary-body')).toHaveTextContent('the summary body')
+
+        fireEvent.click(toggle)
+        expect(screen.queryByTestId('compact-summary-body')).toBeNull()
+    })
+
+    it('reflects the expanded state on aria-expanded', () => {
+        render(<CompactSummaryCard delta={null} text="" />)
+
+        const toggle = screen.getByRole('button')
+        expect(toggle.getAttribute('aria-expanded')).toBe('false')
+        fireEvent.click(toggle)
+        expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    })
+})

--- a/web/src/components/AssistantChat/messages/SystemMessage.tsx
+++ b/web/src/components/AssistantChat/messages/SystemMessage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { MessagePrimitive, useAuiState } from '@assistant-ui/react'
 import { getEventPresentation } from '@/chat/presentation'
 import type { AgentEvent } from '@/chat/types'
@@ -13,6 +14,41 @@ function formatTokenDelta(event: AgentEvent | undefined): string | null {
     if (typeof event.estimatedTokensAfter === 'number') parts.push(event.estimatedTokensAfter.toLocaleString())
     if (parts.length === 0) return null
     return parts.length === 2 ? `${parts[0]} → ${parts[1]} tokens` : `${parts[0]} tokens`
+}
+
+// Compaction summaries are long; keep them collapsed by default and let the
+// chevron reveal the body on demand. Toggle state is intentionally local and
+// non-persistent — revisiting a session collapses the card again.
+export function CompactSummaryCard({ delta, text }: { delta: string | null; text: string }) {
+    const [expanded, setExpanded] = useState(false)
+    return (
+        <div className="mx-auto max-w-[92%] rounded-lg border border-[var(--app-border)] bg-[var(--app-subtle-bg)] px-3 py-2">
+            <button
+                type="button"
+                aria-expanded={expanded}
+                onClick={() => setExpanded((v) => !v)}
+                className="flex w-full items-center gap-1.5 text-left text-xs text-[var(--app-hint)]"
+            >
+                <span aria-hidden="true">📦</span>
+                <span className="font-medium">Context compacted</span>
+                {delta ? <span className="font-normal">· {delta}</span> : null}
+                <MessageTimestamp className="text-[10px]" />
+                <svg
+                    aria-hidden="true"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    className={`ml-auto h-3.5 w-3.5 shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`}
+                >
+                    <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+            </button>
+            {expanded && text ? (
+                <div className="max-h-96 overflow-y-auto pr-1">
+                    <MarkdownRenderer standalone content={text} />
+                </div>
+            ) : null}
+        </div>
+    )
 }
 
 export function HappySystemMessage() {
@@ -43,19 +79,7 @@ export function HappySystemMessage() {
         const delta = formatTokenDelta(compactSummary)
         return (
             <MessagePrimitive.Root id={getConversationMessageAnchorId(messageId)} className="scroll-mt-4 py-1">
-                <div className="mx-auto max-w-[92%] rounded-lg border border-[var(--app-border)] bg-[var(--app-subtle-bg)] px-3 py-2">
-                    <div className="flex items-center gap-1.5 text-xs text-[var(--app-hint)]">
-                        <span aria-hidden="true">📦</span>
-                        <span className="font-medium">Context compacted</span>
-                        {delta ? <span className="font-normal">{delta}</span> : null}
-                        <MessageTimestamp className="text-[10px]" />
-                    </div>
-                    {text ? (
-                        <div className="max-h-96 overflow-y-auto pr-1">
-                            <MarkdownRenderer standalone content={text} />
-                        </div>
-                    ) : null}
-                </div>
+                <CompactSummaryCard delta={delta} text={text} />
             </MessagePrimitive.Root>
         )
     }


### PR DESCRIPTION
### Problem

`/compact` in a Claude session renders poorly in the web chat: two plain status lines ("Compaction started" / "Compaction completed") with no icon, no token info, and no summary — even though Claude Code writes a full compaction summary to its local transcript. On top of that, the slash-command bookkeeping leaks into the chat as a raw `<local-command-stdout>Compacted </local-command-stdout>` terminal block, and the `compact_boundary` system message renders an extra "Conversation compacted" line next to the completion status.

Other flavors already do better: Pi renders a dedicated compact-summary card with the summary markdown and a token delta, and Codex has a structured `context_compacted` event. This brings the Claude flavor to the same level and reuses the existing `compact-summary` event contract end to end.

### Solution

- The completion status is now a token-delta line built from the `compact_boundary` metadata (`pre_tokens`/`post_tokens` — the result message that follows a compact reports all-zero usage, so the boundary is the only real source): `📦 Compacted (34,176 → 1,576 tokens)`.
- On success, the CLI reads the last `isCompactSummary` entry from the session transcript (a pattern this file already uses for session-init detection) and emits the existing `compact-summary` session event, so the web renders the same dedicated card Pi gets. A bounded 5s poll covers the transcript being written slightly after the result; without a summary it falls back to the token-delta line.
- The summary card is now collapsed by default with a chevron toggle — compaction summaries are long, and the header (`📦 Context compacted · before → after tokens`) carries the essential info. This applies to Pi's card too, for consistency.
- User-role messages that are Claude Code's `<local-command-*>` bookkeeping are flagged meta so they stop leaking into the chat.
- During a manual `/compact`, the `compact_boundary` system message is no longer relayed, since its only web rendering would duplicate the completion output. Auto-compact boundaries are unaffected.

### Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/ec7a1726-70ed-4947-b540-4a9f2a7e2ae4) | ![in-progress](https://github.com/user-attachments/assets/aac0f87f-e35c-4994-8068-9e6391e38d0c) |

| Collapsed by default | Expanded |
|---|---|
| ![collapsed](https://github.com/user-attachments/assets/ee8dd801-6375-465d-aa13-dbf7889c4d3e) | ![expanded](https://github.com/user-attachments/assets/c327522a-54ee-459a-ab6c-b63ff05d41cf) |

### Tests

- New unit tests for the completion-event builder (success / no-summary / token fallback / failure), the `<local-command-*>` meta flagging, the boundary relay suppression, and the collapsed/expanded card rendering.
- `bun typecheck` and `bun run test` pass across all packages.
- Manually verified end to end against a live isolated hub + runner + Claude (Haiku) session: `/compact` renders the started line, stores a `compact-summary` event with the transcript summary, and the card collapses/expands as expected with no duplicate status line.
