### PR TITLE
fix(web): align file preview content around scrollbars

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -334,6 +334,28 @@ html:has(.chat-scroll-y) #root {
     touch-action: pan-y;
 }
 
+/* Keep file-preview content aligned to the previous left edge while reserving
+ * the scrollbar slot on the right on both touch and pointer devices. */
+.file-preview-scroll-y {
+    overflow-x: hidden;
+    scrollbar-gutter: stable;
+}
+
+/* Older WebViews without scrollbar-gutter still need a stable right slot. */
+@supports not (scrollbar-gutter: stable) {
+    .file-preview-scroll-y {
+        overflow-y: scroll;
+    }
+}
+
+/* Include the reserved scrollbar width in the visible content width so the
+ * outer left and right edge spacing remains equal. */
+.file-preview-scroll-content {
+    width: calc(100% + var(--file-preview-scrollbar-compensation, 0px));
+    max-width: calc(var(--content-max-w, 960px) + var(--file-preview-scrollbar-compensation, 0px));
+    transform: translateX(var(--file-preview-scroll-content-offset, 0px));
+}
+
 /* On touch-first devices, keep the chat scrollbar from shifting centered content. */
 @media (hover: none) and (pointer: coarse) {
     .chat-scroll-y {

--- a/web/src/routes/sessions/file.test.tsx
+++ b/web/src/routes/sessions/file.test.tsx
@@ -88,6 +88,8 @@ describe('FilePage markdown preview', () => {
         await waitFor(() => {
             expect(screen.getByTestId('markdown-preview')).toHaveTextContent('# Heading')
         })
+        expect(screen.getByTestId('markdown-preview').closest('.file-preview-scroll-content')).not.toBeNull()
+        expect(screen.getByTestId('markdown-preview').closest('.file-preview-scroll-y')).not.toBeNull()
         expect(screen.getByText(formatFileMetadata(fileSize, fileModified, 'en')!)).toBeInTheDocument()
         expect(screen.getAllByText(filePath)).toHaveLength(1)
         const previewCopyButton = screen.getByRole('button', { name: 'Copy file content' })

--- a/web/src/routes/sessions/file.tsx
+++ b/web/src/routes/sessions/file.tsx
@@ -322,6 +322,31 @@ export default function FilePage() {
         restoreFileScroll()
         restoredScrollKeyRef.current = fileScrollKey
     }, [diffQuery.isLoading, fileQuery.isLoading, fileScrollKey, restoreFileScroll])
+    useLayoutEffect(() => {
+        const element = fileScrollRef.current
+        if (!element) return
+        const content = element.querySelector<HTMLElement>('.file-preview-scroll-content')
+
+        const updateScrollbarCompensation = () => {
+            const scrollbarWidth = Math.max(0, element.offsetWidth - element.clientWidth)
+            element.style.setProperty('--file-preview-scrollbar-compensation', `${scrollbarWidth}px`)
+            const contentWidth = content?.getBoundingClientRect().width ?? 0
+            const contentOffset = scrollbarWidth > 0 && contentWidth <= element.clientWidth
+                ? scrollbarWidth / 2
+                : 0
+            element.style.setProperty('--file-preview-scroll-content-offset', `${contentOffset}px`)
+        }
+
+        updateScrollbarCompensation()
+        const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateScrollbarCompensation)
+        resizeObserver?.observe(element)
+        if (content) resizeObserver?.observe(content)
+        window.addEventListener('resize', updateScrollbarCompensation)
+        return () => {
+            resizeObserver?.disconnect()
+            window.removeEventListener('resize', updateScrollbarCompensation)
+        }
+    }, [])
 
     const setMarkdownPreviewMode = (mode: MarkdownPreviewMode) => {
         setMarkdownMode(mode)
@@ -438,8 +463,8 @@ export default function FilePage() {
                 </div>
             ) : null}
 
-            <div ref={fileScrollRef} data-hapi-file-scroll="true" className="app-scroll-y flex-1 min-h-0">
-                <div className="mx-auto w-full max-w-content p-4">
+            <div ref={fileScrollRef} data-hapi-file-scroll="true" className="app-scroll-y file-preview-scroll-y flex-1 min-h-0">
+                <div className="file-preview-scroll-content mx-auto w-full max-w-content p-4">
                     {diffErrorMessage ? (
                         <div className="mb-3 rounded-md bg-amber-500/10 p-2 text-xs text-[var(--app-hint)]">
                             {diffErrorMessage}

--- a/web/src/routes/sessions/file.tsx
+++ b/web/src/routes/sessions/file.tsx
@@ -330,9 +330,12 @@ export default function FilePage() {
         const updateScrollbarCompensation = () => {
             const scrollbarWidth = Math.max(0, element.offsetWidth - element.clientWidth)
             element.style.setProperty('--file-preview-scrollbar-compensation', `${scrollbarWidth}px`)
-            const contentWidth = content?.getBoundingClientRect().width ?? 0
-            const contentOffset = scrollbarWidth > 0 && contentWidth <= element.clientWidth
-                ? scrollbarWidth / 2
+            const contentWidth = content?.getBoundingClientRect().width ?? element.clientWidth
+            const contentOffset = scrollbarWidth > 0
+                ? Math.min(
+                    scrollbarWidth / 2,
+                    Math.max(0, (element.offsetWidth - contentWidth) / 2)
+                )
                 : 0
             element.style.setProperty('--file-preview-scroll-content-offset', `${contentOffset}px`)
         }


### PR DESCRIPTION
## Summary

- Align file preview content symmetrically with the viewport edges when the vertical scrollbar consumes layout width.
- Measure the actual scrollbar occupancy and compensate the content width without changing the existing left inset.
- Prevent the outer file preview viewport from exposing a horizontal scrollbar while preserving inner Markdown code and table scrolling.
- Add regression assertions for the file preview scroll containers.
- No API, data, dependency, or migration changes.

## Validation

- `bun typecheck` — passed.
- `bun run --cwd web test -- src/routes/sessions/file.test.tsx` — 2 tests passed.
- `bun run build` — passed.
- Live Playwright geometry verification through the task wrapper — 4/4 passed:
  - Desktop narrow viewport: symmetric spacing and no outer horizontal scrollbar.
  - Desktop wide viewport: symmetric outer spacing.
  - Mobile classic scrollbar: symmetric outer spacing.
  - Mobile overlay scrollbar: symmetric outer spacing.
- `git diff --check` — passed.

## Related Issues

None

## AI Disclosure

OpenAI Codex assisted with the implementation and validation. Model: GPT-5.6.