### PR TITLE
fix(web): keep streamed reasoning/text block ids stable across snapshot rows

### DIFF
--- a/android/core/protocol/src/main/kotlin/app/hapi/protocol/chat/ReducerTimeline.kt
+++ b/android/core/protocol/src/main/kotlin/app/hapi/protocol/chat/ReducerTimeline.kt
@@ -25,6 +25,14 @@ class TimelineResult(
 
 private fun getEventString(event: JsonObject, key: String): String? = asString(event[key])
 
+/**
+ * Stream identity must match the wire-level semantics in shared/src/messages.ts
+ * (blank ids are not streams): a blank value falls back to row-derived ids
+ * instead of colliding every blank-id row onto one block identity.
+ */
+private fun nonBlankStreamId(value: String?): String? =
+    value?.takeIf { it.isNotBlank() }
+
 private fun getEventNumber(event: JsonObject, key: String): Double? = asNumber(event[key])
 
 private fun getAgentRunStartedAt(event: JsonObject): Double? =
@@ -775,7 +783,7 @@ fun reduceTimeline(
                             )
                             continue
                         }
-                        val streamId = c.streamId
+                        val streamId = nonBlankStreamId(c.streamId)
                         if (streamId != null) {
                             val existing = textBlocksByStreamId[streamId]
                             if (existing != null) {
@@ -825,7 +833,7 @@ fun reduceTimeline(
                     }
 
                     is NormalizedAgentContent.Reasoning -> {
-                        val streamId = c.streamId
+                        val streamId = nonBlankStreamId(c.streamId)
                         if (streamId != null) {
                             val existing = reasoningBlocksByStreamId[streamId]
                             if (existing != null) {

--- a/android/core/protocol/src/main/kotlin/app/hapi/protocol/chat/ReducerTimeline.kt
+++ b/android/core/protocol/src/main/kotlin/app/hapi/protocol/chat/ReducerTimeline.kt
@@ -789,7 +789,11 @@ fun reduceTimeline(
                         }
 
                         val block = AgentTextBlock(
-                            id = "${msg.id}:$idx",
+                            // Stream-stable id (mirrors web/src/chat/reducerTimeline.ts):
+                            // snapshots of one stream arrive as separate rows that
+                            // the window keeps swapping, so a row-derived id would
+                            // churn per snapshot and remount the rendered block.
+                            id = streamId ?: "${msg.id}:$idx",
                             localId = msg.localId,
                             createdAt = msg.createdAt,
                             invokedAt = msg.invokedAt,
@@ -835,7 +839,10 @@ fun reduceTimeline(
                         }
 
                         val block = AgentReasoningBlock(
-                            id = "${msg.id}:$idx",
+                            // Stream-stable id (mirrors web/src/chat/reducerTimeline.ts):
+                            // keeps the reasoning block identity stable across its
+                            // snapshot rows so clients update it in place.
+                            id = streamId ?: "${msg.id}:$idx",
                             localId = msg.localId,
                             createdAt = msg.createdAt,
                             invokedAt = msg.invokedAt,

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -212,6 +212,8 @@ On first run, HAPI:
 | `HAPI_TITLE_PROVIDER_MODEL` | - | - | Server-only lightweight model used for generated session titles |
 | `HAPI_TITLE_SUGGESTION_RATE_LIMIT` | `5` | - | Maximum title suggestions per session in the rate-limit window |
 | `HAPI_TITLE_SUGGESTION_RATE_WINDOW_MS` | `600000` | - | Title suggestion rate-limit window in milliseconds |
+| `HAPI_TITLE_PROVIDER_MAX_TOKENS` | `64` | - | Maximum completion-token budget per generated title; raise for reasoning-model providers |
+| `HAPI_TITLE_PROVIDER_TIMEOUT_MS` | `10000` | - | Title provider request timeout in milliseconds |
 </details>
 
 The session rename dialog's **Generate** action is unavailable until all three

--- a/hub/src/sync/titleSuggestion.test.ts
+++ b/hub/src/sync/titleSuggestion.test.ts
@@ -7,6 +7,7 @@ import {
     normalizeTitleSuggestion,
     OpenAICompatibleTitleProvider,
     readTitleProviderConfig,
+    readTitleProviderRequestLimits,
     readTitleSuggestionLimits,
     TitleSuggestionError,
     TitleSuggestionService
@@ -97,6 +98,35 @@ describe('OpenAI-compatible title provider', () => {
         expect(normalizeTitleSuggestion('Title: "A useful title"\nExtra text')).toBe('A useful title')
         expect(normalizeTitleSuggestion('   ')).toBeNull()
         expect(normalizeTitleSuggestion('x'.repeat(100))).toHaveLength(80)
+    })
+
+    it('honors env-tunable max_tokens and timeout', async () => {
+        expect(readTitleProviderRequestLimits({})).toEqual({ maxTokens: 64, timeoutMs: 10_000 })
+        expect(readTitleProviderRequestLimits({
+            HAPI_TITLE_PROVIDER_MAX_TOKENS: '4096',
+            HAPI_TITLE_PROVIDER_TIMEOUT_MS: '90000'
+        })).toEqual({ maxTokens: 4096, timeoutMs: 90_000 })
+        // Invalid values fall back to the defaults instead of breaking startup.
+        expect(readTitleProviderRequestLimits({ HAPI_TITLE_PROVIDER_MAX_TOKENS: '-5' })).toEqual({ maxTokens: 64, timeoutMs: 10_000 })
+
+        let request: Request | undefined
+        const provider = new OpenAICompatibleTitleProvider(
+            {
+                baseUrl: 'https://example.test/v1',
+                apiKey: 'secret',
+                model: 'small-model',
+                maxTokens: 4096
+            },
+            async (input, init) => {
+                request = new Request(String(input), init)
+                return new Response(JSON.stringify({
+                    choices: [{ message: { content: 'Title' } }]
+                }), { status: 200 })
+            }
+        )
+
+        await provider.suggest('Recent conversation')
+        expect(await request?.json()).toMatchObject({ max_tokens: 4096 })
     })
 })
 

--- a/hub/src/sync/titleSuggestion.test.ts
+++ b/hub/src/sync/titleSuggestion.test.ts
@@ -128,6 +128,26 @@ describe('OpenAI-compatible title provider', () => {
         await provider.suggest('Recent conversation')
         expect(await request?.json()).toMatchObject({ max_tokens: 4096 })
     })
+
+    it('aborts the request when the configured timeout elapses', async () => {
+        const provider = new OpenAICompatibleTitleProvider(
+            {
+                baseUrl: 'https://example.test/v1',
+                apiKey: 'secret',
+                model: 'small-model',
+                timeoutMs: 20
+            },
+            async (input, init) => {
+                return new Promise((resolve, reject) => {
+                    const signal = init?.signal
+                    if (!signal) throw new Error('expected an AbortSignal')
+                    signal.addEventListener('abort', () => reject(signal.reason))
+                })
+            }
+        )
+
+        await expect(provider.suggest('Recent conversation')).rejects.toMatchObject({ name: 'AbortError' })
+    })
 })
 
 describe('TitleSuggestionService', () => {

--- a/hub/src/sync/titleSuggestion.ts
+++ b/hub/src/sync/titleSuggestion.ts
@@ -13,8 +13,11 @@ export const TITLE_SUGGESTION_MAX_TITLE_CHARS = 80
 export const TITLE_SUGGESTION_RATE_LIMIT = 5
 export const TITLE_SUGGESTION_RATE_WINDOW_MS = 10 * 60 * 1000
 export const TITLE_SUGGESTION_TIMEOUT_MS = 10_000
+export const TITLE_SUGGESTION_MAX_TOKENS = 64
 const TITLE_SUGGESTION_RATE_LIMIT_ENV = 'HAPI_TITLE_SUGGESTION_RATE_LIMIT'
 const TITLE_SUGGESTION_RATE_WINDOW_ENV = 'HAPI_TITLE_SUGGESTION_RATE_WINDOW_MS'
+const TITLE_PROVIDER_MAX_TOKENS_ENV = 'HAPI_TITLE_PROVIDER_MAX_TOKENS'
+const TITLE_PROVIDER_TIMEOUT_MS_ENV = 'HAPI_TITLE_PROVIDER_TIMEOUT_MS'
 
 type TitleSuggestionErrorCode = 'unavailable' | 'empty' | 'rate-limited' | 'provider'
 
@@ -36,6 +39,7 @@ export type OpenAICompatibleTitleProviderConfig = {
     apiKey: string
     model: string
     timeoutMs?: number
+    maxTokens?: number
 }
 
 type TitleProviderFetch = (
@@ -72,6 +76,18 @@ export function readTitleSuggestionLimits(
     return {
         rateLimit: readPositiveInteger(env[TITLE_SUGGESTION_RATE_LIMIT_ENV], TITLE_SUGGESTION_RATE_LIMIT),
         rateWindowMs: readPositiveInteger(env[TITLE_SUGGESTION_RATE_WINDOW_ENV], TITLE_SUGGESTION_RATE_WINDOW_MS)
+    }
+}
+
+/// Some providers (e.g. reasoning models) need more than one emitted token
+/// per title and more than 10s to produce it, so both knobs are tunable via
+/// environment without changing the defaults for standard providers.
+export function readTitleProviderRequestLimits(
+    env: TitleProviderEnvironment = process.env
+): { maxTokens: number; timeoutMs: number } {
+    return {
+        maxTokens: readPositiveInteger(env[TITLE_PROVIDER_MAX_TOKENS_ENV], TITLE_SUGGESTION_MAX_TOKENS),
+        timeoutMs: readPositiveInteger(env[TITLE_PROVIDER_TIMEOUT_MS_ENV], TITLE_SUGGESTION_TIMEOUT_MS)
     }
 }
 
@@ -221,12 +237,14 @@ function extractProviderText(value: unknown): string | null {
 
 export class OpenAICompatibleTitleProvider {
     private readonly timeoutMs: number
+    private readonly maxTokens: number
 
     constructor(
         private readonly config: OpenAICompatibleTitleProviderConfig,
         private readonly fetchImpl: TitleProviderFetch = fetch
     ) {
         this.timeoutMs = config.timeoutMs ?? TITLE_SUGGESTION_TIMEOUT_MS
+        this.maxTokens = config.maxTokens ?? TITLE_SUGGESTION_MAX_TOKENS
     }
 
     async suggest(prompt: string): Promise<string> {
@@ -243,7 +261,7 @@ export class OpenAICompatibleTitleProvider {
                 body: JSON.stringify({
                     model: this.config.model,
                     temperature: 0.2,
-                    max_tokens: 64,
+                    max_tokens: this.maxTokens,
                     messages: [
                         {
                             role: 'system',
@@ -350,10 +368,11 @@ export class TitleSuggestionService {
 export function createTitleSuggestionService(store: Store): TitleSuggestionService {
     const config = readTitleProviderConfig()
     const limits = readTitleSuggestionLimits()
+    const requestLimits = readTitleProviderRequestLimits()
     return new TitleSuggestionService(
         store,
         {
-            provider: config ? new OpenAICompatibleTitleProvider(config) : null,
+            provider: config ? new OpenAICompatibleTitleProvider({ ...config, ...requestLimits }) : null,
             ...limits
         }
     )

--- a/ios/Packages/HapiKit/Sources/HapiProtocol/Chat/ReducerTimeline.swift
+++ b/ios/Packages/HapiKit/Sources/HapiProtocol/Chat/ReducerTimeline.swift
@@ -317,6 +317,15 @@ private func setDurationMs(_ box: BlockBox, _ durationMs: Int) {
 // MARK: - reduceTimeline
 
 /// Port of `reduceTimeline`.
+
+/// Stream identity must match the wire-level semantics in shared/src/messages.ts
+/// (blank ids are not streams): a blank value falls back to row-derived ids
+/// instead of colliding every blank-id row onto one block identity.
+private func nonBlankStreamId(_ value: String?) -> String? {
+    guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+    return value
+}
+
 // swiftlint:disable:next cyclomatic_complexity function_body_length
 func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) -> TimelineResult {
     var blocks: [BlockBox] = []
@@ -784,7 +793,7 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                         ))))
                         continue
                     }
-                    if let streamId = textContent.streamId, let existingBox = textBlocksByStreamId[streamId] {
+                    if let streamId = nonBlankStreamId(textContent.streamId), let existingBox = textBlocksByStreamId[streamId] {
                         if var existing = existingBox.block.asAgentText {
                             existing.text = textContent.text
                             existing.usage = msg.usage
@@ -812,7 +821,7 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                         meta: msg.meta
                     )))
                     blocks.append(box)
-                    if let streamId = textContent.streamId {
+                    if let streamId = nonBlankStreamId(textContent.streamId) {
                         textBlocksByStreamId[streamId] = box
                     }
                     continue
@@ -832,7 +841,7 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                     continue
 
                 case .reasoning(let reasoningContent):
-                    if let streamId = reasoningContent.streamId, let existingBox = reasoningBlocksByStreamId[streamId] {
+                    if let streamId = nonBlankStreamId(reasoningContent.streamId), let existingBox = reasoningBlocksByStreamId[streamId] {
                         if var existing = existingBox.block.asAgentReasoning {
                             existing.text = reasoningContent.text
                             existing.usage = msg.usage
@@ -859,7 +868,7 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                         meta: msg.meta
                     )))
                     blocks.append(box)
-                    if let streamId = reasoningContent.streamId {
+                    if let streamId = nonBlankStreamId(reasoningContent.streamId) {
                         reasoningBlocksByStreamId[streamId] = box
                     }
                     continue

--- a/ios/Packages/HapiKit/Sources/HapiProtocol/Chat/ReducerTimeline.swift
+++ b/ios/Packages/HapiKit/Sources/HapiProtocol/Chat/ReducerTimeline.swift
@@ -797,7 +797,11 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                     }
 
                     let box = BlockBox(.agentText(AgentTextBlock(
-                        id: "\(msg.id):\(idx)",
+                        // Stream-stable id (mirrors web/src/chat/reducerTimeline.ts):
+                        // snapshots of one stream arrive as separate rows that
+                        // the window keeps swapping, so a row-derived id would
+                        // churn per snapshot and remount the rendered block.
+                        id: textContent.streamId ?? "\(msg.id):\(idx)",
                         localId: msg.localId,
                         createdAt: msg.createdAt,
                         invokedAt: msg.invokedAt,
@@ -841,7 +845,10 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                     }
 
                     let box = BlockBox(.agentReasoning(AgentReasoningBlock(
-                        id: "\(msg.id):\(idx)",
+                        // Stream-stable id (mirrors web/src/chat/reducerTimeline.ts):
+                        // keeps the reasoning block identity stable across its
+                        // snapshot rows so clients update it in place.
+                        id: reasoningContent.streamId ?? "\(msg.id):\(idx)",
                         localId: msg.localId,
                         createdAt: msg.createdAt,
                         invokedAt: msg.invokedAt,

--- a/ios/Packages/HapiKit/Sources/HapiProtocol/Chat/ReducerTimeline.swift
+++ b/ios/Packages/HapiKit/Sources/HapiProtocol/Chat/ReducerTimeline.swift
@@ -793,7 +793,8 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                         ))))
                         continue
                     }
-                    if let streamId = nonBlankStreamId(textContent.streamId), let existingBox = textBlocksByStreamId[streamId] {
+                    let streamId = nonBlankStreamId(textContent.streamId)
+                    if let streamId, let existingBox = textBlocksByStreamId[streamId] {
                         if var existing = existingBox.block.asAgentText {
                             existing.text = textContent.text
                             existing.usage = msg.usage
@@ -810,7 +811,7 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                         // snapshots of one stream arrive as separate rows that
                         // the window keeps swapping, so a row-derived id would
                         // churn per snapshot and remount the rendered block.
-                        id: textContent.streamId ?? "\(msg.id):\(idx)",
+                        id: streamId ?? "\(msg.id):\(idx)",
                         localId: msg.localId,
                         createdAt: msg.createdAt,
                         invokedAt: msg.invokedAt,
@@ -821,7 +822,7 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                         meta: msg.meta
                     )))
                     blocks.append(box)
-                    if let streamId = nonBlankStreamId(textContent.streamId) {
+                    if let streamId {
                         textBlocksByStreamId[streamId] = box
                     }
                     continue
@@ -841,7 +842,8 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                     continue
 
                 case .reasoning(let reasoningContent):
-                    if let streamId = nonBlankStreamId(reasoningContent.streamId), let existingBox = reasoningBlocksByStreamId[streamId] {
+                    let streamId = nonBlankStreamId(reasoningContent.streamId)
+                    if let streamId, let existingBox = reasoningBlocksByStreamId[streamId] {
                         if var existing = existingBox.block.asAgentReasoning {
                             existing.text = reasoningContent.text
                             existing.usage = msg.usage
@@ -857,7 +859,7 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                         // Stream-stable id (mirrors web/src/chat/reducerTimeline.ts):
                         // keeps the reasoning block identity stable across its
                         // snapshot rows so clients update it in place.
-                        id: reasoningContent.streamId ?? "\(msg.id):\(idx)",
+                        id: streamId ?? "\(msg.id):\(idx)",
                         localId: msg.localId,
                         createdAt: msg.createdAt,
                         invokedAt: msg.invokedAt,
@@ -868,7 +870,7 @@ func reduceTimeline(_ messages: [NormalizedMessage], context: ReducerContext) ->
                         meta: msg.meta
                     )))
                     blocks.append(box)
-                    if let streamId = nonBlankStreamId(reasoningContent.streamId) {
+                    if let streamId {
                         reasoningBlocksByStreamId[streamId] = box
                     }
                     continue

--- a/ios/Packages/HapiKit/Tests/HapiProtocolTests/ChatStreamIdentityTests.swift
+++ b/ios/Packages/HapiKit/Tests/HapiProtocolTests/ChatStreamIdentityTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import HapiProtocol
+import Testing
+
+/// Stream-id identity rules for the timeline reducer: streamed reasoning/text
+/// blocks must take their identity from the (non-blank) stream id, and blank
+/// stream ids — which are not streams per shared/src/messages.ts — must fall
+/// back to row-derived ids instead of colliding onto one blank identity.
+@Suite("Chat stream identity")
+struct ChatStreamIdentityTests {
+    private static func agentMessage(_ id: String, text: String, streamId: String?) -> NormalizedMessage {
+        NormalizedMessage(
+            id: id,
+            createdAt: 1_700_000_000_000,
+            content: .agent([.reasoning(.init(text: text, uuid: id, streamId: streamId))])
+        )
+    }
+
+    private static func textMessage(_ id: String, text: String, streamId: String?) -> NormalizedMessage {
+        NormalizedMessage(
+            id: id,
+            createdAt: 1_700_000_000_000,
+            content: .agent([.text(.init(text: text, uuid: id, streamId: streamId))])
+        )
+    }
+
+    private static func reasoningIds(_ messages: [NormalizedMessage]) -> [String] {
+        reduceChatBlocks(messages, agentState: nil).blocks.compactMap { $0.asAgentReasoning?.id }
+    }
+
+    private static func textIds(_ messages: [NormalizedMessage]) -> [String] {
+        reduceChatBlocks(messages, agentState: nil).blocks.compactMap { $0.asAgentText?.id }
+    }
+
+    @Test("reasoning blocks take the stream id as their identity")
+    func reasoningIdentityUsesStreamId() {
+        let rows = [
+            Self.agentMessage("row-1", text: "partial", streamId: "stream-1"),
+            Self.agentMessage("row-2", text: "partial extended", streamId: "stream-1")
+        ]
+
+        #expect(Self.reasoningIds(rows) == ["stream-1"])
+    }
+
+    @Test("text blocks take the stream id as their identity")
+    func textIdentityUsesStreamId() {
+        let rows = [
+            Self.textMessage("row-1", text: "partial", streamId: "stream-1"),
+            Self.textMessage("row-2", text: "partial extended", streamId: "stream-1")
+        ]
+
+        #expect(Self.textIds(rows) == ["stream-1"])
+    }
+
+    @Test("blank reasoning stream ids fall back to distinct row-derived ids")
+    func blankReasoningStreamIdsFallBackToRowIds() {
+        let rows = [
+            Self.agentMessage("blank-1", text: "one", streamId: ""),
+            Self.agentMessage("blank-2", text: "two", streamId: "   ")
+        ]
+
+        #expect(Self.reasoningIds(rows) == ["blank-1:0", "blank-2:0"])
+    }
+
+    @Test("blank text stream ids fall back to distinct row-derived ids")
+    func blankTextStreamIdsFallBackToRowIds() {
+        let rows = [
+            Self.textMessage("blank-1", text: "one", streamId: ""),
+            Self.textMessage("blank-2", text: "two", streamId: "   ")
+        ]
+
+        #expect(Self.textIds(rows) == ["blank-1:0", "blank-2:0"])
+    }
+}

--- a/shared/fixtures/chat/codex-blank-stream-ids.json
+++ b/shared/fixtures/chat/codex-blank-stream-ids.json
@@ -1,0 +1,145 @@
+{
+    "description": "Codex family: blank (empty or whitespace-only) data.id values are not stream identities (shared/src/messages.ts trims before accepting) — each payload keeps its own row-derived block id instead of collapsing onto a shared blank identity.",
+    "expected": {
+        "blocks": [
+            {
+                "createdAt": 1755000000000,
+                "id": "msg-codex-065:0",
+                "kind": "agent-reasoning",
+                "localId": null,
+                "text": "blank id one"
+            },
+            {
+                "createdAt": 1755000000100,
+                "id": "msg-codex-066:0",
+                "kind": "agent-reasoning",
+                "localId": null,
+                "text": "blank id two"
+            },
+            {
+                "createdAt": 1755000000200,
+                "id": "msg-codex-067:0",
+                "kind": "agent-text",
+                "localId": null,
+                "text": "blank id text one"
+            },
+            {
+                "createdAt": 1755000000300,
+                "id": "msg-codex-068:0",
+                "kind": "agent-text",
+                "localId": null,
+                "text": "blank id text two"
+            }
+        ],
+        "hasReadyEvent": false,
+        "latestUsage": null,
+        "visibleBlocks": [
+            {
+                "createdAt": 1755000000000,
+                "id": "msg-codex-065:0",
+                "kind": "agent-reasoning",
+                "localId": null,
+                "text": "blank id one"
+            },
+            {
+                "createdAt": 1755000000100,
+                "id": "msg-codex-066:0",
+                "kind": "agent-reasoning",
+                "localId": null,
+                "text": "blank id two"
+            },
+            {
+                "createdAt": 1755000000200,
+                "id": "msg-codex-067:0",
+                "kind": "agent-text",
+                "localId": null,
+                "text": "blank id text one"
+            },
+            {
+                "createdAt": 1755000000300,
+                "id": "msg-codex-068:0",
+                "kind": "agent-text",
+                "localId": null,
+                "text": "blank id text two"
+            }
+        ]
+    },
+    "fixtureVersion": 1,
+    "input": {
+        "agentState": null,
+        "messages": [
+            {
+                "content": {
+                    "content": {
+                        "data": {
+                            "id": "",
+                            "message": "blank id one",
+                            "type": "reasoning"
+                        },
+                        "type": "codex"
+                    },
+                    "role": "agent"
+                },
+                "createdAt": 1755000000000,
+                "id": "msg-codex-065",
+                "localId": null,
+                "seq": 1
+            },
+            {
+                "content": {
+                    "content": {
+                        "data": {
+                            "id": "   ",
+                            "message": "blank id two",
+                            "type": "reasoning"
+                        },
+                        "type": "codex"
+                    },
+                    "role": "agent"
+                },
+                "createdAt": 1755000000100,
+                "id": "msg-codex-066",
+                "localId": null,
+                "seq": 2
+            },
+            {
+                "content": {
+                    "content": {
+                        "data": {
+                            "id": "",
+                            "message": "blank id text one",
+                            "type": "message"
+                        },
+                        "type": "codex"
+                    },
+                    "role": "agent"
+                },
+                "createdAt": 1755000000200,
+                "id": "msg-codex-067",
+                "localId": null,
+                "seq": 3
+            },
+            {
+                "content": {
+                    "content": {
+                        "data": {
+                            "id": "   ",
+                            "message": "blank id text two",
+                            "type": "message"
+                        },
+                        "type": "codex"
+                    },
+                    "role": "agent"
+                },
+                "createdAt": 1755000000300,
+                "id": "msg-codex-068",
+                "localId": null,
+                "seq": 4
+            }
+        ],
+        "options": {
+            "hasMoreMessages": false
+        }
+    },
+    "name": "codex-blank-stream-ids"
+}

--- a/shared/fixtures/chat/codex-message-stream-snapshot.json
+++ b/shared/fixtures/chat/codex-message-stream-snapshot.json
@@ -4,7 +4,7 @@
         "blocks": [
             {
                 "createdAt": 1755000000000,
-                "id": "msg-codex-051:0",
+                "id": "item_7",
                 "kind": "agent-text",
                 "localId": null,
                 "text": "Tracking down the failing pagination test: the cursor math drops the epoch check when seq wraps."
@@ -15,7 +15,7 @@
         "visibleBlocks": [
             {
                 "createdAt": 1755000000000,
-                "id": "msg-codex-051:0",
+                "id": "item_7",
                 "kind": "agent-text",
                 "localId": null,
                 "text": "Tracking down the failing pagination test: the cursor math drops the epoch check when seq wraps."

--- a/shared/fixtures/chat/codex-message-stream-snapshot.json
+++ b/shared/fixtures/chat/codex-message-stream-snapshot.json
@@ -1,5 +1,5 @@
 {
-    "description": "Codex family: two message payloads sharing a stream id (data.id) are cumulative snapshots. Expects a single agent-text block keyed by the first message, carrying the final snapshot text.",
+    "description": "Codex family: two message payloads sharing a stream id (data.id) are cumulative snapshots. Expects a single agent-text block keyed by that stable stream id, carrying the final snapshot text.",
     "expected": {
         "blocks": [
             {

--- a/shared/fixtures/chat/codex-reasoning.json
+++ b/shared/fixtures/chat/codex-reasoning.json
@@ -1,5 +1,5 @@
 {
-    "description": "Codex family: reasoning payload becomes an agent-reasoning block (stream id kept internal — not part of the projection).",
+    "description": "Codex family: reasoning payload becomes an agent-reasoning block keyed by its stream id (data.id).",
     "expected": {
         "blocks": [
             {

--- a/shared/fixtures/chat/codex-reasoning.json
+++ b/shared/fixtures/chat/codex-reasoning.json
@@ -4,7 +4,7 @@
         "blocks": [
             {
                 "createdAt": 1755000000000,
-                "id": "msg-codex-061:0",
+                "id": "rs_0af3d219",
                 "kind": "agent-reasoning",
                 "localId": null,
                 "text": "**Weighing pagination approaches**\n\nThe epoch guard only fires when the server resets, so the client must drop its window on mismatch."
@@ -15,7 +15,7 @@
         "visibleBlocks": [
             {
                 "createdAt": 1755000000000,
-                "id": "msg-codex-061:0",
+                "id": "rs_0af3d219",
                 "kind": "agent-reasoning",
                 "localId": null,
                 "text": "**Weighing pagination approaches**\n\nThe epoch guard only fires when the server resets, so the client must drop its window on mismatch."

--- a/web/scripts/fixtures/cases/codex.ts
+++ b/web/scripts/fixtures/cases/codex.ts
@@ -9,7 +9,7 @@ import { T0, wireMessage } from './support'
 export const codexCases: FixtureCase[] = [
     {
         name: 'codex-message-stream-snapshot',
-        description: 'Codex family: two message payloads sharing a stream id (data.id) are cumulative snapshots. Expects a single agent-text block keyed by the first message, carrying the final snapshot text.',
+        description: 'Codex family: two message payloads sharing a stream id (data.id) are cumulative snapshots. Expects a single agent-text block keyed by that stable stream id, carrying the final snapshot text.',
         messages: [
             wireMessage({
                 id: 'msg-codex-051',
@@ -47,7 +47,7 @@ export const codexCases: FixtureCase[] = [
     },
     {
         name: 'codex-reasoning',
-        description: 'Codex family: reasoning payload becomes an agent-reasoning block (stream id kept internal — not part of the projection).',
+        description: 'Codex family: reasoning payload becomes an agent-reasoning block keyed by its stream id (data.id).',
         messages: [
             wireMessage({
                 id: 'msg-codex-061',
@@ -61,6 +61,76 @@ export const codexCases: FixtureCase[] = [
                             type: 'reasoning',
                             id: 'rs_0af3d219',
                             message: '**Weighing pagination approaches**\n\nThe epoch guard only fires when the server resets, so the client must drop its window on mismatch.'
+                        }
+                    }
+                }
+            })
+        ]
+    },
+    {
+        name: 'codex-blank-stream-ids',
+        description: 'Codex family: blank (empty or whitespace-only) data.id values are not stream identities (shared/src/messages.ts trims before accepting) — each payload keeps its own row-derived block id instead of collapsing onto a shared blank identity.',
+        messages: [
+            wireMessage({
+                id: 'msg-codex-065',
+                seq: 1,
+                createdAt: T0,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'codex',
+                        data: {
+                            type: 'reasoning',
+                            id: '',
+                            message: 'blank id one'
+                        }
+                    }
+                }
+            }),
+            wireMessage({
+                id: 'msg-codex-066',
+                seq: 2,
+                createdAt: T0 + 100,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'codex',
+                        data: {
+                            type: 'reasoning',
+                            id: '   ',
+                            message: 'blank id two'
+                        }
+                    }
+                }
+            }),
+            wireMessage({
+                id: 'msg-codex-067',
+                seq: 3,
+                createdAt: T0 + 200,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'codex',
+                        data: {
+                            type: 'message',
+                            id: '',
+                            message: 'blank id text one'
+                        }
+                    }
+                }
+            }),
+            wireMessage({
+                id: 'msg-codex-068',
+                seq: 4,
+                createdAt: T0 + 300,
+                content: {
+                    role: 'agent',
+                    content: {
+                        type: 'codex',
+                        data: {
+                            type: 'message',
+                            id: '   ',
+                            message: 'blank id text two'
                         }
                     }
                 }

--- a/web/src/chat/reducerTimeline.test.ts
+++ b/web/src/chat/reducerTimeline.test.ts
@@ -327,6 +327,33 @@ describe('reduceTimeline', () => {
         expect(secondBlock.text).toBe('partial extended')
     })
 
+    it('treats blank stream ids as no stream so rows keep distinct row-derived ids', () => {
+        const makeRow = (id: string, streamId: string): TracedMessage => ({
+            id,
+            localId: null,
+            createdAt: 1_700_000_000_000,
+            role: 'agent',
+            content: [{
+                type: 'reasoning',
+                text: `text of ${id}`,
+                uuid: id,
+                streamId,
+                parentUUID: null
+            }],
+            isSidechain: false
+        } as TracedMessage)
+
+        const { blocks } = reduceTimeline([
+            makeRow('blank-1', ''),
+            makeRow('blank-2', '   ')
+        ], makeContext())
+        const reasoningBlocks = blocks.filter((block) => block.kind === 'agent-reasoning')
+
+        expect(reasoningBlocks).toHaveLength(2)
+        expect(reasoningBlocks[0]).toMatchObject({ id: 'blank-1:0' })
+        expect(reasoningBlocks[1]).toMatchObject({ id: 'blank-2:0' })
+    })
+
     it('collapses text snapshots with the same stream id while leaving legacy text separate', () => {
         const first = makeAgentMessage('first ', {
             id: 'text-row-1',

--- a/web/src/chat/reducerTimeline.test.ts
+++ b/web/src/chat/reducerTimeline.test.ts
@@ -291,9 +291,40 @@ describe('reduceTimeline', () => {
 
         expect(reasoningBlocks).toHaveLength(1)
         expect(reasoningBlocks[0]).toMatchObject({
-            id: 'reasoning-row-1:0',
+            id: 'reasoning-stream-1',
             text: 'first second'
         })
+    })
+
+    it('keeps reasoning block identity stable when the surviving snapshot row changes', () => {
+        // Production flow: the window store only keeps the newest snapshot row
+        // of a stream, so each reduce pass can see a different underlying
+        // message row. The block id must not churn with it, or the rendered
+        // reasoning panel remounts (replaying its open animation) per snapshot.
+        const makeRow = (id: string, text: string): TracedMessage => ({
+            id,
+            localId: null,
+            createdAt: 1_700_000_000_000,
+            role: 'agent',
+            content: [{
+                type: 'reasoning',
+                text,
+                uuid: id,
+                streamId: 'reasoning-stream-1',
+                parentUUID: null
+            }],
+            isSidechain: false
+        } as TracedMessage)
+
+        const firstPass = reduceTimeline([makeRow('row-1', 'partial')], makeContext())
+        const secondPass = reduceTimeline([makeRow('row-2', 'partial extended')], makeContext())
+
+        const firstBlock = firstPass.blocks.find((block) => block.kind === 'agent-reasoning') as any
+        const secondBlock = secondPass.blocks.find((block) => block.kind === 'agent-reasoning') as any
+
+        expect(firstBlock.id).toBe('reasoning-stream-1')
+        expect(secondBlock.id).toBe(firstBlock.id)
+        expect(secondBlock.text).toBe('partial extended')
     })
 
     it('collapses text snapshots with the same stream id while leaving legacy text separate', () => {
@@ -332,7 +363,7 @@ describe('reduceTimeline', () => {
 
         expect(textBlocks).toHaveLength(2)
         expect(textBlocks[0]).toMatchObject({
-            id: 'text-row-1:0',
+            id: 'text-stream-1',
             text: 'first second'
         })
         expect(textBlocks[1]).toMatchObject({

--- a/web/src/chat/reducerTimeline.ts
+++ b/web/src/chat/reducerTimeline.ts
@@ -10,6 +10,14 @@ function getEventString(event: Record<string, unknown>, key: string): string | n
     return asString(event[key])
 }
 
+// Stream identity must match the wire-level semantics in @hapi/protocol
+// (blank ids are not streams): a blank value falls back to row-derived ids
+// instead of colliding every blank-id row onto one block identity.
+function nonBlank(value: unknown): string | null {
+    const raw = asString(value)
+    return raw !== null && raw.trim().length > 0 ? raw : null
+}
+
 function getEventNumber(event: Record<string, unknown>, key: string): number | null {
     const value = event[key]
     return typeof value === 'number' && Number.isFinite(value) ? value : null
@@ -788,7 +796,7 @@ export function reduceTimeline(
                         }))
                         continue
                     }
-                    const streamId = asString(c.streamId)
+                    const streamId = nonBlank(c.streamId)
                     if (streamId) {
                         const existing = textBlocksByStreamId.get(streamId)
                         if (existing) {
@@ -842,7 +850,7 @@ export function reduceTimeline(
                 }
 
                 if (c.type === 'reasoning') {
-                    const streamId = asString(c.streamId)
+                    const streamId = nonBlank(c.streamId)
                     if (streamId) {
                         const existing = reasoningBlocksByStreamId.get(streamId)
                         if (existing) {

--- a/web/src/chat/reducerTimeline.ts
+++ b/web/src/chat/reducerTimeline.ts
@@ -803,7 +803,13 @@ export function reduceTimeline(
 
                     const block: AgentTextBlock = {
                         kind: 'agent-text',
-                        id: `${msg.id}:${idx}`,
+                        // Streamed snapshots under one stream id arrive as
+                        // separate message rows that the window keeps swapping
+                        // for newer rows. Deriving the id from the stream id
+                        // (unique per stream) keeps the block identity stable
+                        // across snapshots so the rendered component is
+                        // updated in place instead of being remounted.
+                        id: streamId ?? `${msg.id}:${idx}`,
                         localId: msg.localId,
                         createdAt: msg.createdAt,
                         invokedAt: msg.invokedAt,
@@ -851,7 +857,11 @@ export function reduceTimeline(
 
                     const block: AgentReasoningBlock = {
                         kind: 'agent-reasoning',
-                        id: `${msg.id}:${idx}`,
+                        // Same as agent-text above: a stream-stable id keeps
+                        // the reasoning panel mounted while its snapshots
+                        // arrive, so the smooth streaming continues from the
+                        // previous text instead of replaying from a remount.
+                        id: streamId ?? `${msg.id}:${idx}`,
                         localId: msg.localId,
                         createdAt: msg.createdAt,
                         invokedAt: msg.invokedAt,


### PR DESCRIPTION
## Problem

While a pi/codex session streams, the web UI reasoning panel re-renders from scratch on every snapshot tick (~every 250ms): the panel's open/collapse animation replays and the smooth typewriter restarts, which looks like constant flashing for the entire duration of the thinking phase.

### Root cause

The chain is:

1. CLI emits full-text snapshots for one reasoning stream every ~250ms, each under the **same stream id** but as separate message rows (`pi-…-reasoning-N` / `rs_…`).
2. The hub retires older live snapshot rows, and the web window store (`dropSupersededReasoningSnapshots`) keeps only the newest row per stream — so the timeline reducer sees a **different underlying message row on every pass**.
3. `reducerTimeline.ts` folded snapshots into a single block by stream id (good), but derived the block `id` from whichever row was first encountered: `` id: `${msg.id}:${idx}` ``.
4. So the block id — and the `threadMessageId` (`agent-reasoning:<id>`) built from it — **changed on every snapshot**. The React key changed, the whole reasoning message + collapsible group remounted, the open animation (`max-h`/`opacity` transition) replayed and the smooth streaming restarted from empty text. Every 250ms.

## Fix

When a content block carries a `streamId` (unique per stream, stable across its snapshot rows), use it as the block id; keep `` `${msg.id}:${idx}` `` as the fallback for content without a stream id. Applied to both `agent-reasoning` and `agent-text` (text has the same churn with `streamSnapshot` rows).

With a stable id, the timeline/assistant-ui pipeline updates the block in place: no remount, no animation replay, and the smooth typewriter appends only the delta — which is the desired streaming UX.

This also makes block ids more stable across history reloads: after a reload the surviving snapshot row is the newest one, so a row-derived id would differ from the id seen live, while the stream id does not change.

## Testing

- Updated the two stream-collapse tests in `reducerTimeline.test.ts` for the new id shape.
- Added a regression test: two reduce passes over different snapshot rows of the same stream produce the same block id (this mirrors the production window-retirement flow).
- Reran `bun run gen:fixtures` — only the two fixtures carrying streamed reasoning/text change (id field only).
- `cd web && vitest run` — 2860 tests pass (incl. the refreshed golden fixtures); `tsc --noEmit` clean.

## AI disclosure (per CONTRIBUTING)

Code authored with AI assistance (GLM, Z.ai) under human direction, based on a root-cause debugging session of the flashing reasoning panel.