### PR TITLE
fix(web,hub): friendly file preview when session CLI is offline

### DIFF
--- a/docs/api/client-contract/errors.md
+++ b/docs/api/client-contract/errors.md
@@ -46,14 +46,14 @@ When no `code` is present, branch on status alone and treat the failure generica
 | 503 | — | `guards.ts` `requireSyncEngine` → `{error: 'Not connected'}` — hub subsystems not up (startup/shutdown window); also Telegram-disabled on `/api/auth` initData path | Retry with backoff |
 | 503 | `no_machine_online` | resume/reopen/spawn-flow result mapping (`sessions.ts`) | The machine that owns the session is offline — tell the user to start the runner |
 | 503 | `machine_offline` | `machines.ts` restart-runner | Same |
-| 503 | `rpc_target_missing` | `machines.ts` pi/codex model catalogs (`RPC_TARGET_MISSING_ERROR_CODE` in `shared/src/rpcMethods.ts` — RPC handler unregistered or socket disconnected) | CLI-side target gone — treat as offline |
+| 503 | `rpc_target_missing` | `machines.ts` pi/codex model catalogs; `git.ts` `/sessions/:id/file` and `/git-diff-file` (`RPC_TARGET_MISSING_ERROR_CODE` in `shared/src/rpcMethods.ts` — RPC handler unregistered or socket disconnected) | CLI-side target gone — treat as offline |
 
 ## RPC-wrapped endpoints
 
 Many endpoints do not answer from hub state — the hub relays the request over Socket.IO to the session's CLI process (or the machine's runner) and forwards the result: git/file/directory/search, generated images, uploads, model catalogs, Agent availability, slash-commands, skills, spawn, list-directory, paths/exists. (The mode/model/effort config endpoints are RPC-backed too, but map apply-failures to 409 with a message.) Their failure modes differ from plain endpoints:
 
 1. **CLI reachable, command failed** → HTTP **200** with `{success: false, error}` (e.g. `runRpc` in `hub/src/web/routes/git.ts` catches RPC errors, including the 30 s RPC timeout, and returns them as a JSON envelope). Clients must check the `success` field on every RPC-shaped response; HTTP 200 alone means nothing.
-2. **CLI offline / handler missing** → depends on the route: the model-catalog routes in `machines.ts` map `RpcTargetMissingError` to **503 `rpc_target_missing`**; `git.ts`-style routes fold it into the 200 `{success: false}` envelope; resume/reopen surface **503 `no_machine_online`**.
+2. **CLI offline / handler missing** → depends on the route: the model-catalog routes in `machines.ts` and the session file read / git-diff-file routes in `git.ts` map `RpcTargetMissingError` to **503 `rpc_target_missing`**; other `git.ts` routes still fold RPC failures into the 200 `{success: false}` envelope; resume/reopen surface **503 `no_machine_online`**.
 3. **Hub subsystems not up** → **503 `Not connected`** from `requireSyncEngine` (brief startup/shutdown window).
 
 Practical rule: treat `success: false`, 503 `rpc_target_missing`, and 503 `no_machine_online` as the same user-facing condition — "the computer running this session is not reachable" — with the raw `error` string available in a details view.

--- a/hub/src/web/routes/git.test.ts
+++ b/hub/src/web/routes/git.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { Hono } from 'hono'
 import type { Session, SyncEngine } from '../../sync/syncEngine'
+import { RpcTargetMissingError } from '../../sync/rpcGateway'
 import type { WebAppEnv } from '../middleware/auth'
 import { createGitRoutes } from './git'
 
@@ -298,6 +299,51 @@ describe('file search route', () => {
             files: [
                 { fileName: 'file\\name.ts', filePath: 'src', fullPath: 'src/file\\name.ts', fileType: 'file', size: 10, modified: 100 },
             ]
+        })
+    })
+})
+
+describe('session file routes', () => {
+    const session = {
+        id: 'session-1',
+        namespace: 'default',
+        active: false,
+        metadata: { path: '/project' }
+    } as unknown as Session
+
+    it('maps RpcTargetMissingError on /file to 503 rpc_target_missing', async () => {
+        const engine = {
+            resolveSessionAccess: () => ({ ok: true as const, sessionId: 'session-1', session }),
+            readSessionFile: async () => {
+                throw new RpcTargetMissingError('readFile', 'handler-not-registered')
+            }
+        } as unknown as Partial<SyncEngine>
+
+        const response = await buildApp(engine).request('/api/sessions/session-1/file?path=README.md')
+
+        expect(response.status).toBe(503)
+        expect(await response.json()).toEqual({
+            success: false,
+            error: 'RPC handler not registered: readFile',
+            code: 'rpc_target_missing'
+        })
+    })
+
+    it('maps RpcTargetMissingError on /git-diff-file to 503 rpc_target_missing', async () => {
+        const engine = {
+            resolveSessionAccess: () => ({ ok: true as const, sessionId: 'session-1', session }),
+            getGitDiffFile: async () => {
+                throw new RpcTargetMissingError('git-diff-file', 'socket-disconnected')
+            }
+        } as unknown as Partial<SyncEngine>
+
+        const response = await buildApp(engine).request('/api/sessions/session-1/git-diff-file?path=README.md')
+
+        expect(response.status).toBe(503)
+        expect(await response.json()).toEqual({
+            success: false,
+            error: 'RPC socket disconnected: git-diff-file',
+            code: 'rpc_target_missing'
         })
     })
 })

--- a/hub/src/web/routes/git.ts
+++ b/hub/src/web/routes/git.ts
@@ -1,7 +1,9 @@
 import { Hono } from 'hono'
 import { isWildcardSearch, matchesSearchQuery, toSearchGlob } from '@hapi/protocol'
+import { RPC_TARGET_MISSING_ERROR_CODE } from '@hapi/protocol/rpcMethods'
 import { z } from 'zod'
 import type { SyncEngine } from '../../sync/syncEngine'
+import { RpcTargetMissingError } from '../../sync/rpcGateway'
 import type { WebAppEnv } from '../middleware/auth'
 import { requireSessionFromParam, requireSyncEngine } from './guards'
 
@@ -40,7 +42,18 @@ async function runRpc<T>(fn: () => Promise<T>): Promise<T | { success: false; er
     try {
         return await fn()
     } catch (error) {
+        if (error instanceof RpcTargetMissingError) {
+            throw error
+        }
         return { success: false, error: error instanceof Error ? error.message : String(error) }
+    }
+}
+
+function rpcTargetMissingJson(error: RpcTargetMissingError) {
+    return {
+        success: false as const,
+        error: error.message,
+        code: RPC_TARGET_MISSING_ERROR_CODE
     }
 }
 
@@ -125,12 +138,19 @@ export function createGitRoutes(getSyncEngine: () => SyncEngine | null): Hono<We
         }
 
         const staged = parseBooleanParam(c.req.query('staged'))
-        const result = await runRpc(() => engine.getGitDiffFile(sessionResult.sessionId, {
-            cwd: sessionPath,
-            filePath: parsed.data.path,
-            staged
-        }))
-        return c.json(result)
+        try {
+            const result = await runRpc(() => engine.getGitDiffFile(sessionResult.sessionId, {
+                cwd: sessionPath,
+                filePath: parsed.data.path,
+                staged
+            }))
+            return c.json(result)
+        } catch (error) {
+            if (error instanceof RpcTargetMissingError) {
+                return c.json(rpcTargetMissingJson(error), 503)
+            }
+            throw error
+        }
     })
 
     app.get('/sessions/:id/file', async (c) => {
@@ -154,8 +174,15 @@ export function createGitRoutes(getSyncEngine: () => SyncEngine | null): Hono<We
             return c.json({ error: 'Invalid file path' }, 400)
         }
 
-        const result = await runRpc(() => engine.readSessionFile(sessionResult.sessionId, parsed.data.path))
-        return c.json(result)
+        try {
+            const result = await runRpc(() => engine.readSessionFile(sessionResult.sessionId, parsed.data.path))
+            return c.json(result)
+        } catch (error) {
+            if (error instanceof RpcTargetMissingError) {
+                return c.json(rpcTargetMissingJson(error), 503)
+            }
+            throw error
+        }
     })
 
     app.get('/sessions/:id/generated-images/:imageId', async (c) => {

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -666,6 +666,7 @@ export type CommandResponse = {
     stderr?: string
     exitCode?: number
     error?: string
+    code?: string
 }
 
 export type GitCommandResponse = CommandResponse
@@ -676,6 +677,7 @@ export type FileReadResponse = {
     size?: number
     modified?: number
     error?: string
+    code?: string
 }
 
 export type GeneratedImageResponse = {

--- a/web/src/lib/files-i18n.test.ts
+++ b/web/src/lib/files-i18n.test.ts
@@ -3,6 +3,7 @@ import {
     formatDiffError,
     formatDirectoryError,
     formatFileSearchError,
+    formatFileSessionOfflineError,
     formatGitStatusError,
     formatReadFileError,
     getDetachedBranchLabel,
@@ -24,6 +25,7 @@ const translations: Record<string, string> = {
     'file.error.readFailedWithDetail': '读取文件失败：{error}',
     'file.error.diffUnavailable': 'Diff 不可用',
     'file.error.diffUnavailableWithDetail': 'Diff 不可用：{error}',
+    'file.error.sessionOffline': '会话离线',
 }
 
 function t(key: string, params?: Record<string, string | number>): string {
@@ -63,7 +65,10 @@ describe('files i18n helpers', () => {
     it('formats file read and diff errors', () => {
         expect(formatReadFileError('Failed to read file', t)).toBe('读取文件失败')
         expect(formatReadFileError('EACCES', t)).toBe('读取文件失败：EACCES')
+        expect(formatReadFileError('RPC handler not registered: readFile', t)).toBe('会话离线')
         expect(formatDiffError('Failed to load diff', t)).toBe('Diff 不可用')
         expect(formatDiffError('fatal: bad revision', t)).toBe('Diff 不可用：fatal: bad revision')
+        expect(formatDiffError('RPC socket disconnected: git-diff-file', t)).toBe('会话离线')
+        expect(formatFileSessionOfflineError(t)).toBe('会话离线')
     })
 })

--- a/web/src/lib/files-i18n.ts
+++ b/web/src/lib/files-i18n.ts
@@ -78,6 +78,9 @@ export function formatReadFileError(error: string | null | undefined, t: Transla
     if (!detail || detail === 'Failed to read file' || detail === 'Missing session or path' || detail === 'Session unavailable') {
         return t('file.error.readFailed')
     }
+    if (detail.startsWith('RPC handler not registered:') || detail.startsWith('RPC socket disconnected:')) {
+        return t('file.error.sessionOffline')
+    }
     return t('file.error.readFailedWithDetail', { error: detail })
 }
 
@@ -86,5 +89,12 @@ export function formatDiffError(error: string | null | undefined, t: Translate):
     if (!detail || detail === 'Failed to load diff' || detail === 'Missing session or path' || detail === 'Session unavailable') {
         return t('file.error.diffUnavailable')
     }
+    if (detail.startsWith('RPC handler not registered:') || detail.startsWith('RPC socket disconnected:')) {
+        return t('file.error.sessionOffline')
+    }
     return t('file.error.diffUnavailableWithDetail', { error: detail })
+}
+
+export function formatFileSessionOfflineError(t: Translate): string {
+    return t('file.error.sessionOffline')
 }

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -521,6 +521,8 @@ export default {
   'file.error.readFailedWithDetail': 'Failed to read file: {error}',
   'file.error.diffUnavailable': 'Diff unavailable.',
   'file.error.diffUnavailableWithDetail': 'Diff unavailable: {error}',
+  'file.error.sessionOffline': 'This session is not connected to your computer right now. Reopen it to load this file.',
+  'file.action.reopen': 'Reopen session',
 
   // Inline media
   'media.displayed.image': 'Displayed image',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -520,6 +520,8 @@ export default {
   'file.error.readFailedWithDetail': '读取文件失败：{error}',
   'file.error.diffUnavailable': 'Diff 不可用。',
   'file.error.diffUnavailableWithDetail': 'Diff 不可用：{error}',
+  'file.error.sessionOffline': '此会话当前未连接到您的电脑。请重新打开会话以加载此文件。',
+  'file.action.reopen': '重新打开会话',
 
   // 内联媒体
   'media.displayed.image': '展示图片',

--- a/web/src/lib/rpc-target-missing.ts
+++ b/web/src/lib/rpc-target-missing.ts
@@ -1,0 +1,34 @@
+import { RPC_TARGET_MISSING_ERROR_CODE } from '@hapi/protocol/rpcMethods'
+import { ApiError } from '@/api/client'
+
+export function isRpcTargetMissingCode(code: string | undefined): boolean {
+    return code === RPC_TARGET_MISSING_ERROR_CODE
+}
+
+export function isRpcTargetMissingError(error: unknown): boolean {
+    return error instanceof ApiError && isRpcTargetMissingCode(error.code)
+}
+
+export function hasRpcTargetMissingResponse(
+    response: { success: boolean; code?: string } | undefined
+): boolean {
+    return response?.success === false && isRpcTargetMissingCode(response.code)
+}
+
+export async function catchRpcTargetMissing<T extends { success: boolean; code?: string; error?: string }>(
+    fn: () => Promise<T>
+): Promise<T> {
+    try {
+        return await fn()
+    } catch (error: unknown) {
+        const apiError = error instanceof ApiError ? error : null
+        if (apiError && isRpcTargetMissingCode(apiError.code)) {
+            return {
+                success: false,
+                error: apiError.message,
+                code: RPC_TARGET_MISSING_ERROR_CODE
+            } as unknown as T
+        }
+        throw error
+    }
+}

--- a/web/src/routes/sessions/file.test.tsx
+++ b/web/src/routes/sessions/file.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RPC_TARGET_MISSING_ERROR_CODE } from '@hapi/protocol/rpcMethods'
+import { ApiError } from '@/api/client'
 import { I18nProvider } from '@/lib/i18n-context'
 import { formatFileMetadata } from '@/lib/file-metadata'
 import { encodeBase64 } from '@/lib/utils'
@@ -8,6 +10,9 @@ import FilePage from './file'
 
 const goBackMock = vi.fn()
 const copyMock = vi.hoisted(() => vi.fn())
+const reopenSessionMock = vi.hoisted(() => vi.fn())
+const readSessionFileMock = vi.hoisted(() => vi.fn())
+const getGitDiffFileMock = vi.hoisted(() => vi.fn())
 
 const sampleMarkdown = '# Heading\n\n| Col A | Col B |\n| --- | --- |\n| one | two |'
 const filePath = 'docs/README.md'
@@ -24,16 +29,44 @@ vi.mock('@tanstack/react-router', () => ({
     }),
 }))
 
+vi.mock('@/hooks/queries/useSession', () => ({
+    useSession: () => ({
+        session: {
+            id: 'session-1',
+            active: false,
+            metadata: {
+                path: '/project',
+                flavor: 'cursor',
+                cursorSessionId: 'cursor-thread-1',
+            },
+        },
+        isLoading: false,
+        error: null,
+        notFound: false,
+        refetch: vi.fn(),
+    }),
+}))
+
+vi.mock('@/hooks/queries/useCursorChatStoreStatus', () => ({
+    useCursorChatStoreStatus: () => ({
+        status: { onDisk: true },
+        error: null,
+        isLoading: false,
+    }),
+}))
+
+vi.mock('@/hooks/mutations/useSessionActions', () => ({
+    useSessionActions: () => ({
+        reopenSession: reopenSessionMock,
+        isPending: false,
+    }),
+}))
+
 vi.mock('@/lib/app-context', () => ({
     useAppContext: () => ({
         api: {
-            getGitDiffFile: vi.fn(async () => ({ success: true, stdout: '' })),
-            readSessionFile: vi.fn(async () => ({
-                success: true,
-                content: encodedContent,
-                size: fileSize,
-                modified: fileModified,
-            })),
+            getGitDiffFile: getGitDiffFileMock,
+            readSessionFile: readSessionFileMock,
         },
     }),
 }))
@@ -80,6 +113,14 @@ describe('FilePage markdown preview', () => {
         vi.clearAllMocks()
         window.localStorage.clear()
         window.sessionStorage.clear()
+        getGitDiffFileMock.mockResolvedValue({ success: true, stdout: '' })
+        readSessionFileMock.mockResolvedValue({
+            success: true,
+            content: encodedContent,
+            size: fileSize,
+            modified: fileModified,
+        })
+        reopenSessionMock.mockResolvedValue({ ok: true, sessionId: 'session-1', resumed: true })
     })
 
     it('renders markdown preview by default and toggles to source', async () => {
@@ -133,5 +174,55 @@ describe('FilePage markdown preview', () => {
         })
         const secondScrollRegion = document.querySelector('[data-hapi-file-scroll="true"]') as HTMLElement
         expect(secondScrollRegion.scrollTop).toBe(123)
+    })
+})
+
+describe('FilePage offline session', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        window.localStorage.clear()
+        window.sessionStorage.clear()
+        const rpcError = new ApiError(
+            'HTTP 503: rpc target missing',
+            503,
+            RPC_TARGET_MISSING_ERROR_CODE,
+            JSON.stringify({ success: false, code: RPC_TARGET_MISSING_ERROR_CODE })
+        )
+        getGitDiffFileMock.mockRejectedValue(rpcError)
+        readSessionFileMock.mockRejectedValue(rpcError)
+        reopenSessionMock.mockResolvedValue({ ok: true, sessionId: 'session-1', resumed: true })
+    })
+
+    it('shows friendly offline copy and reopen affordance instead of raw RPC errors', async () => {
+        renderWithProviders()
+
+        await waitFor(() => {
+            expect(screen.getByText(/not connected to your computer right now/i)).toBeInTheDocument()
+        })
+        expect(screen.queryByText(/RPC handler not registered/i)).toBeNull()
+        expect(screen.getByRole('button', { name: 'Reopen session' })).toBeInTheDocument()
+    })
+
+    it('refetches file queries after reopen succeeds', async () => {
+        renderWithProviders()
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Reopen session' })).toBeInTheDocument()
+        })
+
+        readSessionFileMock.mockResolvedValue({
+            success: true,
+            content: encodedContent,
+            size: fileSize,
+            modified: fileModified,
+        })
+        getGitDiffFileMock.mockResolvedValue({ success: true, stdout: '' })
+
+        fireEvent.click(screen.getByRole('button', { name: 'Reopen session' }))
+
+        await waitFor(() => {
+            expect(reopenSessionMock).toHaveBeenCalled()
+            expect(readSessionFileMock).toHaveBeenCalledTimes(2)
+        })
     })
 })

--- a/web/src/routes/sessions/file.tsx
+++ b/web/src/routes/sessions/file.tsx
@@ -1,13 +1,17 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams, useSearch } from '@tanstack/react-router'
 import type { GitCommandResponse } from '@/types/api'
 import { FileIcon } from '@/components/FileIcon'
 import { CopyIcon, CheckIcon } from '@/components/icons'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { useAppContext } from '@/lib/app-context'
 import { useAppGoBack } from '@/hooks/useAppGoBack'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
-import { formatDiffError, formatReadFileError } from '@/lib/files-i18n'
+import { useSessionActions } from '@/hooks/mutations/useSessionActions'
+import { useSession } from '@/hooks/queries/useSession'
+import { useCursorChatStoreStatus } from '@/hooks/queries/useCursorChatStoreStatus'
+import { formatDiffError, formatFileSessionOfflineError, formatReadFileError } from '@/lib/files-i18n'
 import { queryKeys } from '@/lib/query-keys'
 import { langAlias, useShikiHighlighter } from '@/lib/shiki'
 import { useTranslation } from '@/lib/use-translation'
@@ -22,6 +26,10 @@ import {
     type MarkdownPreviewMode,
 } from '@/lib/file-markdown-preview'
 import { downloadBase64File } from '@/lib/file-download'
+import { catchRpcTargetMissing, hasRpcTargetMissingResponse } from '@/lib/rpc-target-missing'
+import { formatReopenError } from '@/lib/reopenError'
+import { inactiveSessionCanResume, resolveCursorReopenGate } from '@/lib/sessionResume'
+import { retargetSharePendingTransfer } from '@/lib/sharePendingState'
 
 const MAX_COPYABLE_FILE_BYTES = 1_000_000
 const FILE_SCROLL_KEY_PREFIX = 'hapi-file-scroll-'
@@ -205,6 +213,7 @@ function extractCommandError(result: GitCommandResponse | undefined): string | n
 
 export default function FilePage() {
     const { api } = useAppContext()
+    const queryClient = useQueryClient()
     const { t, locale } = useTranslation()
     const { copied: pathCopied, copy: copyPath } = useCopyToClipboard()
     const { copied: contentCopied, copy: copyContent } = useCopyToClipboard()
@@ -213,6 +222,13 @@ export default function FilePage() {
     const search = useSearch({ from: '/sessions/$sessionId/file' })
     const encodedPath = typeof search.path === 'string' ? search.path : ''
     const staged = search.staged
+    const { session } = useSession(api, sessionId)
+    const { reopenSession, isPending: reopenPending } = useSessionActions(
+        api,
+        sessionId,
+        session?.metadata?.flavor ?? null
+    )
+    const [reopenError, setReopenError] = useState<string | null>(null)
 
     const filePath = useMemo(() => decodePath(encodedPath), [encodedPath])
     const fileName = filePath.split('/').pop() || filePath || t('file.page.fallbackName')
@@ -225,7 +241,7 @@ export default function FilePage() {
             if (!api || !sessionId || !filePath) {
                 throw new Error('Missing session or path')
             }
-            return await api.getGitDiffFile(sessionId, filePath, staged)
+            return await catchRpcTargetMissing(() => api.getGitDiffFile(sessionId, filePath, staged))
         },
         enabled: Boolean(api && sessionId && filePath)
     })
@@ -236,10 +252,62 @@ export default function FilePage() {
             if (!api || !sessionId || !filePath) {
                 throw new Error('Missing session or path')
             }
-            return await api.readSessionFile(sessionId, filePath)
+            return await catchRpcTargetMissing(() => api.readSessionFile(sessionId, filePath))
         },
         enabled: Boolean(api && sessionId && filePath)
     })
+
+    const {
+        status: cursorChatStoreStatus,
+        error: cursorChatStoreError,
+        isLoading: cursorChatStoreLoading,
+    } = useCursorChatStoreStatus({ api, session })
+    const cursorReopenGate = resolveCursorReopenGate({
+        applicable: session?.metadata?.flavor === 'cursor',
+        onDisk: cursorChatStoreStatus?.onDisk,
+        error: cursorChatStoreError,
+        isLoading: cursorChatStoreLoading,
+    })
+    const canReopen = session && !session.active
+        ? inactiveSessionCanResume(session, 1, cursorChatStoreStatus?.onDisk)
+        : false
+    const reopenDisabledReason = cursorReopenGate.disabledReason === 'missing'
+        ? t('session.action.reopenCursorMissing')
+        : cursorReopenGate.disabledReason === 'checking'
+            ? t('session.action.reopenCursorChecking')
+            : undefined
+    const sessionRpcOffline = hasRpcTargetMissingResponse(fileQuery.data)
+        || hasRpcTargetMissingResponse(diffQuery.data)
+
+    const invalidateFileQueries = useCallback(async () => {
+        if (!sessionId || !filePath) return
+        await queryClient.invalidateQueries({ queryKey: queryKeys.sessionFile(sessionId, filePath) })
+        await queryClient.invalidateQueries({ queryKey: queryKeys.gitFileDiff(sessionId, filePath, staged) })
+    }, [filePath, queryClient, sessionId, staged])
+
+    const handleReopen = useCallback(async () => {
+        if (!canReopen || reopenDisabledReason) return
+        setReopenError(null)
+        try {
+            const result = await reopenSession()
+            if (result.sessionId && result.sessionId !== sessionId) {
+                retargetSharePendingTransfer(sessionId, result.sessionId)
+            }
+            await invalidateFileQueries()
+        } catch (error) {
+            setReopenError(formatReopenError(error))
+        }
+    }, [canReopen, invalidateFileQueries, reopenDisabledReason, reopenSession, sessionId])
+
+    const prevSessionActiveRef = useRef(session?.active)
+    useEffect(() => {
+        const wasInactive = prevSessionActiveRef.current === false
+        const nowActive = session?.active === true
+        prevSessionActiveRef.current = session?.active
+        if (wasInactive && nowActive && sessionRpcOffline) {
+            void invalidateFileQueries()
+        }
+    }, [invalidateFileQueries, session?.active, sessionRpcOffline])
 
     const diffContent = diffQuery.data?.success ? (diffQuery.data.stdout ?? '') : ''
     const diffError = extractCommandError(diffQuery.data)
@@ -343,12 +411,17 @@ export default function FilePage() {
     }, [diffSuccess, diffFailed, diffContent, imageMimeType])
 
     const loading = diffQuery.isLoading || fileQuery.isLoading
-    const fileError = fileContentResult && !fileContentResult.success
+    const fileError = fileContentResult && !fileContentResult.success && !hasRpcTargetMissingResponse(fileContentResult)
         ? (fileContentResult.error ?? 'Failed to read file')
         : null
     const missingPath = !filePath
-    const diffErrorMessage = diffError ? formatDiffError(diffError, t) : null
-    const fileErrorMessage = fileError ? formatReadFileError(fileError, t) : null
+    const sessionOfflineMessage = sessionRpcOffline ? formatFileSessionOfflineError(t) : null
+    const diffErrorMessage = sessionRpcOffline
+        ? null
+        : diffError
+            ? formatDiffError(diffError, t)
+            : null
+    const fileErrorMessage = sessionOfflineMessage ?? (fileError ? formatReadFileError(fileError, t) : null)
     const fileMetadata = formatFileMetadata(fileContentResult?.size, fileContentResult?.modified, locale)
 
     return (
@@ -449,6 +522,23 @@ export default function FilePage() {
                         <div className="text-sm text-[var(--app-hint)]">{t('file.page.missingPath')}</div>
                     ) : loading ? (
                         <FileContentSkeleton label={t('loading.file')} />
+                    ) : sessionOfflineMessage ? (
+                        <div className="space-y-3">
+                            <div className="text-sm text-[var(--app-hint)]">{sessionOfflineMessage}</div>
+                            {canReopen ? (
+                                <button
+                                    type="button"
+                                    onClick={() => void handleReopen()}
+                                    disabled={Boolean(reopenDisabledReason) || reopenPending}
+                                    className="rounded-md bg-[var(--app-button)] px-3 py-2 text-sm font-semibold text-[var(--app-button-text)] disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                    {t('file.action.reopen')}
+                                </button>
+                            ) : null}
+                            {reopenDisabledReason ? (
+                                <div className="text-xs text-[var(--app-hint)]">{reopenDisabledReason}</div>
+                            ) : null}
+                        </div>
                     ) : fileErrorMessage ? (
                         <div className="text-sm text-[var(--app-hint)]">{fileErrorMessage}</div>
                     ) : displayMode === 'diff' && diffContent ? (
@@ -509,6 +599,20 @@ export default function FilePage() {
                     )}
                 </div>
             </div>
+
+            {reopenError ? (
+                <ConfirmDialog
+                    isOpen={true}
+                    onClose={() => setReopenError(null)}
+                    title={t('dialog.reopen.errorTitle')}
+                    description={reopenError}
+                    confirmLabel={t('dialog.reopen.dismiss')}
+                    confirmingLabel={t('dialog.reopen.dismiss')}
+                    onConfirm={async () => setReopenError(null)}
+                    isPending={false}
+                    centerTitle
+                />
+            ) : null}
         </div>
     )
 }


### PR DESCRIPTION
## Summary

- Map `RpcTargetMissingError` on `GET /sessions/:id/file` and `GET /sessions/:id/git-diff-file` to **503** `{ success: false, code: rpc_target_missing }` (matches `machines.ts` codex/pi model catalogs).
- File page shows actionable offline copy instead of raw `RPC handler not registered: …` strings, with **Reopen session** when the inactive session is reopenable.
- After reopen or `session.active` flip, invalidates `sessionFile` + `gitFileDiff` so the same chat file URL reloads without back-nav.

Closes tiann/hapi#1536

## Proof

Fabricated peer-stack sessions only (mocked API — no live estate data):

![File preview offline UX with reopen affordance](https://github.com/heavygee/hapi/releases/download/pr-attach-proof-1718/proof-2026-08-29T17-56-53-1536-file-offline-ux-proof.png)

## Test plan

- [x] Hub: `bun test src/web/routes/git.test.ts` — `rpc_target_missing` mapping for `/file` + `/git-diff-file`
- [x] Web: `vitest run src/routes/sessions/file.test.tsx src/lib/files-i18n.test.ts`
- [x] `web` + `hub` typecheck
- [ ] Manual: idle session → open chat file link → friendly message → Reopen → file loads