### PR TITLE
fix(web): Enter inserts newline when composer is expanded

### DIFF
--- a/web/src/components/AssistantChat/HappyComposer.expandEnter.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.expandEnter.test.tsx
@@ -28,6 +28,24 @@ describe('resolveComposerEnterKeyAction', () => {
         })).toBe('send')
     })
 
+    it('keeps expanded Alt+Enter ignored in the current send-mode main behavior', () => {
+        expect(resolveComposerEnterKeyAction({
+            composerEnterBehavior: 'send',
+            isExpanded: true,
+            ctrlOrMeta: false,
+            altKey: true,
+        })).toBe('ignore')
+    })
+
+    it('preserves newline-mode Alt+Enter behavior while expanded', () => {
+        expect(resolveComposerEnterKeyAction({
+            composerEnterBehavior: 'newline',
+            isExpanded: true,
+            ctrlOrMeta: false,
+            altKey: true,
+        })).toBe('newline')
+    })
+
     it('honors collapsed send preference for plain Enter', () => {
         expect(resolveComposerEnterKeyAction({
             composerEnterBehavior: 'send',

--- a/web/src/components/AssistantChat/HappyComposer.expandEnter.test.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.expandEnter.test.tsx
@@ -1,0 +1,244 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode, TextareaHTMLAttributes } from 'react'
+import { useRef, useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { I18nProvider } from '@/lib/i18n-context'
+import type { ComposerSendIntent } from '@/lib/messageDelivery'
+import {
+    HappyComposer,
+    resolveComposerEnterKeyAction,
+} from './HappyComposer'
+
+describe('resolveComposerEnterKeyAction', () => {
+    it('forces newline semantics while expanded even when Settings prefer send', () => {
+        expect(resolveComposerEnterKeyAction({
+            composerEnterBehavior: 'send',
+            isExpanded: true,
+            ctrlOrMeta: false,
+            altKey: false,
+        })).toBe('newline')
+    })
+
+    it('sends on Ctrl/Cmd+Enter while expanded', () => {
+        expect(resolveComposerEnterKeyAction({
+            composerEnterBehavior: 'send',
+            isExpanded: true,
+            ctrlOrMeta: true,
+            altKey: false,
+        })).toBe('send')
+    })
+
+    it('honors collapsed send preference for plain Enter', () => {
+        expect(resolveComposerEnterKeyAction({
+            composerEnterBehavior: 'send',
+            isExpanded: false,
+            ctrlOrMeta: false,
+            altKey: false,
+        })).toBe('send')
+    })
+
+    it('honors collapsed newline preference for plain Enter and Ctrl/Cmd+Enter', () => {
+        expect(resolveComposerEnterKeyAction({
+            composerEnterBehavior: 'newline',
+            isExpanded: false,
+            ctrlOrMeta: false,
+            altKey: false,
+        })).toBe('newline')
+        expect(resolveComposerEnterKeyAction({
+            composerEnterBehavior: 'newline',
+            isExpanded: false,
+            ctrlOrMeta: true,
+            altKey: false,
+        })).toBe('send')
+    })
+})
+
+type FakeAttachment = { id: string; status: { type: 'complete' } }
+type MockComposerInputProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+    asChild?: boolean
+    maxRows?: number
+    submitOnEnter?: boolean
+    cancelOnEscape?: boolean
+}
+type FakeRuntimeState = {
+    composer: { text: string; attachments: FakeAttachment[] }
+    thread: { isRunning: boolean; isDisabled: boolean }
+}
+
+const runtime = vi.hoisted(() => ({
+    snapshot: {
+        composer: { text: '', attachments: [] as FakeAttachment[] },
+        thread: { isRunning: false, isDisabled: false },
+    } as FakeRuntimeState,
+    setSnapshot: null as null | ((updater: (current: FakeRuntimeState) => FakeRuntimeState) => void),
+    pendingSendIntentRef: null as null | { current: ComposerSendIntent },
+    sentIntents: [] as ComposerSendIntent[],
+}))
+
+vi.mock('@assistant-ui/react', async () => {
+    const React = await import('react')
+    return {
+        useAui: () => ({
+            composer: () => ({
+                setText: (text: string) => {
+                    runtime.setSnapshot!((current) => ({
+                        ...current,
+                        composer: { ...current.composer, text },
+                    }))
+                },
+                send: () => {
+                    const intent = runtime.pendingSendIntentRef?.current ?? 'default'
+                    runtime.sentIntents.push(intent)
+                    if (runtime.pendingSendIntentRef) runtime.pendingSendIntentRef.current = 'default'
+                    runtime.setSnapshot!((current) => ({
+                        ...current,
+                        composer: { text: '', attachments: [] },
+                    }))
+                },
+                addAttachment: async () => {},
+            }),
+            thread: () => ({ cancelRun: () => {} }),
+        }),
+        useAuiState: (selector: (state: typeof runtime.snapshot) => unknown) => selector(runtime.snapshot),
+        ComposerPrimitive: {
+            Root: ({ children, onSubmit }: { children: ReactNode; onSubmit?: () => void }) => (
+                <form onSubmit={onSubmit}>{children}</form>
+            ),
+            Input: React.forwardRef<HTMLTextAreaElement, MockComposerInputProps>(
+                ({
+                    asChild: _asChild,
+                    onChange,
+                    maxRows: _maxRows,
+                    submitOnEnter: _submitOnEnter,
+                    cancelOnEscape: _cancelOnEscape,
+                    ...props
+                }, ref) => (
+                    <textarea
+                        {...props}
+                        ref={ref}
+                        value={runtime.snapshot.composer.text}
+                        onChange={(event) => {
+                            runtime.setSnapshot!((current) => ({
+                                ...current,
+                                composer: { ...current.composer, text: event.target.value },
+                            }))
+                            onChange?.(event)
+                        }}
+                    />
+                ),
+            ),
+            Attachments: () => null,
+        },
+    }
+})
+
+vi.mock('@/lib/composerSegments', () => ({
+    isRichComposerMentionsEnabled: () => false,
+    resolveComposerPlaceholderKey: ({ showContinueHint }: { showContinueHint: boolean }) =>
+        showContinueHint ? 'misc.typeMessage' : 'misc.typeAMessage',
+}))
+vi.mock('@/hooks/useComposerDraft', () => ({
+    useComposerDraft: (sessionId: string | undefined) => ({ sessionId, complete: true, restoredAny: false }),
+}))
+vi.mock('@/hooks/useComposerEnterBehavior', () => ({
+    useComposerEnterBehavior: () => ({ composerEnterBehavior: 'send' }),
+}))
+vi.mock('@/hooks/usePlatform', () => ({
+    usePlatform: () => ({ haptic: { impact: () => {}, notification: () => {} }, isTouch: false }),
+}))
+vi.mock('@/hooks/usePWAInstall', () => ({
+    usePWAInstall: () => ({ isStandalone: false, isIOS: false }),
+}))
+vi.mock('@/hooks/useActiveWord', () => ({ useActiveWord: () => null }))
+vi.mock('@/hooks/useActiveSuggestions', () => ({
+    useActiveSuggestions: () => [[], -1, () => {}, () => {}, () => {}],
+}))
+vi.mock('@/components/ChatInput/FloatingOverlay', () => ({
+    FloatingOverlay: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+vi.mock('@/components/ChatInput/Autocomplete', () => ({ Autocomplete: () => null }))
+vi.mock('@/components/AssistantChat/StatusBar', () => ({ StatusBar: () => null }))
+vi.mock('./PiModelPanel', () => ({ PiModelPanel: () => null }))
+vi.mock('./PiThinkingLevelPanel', () => ({ PiThinkingLevelPanel: () => null }))
+vi.mock('@/components/AssistantChat/ComposerButtons', () => ({
+    ComposerButtons: (props: {
+        onSend: () => void
+        expanded: boolean
+        onExpandedToggle: () => void
+    }) => (
+        <div>
+            <button type="button" onClick={props.onSend}>send</button>
+            <button type="button" onClick={props.onExpandedToggle}>
+                {props.expanded ? 'collapse' : 'expand'}
+            </button>
+        </div>
+    ),
+}))
+
+function ComposerHarness(props: { initialText: string }) {
+    const [snapshot, setSnapshot] = useState<FakeRuntimeState>(() => ({
+        composer: { text: props.initialText, attachments: [] },
+        thread: { isRunning: false, isDisabled: false },
+    }))
+    const pendingSendIntentRef = useRef<ComposerSendIntent>('default')
+
+    runtime.snapshot = snapshot
+    runtime.setSnapshot = setSnapshot
+    runtime.pendingSendIntentRef = pendingSendIntentRef
+
+    return (
+        <I18nProvider>
+            <HappyComposer
+                agentFlavor="claude"
+                pendingSendIntentRef={pendingSendIntentRef}
+            />
+        </I18nProvider>
+    )
+}
+
+function input(): HTMLTextAreaElement {
+    return screen.getByRole('textbox') as HTMLTextAreaElement
+}
+
+describe('HappyComposer expanded Enter (Settings Enter=send)', () => {
+    afterEach(() => {
+        cleanup()
+        runtime.pendingSendIntentRef = null
+        runtime.sentIntents = []
+    })
+
+    it('does not send on plain Enter while expanded; Ctrl+Enter sends', async () => {
+        render(<ComposerHarness initialText="long form draft" />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'expand' }))
+        await waitFor(() => {
+            expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded')
+        })
+
+        fireEvent.keyDown(input(), { key: 'Enter' })
+        expect(runtime.sentIntents).toEqual([])
+        expect(input()).toHaveValue('long form draft')
+
+        fireEvent.keyDown(input(), { key: 'Enter', ctrlKey: true })
+        expect(runtime.sentIntents).toEqual(['default'])
+    })
+
+    it('sends on Cmd+Enter while expanded', async () => {
+        render(<ComposerHarness initialText="mac draft" />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'expand' }))
+        await waitFor(() => {
+            expect(screen.getByTestId('composer-shell')).toHaveAttribute('data-expanded')
+        })
+
+        fireEvent.keyDown(input(), { key: 'Enter', metaKey: true })
+        expect(runtime.sentIntents).toEqual(['default'])
+    })
+
+    it('still sends on plain Enter when collapsed with Enter=send', () => {
+        render(<ComposerHarness initialText="collapsed send" />)
+
+        fireEvent.keyDown(input(), { key: 'Enter' })
+        expect(runtime.sentIntents).toEqual(['default'])
+    })
+})

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -97,6 +97,12 @@ export function resolveComposerEnterKeyAction(input: {
     ctrlOrMeta: boolean
     altKey: boolean
 }): ComposerEnterKeyAction {
+    // The current main branch no longer has the old Pi Alt+Enter queue
+    // gesture (#1480). Preserve its existing send-mode modifier behavior
+    // rather than turning that shortcut into an unintended line break.
+    if (input.isExpanded && input.altKey && input.composerEnterBehavior === 'send') {
+        return 'ignore'
+    }
     const insertNewline = input.isExpanded || input.composerEnterBehavior === 'newline'
     if (insertNewline) {
         if (input.ctrlOrMeta && !input.altKey) return 'send'

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -82,6 +82,31 @@ export function getComposerEscapeAction(input: {
 }
 
 /**
+ * Enter key after IME / Shift+Enter / suggestions are handled.
+ *
+ * Expanded composer always uses newline semantics (long-form drafting) even when
+ * Settings → Chat → Enter behavior is `send`. Collapsed honors that setting.
+ * Ctrl/Cmd+Enter sends in newline (or expanded) mode; plain modifiers otherwise
+ * are ignored (and the caller still preventDefaults in send mode).
+ */
+export type ComposerEnterKeyAction = 'send' | 'newline' | 'ignore'
+
+export function resolveComposerEnterKeyAction(input: {
+    composerEnterBehavior: 'send' | 'newline'
+    isExpanded: boolean
+    ctrlOrMeta: boolean
+    altKey: boolean
+}): ComposerEnterKeyAction {
+    const insertNewline = input.isExpanded || input.composerEnterBehavior === 'newline'
+    if (insertNewline) {
+        if (input.ctrlOrMeta && !input.altKey) return 'send'
+        return 'newline'
+    }
+    if (!input.ctrlOrMeta && !input.altKey) return 'send'
+    return 'ignore'
+}
+
+/**
  * One rejected send.  `id` is bumped per failure so two failures with the
  * same `text` still trigger a fresh restore (the dedupe key is the id, not
  * the text).
@@ -1264,18 +1289,20 @@ export function HappyComposer(props: {
             return
         }
 
-        // Only plain Enter (no modifiers) sends; other modifier combos are ignored
+        // Collapsed: honor Settings Enter behavior. Expanded: always newline
+        // (plain Enter inserts; Ctrl/Cmd+Enter or the send button submits).
         if (key === 'Enter') {
-            if (composerEnterBehavior === 'newline') {
-                if ((e.ctrlKey || e.metaKey) && !e.altKey && canSend) {
-                    e.preventDefault()
-                    flushAndSend()
-                    setShowContinueHint(false)
-                }
+            const action = resolveComposerEnterKeyAction({
+                composerEnterBehavior,
+                isExpanded,
+                ctrlOrMeta: e.ctrlKey || e.metaKey,
+                altKey: e.altKey,
+            })
+            if (action === 'newline') {
                 return
             }
             e.preventDefault()
-            if (!e.ctrlKey && !e.altKey && !e.metaKey && canSend) {
+            if (action === 'send' && canSend) {
                 flushAndSend()
                 setShowContinueHint(false)
             }


### PR DESCRIPTION
## Summary

- Make plain Enter insert a newline when the composer is expanded, even when Chat settings use Enter to send.
- Keep Ctrl/Cmd+Enter and the Send button as explicit submit actions.
- Preserve collapsed-composer Enter behavior and the current main-branch Alt+Enter behavior.
- Add regression coverage for expanded, collapsed, and modifier-key combinations.

## Validation

- `bun typecheck` — passed.
- `bun run --cwd web test src/components/AssistantChat/HappyComposer.expandEnter.test.tsx src/components/AssistantChat/HappyComposer.expandSelection.test.tsx src/components/AssistantChat/HappyComposer.richBridge.test.tsx src/components/AssistantChat/HappyComposer.sendError.test.tsx src/components/AssistantChat/HappyComposer.modelEffort.test.tsx src/components/AssistantChat/HappyComposer.modelEffortButtons.test.tsx src/components/AssistantChat/ComposerButtons.test.tsx src/components/AssistantChat/RichComposerInput.test.tsx src/components/AssistantChat/RichComposerInput.segments.test.ts src/hooks/useComposerEnterBehavior.test.ts src/lib/messageDelivery.test.ts src/lib/assistant-runtime.test.ts src/components/SessionChat.test.ts` — 13 files, 196 tests passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name fix-issue-1403-enter-newline -Suite Root -TestArgs terminal-wrap-fidelity.spec.ts` — 2 tests passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name fix-issue-1403-enter-newline -Suite Live` — 2 tests passed against the built Full environment, covering rich composer and textarea fallback.
- `bun run build` — passed.

## Related Issues

Fixes #1403

## AI Disclosure

Implemented with assistance from OpenAI Codex (GPT-5.6).