### PR TITLE
feat(web): add collapsible session sidebar

### DIFF
--- a/web/src/components/SessionList.directory-action.test.tsx
+++ b/web/src/components/SessionList.directory-action.test.tsx
@@ -14,6 +14,7 @@ afterEach(() => {
     cleanup()
     localStorage.removeItem('hapi-session-preview-limit')
     localStorage.removeItem('hapi-pin-in-progress-sessions')
+    localStorage.removeItem('hapi-session-list-status-mode')
 })
 
 function makeSession(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
@@ -59,6 +60,37 @@ function renderWithProviders(children: ReactNode) {
 }
 
 describe('SessionList directory action', () => {
+    it('does not reference hidden schedule details from compact rows', () => {
+        localStorage.setItem('hapi-session-list-status-mode', 'detailed')
+        const session = makeSession({
+            id: 'scheduled-session',
+            futureScheduledMessageCount: 1,
+            nextScheduledAt: Date.now() + 60_000,
+            metadata: {
+                path: '/home/ubuntu',
+                name: 'Scheduled session',
+                flavor: 'codex',
+            }
+        })
+
+        renderWithProviders(
+            <SessionList
+                compact
+                sessions={[session]}
+                selectedSessionId={null}
+                onSelect={vi.fn()}
+                onNewSession={vi.fn()}
+                onRefresh={vi.fn()}
+                isLoading={false}
+                renderHeader={false}
+                api={null}
+            />
+        )
+
+        expect(screen.getByRole('button', { name: 'Scheduled session' })).not.toHaveAttribute('aria-describedby')
+        expect(screen.queryByRole('tooltip', { hidden: true })).not.toBeInTheDocument()
+    })
+
     it('starts a new session with the project machine and directory', () => {
         const onNewSessionInDirectory = vi.fn()
         const session = makeSession({

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -903,6 +903,7 @@ export function SessionListSearch(props: {
 function SessionItem(props: {
     session: SessionSummary
     onSelect: (sessionId: string) => void
+    compact?: boolean
     showPath?: boolean
     api: ApiClient | null
     titleSuggestionAvailable?: boolean
@@ -918,6 +919,7 @@ function SessionItem(props: {
     const {
         session: s,
         onSelect,
+        compact = false,
         showPath = true,
         api,
         titleSuggestionAvailable = false,
@@ -1027,20 +1029,21 @@ function SessionItem(props: {
     const hasScheduleTooltip = showDetailedStatus && s.futureScheduledMessageCount > 0
     const { attentionId, scheduleId, describedBy } = useSessionRowTooltipIds(
         Boolean(attention),
-        hasScheduleTooltip
+        hasScheduleTooltip && !compact
     )
     return (
         <>
             <button
                 type="button"
                 {...longPressHandlers}
-                className={`session-list-item group/session-row flex w-full flex-col gap-1 py-2 pl-2.5 pr-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)] select-none rounded-lg ${selected ? 'bg-[var(--app-secondary-bg)]' : ''}`}
+                className={`session-list-item group/session-row flex w-full flex-col text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)] select-none rounded-lg ${compact ? 'gap-0 py-1 pl-1.5 pr-1' : 'gap-1 py-2 pl-2.5 pr-2'} ${selected ? 'bg-[var(--app-secondary-bg)]' : ''}`}
                 style={{ WebkitTouchCallout: 'none' }}
                 aria-current={selected ? 'page' : undefined}
                 aria-describedby={describedBy}
             >
                 <SessionRowSummary
                     session={s}
+                    compact={compact}
                     showPath={showPath}
                     showDetailedStatus={showDetailedStatus}
                     selected={selected}
@@ -1048,7 +1051,9 @@ function SessionItem(props: {
                     attentionTooltipId={attentionId}
                     lastSeenVersion={lastSeenVersion}
                     scheduleTooltipId={scheduleId}
-                    inRunningSection={inRunningSection}
+                    // Compact rows keep activity as a dot/spinner rather than
+                    // expanding into status labels that would crowd the rail.
+                    inRunningSection={compact || inRunningSection}
                     projectLabel={projectLabel}
                     machineLabel={machineLabel}
                 />
@@ -1190,6 +1195,8 @@ export function SessionList(props: {
     machineLabelsById?: Record<string, string>
     machinesById?: Record<string, Machine>
     selectedSessionId?: string | null
+    /** Compact directory/session index used while the detail sidebar is collapsed. */
+    compact?: boolean
 }) {
     const { t } = useTranslation()
     const {
@@ -1197,6 +1204,7 @@ export function SessionList(props: {
         api,
         titleSuggestionAvailable = false,
         selectedSessionId,
+        compact = false,
         machineLabelsById = {},
         machinesById = {},
         onNewSessionInDirectory
@@ -1285,10 +1293,13 @@ export function SessionList(props: {
         }),
         [machineFilters, machinesById]
     )
-    const showMachineFilterBar = machineFilters.length >= 2
+    const hasMachineFilter = machineFilters.length >= 2
+    // Keep the selected machine filter active in compact mode; only hide the
+    // controls that cannot fit in the narrow rail.
+    const showMachineFilterBar = !compact && hasMachineFilter
     // A persisted filter whose machine no longer has sessions falls back to
     // "All"; with at most one machine the bar is hidden and never filters.
-    const activeMachineFilter = showMachineFilterBar && machineFilter !== null
+    const activeMachineFilter = hasMachineFilter && machineFilter !== null
         && machineFilters.some(mg => (mg.machineId ?? UNKNOWN_MACHINE_ID) === machineFilter)
         ? machineFilter
         : null
@@ -1528,6 +1539,7 @@ export function SessionList(props: {
                                             key={s.id}
                                             session={s}
                                             onSelect={props.onSelect}
+                                            compact={compact}
                                             showPath={false}
                                             api={api}
                                             titleSuggestionAvailable={titleSuggestionAvailable}
@@ -1589,7 +1601,7 @@ export function SessionList(props: {
 
     const renderDirectoryGroup = (group: SessionGroup) => {
         const isCollapsed = isGroupCollapsed(group)
-        const visibleGroupSessions = getVisibleGroupSessions(group)
+        const visibleGroupSessions = compact ? group.sessions : getVisibleGroupSessions(group)
         const hiddenSessionCount = group.sessions.length - visibleGroupSessions.length
         const currentLimit = Math.min(
             getGroupVisibleCount(group),
@@ -1606,22 +1618,26 @@ export function SessionList(props: {
         const canStartInGroupDirectory = group.directory !== 'Other'
         // With multiple machines in the unfiltered view, disambiguate
         // same-named directories by suffixing the machine label.
-        const groupTitle = showMachineFilterBar && activeMachineFilter === null
+        const groupTitle = hasMachineFilter && activeMachineFilter === null
             ? `${group.displayName} · ${resolveMachineLabel(group.machineId)}`
             : group.displayName
         return (
             <div key={group.key}>
                 <div
-                    className="group/project sticky top-0 z-10 flex items-center gap-2 bg-[var(--app-bg)] py-1.5 pl-2 pr-2 text-left rounded-lg transition-colors hover:bg-[var(--app-secondary-bg)] cursor-pointer min-w-0 w-full select-none"
+                    className={cn(
+                        'group/project sticky top-0 z-10 flex items-center bg-[var(--app-bg)] text-left rounded-lg transition-colors hover:bg-[var(--app-secondary-bg)] cursor-pointer min-w-0 w-full select-none',
+                        compact ? 'gap-1' : 'gap-2',
+                        compact ? 'py-1 pl-1.5 pr-1' : 'py-1.5 pl-2 pr-2'
+                    )}
                     onClick={() => toggleGroup(group.key, isCollapsed)}
                     title={group.directory}
                 >
-                    <ChevronIcon className="h-3.5 w-3.5 text-[var(--app-hint)] shrink-0" collapsed={isCollapsed} />
-                    <span className="font-medium text-sm truncate flex-1">
+                    <ChevronIcon className={compact ? 'h-3 w-3 text-[var(--app-hint)] shrink-0' : 'h-3.5 w-3.5 text-[var(--app-hint)] shrink-0'} collapsed={isCollapsed} />
+                    <span className={cn('font-medium truncate flex-1 min-w-0', compact ? 'text-[10px]' : 'text-sm')}>
                         {groupTitle}
                     </span>
-                    <CopyPathButton path={group.directory} className="opacity-0 group-hover/project:opacity-100 transition-opacity duration-150" />
-                    {onNewSessionInDirectory && canStartInGroupDirectory ? (
+                    {!compact ? <CopyPathButton path={group.directory} className="opacity-0 group-hover/project:opacity-100 transition-opacity duration-150" /> : null}
+                    {!compact && onNewSessionInDirectory && canStartInGroupDirectory ? (
                         <button
                             type="button"
                             onClick={(event) => {
@@ -1638,7 +1654,7 @@ export function SessionList(props: {
                             <PlusIcon className="h-3.5 w-3.5" />
                         </button>
                     ) : null}
-                    <span className="text-[11px] tabular-nums text-[var(--app-hint)] shrink-0">
+                    <span className={cn('tabular-nums text-[var(--app-hint)] shrink-0', compact ? 'text-[9px]' : 'text-[10px]')}>
                         ({group.sessions.length})
                     </span>
                 </div>
@@ -1658,6 +1674,7 @@ export function SessionList(props: {
                                 <SessionItem
                                     session={s}
                                     onSelect={props.onSelect}
+                                    compact={compact}
                                     showPath={false}
                                     api={api}
                                     titleSuggestionAvailable={titleSuggestionAvailable}
@@ -1667,7 +1684,7 @@ export function SessionList(props: {
                                 />
                             </div>
                         ))}
-                        {group.sessions.length > sessionPreviewLimit && (hiddenSessionCount > 0 || canShowFewerSessions) ? (
+                        {!compact && group.sessions.length > sessionPreviewLimit && (hiddenSessionCount > 0 || canShowFewerSessions) ? (
                             <div className="ml-2.5 mr-2 my-1 flex gap-1.5">
                                 {canShowFewerSessions ? (
                                     <button
@@ -1772,7 +1789,7 @@ export function SessionList(props: {
     // The search control unmounts when the list empties; reset the expansion so
     // it cannot suppress header actions (or re-expand on its own when sessions
     // return) while no search control is rendered.
-    const showSearch = props.sessions.length > 0
+    const showSearch = !compact && props.sessions.length > 0
     useEffect(() => {
         if (!showSearch) setSearchExpanded(false)
     }, [showSearch])
@@ -1872,7 +1889,7 @@ export function SessionList(props: {
         <div className="flex min-h-0 w-full flex-1 flex-col">
             <div className="session-list-scrollbar-offset mx-auto w-full max-w-content shrink-0">
             {showHeaderRow ? (
-                <div className="flex items-center gap-1 px-2 py-1">
+                <div className={cn('flex items-center gap-1 py-1', compact ? 'px-1' : 'px-2')}>
                     {showSearch ? (
                         <SessionListSearch
                             value={searchQuery}
@@ -1899,30 +1916,32 @@ export function SessionList(props: {
                                     onChange={setMachineFilter}
                                 />
                             ) : null}
-                            <button
-                                type="button"
-                                onClick={() => setShowUnreadOnly(!showUnreadOnly)}
-                                aria-pressed={showUnreadOnly}
-                                title={t('sessions.unreadFilter.toggle')}
-                                aria-label={t('sessions.unreadFilter.toggle')}
-                                className={cn(
-                                    'flex h-9 w-9 items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]',
-                                    showUnreadOnly
-                                        ? 'bg-[var(--app-subtle-bg)]'
-                                        : 'hover:bg-[var(--app-subtle-bg)]'
-                                )}
-                            >
-                                {/* Same shape/color language as session-row unread dots (SessionAttentionIndicator). */}
-                                <span
-                                    aria-hidden
+                            {!compact ? (
+                                <button
+                                    type="button"
+                                    onClick={() => setShowUnreadOnly(!showUnreadOnly)}
+                                    aria-pressed={showUnreadOnly}
+                                    title={t('sessions.unreadFilter.toggle')}
+                                    aria-label={t('sessions.unreadFilter.toggle')}
                                     className={cn(
-                                        'inline-flex h-2.5 w-2.5 shrink-0 rounded-full',
+                                        'flex h-9 w-9 items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]',
                                         showUnreadOnly
-                                            ? 'bg-[var(--app-link)]'
-                                            : 'bg-[var(--app-hint)]'
+                                            ? 'bg-[var(--app-subtle-bg)]'
+                                            : 'hover:bg-[var(--app-subtle-bg)]'
                                     )}
-                                />
-                            </button>
+                                >
+                                    {/* Same shape/color language as session-row unread dots (SessionAttentionIndicator). */}
+                                    <span
+                                        aria-hidden
+                                        className={cn(
+                                            'inline-flex h-2.5 w-2.5 shrink-0 rounded-full',
+                                            showUnreadOnly
+                                                ? 'bg-[var(--app-link)]'
+                                                : 'bg-[var(--app-hint)]'
+                                        )}
+                                    />
+                                </button>
+                            ) : null}
                             {renderHeader ? (
                                 <button
                                     type="button"
@@ -2021,6 +2040,7 @@ export function SessionList(props: {
                                             key={s.id}
                                             session={s}
                                             onSelect={props.onSelect}
+                                            compact={compact}
                                             showPath={false}
                                             api={api}
                                             titleSuggestionAvailable={titleSuggestionAvailable}

--- a/web/src/components/SessionRowSummary.tsx
+++ b/web/src/components/SessionRowSummary.tsx
@@ -99,6 +99,8 @@ function getSessionTimeLabel(
  */
 export function SessionRowSummary(props: {
     session: SessionSummary
+    /** Compact rows used by the collapsed session index rail. */
+    compact?: boolean
     showPath?: boolean
     showDetailedStatus?: boolean
     selected?: boolean
@@ -122,6 +124,7 @@ export function SessionRowSummary(props: {
 }) {
     const {
         session: s,
+        compact = false,
         showPath = true,
         showDetailedStatus = true,
         selected = false,
@@ -164,12 +167,12 @@ export function SessionRowSummary(props: {
     const timeLabel = getSessionTimeLabel(s, t)
 
     return (
-        <div className={`flex w-full min-w-0 flex-col gap-1 ${className ?? ''}`}>
-            <div className={`grid grid-cols-[minmax(9rem,1fr)_minmax(0,max-content)] items-center gap-2 ${!s.active ? 'opacity-50' : ''}`}>
-                <div className="flex min-w-0 items-center gap-2">
-                    <AgentFlavorIcon flavor={s.metadata?.flavor} className="h-4 w-4 shrink-0 -translate-y-px" />
+        <div className={`flex w-full min-w-0 flex-col ${compact ? 'gap-0' : 'gap-1'} ${className ?? ''}`}>
+            <div className={`grid min-w-0 items-center ${compact ? 'grid-cols-[minmax(0,1fr)] gap-1' : 'grid-cols-[minmax(9rem,1fr)_minmax(0,max-content)] gap-2'} ${!s.active ? 'opacity-50' : ''}`}>
+                <div className={`flex min-w-0 items-center ${compact ? 'gap-1' : 'gap-2'}`}>
+                    <AgentFlavorIcon flavor={s.metadata?.flavor} className={compact ? 'h-3.5 w-3.5 shrink-0 -translate-y-px' : 'h-4 w-4 shrink-0 -translate-y-px'} />
                     <div
-                        className={`min-w-0 flex-1 truncate text-sm font-medium ${s.active ? 'text-[var(--app-fg)]' : 'text-[var(--app-hint)]'}`}
+                        className={`min-w-0 flex-1 truncate font-medium ${compact ? 'text-xs' : 'text-sm'} ${s.active ? 'text-[var(--app-fg)]' : 'text-[var(--app-hint)]'}`}
                         title={sessionName}
                     >
                         {sessionName}
@@ -188,7 +191,7 @@ export function SessionRowSummary(props: {
                             aria-label={attentionLabel ?? undefined}
                         />
                     ) : s.active && s.thinking ? (
-                        <LoaderIcon className="h-3.5 w-3.5 shrink-0 animate-spin-slow text-[var(--app-badge-success-text)]" />
+                        <LoaderIcon className={compact ? 'h-3 w-3 shrink-0 animate-spin-slow text-[var(--app-badge-success-text)]' : 'h-3.5 w-3.5 shrink-0 animate-spin-slow text-[var(--app-badge-success-text)]'} />
                     ) : urgentAttention && nestedTooltips && attentionId ? (
                         <SessionAttentionIndicator
                             attention={attention}
@@ -249,7 +252,7 @@ export function SessionRowSummary(props: {
                             aria-label={attentionLabel ?? undefined}
                         />
                     ) : null}
-                    {hasScheduleTooltip && nestedTooltips && scheduleId ? (
+                    {!compact && hasScheduleTooltip && nestedTooltips && scheduleId ? (
                         <HoverTooltip
                             id={scheduleId}
                             target={<ScheduleIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />}
@@ -265,13 +268,13 @@ export function SessionRowSummary(props: {
                                 </span>
                             </span>
                         </HoverTooltip>
-                    ) : hasScheduleTooltip ? (
+                    ) : !compact && hasScheduleTooltip ? (
                         <span className="shrink-0" aria-label={scheduledLabel} title={scheduledLabel}>
                             <ScheduleIcon className="h-3.5 w-3.5 text-[var(--app-hint)]" />
                         </span>
                     ) : null}
                 </div>
-                <div className="flex min-w-0 items-center justify-end gap-2 overflow-hidden text-xs">
+                {!compact ? <div className="flex min-w-0 items-center justify-end gap-2 overflow-hidden text-xs">
                     {todoProgress ? (
                         <span className="flex shrink-0 items-center gap-1 text-[var(--app-hint)]">
                             <BulbIcon className="h-3 w-3" />
@@ -286,13 +289,13 @@ export function SessionRowSummary(props: {
                     {timeLabel ? (
                         <span className="min-w-0 truncate whitespace-nowrap tabular-nums text-[var(--app-hint)]">{timeLabel}</span>
                     ) : null}
-                </div>
+                </div> : null}
             </div>
-            {projectLabel || machineLabel ? (
+            {!compact && (projectLabel || machineLabel) ? (
                 <div className="truncate text-xs text-[var(--app-hint)]" title={[projectLabel, machineLabel].filter(Boolean).join(' · ')}>
                     {[projectLabel, machineLabel].filter(Boolean).join(' · ')}
                 </div>
-            ) : showPath || worktreeLabel ? (
+            ) : !compact && (showPath || worktreeLabel) ? (
                 <div
                     className="truncate text-xs text-[var(--app-hint)]"
                     title={worktreeLabel

--- a/web/src/hooks/useSidebarCollapsed.test.ts
+++ b/web/src/hooks/useSidebarCollapsed.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getInitialSidebarCollapsed } from './useSidebarCollapsed'
+
+describe('useSidebarCollapsed helpers', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('defaults to expanded', () => {
+        expect(getInitialSidebarCollapsed()).toBe(false)
+    })
+
+    it('reads the client-local collapsed state', () => {
+        localStorage.setItem('hapi-sidebar-collapsed-v1', 'true')
+        expect(getInitialSidebarCollapsed()).toBe(true)
+    })
+})

--- a/web/src/hooks/useSidebarCollapsed.ts
+++ b/web/src/hooks/useSidebarCollapsed.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const SIDEBAR_COLLAPSED_STORAGE_KEY = 'hapi-sidebar-collapsed-v1'
+
+function isBrowser(): boolean {
+    return typeof window !== 'undefined' && typeof document !== 'undefined'
+}
+
+function readCollapsed(): boolean {
+    if (!isBrowser()) return false
+    try {
+        return localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === 'true'
+    } catch {
+        return false
+    }
+}
+
+function writeCollapsed(collapsed: boolean): void {
+    if (!isBrowser()) return
+    try {
+        if (collapsed) {
+            localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, 'true')
+        } else {
+            localStorage.removeItem(SIDEBAR_COLLAPSED_STORAGE_KEY)
+        }
+    } catch {
+        // Ignore storage errors; the in-memory state still works for this tab.
+    }
+}
+
+export function getInitialSidebarCollapsed(): boolean {
+    return readCollapsed()
+}
+
+export function useSidebarCollapsed(): {
+    sidebarCollapsed: boolean
+    setSidebarCollapsed: (collapsed: boolean) => void
+} {
+    const [sidebarCollapsed, setSidebarCollapsedState] = useState(getInitialSidebarCollapsed)
+
+    useEffect(() => {
+        if (!isBrowser()) return
+
+        const onStorage = (event: StorageEvent) => {
+            if (event.key !== SIDEBAR_COLLAPSED_STORAGE_KEY) return
+            setSidebarCollapsedState(event.newValue === 'true')
+        }
+
+        window.addEventListener('storage', onStorage)
+        return () => window.removeEventListener('storage', onStorage)
+    }, [])
+
+    const setSidebarCollapsed = useCallback((collapsed: boolean) => {
+        setSidebarCollapsedState(collapsed)
+        writeCollapsed(collapsed)
+    }, [])
+
+    return { sidebarCollapsed, setSidebarCollapsed }
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -431,6 +431,13 @@ html:has(.chat-scroll-y) #root {
     opacity: 0.6;
 }
 
+.sidebar-collapsed-rail {
+    /* Keep a compact session index visible instead of reducing the sidebar to
+       an empty toggle rail. The list still preserves directory grouping while
+       leaving the main detail pane substantially wider than the full sidebar. */
+    width: 96px;
+}
+
 /*
  * Keep message layout fully realized while scrolling. `content-visibility: auto`
  * made Chromium replace rough intrinsic heights as older messages entered view,

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -64,6 +64,8 @@ export default {
 
   // Sessions page
   'sessions.new': 'New Session',
+  'sessions.sidebar.collapse': 'Collapse session list',
+  'sessions.sidebar.expand': 'Expand session list',
   'sessions.empty.title': 'No sessions yet',
   'sessions.empty.hint': 'Start a coding session in any folder under your workspace, or browse the tree first.',
   'sessions.empty.startSession': 'Start a session',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -64,6 +64,8 @@ export default {
 
   // Sessions page
   'sessions.new': '新建会话',
+  'sessions.sidebar.collapse': '收起会话列表',
+  'sessions.sidebar.expand': '展开会话列表',
   'sessions.empty.title': '还没有会话',
   'sessions.empty.hint': '在 workspace 下任意目录启动一个会话，或先浏览目录树看看。',
   'sessions.empty.startSession': '启动会话',

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -27,6 +27,7 @@ import { useAppContext } from '@/lib/app-context'
 import { useAppGoBack } from '@/hooks/useAppGoBack'
 import { isTelegramApp } from '@/hooks/useTelegram'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
+import { useSidebarCollapsed } from '@/hooks/useSidebarCollapsed'
 import { useMessages } from '@/hooks/queries/useMessages'
 import { useMachines } from '@/hooks/queries/useMachines'
 import { useMachineLabels } from '@/hooks/useMachineLabels'
@@ -91,6 +92,28 @@ function BackIcon(props: { className?: string }) {
             className={props.className}
         >
             <polyline points="15 18 9 12 15 6" />
+        </svg>
+    )
+}
+
+function SidebarCollapseIcon(props: { className?: string; direction: 'left' | 'right' }) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={props.className}
+            aria-hidden="true"
+        >
+            <rect x="3" y="4" width="18" height="16" rx="2" />
+            <path d="M9 4v16" />
+            {props.direction === 'left' ? <path d="m14 9-3 3 3 3" /> : <path d="m6 9 3 3-3 3" />}
         </svg>
     )
 }
@@ -214,6 +237,10 @@ function SessionsPage() {
     }, [selectedSessionId, selectedSession?.updatedAt])
     const isSessionsIndex = pathname === '/sessions' || pathname === '/sessions/'
     const sidebar = useSidebarResize()
+    const sidebarCollapse = useSidebarCollapsed()
+    // On the sessions index there is no detail pane to reveal, so keep the list
+    // visible even when a collapsed preference was saved on another route.
+    const sidebarIsCollapsed = sidebarCollapse.sidebarCollapsed && !isSessionsIndex
     const handleNewSessionInDirectory = useCallback((args: { machineId: string | null; directory: string }) => {
         navigate({
             to: '/sessions/new',
@@ -228,16 +255,19 @@ function SessionsPage() {
         <>
             <div className="flex h-full min-h-0">
             <div
-                className={`${isSessionsIndex ? 'flex' : 'hidden split:flex'} w-full shrink-0 flex-col bg-[var(--app-bg)]`}
-                style={{ '--sidebar-w': `${sidebar.width}px` } as React.CSSProperties}
+                className={sidebarIsCollapsed
+                    ? 'sidebar-collapsed-rail hidden split:flex shrink-0 flex-col border-r border-[var(--app-divider)] bg-[var(--app-bg)]'
+                    : `${isSessionsIndex ? 'flex' : 'hidden split:flex'} w-full shrink-0 flex-col bg-[var(--app-bg)]`}
+                style={!sidebarIsCollapsed ? { '--sidebar-w': `${sidebar.width}px` } as React.CSSProperties : undefined}
             >
                 <div className="flex min-h-0 flex-1 flex-col pt-[env(safe-area-inset-top)]">
-                    {error ? (
+                    {error && !sidebarIsCollapsed ? (
                         <div className="mx-auto w-full max-w-content px-3 py-2">
                             <div className="text-sm text-red-600">{error}</div>
                         </div>
                     ) : null}
                     <SessionList
+                        compact={sidebarIsCollapsed}
                         key={initializedHub === baseUrl ? 'last-seen-ready' : 'last-seen-pending'}
                         sessions={sessions}
                         selectedSessionId={selectedSessionId}
@@ -251,8 +281,29 @@ function SessionsPage() {
                         onRefresh={handleRefresh}
                         isLoading={isLoading}
                         renderHeader={false}
-                        headerActions={(
+                        headerActions={sidebarIsCollapsed ? (
+                            <button
+                                type="button"
+                                onClick={() => sidebarCollapse.setSidebarCollapsed(false)}
+                                className="flex h-8 w-8 items-center justify-center rounded-full text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
+                                title={t('sessions.sidebar.expand')}
+                                aria-label={t('sessions.sidebar.expand')}
+                            >
+                                <SidebarCollapseIcon direction="right" className="h-4 w-4" />
+                            </button>
+                        ) : (
                             <div className="flex items-center gap-2">
+                                {!isSessionsIndex && (
+                                    <button
+                                        type="button"
+                                        onClick={() => sidebarCollapse.setSidebarCollapsed(true)}
+                                        className="hidden split:flex h-9 w-9 items-center justify-center rounded-full text-[var(--app-hint)] transition-colors hover:bg-[var(--app-subtle-bg)] hover:text-[var(--app-fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]"
+                                        title={t('sessions.sidebar.collapse')}
+                                        aria-label={t('sessions.sidebar.collapse')}
+                                    >
+                                        <SidebarCollapseIcon direction="left" className="h-5 w-5" />
+                                    </button>
+                                )}
                                 {canBrowse && (
                                     <button
                                         type="button"
@@ -293,11 +344,13 @@ function SessionsPage() {
             </div>
 
             {/* Resize handle - desktop only */}
-            <div
-                className="sidebar-resize-handle hidden split:block shrink-0"
-                data-dragging={sidebar.isDragging || undefined}
-                onPointerDown={sidebar.onPointerDown}
-            />
+            {!sidebarIsCollapsed ? (
+                <div
+                    className="sidebar-resize-handle hidden split:block shrink-0"
+                    data-dragging={sidebar.isDragging || undefined}
+                    onPointerDown={sidebar.onPointerDown}
+                />
+            ) : null}
 
             <div className={`${isSessionsIndex ? 'hidden split:flex' : 'flex'} min-w-0 flex-1 flex-col bg-[var(--app-bg)]`}>
                 <div className="flex-1 min-h-0">


### PR DESCRIPTION
## Summary

- add desktop controls to collapse and expand the session sidebar
- keep a 96px compact session rail with project grouping and live status indicators
- persist the collapsed preference locally while keeping the sessions index and mobile layout expanded
- hide secondary row metadata and inaccessible schedule tooltip references in compact mode

## Testing

- `bun typecheck`
- `bun run test`