### PR TITLE
fix(web): keep mobile code gutters clear across renderers

### DIFF
--- a/e2e/terminal-wrap-fidelity.spec.ts
+++ b/e2e/terminal-wrap-fidelity.spec.ts
@@ -10,9 +10,15 @@ test.describe('terminal wrap fidelity', () => {
         await page.addInitScript(() => window.localStorage.setItem('hapi-code-wrap', '1'))
         await page.goto(fixtureUrl)
 
-        await page.getByRole('button', { name: /node scripts\/render-report/i }).click()
+        const terminalPreview = page.getByRole('button', { name: /node scripts\/render-report/i })
+        await terminalPreview.click()
         const dialog = page.getByRole('dialog')
         await expect(dialog).toBeVisible()
+
+        const codeHeader = dialog.locator('.aui-code-surface-header')
+        await expect(codeHeader).toHaveCount(1)
+        await expect(codeHeader).toHaveCSS('padding-left', '22px')
+        await expect(codeHeader).toHaveCSS('padding-right', '10px')
 
         const metrics = await dialog.evaluate((element) => {
             const body = element.querySelector<HTMLElement>('[data-hapi-code-body="true"]')!
@@ -61,6 +67,7 @@ test.describe('terminal wrap fidelity', () => {
     test('exposes one visible preview trigger, share-safe toggles, and wrapping geometry in inline diff surfaces', async ({ page }) => {
         await page.goto(fixtureUrl)
 
+        const terminalPreview = page.getByRole('button', { name: /node scripts\/render-report/i })
         const preview = page.getByTestId('diff-preview')
         const wrapToggle = preview.locator('[data-hapi-code-wrap-toggle="true"]')
         await expect(wrapToggle).toHaveCount(1)
@@ -70,7 +77,7 @@ test.describe('terminal wrap fidelity', () => {
 
         await wrapToggle.click()
         await expect(wrapToggle).toHaveAttribute('aria-pressed', 'true')
-        await expect(page.locator('[data-hapi-code-grid="true"]')).toHaveAttribute('style', /minmax\(0px, 1fr\)/)
+        await expect(terminalPreview.locator('[data-hapi-code-grid="true"]')).toHaveAttribute('style', /minmax\(0px, 1fr\)/)
 
         const inline = page.getByTestId('diff-inline')
         await expect(inline.locator('.whitespace-pre-wrap')).toHaveCount(2)
@@ -108,5 +115,69 @@ test.describe('terminal wrap fidelity', () => {
         await expect(dialog.getByRole('button', { pressed: true })).toHaveCount(1)
         await dialog.getByRole('button', { name: 'Close' }).click()
         await expect(previewTrigger).toBeFocused()
+    })
+
+    test('wrap-on keeps Markdown, md, and standalone gutters clear on mobile', async ({ page }, testInfo) => {
+        await page.addInitScript(() => window.localStorage.setItem('hapi-code-wrap', '1'))
+        await page.goto(fixtureUrl)
+
+        const fixtures = [
+            page.getByTestId('markdown-gutter-markdown'),
+            page.getByTestId('markdown-gutter-md'),
+            page.getByTestId('markdown-gutter-standalone'),
+        ]
+        const metrics = await Promise.all(fixtures.map(async (fixture) => {
+            await expect(fixture.locator('[data-line-number]')).toHaveCount(123)
+            return fixture.evaluate((element) => {
+                const header = element.querySelector<HTMLElement>('[data-hapi-code-header="true"]')!
+                const body = element.querySelector<HTMLElement>('[data-hapi-code-body="true"]')!
+                const grid = element.querySelector<HTMLElement>('[data-hapi-code-grid="true"]')!
+                const cells = Array.from(element.querySelectorAll<HTMLElement>('[data-code-cell]'))
+                const gutters = Array.from(element.querySelectorAll<HTMLElement>('[data-line-number]'))
+                const measure = (index: number) => {
+                    const cell = cells[index]!
+                    const gutter = gutters[index]!
+                    const codeRange = document.createRange()
+                    codeRange.selectNodeContents(cell)
+                    const codeRect = codeRange.getClientRects()[0] ?? cell.getBoundingClientRect()
+                    const numberRange = document.createRange()
+                    numberRange.selectNodeContents(gutter)
+                    const numberRects = Array.from(numberRange.getClientRects()).filter((rect) => rect.width > 0)
+                    const gutterRect = gutter.getBoundingClientRect()
+                    return {
+                        gap: codeRect.left - Math.max(...numberRects.map((rect) => rect.right)),
+                        gutterWidth: gutterRect.width,
+                        numberWidth: Math.max(...numberRects.map((rect) => rect.width)),
+                        codeTextLeft: codeRect.left,
+                        gutterLeft: gutterRect.left,
+                    }
+                }
+                return {
+                    header: { paddingLeft: getComputedStyle(header).paddingLeft, paddingRight: getComputedStyle(header).paddingRight },
+                    gridTemplateColumns: grid.style.gridTemplateColumns,
+                    body: { clientWidth: body.clientWidth, scrollWidth: body.scrollWidth },
+                    grid: { clientWidth: grid.clientWidth, scrollWidth: grid.scrollWidth },
+                    line10: measure(9),
+                    line100: measure(99),
+                }
+            })
+        }))
+
+        await testInfo.attach('markdown-gutter-geometry.json', {
+            body: JSON.stringify(metrics, null, 2),
+            contentType: 'application/json',
+        })
+        await page.screenshot({ path: testInfo.outputPath('markdown-gutters.png'), fullPage: true })
+
+        for (const metric of metrics) {
+            expect(metric.header).toEqual({ paddingLeft: '22px', paddingRight: '10px' })
+            expect(metric.gridTemplateColumns).toContain('calc(3ch + 1.5rem)')
+            expect(metric.body.scrollWidth).toBe(metric.body.clientWidth)
+            expect(metric.grid.scrollWidth).toBe(metric.grid.clientWidth)
+            expect(metric.line10.gap).toBeGreaterThanOrEqual(16)
+            expect(metric.line100.gap).toBeGreaterThanOrEqual(16)
+            expect(metric.line100.codeTextLeft - metric.line100.gutterLeft)
+                .toBeGreaterThanOrEqual(metric.line100.numberWidth + 24)
+        }
     })
 })

--- a/web/e2e-fixtures/terminal-wrap-fixture.tsx
+++ b/web/e2e-fixtures/terminal-wrap-fixture.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import '../src/index.css'
 import { CliOutputBlock } from '../src/components/CliOutputBlock'
 import { DiffView } from '../src/components/DiffView'
+import { MarkdownRenderer } from '../src/components/MarkdownRenderer'
 import { ToolCard } from '../src/components/ToolCard/ToolCard'
 import { I18nProvider } from '../src/lib/i18n-context'
 import type { ApiClient } from '../src/api/client'
@@ -27,6 +28,17 @@ const codexDiffBlock: ToolCallBlock = {
     }, children: [],
 }
 
+const markdownCode = Array.from({ length: 123 }, (_, index) => {
+    const line = index + 1
+    if (line === 10) return 'const tenth = "two-digit gutter"'
+    if (line === 100) return 'const oneHundredth = "three-digit gutter"'
+    return `const line${line} = "sample"`
+}).join('\n')
+
+function fencedCode(language: 'markdown' | 'md') {
+    return [`\`\`\`${language}`, markdownCode, '\`\`\`'].join('\n')
+}
+
 function TerminalWrapFixture() {
     return (
         <div className="flex flex-col gap-4" data-testid="terminal-wrap-fixture">
@@ -49,6 +61,17 @@ function TerminalWrapFixture() {
             </div>
             <div data-testid="toolcard-codex-diff">
                 <ToolCard api={{} as ApiClient} sessionId="fixture-session" metadata={null} terminalToolDisplayMode="detailed" disabled={false} onDone={() => {}} block={codexDiffBlock} />
+            </div>
+            <div data-testid="markdown-gutter-fixtures" className="flex flex-col gap-4">
+                <div data-testid="markdown-gutter-markdown">
+                    <MarkdownRenderer content={fencedCode('markdown')} />
+                </div>
+                <div data-testid="markdown-gutter-md">
+                    <MarkdownRenderer content={fencedCode('md')} />
+                </div>
+                <div data-testid="markdown-gutter-standalone">
+                    <MarkdownRenderer standalone content={fencedCode('markdown')} />
+                </div>
             </div>
         </div>
     )

--- a/web/src/components/CodeBlock.test.tsx
+++ b/web/src/components/CodeBlock.test.tsx
@@ -16,7 +16,7 @@ describe('CodeBlock', () => {
 
     it('renders a header label and truncation badge for long content', () => {
         const longCode = Array.from({ length: 40 }, (_, index) => `line ${index + 1}`).join('\n')
-        render(
+        const { container } = render(
             <I18nProvider>
                 <CodeBlock
                     code={longCode}
@@ -29,6 +29,7 @@ describe('CodeBlock', () => {
         )
 
         expect(screen.getByText('TypeScript')).toBeInTheDocument()
+        expect(container.querySelector('.aui-code-surface-header')).toHaveClass('pl-[22px]', 'pr-[10px]')
         expect(screen.getByTitle('Copy')).toBeInTheDocument()
         expect(screen.getByText(/Preview truncated/)).toBeInTheDocument()
     })

--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -2,6 +2,7 @@ import { type CSSProperties, type ReactNode } from 'react'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { useCodeWrap } from '@/hooks/useCodeWrap'
 import { useShikiHighlightedLines, splitCodeLines } from '@/lib/shiki'
+import { getCodeGutterTrack } from '@/lib/code-gutter'
 import { CopyIcon, CheckIcon, WrapIcon } from '@/components/icons'
 import { useTranslation } from '@/lib/use-translation'
 
@@ -9,8 +10,6 @@ const DEFAULT_COLLAPSE_LINE_THRESHOLD = 18
 const DEFAULT_COLLAPSE_CHAR_THRESHOLD = 1800
 const DEFAULT_COLLAPSED_HEIGHT = 260
 const DEFAULT_SCROLL_HEIGHT = 420
-const GUTTER_HORIZONTAL_PADDING_REM = 1.5
-
 function shouldCollapseCode(code: string, lineThreshold: number, charThreshold: number): boolean {
     if (code.length > charThreshold) return true
     return code.split('\n').length > lineThreshold
@@ -83,7 +82,7 @@ export function CodeBlock(props: {
     // (minmax(0,1fr)) so long lines wrap instead of overflowing; unwrapped it
     // grows to its content (max-content) inside the horizontal-scroll body.
     const codeGridStyle = {
-        gridTemplateColumns: `calc(${lineNumberWidth}ch + ${GUTTER_HORIZONTAL_PADDING_REM}rem) ${codeWrap ? 'minmax(0, 1fr)' : 'max-content'}`
+        gridTemplateColumns: `${getCodeGutterTrack(lineNumberWidth)} ${codeWrap ? 'minmax(0, 1fr)' : 'max-content'}`
     } satisfies CSSProperties
     const codeCellStyle = codeWrap
         ? { whiteSpace: 'pre-wrap' as const, wordBreak: 'break-word' as const }
@@ -96,7 +95,7 @@ export function CodeBlock(props: {
 
     return (
         <div data-hapi-code-block="true" className="aui-code-surface relative min-w-0 max-w-full overflow-hidden rounded-xl bg-[var(--app-code-bg)] shadow-none">
-            <div className="aui-code-surface-header flex items-center justify-between gap-3 bg-[var(--app-code-header-bg)] px-3 py-2">
+            <div className="aui-code-surface-header flex items-center justify-between gap-3 bg-[var(--app-code-header-bg)] pl-[22px] pr-[10px] py-2">
                 <div className="min-w-0 flex-1 truncate font-mono text-[11px] uppercase tracking-[0.08em] text-[var(--app-code-header-fg)]">
                     {label}
                 </div>

--- a/web/src/components/MarkdownRenderer.test.tsx
+++ b/web/src/components/MarkdownRenderer.test.tsx
@@ -28,4 +28,17 @@ describe('MarkdownRenderer', () => {
         expect(document.querySelector('.aui-md-codeblock')).toBeFalsy()
         expect(document.querySelector('.aui-md-code')).toBeTruthy()
     })
+
+    it.each(['markdown', 'md'])('keeps the gutter padding for %s fenced blocks', (language) => {
+        const code = Array.from({ length: 123 }, (_, index) => `line ${index + 1}`).join('\n')
+        render(
+            <I18nProvider>
+                <MarkdownRenderer standalone content={`\`\`\`${language}\n${code}\n\`\`\``} />
+            </I18nProvider>
+        )
+
+        const grid = document.querySelector('[data-hapi-code-grid="true"]') as HTMLElement | null
+        expect(grid?.style.gridTemplateColumns).toBe('calc(3ch + 1.5rem) max-content')
+        expect(document.querySelectorAll('[data-line-number]')).toHaveLength(123)
+    })
 })

--- a/web/src/components/assistant-ui/markdown-text-codeblock.test.tsx
+++ b/web/src/components/assistant-ui/markdown-text-codeblock.test.tsx
@@ -29,6 +29,7 @@ describe('markdown-text CodeHeader + Pre wrap toggle', () => {
             </I18nProvider>
         )
 
+        expect(container.querySelector('.aui-code-shell-header')).toHaveClass('pl-[22px]', 'pr-[10px]')
         expect(container.querySelector('.overflow-x-auto')).not.toBeNull()
         expect(container.querySelector('.aui-md-pre')).toHaveClass('w-max')
         expect((container.querySelector('.aui-md-pre') as HTMLElement | null)?.style.whiteSpace).not.toBe('pre-wrap')

--- a/web/src/components/assistant-ui/markdown-text.tsx
+++ b/web/src/components/assistant-ui/markdown-text.tsx
@@ -410,7 +410,7 @@ function CodeHeader(props: CodeHeaderProps) {
     const language = props.language && props.language !== 'unknown' ? props.language : 'text'
 
     return (
-        <div data-hapi-code-header="true" className="aui-code-shell-header flex items-center justify-between gap-3 rounded-t-xl bg-[var(--app-code-header-bg)] px-3 py-2 text-[11px] uppercase tracking-[0.08em] text-[var(--app-code-header-fg)]">
+        <div data-hapi-code-header="true" className="aui-code-shell-header flex items-center justify-between gap-3 rounded-t-xl bg-[var(--app-code-header-bg)] pl-[22px] pr-[10px] py-2 text-[11px] uppercase tracking-[0.08em] text-[var(--app-code-header-fg)]">
             <div className="min-w-0 flex-1 truncate font-mono">
                 {language}
             </div>

--- a/web/src/components/assistant-ui/shiki-highlighter.test.tsx
+++ b/web/src/components/assistant-ui/shiki-highlighter.test.tsx
@@ -88,4 +88,16 @@ describe('SyntaxHighlighter wrap toggle', () => {
         expect(codeCells[0]).toHaveTextContent('plain one')
         expect(codeCells[1]).toHaveTextContent('plain two')
     })
+
+    it.each([1, 12, 123])('includes the line-number cell padding in the %i-line gutter track', (lineCount) => {
+        const code = Array.from({ length: lineCount }, (_, index) => `line ${index + 1}`).join('\n')
+        const { container } = render(
+            <I18nProvider>
+                <SyntaxHighlighter code={code} language="text" components={{ Pre: StubPre, Code: StubCode }} />
+            </I18nProvider>
+        )
+
+        const grid = container.querySelector('[data-hapi-code-grid="true"]') as HTMLElement | null
+        expect(grid?.style.gridTemplateColumns).toBe('calc(3ch + 1.5rem) max-content')
+    })
 })

--- a/web/src/components/assistant-ui/shiki-highlighter.tsx
+++ b/web/src/components/assistant-ui/shiki-highlighter.tsx
@@ -1,6 +1,7 @@
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-markdown'
 import type { CSSProperties, ReactNode } from 'react'
 import { useShikiHighlightedLines, splitCodeLines } from '@/lib/shiki'
+import { getCodeGutterTrack } from '@/lib/code-gutter'
 import { useCodeWrap } from '@/hooks/useCodeWrap'
 
 // `@assistant-ui/react-markdown`'s DefaultCodeBlock renders this component
@@ -15,7 +16,7 @@ export function SyntaxHighlighter(props: SyntaxHighlighterProps) {
     const codeLines: ReactNode[] = highlightedLines ?? splitCodeLines(props.code)
     const lineNumberWidth = Math.max(String(codeLines.length).length, 3)
     const codeGridStyle = {
-        gridTemplateColumns: `${lineNumberWidth}ch ${codeWrap ? 'minmax(0, 1fr)' : 'max-content'}`
+        gridTemplateColumns: `${getCodeGutterTrack(lineNumberWidth)} ${codeWrap ? 'minmax(0, 1fr)' : 'max-content'}`
     } satisfies CSSProperties
     // Inline style, not a Tailwind class: `.aui-md :where(pre)
     // { white-space: pre }` in index.css is unlayered CSS that outranks any

--- a/web/src/lib/code-gutter.ts
+++ b/web/src/lib/code-gutter.ts
@@ -1,0 +1,10 @@
+/**
+ * The line-number cells use `px-3`, so their grid track must include both
+ * horizontal padding edges or a three-digit line number can crowd the code.
+ * Keep this calculation shared by CodeBlock and Markdown's highlighter.
+ */
+const CODE_GUTTER_HORIZONTAL_PADDING_REM = 1.5
+
+export function getCodeGutterTrack(lineNumberWidth: number): string {
+    return `calc(${lineNumberWidth}ch + ${CODE_GUTTER_HORIZONTAL_PADDING_REM}rem)`
+}


### PR DESCRIPTION
## Summary

- Include both horizontal padding edges in the line-number grid track.
- Share the gutter calculation between `CodeBlock` and Markdown's `SyntaxHighlighter`, covering `markdown` and `md` fenced blocks.
- Align mobile code-block header content with 22px left and 10px right padding.
- Add unit and mobile E2E coverage for 1-, 2-, and 3-digit line-number boundaries.

## Problem / Motivation

On narrow viewports, Markdown code blocks allocated only the character width to the line-number column while the line-number cells also used horizontal padding. This could crowd or overlap the code, especially when line numbers reached three digits.

The existing gutter correction covered the regular `CodeBlock` path but not Markdown's syntax-highlighter path. The code-block header also used spacing that left the language label and action controls visually misaligned on mobile.

## User Impact

Markdown, MD, tool-output, diff, and CLI code surfaces keep their line numbers clear of code text on narrow viewports, while the header label and controls remain visually aligned.

## Risk / Migration

- Web-only layout and test changes.
- No API, protocol, database, dependency, or migration changes.

## Validation

- `bun typecheck` — passed.
- `bun run test:e2e -- terminal-wrap-fidelity.spec.ts` — 3 passed.
- Related Web Vitest files — 4 files, 27 tests passed.
- `bun run build` — passed.
- Deployed Full Live mobile smoke check — passed; both header paths reported 22px left and 10px right padding.

## Related Issues

Fixes #1074

## AI Assistance

OpenAI Codex using GPT-5.6 assisted with the implementation, testing, and PR preparation.