### PR TITLE
fix(web): let the installed Android status bar follow the system

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -96,7 +96,16 @@ export default defineConfig({
                 name: 'HAPI',
                 short_name: 'HAPI',
                 description: 'AI-powered development assistant',
-                theme_color: '#ffffff',
+                // An installed Android WebAPK stores theme_color once at install time and uses it
+                // as a fixed toolbar color, so any value here pins the status bar to one appearance.
+                // With none, Chrome falls back to white in light mode and black in dark mode. That
+                // follows the Android system uiMode, not the in-app appearance setting, so the bar
+                // and the app diverge while an appearance override is active. `undefined` is
+                // explicit because the plugin fills in its own #42b883 default otherwise, and the
+                // resulting "theme_color is missing" build warning is wrong: theme_color is
+                // optional for installability.
+                theme_color: undefined,
+                // Splash background stays light; only the status bar needed to become adaptive.
                 background_color: '#ffffff',
                 display: 'standalone',
                 orientation: 'portrait',


### PR DESCRIPTION
## Problem

On Android, an installed HAPI PWA showed a white status bar whose icons also turned white under dark app themes, hiding the clock, signal and battery.

The manifest declared `theme_color: '#ffffff'`. An installed WebAPK reads that value once at install time into its Android meta-data and uses it as a fixed toolbar color. Runtime `<meta name="theme-color">` updates never repaint that background; only the icon tint follows them. So the background stayed white while the icons tracked the dark app theme.

## Solution

Drop `theme_color` from the manifest. With no theme color present, `WebApkIntentDataProviderFactory` reads `ColorUtils.INVALID_COLOR` and `WebappIntentDataProvider` falls back to `Color.WHITE`, or to `Color.BLACK` when the system is dark, choosing between them by `Configuration.uiMode`. The status bar then follows the Android system theme and its icons stay readable in both.

A per-scheme color cannot come from the manifest instead. Chromium removed dark color parsing from the manifest parser in Chrome 128 and the `dark_theme_color` and `dark_background_color` mojom fields are marked obsolete, so declaring any single `theme_color` pins both schemes to that one value: the light color wins whenever it is valid.

`undefined` is explicit rather than omitting the key, because `vite-plugin-pwa` merges its own `#42b883` default over a missing one. The plugin then prints `WARNING: "theme_color" is missing from the web manifest, your application will not be able to be installed` on every build. That warning is wrong. `theme_color` is optional for installability, and the app installs and runs normally without it.

`background_color` is unchanged, so the install splash stays white in dark mode; only the status bar needed to become adaptive.

The bar follows the Android system uiMode rather than the in-app appearance setting, so the two diverge while an appearance override is active. On a Samsung SM-S938N running Android 16, after uninstalling and reinstalling the PWA, a dark system gives a black bar with white icons, and forcing the in-app appearance to light leaves the bar black with white icons. Both are readable, unlike the white-on-white they replace. The light-system case was not captured separately; it is unchanged from the white the manifest pinned before. Desktop installed PWAs no longer get a manifest-supplied title bar tint, which was not verified separately.

## Tests

`bun run typecheck` and `bun run test` pass, and `bun run build:web` emits a manifest with no `theme_color`. No automated test is added: the change is the absence of one manifest key, and the behavior it drives lives in the Android WebAPK shell, so it was verified on-device by a fresh install rather than in the browser.
