### PR TITLE
fix(hub): capture AGENT_NOTIFY_SUMMARY from peer user-role deliveries

### DIFF
--- a/cli/src/claude/utils/startHappyServer.ts
+++ b/cli/src/claude/utils/startHappyServer.ts
@@ -301,6 +301,7 @@ function createHapiMcpServer(
             const result = await pingPeer({
                 sessionIdPrefix: args.sessionIdPrefix,
                 message: args.message,
+                sourceSessionId: client.sessionId,
             });
             return {
                 content: [

--- a/cli/src/commands/pingPeer.ts
+++ b/cli/src/commands/pingPeer.ts
@@ -41,6 +41,7 @@ ${chalk.bold('Notes:')}
 
 ${chalk.bold('Env:')}
   HAPI_API_URL / CLI_API_TOKEN (or ~/.hapi/settings.json via \`hapi auth login\`)
+  HAPI_SESSION_ID (required for attributed peer delivery; set automatically inside a HAPI session)
   HAPI_WAIT_ACTIVE_SECS (default 60; overridable with --wait)
 `)
 }

--- a/cli/src/commands/pingPeer.ts
+++ b/cli/src/commands/pingPeer.ts
@@ -41,7 +41,7 @@ ${chalk.bold('Notes:')}
 
 ${chalk.bold('Env:')}
   HAPI_API_URL / CLI_API_TOKEN (or ~/.hapi/settings.json via \`hapi auth login\`)
-  HAPI_SESSION_ID (required for attributed peer delivery; set automatically inside a HAPI session)
+  HAPI_SESSION_ID (optional; when set, delivery is attributed via /cli peer-messages + notify stamp)
   HAPI_WAIT_ACTIVE_SECS (default 60; overridable with --wait)
 `)
 }

--- a/cli/src/modules/pingPeer/pingPeer.test.ts
+++ b/cli/src/modules/pingPeer/pingPeer.test.ts
@@ -79,8 +79,8 @@ describe('pingPeer', () => {
                     expect(body).toEqual({ accessToken: 'tok' })
                     return { status: 200, data: { token: 'jwt' } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/messages`)) {
-                    expect(body).toEqual({ text: 'hello peer', notifySource: 'peer' })
+                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
+                    expect(body).toEqual({ text: 'hello peer' })
                     return { status: 200, data: { ok: true } }
                 }
                 throw new Error(`unexpected POST ${url}`)
@@ -143,7 +143,7 @@ describe('pingPeer', () => {
                 if (url.endsWith(`/api/sessions/${sessionId}/resume`)) {
                     return { status: 200, data: { type: 'success', sessionId, resumed: true } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/messages`)) {
+                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
                     expect(active).toBe(true)
                     return { status: 200, data: { ok: true } }
                 }
@@ -215,7 +215,7 @@ describe('pingPeer', () => {
                     resumeCalls += 1
                     return { status: 200, data: { type: 'success', sessionId, resumed: true } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/messages`)) {
+                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
                     expect(active).toBe(true)
                     expect(resumeCalls).toBe(1)
                     return { status: 200, data: { ok: true } }
@@ -284,7 +284,7 @@ describe('pingPeer', () => {
                 if (url.endsWith('/api/auth')) {
                     return { status: 200, data: { token: 'jwt' } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/messages`)) {
+                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
                     expect(piSessionId).toBe('pi-ready-1')
                     return { status: 200, data: { ok: true } }
                 }
@@ -631,7 +631,7 @@ describe('listSessions query params', () => {
                 if (url.endsWith('/api/auth')) {
                     return { status: 200, data: { token: 'jwt' } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/messages`)) {
+                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
                     expect(body).toMatchObject({ text: 'hi' })
                     return { status: 200, data: { ok: true } }
                 }

--- a/cli/src/modules/pingPeer/pingPeer.test.ts
+++ b/cli/src/modules/pingPeer/pingPeer.test.ts
@@ -63,6 +63,7 @@ describe('resolveSessionByPrefix', () => {
 })
 
 describe('pingPeer', () => {
+    const sourceSessionId = 'aaaaaaaa-1111-1111-1111-111111111111'
     let nowMs: number
     let sleepCalls: number[]
 
@@ -79,8 +80,8 @@ describe('pingPeer', () => {
                     expect(body).toEqual({ accessToken: 'tok' })
                     return { status: 200, data: { token: 'jwt' } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
-                    expect(body).toEqual({ text: 'hello peer' })
+                if (url.endsWith(`/cli/sessions/${sourceSessionId}/peer-messages`)) {
+                    expect(body).toEqual({ text: 'hello peer', targetSessionId: sessionId })
                     return { status: 200, data: { ok: true } }
                 }
                 throw new Error(`unexpected POST ${url}`)
@@ -115,6 +116,7 @@ describe('pingPeer', () => {
         })
 
         const result = await pingPeer({
+            sourceSessionId,
             sessionIdPrefix: '05d9f0f2',
             message: 'hello peer',
             accessToken: 'tok',
@@ -131,7 +133,7 @@ describe('pingPeer', () => {
     })
 
     it('resumes an inactive session, waits for active, then sends', async () => {
-        const sessionId = 'aaaaaaaa-1111-1111-1111-111111111111'
+        const sessionId = 'bbbbbbbb-2222-2222-2222-222222222222'
         let active = false
         let polls = 0
 
@@ -143,7 +145,7 @@ describe('pingPeer', () => {
                 if (url.endsWith(`/api/sessions/${sessionId}/resume`)) {
                     return { status: 200, data: { type: 'success', sessionId, resumed: true } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
+                if (url.endsWith(`/cli/sessions/${sourceSessionId}/peer-messages`)) {
                     expect(active).toBe(true)
                     return { status: 200, data: { ok: true } }
                 }
@@ -183,7 +185,8 @@ describe('pingPeer', () => {
         })
 
         const result = await pingPeer({
-            sessionIdPrefix: 'aaaaaaaa',
+            sourceSessionId,
+            sessionIdPrefix: 'bbbbbbbb',
             message: 'wake up',
             accessToken: 'tok',
             apiUrl: 'http://hub.test',
@@ -215,7 +218,7 @@ describe('pingPeer', () => {
                     resumeCalls += 1
                     return { status: 200, data: { type: 'success', sessionId, resumed: true } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
+                if (url.endsWith(`/cli/sessions/${sourceSessionId}/peer-messages`)) {
                     expect(active).toBe(true)
                     expect(resumeCalls).toBe(1)
                     return { status: 200, data: { ok: true } }
@@ -253,6 +256,7 @@ describe('pingPeer', () => {
         })
 
         const result = await pingPeer({
+            sourceSessionId,
             sessionIdPrefix: 'bbbbbbbb',
             message: 'still here?',
             accessToken: 'tok',
@@ -284,7 +288,7 @@ describe('pingPeer', () => {
                 if (url.endsWith('/api/auth')) {
                     return { status: 200, data: { token: 'jwt' } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
+                if (url.endsWith(`/cli/sessions/${sourceSessionId}/peer-messages`)) {
                     expect(piSessionId).toBe('pi-ready-1')
                     return { status: 200, data: { ok: true } }
                 }
@@ -324,6 +328,7 @@ describe('pingPeer', () => {
         })
 
         await pingPeer({
+            sourceSessionId,
             sessionIdPrefix: 'piiiiiii',
             message: 'hi pi',
             accessToken: 'tok',
@@ -382,6 +387,7 @@ describe('pingPeer', () => {
         })
 
         await expect(pingPeer({
+            sourceSessionId,
             sessionIdPrefix: 'deadbeef',
             message: 'nudge',
             accessToken: 'tok',
@@ -599,6 +605,7 @@ describe('listSessions query params', () => {
         const listParams: Array<Record<string, unknown> | undefined> = []
         const pingParams: Array<Record<string, unknown> | undefined> = []
         const sessionId = 'zzzzzzzz-9999-9999-9999-999999999999'
+        const sourceSessionId = 'aaaaaaaa-1111-1111-1111-111111111111'
 
         const listHttp = createHttpMock({
             post: (url) => {
@@ -631,8 +638,8 @@ describe('listSessions query params', () => {
                 if (url.endsWith('/api/auth')) {
                     return { status: 200, data: { token: 'jwt' } }
                 }
-                if (url.endsWith(`/api/sessions/${sessionId}/peer-messages`)) {
-                    expect(body).toMatchObject({ text: 'hi' })
+                if (url.endsWith(`/cli/sessions/${sourceSessionId}/peer-messages`)) {
+                    expect(body).toMatchObject({ text: 'hi', targetSessionId: sessionId })
                     return { status: 200, data: { ok: true } }
                 }
                 throw new Error(`unexpected POST ${url}`)
@@ -662,6 +669,7 @@ describe('listSessions query params', () => {
             }
         })
         const result = await pingPeer({
+            sourceSessionId,
             sessionIdPrefix: sessionId,
             message: 'hi',
             apiUrl: 'http://hub.test',

--- a/cli/src/modules/pingPeer/pingPeer.test.ts
+++ b/cli/src/modules/pingPeer/pingPeer.test.ts
@@ -70,6 +70,7 @@ describe('pingPeer', () => {
     beforeEach(() => {
         nowMs = 1_000_000
         sleepCalls = []
+        delete process.env.HAPI_SESSION_ID
     })
 
     it('sends to an already-active session without resume', async () => {
@@ -129,6 +130,62 @@ describe('pingPeer', () => {
             name: 'Orchestrator',
             resumed: false
         })
+        expect(http.post).toHaveBeenCalledTimes(2)
+    })
+
+    it('sends unattributed via /messages when no source session is set', async () => {
+        const sessionId = '05d9f0f2-9273-4137-933c-07459a1146a2'
+        const http = createHttpMock({
+            post: (url, body) => {
+                if (url.endsWith('/api/auth')) {
+                    return { status: 200, data: { token: 'jwt' } }
+                }
+                if (url.endsWith(`/api/sessions/${sessionId}/messages`)) {
+                    expect(body).toEqual({ text: 'hello peer' })
+                    return { status: 200, data: { ok: true } }
+                }
+                throw new Error(`unexpected POST ${url}`)
+            },
+            get: (url) => {
+                if (url.endsWith('/api/sessions')) {
+                    return {
+                        status: 200,
+                        data: {
+                            sessions: [{
+                                id: sessionId,
+                                active: true,
+                                metadata: { name: 'Orchestrator', flavor: 'cursor' }
+                            }]
+                        }
+                    }
+                }
+                if (url.endsWith(`/api/sessions/${sessionId}`)) {
+                    return {
+                        status: 200,
+                        data: {
+                            session: {
+                                id: sessionId,
+                                active: true,
+                                metadata: { name: 'Orchestrator', flavor: 'cursor' }
+                            }
+                        }
+                    }
+                }
+                throw new Error(`unexpected GET ${url}`)
+            }
+        })
+
+        const result = await pingPeer({
+            sessionIdPrefix: '05d9f0f2',
+            message: 'hello peer',
+            accessToken: 'tok',
+            apiUrl: 'http://127.0.0.1:3006',
+            http: http as never,
+            now: () => nowMs,
+            sleep: async (ms) => { sleepCalls.push(ms) }
+        })
+
+        expect(result.sessionId).toBe(sessionId)
         expect(http.post).toHaveBeenCalledTimes(2)
     })
 

--- a/cli/src/modules/pingPeer/pingPeer.test.ts
+++ b/cli/src/modules/pingPeer/pingPeer.test.ts
@@ -80,7 +80,7 @@ describe('pingPeer', () => {
                     return { status: 200, data: { token: 'jwt' } }
                 }
                 if (url.endsWith(`/api/sessions/${sessionId}/messages`)) {
-                    expect(body).toEqual({ text: 'hello peer' })
+                    expect(body).toEqual({ text: 'hello peer', notifySource: 'peer' })
                     return { status: 200, data: { ok: true } }
                 }
                 throw new Error(`unexpected POST ${url}`)

--- a/cli/src/modules/pingPeer/pingPeer.ts
+++ b/cli/src/modules/pingPeer/pingPeer.ts
@@ -377,16 +377,40 @@ async function sendPeerMessage(
     throw new PingPeerError('send_failed', `send failed: ${detail}`)
 }
 
-function resolveSourceSessionId(explicit?: string): string {
+/** Unattributed delivery (standalone CLI shell without HAPI_SESSION_ID) — no peer notify stamp. */
+async function sendMessage(
+    apiUrl: string,
+    jwt: string,
+    sessionId: string,
+    message: string,
+    http: AxiosInstance
+): Promise<void> {
+    const response = await http.post(
+        `${apiUrl}/api/sessions/${encodeURIComponent(sessionId)}/messages`,
+        { text: message },
+        {
+            headers: authHeaders(jwt),
+            timeout: 30_000,
+            validateStatus: () => true
+        }
+    )
+    if (response.status >= 200 && response.status < 300 && response.data?.ok === true) {
+        return
+    }
+    const detail = typeof response.data?.error === 'string'
+        ? response.data.error
+        : typeof response.data?.code === 'string'
+            ? response.data.code
+            : `HTTP ${response.status}`
+    throw new PingPeerError('send_failed', `send failed: ${detail}`)
+}
+
+function resolveSourceSessionId(explicit?: string): string | null {
     const fromOption = explicit?.trim() ?? ''
     if (fromOption) return fromOption
     const fromEnv = (process.env[HAPI_SESSION_ID_ENV] ?? '').trim()
     if (fromEnv) return fromEnv
-    throw new PingPeerError(
-        'bad_args',
-        'source session id required for peer delivery ' +
-            `(set ${HAPI_SESSION_ID_ENV} inside a HAPI session, or pass sourceSessionId)`
-    )
+    return null
 }
 
 export async function listPeerSessions(
@@ -507,7 +531,7 @@ export async function pingPeer(options: PingPeerOptions): Promise<PingPeerResult
     const name = resolvePeerSessionLabel(matched)
     onProgress?.(`resolved ${matched.id}  active=${matched.active}  name="${name}"`)
 
-    if (matched.id === sourceSessionId) {
+    if (sourceSessionId && matched.id === sourceSessionId) {
         throw new PingPeerError('bad_args', 'cannot ping the source session itself')
     }
 
@@ -543,8 +567,13 @@ export async function pingPeer(options: PingPeerOptions): Promise<PingPeerResult
         }
     }
 
-    onProgress?.(`sending message (${message.length} chars) from ${sourceSessionId.slice(0, 8)}...`)
-    await sendPeerMessage(apiUrl, accessToken, sourceSessionId, matched.id, message, http)
+    if (sourceSessionId) {
+        onProgress?.(`sending attributed peer message (${message.length} chars) from ${sourceSessionId.slice(0, 8)}...`)
+        await sendPeerMessage(apiUrl, accessToken, sourceSessionId, matched.id, message, http)
+    } else {
+        onProgress?.(`sending message (${message.length} chars)...`)
+        await sendMessage(apiUrl, jwt, matched.id, message, http)
+    }
 
     return {
         sessionId: matched.id,

--- a/cli/src/modules/pingPeer/pingPeer.ts
+++ b/cli/src/modules/pingPeer/pingPeer.ts
@@ -14,6 +14,7 @@ import { normalizeSessionIdPrefix } from '@hapi/protocol/sessionCitation'
 import { configuration } from '@/configuration'
 import { getAuthToken } from '@/api/auth'
 import { buildHubRequestHeaders } from '@/api/hubExtraHeaders'
+import { HAPI_SESSION_ID_ENV } from '@/agent/hapiSessionEnv'
 
 export type PingPeerErrorCode =
     | 'bad_args'
@@ -52,6 +53,11 @@ export type PingPeerSessionSummary = {
 export type PingPeerOptions = {
     sessionIdPrefix: string
     message: string
+    /**
+     * Sending session id for CLI peer attribution (`POST /cli/sessions/:source/peer-messages`).
+     * Defaults to `HAPI_SESSION_ID` when unset.
+     */
+    sourceSessionId?: string
     waitActiveSecs?: number
     apiUrl?: string
     accessToken?: string
@@ -340,18 +346,22 @@ async function waitForPiReady(
     )
 }
 
-async function sendMessage(
+async function sendPeerMessage(
     apiUrl: string,
-    jwt: string,
-    sessionId: string,
+    accessToken: string,
+    sourceSessionId: string,
+    targetSessionId: string,
     message: string,
     http: AxiosInstance
 ): Promise<void> {
     const response = await http.post(
-        `${apiUrl}/api/sessions/${encodeURIComponent(sessionId)}/peer-messages`,
-        { text: message },
+        `${apiUrl}/cli/sessions/${encodeURIComponent(sourceSessionId)}/peer-messages`,
+        { text: message, targetSessionId },
         {
-            headers: authHeaders(jwt),
+            headers: buildHubRequestHeaders({
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json'
+            }),
             timeout: 30_000,
             validateStatus: () => true
         }
@@ -365,6 +375,18 @@ async function sendMessage(
             ? response.data.code
             : `HTTP ${response.status}`
     throw new PingPeerError('send_failed', `send failed: ${detail}`)
+}
+
+function resolveSourceSessionId(explicit?: string): string {
+    const fromOption = explicit?.trim() ?? ''
+    if (fromOption) return fromOption
+    const fromEnv = (process.env[HAPI_SESSION_ID_ENV] ?? '').trim()
+    if (fromEnv) return fromEnv
+    throw new PingPeerError(
+        'bad_args',
+        'source session id required for peer delivery ' +
+            `(set ${HAPI_SESSION_ID_ENV} inside a HAPI session, or pass sourceSessionId)`
+    )
 }
 
 export async function listPeerSessions(
@@ -465,6 +487,8 @@ export async function pingPeer(options: PingPeerOptions): Promise<PingPeerResult
         throw new PingPeerError('bad_args', 'message is required')
     }
 
+    const sourceSessionId = resolveSourceSessionId(options.sourceSessionId)
+
     const waitActiveSecs = options.waitActiveSecs ?? DEFAULT_WAIT_ACTIVE_SECS
     if (!Number.isFinite(waitActiveSecs) || waitActiveSecs <= 0) {
         throw new PingPeerError('bad_args', 'waitActiveSecs must be a positive number')
@@ -482,6 +506,10 @@ export async function pingPeer(options: PingPeerOptions): Promise<PingPeerResult
     const matched = resolveSessionByPrefix(sessions, prefix)
     const name = resolvePeerSessionLabel(matched)
     onProgress?.(`resolved ${matched.id}  active=${matched.active}  name="${name}"`)
+
+    if (matched.id === sourceSessionId) {
+        throw new PingPeerError('bad_args', 'cannot ping the source session itself')
+    }
 
     let resumed = false
     const ensureActive = async (progressMessage: string): Promise<PingPeerSessionSummary> => {
@@ -515,8 +543,8 @@ export async function pingPeer(options: PingPeerOptions): Promise<PingPeerResult
         }
     }
 
-    onProgress?.(`sending message (${message.length} chars)...`)
-    await sendMessage(apiUrl, jwt, matched.id, message, http)
+    onProgress?.(`sending message (${message.length} chars) from ${sourceSessionId.slice(0, 8)}...`)
+    await sendPeerMessage(apiUrl, accessToken, sourceSessionId, matched.id, message, http)
 
     return {
         sessionId: matched.id,

--- a/cli/src/modules/pingPeer/pingPeer.ts
+++ b/cli/src/modules/pingPeer/pingPeer.ts
@@ -349,7 +349,7 @@ async function sendMessage(
 ): Promise<void> {
     const response = await http.post(
         `${apiUrl}/api/sessions/${encodeURIComponent(sessionId)}/messages`,
-        { text: message },
+        { text: message, notifySource: 'peer' },
         {
             headers: authHeaders(jwt),
             timeout: 30_000,

--- a/cli/src/modules/pingPeer/pingPeer.ts
+++ b/cli/src/modules/pingPeer/pingPeer.ts
@@ -348,8 +348,8 @@ async function sendMessage(
     http: AxiosInstance
 ): Promise<void> {
     const response = await http.post(
-        `${apiUrl}/api/sessions/${encodeURIComponent(sessionId)}/messages`,
-        { text: message, notifySource: 'peer' },
+        `${apiUrl}/api/sessions/${encodeURIComponent(sessionId)}/peer-messages`,
+        { text: message },
         {
             headers: authHeaders(jwt),
             timeout: 30_000,

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -853,6 +853,8 @@ export class MessageService {
             scheduledAt?: number | null
             deliveryMode?: MessageDeliveryMode
             notifySource?: 'peer'
+            /** Required when notifySource=peer — sending session for work_ad attribution. */
+            peerSourceSessionId?: string
         }
     ): Promise<{ actualSessionId: string; createdAt: number; message: DecryptedMessage }> {
         // Defence-in-depth invariant for non-REST callers (Telegram bot, MCP,
@@ -865,6 +867,12 @@ export class MessageService {
         // !localId throw.
         if (payload.scheduledAt != null && (payload.attachments?.length ?? 0) > 0) {
             throw new Error('sendMessage: scheduled messages with attachments are not supported')
+        }
+        if (payload.notifySource === 'peer') {
+            const sourceId = payload.peerSourceSessionId?.trim()
+            if (!sourceId) {
+                throw new Error('sendMessage: notifySource=peer requires peerSourceSessionId')
+            }
         }
 
         const sentFrom = payload.sentFrom ?? 'webapp'
@@ -884,7 +892,12 @@ export class MessageService {
             meta: {
                 sentFrom,
                 deliveryMode,
-                ...(payload.notifySource === 'peer' ? { notifySource: 'peer' as const } : {})
+                ...(payload.notifySource === 'peer' && payload.peerSourceSessionId
+                    ? {
+                        notifySource: 'peer' as const,
+                        sourceSessionId: payload.peerSourceSessionId
+                    }
+                    : {})
             }
         }
 

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -849,7 +849,7 @@ export class MessageService {
             text: string
             localId?: string | null
             attachments?: AttachmentMetadata[]
-            sentFrom?: 'telegram-bot' | 'webapp'
+            sentFrom?: 'telegram-bot' | 'webapp' | 'peer'
             scheduledAt?: number | null
             deliveryMode?: MessageDeliveryMode
             notifySource?: 'peer'

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -852,6 +852,7 @@ export class MessageService {
             sentFrom?: 'telegram-bot' | 'webapp'
             scheduledAt?: number | null
             deliveryMode?: MessageDeliveryMode
+            notifySource?: 'peer'
         }
     ): Promise<{ actualSessionId: string; createdAt: number }> {
         // Defence-in-depth invariant for non-REST callers (Telegram bot, MCP,
@@ -882,7 +883,8 @@ export class MessageService {
             },
             meta: {
                 sentFrom,
-                deliveryMode
+                deliveryMode,
+                ...(payload.notifySource === 'peer' ? { notifySource: 'peer' as const } : {})
             }
         }
 

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -854,7 +854,7 @@ export class MessageService {
             deliveryMode?: MessageDeliveryMode
             notifySource?: 'peer'
         }
-    ): Promise<{ actualSessionId: string; createdAt: number }> {
+    ): Promise<{ actualSessionId: string; createdAt: number; message: DecryptedMessage }> {
         // Defence-in-depth invariant for non-REST callers (Telegram bot, MCP,
         // internal callers).  Attachment paths live under the CLI session's
         // upload directory which `cleanupUploadDir` purges on session end; a
@@ -948,7 +948,11 @@ export class MessageService {
                 ...(msg.deliveryState ? { deliveryState: msg.deliveryState } : {})
             }
         })
-        return { actualSessionId, createdAt: msg.createdAt }
+        return {
+            actualSessionId,
+            createdAt: msg.createdAt,
+            message: toDecryptedMessage(msg)
+        }
     }
 
     /**

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -1010,6 +1010,7 @@ export class SyncEngine {
             sentFrom?: 'telegram-bot' | 'webapp'
             scheduledAt?: number | null
             deliveryMode?: MessageDeliveryMode
+            notifySource?: 'peer'
         }
     ): Promise<void> {
         if (this.historyActionsInFlight.has(sessionId)) {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -490,23 +490,7 @@ export class SyncEngine {
         if (event.type === 'message-received' && event.sessionId && 'message' in event && event.message) {
             // A2A P3: well-formed AGENT_NOTIFY_SUMMARY → work-graph work_ad.
             // Capture is independent of chat display settings (#1462/#1464).
-            const session = this.getSession(event.sessionId)
-            if (session) {
-                try {
-                    ingestNotifySummaryFromMessage({
-                        store: this.store,
-                        namespace: session.namespace,
-                        sessionId: session.id,
-                        messageId: event.message.id,
-                        content: event.message.content,
-                        ts: event.message.createdAt,
-                        ownerUserId: this.hubOwnerUserId,
-                        flavor: session.metadata?.flavor ?? null
-                    })
-                } catch (error) {
-                    console.error('[work-graph] notify ingest failed', error)
-                }
-            }
+            this.captureNotifyFromMessage(event.sessionId, event.message)
         }
     }
 
@@ -1016,9 +1000,35 @@ export class SyncEngine {
         if (this.historyActionsInFlight.has(sessionId)) {
             throw new Error('Conversation history action already in progress')
         }
-        const { actualSessionId, createdAt: activeTurnStartedAt } = await this.messageService.sendMessage(sessionId, payload)
+        const { actualSessionId, createdAt: activeTurnStartedAt, message } =
+            await this.messageService.sendMessage(sessionId, payload)
         this.sessionCache.markMessageQueued(actualSessionId, Date.now(), activeTurnStartedAt)
         this.sessionCache.recordSessionActivity(actualSessionId, Date.now())
+        this.captureNotifyFromMessage(actualSessionId, message)
+    }
+
+    private captureNotifyFromMessage(
+        sessionId: string,
+        message: { id: string; content: unknown; createdAt: number }
+    ): void {
+        const session = this.getSession(sessionId)
+        if (!session) {
+            return
+        }
+        try {
+            ingestNotifySummaryFromMessage({
+                store: this.store,
+                namespace: session.namespace,
+                sessionId: session.id,
+                messageId: message.id,
+                content: message.content,
+                ts: message.createdAt,
+                ownerUserId: this.hubOwnerUserId,
+                flavor: session.metadata?.flavor ?? null
+            })
+        } catch (error) {
+            console.error('[work-graph] notify ingest failed', error)
+        }
     }
 
     async cancelQueuedMessage(

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -995,6 +995,7 @@ export class SyncEngine {
             scheduledAt?: number | null
             deliveryMode?: MessageDeliveryMode
             notifySource?: 'peer'
+            peerSourceSessionId?: string
         }
     ): Promise<void> {
         if (this.historyActionsInFlight.has(sessionId)) {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -1005,17 +1005,26 @@ export class SyncEngine {
             await this.messageService.sendMessage(sessionId, payload)
         this.sessionCache.markMessageQueued(actualSessionId, Date.now(), activeTurnStartedAt)
         this.sessionCache.recordSessionActivity(actualSessionId, Date.now())
-        this.captureNotifyFromMessage(actualSessionId, message)
+        this.captureNotifyFromMessage(actualSessionId, message, {
+            trustedPeerSourceSessionId: payload.notifySource === 'peer'
+                ? payload.peerSourceSessionId
+                : undefined
+        })
     }
 
     private captureNotifyFromMessage(
         sessionId: string,
-        message: { id: string; content: unknown; createdAt: number }
+        message: { id: string; content: unknown; createdAt: number },
+        options?: { trustedPeerSourceSessionId?: string }
     ): void {
         const session = this.getSession(sessionId)
         if (!session) {
             return
         }
+        const peerSourceSessionId = options?.trustedPeerSourceSessionId?.trim() || null
+        const principalSession = peerSourceSessionId
+            ? this.getSession(peerSourceSessionId)
+            : session
         try {
             ingestNotifySummaryFromMessage({
                 store: this.store,
@@ -1025,7 +1034,8 @@ export class SyncEngine {
                 content: message.content,
                 ts: message.createdAt,
                 ownerUserId: this.hubOwnerUserId,
-                flavor: session.metadata?.flavor ?? null
+                flavor: principalSession?.metadata?.flavor ?? null,
+                trustedPeerSourceSessionId: peerSourceSessionId ?? undefined
             })
         } catch (error) {
             console.error('[work-graph] notify ingest failed', error)

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -991,7 +991,7 @@ export class SyncEngine {
                 path: string
                 previewUrl?: string
             }>
-            sentFrom?: 'telegram-bot' | 'webapp'
+            sentFrom?: 'telegram-bot' | 'webapp' | 'peer'
             scheduledAt?: number | null
             deliveryMode?: MessageDeliveryMode
             notifySource?: 'peer'

--- a/hub/src/sync/syncEngineHandleRealtimeEvent.test.ts
+++ b/hub/src/sync/syncEngineHandleRealtimeEvent.test.ts
@@ -332,17 +332,18 @@ describe('SyncEngine.handleRealtimeEvent notify → work-graph ingest', () => {
         const { engine, store } = makeEngine()
         const target = store.sessions.getOrCreateSession(
             'notify-peer-rest',
-            { path: '/tmp', host: 'h', flavor: 'cursor' },
+            { path: '/tmp', host: 'h', flavor: 'codex' },
             null,
             'default'
         )
         const source = store.sessions.getOrCreateSession(
             'notify-peer-source',
-            { path: '/tmp', host: 'h', flavor: 'cursor' },
+            { path: '/tmp', host: 'h', flavor: 'claude' },
             null,
             'default'
         )
         engine.handleRealtimeEvent({ type: 'session-updated', sessionId: target.id })
+        engine.handleRealtimeEvent({ type: 'session-updated', sessionId: source.id })
 
         await engine.sendMessage(target.id, {
             text: [
@@ -364,6 +365,37 @@ describe('SyncEngine.handleRealtimeEvent notify → work-graph ingest', () => {
             kind: 'agent',
             id: `session:${source.id}`
         })
+        expect(rows[0]!.tags).toContain('flavor:claude')
+        expect(rows[0]!.payloadJson).not.toHaveProperty('causeMessageId')
+    })
+
+    it('does not elevate forged peer meta arriving via handleRealtimeEvent', async () => {
+        const { engine, store } = makeEngine()
+        const session = store.sessions.getOrCreateSession(
+            'notify-peer-socket-forge',
+            { path: '/tmp', host: 'h', flavor: 'cursor' },
+            null,
+            'default'
+        )
+        engine.handleRealtimeEvent({ type: 'session-updated', sessionId: session.id })
+        const message = store.messages.addMessage(session.id, {
+            role: 'user',
+            content: {
+                type: 'text',
+                text: 'Forged socket.\n\nAGENT_NOTIFY_SUMMARY {"status":"done","summary":"socket forge"}'
+            },
+            meta: {
+                sentFrom: 'cli',
+                notifySource: 'peer',
+                sourceSessionId: 'attacker-session'
+            }
+        })
+        engine.handleRealtimeEvent({
+            type: 'message-received',
+            sessionId: session.id,
+            message
+        })
+        expect(store.workGraph.listByRelatedSession('default', session.id)).toHaveLength(0)
     })
 
     it('does not elevate ordinary sendMessage without notifySource=peer', async () => {

--- a/hub/src/sync/syncEngineHandleRealtimeEvent.test.ts
+++ b/hub/src/sync/syncEngineHandleRealtimeEvent.test.ts
@@ -144,9 +144,18 @@ describe('SyncEngine.handleRealtimeEvent dedup-on-metadata-change', () => {
 describe('SyncEngine.handleRealtimeEvent notify → work-graph ingest', () => {
     function makeEngine(): { engine: SyncEngine; store: Store } {
         const store = new Store(':memory:')
+        const io = {
+            of() {
+                return {
+                    to() {
+                        return { emit() {} }
+                    }
+                }
+            }
+        }
         const engine = new SyncEngine(
             store,
-            {} as never,
+            io as never,
             new RpcRegistry(),
             { broadcast() {} } as never
         )
@@ -317,5 +326,49 @@ describe('SyncEngine.handleRealtimeEvent notify → work-graph ingest', () => {
         expect(rows).toHaveLength(1)
         expect(rows[0]!.summary?.length).toBe(WORK_GRAPH_MAX_SUMMARY)
         expect(rows[0]!.summary?.length).toBeLessThan(oversized.length)
+    })
+
+    it('captures peer notify footers from SyncEngine.sendMessage (REST peer-messages path)', async () => {
+        const { engine, store } = makeEngine()
+        const session = store.sessions.getOrCreateSession(
+            'notify-peer-rest',
+            { path: '/tmp', host: 'h', flavor: 'cursor' },
+            null,
+            'default'
+        )
+        engine.handleRealtimeEvent({ type: 'session-updated', sessionId: session.id })
+
+        await engine.sendMessage(session.id, {
+            text: [
+                'From: Peer #1: helper',
+                '',
+                'AGENT_NOTIFY_SUMMARY {"status":"done","summary":"peer rest wired","action":"idle"}'
+            ].join('\n'),
+            sentFrom: 'webapp',
+            notifySource: 'peer'
+        })
+
+        const rows = store.workGraph.listByRelatedSession('default', session.id)
+        expect(rows).toHaveLength(1)
+        expect(rows[0]!.summary).toBe('peer rest wired')
+        expect(rows[0]!.provenance).toBe('AGENT_NOTIFY_SUMMARY')
+    })
+
+    it('does not elevate ordinary sendMessage without notifySource=peer', async () => {
+        const { engine, store } = makeEngine()
+        const session = store.sessions.getOrCreateSession(
+            'notify-web-rest',
+            { path: '/tmp', host: 'h', flavor: 'cursor' },
+            null,
+            'default'
+        )
+        engine.handleRealtimeEvent({ type: 'session-updated', sessionId: session.id })
+
+        await engine.sendMessage(session.id, {
+            text: 'Paste.\n\nAGENT_NOTIFY_SUMMARY {"status":"done","summary":"should not land"}',
+            sentFrom: 'webapp'
+        })
+
+        expect(store.workGraph.listByRelatedSession('default', session.id)).toHaveLength(0)
     })
 })

--- a/hub/src/sync/syncEngineHandleRealtimeEvent.test.ts
+++ b/hub/src/sync/syncEngineHandleRealtimeEvent.test.ts
@@ -351,7 +351,7 @@ describe('SyncEngine.handleRealtimeEvent notify → work-graph ingest', () => {
                 '',
                 'AGENT_NOTIFY_SUMMARY {"status":"done","summary":"peer rest wired","action":"idle"}'
             ].join('\n'),
-            sentFrom: 'webapp',
+            sentFrom: 'peer',
             notifySource: 'peer',
             peerSourceSessionId: source.id
         })

--- a/hub/src/sync/syncEngineHandleRealtimeEvent.test.ts
+++ b/hub/src/sync/syncEngineHandleRealtimeEvent.test.ts
@@ -328,30 +328,42 @@ describe('SyncEngine.handleRealtimeEvent notify → work-graph ingest', () => {
         expect(rows[0]!.summary?.length).toBeLessThan(oversized.length)
     })
 
-    it('captures peer notify footers from SyncEngine.sendMessage (REST peer-messages path)', async () => {
+    it('captures peer notify footers from SyncEngine.sendMessage (CLI peer-messages path)', async () => {
         const { engine, store } = makeEngine()
-        const session = store.sessions.getOrCreateSession(
+        const target = store.sessions.getOrCreateSession(
             'notify-peer-rest',
             { path: '/tmp', host: 'h', flavor: 'cursor' },
             null,
             'default'
         )
-        engine.handleRealtimeEvent({ type: 'session-updated', sessionId: session.id })
+        const source = store.sessions.getOrCreateSession(
+            'notify-peer-source',
+            { path: '/tmp', host: 'h', flavor: 'cursor' },
+            null,
+            'default'
+        )
+        engine.handleRealtimeEvent({ type: 'session-updated', sessionId: target.id })
 
-        await engine.sendMessage(session.id, {
+        await engine.sendMessage(target.id, {
             text: [
                 'From: Peer #1: helper',
                 '',
                 'AGENT_NOTIFY_SUMMARY {"status":"done","summary":"peer rest wired","action":"idle"}'
             ].join('\n'),
             sentFrom: 'webapp',
-            notifySource: 'peer'
+            notifySource: 'peer',
+            peerSourceSessionId: source.id
         })
 
-        const rows = store.workGraph.listByRelatedSession('default', session.id)
+        const rows = store.workGraph.listByRelatedSession('default', target.id)
         expect(rows).toHaveLength(1)
         expect(rows[0]!.summary).toBe('peer rest wired')
         expect(rows[0]!.provenance).toBe('AGENT_NOTIFY_SUMMARY')
+        expect(rows[0]!.sourceRef).toBe(source.id)
+        expect(rows[0]!.principal).toMatchObject({
+            kind: 'agent',
+            id: `session:${source.id}`
+        })
     })
 
     it('does not elevate ordinary sendMessage without notifySource=peer', async () => {

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -650,7 +650,7 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         ].join('\n')
         const peer = store.messages.addMessage(
             session.id,
-            userInbound(peerText, 'webapp', {
+            userInbound(peerText, 'peer', {
                 notifySource: 'peer',
                 sourceSessionId: 'sess-sender'
             })
@@ -686,7 +686,7 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         expect(recipientAd?.event.payloadJson).toMatchObject({
             messageId: assistant.id,
             causeMessageId: peer.id,
-            causeKind: 'webapp'
+            causeKind: 'peer'
         })
         expect((recipientAd?.event.payloadJson as { causeText?: string })?.causeText)
             ?.toContain('Please resume this lease.')

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -635,6 +635,50 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         })
     })
 
+    it('recipient assistant notify keeps peer-stamped handoff as cause after peer work_ad', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-cause-peer-elevate', {}, null, 'default')
+        const peerText = [
+            'From: /sessions/sess-sender',
+            '',
+            'Please resume this lease.',
+            '',
+            'AGENT_NOTIFY_SUMMARY {"version":1,"status":"done","summary":"peer standing down","action":"idle"}'
+        ].join('\n')
+        const peer = store.messages.addMessage(
+            session.id,
+            userInbound(peerText, 'webapp', {
+                notifySource: 'peer',
+                sourceSessionId: 'sess-sender'
+            })
+        )
+        const peerAd = ingestNotify(store, session.id, 'default', peer.content, peer.id)
+        expect(peerAd?.inserted).toBe(true)
+        expect(peerAd?.event.sourceRef).toBe('sess-sender')
+
+        const assistant = store.messages.addMessage(
+            session.id,
+            assistantOutput(notifyFooter('Ack peer handoff'))
+        )
+        const recipientAd = ingestNotify(
+            store,
+            session.id,
+            'default',
+            assistant.content,
+            assistant.id
+        )
+
+        expect(recipientAd?.inserted).toBe(true)
+        expect(recipientAd?.event.sourceRef).toBe(session.id)
+        expect(recipientAd?.event.payloadJson).toMatchObject({
+            messageId: assistant.id,
+            causeMessageId: peer.id,
+            causeKind: 'webapp'
+        })
+        expect((recipientAd?.event.payloadJson as { causeText?: string })?.causeText)
+            ?.toContain('Please resume this lease.')
+    })
+
     it('skips agent-role tool/prose rows when choosing cause', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-cause-skip-agent', {}, null, 'default')

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -243,7 +243,7 @@ describe('ingestNotifySummaryFromMessage', () => {
         expect(store.workGraph.listByRelatedSession('default', session.id)).toHaveLength(0)
     })
 
-    it('captures AGENT_NOTIFY_SUMMARY from peer-stamped user-role deliveries', () => {
+    it('captures AGENT_NOTIFY_SUMMARY from hub-validated peer deliveries', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-peer-user', {}, null, 'default')
         const content = {
@@ -269,7 +269,8 @@ describe('ingestNotifySummaryFromMessage', () => {
             content,
             ts: Date.now(),
             ownerUserId: 1,
-            flavor: 'cursor'
+            flavor: 'claude',
+            trustedPeerSourceSessionId: 'sess-sender'
         })
 
         expect(result?.inserted).toBe(true)
@@ -282,13 +283,15 @@ describe('ingestNotifySummaryFromMessage', () => {
             kind: 'agent',
             id: 'session:sess-sender'
         })
+        expect(result?.event.tags).toContain('flavor:claude')
         expect(result?.event.payloadJson).toMatchObject({
             status: 'done',
             action: 'idle until dogfood'
         })
+        expect(result?.event.payloadJson).not.toHaveProperty('causeMessageId')
     })
 
-    it('does not elevate peer stamp without sourceSessionId', () => {
+    it('does not elevate forged peer meta without trustedPeerSourceSessionId', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-peer-forge', {}, null, 'default')
         const content = {
@@ -297,7 +300,7 @@ describe('ingestNotifySummaryFromMessage', () => {
                 type: 'text' as const,
                 text: 'Forged.\n\nAGENT_NOTIFY_SUMMARY {"version":1,"status":"done","summary":"should not land"}'
             },
-            meta: { sentFrom: 'webapp', notifySource: 'peer' as const }
+            meta: { sentFrom: 'webapp', notifySource: 'peer' as const, sourceSessionId: 'sess-attacker' }
         }
 
         const result = ingestNotifySummaryFromMessage({
@@ -652,9 +655,19 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
                 sourceSessionId: 'sess-sender'
             })
         )
-        const peerAd = ingestNotify(store, session.id, 'default', peer.content, peer.id)
+        const peerAd = ingestNotifySummaryFromMessage({
+            store,
+            namespace: 'default',
+            sessionId: session.id,
+            messageId: peer.id,
+            content: peer.content,
+            ts: Date.now(),
+            ownerUserId: 1,
+            trustedPeerSourceSessionId: 'sess-sender'
+        })
         expect(peerAd?.inserted).toBe(true)
         expect(peerAd?.event.sourceRef).toBe('sess-sender')
+        expect(peerAd?.event.payloadJson).not.toHaveProperty('causeMessageId')
 
         const assistant = store.messages.addMessage(
             session.id,
@@ -677,6 +690,33 @@ describe('ingestNotifySummaryFromMessage cause stamping', () => {
         })
         expect((recipientAd?.event.payloadJson as { causeText?: string })?.causeText)
             ?.toContain('Please resume this lease.')
+    })
+
+    it('peer work_ad does not adopt a prior recipient prompt as cause', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-peer-no-cause', {}, null, 'default')
+        store.messages.addMessage(session.id, userInbound('unrelated target prompt'))
+        const peer = store.messages.addMessage(
+            session.id,
+            userInbound(
+                'Peer handoff.\n\nAGENT_NOTIFY_SUMMARY {"version":1,"status":"done","summary":"peer done"}',
+                'webapp',
+                { notifySource: 'peer', sourceSessionId: 'sess-sender' }
+            )
+        )
+        const peerAd = ingestNotifySummaryFromMessage({
+            store,
+            namespace: 'default',
+            sessionId: session.id,
+            messageId: peer.id,
+            content: peer.content,
+            ts: Date.now(),
+            ownerUserId: 1,
+            trustedPeerSourceSessionId: 'sess-sender'
+        })
+        expect(peerAd?.inserted).toBe(true)
+        expect(peerAd?.event.payloadJson).not.toHaveProperty('causeMessageId')
+        expect(peerAd?.event.payloadJson).not.toHaveProperty('causeText')
     })
 
     it('skips agent-role tool/prose rows when choosing cause', () => {

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -243,6 +243,41 @@ describe('ingestNotifySummaryFromMessage', () => {
         expect(store.workGraph.listByRelatedSession('default', session.id)).toHaveLength(0)
     })
 
+    it('captures AGENT_NOTIFY_SUMMARY from user-role peer deliveries', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-peer-user', {}, null, 'default')
+        const content = userInbound(
+            [
+                'From: Peer #1717: blocked list UX',
+                '',
+                'LEASE: already released.',
+                '',
+                'AGENT_NOTIFY_SUMMARY {"version":1,"status":"done","action":"idle until dogfood","summary":"lease confirmed released; standing down"}'
+            ].join('\n'),
+            'peer'
+        )
+
+        const result = ingestNotifySummaryFromMessage({
+            store,
+            namespace: 'default',
+            sessionId: session.id,
+            messageId: 'msg-peer-ping',
+            content,
+            ts: Date.now(),
+            ownerUserId: 1,
+            flavor: 'cursor'
+        })
+
+        expect(result?.inserted).toBe(true)
+        expect(result?.event.eventType).toBe('work_ad')
+        expect(result?.event.summary).toBe('lease confirmed released; standing down')
+        expect(result?.event.provenance).toBe('AGENT_NOTIFY_SUMMARY')
+        expect(result?.event.payloadJson).toMatchObject({
+            status: 'done',
+            action: 'idle until dogfood'
+        })
+    })
+
     it('does not require a chat display setting — capture always runs when well-formed', () => {
         // Kill criterion: display-off does not block capture. This path has no
         // display gate at all; presence of a footer is sufficient.

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -243,19 +243,23 @@ describe('ingestNotifySummaryFromMessage', () => {
         expect(store.workGraph.listByRelatedSession('default', session.id)).toHaveLength(0)
     })
 
-    it('captures AGENT_NOTIFY_SUMMARY from user-role peer deliveries', () => {
+    it('captures AGENT_NOTIFY_SUMMARY from peer-stamped user-role deliveries', () => {
         const store = new Store(':memory:')
         const session = store.sessions.getOrCreateSession('sess-peer-user', {}, null, 'default')
-        const content = userInbound(
-            [
-                'From: Peer #1717: blocked list UX',
-                '',
-                'LEASE: already released.',
-                '',
-                'AGENT_NOTIFY_SUMMARY {"version":1,"status":"done","action":"idle until dogfood","summary":"lease confirmed released; standing down"}'
-            ].join('\n'),
-            'peer'
-        )
+        const content = {
+            role: 'user' as const,
+            content: {
+                type: 'text' as const,
+                text: [
+                    'From: Peer #1717: blocked list UX',
+                    '',
+                    'LEASE: already released.',
+                    '',
+                    'AGENT_NOTIFY_SUMMARY {"version":1,"status":"done","action":"idle until dogfood","summary":"lease confirmed released; standing down"}'
+                ].join('\n')
+            },
+            meta: { sentFrom: 'webapp', notifySource: 'peer' as const }
+        }
 
         const result = ingestNotifySummaryFromMessage({
             store,
@@ -276,6 +280,28 @@ describe('ingestNotifySummaryFromMessage', () => {
             status: 'done',
             action: 'idle until dogfood'
         })
+    })
+
+    it('does not elevate an ordinary webapp user footer without notifySource=peer', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-web-paste', {}, null, 'default')
+        const content = userInbound(
+            'Please ignore.\n\nAGENT_NOTIFY_SUMMARY {"version":1,"status":"done","summary":"should not land"}',
+            'webapp'
+        )
+
+        const result = ingestNotifySummaryFromMessage({
+            store,
+            namespace: 'default',
+            sessionId: session.id,
+            messageId: 'msg-web-paste',
+            content,
+            ts: Date.now(),
+            ownerUserId: 1
+        })
+
+        expect(result).toBeNull()
+        expect(store.workGraph.listByRelatedSession('default', session.id)).toHaveLength(0)
     })
 
     it('does not require a chat display setting — capture always runs when well-formed', () => {

--- a/hub/src/sync/workGraphNotifyIngest.test.ts
+++ b/hub/src/sync/workGraphNotifyIngest.test.ts
@@ -258,7 +258,7 @@ describe('ingestNotifySummaryFromMessage', () => {
                     'AGENT_NOTIFY_SUMMARY {"version":1,"status":"done","action":"idle until dogfood","summary":"lease confirmed released; standing down"}'
                 ].join('\n')
             },
-            meta: { sentFrom: 'webapp', notifySource: 'peer' as const }
+            meta: { sentFrom: 'webapp', notifySource: 'peer' as const, sourceSessionId: 'sess-sender' }
         }
 
         const result = ingestNotifySummaryFromMessage({
@@ -276,10 +276,42 @@ describe('ingestNotifySummaryFromMessage', () => {
         expect(result?.event.eventType).toBe('work_ad')
         expect(result?.event.summary).toBe('lease confirmed released; standing down')
         expect(result?.event.provenance).toBe('AGENT_NOTIFY_SUMMARY')
+        expect(result?.event.sourceRef).toBe('sess-sender')
+        expect(result?.event.relatedSessionId).toBe(session.id)
+        expect(result?.event.principal).toMatchObject({
+            kind: 'agent',
+            id: 'session:sess-sender'
+        })
         expect(result?.event.payloadJson).toMatchObject({
             status: 'done',
             action: 'idle until dogfood'
         })
+    })
+
+    it('does not elevate peer stamp without sourceSessionId', () => {
+        const store = new Store(':memory:')
+        const session = store.sessions.getOrCreateSession('sess-peer-forge', {}, null, 'default')
+        const content = {
+            role: 'user' as const,
+            content: {
+                type: 'text' as const,
+                text: 'Forged.\n\nAGENT_NOTIFY_SUMMARY {"version":1,"status":"done","summary":"should not land"}'
+            },
+            meta: { sentFrom: 'webapp', notifySource: 'peer' as const }
+        }
+
+        const result = ingestNotifySummaryFromMessage({
+            store,
+            namespace: 'default',
+            sessionId: session.id,
+            messageId: 'msg-forge',
+            content,
+            ts: Date.now(),
+            ownerUserId: 1
+        })
+
+        expect(result).toBeNull()
+        expect(store.workGraph.listByRelatedSession('default', session.id)).toHaveLength(0)
     })
 
     it('does not elevate an ordinary webapp user footer without notifySource=peer', () => {

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -257,10 +257,7 @@ function listPreviousWorkAds(
     // work_ad rows; those must not steal related_event_id, follows, or sticky cause.
     return store.workGraph
         .listWorkAdsByRelatedSession(namespace, sessionId)
-        .filter((event) => (
-            event.provenance === 'AGENT_NOTIFY_SUMMARY'
-            && event.sourceRef === sessionId
-        ))
+        .filter((event) => event.provenance === 'AGENT_NOTIFY_SUMMARY')
 }
 
 function consumedInboundIds(
@@ -381,6 +378,11 @@ export function buildWorkAdFromNotify(params: {
     expiresAt?: number
     cause?: WorkAdCause | null
     relatedEventId?: string | null
+    /**
+     * Session that authored the notify (peer source). Defaults to sessionId
+     * (message home / assistant turn). Peer deliveries set this to the sender.
+     */
+    principalSessionId?: string
 }): WorkGraphEventCreate {
     const status = mapNotifyStatusToWorkAdStatus(params.notify.status)
     // Footer fields are untrusted. Clamp to ledger schema bounds so elevation
@@ -399,13 +401,14 @@ export function buildWorkAdFromNotify(params: {
     const causeKind = cause?.causeKind == null
         ? null
         : clampJsonUtf8(cause.causeKind, WORK_GRAPH_MAX_TAG)
+    const principalSessionId = params.principalSessionId ?? params.sessionId
     // Audit principal is always session-bound. notify.agent is untrusted
     // self-label text and stays advisory in payload/tags only.
     // Do not nest a full notify_summary copy — duplicating clamped strings
     // can blow the 32 KiB payload_json cap and silently drop the ledger row.
     return {
         source_kind: 'session',
-        source_ref: params.sessionId,
+        source_ref: principalSessionId,
         event_type: 'work_ad',
         summary,
         payload_json: {
@@ -434,7 +437,7 @@ export function buildWorkAdFromNotify(params: {
         expires_at: params.expiresAt ?? (params.ts + WORK_AD_DEFAULT_TTL_MS),
         principal: {
             kind: 'agent',
-            id: `session:${params.sessionId}`,
+            id: `session:${principalSessionId}`,
             on_behalf_of: String(params.ownerUserId)
         }
     }
@@ -444,18 +447,26 @@ export function buildWorkAdFromNotify(params: {
  * On message ingest: well-formed trailing AGENT_NOTIFY_SUMMARY →
  * idempotent work_ad row. Invalid/missing footer → no-op (null).
  *
- * Accepts agent assistant text, plus user-role deliveries stamped
- * `meta.notifySource: "peer"` (hapi-ping-peer / MCP ping_peer). Ordinary
- * web/CLI/Telegram prompts are never elevated even if they paste a footer.
+ * Accepts agent assistant text, plus user-role deliveries stamped by the
+ * CLI peer path (`meta.notifySource: "peer"` + `meta.sourceSessionId` from
+ * `POST /cli/sessions/:source/peer-messages`). Ordinary web/CLI/Telegram
+ * prompts are never elevated even if they paste a footer.
  *
  * Ledger rows are append-only audit: deleting the related session does not
  * delete work_ad rows (cold review M1).
  */
-function isPeerNotifyDelivery(content: unknown): boolean {
+function extractPeerSourceSessionId(content: unknown): string | null {
     const record = asRecord(content)
-    if (record?.role !== 'user') return false
+    if (record?.role !== 'user') return null
     const meta = asRecord(record.meta)
-    return meta?.notifySource === 'peer'
+    if (meta?.notifySource !== 'peer') return null
+    return typeof meta.sourceSessionId === 'string' && meta.sourceSessionId.trim().length > 0
+        ? meta.sourceSessionId.trim()
+        : null
+}
+
+function isPeerNotifyDelivery(content: unknown): boolean {
+    return extractPeerSourceSessionId(content) !== null
 }
 
 function extractPlainTextForNotify(content: unknown): string | null {
@@ -481,6 +492,8 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
         return null
     }
 
+    const peerSourceSessionId = extractPeerSourceSessionId(input.content)
+
     // Cause is hub-derived from session messages SQL (no REST 200 cap).
     const previousWorkAds = listPreviousWorkAds(input.store, input.namespace, input.sessionId)
     const messages = loadMessagesForCause(input.store, input.sessionId, previousWorkAds)
@@ -499,7 +512,8 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
         flavor: input.flavor,
         ts: input.ts,
         cause,
-        relatedEventId: previousEventId
+        relatedEventId: previousEventId,
+        principalSessionId: peerSourceSessionId ?? undefined
     })
 
     try {

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -444,22 +444,27 @@ export function buildWorkAdFromNotify(params: {
  * On message ingest: well-formed trailing AGENT_NOTIFY_SUMMARY →
  * idempotent work_ad row. Invalid/missing footer → no-op (null).
  *
- * Accepts agent assistant text and user-role deliveries (hapi-ping-peer /
- * attributed peer posts land as role=user). Capture must not depend on chat
- * display settings.
+ * Accepts agent assistant text, plus user-role deliveries stamped
+ * `meta.notifySource: "peer"` (hapi-ping-peer / MCP ping_peer). Ordinary
+ * web/CLI/Telegram prompts are never elevated even if they paste a footer.
  *
  * Ledger rows are append-only audit: deleting the related session does not
  * delete work_ad rows (cold review M1).
  */
+function isPeerNotifyDelivery(content: unknown): boolean {
+    const record = asRecord(content)
+    if (record?.role !== 'user') return false
+    const meta = asRecord(record.meta)
+    return meta?.notifySource === 'peer'
+}
+
 function extractPlainTextForNotify(content: unknown): string | null {
     if (isAgentMessageContent(content)) {
         const agentBody = unwrapRoleWrappedRecordEnvelope(content)
         const agentContent = agentBody?.role === 'agent' ? agentBody.content : content
         return extractAssistantPlainText(agentContent)
     }
-    if (isInboundUserMessage(content)) {
-        // Peer pings / attributed deliveries are role=user text with a trailing
-        // AGENT_NOTIFY_SUMMARY — same contract as agent footers.
+    if (isPeerNotifyDelivery(content)) {
         return extractInboundCauseText(content)
     }
     return null

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -122,6 +122,11 @@ export type NotifyIngestInput = {
     /** Authenticated hub owner id; required for accountable agent principal. */
     ownerUserId: string | number
     flavor?: string | null
+    /**
+     * Hub-validated peer sender id from POST /cli/sessions/:source/peer-messages.
+     * Never derived from persisted message meta (socket clients can forge that).
+     */
+    trustedPeerSourceSessionId?: string
 }
 
 export type NotifyIngestResult = InsertWorkGraphEventResult | null
@@ -454,42 +459,26 @@ export function buildWorkAdFromNotify(params: {
  * On message ingest: well-formed trailing AGENT_NOTIFY_SUMMARY →
  * idempotent work_ad row. Invalid/missing footer → no-op (null).
  *
- * Accepts agent assistant text, plus user-role deliveries stamped by the
- * CLI peer path (`meta.notifySource: "peer"` + `meta.sourceSessionId` from
- * `POST /cli/sessions/:source/peer-messages`). Ordinary web/CLI/Telegram
- * prompts are never elevated even if they paste a footer.
+ * Accepts agent assistant text, plus user-role deliveries from the
+ * validated CLI peer route (caller passes trustedPeerSourceSessionId).
+ * Persisted meta.notifySource is never trusted — socket clients can forge it.
+ * Ordinary web/CLI/Telegram prompts are never elevated even if they paste a footer.
  *
  * Ledger rows are append-only audit: deleting the related session does not
  * delete work_ad rows (cold review M1).
  */
-function extractPeerSourceSessionId(content: unknown): string | null {
-    const record = asRecord(content)
-    if (record?.role !== 'user') return null
-    const meta = asRecord(record.meta)
-    if (meta?.notifySource !== 'peer') return null
-    return typeof meta.sourceSessionId === 'string' && meta.sourceSessionId.trim().length > 0
-        ? meta.sourceSessionId.trim()
-        : null
-}
-
-function isPeerNotifyDelivery(content: unknown): boolean {
-    return extractPeerSourceSessionId(content) !== null
-}
-
-function extractPlainTextForNotify(content: unknown): string | null {
-    if (isAgentMessageContent(content)) {
-        const agentBody = unwrapRoleWrappedRecordEnvelope(content)
-        const agentContent = agentBody?.role === 'agent' ? agentBody.content : content
-        return extractAssistantPlainText(agentContent)
-    }
-    if (isPeerNotifyDelivery(content)) {
-        return extractInboundCauseText(content)
-    }
-    return null
+function extractAgentNotifyText(content: unknown): string | null {
+    if (!isAgentMessageContent(content)) return null
+    const agentBody = unwrapRoleWrappedRecordEnvelope(content)
+    const agentContent = agentBody?.role === 'agent' ? agentBody.content : content
+    return extractAssistantPlainText(agentContent)
 }
 
 export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): NotifyIngestResult {
-    const plainText = extractPlainTextForNotify(input.content)
+    const peerSourceSessionId = input.trustedPeerSourceSessionId?.trim() || null
+    const plainText = peerSourceSessionId
+        ? extractInboundCauseText(input.content)
+        : extractAgentNotifyText(input.content)
     if (!plainText) {
         return null
     }
@@ -499,7 +488,6 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
         return null
     }
 
-    const peerSourceSessionId = extractPeerSourceSessionId(input.content)
     const principalSessionId = peerSourceSessionId ?? input.sessionId
 
     // Cause is hub-derived from session messages SQL (no REST 200 cap).
@@ -509,13 +497,22 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
         input.sessionId,
         principalSessionId
     )
-    const messages = loadMessagesForCause(input.store, input.sessionId, previousWorkAds)
-    const assistantSeq = messages.find((message) => message.id === input.messageId)?.seq ?? null
-    const { cause, previousEventId } = resolveWorkAdCause({
-        messages,
-        previousWorkAds,
-        assistantSeq
-    })
+    // Peer deliveries are not a recipient turn response — do not attribute
+    // unrelated target prompts as cause of the peer-authored work_ad.
+    const { cause, previousEventId } = peerSourceSessionId
+        ? {
+            cause: null,
+            previousEventId: previousWorkAds.at(-1)?.id ?? null
+        }
+        : (() => {
+            const messages = loadMessagesForCause(input.store, input.sessionId, previousWorkAds)
+            const assistantSeq = messages.find((message) => message.id === input.messageId)?.seq ?? null
+            return resolveWorkAdCause({
+                messages,
+                previousWorkAds,
+                assistantSeq
+            })
+        })()
 
     const create = buildWorkAdFromNotify({
         sessionId: input.sessionId,

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -441,20 +441,32 @@ export function buildWorkAdFromNotify(params: {
 }
 
 /**
- * On assistant message ingest: well-formed trailing AGENT_NOTIFY_SUMMARY →
+ * On message ingest: well-formed trailing AGENT_NOTIFY_SUMMARY →
  * idempotent work_ad row. Invalid/missing footer → no-op (null).
+ *
+ * Accepts agent assistant text and user-role deliveries (hapi-ping-peer /
+ * attributed peer posts land as role=user). Capture must not depend on chat
+ * display settings.
  *
  * Ledger rows are append-only audit: deleting the related session does not
  * delete work_ad rows (cold review M1).
  */
-export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): NotifyIngestResult {
-    if (!isAgentMessageContent(input.content)) {
-        return null
+function extractPlainTextForNotify(content: unknown): string | null {
+    if (isAgentMessageContent(content)) {
+        const agentBody = unwrapRoleWrappedRecordEnvelope(content)
+        const agentContent = agentBody?.role === 'agent' ? agentBody.content : content
+        return extractAssistantPlainText(agentContent)
     }
+    if (isInboundUserMessage(content)) {
+        // Peer pings / attributed deliveries are role=user text with a trailing
+        // AGENT_NOTIFY_SUMMARY — same contract as agent footers.
+        return extractInboundCauseText(content)
+    }
+    return null
+}
 
-    const agentBody = unwrapRoleWrappedRecordEnvelope(input.content)
-    const agentContent = agentBody?.role === 'agent' ? agentBody.content : input.content
-    const plainText = extractAssistantPlainText(agentContent)
+export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): NotifyIngestResult {
+    const plainText = extractPlainTextForNotify(input.content)
     if (!plainText) {
         return null
     }

--- a/hub/src/sync/workGraphNotifyIngest.ts
+++ b/hub/src/sync/workGraphNotifyIngest.ts
@@ -251,13 +251,20 @@ function loadMessagesForCause(
 function listPreviousWorkAds(
     store: Store,
     namespace: string,
-    sessionId: string
+    sessionId: string,
+    principalSessionId: string
 ): WorkGraphEvent[] {
-    // Only hub notify elevation. Client POST /work-graph/events can mint
-    // work_ad rows; those must not steal related_event_id, follows, or sticky cause.
+    // Only hub notify elevation for this principal. Peer-authored rows share
+    // related_session_id with the recipient but must not steal related_event_id,
+    // follows, or sticky/legacy cause consume for the recipient's next summary.
+    // Client POST /work-graph/events can mint work_ad rows; those stay out via
+    // provenance !== AGENT_NOTIFY_SUMMARY.
     return store.workGraph
         .listWorkAdsByRelatedSession(namespace, sessionId)
-        .filter((event) => event.provenance === 'AGENT_NOTIFY_SUMMARY')
+        .filter((event) => (
+            event.provenance === 'AGENT_NOTIFY_SUMMARY'
+            && event.sourceRef === principalSessionId
+        ))
 }
 
 function consumedInboundIds(
@@ -493,9 +500,15 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
     }
 
     const peerSourceSessionId = extractPeerSourceSessionId(input.content)
+    const principalSessionId = peerSourceSessionId ?? input.sessionId
 
     // Cause is hub-derived from session messages SQL (no REST 200 cap).
-    const previousWorkAds = listPreviousWorkAds(input.store, input.namespace, input.sessionId)
+    const previousWorkAds = listPreviousWorkAds(
+        input.store,
+        input.namespace,
+        input.sessionId,
+        principalSessionId
+    )
     const messages = loadMessagesForCause(input.store, input.sessionId, previousWorkAds)
     const assistantSeq = messages.find((message) => message.id === input.messageId)?.seq ?? null
     const { cause, previousEventId } = resolveWorkAdCause({
@@ -513,7 +526,7 @@ export function ingestNotifySummaryFromMessage(input: NotifyIngestInput): Notify
         ts: input.ts,
         cause,
         relatedEventId: previousEventId,
-        principalSessionId: peerSourceSessionId ?? undefined
+        principalSessionId
     })
 
     try {

--- a/hub/src/web/routes/cli.ts
+++ b/hub/src/web/routes/cli.ts
@@ -5,6 +5,7 @@ import {
     CreateOrLoadSessionRequestSchema,
     ClearOpencodeSessionCallbackRequestSchema,
     CursorMigrateToAcpRequestSchema,
+    PeerMessageRequestSchema,
     PROTOCOL_VERSION
 } from '@hapi/protocol'
 import { getConfiguration } from '../../configuration'
@@ -283,6 +284,52 @@ export function createCliRoutes(getSyncEngine: () => SyncEngine | null): Hono<Cl
             now: Date.now()
         })
         return c.json({ messages })
+    })
+
+    /**
+     * Peer delivery with trusted source identity (CLI_API_TOKEN namespace).
+     * Path `:id` is the source session; body.targetSessionId is the recipient.
+     * Web JWT `/api/*` cannot stamp notifySource=peer.
+     */
+    app.post('/sessions/:id/peer-messages', async (c) => {
+        const engine = getSyncEngine()
+        if (!engine) {
+            return c.json({ error: 'Not ready' }, 503)
+        }
+        const sourceSessionId = c.req.param('id')
+        const namespace = c.get('namespace')
+        const source = resolveSessionForNamespace(engine, sourceSessionId, namespace)
+        if (!source.ok) {
+            return c.json({ error: source.error }, source.status)
+        }
+
+        const body = await c.req.json().catch(() => null)
+        const parsed = PeerMessageRequestSchema.safeParse(body)
+        if (!parsed.success) {
+            return c.json({ error: 'Invalid body', issues: parsed.error.flatten() }, 400)
+        }
+
+        const target = resolveSessionForNamespace(engine, parsed.data.targetSessionId, namespace)
+        if (!target.ok) {
+            return c.json({ error: target.error }, target.status)
+        }
+        if (target.sessionId === source.sessionId) {
+            return c.json({
+                error: 'Source and target session must differ',
+                code: 'peer_source_equals_target'
+            }, 400)
+        }
+        if (!target.session.active) {
+            return c.json({ error: 'Session is not active', code: 'session_inactive' }, 409)
+        }
+
+        await engine.sendMessage(target.sessionId, {
+            text: parsed.data.text,
+            sentFrom: 'webapp',
+            notifySource: 'peer',
+            peerSourceSessionId: source.sessionId
+        })
+        return c.json({ ok: true })
     })
 
     app.post('/sessions/:id/migrate-to-acp', async (c) => {

--- a/hub/src/web/routes/cli.ts
+++ b/hub/src/web/routes/cli.ts
@@ -325,7 +325,7 @@ export function createCliRoutes(getSyncEngine: () => SyncEngine | null): Hono<Cl
 
         await engine.sendMessage(target.sessionId, {
             text: parsed.data.text,
-            sentFrom: 'webapp',
+            sentFrom: 'peer',
             notifySource: 'peer',
             peerSourceSessionId: source.sessionId
         })

--- a/hub/src/web/routes/messages.ts
+++ b/hub/src/web/routes/messages.ts
@@ -1,5 +1,10 @@
 import { Hono } from 'hono'
-import { MessagesQuerySchema, QueuedStateRequestSchema, SendMessageRequestSchema } from '@hapi/protocol'
+import {
+    MessagesQuerySchema,
+    PeerMessageRequestSchema,
+    QueuedStateRequestSchema,
+    SendMessageRequestSchema
+} from '@hapi/protocol'
 import type { SyncEngine } from '../../sync/syncEngine'
 import type { WebAppEnv } from '../middleware/auth'
 import { requireSessionFromParam, requireSyncEngine } from './guards'
@@ -147,8 +152,34 @@ export function createMessagesRoutes(getSyncEngine: () => SyncEngine | null): Ho
             attachments: parsed.data.attachments,
             sentFrom: 'webapp',
             scheduledAt: parsed.data.scheduledAt,
-            deliveryMode: parsed.data.deliveryMode,
-            notifySource: parsed.data.notifySource
+            deliveryMode: parsed.data.deliveryMode
+        })
+        return c.json({ ok: true })
+    })
+
+    app.post('/sessions/:id/peer-messages', async (c) => {
+        const engine = requireSyncEngine(c, getSyncEngine)
+        if (engine instanceof Response) {
+            return engine
+        }
+
+        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
+        if (sessionResult instanceof Response) {
+            return sessionResult
+        }
+        const sessionId = sessionResult.sessionId
+
+        const body = await c.req.json().catch(() => null)
+        const parsed = PeerMessageRequestSchema.safeParse(body)
+        if (!parsed.success) {
+            return c.json({ error: 'Invalid body', issues: parsed.error.flatten() }, 400)
+        }
+
+        // Server-side stamp only — clients cannot set notifySource on ordinary /messages.
+        await engine.sendMessage(sessionId, {
+            text: parsed.data.text,
+            sentFrom: 'webapp',
+            notifySource: 'peer'
         })
         return c.json({ ok: true })
     })

--- a/hub/src/web/routes/messages.ts
+++ b/hub/src/web/routes/messages.ts
@@ -1,7 +1,6 @@
 import { Hono } from 'hono'
 import {
     MessagesQuerySchema,
-    PeerMessageRequestSchema,
     QueuedStateRequestSchema,
     SendMessageRequestSchema
 } from '@hapi/protocol'
@@ -153,33 +152,6 @@ export function createMessagesRoutes(getSyncEngine: () => SyncEngine | null): Ho
             sentFrom: 'webapp',
             scheduledAt: parsed.data.scheduledAt,
             deliveryMode: parsed.data.deliveryMode
-        })
-        return c.json({ ok: true })
-    })
-
-    app.post('/sessions/:id/peer-messages', async (c) => {
-        const engine = requireSyncEngine(c, getSyncEngine)
-        if (engine instanceof Response) {
-            return engine
-        }
-
-        const sessionResult = requireSessionFromParam(c, engine, { requireActive: true })
-        if (sessionResult instanceof Response) {
-            return sessionResult
-        }
-        const sessionId = sessionResult.sessionId
-
-        const body = await c.req.json().catch(() => null)
-        const parsed = PeerMessageRequestSchema.safeParse(body)
-        if (!parsed.success) {
-            return c.json({ error: 'Invalid body', issues: parsed.error.flatten() }, 400)
-        }
-
-        // Server-side stamp only — clients cannot set notifySource on ordinary /messages.
-        await engine.sendMessage(sessionId, {
-            text: parsed.data.text,
-            sentFrom: 'webapp',
-            notifySource: 'peer'
         })
         return c.json({ ok: true })
     })

--- a/hub/src/web/routes/messages.ts
+++ b/hub/src/web/routes/messages.ts
@@ -147,7 +147,8 @@ export function createMessagesRoutes(getSyncEngine: () => SyncEngine | null): Ho
             attachments: parsed.data.attachments,
             sentFrom: 'webapp',
             scheduledAt: parsed.data.scheduledAt,
-            deliveryMode: parsed.data.deliveryMode
+            deliveryMode: parsed.data.deliveryMode,
+            notifySource: parsed.data.notifySource
         })
         return c.json({ ok: true })
     })

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -548,9 +548,15 @@ export const SendMessageRequestSchema = z.object({
 
 export type SendMessageRequest = z.infer<typeof SendMessageRequestSchema>
 
-/** Peer-delivery only (hapi-ping-peer). Hub stamps meta.notifySource=peer; clients cannot set it on ordinary /messages. */
+/**
+ * CLI peer-delivery body (`POST /cli/sessions/:sourceSessionId/peer-messages`).
+ * Path id is the authenticated source session (CLI_API_TOKEN namespace); hub stamps
+ * meta.notifySource=peer + sourceSessionId. Web JWT `/api/*` cannot mint this stamp.
+ */
 export const PeerMessageRequestSchema = z.object({
-    text: z.string().min(1)
+    text: z.string().min(1),
+    /** Receiving session id — must exist in the same hub namespace as the source. */
+    targetSessionId: z.string().min(1)
 })
 
 export type PeerMessageRequest = z.infer<typeof PeerMessageRequestSchema>

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -531,9 +531,7 @@ export const SendMessageRequestSchema = z.object({
     localId: z.string().min(1).optional(),
     attachments: z.array(AttachmentMetadataSchema).optional(),
     scheduledAt: z.number().int().positive().nullable().optional(),
-    deliveryMode: MessageDeliveryModeSchema.optional(),
-    /** When set by peer-delivery clients (hapi-ping-peer / MCP ping_peer), hub stamps message meta for notify ingest. */
-    notifySource: z.literal('peer').optional()
+    deliveryMode: MessageDeliveryModeSchema.optional()
 }).refine(
     (data) => data.scheduledAt == null || typeof data.localId === 'string',
     { message: 'scheduledAt requires localId', path: ['localId'] }
@@ -549,6 +547,13 @@ export const SendMessageRequestSchema = z.object({
 )
 
 export type SendMessageRequest = z.infer<typeof SendMessageRequestSchema>
+
+/** Peer-delivery only (hapi-ping-peer). Hub stamps meta.notifySource=peer; clients cannot set it on ordinary /messages. */
+export const PeerMessageRequestSchema = z.object({
+    text: z.string().min(1)
+})
+
+export type PeerMessageRequest = z.infer<typeof PeerMessageRequestSchema>
 
 export const ForkConversationRequestSchema = z.object({
     messageLocalId: z.string().min(1).optional()

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -531,7 +531,9 @@ export const SendMessageRequestSchema = z.object({
     localId: z.string().min(1).optional(),
     attachments: z.array(AttachmentMetadataSchema).optional(),
     scheduledAt: z.number().int().positive().nullable().optional(),
-    deliveryMode: MessageDeliveryModeSchema.optional()
+    deliveryMode: MessageDeliveryModeSchema.optional(),
+    /** When set by peer-delivery clients (hapi-ping-peer / MCP ping_peer), hub stamps message meta for notify ingest. */
+    notifySource: z.literal('peer').optional()
 }).refine(
     (data) => data.scheduledAt == null || typeof data.localId === 'string',
     { message: 'scheduledAt requires localId', path: ['localId'] }


### PR DESCRIPTION
## Summary

- `ingestNotifySummaryFromMessage` rejected non-agent message shapes, so `hapi-ping-peer` / attributed peer deliveries (`role=user` text with a trailing `AGENT_NOTIFY_SUMMARY`) never became work-graph `work_ad` rows.
- Now extracts plain text from user-role inbound the same way cause stamping already does, then applies the existing notify footer parser.
- Agent path unchanged.

## Test plan

- [x] `bun test hub/src/sync/workGraphNotifyIngest.test.ts` (includes new peer user-role case)
- [ ] Dogfood: peer ping with trailing `AGENT_NOTIFY_SUMMARY` → work_ad / Session Log capture on a hub that has this tip

## Issues

Fixes #1737