### PR TITLE
fix(cli): auto-Continue on Cursor post-tool interrupt; Blocked only on give-up

### DIFF
--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -869,14 +869,14 @@ describe('cursorAcpRemoteLauncher', () => {
         expect(harness.promptCalls).toBe(1);
     });
 
-    it('does not replay a prompt when a transient failure follows tool activity', async () => {
-        harness.promptMessages = [{
+    it('auto-continues once when a transient failure follows tool activity instead of replaying the prompt', async () => {
+        harness.promptMessageBatches = [[{
             type: 'tool_call',
             id: 'tool-1',
             name: 'shell',
             input: { command: 'touch output.txt' },
             status: 'completed'
-        }];
+        }], []];
         harness.promptErrors = [
             new Error('Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL')
         ];
@@ -903,12 +903,67 @@ describe('cursorAcpRemoteLauncher', () => {
 
         await cursorAcpRemoteLauncher(session);
 
-        expect(harness.promptCalls).toBe(1);
-        expect(client.sendAgentMessage).toHaveBeenCalledWith(expect.objectContaining({
+        expect(harness.promptCalls).toBe(2);
+        expect(harness.prompts[0]).toEqual([{ type: 'text', text: 'finish the task' }]);
+        expect(harness.prompts[1]).toEqual([{ type: 'text', text: 'Continue.' }]);
+        // Successful auto-continue must not stamp Blocked / "not retried" give-up.
+        expect(client.sendAgentMessage).not.toHaveBeenCalledWith(expect.objectContaining({
             type: 'error',
             message: expect.stringContaining('not retried')
         }));
-        // Assistant text footer stamps lastNotify → estate Blocked chrome (#1724).
+        expect(client.sendAgentMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+            type: 'message',
+            message: expect.stringMatching(/AGENT_NOTIFY_SUMMARY \{.*"status":"blocked"/)
+        }));
+    });
+
+    it('stamps Blocked when auto-continue after tool activity also fails', async () => {
+        harness.promptMessageBatches = [[{
+            type: 'tool_call',
+            id: 'tool-1',
+            name: 'shell',
+            input: { command: 'touch output.txt' },
+            status: 'completed'
+        }], [{
+            type: 'tool_call',
+            id: 'tool-2',
+            name: 'shell',
+            input: { command: 'touch again.txt' },
+            status: 'completed'
+        }]];
+        harness.promptErrors = [
+            new Error('Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL'),
+            new Error('Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL')
+        ];
+        const queue = new MessageQueue2<EnhancedMode>(() => 'mode');
+        const client = makeClient() as unknown as ApiSessionClient & {
+            sendAgentMessage: ReturnType<typeof vi.fn>;
+        };
+        const session = new CursorSession({
+            api: {} as never,
+            client,
+            path: '/tmp/project',
+            logPath: '/tmp/log',
+            sessionId: null,
+            messageQueue: queue,
+            onModeChange: vi.fn(),
+            mode: 'remote',
+            startedBy: 'runner',
+            startingMode: 'remote',
+            permissionMode: 'default'
+        });
+        session.onSessionFoundWithProtocol = vi.fn();
+        queue.push('finish the task', { permissionMode: 'default' });
+        queue.close();
+
+        await cursorAcpRemoteLauncher(session);
+
+        expect(harness.promptCalls).toBe(2);
+        expect(harness.prompts[1]).toEqual([{ type: 'text', text: 'Continue.' }]);
+        expect(client.sendAgentMessage).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'error',
+            message: expect.stringContaining('auto-continue also failed')
+        }));
         expect(client.sendAgentMessage).toHaveBeenCalledWith(expect.objectContaining({
             type: 'message',
             message: expect.stringMatching(

--- a/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.test.ts
@@ -908,6 +908,13 @@ describe('cursorAcpRemoteLauncher', () => {
             type: 'error',
             message: expect.stringContaining('not retried')
         }));
+        // Assistant text footer stamps lastNotify → estate Blocked chrome (#1724).
+        expect(client.sendAgentMessage).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'message',
+            message: expect.stringMatching(
+                /AGENT_NOTIFY_SUMMARY \{.*"status":"blocked".*\}/
+            )
+        }));
     });
 
     it('removes the Cursor MCP overlay even when backend.disconnect rejects', async () => {

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -51,6 +51,7 @@ import {
     isRetryableCursorError,
     stripRetryableCursorError
 } from './cursorAutoRetry';
+import { formatUnexpectedStopBlockedFooter } from './unexpectedStopBlockedFooter';
 
 const CURSOR_ABORT_DRAIN_TIMEOUT_MS = 5_000;
 
@@ -904,6 +905,13 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
         const converted = convertAgentMessage({ type: 'error', message });
         if (converted) this.session.sendAgentMessage(converted);
         this.messageBuffer.addMessage(message, 'status');
+        // Estate Blocked chrome (#1717) keys off lastNotify from AGENT_NOTIFY_SUMMARY
+        // on assistant text — not error rows (#1724).
+        const footer = convertAgentMessage({
+            type: 'text',
+            text: formatUnexpectedStopBlockedFooter({ summary: message })
+        });
+        if (footer) this.session.sendAgentMessage(footer);
     }
 
     private installLiveSessionConfigSync(

--- a/cli/src/cursor/cursorAcpRemoteLauncher.ts
+++ b/cli/src/cursor/cursorAcpRemoteLauncher.ts
@@ -52,6 +52,11 @@ import {
     stripRetryableCursorError
 } from './cursorAutoRetry';
 import { formatUnexpectedStopBlockedFooter } from './unexpectedStopBlockedFooter';
+import {
+    CURSOR_POST_TOOL_INTERRUPT_AUTO_CONTINUE_STATUS,
+    CURSOR_POST_TOOL_INTERRUPT_CONTINUE,
+    CURSOR_POST_TOOL_INTERRUPT_GIVE_UP_MESSAGE
+} from './cursorPostToolInterruptContinue';
 
 const CURSOR_ABORT_DRAIN_TIMEOUT_MS = 5_000;
 
@@ -619,7 +624,7 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
 
             // skill_lookup discovery lives on the MCP tool description — do not
             // prepend instructions onto user turns (prompt-injection false positive).
-            const promptContent: PromptContent[] = [{
+            let promptContent: PromptContent[] = [{
                 type: 'text',
                 text: batch.message
             }];
@@ -632,6 +637,9 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
             try {
                 this.promptInFlight = true;
                 this.userAbortRequested = false;
+                // One auto-Continue after post-tool interrupt (#1724) — not a full
+                // prompt replay (duplicate tool risk). Matches operator "Continue".
+                let postToolAutoContinueUsed = false;
                 for (let retryAttempt = 0; retryAttempt <= CURSOR_AUTO_RETRY_LIMIT; retryAttempt += 1) {
                     this.pendingRetryableError = null;
                     this.pendingRetryableFromStderr = false;
@@ -662,7 +670,22 @@ class CursorAcpRemoteLauncher extends RemoteLauncherBase {
                     }
 
                     if (this.attemptProducedToolActivity) {
-                        this.surfacePromptFailure('Cursor connection interrupted after tool activity; the prompt was not retried.');
+                        if (!postToolAutoContinueUsed) {
+                            postToolAutoContinueUsed = true;
+                            promptContent = [{
+                                type: 'text',
+                                text: CURSOR_POST_TOOL_INTERRUPT_CONTINUE
+                            }];
+                            this.messageBuffer.addMessage(
+                                CURSOR_POST_TOOL_INTERRUPT_AUTO_CONTINUE_STATUS,
+                                'status'
+                            );
+                            // Spend a fresh attempt budget on Continue (not the
+                            // original prompt). Reset so the for-loop can still run.
+                            retryAttempt = -1;
+                            continue;
+                        }
+                        this.surfacePromptFailure(CURSOR_POST_TOOL_INTERRUPT_GIVE_UP_MESSAGE);
                         break;
                     }
                     if (retryAttempt < CURSOR_AUTO_RETRY_LIMIT) {

--- a/cli/src/cursor/cursorPostToolInterruptContinue.ts
+++ b/cli/src/cursor/cursorPostToolInterruptContinue.ts
@@ -1,0 +1,15 @@
+/**
+ * Auto-recovery when Cursor ACP dies mid-turn after tools already ran (#1724).
+ *
+ * Replaying the original user prompt risks duplicate side effects. The operator
+ * recovery that always works is a fresh "Continue." turn — same as tapping
+ * Continue in the web UI — so the harness does that once automatically.
+ */
+
+export const CURSOR_POST_TOOL_INTERRUPT_CONTINUE = 'Continue.';
+
+export const CURSOR_POST_TOOL_INTERRUPT_AUTO_CONTINUE_STATUS =
+    'Cursor connection interrupted after tool activity; auto-continuing.';
+
+export const CURSOR_POST_TOOL_INTERRUPT_GIVE_UP_MESSAGE =
+    'Cursor connection interrupted after tool activity; auto-continue also failed.';

--- a/cli/src/cursor/unexpectedStopBlockedFooter.test.ts
+++ b/cli/src/cursor/unexpectedStopBlockedFooter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { extractNotifySummary } from '@hapi/protocol';
+import {
+    UNEXPECTED_STOP_BLOCKED_ACTION,
+    formatUnexpectedStopBlockedFooter
+} from './unexpectedStopBlockedFooter';
+
+describe('formatUnexpectedStopBlockedFooter', () => {
+    it('emits a last-line AGENT_NOTIFY_SUMMARY with blocked status for lastNotify ingest', () => {
+        const text = formatUnexpectedStopBlockedFooter({
+            summary: 'Cursor connection interrupted after tool activity; the prompt was not retried.'
+        });
+        const lines = text.split('\n').filter((line) => line.trim().length > 0);
+        expect(lines.at(-1)).toMatch(/^AGENT_NOTIFY_SUMMARY \{/);
+
+        const notify = extractNotifySummary(text);
+        expect(notify).toMatchObject({
+            version: 1,
+            status: 'blocked',
+            action: UNEXPECTED_STOP_BLOCKED_ACTION,
+            summary: 'Cursor connection interrupted after tool activity; the prompt was not retried.'
+        });
+    });
+
+    it('clamps an oversized summary so the footer stays parseable and note-sized', () => {
+        const summary = `x${'y'.repeat(400)}`;
+        const notify = extractNotifySummary(formatUnexpectedStopBlockedFooter({ summary }));
+        expect(notify?.status).toBe('blocked');
+        expect(notify?.summary?.length).toBeLessThanOrEqual(160);
+        expect(notify?.summary?.endsWith('…')).toBe(true);
+    });
+
+    it('allows a custom action when the caller has a sharper next step', () => {
+        const notify = extractNotifySummary(formatUnexpectedStopBlockedFooter({
+            summary: 'Cursor Agent failed after 3 retries.',
+            action: 'Resend the prompt'
+        }));
+        expect(notify?.action).toBe('Resend the prompt');
+    });
+});

--- a/cli/src/cursor/unexpectedStopBlockedFooter.ts
+++ b/cli/src/cursor/unexpectedStopBlockedFooter.ts
@@ -1,0 +1,37 @@
+/**
+ * Harness-side Blocked stamp for unexpected Cursor stop exits (#1724).
+ *
+ * Estate Blocked chrome (#1717) reads `lastNotify` from a real
+ * `AGENT_NOTIFY_SUMMARY` footer on assistant **text**. Error-shaped chat rows
+ * alone never reach that path (`extractAssistantPlainText` skips them).
+ *
+ * Clamping is local (not `clampNotifyNote` from protocol) so this PR does not
+ * stack on the blocked-list soup layer.
+ */
+
+/** Default action when the launcher has no sharper next step. */
+export const UNEXPECTED_STOP_BLOCKED_ACTION = 'Continue or investigate';
+
+/** Matches estate note budget used by blocked-list chrome. */
+const SUMMARY_MAX_CHARS = 160;
+
+function clampNote(value: string): string {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return 'Unexpected stop; turn did not finish.';
+    if (trimmed.length <= SUMMARY_MAX_CHARS) return trimmed;
+    return `${trimmed.slice(0, SUMMARY_MAX_CHARS - 1)}…`;
+}
+
+export function formatUnexpectedStopBlockedFooter(input: {
+    summary: string;
+    action?: string;
+}): string {
+    const summary = clampNote(input.summary);
+    const action = clampNote(input.action ?? UNEXPECTED_STOP_BLOCKED_ACTION);
+    return `AGENT_NOTIFY_SUMMARY ${JSON.stringify({
+        version: 1,
+        status: 'blocked',
+        action,
+        summary
+    })}`;
+}


### PR DESCRIPTION
## Summary
- When Cursor ACP dies mid-turn **after tool activity**, auto-send `Continue.` once (same recovery operators always use) instead of stopping for a human tap.
- Do **not** replay the original user prompt (duplicate tool risk).
- Stamp `AGENT_NOTIFY_SUMMARY` `blocked` **only** if that auto-continue also fails.
- Independent of model-error PR #987 / `lastModelError`.

## Test plan
- [x] Auto-continue success: 2 prompts (original + `Continue.`), no blocked footer
- [x] Auto-continue failure: blocked footer + give-up error
- [x] Existing transient retry suite still green
- [x] `bun typecheck`
- [ ] Remat soup layer; archive/reopen long-lived Cursor sessions so they load the tip

## Issues
Fixes #1724