### PR TITLE
feat(web,ios,android): let Claude pick a permission mode when creating a session

### DIFF
--- a/android/app/src/main/kotlin/app/hapi/companion/feature/newsession/NewSessionForm.kt
+++ b/android/app/src/main/kotlin/app/hapi/companion/feature/newsession/NewSessionForm.kt
@@ -56,28 +56,37 @@ object NewSessionLogic {
     fun usesCodexFamilyPermissionModes(flavor: String?): Boolean =
         flavor in CODEX_FAMILY_PERMISSION_AGENTS
 
-    /** Flavors whose permission control is the native-mode select. */
+    /**
+     * Flavors whose permission control is the native-mode select. claude and
+     * grok do not share the codex-family mode set, but they render through
+     * the same native select (web `usesNativePermissionSelect`,
+     * `web/src/lib/codexFamilyPermissionAgents.ts`).
+     */
     fun usesNativePermissionSelect(flavor: String?): Boolean =
-        flavor == "grok" || usesCodexFamilyPermissionModes(flavor)
+        flavor == "claude" || flavor == "grok" || usesCodexFamilyPermissionModes(flavor)
 
     /**
      * Exact spawn body (`POST /api/machines/:id/spawn`), field-for-field port
      * of the web `handleCreate` mapping:
      * - `model`/`effort` only for flavors whose picker exists in this v1
      *   (claude static list, codex machine catalog; others send no model);
-     * - `yolo` for non-grok/non-codex-family flavors — **including `false`**;
-     * - `permissionMode` for grok + codex-family — including `'default'`;
+     * - `yolo` only for flavors still on the YOLO toggle (not
+     *   `usesNativePermissionSelect`) — **including `false`**;
+     * - `permissionMode` for every `usesNativePermissionSelect` flavor —
+     *   including `'default'`;
      * - `sessionType` always; `worktreeName` only for worktree and non-blank;
      * - `serviceTier` only while the codex fast tier is visible (then also
      *   `'standard'`); `collaborationMode` only when not `'default'`;
      * - `copilotAgentMode` always for copilot;
      * - `startingMode` omitted = the runner's `'remote'` default (v1 fixes
      *   remote; pty is deferred, matching the web create form).
+     *
+     * Unlike web, Android has no persistent YOLO preference to migrate: the
+     * toggle only lives in the in-memory form / a draft that is deleted on
+     * success, so there is nothing to bridge into `permissionMode` here.
      */
     fun buildSpawnRequest(form: NewSessionForm, codexFastTierVisible: Boolean): SpawnSessionRequest {
         val agent = form.agent
-        val codexFamily = usesCodexFamilyPermissionModes(agent)
-        val isGrok = agent == "grok"
         val resolvedModel = when {
             // v1 model pickers: claude (static presets) and codex (machine
             // catalog). Other flavors' discovery endpoints are TODO(M3d+),
@@ -95,8 +104,8 @@ object NewSessionLogic {
             } else {
                 null
             },
-            yolo = if (agent == "dsh" || isGrok || codexFamily) null else form.yolo,
-            permissionMode = if (isGrok || codexFamily) form.permissionMode else null,
+            yolo = if (agent == "dsh" || usesNativePermissionSelect(agent)) null else form.yolo,
+            permissionMode = if (usesNativePermissionSelect(agent)) form.permissionMode else null,
             sessionType = form.sessionType,
             worktreeName = if (form.sessionType == SESSION_TYPE_WORKTREE) {
                 form.worktreeName.trim().ifEmpty { null }

--- a/android/app/src/main/kotlin/app/hapi/companion/feature/newsession/NewSessionViewModel.kt
+++ b/android/app/src/main/kotlin/app/hapi/companion/feature/newsession/NewSessionViewModel.kt
@@ -79,10 +79,13 @@ class NewSessionStrings(
 
 /** Which permission control the current flavor renders (web `PermissionField`). */
 sealed interface PermissionUi {
-    /** Native permission-mode picker (grok + codex-family). */
+    /**
+     * Native permission-mode picker (claude, grok, codex-family —
+     * [NewSessionLogic.usesNativePermissionSelect]).
+     */
     data class NativeSelect(val options: List<OptionItem>) : PermissionUi
 
-    /** HAPI YOLO toggle (claude/agy/cursor) with the native mode it maps to. */
+    /** HAPI YOLO toggle (agy/cursor) with the native mode it maps to. */
     data class YoloToggle(val nativeModeLabel: String?) : PermissionUi
 
     /** Pi: the agent manages its own permissions. */

--- a/android/app/src/test/kotlin/app/hapi/companion/feature/newsession/NewSessionViewModelTest.kt
+++ b/android/app/src/test/kotlin/app/hapi/companion/feature/newsession/NewSessionViewModelTest.kt
@@ -164,7 +164,7 @@ private fun encode(request: SpawnSessionRequest): JsonObject =
 class SpawnBodyTest {
 
     @Test
-    fun `claude simple session with model, effort and yolo off`() {
+    fun `claude simple session with model, effort and permission mode`() {
         val body = encode(
             NewSessionLogic.buildSpawnRequest(
                 NewSessionForm(
@@ -173,23 +173,27 @@ class SpawnBodyTest {
                     agent = "claude",
                     model = "opus",
                     effort = "high",
-                    yolo = false,
+                    permissionMode = "plan",
+                    yolo = true,
                 ),
                 codexFastTierVisible = false,
             ),
         )
-        // Exact SpawnSessionRequestSchema field set — yolo false IS sent for
-        // claude; permissionMode / reasoning / codex fields are absent.
+        // Exact SpawnSessionRequestSchema field set — claude is on the native
+        // permission select now, so permissionMode IS sent (even a picked
+        // non-default mode) and yolo is absent, even when set on the form (a
+        // stale toggle value from before the flavor switch).
         assertEquals(
-            setOf("directory", "agent", "model", "effort", "yolo", "sessionType"),
+            setOf("directory", "agent", "model", "effort", "permissionMode", "sessionType"),
             body.keys,
         )
         assertEquals("/data/github/hapi", body["directory"]!!.jsonPrimitive.content)
         assertEquals("claude", body["agent"]!!.jsonPrimitive.content)
         assertEquals("opus", body["model"]!!.jsonPrimitive.content)
         assertEquals("high", body["effort"]!!.jsonPrimitive.content)
-        assertEquals(false, body["yolo"]!!.jsonPrimitive.boolean)
+        assertEquals("plan", body["permissionMode"]!!.jsonPrimitive.content)
         assertEquals("simple", body["sessionType"]!!.jsonPrimitive.content)
+        assertNull(body["yolo"])
     }
 
     @Test
@@ -907,6 +911,12 @@ class NewSessionViewModelTest {
         assertTrue(vm.uiState.value.permission is PermissionUi.Managed)
 
         vm.setAgent("claude")
+        advanceUntilIdle()
+        // Claude is on the native select now; the YOLO toggle only remains for
+        // the flavors still carrying it (cursor here).
+        assertTrue(vm.uiState.value.permission is PermissionUi.NativeSelect)
+
+        vm.setAgent("cursor")
         advanceUntilIdle()
         val toggle = vm.uiState.value.permission
         assertTrue(toggle is PermissionUi.YoloToggle)

--- a/ios/Hapi/Features/NewSession/NewSessionModel.swift
+++ b/ios/Hapi/Features/NewSession/NewSessionModel.swift
@@ -22,9 +22,10 @@ struct DirectoryStatusUI: Equatable {
 
 /// Which permission control the current flavor renders (web `PermissionField`).
 enum PermissionUI: Equatable {
-    /// Native permission-mode picker (grok + codex-family).
+    /// Native permission-mode picker (claude, grok, codex-family —
+    /// `NewSessionLogic.usesNativePermissionSelect`).
     case nativeSelect([PermissionModeOption])
-    /// HAPI YOLO toggle (claude/agy/cursor) with the native mode it maps to.
+    /// HAPI YOLO toggle (agy/cursor) with the native mode it maps to.
     case yoloToggle(nativeModeLabel: String?)
     /// Pi: the agent manages its own permissions.
     case managed

--- a/ios/Packages/HapiKit/Sources/HapiClient/NewSession/NewSessionForm.swift
+++ b/ios/Packages/HapiKit/Sources/HapiClient/NewSession/NewSessionForm.swift
@@ -122,9 +122,12 @@ public enum NewSessionLogic {
         codexFamilyPermissionAgents.contains(flavor)
     }
 
-    /// Flavors whose permission control is the native-mode select.
+    /// Flavors whose permission control is the native-mode select. claude
+    /// and grok do not share the codex-family mode set, but they render
+    /// through the same native select (web `usesNativePermissionSelect`,
+    /// `web/src/lib/codexFamilyPermissionAgents.ts`).
     public static func usesNativePermissionSelect(_ flavor: AgentFlavor) -> Bool {
-        flavor == .grok || usesCodexFamilyPermissionModes(flavor)
+        flavor == .claude || flavor == .grok || usesCodexFamilyPermissionModes(flavor)
     }
 
     /// `resolveHapiYoloPermissionMode` (`shared/src/agentConfig.ts`) — the
@@ -144,21 +147,25 @@ public enum NewSessionLogic {
     /// port of the web `handleCreate` mapping:
     /// - `model`/`effort` only for flavors whose picker exists in this v1
     ///   (claude static list, codex machine catalog; others send no model);
-    /// - `yolo` for non-grok/non-codex-family flavors — **including `false`**;
-    /// - `permissionMode` for grok + codex-family — including `'default'`;
+    /// - `yolo` only for flavors still on the YOLO toggle (not
+    ///   `usesNativePermissionSelect`) — **including `false`**;
+    /// - `permissionMode` for every `usesNativePermissionSelect` flavor —
+    ///   including `'default'`;
     /// - `sessionType` always; `worktreeName` only for worktree and non-blank;
     /// - `serviceTier` only while the codex fast tier is visible (then also
     ///   `'standard'`); `collaborationMode` only when not `'default'`;
     /// - `copilotAgentMode` always for copilot;
     /// - `startingMode` omitted = the runner's `'remote'` default (v1 fixes
     ///   remote; pty is deferred, matching the web create form).
+    ///
+    /// Unlike web, iOS has no persistent YOLO preference to migrate: the
+    /// toggle only lives in the in-memory form / a draft that is deleted on
+    /// success, so there is nothing to bridge into `permissionMode` here.
     public static func buildSpawnRequest(
         form: NewSessionForm,
         codexFastTierVisible: Bool
     ) -> SpawnRequest {
         let agent = form.agent
-        let codexFamily = usesCodexFamilyPermissionModes(agent)
-        let isGrok = agent == .grok
         // v1 model pickers: claude (static presets) and codex (machine
         // catalog). Other flavors' discovery endpoints are TODO(M4+), so
         // their model is never sent.
@@ -174,8 +181,8 @@ public enum NewSessionLogic {
             modelReasoningEffort: (agent == .codex && form.modelReasoningEffort != "default")
                 ? form.modelReasoningEffort
                 : nil,
-            yolo: (agent == .dsh || isGrok || codexFamily) ? nil : form.yolo,
-            permissionMode: (isGrok || codexFamily) ? form.permissionMode : nil,
+            yolo: (agent == .dsh || usesNativePermissionSelect(agent)) ? nil : form.yolo,
+            permissionMode: usesNativePermissionSelect(agent) ? form.permissionMode : nil,
             sessionType: form.sessionType,
             worktreeName: (form.sessionType == .worktree && !trimmedWorktreeName.isEmpty)
                 ? trimmedWorktreeName

--- a/ios/Packages/HapiKit/Tests/HapiClientTests/NewSessionFormTests.swift
+++ b/ios/Packages/HapiKit/Tests/HapiClientTests/NewSessionFormTests.swift
@@ -19,9 +19,11 @@ struct NewSessionSpawnBodyTests {
         return String(decoding: data, as: UTF8.self)
     }
 
-    @Test func claudeSimpleSessionWithModelEffortAndYoloOff() throws {
-        // Exact SpawnSessionRequestSchema field set — yolo false IS sent for
-        // claude; permissionMode / reasoning / codex fields are absent.
+    @Test func claudeSimpleSessionWithModelEffortAndPermissionMode() throws {
+        // Exact SpawnSessionRequestSchema field set — claude is on the
+        // native permission select now, so permissionMode IS sent (even a
+        // picked non-default mode) and yolo is absent, even when set on the
+        // form (a stale toggle value from before the flavor switch).
         let body = try canonicalBody(
             NewSessionForm(
                 machineId: "m1",
@@ -29,13 +31,14 @@ struct NewSessionSpawnBodyTests {
                 agent: .claude,
                 model: "opus",
                 effort: "high",
-                yolo: false
+                permissionMode: .plan,
+                yolo: true
             ),
             codexFastTierVisible: false
         )
         #expect(body == """
         {"agent":"claude","directory":"/data/github/hapi","effort":"high",\
-        "model":"opus","sessionType":"simple","yolo":false}
+        "model":"opus","permissionMode":"plan","sessionType":"simple"}
         """)
     }
 

--- a/web/src/components/NewSession/PermissionField.test.tsx
+++ b/web/src/components/NewSession/PermissionField.test.tsx
@@ -40,8 +40,17 @@ describe('PermissionField', () => {
         expect(screen.getByText(/did not enable Auto permissions/i)).toBeInTheDocument()
     })
 
+    it('renders Claude permission modes as a native select', () => {
+        const onChange = vi.fn()
+        renderField({ agent: 'claude', nativeValue: 'default', onNativeChange: onChange })
+        expect(screen.getByRole('combobox')).toBeTruthy()
+        expect(screen.getByRole('option', { name: 'Plan Mode' })).toBeTruthy()
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'plan' } })
+        expect(onChange).toHaveBeenCalledWith('plan')
+    })
+
     it('renders the YOLO toggle with its native mapping for toggle flavors', () => {
-        renderField({ agent: 'claude' })
+        renderField({ agent: 'cursor' })
         expect(screen.getByRole('checkbox')).toBeTruthy()
         expect(screen.getByText(/applies native Yolo mode/i)).toBeInTheDocument()
     })

--- a/web/src/components/NewSession/PermissionField.tsx
+++ b/web/src/components/NewSession/PermissionField.tsx
@@ -6,7 +6,7 @@ import {
     type PermissionMode
 } from '@hapi/protocol'
 import { useTranslation } from '@/lib/use-translation'
-import { usesCodexFamilyPermissionModes } from '@/lib/codexFamilyPermissionAgents'
+import { usesNativePermissionSelect } from '@/lib/codexFamilyPermissionAgents'
 import type { AgentType } from './types'
 import { SelectControl } from '@/components/ui/select-control'
 import { YoloToggle } from './YoloToggle'
@@ -58,7 +58,7 @@ export function PermissionField(props: PermissionFieldProps) {
         )
     }
 
-    if (field.kind === 'select' && (props.agent === 'grok' || usesCodexFamilyPermissionModes(props.agent))) {
+    if (field.kind === 'select' && usesNativePermissionSelect(props.agent)) {
         const options = getPermissionModeOptionsForFlavor(props.agent)
         return (
             <div className="flex flex-col gap-1.5 px-3 py-3">

--- a/web/src/components/NewSession/PermissionField.tsx
+++ b/web/src/components/NewSession/PermissionField.tsx
@@ -28,9 +28,11 @@ export type PermissionFieldProps = {
  *
  * - `status` fields (Pi) surface a managed note instead of a control so the
  *   HAPI YOLO policy is never silently ignored for agents that cannot apply it.
- * - `select` fields render the agent's native permission modes.
- * - Flavors whose create surface still carries the persistent HAPI YOLO
- *   preference render the YOLO toggle with the native mode it maps to.
+ * - `select` fields render the agent's native permission modes. Claude and
+ *   grok get this native select at create time even though neither shares
+ *   the codex-family mode set (see usesNativePermissionSelect).
+ * - Remaining flavors whose create surface still carries the persistent HAPI
+ *   YOLO preference render the YOLO toggle with the native mode it maps to.
  */
 export function PermissionField(props: PermissionFieldProps) {
     const { t } = useTranslation()

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -197,9 +197,14 @@ vi.mock('./PermissionField', () => ({
         onNativeChange: (mode: string) => void
         onYoloToggle: (value: boolean) => void
     }) => (
-        <button type="button" data-testid="permission-mode" onClick={() => props.onNativeChange('yolo')}>
-            {props.nativeValue}
-        </button>
+        <>
+            <button type="button" data-testid="permission-mode" onClick={() => props.onNativeChange('yolo')}>
+                {props.nativeValue}
+            </button>
+            <button type="button" data-testid="permission-mode-plan" onClick={() => props.onNativeChange('plan')}>
+                {props.nativeValue}
+            </button>
+        </>
     )
 }))
 vi.mock('./CopilotAgentModeSelector', () => ({ CopilotAgentModeSelector: () => null }))
@@ -607,6 +612,72 @@ describe('NewSession launch preferences', () => {
             yolo: undefined,
             permissionMode: undefined
         }))
+    })
+
+    it('lets Claude create with a chosen permission mode instead of the global YOLO toggle', async () => {
+        savePreferredAgent('claude')
+        mocks.spawnSession.mockResolvedValue({ type: 'success', sessionId: 'claude-session' })
+        render(<NewSession api={api} machines={[machine]} initialMachineId="machine-1" initialDirectory="C:\\repo" onSuccess={mocks.onSuccess} onCancel={() => {}} />)
+
+        fireEvent.click(screen.getByTestId('permission-mode-plan'))
+        fireEvent.click(screen.getByTestId('create'))
+
+        await waitFor(() => expect(mocks.onSuccess).toHaveBeenCalledWith('claude-session'))
+        expect(mocks.spawnSession).toHaveBeenCalledWith(expect.objectContaining({
+            agent: 'claude',
+            yolo: undefined,
+            permissionMode: 'plan'
+        }))
+    })
+
+    it('does not carry a permission mode picked under another flavor into the Claude spawn payload', async () => {
+        savePreferredAgent('codex')
+        mocks.spawnSession.mockResolvedValue({ type: 'success', sessionId: 'claude-session' })
+        render(<NewSession api={api} machines={[machine]} initialMachineId="machine-1" initialDirectory="C:\\repo" onSuccess={mocks.onSuccess} onCancel={() => {}} />)
+
+        // Starts as codex; picking the mocked native-select button sets the
+        // shared nativePermissionMode state to 'yolo', a value 'claude' does
+        // not carry in its own permission catalog.
+        await waitFor(() => expect(screen.getByDisplayValue('codex')).toBeChecked())
+        fireEvent.click(screen.getByTestId('permission-mode'))
+        fireEvent.click(screen.getByDisplayValue('claude'))
+        await waitFor(() => expect(screen.getByDisplayValue('claude')).toBeChecked())
+        fireEvent.click(screen.getByTestId('create'))
+
+        await waitFor(() => expect(mocks.onSuccess).toHaveBeenCalledWith('claude-session'))
+        expect(mocks.spawnSession).toHaveBeenCalledWith(expect.objectContaining({
+            agent: 'claude',
+            permissionMode: 'default'
+        }))
+    })
+
+    it('migrates a legacy YOLO value owned by Claude to bypassPermissions', async () => {
+        savePreferredAgent('claude')
+        savePreferredYoloMode(true)
+
+        render(<NewSession api={api} machines={[machine]} initialMachineId="machine-1" initialDirectory="C:\\repo" onSuccess={mocks.onSuccess} onCancel={() => {}} />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('permission-mode')).toHaveTextContent('bypassPermissions')
+        })
+    })
+
+    it('does not preselect bypassPermissions for Claude from a legacy YOLO value owned by another flavor', async () => {
+        // hapi:newSession:yolo is a flavor-agnostic global key. The legacyYoloAgent
+        // snapshot (captured once at mount, see index.tsx) is what stops a YOLO
+        // toggle left on under cursor from silently preselecting bypassPermissions
+        // the next time Claude is picked.
+        savePreferredAgent('cursor')
+        savePreferredYoloMode(true)
+
+        render(<NewSession api={api} machines={[machine]} initialMachineId="machine-1" initialDirectory="C:\\repo" onSuccess={mocks.onSuccess} onCancel={() => {}} />)
+
+        await waitFor(() => expect(screen.getByDisplayValue('cursor')).toBeChecked())
+        fireEvent.click(screen.getByDisplayValue('claude'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('permission-mode')).toHaveTextContent('default')
+        })
     })
 
     it('keeps an explicit OpenCode Default selection instead of restoring a concrete model', async () => {

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -560,7 +560,7 @@ describe('NewSession launch preferences', () => {
         saveNewSessionFormDraft({
             agent: 'agy', model: 'gemini-3.6-flash-low', cursorSelectedBase: 'auto', machineId: 'machine-1',
             effort: 'auto', modelReasoningEffort: 'default', serviceTier: 'standard', collaborationMode: 'default',
-            copilotAgentMode: 'interactive', yoloMode: false, codexFamilyPermissionMode: 'default',
+            copilotAgentMode: 'interactive', yoloMode: false, nativePermissionMode: 'default',
             grokPermissionMode: 'default', sessionType: 'simple', worktreeName: ''
         })
         render(<NewSession api={api} machines={[machine]} initialMachineId="machine-1" initialDirectory="C:\repo" onSuccess={mocks.onSuccess} onCancel={() => {}} />)
@@ -572,7 +572,7 @@ describe('NewSession launch preferences', () => {
         saveNewSessionFormDraft({
             agent: 'agy', model: 'removed-model', cursorSelectedBase: 'auto', machineId: 'machine-1',
             effort: 'auto', modelReasoningEffort: 'default', serviceTier: 'standard', collaborationMode: 'default',
-            copilotAgentMode: 'interactive', yoloMode: false, codexFamilyPermissionMode: 'default',
+            copilotAgentMode: 'interactive', yoloMode: false, nativePermissionMode: 'default',
             grokPermissionMode: 'default', sessionType: 'simple', worktreeName: ''
         })
         render(<NewSession api={api} machines={[machine]} initialMachineId="machine-1" initialDirectory="C:\repo" onSuccess={mocks.onSuccess} onCancel={() => {}} />)
@@ -899,7 +899,7 @@ describe('NewSession launch preferences', () => {
             collaborationMode: 'default',
             copilotAgentMode: 'interactive',
             yoloMode: false,
-            codexFamilyPermissionMode: 'default',
+            nativePermissionMode: 'default',
             grokPermissionMode: 'default',
             sessionType: 'simple',
             worktreeName: ''

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -68,7 +68,7 @@ import {
 } from './preferences'
 import { SessionTypeSelector } from './SessionTypeSelector'
 import { PermissionField } from './PermissionField'
-import { usesCodexFamilyPermissionModes, usesNativePermissionSelect } from '@/lib/codexFamilyPermissionAgents'
+import { usesNativePermissionSelect, usesSharedPermissionModeState } from '@/lib/codexFamilyPermissionAgents'
 import { CodexSessionSyncDialog } from '@/components/CodexSessionSyncDialog'
 import { PiSessionImportDialog } from '@/components/PiSessionImportDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
@@ -101,8 +101,13 @@ export function NewSession(props: {
     const [suppressSuggestions, setSuppressSuggestions] = useState(false)
     const [isDirectoryFocused, setIsDirectoryFocused] = useState(false)
     const [agent, setAgent] = useState<AgentType>(loadPreferredAgent)
-    const [legacyCodexYolo] = useState(
-        () => loadPreferredAgent() === 'codex' && loadPreferredYoloMode()
+    // Snapshot taken once at mount, before any savePreferredAgent() call this
+    // component makes can overwrite the stored agent. savePreferredAgent()
+    // runs on every agent change (below), so reading loadPreferredAgent()
+    // again later would always equal the current agent and make the
+    // legacyYoloAgent === agent gate at the restore effect below vacuous.
+    const [legacyYoloAgent] = useState(
+        () => (loadPreferredYoloMode() ? loadPreferredAgent() : null)
     )
     const [model, setModel] = useState('auto')
     const [cursorSelectedBase, setCursorSelectedBase] = useState('auto')
@@ -778,6 +783,9 @@ export function NewSession(props: {
         setOpencodeSelectedModel(undefined)
     }, [agent, machineId, deferredDirectory])
 
+    const usesNativeSelect = usesNativePermissionSelect(agent)
+    const usesSharedPermissionMode = usesSharedPermissionModeState(agent)
+
     useEffect(() => {
         if (!machineId || preserveRestoredDraftRef.current) {
             return
@@ -786,14 +794,14 @@ export function NewSession(props: {
         const preferred = resolvePreferredLaunchSettings(
             agent,
             loadPreferredLaunchSettings(machineId, agent),
-            legacyCodexYolo
+            legacyYoloAgent === agent
         )
 
         setModel(agent === 'opencode' ? 'auto' : preferred.model)
         setCursorSelectedBase(preferred.cursorSelectedBase)
         setEffort(preferred.effort)
         setModelReasoningEffort(preferred.modelReasoningEffort)
-        if (usesCodexFamilyPermissionModes(agent)) {
+        if (usesSharedPermissionMode) {
             setNativePermissionMode(preferred.permissionMode ?? 'default')
         }
         setOpencodeSelectedModel(
@@ -802,7 +810,7 @@ export function NewSession(props: {
         setAgySelectedModel(
             agent === 'agy' && preferred.model !== 'auto' ? preferred.model : null
         )
-    }, [agent, legacyCodexYolo, machineId])
+    }, [agent, legacyYoloAgent, machineId, usesSharedPermissionMode])
 
     useEffect(() => {
         if (
@@ -1466,7 +1474,6 @@ export function NewSession(props: {
             const resolvedModelReasoningEffort = (agent === 'codex' || agent === 'opencode') && modelReasoningEffort !== 'default'
                 ? modelReasoningEffort
                 : undefined
-            const usesCodexFamilyPermissions = usesCodexFamilyPermissionModes(agent)
             const preferredLaunchSettings = {
                 model: agent === 'agy'
                     ? (agySelectedModel ?? 'auto')
@@ -1476,7 +1483,7 @@ export function NewSession(props: {
                 cursorSelectedBase,
                 effort,
                 modelReasoningEffort,
-                ...(usesCodexFamilyPermissions ? { permissionMode: nativePermissionMode } : {})
+                ...(usesSharedPermissionMode ? { permissionMode: nativePermissionMode } : {})
             }
             const resolvedServiceTier = agent === 'codex' && showCodexFastMode
                 ? serviceTier
@@ -1557,10 +1564,10 @@ export function NewSession(props: {
                 model: resolvedModel,
                 effort: resolvedEffort,
                 modelReasoningEffort: resolvedModelReasoningEffort,
-                yolo: agent === 'dsh' || usesNativePermissionSelect(agent) ? undefined : yoloMode,
+                yolo: agent === 'dsh' || usesNativeSelect ? undefined : yoloMode,
                 permissionMode: agent === 'grok'
                     ? grokPermissionMode
-                    : usesCodexFamilyPermissions
+                    : usesSharedPermissionMode
                         ? nativePermissionMode
                         : undefined,
                 sessionType,

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -68,7 +68,7 @@ import {
 } from './preferences'
 import { SessionTypeSelector } from './SessionTypeSelector'
 import { PermissionField } from './PermissionField'
-import { usesCodexFamilyPermissionModes } from '@/lib/codexFamilyPermissionAgents'
+import { usesCodexFamilyPermissionModes, usesNativePermissionSelect } from '@/lib/codexFamilyPermissionAgents'
 import { CodexSessionSyncDialog } from '@/components/CodexSessionSyncDialog'
 import { PiSessionImportDialog } from '@/components/PiSessionImportDialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
@@ -114,7 +114,7 @@ export function NewSession(props: {
     const [collaborationMode, setCollaborationMode] = useState<CodexCollaborationMode>('default')
     const [copilotAgentMode, setCopilotAgentMode] = useState<CopilotAgentMode>('interactive')
     const [yoloMode, setYoloMode] = useState(loadPreferredYoloMode)
-    const [codexFamilyPermissionMode, setCodexFamilyPermissionMode] = useState<PermissionMode>('default')
+    const [nativePermissionMode, setNativePermissionMode] = useState<PermissionMode>('default')
     const [grokPermissionMode, setGrokPermissionMode] = useState<GrokPermissionMode>('default')
     const [sessionType, setSessionType] = useState<SessionType>('simple')
     const [worktreeName, setWorktreeName] = useState('')
@@ -170,7 +170,7 @@ export function NewSession(props: {
         setEffort('auto')
         setModelReasoningEffort('default')
         setGrokPermissionMode('default')
-        setCodexFamilyPermissionMode('default')
+        setNativePermissionMode('default')
         setServiceTier('standard')
         setCollaborationMode('default')
         setCopilotAgentMode('interactive')
@@ -246,7 +246,7 @@ export function NewSession(props: {
         setCollaborationMode(draft.collaborationMode)
         setCopilotAgentMode(draft.copilotAgentMode)
         setYoloMode(draft.yoloMode)
-        setCodexFamilyPermissionMode(draft.codexFamilyPermissionMode)
+        setNativePermissionMode(draft.nativePermissionMode)
         setGrokPermissionMode(draft.grokPermissionMode)
         setSessionType(draft.sessionType)
         setWorktreeName(draft.worktreeName)
@@ -794,7 +794,7 @@ export function NewSession(props: {
         setEffort(preferred.effort)
         setModelReasoningEffort(preferred.modelReasoningEffort)
         if (usesCodexFamilyPermissionModes(agent)) {
-            setCodexFamilyPermissionMode(preferred.permissionMode ?? 'default')
+            setNativePermissionMode(preferred.permissionMode ?? 'default')
         }
         setOpencodeSelectedModel(
             agent === 'opencode' && preferred.model !== 'auto' ? preferred.model : null
@@ -1321,7 +1321,7 @@ export function NewSession(props: {
             collaborationMode,
             copilotAgentMode,
             yoloMode,
-            codexFamilyPermissionMode,
+            nativePermissionMode,
             grokPermissionMode,
             sessionType,
             worktreeName
@@ -1341,7 +1341,7 @@ export function NewSession(props: {
         collaborationMode,
         copilotAgentMode,
         yoloMode,
-        codexFamilyPermissionMode,
+        nativePermissionMode,
         grokPermissionMode,
         sessionType,
         worktreeName,
@@ -1476,7 +1476,7 @@ export function NewSession(props: {
                 cursorSelectedBase,
                 effort,
                 modelReasoningEffort,
-                ...(usesCodexFamilyPermissions ? { permissionMode: codexFamilyPermissionMode } : {})
+                ...(usesCodexFamilyPermissions ? { permissionMode: nativePermissionMode } : {})
             }
             const resolvedServiceTier = agent === 'codex' && showCodexFastMode
                 ? serviceTier
@@ -1495,7 +1495,7 @@ export function NewSession(props: {
                     modelReasoningEffort: resolvedModelReasoningEffort ?? null,
                     serviceTier: resolvedServiceTier,
                     collaborationMode: resolvedCollaborationMode ?? 'default',
-                    yolo: codexFamilyPermissionMode === 'yolo'
+                    yolo: nativePermissionMode === 'yolo'
                 })
                 if (result.success) {
                     const importedSessionId = result.hapiSessionIds?.[0]
@@ -1506,8 +1506,8 @@ export function NewSession(props: {
                     // 这里立刻 resume，避免进入会话页时先看到离线，等首条消息才触发启动。
                     const resumedSessionId = await props.api.resumeSession(
                         importedSessionId,
-                        codexFamilyPermissionMode !== 'default'
-                            ? { permissionMode: codexFamilyPermissionMode }
+                        nativePermissionMode !== 'default'
+                            ? { permissionMode: nativePermissionMode }
                             : undefined
                     )
                     haptic.notification('success')
@@ -1557,11 +1557,11 @@ export function NewSession(props: {
                 model: resolvedModel,
                 effort: resolvedEffort,
                 modelReasoningEffort: resolvedModelReasoningEffort,
-                yolo: agent === 'dsh' || agent === 'grok' || usesCodexFamilyPermissions ? undefined : yoloMode,
+                yolo: agent === 'dsh' || usesNativePermissionSelect(agent) ? undefined : yoloMode,
                 permissionMode: agent === 'grok'
                     ? grokPermissionMode
                     : usesCodexFamilyPermissions
-                        ? codexFamilyPermissionMode
+                        ? nativePermissionMode
                         : undefined,
                 sessionType,
                 worktreeName: sessionType === 'worktree' ? (worktreeName.trim() || undefined) : undefined,
@@ -1849,7 +1849,7 @@ export function NewSession(props: {
             ) : null}
             <PermissionField
                 agent={agent}
-                nativeValue={agent === 'grok' ? grokPermissionMode : codexFamilyPermissionMode}
+                nativeValue={agent === 'grok' ? grokPermissionMode : nativePermissionMode}
                 yoloMode={yoloMode}
                 autoPermissionModeSupported={agent === 'grok' ? grokModelsState.autoPermissionModeSupported : null}
                 isDisabled={isFormDisabled}
@@ -1857,7 +1857,7 @@ export function NewSession(props: {
                     if (agent === 'grok') {
                         setGrokPermissionMode(mode as GrokPermissionMode)
                     } else {
-                        setCodexFamilyPermissionMode(mode)
+                        setNativePermissionMode(mode)
                     }
                 }}
                 onYoloToggle={setYoloMode}

--- a/web/src/components/NewSession/newSessionFormDraft.test.ts
+++ b/web/src/components/NewSession/newSessionFormDraft.test.ts
@@ -135,7 +135,10 @@ describe('newSessionFormDraft', () => {
         expect(loaded.machineId).toBe('machine-1')
     })
 
-    it('maps legacy yoloMode to codex-family permission mode when restoring copilot drafts', () => {
+    it('does not bridge a legacy yoloMode for a flavor outside the legacy YOLO allow-list (copilot)', () => {
+        // copilot moved to the native permission select before the YOLO
+        // toggle era; its restore-time bridge target already settled on
+        // 'default' and stays there (see LEGACY_YOLO_BRIDGE_AGENTS).
         sessionStorage.setItem('hapi:new-session-form-draft', JSON.stringify({
             agent: 'copilot',
             model: 'auto',
@@ -153,6 +156,69 @@ describe('newSessionFormDraft', () => {
 
         const loaded = loadNewSessionFormDraft()!
         expect(loaded.agent).toBe('copilot')
+        expect(loaded.nativePermissionMode).toBe('default')
+    })
+
+    it('does not bridge a legacy yoloMode for opencode', () => {
+        sessionStorage.setItem('hapi:new-session-form-draft', JSON.stringify({
+            agent: 'opencode',
+            model: 'auto',
+            cursorSelectedBase: 'auto',
+            machineId: 'machine-1',
+            effort: 'auto',
+            modelReasoningEffort: 'default',
+            serviceTier: 'standard',
+            collaborationMode: 'default',
+            copilotAgentMode: 'interactive',
+            yoloMode: true,
+            sessionType: 'simple',
+            worktreeName: ''
+        }))
+
+        const loaded = loadNewSessionFormDraft()!
+        expect(loaded.agent).toBe('opencode')
+        expect(loaded.nativePermissionMode).toBe('default')
+    })
+
+    it('bridges a legacy yoloMode to yolo when restoring codex drafts (pin: codex stays in the allow-list)', () => {
+        sessionStorage.setItem('hapi:new-session-form-draft', JSON.stringify({
+            agent: 'codex',
+            model: 'auto',
+            cursorSelectedBase: 'auto',
+            machineId: 'machine-1',
+            effort: 'auto',
+            modelReasoningEffort: 'default',
+            serviceTier: 'standard',
+            collaborationMode: 'default',
+            copilotAgentMode: 'interactive',
+            yoloMode: true,
+            sessionType: 'simple',
+            worktreeName: ''
+        }))
+
+        const loaded = loadNewSessionFormDraft()!
+        expect(loaded.agent).toBe('codex')
         expect(loaded.nativePermissionMode).toBe('yolo')
+    })
+
+    it('maps legacy yoloMode to bypassPermissions when restoring claude drafts', () => {
+        sessionStorage.setItem('hapi:new-session-form-draft', JSON.stringify({
+            agent: 'claude',
+            model: 'auto',
+            cursorSelectedBase: 'auto',
+            machineId: 'machine-1',
+            effort: 'auto',
+            modelReasoningEffort: 'default',
+            serviceTier: 'standard',
+            collaborationMode: 'default',
+            copilotAgentMode: 'interactive',
+            yoloMode: true,
+            sessionType: 'simple',
+            worktreeName: ''
+        }))
+
+        const loaded = loadNewSessionFormDraft()!
+        expect(loaded.agent).toBe('claude')
+        expect(loaded.nativePermissionMode).toBe('bypassPermissions')
     })
 })

--- a/web/src/components/NewSession/newSessionFormDraft.test.ts
+++ b/web/src/components/NewSession/newSessionFormDraft.test.ts
@@ -24,7 +24,7 @@ describe('newSessionFormDraft', () => {
             collaborationMode: 'default',
             copilotAgentMode: 'interactive',
             yoloMode: false,
-            codexFamilyPermissionMode: 'default',
+            nativePermissionMode: 'default',
             grokPermissionMode: 'default',
             sessionType: 'simple',
             worktreeName: ''
@@ -41,7 +41,7 @@ describe('newSessionFormDraft', () => {
             collaborationMode: 'default',
             copilotAgentMode: 'interactive',
             yoloMode: false,
-            codexFamilyPermissionMode: 'default',
+            nativePermissionMode: 'default',
             grokPermissionMode: 'default',
             sessionType: 'simple',
             worktreeName: ''
@@ -71,7 +71,7 @@ describe('newSessionFormDraft', () => {
             collaborationMode: 'default',
             copilotAgentMode: 'interactive',
             yoloMode: false,
-            codexFamilyPermissionMode: 'default',
+            nativePermissionMode: 'default',
             grokPermissionMode: 'default',
             sessionType: 'simple',
             worktreeName: ''
@@ -92,7 +92,7 @@ describe('newSessionFormDraft', () => {
             collaborationMode: 'plan',
             copilotAgentMode: 'interactive',
             yoloMode: false,
-            codexFamilyPermissionMode: 'default',
+            nativePermissionMode: 'default',
             grokPermissionMode: 'default',
             sessionType: 'simple',
             worktreeName: ''
@@ -115,7 +115,7 @@ describe('newSessionFormDraft', () => {
             collaborationMode: 'plan',
             copilotAgentMode: 'interactive',
             yoloMode: true,
-            codexFamilyPermissionMode: 'default',
+            nativePermissionMode: 'default',
             grokPermissionMode: 'default',
             sessionType: 'simple',
             worktreeName: ''
@@ -153,6 +153,6 @@ describe('newSessionFormDraft', () => {
 
         const loaded = loadNewSessionFormDraft()!
         expect(loaded.agent).toBe('copilot')
-        expect(loaded.codexFamilyPermissionMode).toBe('yolo')
+        expect(loaded.nativePermissionMode).toBe('yolo')
     })
 })

--- a/web/src/components/NewSession/newSessionFormDraft.ts
+++ b/web/src/components/NewSession/newSessionFormDraft.ts
@@ -3,12 +3,14 @@ import {
     GROK_PERMISSION_MODES,
     getPermissionModesForFlavor,
     normalizeCopilotAgentMode,
+    resolveHapiYoloPermissionMode,
     type CodexCollaborationMode,
     type CopilotAgentMode,
     type GrokPermissionMode,
     type PermissionMode
 } from '@hapi/protocol'
 import type { AgentType, LaunchEffort, CodexReasoningEffort, NewSessionServiceTier, SessionType } from './types'
+import { LEGACY_YOLO_BRIDGE_AGENTS } from '@/lib/codexFamilyPermissionAgents'
 
 const DRAFT_STORAGE_KEY = 'hapi:new-session-form-draft'
 
@@ -78,8 +80,11 @@ export function loadNewSessionFormDraft(): NewSessionFormDraft | null {
                 if (agentPreserved && parsedMode && modes.includes(parsedMode)) {
                     return parsedMode
                 }
-                if (agentPreserved && parsed.yoloMode && modes.includes('yolo')) {
-                    return 'yolo'
+                const yoloBridgeMode = LEGACY_YOLO_BRIDGE_AGENTS.includes(restoredAgent)
+                    ? resolveHapiYoloPermissionMode(restoredAgent)
+                    : null
+                if (agentPreserved && parsed.yoloMode && yoloBridgeMode && modes.includes(yoloBridgeMode)) {
+                    return yoloBridgeMode
                 }
                 return 'default'
             })(),

--- a/web/src/components/NewSession/newSessionFormDraft.ts
+++ b/web/src/components/NewSession/newSessionFormDraft.ts
@@ -23,7 +23,7 @@ export type NewSessionFormDraft = {
     collaborationMode: CodexCollaborationMode
     copilotAgentMode: CopilotAgentMode
     yoloMode: boolean
-    codexFamilyPermissionMode: PermissionMode
+    nativePermissionMode: PermissionMode
     grokPermissionMode: GrokPermissionMode
     sessionType: SessionType
     worktreeName: string
@@ -72,9 +72,9 @@ export function loadNewSessionFormDraft(): NewSessionFormDraft | null {
                 ? normalizeCopilotAgentMode(parsed.copilotAgentMode)
                 : 'interactive',
             yoloMode: Boolean(parsed.yoloMode),
-            codexFamilyPermissionMode: (() => {
+            nativePermissionMode: (() => {
                 const modes = getPermissionModesForFlavor(restoredAgent)
-                const parsedMode = parsed.codexFamilyPermissionMode as PermissionMode | undefined
+                const parsedMode = parsed.nativePermissionMode as PermissionMode | undefined
                 if (agentPreserved && parsedMode && modes.includes(parsedMode)) {
                     return parsedMode
                 }

--- a/web/src/components/NewSession/preferences.test.ts
+++ b/web/src/components/NewSession/preferences.test.ts
@@ -133,7 +133,8 @@ describe('NewSession preferences', () => {
             model: 'auto',
             cursorSelectedBase: 'auto',
             effort: 'auto',
-            modelReasoningEffort: 'default'
+            modelReasoningEffort: 'default',
+            permissionMode: 'default'
         })
     })
 
@@ -175,6 +176,29 @@ describe('NewSession preferences', () => {
         expect(resolvePreferredLaunchSettings('codex', null, true).permissionMode).toBe('yolo')
         expect(resolvePreferredLaunchSettings('copilot', null, true).permissionMode).toBe('default')
         expect(resolvePreferredLaunchSettings('codex', null, false).permissionMode).toBe('default')
+    })
+
+    it('migrates the legacy YOLO preference for Claude to bypassPermissions', () => {
+        expect(resolvePreferredLaunchSettings('claude', null, true).permissionMode).toBe('bypassPermissions')
+        expect(resolvePreferredLaunchSettings('claude', null, false).permissionMode).toBe('default')
+    })
+
+    it('round-trips a Claude permission mode through storage', () => {
+        savePreferredLaunchSettings('machine-1', 'claude', {
+            model: 'auto',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'default',
+            permissionMode: 'plan'
+        })
+
+        expect(loadPreferredLaunchSettings('machine-1', 'claude')).toEqual({
+            model: 'auto',
+            cursorSelectedBase: 'auto',
+            effort: 'auto',
+            modelReasoningEffort: 'default',
+            permissionMode: 'plan'
+        })
     })
 
     it.each([

--- a/web/src/components/NewSession/preferences.ts
+++ b/web/src/components/NewSession/preferences.ts
@@ -1,6 +1,7 @@
 import {
     CREATABLE_AGENT_FLAVORS,
     getPermissionModesForFlavor,
+    resolveHapiYoloPermissionMode,
     type PermissionMode
 } from '@hapi/protocol'
 import {
@@ -11,7 +12,7 @@ import {
     type CodexReasoningEffort,
     type LaunchEffort
 } from './types'
-import { usesCodexFamilyPermissionModes } from '@/lib/codexFamilyPermissionAgents'
+import { LEGACY_YOLO_BRIDGE_AGENTS, usesSharedPermissionModeState } from '@/lib/codexFamilyPermissionAgents'
 
 const AGENT_STORAGE_KEY = 'hapi:newSession:agent'
 const YOLO_STORAGE_KEY = 'hapi:newSession:yolo'
@@ -128,7 +129,7 @@ function resolvePreferredOptionValue(
 export function resolvePreferredLaunchSettings(
     agent: AgentType,
     preferred: PreferredLaunchSettings | null,
-    legacyCodexYolo = false
+    legacyYolo = false
 ): PreferredLaunchSettings {
     const preferredModel = preferred?.model ?? 'auto'
     const staticModelValues = MODEL_OPTIONS[agent].map((option) => option.value)
@@ -151,14 +152,17 @@ export function resolvePreferredLaunchSettings(
             'default'
         )
         : (preferred?.modelReasoningEffort ?? 'default')
-    const supportsCodexFamilyPermissionMode = usesCodexFamilyPermissionModes(agent)
+    const usesSharedPermissionMode = usesSharedPermissionModeState(agent)
     const availablePermissionModes = getPermissionModesForFlavor(agent)
     const preferredPermissionMode = preferred?.permissionMode
-    const permissionMode = supportsCodexFamilyPermissionMode
+    const legacyYoloBridgeMode = legacyYolo && LEGACY_YOLO_BRIDGE_AGENTS.includes(agent)
+        ? resolveHapiYoloPermissionMode(agent)
+        : null
+    const permissionMode = usesSharedPermissionMode
         ? preferredPermissionMode && availablePermissionModes.includes(preferredPermissionMode)
             ? preferredPermissionMode
-            : agent === 'codex' && legacyCodexYolo
-                ? 'yolo'
+            : legacyYoloBridgeMode && availablePermissionModes.includes(legacyYoloBridgeMode)
+                ? legacyYoloBridgeMode
                 : 'default'
         : undefined
 

--- a/web/src/lib/codexFamilyPermissionAgents.ts
+++ b/web/src/lib/codexFamilyPermissionAgents.ts
@@ -23,7 +23,28 @@ export function usesCodexFamilyPermissionModes(
  * Ports: `NewSessionLogic.usesNativePermissionSelect`
  * (`ios/Packages/HapiKit/Sources/HapiClient/NewSession/NewSessionForm.swift`,
  * `android/app/src/main/kotlin/app/hapi/companion/feature/newsession/NewSessionForm.kt`).
+ * claude and grok do not share the codex-family mode set, but they render
+ * through the same native select.
  */
 export function usesNativePermissionSelect(flavor: string | null | undefined): boolean {
-    return flavor === 'grok' || usesCodexFamilyPermissionModes(flavor)
+    return flavor === 'claude' || flavor === 'grok' || usesCodexFamilyPermissionModes(flavor)
 }
+
+/**
+ * Flavors that keep their create-form permission choice in the single shared
+ * `nativePermissionMode` state. Grok is a native-select flavor but is
+ * excluded: its Auto option depends on a machine capability
+ * (`autoPermissionModeSupported`) that the other native-select flavors do
+ * not gate on, so it keeps its own state (`grokPermissionMode`) instead.
+ */
+export function usesSharedPermissionModeState(flavor: string | null | undefined): boolean {
+    return usesNativePermissionSelect(flavor) && flavor !== 'grok'
+}
+
+/**
+ * Flavors whose create surface carried the HAPI YOLO toggle before it moved
+ * to the native permission select. Their stored toggle preference migrates
+ * once into the native mode it mapped to; flavors that moved earlier already
+ * settled on 'default' and are intentionally left alone.
+ */
+export const LEGACY_YOLO_BRIDGE_AGENTS: readonly AgentFlavor[] = ['codex', 'claude']

--- a/web/src/lib/codexFamilyPermissionAgents.ts
+++ b/web/src/lib/codexFamilyPermissionAgents.ts
@@ -17,3 +17,13 @@ export function usesCodexFamilyPermissionModes(
     return typeof flavor === 'string'
         && (CODEX_FAMILY_PERMISSION_AGENTS as readonly string[]).includes(flavor)
 }
+
+/**
+ * Flavors whose create-form permission control is the native-mode select.
+ * Ports: `NewSessionLogic.usesNativePermissionSelect`
+ * (`ios/Packages/HapiKit/Sources/HapiClient/NewSession/NewSessionForm.swift`,
+ * `android/app/src/main/kotlin/app/hapi/companion/feature/newsession/NewSessionForm.kt`).
+ */
+export function usesNativePermissionSelect(flavor: string | null | undefined): boolean {
+    return flavor === 'grok' || usesCodexFamilyPermissionModes(flavor)
+}


### PR DESCRIPTION
## Problem

Claude's create form has no permission picker. It gets the global HAPI YOLO toggle, while grok and the codex family already get the native permission select. Starting a Claude session in Plan Mode therefore means creating the session first, opening the composer settings, switching the mode there, and only then sending the first message.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/dd908a4c-8441-4a5d-bc87-c6fce549e6a6) | ![after](https://github.com/user-attachments/assets/468e8dcf-0306-4e72-a7f7-af77d6fd3968) |

This is the Claude part of #1438, which describes the same split and asks for Permission to be a first-class control on the Create surface. The agent config descriptor already declares Claude's permission field as a `select` available at create time, and `hapi claude` already accepts every Claude mode over `--permission-mode`; only the create UI was still on the toggle.

## Solution

`usesNativePermissionSelect(flavor)` becomes the single gate for the native select, and Claude joins grok and the codex family in it. The predicate already existed under that name in the iOS and Android ports, so this adds the web counterpart and extends all three together, and each `buildSpawnRequest` now derives `yolo` and `permissionMode` from that one predicate.

For Claude the spawn body carries `permissionMode` (including `default`) and no longer carries `yolo`, which is the shape the other native-select flavors already send. The two are equivalent for a remote Claude session: the extra `--dangerously-skip-permissions` that `--yolo` appends never reaches the SDK spawn (`filterCatalogAffectingClaudeArgs` drops it), and the auto-approval comes from the permission handler's `bypassPermissions` branch.

An existing `hapi:newSession:yolo` preference is bridged into the select rather than dropped, but only for the flavors that have actually moved onto it (`LEGACY_YOLO_BRIDGE_AGENTS` = codex, claude). copilot, gemini, kimi and opencode moved earlier and settled on Default, so turning Yolo back on for them would widen permissions rather than migrate a preference.

The sessionStorage draft bridge follows the same list. It used to fire for the whole codex family, so a copilot / kimi / opencode draft restore now yields Default instead of Yolo, which is what their stored preference already produced.

cursor and agy keep the toggle here. They have native modes too and could follow, but that is a separate behavior change for two more flavors.

## Tests

`bun typecheck && bun run test`, `swift test --package-path ios/Packages/HapiKit` and `./gradlew :core:protocol:test :app:testDebugUnitTest` all pass.

The unit tests stop at the request body, so I ran the rest on an isolated hub with its own runner:

- picking Plan Mode spawns the agent as `claude ... --permission-mode plan`
- picking Yolo spawns it as `claude ... --permission-mode bypassPermissions`
- both sessions then report that mode as current in the composer settings sheet
