### PR TITLE
feat(web): session-list scrollbar tick for open session position

### DIFF
--- a/web/src/components/SessionList.test.ts
+++ b/web/src/components/SessionList.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { toSessionSummary, type Session } from '@hapi/protocol'
 import type { SessionSummary } from '@/types/api'
 import {
+    computeOpenSessionTickRatio,
     deduplicateSessionsByAgentId,
     expandSelectedSessionCollapseOverrides,
     filterActiveSessionsOnly,
@@ -20,6 +21,7 @@ import {
     prepareSidebarSessions,
     sessionMatchesQuery,
     sessionMatchesTimeRange,
+    shouldShowOpenSessionTick,
     shouldShowPinnedDivider,
     shouldShowSessionInSidebar
 } from './SessionList'
@@ -651,5 +653,87 @@ describe('getPullRefreshIndicatorRotation', () => {
     it('turns the pull indicator upward once refresh is ready', () => {
         expect(getPullRefreshIndicatorRotation('pulling')).toBe(0)
         expect(getPullRefreshIndicatorRotation('ready')).toBe(180)
+    })
+})
+
+describe('computeOpenSessionTickRatio', () => {
+    it('maps the row midpoint into the scroll extent as a 0..1 rail ratio', () => {
+        expect(computeOpenSessionTickRatio({
+            scrollHeight: 1000,
+            clientHeight: 400,
+            contentOffsetTop: 200,
+            targetHeight: 40,
+        })).toBeCloseTo(0.22)
+    })
+
+    it('clamps to the rail ends', () => {
+        expect(computeOpenSessionTickRatio({
+            scrollHeight: 1000,
+            clientHeight: 400,
+            contentOffsetTop: -10,
+            targetHeight: 20,
+        })).toBe(0)
+        expect(computeOpenSessionTickRatio({
+            scrollHeight: 1000,
+            clientHeight: 400,
+            contentOffsetTop: 990,
+            targetHeight: 40,
+        })).toBe(1)
+    })
+
+    it('hides when the list does not overflow (no scrollbar)', () => {
+        expect(computeOpenSessionTickRatio({
+            scrollHeight: 300,
+            clientHeight: 400,
+            contentOffsetTop: 40,
+            targetHeight: 40,
+        })).toBeNull()
+    })
+
+    it('hides when the row has no laid-out height', () => {
+        expect(computeOpenSessionTickRatio({
+            scrollHeight: 1000,
+            clientHeight: 400,
+            contentOffsetTop: 200,
+            targetHeight: 0,
+        })).toBeNull()
+    })
+})
+
+describe('shouldShowOpenSessionTick', () => {
+    it('shows only when the open session row is present and not collapsed away', () => {
+        expect(shouldShowOpenSessionTick({
+            selectedSessionId: 's-1',
+            rowFound: true,
+            insideCollapsedPanel: false,
+            tickRatio: 0.4,
+        })).toBe(true)
+    })
+
+    it('hides when nothing is open, the row is missing, collapsed, or ratio is null', () => {
+        expect(shouldShowOpenSessionTick({
+            selectedSessionId: null,
+            rowFound: true,
+            insideCollapsedPanel: false,
+            tickRatio: 0.4,
+        })).toBe(false)
+        expect(shouldShowOpenSessionTick({
+            selectedSessionId: 's-1',
+            rowFound: false,
+            insideCollapsedPanel: false,
+            tickRatio: 0.4,
+        })).toBe(false)
+        expect(shouldShowOpenSessionTick({
+            selectedSessionId: 's-1',
+            rowFound: true,
+            insideCollapsedPanel: true,
+            tickRatio: 0.4,
+        })).toBe(false)
+        expect(shouldShowOpenSessionTick({
+            selectedSessionId: 's-1',
+            rowFound: true,
+            insideCollapsedPanel: false,
+            tickRatio: null,
+        })).toBe(false)
     })
 })

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -582,6 +582,58 @@ export function shouldShowPinnedDivider(sessions: SessionSummary[], index: numbe
     return Boolean(sessions[index - 1]?.pinned) && !sessions[index]?.pinned
 }
 
+/**
+ * Map an open-session row's midpoint in scroll content to a 0..1 position on the
+ * list scroll rail. Returns null when a mark would lie (no overflow, no layout).
+ */
+export function computeOpenSessionTickRatio(input: {
+    scrollHeight: number
+    clientHeight: number
+    contentOffsetTop: number
+    targetHeight: number
+}): number | null {
+    const { scrollHeight, clientHeight, contentOffsetTop, targetHeight } = input
+    if (!(scrollHeight > 0) || !(clientHeight > 0)) return null
+    if (scrollHeight <= clientHeight) return null
+    if (!(targetHeight > 0)) return null
+    const mid = contentOffsetTop + targetHeight / 2
+    const ratio = mid / scrollHeight
+    if (!Number.isFinite(ratio)) return null
+    return Math.min(1, Math.max(0, ratio))
+}
+
+export function shouldShowOpenSessionTick(input: {
+    selectedSessionId: string | null | undefined
+    rowFound: boolean
+    insideCollapsedPanel: boolean
+    tickRatio: number | null
+}): boolean {
+    if (!input.selectedSessionId) return false
+    if (!input.rowFound) return false
+    if (input.insideCollapsedPanel) return false
+    if (input.tickRatio == null) return false
+    return true
+}
+
+/** True when the row lives inside a closed `.collapsible-panel` (group collapsed). */
+export function isSessionRowInsideCollapsedPanel(row: Element): boolean {
+    const panel = row.closest('.collapsible-panel')
+    if (!panel) return false
+    return !panel.hasAttribute('data-open')
+}
+
+export function measureOpenSessionTickContentOffset(
+    container: HTMLElement,
+    row: HTMLElement
+): { contentOffsetTop: number; targetHeight: number } {
+    const containerRect = container.getBoundingClientRect()
+    const rowRect = row.getBoundingClientRect()
+    return {
+        contentOffsetTop: rowRect.top - containerRect.top + container.scrollTop,
+        targetHeight: rowRect.height,
+    }
+}
+
 function CalendarIcon(props: { className?: string }) {
     return (
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={props.className}>
@@ -1034,6 +1086,7 @@ function SessionItem(props: {
             <button
                 type="button"
                 {...longPressHandlers}
+                data-session-id={s.id}
                 className={`session-list-item group/session-row flex w-full flex-col gap-1 py-2 pl-2.5 pr-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)] select-none rounded-lg ${selected ? 'bg-[var(--app-secondary-bg)]' : ''}`}
                 style={{ WebkitTouchCallout: 'none' }}
                 aria-current={selected ? 'page' : undefined}
@@ -1788,9 +1841,82 @@ export function SessionList(props: {
     const [isRefreshing, setIsRefreshing] = useState(false)
     const isRefreshingRef = useRef(false)
     const onRefreshRef = useRef(props.onRefresh)
+    const [openSessionTickRatio, setOpenSessionTickRatio] = useState<number | null>(null)
     useEffect(() => {
         onRefreshRef.current = props.onRefresh
     }, [props.onRefresh])
+
+    // Visual-only tick on the left scrollbar rail for the currently open session.
+    // Hides when the row is filtered out or lives in a collapsed group (no lying).
+    useEffect(() => {
+        const container = scrollContainerRef.current
+        if (!container || !selectedSessionId) {
+            setOpenSessionTickRatio(null)
+            return
+        }
+
+        let frame = 0
+        const updateTick = () => {
+            cancelAnimationFrame(frame)
+            frame = requestAnimationFrame(() => {
+                const row = container.querySelector<HTMLElement>(
+                    `.session-list-item[data-session-id="${CSS.escape(selectedSessionId)}"]`
+                )
+                if (!row || isSessionRowInsideCollapsedPanel(row)) {
+                    setOpenSessionTickRatio(null)
+                    return
+                }
+                const measured = measureOpenSessionTickContentOffset(container, row)
+                const ratio = computeOpenSessionTickRatio({
+                    scrollHeight: container.scrollHeight,
+                    clientHeight: container.clientHeight,
+                    contentOffsetTop: measured.contentOffsetTop,
+                    targetHeight: measured.targetHeight,
+                })
+                setOpenSessionTickRatio(
+                    shouldShowOpenSessionTick({
+                        selectedSessionId,
+                        rowFound: true,
+                        insideCollapsedPanel: false,
+                        tickRatio: ratio,
+                    })
+                        ? ratio
+                        : null
+                )
+            })
+        }
+
+        updateTick()
+        const resizeObserver = new ResizeObserver(updateTick)
+        resizeObserver.observe(container)
+        const mutationObserver = new MutationObserver(updateTick)
+        mutationObserver.observe(container, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['data-open'],
+        })
+        return () => {
+            cancelAnimationFrame(frame)
+            resizeObserver.disconnect()
+            mutationObserver.disconnect()
+        }
+    }, [
+        selectedSessionId,
+        groups,
+        globalPinnedSessions,
+        runningSessionTotal,
+        activeSessionTotal,
+        pinnedSectionCollapsed,
+        runningSectionCollapsed,
+        activeSectionCollapsed,
+        collapseOverrides,
+        sessionVisibleCounts,
+        isFiltering,
+        showUnreadOnly,
+        activeMachineFilter,
+        searchQuery,
+    ])
 
     useEffect(() => {
         const container = scrollContainerRef.current
@@ -2060,6 +2186,14 @@ export function SessionList(props: {
                 {actionOnlyGroups.map(renderActionOnlyGroupHeader)}
             </div>
             </div>
+            {openSessionTickRatio != null ? (
+                <span
+                    className="session-list-open-tick"
+                    style={{ top: `${openSessionTickRatio * 100}%` }}
+                    title={t('sessions.openTick.tooltip')}
+                    aria-hidden="true"
+                />
+            ) : null}
             </div>
         </div>
     )

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1860,7 +1860,7 @@ export function SessionList(props: {
             cancelAnimationFrame(frame)
             frame = requestAnimationFrame(() => {
                 const row = container.querySelector<HTMLElement>(
-                    `.session-list-item[data-session-id="${CSS.escape(selectedSessionId)}"]`
+                    '.session-list-item[aria-current="page"]'
                 )
                 if (!row || isSessionRowInsideCollapsedPanel(row)) {
                     setOpenSessionTickRatio(null)
@@ -1887,19 +1887,25 @@ export function SessionList(props: {
         }
 
         updateTick()
-        const resizeObserver = new ResizeObserver(updateTick)
-        resizeObserver.observe(container)
-        const mutationObserver = new MutationObserver(updateTick)
-        mutationObserver.observe(container, {
+        const resizeObserver = typeof ResizeObserver !== 'undefined'
+            ? new ResizeObserver(updateTick)
+            : null
+        resizeObserver?.observe(container)
+        const mutationObserver = typeof MutationObserver !== 'undefined'
+            ? new MutationObserver(updateTick)
+            : null
+        mutationObserver?.observe(container, {
             childList: true,
             subtree: true,
             attributes: true,
             attributeFilter: ['data-open'],
         })
+        window.addEventListener('resize', updateTick)
         return () => {
             cancelAnimationFrame(frame)
-            resizeObserver.disconnect()
-            mutationObserver.disconnect()
+            resizeObserver?.disconnect()
+            mutationObserver?.disconnect()
+            window.removeEventListener('resize', updateTick)
         }
     }, [
         selectedSessionId,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -398,6 +398,28 @@ html:has(.chat-scroll-y) #root {
     padding-left: 8px;
 }
 
+/*
+ * Open-session position mark on the left scrollbar gutter.
+ * Visual-only: tiny hit target for the native title tooltip; does not replace
+ * scrollbar click-to-seek. Sibling of `.session-list-scrollbar-left` inside the
+ * relative scroll shell so `top` maps onto the visible rail.
+ */
+.session-list-open-tick {
+    position: absolute;
+    left: 0;
+    z-index: 10;
+    /* Narrow hit target: enough for hover tooltip, not a jump button.
+       Native scrollbar beside it remains the click-to-seek surface. */
+    width: 4px;
+    height: 6px;
+    margin-top: -3px;
+    pointer-events: auto;
+    border-radius: 1px;
+    background: var(--app-link);
+    opacity: 0.9;
+    box-shadow: 0 0 0 1px var(--app-bg);
+}
+
 /* Desktop sidebar: use custom width from CSS variable.
    Kept in sync with the Tailwind `split` breakpoint (see tailwind.config.ts)
    so the sidebar width/resize applies as soon as the split view appears on

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -73,6 +73,7 @@ export default {
   'sessions.search.clear': 'Clear search',
   'sessions.search.noResults': 'No sessions match your filters.',
   'sessions.unreadFilter.toggle': 'Unread only',
+  'sessions.openTick.tooltip': 'Open session — click the scrollbar near this mark to jump there',
   'sessions.timeFilter.label': 'Filter sessions by last activity',
   'sessions.timeFilter.pickStart': 'Select start date',
   'sessions.timeFilter.pickEnd': 'Select end date',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -73,6 +73,7 @@ export default {
   'sessions.search.clear': '清除搜索',
   'sessions.search.noResults': '没有符合筛选条件的会话。',
   'sessions.unreadFilter.toggle': '仅显示未读',
+  'sessions.openTick.tooltip': '当前打开的会话 — 在滚动条靠近此标记处点击即可跳转',
   'sessions.timeFilter.label': '按最后活动时间筛选会话',
   'sessions.timeFilter.pickStart': '选择开始日期',
   'sessions.timeFilter.pickEnd': '选择结束日期',


### PR DESCRIPTION
## Summary
- Adds a small visual-only tick on the session-list left scrollbar gutter showing where the currently open session sits in the scroll extent.
- Operators click the **native scrollbar** near the mark (not the mark itself) to jump; hover `title` explains the affordance.
- Hides when the open row is filtered out or lives in a collapsed group so the mark never lies.

## Test plan
- [ ] Open a session in a long sidebar list; confirm a small tick appears on the left scrollbar rail at roughly that session's position
- [ ] Hover the tick; tooltip explains open-session position / click scrollbar nearby
- [ ] Scroll the list away from the open session; click the scrollbar near the tick; open session comes into view
- [ ] Collapse the open session's group (if possible without auto-expand fighting you) or filter it out; tick disappears
- [ ] `cd web && bun run test src/components/SessionList.test.ts`

## Issues
Fixes #1732