### PR TITLE
test(cli): stub the Claude binary so the runner integration suite passes without a local Claude install

### DIFF
--- a/cli/src/test/globalSetup.ts
+++ b/cli/src/test/globalSetup.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -58,6 +58,19 @@ export async function setup() {
     const token = randomBytes(20).toString('base64url')
     const bunExec = findBunExec()
 
+    // The runner integration suite spawns sessions whose agent-availability
+    // preflight requires an installable Claude CLI. CI runners have none, so
+    // provide a stub binary and point workers at it (see setup.ts). POSIX
+    // only: the shebang stub is meaningless on Windows, and the integration
+    // suite is not part of any Windows path anyway.
+    let stubClaudePath: string | undefined
+    if (process.platform !== 'win32') {
+        const stubBin = join(tmpHome, 'bin')
+        mkdirSync(stubBin, { recursive: true })
+        stubClaudePath = join(stubBin, 'claude')
+        writeFileSync(stubClaudePath, '#!/bin/sh\nexec sleep 300\n', { mode: 0o755 })
+    }
+
     // Use a minimal env whitelist to prevent shell credentials (DB_PATH,
     // TELEGRAM_BOT_TOKEN, ELEVENLABS_API_KEY, etc.) from leaking into the
     // test hub and triggering real notifications or opening a production DB.
@@ -77,7 +90,7 @@ export async function setup() {
     }
 
     // Write config so setupFile.ts can inject env vars into each test worker
-    writeFileSync(TEST_CONFIG_FILE, JSON.stringify({ port, token, tmpHome, bunExec }))
+    writeFileSync(TEST_CONFIG_FILE, JSON.stringify({ port, token, tmpHome, bunExec, stubClaudePath }))
 
     const hubEntry = join(
         dirname(fileURLToPath(import.meta.url)),

--- a/cli/src/test/setup.ts
+++ b/cli/src/test/setup.ts
@@ -14,7 +14,7 @@ if (!existsSync(CONFIG_FILE)) {
     )
 }
 
-let config: { port: number; token: string; tmpHome: string; bunExec: string }
+let config: { port: number; token: string; tmpHome: string; bunExec: string; stubClaudePath?: string }
 try {
     config = JSON.parse(readFileSync(CONFIG_FILE, 'utf8'))
 } catch (err) {
@@ -25,6 +25,9 @@ process.env.HAPI_API_URL = `http://127.0.0.1:${config.port}`
 process.env.CLI_API_TOKEN = config.token
 process.env.HAPI_HOME = config.tmpHome
 process.env.HAPI_BUN_EXEC = config.bunExec
+// The runner agent-availability preflight must see an installable Claude CLI
+// even on machines (CI) without one; globalSetup provides a stub binary.
+if (config.stubClaudePath) process.env.HAPI_CLAUDE_PATH = config.stubClaudePath
 // The stress test starts 20 real CLI children. On slower/loaded machines their
 // session webhooks can take longer than the production control-client default.
 process.env.HAPI_RUNNER_HTTP_TIMEOUT ??= '60000'


### PR DESCRIPTION
**Problem**

Since e5a8212f, the runner's agent-availability preflight rejects session spawns on machines without a Claude CLI — which includes CI runners. So the four spawn-based tests in `src/runner/runner.integration.test.ts` fail on every recent `main` run, and that red integration check spills onto unrelated open PRs too.

**Solution**

The isolated test env now writes a minimal stub `claude` into the temp home (same pattern as `agentAvailability.test.ts`) and points workers at it via `HAPI_CLAUDE_PATH`, the override the production launcher already honors. Production behavior is untouched; the suite still exercises the real preflight path. Windows skips the stub, and setup only injects the override when the config supplies one.

**Tests**

- Reproduced the exact four CI failures locally with `claude` off `PATH` and no `HAPI_CLAUDE_PATH` (`4 failed | 9 passed`); all pass after the change (`13 passed | 1 skipped`).
- Full `bun typecheck && bun run test` green on the fork.