### PR TITLE
feat(cli): auto-steer ping_peer messages into an active turn

### DIFF
--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -2095,147 +2095,165 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             }
         };
 
-        // Per-message steer from the waiting queue (web "Steer" button).
+        // Per-message steer from the waiting queue (web "Steer" button). Also
+        // driven by the arrival hook below for steer-tagged peer messages.
+        const steerQueuedByLocalId = async (localId: string): Promise<{ steered: boolean; error?: string }> => {
+            if (!localId) {
+                return { steered: false, error: 'Missing localId' };
+            }
+            if (this.abortInProgress || !turnInFlight || !this.currentThreadId || !this.currentTurnId) {
+                return { steered: false, error: 'No active steerable turn' };
+            }
+            // Reserve before awaiting turn/steer so the main loop cannot
+            // collect the same row for turn/start while steer is in flight.
+            const taken = session.queue.takeByLocalId(localId);
+            if (!taken) {
+                return { steered: false, error: 'Message not in queue' };
+            }
+            // An explicit retry supersedes any old reconciliation poll for
+            // the same held row.
+            pendingSteerReconciliations.delete(localId);
+            const isControlCommand = Boolean(taken.item.isolate)
+                || Boolean(parseCodexSpecialCommand(taken.item.message).type);
+            if (isControlCommand) {
+                session.queue.restoreReservation(taken);
+                return { steered: false, error: 'Control commands cannot be steered' };
+            }
+            if (activeMessage?.hash !== taken.item.modeHash) {
+                session.queue.restoreReservation(taken);
+                return { steered: false, error: 'Queued message mode differs from the active turn' };
+            }
+            const batch: QueuedMessage = {
+                message: taken.item.message,
+                mode: taken.item.mode,
+                isolate: Boolean(taken.item.isolate),
+                hash: taken.item.modeHash
+            };
+            const steerEpoch = this.steerEpoch;
+            // Pin the thread this steer targets: reconciliation must look at
+            // the steer's thread, not whichever turn is current later.
+            const steerThreadId = this.currentThreadId;
+            const steerTurnId = this.currentTurnId;
+            if (!session.queue.beginReservationDispatch(taken)) {
+                return { steered: false, error: 'Steer cancelled' };
+            }
+            const dispatchStatePersisted = await session.client.setSteerDeliveryState([localId], 'dispatching');
+            if (!dispatchStatePersisted) {
+                session.queue.markReservationIndeterminate(taken);
+                session.client.emitSteerIndeterminate([localId]);
+                return { steered: false, error: 'Steer state is indeterminate' };
+            }
+            const restoreQueuedReservation = async (): Promise<boolean> => {
+                if (!taken.originIndeterminate) {
+                    const persisted = await session.client.setSteerDeliveryState([localId], 'queued');
+                    if (!persisted) {
+                        session.queue.markReservationIndeterminate(taken);
+                        session.client.emitSteerIndeterminate([localId]);
+                        return false;
+                    }
+                }
+                if (taken.state !== 'dispatching' || !session.queue.restoreReservation(taken)) {
+                    session.client.emitSteerIndeterminate([localId]);
+                    return false;
+                }
+                return true;
+            };
+            if (taken.state !== 'dispatching') {
+                session.client.emitSteerIndeterminate([localId]);
+                return { steered: false, error: 'Steer cancelled' };
+            }
+            if (!turnInFlight
+                || this.currentThreadId !== steerThreadId
+                || this.currentTurnId !== steerTurnId
+                || !isCurrentSteerHandler(this.steerEpoch, steerEpoch, this.shouldExit)) {
+                await restoreQueuedReservation();
+                return { steered: false, error: 'Active turn changed' };
+            }
+            const steer = await trySteerActiveTurn(batch, localId);
+            if (steer) {
+                const reconcileDispatchedSteer = (
+                    localId: string,
+                    taken: QueueReservation<EnhancedMode>,
+                    batch: QueuedMessage
+                ) => {
+                    const threadId = steerThreadId;
+                    if (!threadId) {
+                        session.queue.markReservationIndeterminate(taken);
+                        session.client.emitSteerIndeterminate([localId]);
+                        return;
+                    }
+                    const entry = { threadId, taken, batch, expiresAt: Date.now() + 60_000 };
+                    pendingSteerReconciliations.set(localId, entry);
+                    markReconcileEntryIndeterminate(localId, entry);
+                    scheduleSteerReconcileRetry();
+                };
+                try {
+                    await steer.dispatched;
+                } catch (error) {
+                    // A stalled/aborted stdin callback is indeterminate: the
+                    // bytes may have reached Codex even though dispatch did
+                    // not report success. Reconcile instead of replaying.
+                    void steer.completed.catch(() => {});
+                    if (isIndeterminateError(error)) {
+                        reconcileDispatchedSteer(localId, taken, batch);
+                        return { steered: false, error: 'Steer outcome is being reconciled' };
+                    }
+                    await restoreQueuedReservation();
+                    return { steered: false, error: error instanceof Error ? error.message : 'Steer failed' };
+                }
+                try {
+                    // Await app-server acceptance before reporting success:
+                    // an explicit JSON-RPC rejection must surface as failed
+                    // (row restored, normal turn/start delivers it later)
+                    // rather than a false steered. turn/steer's response is
+                    // the inject acceptance, not the full turn completion.
+                    await steer.completed;
+                } catch (error) {
+                    if (isIndeterminateError(error)) {
+                        // Transport failure after dispatch: the outcome is
+                        // unknown — keep the row reserved and reconcile the
+                        // thread once the app-server is reachable again.
+                        reconcileDispatchedSteer(localId, taken, batch);
+                        return { steered: false, error: 'Steer outcome is being reconciled' };
+                    }
+                    await restoreQueuedReservation();
+                    return { steered: false, error: error instanceof Error ? error.message : 'Steer failed' };
+                }
+                session.queue.commitReservation(taken);
+                messageBuffer.addMessage(batch.message, 'user');
+                session.client.emitMessagesConsumed([localId], { steered: true });
+                return { steered: true };
+            }
+            if (!isCurrentSteerHandler(this.steerEpoch, steerEpoch, this.shouldExit)) {
+                await restoreQueuedReservation();
+                return { steered: false, error: 'Steer cancelled' };
+            }
+            await restoreQueuedReservation();
+            return { steered: false, error: 'Active turn is not steerable' };
+        };
+
         session.client.rpcHandlerManager.registerHandler(
             RPC_METHODS.SteerQueuedMessage,
             async (payload: unknown) => {
                 const localId = typeof (payload as { localId?: unknown } | null)?.localId === 'string'
                     ? (payload as { localId: string }).localId
                     : '';
-                if (!localId) {
-                    return { steered: false, error: 'Missing localId' };
-                }
-                if (this.abortInProgress || !turnInFlight || !this.currentThreadId || !this.currentTurnId) {
-                    return { steered: false, error: 'No active steerable turn' };
-                }
-                // Reserve before awaiting turn/steer so the main loop cannot
-                // collect the same row for turn/start while steer is in flight.
-                const taken = session.queue.takeByLocalId(localId);
-                if (!taken) {
-                    return { steered: false, error: 'Message not in queue' };
-                }
-                // An explicit retry supersedes any old reconciliation poll for
-                // the same held row.
-                pendingSteerReconciliations.delete(localId);
-                const isControlCommand = Boolean(taken.item.isolate)
-                    || Boolean(parseCodexSpecialCommand(taken.item.message).type);
-                if (isControlCommand) {
-                    session.queue.restoreReservation(taken);
-                    return { steered: false, error: 'Control commands cannot be steered' };
-                }
-                if (activeMessage?.hash !== taken.item.modeHash) {
-                    session.queue.restoreReservation(taken);
-                    return { steered: false, error: 'Queued message mode differs from the active turn' };
-                }
-                const batch: QueuedMessage = {
-                    message: taken.item.message,
-                    mode: taken.item.mode,
-                    isolate: Boolean(taken.item.isolate),
-                    hash: taken.item.modeHash
-                };
-                const steerEpoch = this.steerEpoch;
-                // Pin the thread this steer targets: reconciliation must look at
-                // the steer's thread, not whichever turn is current later.
-                const steerThreadId = this.currentThreadId;
-                const steerTurnId = this.currentTurnId;
-                if (!session.queue.beginReservationDispatch(taken)) {
-                    return { steered: false, error: 'Steer cancelled' };
-                }
-                const dispatchStatePersisted = await session.client.setSteerDeliveryState([localId], 'dispatching');
-                if (!dispatchStatePersisted) {
-                    session.queue.markReservationIndeterminate(taken);
-                    session.client.emitSteerIndeterminate([localId]);
-                    return { steered: false, error: 'Steer state is indeterminate' };
-                }
-                const restoreQueuedReservation = async (): Promise<boolean> => {
-                    if (!taken.originIndeterminate) {
-                        const persisted = await session.client.setSteerDeliveryState([localId], 'queued');
-                        if (!persisted) {
-                            session.queue.markReservationIndeterminate(taken);
-                            session.client.emitSteerIndeterminate([localId]);
-                            return false;
-                        }
-                    }
-                    if (taken.state !== 'dispatching' || !session.queue.restoreReservation(taken)) {
-                        session.client.emitSteerIndeterminate([localId]);
-                        return false;
-                    }
-                    return true;
-                };
-                if (taken.state !== 'dispatching') {
-                    session.client.emitSteerIndeterminate([localId]);
-                    return { steered: false, error: 'Steer cancelled' };
-                }
-                if (!turnInFlight
-                    || this.currentThreadId !== steerThreadId
-                    || this.currentTurnId !== steerTurnId
-                    || !isCurrentSteerHandler(this.steerEpoch, steerEpoch, this.shouldExit)) {
-                    await restoreQueuedReservation();
-                    return { steered: false, error: 'Active turn changed' };
-                }
-                const steer = await trySteerActiveTurn(batch, localId);
-                if (steer) {
-                    const reconcileDispatchedSteer = (
-                        localId: string,
-                        taken: QueueReservation<EnhancedMode>,
-                        batch: QueuedMessage
-                    ) => {
-                        const threadId = steerThreadId;
-                        if (!threadId) {
-                            session.queue.markReservationIndeterminate(taken);
-                            session.client.emitSteerIndeterminate([localId]);
-                            return;
-                        }
-                        const entry = { threadId, taken, batch, expiresAt: Date.now() + 60_000 };
-                        pendingSteerReconciliations.set(localId, entry);
-                        markReconcileEntryIndeterminate(localId, entry);
-                        scheduleSteerReconcileRetry();
-                    };
-                    try {
-                        await steer.dispatched;
-                    } catch (error) {
-                        // A stalled/aborted stdin callback is indeterminate: the
-                        // bytes may have reached Codex even though dispatch did
-                        // not report success. Reconcile instead of replaying.
-                        void steer.completed.catch(() => {});
-                        if (isIndeterminateError(error)) {
-                            reconcileDispatchedSteer(localId, taken, batch);
-                            return { steered: false, error: 'Steer outcome is being reconciled' };
-                        }
-                        await restoreQueuedReservation();
-                        return { steered: false, error: error instanceof Error ? error.message : 'Steer failed' };
-                    }
-                    try {
-                        // Await app-server acceptance before reporting success:
-                        // an explicit JSON-RPC rejection must surface as failed
-                        // (row restored, normal turn/start delivers it later)
-                        // rather than a false steered. turn/steer's response is
-                        // the inject acceptance, not the full turn completion.
-                        await steer.completed;
-                    } catch (error) {
-                        if (isIndeterminateError(error)) {
-                            // Transport failure after dispatch: the outcome is
-                            // unknown — keep the row reserved and reconcile the
-                            // thread once the app-server is reachable again.
-                            reconcileDispatchedSteer(localId, taken, batch);
-                            return { steered: false, error: 'Steer outcome is being reconciled' };
-                        }
-                        await restoreQueuedReservation();
-                        return { steered: false, error: error instanceof Error ? error.message : 'Steer failed' };
-                    }
-                    session.queue.commitReservation(taken);
-                    messageBuffer.addMessage(batch.message, 'user');
-                    session.client.emitMessagesConsumed([localId], { steered: true });
-                    return { steered: true };
-                }
-                if (!isCurrentSteerHandler(this.steerEpoch, steerEpoch, this.shouldExit)) {
-                    await restoreQueuedReservation();
-                    return { steered: false, error: 'Steer cancelled' };
-                }
-                await restoreQueuedReservation();
-                return { steered: false, error: 'Active turn is not steerable' };
+                return steerQueuedByLocalId(localId);
             }
         );
+
+        // Steer-tagged arrivals (ping_peer sends deliveryMode 'steer') inject
+        // into the active turn immediately instead of waiting for turn end.
+        // Every refusal path inside steerQueuedByLocalId restores the queue
+        // row, so a failed auto-steer simply delivers at the next turn
+        // boundary via the normal waitForMessagesAndGetAsString consumption.
+        session.queue.setOnMessage((_message, _mode, item) => {
+            if (!item.steerHint || !item.localId) return;
+            if (!turnInFlight || this.abortInProgress || this.shouldExit) return;
+            void steerQueuedByLocalId(item.localId).catch((error) => {
+                logger.debug('[Codex] Auto-steer of a steer-tagged arrival failed:', error);
+            });
+        });
 
         const clearCompactRecovery = (recovery: typeof compactRecovery) => {
             if (!recovery) {
@@ -4280,6 +4298,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             steerReconcileTimer = null;
         }
         pendingSteerReconciliations.clear();
+        // Detach the steer-on-arrival hook: a stale closure must not steer
+        // against a future launcher generation's queue rows.
+        session.queue.setOnMessage(null);
     }
 
     protected async cleanup(): Promise<void> {
@@ -4291,6 +4312,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
         } catch (error) {
             logger.debug('[codex-remote]: Error disconnecting client', error);
         }
+        // Safety net alongside the runMainLoop tail: an exception exit must
+        // still detach the steer-on-arrival hook.
+        this.session.queue.setOnMessage(null);
 
         this.clearAbortHandlers(this.session.client.rpcHandlerManager);
 

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -283,7 +283,10 @@ export async function runCodex(opts: {
                     messageQueue.pushIsolateAndClear(isolatedCommandText, enhancedMode, localId);
                     return;
                 }
-                messageQueue.push(text, enhancedMode, localId);
+                // Peer nudges arrive tagged deliveryMode 'steer' (ping_peer):
+                // the remote launcher's arrival hook injects them into the
+                // active turn when one is in flight.
+                messageQueue.push(text, enhancedMode, localId, message.meta?.deliveryMode === 'steer');
             } catch (error) {
                 logger.debug('[Codex] Failed to handle user message', error);
                 const enhancedMode: EnhancedMode = {
@@ -295,7 +298,12 @@ export async function runCodex(opts: {
                     serviceTier: currentServiceTier,
                     personality: currentPersonality
                 };
-                messageQueue.push(formatMessageWithAttachments(message.content.text, message.content.attachments), enhancedMode, localId);
+                messageQueue.push(
+                    formatMessageWithAttachments(message.content.text, message.content.attachments),
+                    enhancedMode,
+                    localId,
+                    message.meta?.deliveryMode === 'steer'
+                );
             }
         }).catch((error) => {
             logger.debug('[Codex] User message handler chain failed', error);

--- a/cli/src/modules/pingPeer/pingPeer.test.ts
+++ b/cli/src/modules/pingPeer/pingPeer.test.ts
@@ -80,7 +80,8 @@ describe('pingPeer', () => {
                     return { status: 200, data: { token: 'jwt' } }
                 }
                 if (url.endsWith(`/api/sessions/${sessionId}/messages`)) {
-                    expect(body).toEqual({ text: 'hello peer' })
+                    expect(body).toMatchObject({ text: 'hello peer', deliveryMode: 'steer' })
+                    expect(typeof (body as { localId?: unknown }).localId).toBe('string')
                     return { status: 200, data: { ok: true } }
                 }
                 throw new Error(`unexpected POST ${url}`)
@@ -632,7 +633,11 @@ describe('listSessions query params', () => {
                     return { status: 200, data: { token: 'jwt' } }
                 }
                 if (url.endsWith(`/api/sessions/${sessionId}/messages`)) {
-                    expect(body).toMatchObject({ text: 'hi' })
+                    // Steer-tagged + queue-shaped: lets the peer CLI inject the
+                    // message into an active turn and the UI render the waiting row.
+                    expect(body).toMatchObject({ text: 'hi', deliveryMode: 'steer' })
+                    expect(typeof (body as { localId?: unknown }).localId).toBe('string')
+                    expect((body as { localId?: string }).localId?.startsWith('ping-peer-')).toBe(true)
                     return { status: 200, data: { ok: true } }
                 }
                 throw new Error(`unexpected POST ${url}`)

--- a/cli/src/modules/pingPeer/pingPeer.ts
+++ b/cli/src/modules/pingPeer/pingPeer.ts
@@ -9,6 +9,7 @@
  */
 
 import axios, { type AxiosInstance } from 'axios'
+import { randomUUID } from 'node:crypto'
 import { extractAssistantPlainText, isObject } from '@hapi/protocol'
 import { normalizeSessionIdPrefix } from '@hapi/protocol/sessionCitation'
 import { configuration } from '@/configuration'
@@ -349,7 +350,16 @@ async function sendMessage(
 ): Promise<void> {
     const response = await http.post(
         `${apiUrl}/api/sessions/${encodeURIComponent(sessionId)}/messages`,
-        { text: message },
+        {
+            text: message,
+            // A localId makes the row queue-shaped (invokedAt null) so the
+            // receiving UI can render it in the waiting bar, and deliveryMode
+            // 'steer' asks the peer CLI to inject it into an active turn
+            // instead of waiting for turn end (flavors that cannot steer
+            // store an ordinary queue row; hub + CLI both downgrade safely).
+            localId: `ping-peer-${randomUUID()}`,
+            deliveryMode: 'steer'
+        },
         {
             headers: authHeaders(jwt),
             timeout: 30_000,

--- a/cli/src/utils/MessageQueue2.test.ts
+++ b/cli/src/utils/MessageQueue2.test.ts
@@ -692,4 +692,23 @@ describe('MessageQueue2', () => {
         expect(batch3?.message).toBe('after-isolated');
         expect(batch3?.mode.type).toBe('B');
     });
+
+    it('should pass the queued item with steerHint to the onMessage handler', () => {
+        const queue = new MessageQueue2<string>(mode => mode);
+        const seen: Array<{ message: string; steerHint?: boolean }> = [];
+
+        queue.setOnMessage((_message, _mode, item) => {
+            seen.push({ message: item.message, steerHint: item.steerHint });
+        });
+
+        queue.push('plain', 'local', 'lid-1');
+        queue.push('nudge', 'local', 'lid-2', true);
+        queue.pushIsolateAndClear('command', 'local', 'lid-3');
+
+        expect(seen).toEqual([
+            { message: 'plain', steerHint: undefined },
+            { message: 'nudge', steerHint: true },
+            { message: 'command', steerHint: undefined }
+        ]);
+    });
 });

--- a/cli/src/utils/MessageQueue2.ts
+++ b/cli/src/utils/MessageQueue2.ts
@@ -6,6 +6,8 @@ export interface QueueItem<T> {
     modeHash: string;
     localId?: string;
     isolate?: boolean; // If true, this message must be processed alone
+    /** Request mid-turn steer into the active turn instead of waiting for turn end. */
+    steerHint?: boolean;
     /** Stable FIFO key used when an async reservation is restored later. */
     enqueueOrder?: number;
 }
@@ -29,7 +31,7 @@ export class MessageQueue2<T> {
     public queue: QueueItem<T>[] = []; // Made public for testing
     private waiter: ((hasMessages: boolean) => void) | null = null;
     private closed = false;
-    private onMessageHandler: ((message: string, mode: T) => void) | null = null;
+    private onMessageHandler: ((message: string, mode: T, item: QueueItem<T>) => void) | null = null;
     onBatchConsumed: ((localIds: string[]) => void) | null = null;
     modeHasher: (mode: T) => string;
     private readonly reservations = new Map<string, QueueReservation<T>>();
@@ -49,14 +51,14 @@ export class MessageQueue2<T> {
     /**
      * Set a handler that will be called when a message arrives
      */
-    setOnMessage(handler: ((message: string, mode: T) => void) | null): void {
+    setOnMessage(handler: ((message: string, mode: T, item: QueueItem<T>) => void) | null): void {
         this.onMessageHandler = handler;
     }
 
     /**
      * Push a message to the queue with a mode.
      */
-    push(message: string, mode: T, localId?: string): void {
+    push(message: string, mode: T, localId?: string, steerHint?: boolean): void {
         if (this.closed) {
             throw new Error('Cannot push to closed queue');
         }
@@ -64,12 +66,13 @@ export class MessageQueue2<T> {
         const modeHash = this.modeHasher(mode);
         logger.debug(`[MessageQueue2] push() called with mode hash: ${modeHash}`);
 
-        const item = {
+        const item: QueueItem<T> = {
             message,
             mode,
             modeHash,
             localId,
             isolate: false,
+            ...(steerHint === true ? { steerHint: true } : {}),
             enqueueOrder: this.nextEnqueueOrder++
         };
         Object.defineProperty(item, 'enqueueOrder', { value: item.enqueueOrder, enumerable: false, writable: true });
@@ -77,7 +80,7 @@ export class MessageQueue2<T> {
 
         // Trigger message handler if set
         if (this.onMessageHandler) {
-            this.onMessageHandler(message, mode);
+            this.onMessageHandler(message, mode, item);
         }
 
         // Notify waiter if any
@@ -103,7 +106,7 @@ export class MessageQueue2<T> {
         const modeHash = this.modeHasher(mode);
         logger.debug(`[MessageQueue2] pushImmediate() called with mode hash: ${modeHash}`);
 
-        const item = {
+        const item: QueueItem<T> = {
             message,
             mode,
             modeHash,
@@ -116,7 +119,7 @@ export class MessageQueue2<T> {
 
         // Trigger message handler if set
         if (this.onMessageHandler) {
-            this.onMessageHandler(message, mode);
+            this.onMessageHandler(message, mode, item);
         }
 
         // Notify waiter if any
@@ -145,7 +148,7 @@ export class MessageQueue2<T> {
         const modeHash = this.modeHasher(mode);
         logger.debug(`[MessageQueue2] pushIsolated() called with mode hash: ${modeHash} - preserving ${this.queue.length} pending messages`);
 
-        const item = {
+        const item: QueueItem<T> = {
             message,
             mode,
             modeHash,
@@ -157,7 +160,7 @@ export class MessageQueue2<T> {
         this.queue.push(item);
 
         if (this.onMessageHandler) {
-            this.onMessageHandler(message, mode);
+            this.onMessageHandler(message, mode, item);
         }
 
         if (this.waiter) {
@@ -189,7 +192,7 @@ export class MessageQueue2<T> {
         // rejection must not restore a prompt the clear command discarded.
         this.cancelReservations();
 
-        const item = {
+        const item: QueueItem<T> = {
             message,
             mode,
             modeHash,
@@ -202,7 +205,7 @@ export class MessageQueue2<T> {
 
         // Trigger message handler if set
         if (this.onMessageHandler) {
-            this.onMessageHandler(message, mode);
+            this.onMessageHandler(message, mode, item);
         }
 
         // Notify waiter if any
@@ -227,7 +230,7 @@ export class MessageQueue2<T> {
         const modeHash = this.modeHasher(mode);
         logger.debug(`[MessageQueue2] unshift() called with mode hash: ${modeHash}`);
 
-        const item = {
+        const item: QueueItem<T> = {
             message,
             mode,
             modeHash,
@@ -240,7 +243,7 @@ export class MessageQueue2<T> {
 
         // Trigger message handler if set
         if (this.onMessageHandler) {
-            this.onMessageHandler(message, mode);
+            this.onMessageHandler(message, mode, item);
         }
 
         // Notify waiter if any
@@ -269,7 +272,7 @@ export class MessageQueue2<T> {
         const modeHash = this.modeHasher(mode);
         logger.debug(`[MessageQueue2] unshiftIsolated() called with mode hash: ${modeHash}`);
 
-        const item = {
+        const item: QueueItem<T> = {
             message,
             mode,
             modeHash,
@@ -281,7 +284,7 @@ export class MessageQueue2<T> {
         this.queue.unshift(item);
 
         if (this.onMessageHandler) {
-            this.onMessageHandler(message, mode);
+            this.onMessageHandler(message, mode, item);
         }
 
         if (this.waiter) {

--- a/hub/src/sync/messageService.test.ts
+++ b/hub/src/sync/messageService.test.ts
@@ -1249,6 +1249,44 @@ describe('MessageService.sendMessage deliveryMode', () => {
         })
     })
 
+    it('persists steer for steering-capable flavors and downgrades it for claude', async () => {
+        const store = makeStore()
+        const codexSession = store.sessions.getOrCreateSession(
+            'delivery-mode-codex',
+            { path: '/tmp/delivery-mode-codex', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        const claudeSession = store.sessions.getOrCreateSession(
+            'delivery-mode-claude',
+            { path: '/tmp/delivery-mode-claude', host: 'localhost', flavor: 'claude' },
+            null,
+            'default'
+        )
+        const { io } = makeTrackingIo()
+        const service = new MessageService(store, io, makePublisher() as any)
+
+        await service.sendMessage(codexSession.id, {
+            text: 'mid-turn nudge',
+            localId: 'codex-steer',
+            deliveryMode: 'steer'
+        })
+        await service.sendMessage(claudeSession.id, {
+            text: 'claude cannot steer',
+            localId: 'claude-steer',
+            deliveryMode: 'steer'
+        })
+
+        expect(store.messages.getUninvokedLocalMessages(codexSession.id)[0]?.content).toMatchObject({
+            role: 'user',
+            meta: { sentFrom: 'webapp', deliveryMode: 'steer' }
+        })
+        expect(store.messages.getUninvokedLocalMessages(claudeSession.id)[0]?.content).toMatchObject({
+            role: 'user',
+            meta: { sentFrom: 'webapp', deliveryMode: 'queue' }
+        })
+    })
+
     it('delivers a duplicate-localId retry as queue even when the stored row retains steer', async () => {
         const store = makeStore()
         const session = store.sessions.getOrCreateSession(
@@ -1359,7 +1397,7 @@ describe('MessageService.sendMessage deliveryMode', () => {
         ])
     })
 
-    it('downgrades forged steer intent for non-Pi sessions and defaults omitted intent to queue', async () => {
+    it('downgrades forged steer intent for non-steerable sessions and defaults omitted intent to queue', async () => {
         const store = makeStore()
         const session = makeSession(store, 'delivery-mode-non-pi')
         const service = new MessageService(store, makeTrackingIo().io, makePublisher() as any)

--- a/hub/src/sync/messageService.test.ts
+++ b/hub/src/sync/messageService.test.ts
@@ -1249,11 +1249,17 @@ describe('MessageService.sendMessage deliveryMode', () => {
         })
     })
 
-    it('persists steer for steering-capable flavors and downgrades it for claude', async () => {
+    it('persists steer for arrival-steerable flavors and downgrades it for cursor and claude', async () => {
         const store = makeStore()
         const codexSession = store.sessions.getOrCreateSession(
             'delivery-mode-codex',
             { path: '/tmp/delivery-mode-codex', host: 'localhost', flavor: 'codex' },
+            null,
+            'default'
+        )
+        const cursorSession = store.sessions.getOrCreateSession(
+            'delivery-mode-cursor',
+            { path: '/tmp/delivery-mode-cursor', host: 'localhost', flavor: 'cursor' },
             null,
             'default'
         )
@@ -1276,12 +1282,21 @@ describe('MessageService.sendMessage deliveryMode', () => {
             localId: 'claude-steer',
             deliveryMode: 'steer'
         })
+        await service.sendMessage(cursorSession.id, {
+            text: 'cursor steers only via the manual button',
+            localId: 'cursor-steer',
+            deliveryMode: 'steer'
+        })
 
         expect(store.messages.getUninvokedLocalMessages(codexSession.id)[0]?.content).toMatchObject({
             role: 'user',
             meta: { sentFrom: 'webapp', deliveryMode: 'steer' }
         })
         expect(store.messages.getUninvokedLocalMessages(claudeSession.id)[0]?.content).toMatchObject({
+            role: 'user',
+            meta: { sentFrom: 'webapp', deliveryMode: 'queue' }
+        })
+        expect(store.messages.getUninvokedLocalMessages(cursorSession.id)[0]?.content).toMatchObject({
             role: 'user',
             meta: { sentFrom: 'webapp', deliveryMode: 'queue' }
         })

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -11,7 +11,7 @@ import {
     isRedundantGoalStatusEventContent,
     unwrapRoleWrappedRecordEnvelope
 } from '@hapi/protocol/messages'
-import { isObject } from '@hapi/protocol'
+import { isObject, isSteeringSupportedForSession } from '@hapi/protocol'
 import type { MessageDeliveryMode, MessagesResponse, QueuedStateResponse } from '@hapi/protocol/apiTypes'
 import type { Server } from 'socket.io'
 import { randomUUID } from 'node:crypto'
@@ -124,7 +124,12 @@ function getNormalizedDeliveryMode(
         return 'queue'
     }
 
-    return isObject(metadata) && metadata.flavor === 'pi' ? 'steer' : 'queue'
+    // Steer provenance is only meaningful for flavors whose CLI can act on it
+    // (codex turn/steer, pi native steer, cursor ACP soft-send). Everything
+    // else (claude, unknown flavors) stores an ordinary queue row.
+    return isObject(metadata) && isSteeringSupportedForSession(metadata as Parameters<typeof isSteeringSupportedForSession>[0])
+        ? 'steer'
+        : 'queue'
 }
 
 /**

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -11,7 +11,7 @@ import {
     isRedundantGoalStatusEventContent,
     unwrapRoleWrappedRecordEnvelope
 } from '@hapi/protocol/messages'
-import { isObject, isSteeringSupportedForSession } from '@hapi/protocol'
+import { isObject } from '@hapi/protocol'
 import type { MessageDeliveryMode, MessagesResponse, QueuedStateResponse } from '@hapi/protocol/apiTypes'
 import type { Server } from 'socket.io'
 import { randomUUID } from 'node:crypto'
@@ -124,10 +124,12 @@ function getNormalizedDeliveryMode(
         return 'queue'
     }
 
-    // Steer provenance is only meaningful for flavors whose CLI can act on it
-    // (codex turn/steer, pi native steer, cursor ACP soft-send). Everything
-    // else (claude, unknown flavors) stores an ordinary queue row.
-    return isObject(metadata) && isSteeringSupportedForSession(metadata as Parameters<typeof isSteeringSupportedForSession>[0])
+    // Persist steer provenance only for flavors whose CLI consumes the hint on
+    // arrival (codex turn/steer, pi native steer). Cursor ACP steers only via
+    // the manual button today — its inbound path drops the hint, so keep its
+    // rows queued rather than advertising an inject that never happens.
+    return isObject(metadata)
+        && ((metadata.flavor === 'pi' || metadata.flavor === 'codex'))
         ? 'steer'
         : 'queue'
 }

--- a/shared/src/sessionCitation.ts
+++ b/shared/src/sessionCitation.ts
@@ -27,6 +27,7 @@ export const INSPECT_PEER_TOOL_DESCRIPTION =
 /** MCP `ping_peer` tool description (same citation forms as inspect_peer). */
 export const PING_PEER_TOOL_DESCRIPTION =
     'Send a message to another HAPI session (peer handoff / nudge). Resolves by session id prefix, resumes if inactive, then POSTs on the same hub/namespace. ' +
+    'Delivery is steer-tagged: on steerable flavors (codex / pi / cursor) the message is injected into the peer\'s running turn when one is active, otherwise it becomes the peer\'s next prompt. ' +
     'When the user cites a peer via [title](/sessions/<id>), Copy-reference prose See session "…" (/sessions/<id>) for context, or a bare /sessions/<id>, ' +
     'extract <id> and pass it as sessionIdPrefix. /sessions/<id> is a hub path - do NOT search the local filesystem for it. ' +
     'Prefer this (or `hapi ping-peer`) over reinventing JWT+curl. Targets another session - not the current chat.'

--- a/shared/src/sessionCitation.ts
+++ b/shared/src/sessionCitation.ts
@@ -27,7 +27,7 @@ export const INSPECT_PEER_TOOL_DESCRIPTION =
 /** MCP `ping_peer` tool description (same citation forms as inspect_peer). */
 export const PING_PEER_TOOL_DESCRIPTION =
     'Send a message to another HAPI session (peer handoff / nudge). Resolves by session id prefix, resumes if inactive, then POSTs on the same hub/namespace. ' +
-    'Delivery is steer-tagged: on steerable flavors (codex / pi / cursor) the message is injected into the peer\'s running turn when one is active, otherwise it becomes the peer\'s next prompt. ' +
+    'Delivery is steer-tagged: on codex and pi the message is injected into the peer\'s running turn when one is active, otherwise it becomes the peer\'s next prompt. ' +
     'When the user cites a peer via [title](/sessions/<id>), Copy-reference prose See session "…" (/sessions/<id>) for context, or a bare /sessions/<id>, ' +
     'extract <id> and pass it as sessionIdPrefix. /sessions/<id> is a hub path - do NOT search the local filesystem for it. ' +
     'Prefer this (or `hapi ping-peer`) over reinventing JWT+curl. Targets another session - not the current chat.'


### PR DESCRIPTION
## Summary

`ping_peer` messages to a peer that is mid-turn were stored and forwarded immediately, but the peer CLI silently held them until the current turn ended — the nudge looked "sent" yet was ignored by the working agent. This PR delivers peer messages into a running turn automatically (no manual Steer click), while keeping the ordinary queue as the fallback everywhere else.

## Changes

- **`ping_peer` (MCP tool + `hapi ping-peer`)**: sends a generated `localId` (row becomes queue-shaped: visible in the peer's waiting bar, steerable, cancellable) and `deliveryMode: 'steer'` — both are existing protocol fields of `SendMessageRequestSchema`. Tool description documents the steer semantics.
- **Hub** (`messageService.getNormalizedDeliveryMode`): persists steer provenance for every steering-capable flavor via the shared `isSteeringSupportedForSession` predicate (previously pi-only). Claude and unknown flavors still downgrade to an ordinary queue row.
- **Codex CLI** (`codexRemoteLauncher`): the `SteerQueuedMessage` RPC handler is extracted verbatim into `steerQueuedByLocalId` (the web Steer button now delegates to it), and a queue-arrival hook injects a steer-tagged arrival into the active turn via app-server `turn/steer`. Every refusal path restores the queued row, so a refused auto-steer simply delivers at the next turn boundary.
- **Queue** (`MessageQueue2`): `push()` accepts an optional `steerHint` and the `onMessage` handler now receives the queued item.

## Behavior

- Peer idle → unchanged (message is consumed immediately as the next turn).
- Peer mid-turn on codex / pi → message is injected into the running turn; the chat shows the existing "steered" badge (`messages-consumed { steered: true }`). Pi gets this for free: its CLI already honors `meta.deliveryMode === 'steer'`.
- Peer mid-turn on claude / other flavors → unchanged queue-until-turn-end (hub downgrades, CLI unchanged).
- Web composer, Telegram, slash/control commands → unaffected: they never request steer, and the steer routine additionally refuses control commands and mode-mismatched rows.
- Wire protocol unchanged; no fixture-affecting web pipeline changes.

## Testing

- [x] `bun typecheck` (cli / hub / web / relay)
- [x] Full `bun run test` (cli + hub + web + shared + relay)
- New/updated tests:
  - hub: steer provenance stored for codex, downgraded for claude (and flavor-less sessions)
  - cli: `ping_peer` request body carries `localId` (`ping-peer-<uuid>`) + `deliveryMode: 'steer'`
  - cli: `MessageQueue2` passes `steerHint` through to the arrival handler; isolated/clear pushes stay unhinted
