### PR TITLE
fix(hub): keep ambiguous queued-message cancels indeterminate

### DIFF
--- a/hub/src/sync/messageService.test.ts
+++ b/hub/src/sync/messageService.test.ts
@@ -2,8 +2,8 @@
  * MessageService.cancelQueuedMessage race scenario tests
  *
  * Race-A: CLI ack returns { removed: true }  → DB DELETE + status='cancelled'
- * Race-B: CLI ack returns { removed: false } (already shift()-ed) → markMessagesInvoked + status='invoked'
- * Race-C: CLI ack times out (500 ms)         → markMessagesInvoked + status='invoked'
+ * Race-B: CLI ack returns { removed: false } → indeterminate + status='busy'
+ * Race-C: CLI ack times out (500 ms)         → indeterminate + status='busy'
  * Race-D (CLI offline): no CLI socket in room → immediate DELETE, message-cancelled emit, no ack call
  * Race-E (partial ack): broadcast ack receives err + [{ removed: true }] → DELETE + status='cancelled'
  */
@@ -56,7 +56,15 @@ function toProtocolSession(session: ReturnType<typeof makeSession>): Session {
     }
 }
 
-type AckCallback = (err: Error | null, responses: Array<{ removed: boolean }>) => void
+type AckCallback = (
+    err: Error | null,
+    responses: Array<{
+        removed: boolean
+        inFlight?: boolean
+        indeterminate?: boolean
+        consumed?: boolean
+    }>
+) => void
 
 function makeIo(onEmit: (ack: AckCallback) => void, socketCount = 1): Server {
     const broadcastRoom = {
@@ -609,8 +617,8 @@ describe('MessageService.cancelQueuedMessage race scenarios', () => {
         })
     })
 
-    describe('Race-B: CLI ack removed:false (already shift()-ed) → markMessagesInvoked + status=invoked', () => {
-        it('returns invoked with message row when CLI says item was already consumed', async () => {
+    describe('Race-B: CLI ack removed:false is ambiguous → indeterminate + status=busy', () => {
+        it('does not claim delivery when the CLI cannot find the item', async () => {
             const store = makeStore()
             const session = makeSession(store, 'race-b')
             const msg = store.messages.addMessage(
@@ -621,47 +629,35 @@ describe('MessageService.cancelQueuedMessage race scenarios', () => {
 
             const publisher = makePublisher()
             const io = makeIo((callback) => {
-                // CLI already shifted the item before the cancel arrived
+                // Not found does not distinguish a reservation from consumption.
                 callback(null, [{ removed: false }])
             })
 
             const service = new MessageService(store, io, publisher as any)
             const result = await service.cancelQueuedMessage(session.id, msg.id)
 
-            expect(result.status).toBe('invoked')
-            if (result.status === 'invoked') {
-                expect(result.message.id).toBe(msg.id)
-                expect(result.message.localId).toBe('local-b')
-                expect(result.message.invokedAt).not.toBeNull()
-            }
+            expect(result).toEqual({ status: 'busy', localId: 'local-b' })
 
-            // Row must still exist but now have invoked_at set
+            // The durable row remains held and is never presented as sent.
             const rows = store.messages.getMessages(session.id)
             const row = rows.find(r => r.id === msg.id)
             expect(row).toBeDefined()
-            expect(row!.invokedAt).not.toBeNull()
+            expect(row!.invokedAt).toBeNull()
+            expect(row!.deliveryState).toBe('indeterminate')
 
             // No message-cancelled SSE should have been emitted
             const cancelled = publisher.events.find(e => e.type === 'message-cancelled')
             expect(cancelled).toBeUndefined()
 
-            // messages-consumed SSE must be broadcast so other web clients clear the queued row
-            const consumed = publisher.events.find(e => e.type === 'messages-consumed')
-            expect(consumed).toBeDefined()
-            if (consumed?.type === 'messages-consumed') {
-                expect(consumed.sessionId).toBe(session.id)
-                expect(consumed.localIds).toEqual(['local-b'])
-                expect(typeof consumed.invokedAt).toBe('number')
-            }
-
-            // messages-consumed must be emitted exactly once
             const consumedCount = publisher.events.filter(e => e.type === 'messages-consumed').length
-            expect(consumedCount).toBe(1)
+            expect(consumedCount).toBe(0)
+            const held = publisher.events.find(e => e.type === 'messages-indeterminate')
+            expect(held).toBeDefined()
         })
     })
 
-    describe('Race-C: CLI ack timeout → markMessagesInvoked + status=invoked', () => {
-        it('returns invoked with message row when CLI does not respond within timeout', async () => {
+    describe('Race-C: CLI ack timeout → indeterminate + status=busy', () => {
+        it('does not claim delivery when the CLI does not respond', async () => {
             const store = makeStore()
             const session = makeSession(store, 'race-c')
             const msg = store.messages.addMessage(
@@ -679,34 +675,49 @@ describe('MessageService.cancelQueuedMessage race scenarios', () => {
             const service = new MessageService(store, io, publisher as any)
             const result = await service.cancelQueuedMessage(session.id, msg.id)
 
-            expect(result.status).toBe('invoked')
-            if (result.status === 'invoked') {
-                expect(result.message.id).toBe(msg.id)
-                expect(result.message.invokedAt).not.toBeNull()
-            }
+            expect(result).toEqual({ status: 'busy', localId: 'local-c' })
 
-            // Row must still exist with invoked_at stamped
+            // Row remains held without invoked_at.
             const rows = store.messages.getMessages(session.id)
             const row = rows.find(r => r.id === msg.id)
             expect(row).toBeDefined()
-            expect(row!.invokedAt).not.toBeNull()
+            expect(row!.invokedAt).toBeNull()
+            expect(row!.deliveryState).toBe('indeterminate')
 
             // No message-cancelled SSE
             const cancelled = publisher.events.find(e => e.type === 'message-cancelled')
             expect(cancelled).toBeUndefined()
 
-            // messages-consumed SSE must be broadcast so other web clients clear the queued row
-            const consumed = publisher.events.find(e => e.type === 'messages-consumed')
-            expect(consumed).toBeDefined()
-            if (consumed?.type === 'messages-consumed') {
-                expect(consumed.sessionId).toBe(session.id)
-                expect(consumed.localIds).toEqual(['local-c'])
-                expect(typeof consumed.invokedAt).toBe('number')
-            }
-
-            // messages-consumed must be emitted exactly once
             const consumedCount = publisher.events.filter(e => e.type === 'messages-consumed').length
-            expect(consumedCount).toBe(1)
+            expect(consumedCount).toBe(0)
+            const held = publisher.events.find(e => e.type === 'messages-indeterminate')
+            expect(held).toBeDefined()
+        })
+    })
+
+    describe('positive consumed ACK', () => {
+        it('returns invoked only when the CLI explicitly confirms consumption', async () => {
+            const store = makeStore()
+            const session = makeSession(store, 'race-consumed')
+            const msg = store.messages.addMessage(
+                session.id,
+                { role: 'user', content: { type: 'text', text: 'hello' } },
+                'local-consumed'
+            )
+            const publisher = makePublisher()
+            const io = makeIo((callback) => {
+                callback(null, [{ removed: false, consumed: true }])
+            })
+
+            const service = new MessageService(store, io, publisher as any)
+            const result = await service.cancelQueuedMessage(session.id, msg.id)
+
+            expect(result.status).toBe('invoked')
+            if (result.status === 'invoked') {
+                expect(result.message.localId).toBe('local-consumed')
+                expect(result.message.invokedAt).not.toBeNull()
+            }
+            expect(publisher.events.filter(e => e.type === 'messages-consumed')).toHaveLength(1)
         })
     })
 
@@ -835,12 +846,9 @@ describe('MessageService.cancelQueuedMessage race scenarios', () => {
 
 describe('MessageService — cancel × mature race (scheduled messages)', () => {
     // The 5-second mature tick widens the cancel race window for scheduled
-    // messages compared to immediately-queued ones.  When mature fires first,
-    // the CLI shifts the row; a subsequent cancel call gets 'not-found' from
-    // the CLI ack, which stamps invoked_at (PR #568 contract preserved).
-    // The web client surfaces this as "sent".  This test documents that the
-    // behaviour is intentional — it is the expected outcome, not a bug.
-    it('cancel after mature-emit stamps invoked_at (race resolved as invoked — expected behavior)', async () => {
+    // messages compared to immediately-queued ones. When mature fires first,
+    // a later not-found cancel ACK is ambiguous and must not claim delivery.
+    it('holds a mature message as indeterminate after an ambiguous cancel ACK', async () => {
         const store = makeStore()
         const session = makeSession(store, 'race-sched-mature')
         const publisher = makePublisher()
@@ -867,17 +875,12 @@ describe('MessageService — cancel × mature race (scheduled messages)', () => 
         // Then cancel arrives — CLI says not-found
         const result = await service.cancelQueuedMessage(session.id, msg.id)
 
-        // Expected behavior: invoked_at is stamped (PR #568 contract preserved)
-        // Web client will show the message as "sent"
-        expect(result.status).toBe('invoked')
-        if (result.status === 'invoked') {
-            expect(result.message.localId).toBe('local-sched-race')
-            expect(result.message.invokedAt).not.toBeNull()
-        }
+        expect(result).toEqual({ status: 'busy', localId: 'local-sched-race' })
 
-        // messages-consumed SSE ensures web clients remove it from the queued bar
-        const consumed = publisher.events.find(e => e.type === 'messages-consumed')
-        expect(consumed).toBeDefined()
+        const held = store.messages.lookupQueuedMessage(session.id, msg.id)
+        expect(held.status).toBe('indeterminate')
+        expect(publisher.events.some(e => e.type === 'messages-consumed')).toBe(false)
+        expect(publisher.events.some(e => e.type === 'messages-indeterminate')).toBe(true)
     })
 })
 

--- a/hub/src/sync/messageService.ts
+++ b/hub/src/sync/messageService.ts
@@ -557,10 +557,10 @@ export class MessageService {
         }
 
         // Phase 2b: future-scheduled messages were never emitted to the CLI, so they
-        // are not in the CLI's in-memory queue.  Asking the CLI whether it can remove
-        // the item would always return 'not-found', which the normal ack path
-        // misinterprets as "CLI already consumed it" and stamps invoked_at.
-        // Short-circuit: delete the row directly without a CLI ack round-trip.
+        // are not in the CLI's in-memory queue. Asking the CLI whether it can remove
+        // the item would always return 'not-found', forcing an unnecessary
+        // indeterminate state. Short-circuit: delete the row directly without a CLI
+        // ack round-trip.
         //
         // Single event loop turn: the scheduledAt > now check and the
         // deleteQueuedMessageById call execute atomically with no await between
@@ -624,7 +624,7 @@ export class MessageService {
         if (ackResult === 'consumed') {
             return this.recordConsumedAcknowledgement(sessionId, localId)
         }
-        if (ackResult === 'in-flight') {
+        if (ackResult === 'in-flight' || ackResult === 'indeterminate') {
             // The row is inside an async steer (mid-turn delivery): it can
             // neither be removed nor stamped invoked — the steer's eventual
             // accept/reject decides. Report busy so the caller keeps the row.
@@ -632,40 +632,19 @@ export class MessageService {
         }
 
         if (ackResult === 'not-found' || ackResult === 'timeout') {
-            // CLI could not remove the item — it was already shift()-ed or CLI is
-            // offline.  Stamp invoked_at immediately so the message lands in the thread
-            // as 'sent' instead of disappearing.  The agent's later assistant message
-            // (if it produced one) joins the same thread normally.
-            const invokedAt = Date.now()
-            try {
-                this.store.messages.markMessagesInvoked(sessionId, [localId], invokedAt)
-            } catch (err) {
-                console.error('cancelQueuedMessage: markMessagesInvoked failed', err)
-                // DB write failed — let the HTTP 500 surface to the caller.
-                throw err
+            // Neither outcome proves the model consumed the message. The CLI may have
+            // reserved it, disconnected, or simply missed the request. Hold the durable
+            // row out of automatic replay until a positive consumed ACK arrives or the
+            // user explicitly retries/discards it.
+            const changed = this.store.messages.setMessagesDeliveryState(sessionId, [localId], 'indeterminate')
+            if (changed === 0) {
+                const settled = this.store.messages.lookupQueuedMessage(sessionId, resolvedId)
+                if (settled.status === 'invoked') return settled
+                if (settled.status === 'absent') return { status: 'cancelled', localId }
+            } else {
+                this.publisher.emit({ type: 'messages-indeterminate', sessionId, localIds: [localId] })
             }
-            this.forgetScheduledMatureNotified([localId])
-            // Notify all SSE subscribers (other open tabs) that this queued row is now
-            // invoked so they remove it from the floating bar.  Without this emit, only
-            // the tab that sent the DELETE request learns about the status change via the
-            // HTTP response; every other subscriber keeps the row in the queued bar until
-            // a refresh or a later event.  Mirrors the identical publish in the normal
-            // CLI-driven path (sessionHandlers.ts messages-consumed handler).
-            this.publisher.emit({
-                type: 'messages-consumed',
-                sessionId,
-                localIds: [localId],
-                invokedAt,
-            })
-            // Re-fetch the single row via lookupQueuedMessage to avoid the 200-row
-            // pagination cap of getMessages.  After markMessagesInvoked the row will
-            // have invoked_at set, so lookupQueuedMessage returns status='invoked'.
-            const recheck = this.store.messages.lookupQueuedMessage(sessionId, localId)
-            if (recheck.status === 'invoked') {
-                return recheck
-            }
-            // Row absent from DB after markMessagesInvoked — edge case, treat as cancelled
-            return { status: 'cancelled', localId }
+            return { status: 'busy', localId }
         }
 
         // Phase 3: CLI confirmed removal.  Now DELETE the DB row and broadcast SSE.
@@ -1042,12 +1021,10 @@ export class MessageService {
      * restart scenarios (pitfall #2 guard).
      *
      * Race window with cancel: this tick widens the cancel race to 5 s for
-     * scheduled messages (vs near-zero for immediate-queued ones).  If the CLI
-     * has already shift()-ed the row when cancel arrives, cancelQueuedMessage
-     * gets 'not-found' from the CLI ack and stamps invoked_at (PR #568 contract
-     * preserved).  Web client surfaces this as 'sent' in the thread.
-     * See messageService.test.ts "cancel × mature race" for the documented
-     * expected behaviour. */
+     * scheduled messages (vs near-zero for immediate-queued ones). If the CLI
+     * has already shift()-ed the row when cancel arrives, a non-positive cancel
+     * ACK leaves the row indeterminate; only an explicit consumed ACK stamps it
+     * invoked. See messageService.test.ts "cancel × mature race". */
     releaseMatureScheduledMessages(now: number, skipSessionIds?: ReadonlySet<string>): void {
         const mature = this.store.messages.getMatureScheduledMessages(now)
         const maturedSessionIds = new Set<string>()


### PR DESCRIPTION
## Summary

- stop treating a cancel ACK timeout or `not-found` as proof that the CLI consumed the queued prompt
- persist the row as `indeterminate`, publish `messages-indeterminate`, and return the existing `busy` response
- retain the invoked path only for an explicit `consumed: true` ACK
- update the mature-scheduled race contract and regression tests

## Why

A client pressing Cancel could cause the hub to stamp `invoked_at` and emit `messages-consumed` solely because the CLI did not answer or could not find the queue entry. The client then correctly rendered the server-authoritative row as sent, making Cancel appear to deliver the prompt. Timeout/not-found is ambiguous; it is not evidence of model consumption.

## Verification

- `bun test hub/src/sync/messageService.test.ts` — 52 passed
- `bun run test:hub` — 1,209 passed, 3 skipped, 0 failed
- `bun run typecheck:hub` — passed

This pull request was generated with AI assistance (OpenAI Codex) and manually reviewed/tested before submission.