### PR TITLE
fix(web): allow retrying failed attachment uploads

### DIFF
--- a/web/src/components/AssistantChat/AttachmentItem.test.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
     composer: {
         addAttachment: vi.fn(async (_file: File) => {}),
         getState: vi.fn(() => ({ attachments: [] })),
+        subscribe: vi.fn((_listener: () => void) => () => {}),
     },
     attachmentRuntime: {
         remove: vi.fn(async () => {}),
@@ -41,6 +42,7 @@ beforeEach(() => {
     mocks.composer.addAttachment.mockClear()
     mocks.composer.getState.mockReset()
     mocks.composer.getState.mockReturnValue({ attachments: [] })
+    mocks.composer.subscribe.mockClear()
     mocks.attachmentRuntime.remove.mockClear()
 })
 
@@ -204,16 +206,21 @@ describe('AttachmentItem', () => {
         const file = new File(['broken'], 'broken.png', { type: 'image/png' })
         const attachmentOrderRef = { current: ['first-attachment', 'broken-attachment', 'last-attachment'] }
         const onRetry = vi.fn()
+        const unsubscribe = vi.fn()
         mocks.attachment = {
             id: 'broken-attachment',
             name: file.name,
             file,
             status: { type: 'incomplete', reason: 'error' },
         }
-        mocks.composer.addAttachment.mockImplementationOnce(async (retryFile: File) => {
-            mocks.composer.getState.mockReturnValue({
-                attachments: [{ id: 'retried-attachment', file: retryFile }] as never[],
+        mocks.composer.subscribe.mockImplementationOnce((listener: () => void) => {
+            mocks.composer.addAttachment.mockImplementationOnce(async (retryFile: File) => {
+                mocks.composer.getState.mockReturnValue({
+                    attachments: [{ id: 'retried-attachment', file: retryFile }] as never[],
+                })
+                listener()
             })
+            return unsubscribe
         })
 
         render(
@@ -226,6 +233,7 @@ describe('AttachmentItem', () => {
         await waitFor(() => {
             expect(onRetry).toHaveBeenCalledWith('broken-attachment', 'retried-attachment', 1)
         })
+        expect(unsubscribe).toHaveBeenCalledOnce()
     })
 
     it('keeps an error indicator without retrying non-retryable files', () => {
@@ -240,6 +248,7 @@ describe('AttachmentItem', () => {
 
         expect(screen.queryByRole('button', { name: 'Retry upload' })).not.toBeInTheDocument()
         expect(screen.getByTestId('attachment-error-icon')).toBeInTheDocument()
+        expect(screen.getByText('Upload failed')).toHaveClass('sr-only')
     })
 
     it('rechecks filename truncation when an image enters the error layout', () => {

--- a/web/src/components/AssistantChat/AttachmentItem.test.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     } as Record<string, unknown>,
     composer: {
         addAttachment: vi.fn(async (_file: File) => {}),
+        getState: vi.fn(() => ({ attachments: [] })),
     },
     attachmentRuntime: {
         remove: vi.fn(async () => {}),
@@ -38,6 +39,8 @@ afterEach(() => {
 
 beforeEach(() => {
     mocks.composer.addAttachment.mockClear()
+    mocks.composer.getState.mockReset()
+    mocks.composer.getState.mockReturnValue({ attachments: [] })
     mocks.attachmentRuntime.remove.mockClear()
 })
 
@@ -195,6 +198,34 @@ describe('AttachmentItem', () => {
             lastModified: file.lastModified,
         })
         expect(retryFile.size).toBe(file.size)
+    })
+
+    it('reports the fresh retry id with the original attachment index', async () => {
+        const file = new File(['broken'], 'broken.png', { type: 'image/png' })
+        const attachmentOrderRef = { current: ['first-attachment', 'broken-attachment', 'last-attachment'] }
+        const onRetry = vi.fn()
+        mocks.attachment = {
+            id: 'broken-attachment',
+            name: file.name,
+            file,
+            status: { type: 'incomplete', reason: 'error' },
+        }
+        mocks.composer.addAttachment.mockImplementationOnce(async (retryFile: File) => {
+            mocks.composer.getState.mockReturnValue({
+                attachments: [{ id: 'retried-attachment', file: retryFile }] as never[],
+            })
+        })
+
+        render(
+            <I18nProvider>
+                <AttachmentItem attachmentOrderRef={attachmentOrderRef} onRetry={onRetry} />
+            </I18nProvider>,
+        )
+        fireEvent.click(screen.getByRole('button', { name: 'Retry upload' }))
+
+        await waitFor(() => {
+            expect(onRetry).toHaveBeenCalledWith('broken-attachment', 'retried-attachment', 1)
+        })
     })
 
     it('keeps an error indicator without retrying non-retryable files', () => {

--- a/web/src/components/AssistantChat/AttachmentItem.test.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.test.tsx
@@ -2,6 +2,7 @@ import type { ComponentProps, ReactNode } from 'react'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { I18nProvider } from '@/lib/i18n-context'
+import { MAX_UPLOAD_BYTES } from '@/lib/attachmentAdapter'
 
 const mocks = vi.hoisted(() => ({
     attachment: {
@@ -31,7 +32,10 @@ vi.mock('@assistant-ui/react', () => ({
 
 import { AttachmentItem } from './AttachmentItem'
 
-afterEach(() => cleanup())
+afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+})
 
 beforeEach(() => {
     mocks.composer.addAttachment.mockClear()
@@ -141,8 +145,10 @@ describe('AttachmentItem', () => {
     })
 
     it('renders a failed upload with an inline retry icon', () => {
+        const file = new File(['broken'], 'broken.png', { type: 'image/png' })
         mocks.attachment = {
             name: 'broken.png',
+            file,
             status: { type: 'incomplete', reason: 'error' },
             previewUrl: 'data:image/png;base64,YnJva2Vu'
         }
@@ -179,7 +185,56 @@ describe('AttachmentItem', () => {
 
         await waitFor(() => {
             expect(mocks.attachmentRuntime.remove).toHaveBeenCalledOnce()
-            expect(mocks.composer.addAttachment).toHaveBeenCalledWith(file)
+            expect(mocks.composer.addAttachment).toHaveBeenCalledOnce()
         })
+
+        const retryFile = mocks.composer.addAttachment.mock.calls[0]?.[0] as File
+        expect(retryFile).not.toBe(file)
+        expect(retryFile).toMatchObject({
+            name: file.name,
+            type: file.type,
+            lastModified: file.lastModified,
+        })
+        expect(retryFile.size).toBe(file.size)
+    })
+
+    it('keeps an error indicator without retrying oversized files', () => {
+        mocks.attachment = {
+            name: 'oversized.bin',
+            file: { name: 'oversized.bin', size: MAX_UPLOAD_BYTES + 1, type: 'application/octet-stream' } as File,
+            status: { type: 'incomplete', reason: 'error' },
+        }
+
+        renderAttachmentWithControls()
+
+        expect(screen.queryByRole('button', { name: 'Retry upload' })).not.toBeInTheDocument()
+        expect(screen.getByTestId('attachment-error-icon')).toBeInTheDocument()
+    })
+
+    it('rechecks filename truncation when an image enters the error layout', () => {
+        vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockReturnValue(200)
+        vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(100)
+        const file = new File(['broken'], 'a-very-long-filename-that-needs-truncation.png', { type: 'image/png' })
+        mocks.attachment = {
+            name: file.name,
+            file,
+            status: { type: 'running', reason: 'uploading', progress: 0 },
+            previewUrl: 'data:image/png;base64,YnJva2Vu',
+        }
+        const view = renderAttachment()
+
+        mocks.attachment = {
+            name: file.name,
+            file,
+            status: { type: 'incomplete', reason: 'error' },
+            previewUrl: 'data:image/png;base64,YnJva2Vu',
+        }
+        view.rerender(
+            <I18nProvider>
+                <AttachmentItem />
+            </I18nProvider>,
+        )
+
+        expect(screen.getByRole('button', { name: 'Remove attachment' })).toHaveStyle({ marginLeft: '-7px' })
     })
 })

--- a/web/src/components/AssistantChat/AttachmentItem.test.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.test.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, ReactNode } from 'react'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { I18nProvider } from '@/lib/i18n-context'
 
 const mocks = vi.hoisted(() => ({
@@ -8,11 +8,19 @@ const mocks = vi.hoisted(() => ({
         name: 'photo.png',
         status: { type: 'requires-action', reason: 'composer-send' },
         previewUrl: 'data:image/png;base64,cGhvdG8='
-    } as Record<string, unknown>
+    } as Record<string, unknown>,
+    composer: {
+        addAttachment: vi.fn(async (_file: File) => {}),
+    },
+    attachmentRuntime: {
+        remove: vi.fn(async () => {}),
+    }
 }))
 
 vi.mock('@assistant-ui/react', () => ({
     useThreadComposerAttachment: () => mocks.attachment,
+    useComposerRuntime: () => mocks.composer,
+    useThreadComposerAttachmentRuntime: () => mocks.attachmentRuntime,
     AttachmentPrimitive: {
         Root: ({ children, ...props }: ComponentProps<'div'>) => <div {...props}>{children}</div>,
         Remove: ({ children, ...props }: ComponentProps<'button'> & { children?: ReactNode }) => (
@@ -24,6 +32,11 @@ vi.mock('@assistant-ui/react', () => ({
 import { AttachmentItem } from './AttachmentItem'
 
 afterEach(() => cleanup())
+
+beforeEach(() => {
+    mocks.composer.addAttachment.mockClear()
+    mocks.attachmentRuntime.remove.mockClear()
+})
 
 function renderAttachment() {
     return render(
@@ -119,23 +132,54 @@ describe('AttachmentItem', () => {
         expect(dragHandle.parentElement).toHaveClass('gap-1.5', 'px-2')
 
         for (const control of [dragHandle, removeButton]) {
-            expect(control).toHaveClass('hapi-composer-attachment-file-control', 'h-6', 'w-6', '-mx-1', 'items-center')
+            expect(control).toHaveClass('hapi-composer-attachment-file-control', 'h-6', 'w-6', 'items-center')
             expect(control).not.toHaveClass('absolute', 'top-1/2', '-translate-y-1/2')
             expect(control.querySelector('span')).toBeNull()
         }
+        expect(dragHandle).toHaveClass('-mx-1')
+        expect(removeButton).toHaveClass('-mx-1')
     })
 
-    it('keeps upload errors in the existing error layout', () => {
+    it('renders a failed upload with an inline retry icon', () => {
         mocks.attachment = {
             name: 'broken.png',
             status: { type: 'incomplete', reason: 'error' },
             previewUrl: 'data:image/png;base64,YnJva2Vu'
         }
 
-        renderAttachment()
+        renderAttachmentWithControls()
 
         expect(screen.queryByRole('img')).not.toBeInTheDocument()
-        expect(screen.getByText('Upload failed')).toBeInTheDocument()
+        expect(screen.queryByText('Upload failed')).not.toBeInTheDocument()
+        expect(screen.queryByText('Retry')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('attachment-drag-handle')).not.toBeInTheDocument()
         expect(screen.getByText('broken.png')).toHaveClass('line-through')
+        expect(screen.getByRole('button', { name: 'Retry upload' })).toBeInTheDocument()
+        const retryButton = screen.getByRole('button', { name: 'Retry upload' })
+        expect(retryButton).toHaveClass('hapi-composer-attachment-file-control', 'h-6', 'w-6', '-mx-1', 'items-center')
+        expect(screen.getByRole('button', { name: 'Remove attachment' })).toHaveClass(
+            'hapi-composer-attachment-file-control', 'h-6', 'w-6', '-mx-1', 'items-center',
+        )
+        expect(screen.getByRole('button', { name: 'Remove attachment' })).not.toHaveStyle({ marginLeft: '-7px' })
+        expect(retryButton.querySelector('svg')).toHaveClass('h-[18px]', 'w-[18px]')
+        expect(retryButton.querySelector('svg')).toHaveAttribute('viewBox', '0 0 24 24')
+    })
+
+    it('retries a failed upload with the original file', async () => {
+        const file = new File(['broken'], 'broken.png', { type: 'image/png' })
+        mocks.attachment = {
+            id: 'broken-attachment',
+            name: file.name,
+            file,
+            status: { type: 'incomplete', reason: 'error' },
+        }
+
+        renderAttachment()
+        fireEvent.click(screen.getByRole('button', { name: 'Retry upload' }))
+
+        await waitFor(() => {
+            expect(mocks.attachmentRuntime.remove).toHaveBeenCalledOnce()
+            expect(mocks.composer.addAttachment).toHaveBeenCalledWith(file)
+        })
     })
 })

--- a/web/src/components/AssistantChat/AttachmentItem.test.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.test.tsx
@@ -2,7 +2,6 @@ import type { ComponentProps, ReactNode } from 'react'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { I18nProvider } from '@/lib/i18n-context'
-import { MAX_UPLOAD_BYTES } from '@/lib/attachmentAdapter'
 
 const mocks = vi.hoisted(() => ({
     attachment: {
@@ -198,11 +197,12 @@ describe('AttachmentItem', () => {
         expect(retryFile.size).toBe(file.size)
     })
 
-    it('keeps an error indicator without retrying oversized files', () => {
+    it('keeps an error indicator without retrying non-retryable files', () => {
         mocks.attachment = {
             name: 'oversized.bin',
-            file: { name: 'oversized.bin', size: MAX_UPLOAD_BYTES + 1, type: 'application/octet-stream' } as File,
+            file: { name: 'oversized.bin', size: 1, type: 'application/octet-stream' } as File,
             status: { type: 'incomplete', reason: 'error' },
+            retryable: false,
         }
 
         renderAttachmentWithControls()

--- a/web/src/components/AssistantChat/AttachmentItem.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.tsx
@@ -11,6 +11,7 @@ import { ImagePreview } from '@/components/ImagePreview'
 import { Spinner } from '@/components/Spinner'
 import { RefreshIcon } from '@/components/icons'
 import { useComposerParking } from '@/components/AssistantChat/composerParkingContext'
+import { MAX_UPLOAD_BYTES } from '@/lib/attachmentAdapter'
 import { useTranslation } from '@/lib/use-translation'
 
 type ComposerAttachmentWithPreview = PendingAttachment & {
@@ -115,7 +116,8 @@ export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandlePr
     const [isFilenameTruncated, setIsFilenameTruncated] = useState(false)
     const isUploading = status.type === 'running'
     const isError = status.type === 'incomplete'
-    const showRetry = isError && !isParking
+    const isRetryableError = isError && file.size <= MAX_UPLOAD_BYTES
+    const showRetry = isRetryableError && !isParking
 
     useLayoutEffect(() => {
         const element = filenameRef.current
@@ -131,7 +133,7 @@ export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandlePr
         const observer = new ResizeObserver(updateTruncation)
         observer.observe(element)
         return () => observer.disconnect()
-    }, [name])
+    }, [name, isError])
     const surfacePointerDown = props.dragHandleProps?.onSurfacePointerDown
         ? (event: ReactPointerEvent<HTMLElement>) => {
             const target = event.target
@@ -147,8 +149,12 @@ export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandlePr
 
         setIsRetrying(true)
         try {
+            const retryFile = new File([file], file.name, {
+                type: file.type,
+                lastModified: file.lastModified,
+            })
             await attachmentRuntime.remove()
-            await composer.addAttachment(file)
+            await composer.addAttachment(retryFile)
         } catch (error) {
             console.error('Failed to retry attachment upload', error)
         } finally {
@@ -223,8 +229,8 @@ export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandlePr
                 <DragHandle {...props.dragHandleProps} isFile />
             ) : null}
             {isUploading ? <Spinner size="sm" label={null} className="text-[var(--app-hint)]" /> : null}
-            {isError && isParking ? (
-                <span className="text-red-500">
+            {isError && (!showRetry || isParking) ? (
+                <span data-testid="attachment-error-icon" className="text-red-500">
                     <ErrorIcon />
                 </span>
             ) : null}

--- a/web/src/components/AssistantChat/AttachmentItem.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.tsx
@@ -6,7 +6,13 @@ import {
     useThreadComposerAttachmentRuntime,
 } from '@assistant-ui/react'
 import type { PendingAttachment } from '@assistant-ui/react'
-import type { KeyboardEventHandler, MouseEventHandler, PointerEventHandler, PointerEvent as ReactPointerEvent } from 'react'
+import type {
+    KeyboardEventHandler,
+    MouseEventHandler,
+    MutableRefObject,
+    PointerEventHandler,
+    PointerEvent as ReactPointerEvent,
+} from 'react'
 import { ImagePreview } from '@/components/ImagePreview'
 import { Spinner } from '@/components/Spinner'
 import { RefreshIcon } from '@/components/icons'
@@ -29,6 +35,12 @@ export type AttachmentDragHandleProps = {
     onSurfaceContextMenu?: MouseEventHandler<HTMLElement>
     onSurfaceClick?: MouseEventHandler<HTMLElement>
 }
+
+export type AttachmentRetryHandler = (
+    originalId: string,
+    retryId: string,
+    originalIndex: number,
+) => void
 
 function ErrorIcon() {
     return (
@@ -105,8 +117,12 @@ function DragHandle(props: AttachmentDragHandleProps & { isFile?: boolean }) {
     )
 }
 
-export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandleProps } = {}) {
-    const { name, file, status, previewUrl, retryable } = useThreadComposerAttachment() as ComposerAttachmentWithPreview
+export function AttachmentItem(props: {
+    dragHandleProps?: AttachmentDragHandleProps
+    attachmentOrderRef?: MutableRefObject<string[]>
+    onRetry?: AttachmentRetryHandler
+} = {}) {
+    const { id, name, file, status, previewUrl, retryable } = useThreadComposerAttachment() as ComposerAttachmentWithPreview
     const composer = useComposerRuntime()
     const attachmentRuntime = useThreadComposerAttachmentRuntime()
     const isParking = useComposerParking()
@@ -148,18 +164,21 @@ export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandlePr
 
         setIsRetrying(true)
         try {
+            const originalIndex = props.attachmentOrderRef?.current.indexOf(id) ?? -1
             const retryFile = new File([file], file.name, {
                 type: file.type,
                 lastModified: file.lastModified,
             })
             await attachmentRuntime.remove()
             await composer.addAttachment(retryFile)
+            const retryAttachment = composer.getState().attachments.find((attachment) => attachment.file === retryFile)
+            if (retryAttachment) props.onRetry?.(id, retryAttachment.id, originalIndex)
         } catch (error) {
             console.error('Failed to retry attachment upload', error)
         } finally {
             setIsRetrying(false)
         }
-    }, [attachmentRuntime, composer, file, isParking, isRetrying])
+    }, [attachmentRuntime, composer, file, id, isParking, isRetrying, props.attachmentOrderRef, props.onRetry])
 
     if (previewUrl && !isError) {
         return (

--- a/web/src/components/AssistantChat/AttachmentItem.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.tsx
@@ -1,13 +1,23 @@
-import { AttachmentPrimitive, useThreadComposerAttachment } from '@assistant-ui/react'
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import {
+    AttachmentPrimitive,
+    useComposerRuntime,
+    useThreadComposerAttachment,
+    useThreadComposerAttachmentRuntime,
+} from '@assistant-ui/react'
 import type { PendingAttachment } from '@assistant-ui/react'
 import type { KeyboardEventHandler, MouseEventHandler, PointerEventHandler, PointerEvent as ReactPointerEvent } from 'react'
 import { ImagePreview } from '@/components/ImagePreview'
 import { Spinner } from '@/components/Spinner'
+import { RefreshIcon } from '@/components/icons'
 import { useComposerParking } from '@/components/AssistantChat/composerParkingContext'
+import { useTranslation } from '@/lib/use-translation'
 
 type ComposerAttachmentWithPreview = PendingAttachment & {
     previewUrl?: string
 }
+
+const TRUNCATED_REMOVE_MARGIN_LEFT = '-7px'
 
 export type AttachmentDragHandleProps = {
     onPointerDown: PointerEventHandler<HTMLButtonElement>
@@ -95,10 +105,33 @@ function DragHandle(props: AttachmentDragHandleProps & { isFile?: boolean }) {
 }
 
 export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandleProps } = {}) {
-    const { name, status, previewUrl } = useThreadComposerAttachment() as ComposerAttachmentWithPreview
+    const { name, file, status, previewUrl } = useThreadComposerAttachment() as ComposerAttachmentWithPreview
+    const composer = useComposerRuntime()
+    const attachmentRuntime = useThreadComposerAttachmentRuntime()
     const isParking = useComposerParking()
+    const { t } = useTranslation()
+    const [isRetrying, setIsRetrying] = useState(false)
+    const filenameRef = useRef<HTMLSpanElement>(null)
+    const [isFilenameTruncated, setIsFilenameTruncated] = useState(false)
     const isUploading = status.type === 'running'
     const isError = status.type === 'incomplete'
+    const showRetry = isError && !isParking
+
+    useLayoutEffect(() => {
+        const element = filenameRef.current
+        if (!element) return
+
+        const updateTruncation = () => {
+            const next = element.scrollWidth > element.clientWidth
+            setIsFilenameTruncated((current) => current === next ? current : next)
+        }
+        updateTruncation()
+
+        if (typeof ResizeObserver === 'undefined') return
+        const observer = new ResizeObserver(updateTruncation)
+        observer.observe(element)
+        return () => observer.disconnect()
+    }, [name])
     const surfacePointerDown = props.dragHandleProps?.onSurfacePointerDown
         ? (event: ReactPointerEvent<HTMLElement>) => {
             const target = event.target
@@ -108,6 +141,20 @@ export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandlePr
             props.dragHandleProps?.onSurfacePointerDown?.(event)
         }
         : undefined
+
+    const retryUpload = useCallback(async () => {
+        if (isRetrying || isParking) return
+
+        setIsRetrying(true)
+        try {
+            await attachmentRuntime.remove()
+            await composer.addAttachment(file)
+        } catch (error) {
+            console.error('Failed to retry attachment upload', error)
+        } finally {
+            setIsRetrying(false)
+        }
+    }, [attachmentRuntime, composer, file, isParking, isRetrying])
 
     if (previewUrl && !isError) {
         return (
@@ -161,20 +208,38 @@ export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandlePr
             onPointerDown={surfacePointerDown}
             onContextMenu={props.dragHandleProps?.onSurfaceContextMenu}
         >
-            {props.dragHandleProps ? <DragHandle {...props.dragHandleProps} isFile /> : null}
+            {showRetry ? (
+                <button
+                    type="button"
+                    className="hapi-composer-attachment-control hapi-composer-attachment-file-control -mx-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-transparent text-red-500 transition-colors hover:text-red-600 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)] disabled:cursor-wait disabled:opacity-60"
+                    aria-label={t('attachment.retryUpload')}
+                    title={t('attachment.retryUpload')}
+                    disabled={isRetrying}
+                    onClick={() => { void retryUpload() }}
+                >
+                    <RefreshIcon className="h-[18px] w-[18px]" />
+                </button>
+            ) : props.dragHandleProps && !isError ? (
+                <DragHandle {...props.dragHandleProps} isFile />
+            ) : null}
             {isUploading ? <Spinner size="sm" label={null} className="text-[var(--app-hint)]" /> : null}
-            {isError ? (
+            {isError && isParking ? (
                 <span className="text-red-500">
                     <ErrorIcon />
                 </span>
             ) : null}
-            <span className={`max-w-[150px] truncate ${isError ? 'text-red-500 line-through' : ''}`}>{name}</span>
-            {isError ? <span className="text-xs text-red-500 whitespace-nowrap">Upload failed</span> : null}
+            <span
+                ref={filenameRef}
+                className={`max-w-[150px] truncate ${isError ? 'text-red-500 line-through' : ''}`}
+            >
+                {name}
+            </span>
             {!isParking ? (
                 <AttachmentPrimitive.Remove
                     className="hapi-composer-attachment-control hapi-composer-attachment-file-control -mx-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-transparent text-[var(--app-hint)] transition-colors hover:text-[var(--app-fg)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--app-link)]"
                     aria-label="Remove attachment"
                     title="Remove attachment"
+                    style={isError && isFilenameTruncated ? { marginLeft: TRUNCATED_REMOVE_MARGIN_LEFT } : undefined}
                 >
                     <RemoveIcon />
                 </AttachmentPrimitive.Remove>

--- a/web/src/components/AssistantChat/AttachmentItem.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.tsx
@@ -169,10 +169,24 @@ export function AttachmentItem(props: {
                 type: file.type,
                 lastModified: file.lastModified,
             })
-            await attachmentRuntime.remove()
-            await composer.addAttachment(retryFile)
-            const retryAttachment = composer.getState().attachments.find((attachment) => attachment.file === retryFile)
-            if (retryAttachment) props.onRetry?.(id, retryAttachment.id, originalIndex)
+            let unsubscribe: (() => void) | undefined
+            if (props.onRetry) {
+                unsubscribe = composer.subscribe(() => {
+                    const retryAttachment = composer.getState().attachments.find(
+                        (attachment) => attachment.file === retryFile,
+                    )
+                    if (!retryAttachment) return
+                    unsubscribe?.()
+                    unsubscribe = undefined
+                    props.onRetry?.(id, retryAttachment.id, originalIndex)
+                })
+            }
+            try {
+                await attachmentRuntime.remove()
+                await composer.addAttachment(retryFile)
+            } finally {
+                unsubscribe?.()
+            }
         } catch (error) {
             console.error('Failed to retry attachment upload', error)
         } finally {
@@ -249,7 +263,10 @@ export function AttachmentItem(props: {
             {isUploading ? <Spinner size="sm" label={null} className="text-[var(--app-hint)]" /> : null}
             {isError && (!showRetry || isParking) ? (
                 <span data-testid="attachment-error-icon" className="text-red-500">
-                    <ErrorIcon />
+                    <span aria-hidden="true">
+                        <ErrorIcon />
+                    </span>
+                    <span className="sr-only">{t('attachment.uploadFailed')}</span>
                 </span>
             ) : null}
             <span

--- a/web/src/components/AssistantChat/AttachmentItem.tsx
+++ b/web/src/components/AssistantChat/AttachmentItem.tsx
@@ -11,11 +11,11 @@ import { ImagePreview } from '@/components/ImagePreview'
 import { Spinner } from '@/components/Spinner'
 import { RefreshIcon } from '@/components/icons'
 import { useComposerParking } from '@/components/AssistantChat/composerParkingContext'
-import { MAX_UPLOAD_BYTES } from '@/lib/attachmentAdapter'
 import { useTranslation } from '@/lib/use-translation'
 
 type ComposerAttachmentWithPreview = PendingAttachment & {
     previewUrl?: string
+    retryable?: boolean
 }
 
 const TRUNCATED_REMOVE_MARGIN_LEFT = '-7px'
@@ -106,7 +106,7 @@ function DragHandle(props: AttachmentDragHandleProps & { isFile?: boolean }) {
 }
 
 export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandleProps } = {}) {
-    const { name, file, status, previewUrl } = useThreadComposerAttachment() as ComposerAttachmentWithPreview
+    const { name, file, status, previewUrl, retryable } = useThreadComposerAttachment() as ComposerAttachmentWithPreview
     const composer = useComposerRuntime()
     const attachmentRuntime = useThreadComposerAttachmentRuntime()
     const isParking = useComposerParking()
@@ -116,8 +116,7 @@ export function AttachmentItem(props: { dragHandleProps?: AttachmentDragHandlePr
     const [isFilenameTruncated, setIsFilenameTruncated] = useState(false)
     const isUploading = status.type === 'running'
     const isError = status.type === 'incomplete'
-    const isRetryableError = isError && file.size <= MAX_UPLOAD_BYTES
-    const showRetry = isRetryableError && !isParking
+    const showRetry = isError && retryable !== false && !isParking
 
     useLayoutEffect(() => {
         const element = filenameRef.current

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -63,7 +63,8 @@ import { useVoiceInputPreferences } from '@/hooks/useVoiceInputPreferences'
 import { useDictation } from '@/hooks/useDictation'
 import type { ComposerSendIntent } from '@/lib/messageDelivery'
 import type { MessageDeliveryMode } from '@hapi/protocol'
-import { moveAttachmentId, orderItemsById, reconcileAttachmentOrder, type AttachmentDropPosition } from '@/lib/attachmentOrder'
+import { moveAttachmentId, orderItemsById, reconcileAttachmentOrder, replaceAttachmentId, type AttachmentDropPosition } from '@/lib/attachmentOrder'
+import type { AttachmentRetryHandler } from './AttachmentItem'
 
 export interface TextInputState {
     text: string
@@ -476,6 +477,15 @@ export function HappyComposer(props: {
         attachmentOrderRef.current = nextOrder
         setAttachmentOrderRevision((revision) => revision + 1)
     }, [attachmentIds, attachmentOrderRef])
+    const handleAttachmentRetry = useCallback<AttachmentRetryHandler>((originalId, retryId, originalIndex) => {
+        attachmentOrderRef.current = replaceAttachmentId(
+            attachmentOrderRef.current,
+            originalId,
+            retryId,
+            originalIndex,
+        )
+        setAttachmentOrderRevision((revision) => revision + 1)
+    }, [attachmentOrderRef])
     const orderedAttachments = orderItemsById(attachments, orderedAttachmentIds)
     const threadIsRunning = useAuiState((s) => s.thread.isRunning)
     const threadIsDisabled = useAuiState((s) => s.thread.isDisabled)
@@ -2231,6 +2241,8 @@ export function HappyComposer(props: {
                                     orderedAttachmentIds={orderedAttachmentIds}
                                     disabled={controlsDisabled}
                                     onReorder={handleAttachmentReorder}
+                                    attachmentOrderRef={attachmentOrderRef}
+                                    onRetry={handleAttachmentRetry}
                                 />
                             </div>
                         ) : null}

--- a/web/src/components/AssistantChat/SortableComposerAttachments.tsx
+++ b/web/src/components/AssistantChat/SortableComposerAttachments.tsx
@@ -10,8 +10,9 @@ import {
     useRef,
     useState,
 } from 'react'
+import type { MutableRefObject } from 'react'
 import { type AttachmentDropPosition } from '@/lib/attachmentOrder'
-import { AttachmentItem, type AttachmentDragHandleProps } from './AttachmentItem'
+import { AttachmentItem, type AttachmentDragHandleProps, type AttachmentRetryHandler } from './AttachmentItem'
 
 const DRAG_START_DISTANCE_PX = 6
 
@@ -32,6 +33,8 @@ type SortableComposerAttachmentProps = {
     onKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>, id: string) => void
     onContextMenu: (event: ReactMouseEvent<Element>, id: string) => void
     onClick: (event: ReactMouseEvent<Element>, id: string) => void
+    attachmentOrderRef?: MutableRefObject<string[]>
+    onRetry?: AttachmentRetryHandler
 }
 
 type AttachmentDropTarget = {
@@ -64,6 +67,8 @@ function SortableComposerAttachment(props: SortableComposerAttachmentProps) {
         onKeyDown,
         onContextMenu,
         onClick,
+        attachmentOrderRef,
+        onRetry,
     } = props
     const handlePointerDown = useCallback(
         (event: ReactPointerEvent<HTMLButtonElement>) => onPointerDown(event, attachment.id, false),
@@ -100,8 +105,14 @@ function SortableComposerAttachment(props: SortableComposerAttachmentProps) {
         [attachment.name, disabled, handleKeyDown, handlePointerDown],
     )
     const AttachmentWithHandle = useCallback(
-        () => <AttachmentItem dragHandleProps={dragHandleProps} />,
-        [dragHandleProps],
+        () => (
+            <AttachmentItem
+                dragHandleProps={dragHandleProps}
+                attachmentOrderRef={attachmentOrderRef}
+                onRetry={onRetry}
+            />
+        ),
+        [attachmentOrderRef, dragHandleProps, onRetry],
     )
 
     return (
@@ -123,8 +134,10 @@ export function SortableComposerAttachments(props: {
     orderedAttachmentIds: readonly string[]
     disabled?: boolean
     onReorder: (activeId: string, targetId: string, position: AttachmentDropPosition) => void
+    attachmentOrderRef?: MutableRefObject<string[]>
+    onRetry?: AttachmentRetryHandler
 }) {
-    const { attachments, orderedAttachmentIds, onReorder, disabled = false } = props
+    const { attachments, orderedAttachmentIds, onReorder, disabled = false, attachmentOrderRef, onRetry } = props
     const [draggingId, setDraggingId] = useState<string | null>(null)
     const dragRef = useRef<DragState | null>(null)
     const suppressClickIdRef = useRef<string | null>(null)
@@ -267,6 +280,8 @@ export function SortableComposerAttachments(props: {
                         onKeyDown={handleKeyDown}
                         onContextMenu={handleContextMenu}
                         onClick={handleClick}
+                        attachmentOrderRef={attachmentOrderRef}
+                        onRetry={onRetry}
                     />
                 )
             })}

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -98,6 +98,17 @@ export function RewindIcon(props: IconProps) {
     )
 }
 
+export function RefreshIcon(props: IconProps) {
+    return createIcon(
+        <>
+            <path d="M21 12a9 9 0 1 1-3-6.7" />
+            <polyline points="21 3 21 9 15 9" />
+        </>,
+        props,
+        2
+    )
+}
+
 /** Composer schedule-send clock — circle + hands (matches ComposerButtons). */
 export function ScheduleIcon(props: IconProps) {
     return createIcon(

--- a/web/src/lib/attachmentAdapter.test.ts
+++ b/web/src/lib/attachmentAdapter.test.ts
@@ -63,6 +63,47 @@ describe('attachmentAdapter', () => {
         })])
     })
 
+    it('assigns a fresh id when a restored failed upload is retried', async () => {
+        const drafts = await import('./composer-attachment-drafts')
+        const { createAttachmentAdapter } = await import('./attachmentAdapter')
+        const file = new File(['broken'], 'broken.txt', { type: 'text/plain', lastModified: 123 })
+        drafts.saveDraftAttachments('session-1', [{ id: 'restored-failed', file }])
+        const [restored] = await drafts.getDraftAttachments('session-1')
+        expect(restored).toBeDefined()
+
+        const uploadFile = vi.fn()
+            .mockResolvedValueOnce({ success: false })
+            .mockResolvedValueOnce({ success: true, path: '/uploads/retried.txt' })
+        const adapter = createAttachmentAdapter({ uploadFile } as never, 'session-1')
+
+        const firstEmitted: Record<string, unknown>[] = []
+        for await (const attachment of adapter.add({ file: restored! }) as AsyncIterable<Record<string, unknown>>) {
+            firstEmitted.push(attachment)
+        }
+        const failed = firstEmitted.at(-1)!
+        expect(failed).toMatchObject({
+            id: 'restored-failed',
+            status: { type: 'incomplete', reason: 'error' },
+        })
+        await adapter.remove(failed as never)
+
+        const retryFile = new File([restored!], restored!.name, {
+            type: restored!.type,
+            lastModified: restored!.lastModified,
+        })
+        const retriedEmitted: Record<string, unknown>[] = []
+        for await (const attachment of adapter.add({ file: retryFile }) as AsyncIterable<Record<string, unknown>>) {
+            retriedEmitted.push(attachment)
+        }
+
+        expect(uploadFile).toHaveBeenCalledTimes(2)
+        expect(retriedEmitted.at(-1)).toMatchObject({
+            status: { type: 'requires-action', reason: 'composer-send' },
+            path: '/uploads/retried.txt',
+        })
+        expect(retriedEmitted.at(-1)?.id).not.toBe('restored-failed')
+    })
+
     it('uploads an image when the initial preview read fails', async () => {
         let readCount = 0
         class FileReaderMock {

--- a/web/src/lib/attachmentAdapter.test.ts
+++ b/web/src/lib/attachmentAdapter.test.ts
@@ -104,6 +104,25 @@ describe('attachmentAdapter', () => {
         expect(retriedEmitted.at(-1)?.id).not.toBe('restored-failed')
     })
 
+    it('marks deterministic size failures as non-retryable', async () => {
+        const { createAttachmentAdapter, MAX_UPLOAD_BYTES } = await import('./attachmentAdapter')
+        const file = new File(['too-large'], 'too-large.txt', { type: 'text/plain' })
+        Object.defineProperty(file, 'size', { value: MAX_UPLOAD_BYTES + 1 })
+        const uploadFile = vi.fn()
+        const adapter = createAttachmentAdapter({ uploadFile } as never, 'session-1')
+        const emitted: Record<string, unknown>[] = []
+
+        for await (const attachment of adapter.add({ file }) as AsyncIterable<Record<string, unknown>>) {
+            emitted.push(attachment)
+        }
+
+        expect(emitted.at(-1)).toMatchObject({
+            status: { type: 'incomplete', reason: 'error' },
+            retryable: false,
+        })
+        expect(uploadFile).not.toHaveBeenCalled()
+    })
+
     it('uploads an image when the initial preview read fails', async () => {
         let readCount = 0
         class FileReaderMock {

--- a/web/src/lib/attachmentAdapter.ts
+++ b/web/src/lib/attachmentAdapter.ts
@@ -14,6 +14,7 @@ type PendingUploadAttachment = PendingAttachment & {
     path?: string
     previewUrl?: string
     uploadSessionId?: string
+    retryable?: boolean
 }
 
 export function createAttachmentAdapter(
@@ -99,8 +100,9 @@ export function createAttachmentAdapter(
                         name: file.name,
                         contentType,
                         file,
-                        status: { type: 'incomplete', reason: 'error' }
-                    }
+                        status: { type: 'incomplete', reason: 'error' },
+                        retryable: false,
+                    } as PendingUploadAttachment
                     return
                 }
 
@@ -154,8 +156,9 @@ export function createAttachmentAdapter(
                         name: file.name,
                         contentType,
                         file,
-                        status: { type: 'incomplete', reason: 'error' }
-                    }
+                        status: { type: 'incomplete', reason: 'error' },
+                        retryable: true,
+                    } as PendingUploadAttachment
                     return
                 }
 
@@ -178,8 +181,9 @@ export function createAttachmentAdapter(
                     name: file.name,
                     contentType,
                     file,
-                    status: { type: 'incomplete', reason: 'error' }
-                }
+                    status: { type: 'incomplete', reason: 'error' },
+                    retryable: true,
+                } as PendingUploadAttachment
             }
         },
 

--- a/web/src/lib/attachmentOrder.test.ts
+++ b/web/src/lib/attachmentOrder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { moveAttachmentId, orderItemsById, reconcileAttachmentOrder } from './attachmentOrder'
+import { moveAttachmentId, orderItemsById, reconcileAttachmentOrder, replaceAttachmentId } from './attachmentOrder'
 
 describe('attachment order helpers', () => {
     it('keeps existing order while appending newly added attachments', () => {
@@ -15,5 +15,14 @@ describe('attachment order helpers', () => {
     it('orders objects without dropping ids unknown to the order list', () => {
         const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
         expect(orderItemsById(items, ['c', 'a'])).toEqual([{ id: 'c' }, { id: 'a' }, { id: 'b' }])
+    })
+
+    it('replaces a retried attachment at its original index', () => {
+        expect(replaceAttachmentId(['first', 'failed', 'last'], 'failed', 'retried')).toEqual([
+            'first', 'retried', 'last',
+        ])
+        expect(replaceAttachmentId(['first', 'last', 'retried'], 'failed', 'retried', 1)).toEqual([
+            'first', 'retried', 'last',
+        ])
     })
 })

--- a/web/src/lib/attachmentOrder.ts
+++ b/web/src/lib/attachmentOrder.ts
@@ -41,6 +41,19 @@ export function moveAttachmentId(
     return next
 }
 
+export function replaceAttachmentId(
+    order: readonly string[],
+    originalId: string,
+    replacementId: string,
+    originalIndex = order.indexOf(originalId),
+): string[] {
+    const next = order.filter((id) => id !== originalId && id !== replacementId)
+    if (originalIndex < 0) return next
+
+    next.splice(Math.min(originalIndex, next.length), 0, replacementId)
+    return next
+}
+
 export function orderItemsById<T extends { id: string }>(
     items: readonly T[],
     order: readonly string[],

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -422,6 +422,7 @@ export default {
   'chat.sendError.sessionInactive': 'This session is archived. Reopen it to send your message.',
   'chat.sendError.sessionInactive.action': 'Reopen',
   'attachment.retryUpload': 'Retry upload',
+  'attachment.uploadFailed': 'Upload failed',
 
   // Codex review
   'codexReview.title': 'Codex review',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -421,6 +421,7 @@ export default {
   'chat.sendError.fallback': "Couldn't send your message. Edit and try again.",
   'chat.sendError.sessionInactive': 'This session is archived. Reopen it to send your message.',
   'chat.sendError.sessionInactive.action': 'Reopen',
+  'attachment.retryUpload': 'Retry upload',
 
   // Codex review
   'codexReview.title': 'Codex review',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -420,6 +420,7 @@ export default {
   'chat.sendError.fallback': '消息未能发送。请修改后重试。',
   'chat.sendError.sessionInactive': '此会话已归档。请先重新打开再发送消息。',
   'chat.sendError.sessionInactive.action': '重新打开',
+  'attachment.retryUpload': '重试上传',
 
   // Codex review
   'codexReview.title': 'Codex review',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -421,6 +421,7 @@ export default {
   'chat.sendError.sessionInactive': '此会话已归档。请先重新打开再发送消息。',
   'chat.sendError.sessionInactive.action': '重新打开',
   'attachment.retryUpload': '重试上传',
+  'attachment.uploadFailed': '上传失败',
 
   // Codex review
   'codexReview.title': 'Codex review',

--- a/web/src/lib/scratchlistAttachmentAdapter.test.ts
+++ b/web/src/lib/scratchlistAttachmentAdapter.test.ts
@@ -170,6 +170,51 @@ describe('createScratchlistAttachmentAdapter', () => {
         expect((ready as { path?: string }).path).toBe('/scratchlist/sessions/s1/proof.png')
     })
 
+    it('marks deterministic upload failures as non-retryable', async () => {
+        const uploadScratchlistAttachment = vi.fn().mockResolvedValue({
+            success: false,
+            error: 'File too large',
+            code: 'scratchlist_attachment_too_large',
+        })
+        const adapter = createScratchlistAttachmentAdapter(
+            { uploadScratchlistAttachment } as never,
+            'session-1',
+        )
+        const file = new File(['proof'], 'proof.png', { type: 'image/png' })
+        const states: Array<Record<string, unknown>> = []
+
+        for await (const state of adapter.add({ file }) as AsyncGenerator<Record<string, unknown>>) {
+            states.push(state)
+        }
+
+        expect(states.at(-1)).toMatchObject({
+            status: { type: 'incomplete', reason: 'error' },
+            retryable: false,
+        })
+    })
+
+    it('marks upload failures without a deterministic code as retryable', async () => {
+        const uploadScratchlistAttachment = vi.fn().mockResolvedValue({
+            success: false,
+            error: 'Temporary upload failure',
+        })
+        const adapter = createScratchlistAttachmentAdapter(
+            { uploadScratchlistAttachment } as never,
+            'session-1',
+        )
+        const file = new File(['proof'], 'proof.png', { type: 'image/png' })
+        const states: Array<Record<string, unknown>> = []
+
+        for await (const state of adapter.add({ file }) as AsyncGenerator<Record<string, unknown>>) {
+            states.push(state)
+        }
+
+        expect(states.at(-1)).toMatchObject({
+            status: { type: 'incomplete', reason: 'error' },
+            retryable: true,
+        })
+    })
+
     it('keeps a successful upload ready when image preview generation fails', async () => {
         stubUploadThenPreviewReadFailure()
         const attachment = {

--- a/web/src/lib/scratchlistAttachmentAdapter.ts
+++ b/web/src/lib/scratchlistAttachmentAdapter.ts
@@ -20,6 +20,26 @@ type PendingScratchlistAttachment = PendingAttachment & {
     path?: string
     hubAttachment?: ScratchlistAttachmentMetadata
     previewUrl?: string
+    retryable?: boolean
+}
+
+const NON_RETRYABLE_UPLOAD_ERROR_CODES = new Set([
+    'scratchlist_attachment_too_large',
+    'scratchlist_attachment_mime',
+    'scratchlist_attachments_per_entry',
+    'scratchlist_attachments_entry_bytes',
+    'scratchlist_attachments_session_bytes',
+])
+
+function getErrorCode(error: unknown): string | undefined {
+    if (typeof error !== 'object' || error === null) return undefined
+    const code = (error as { code?: unknown }).code
+    return typeof code === 'string' ? code : undefined
+}
+
+function isRetryableUploadError(codeOrError?: unknown): boolean {
+    const code = typeof codeOrError === 'string' ? codeOrError : getErrorCode(codeOrError)
+    return code === undefined || !NON_RETRYABLE_UPLOAD_ERROR_CODES.has(code)
 }
 
 /** Rebuild hub metadata from a composer-draft path so remount does not re-upload. */
@@ -142,8 +162,9 @@ export function createScratchlistAttachmentAdapter(
                         name: file.name,
                         contentType,
                         file,
-                        status: { type: 'incomplete', reason: 'error' }
-                    }
+                        status: { type: 'incomplete', reason: 'error' },
+                        retryable: isRetryableUploadError(result.code),
+                    } as PendingScratchlistAttachment
                     return
                 }
 
@@ -172,15 +193,16 @@ export function createScratchlistAttachmentAdapter(
                     hubAttachment: result.attachment,
                     previewUrl
                 } as PendingScratchlistAttachment
-            } catch {
+            } catch (error) {
                 yield {
                     id,
                     type: 'file',
                     name: file.name,
                     contentType,
                     file,
-                    status: { type: 'incomplete', reason: 'error' }
-                }
+                    status: { type: 'incomplete', reason: 'error' },
+                    retryable: isRetryableUploadError(error),
+                } as PendingScratchlistAttachment
             }
         },
 


### PR DESCRIPTION
## Summary

- Add an inline refresh-style retry control for failed composer attachments.
- Reuse the existing attachment control geometry while hiding the failed-state text and preserving the upstream drag/remove layout.
- Create a fresh `File` for retries so restored draft attachments receive a new upload ID.
- Delegate retry eligibility to the active attachment adapter so deterministic size, MIME, and quota failures do not expose a retry action while transient failures remain retryable.
- Preserve the original attachment position as soon as the replacement appears, including during the upload.
- Balance the remove-button spacing when a long filename is truncated, including when an attachment transitions into the error layout.
- Keep non-retryable failures accessible with a localized hidden failure label.
- Add localized accessible labels and regression coverage for the retry flow, adapter behavior, ordering, and layout.
- No API, database, dependency, or migration changes.

## Validation

- `bun typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name attachment-upload-retry -Suite Root -TestArgs 'terminal-wrap-fidelity.spec.ts'` — 2 passed.
- `bun --cwd web test src/components/AssistantChat/AttachmentItem.test.tsx src/components/AssistantChat/SortableComposerAttachments.test.tsx src/lib/attachmentAdapter.test.ts src/lib/scratchlistAttachmentAdapter.test.ts src/lib/attachmentOrder.test.ts` — 42 passed.
- `bun run build` — passed.

## Related Issues

None

## AI Assistance

OpenAI Codex with GPT-5.6 assisted with implementation, testing, and validation.