### PR TITLE
feat(web): add word wrap to file source previews

### DIFF
--- a/web/src/routes/sessions/file.test.tsx
+++ b/web/src/routes/sessions/file.test.tsx
@@ -116,6 +116,32 @@ describe('FilePage markdown preview', () => {
         })
     })
 
+    it('uses the shared code-wrap preference for the source preview', async () => {
+        window.localStorage.setItem('hapi-code-wrap', '1')
+        renderWithProviders()
+
+        await waitFor(() => {
+            expect(screen.getByTestId('markdown-preview')).toBeInTheDocument()
+        })
+        fireEvent.click(screen.getByRole('button', { name: 'Source' }))
+
+        await waitFor(() => {
+            expect(screen.getByRole('code')).toHaveTextContent('# Heading')
+        })
+        const sourceCode = screen.getByRole('code')
+        const sourcePre = sourceCode.closest('pre')
+        const wrapToggle = screen.getByRole('button', { pressed: true })
+
+        expect(wrapToggle).toBeInTheDocument()
+        expect(sourcePre).toHaveStyle({ whiteSpace: 'pre-wrap', wordBreak: 'break-word' })
+
+        fireEvent.click(wrapToggle)
+
+        expect(screen.getByRole('button', { pressed: false })).toBeInTheDocument()
+        expect(sourcePre).toHaveStyle({ whiteSpace: 'pre' })
+        expect(window.localStorage.getItem('hapi-code-wrap')).toBeNull()
+    })
+
     it('preserves the file preview scroll position across route remounts', async () => {
         const firstRender = renderWithProviders()
 

--- a/web/src/routes/sessions/file.tsx
+++ b/web/src/routes/sessions/file.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useParams, useSearch } from '@tanstack/react-router'
 import type { GitCommandResponse } from '@/types/api'
 import { FileIcon } from '@/components/FileIcon'
-import { CopyIcon, CheckIcon } from '@/components/icons'
+import { CopyIcon, CheckIcon, WrapIcon } from '@/components/icons'
 import { useAppContext } from '@/lib/app-context'
 import { useAppGoBack } from '@/hooks/useAppGoBack'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
@@ -22,6 +22,7 @@ import {
     type MarkdownPreviewMode,
 } from '@/lib/file-markdown-preview'
 import { downloadBase64File } from '@/lib/file-download'
+import { useCodeWrap } from '@/hooks/useCodeWrap'
 
 const MAX_COPYABLE_FILE_BYTES = 1_000_000
 const FILE_SCROLL_KEY_PREFIX = 'hapi-file-scroll-'
@@ -144,8 +145,17 @@ function FileContentHeader(props: {
     label: string
     copied: boolean
     copyLabel: string
-    onCopy: () => void
+    onCopy?: () => void
+    codeWrap?: boolean
+    wrapEnableLabel?: string
+    wrapDisableLabel?: string
+    onToggleWrap?: () => void
 }) {
+    const showWrapToggle = props.onToggleWrap !== undefined
+        && props.wrapEnableLabel !== undefined
+        && props.wrapDisableLabel !== undefined
+    const wrapLabel = props.codeWrap ? props.wrapDisableLabel : props.wrapEnableLabel
+
     return (
         <div
             data-hapi-file-content-header="true"
@@ -154,15 +164,34 @@ function FileContentHeader(props: {
             <div className="min-w-0 flex-1 truncate font-mono text-[11px] uppercase tracking-[0.08em] text-[var(--app-code-header-fg)]">
                 {props.label}
             </div>
-            <button
-                type="button"
-                onClick={props.onCopy}
-                className="shrink-0 rounded-md p-1 text-[var(--app-code-header-fg)] transition-colors hover:bg-[var(--app-code-copy-hover-bg)] hover:text-[var(--app-fg)]"
-                title={props.copyLabel}
-                aria-label={props.copyLabel}
-            >
-                {props.copied ? <CheckIcon className="h-3.5 w-3.5" /> : <CopyIcon className="h-3.5 w-3.5" />}
-            </button>
+            <div className="flex shrink-0 items-center gap-1">
+                {showWrapToggle ? (
+                    <button
+                        type="button"
+                        data-hapi-code-wrap-toggle="true"
+                        data-hapi-wrap-enable-label={props.wrapEnableLabel}
+                        data-hapi-wrap-disable-label={props.wrapDisableLabel}
+                        onClick={props.onToggleWrap}
+                        className={`rounded-md p-1 transition-colors hover:bg-[var(--app-code-copy-hover-bg)] hover:text-[var(--app-fg)] ${props.codeWrap ? 'text-[var(--app-fg)]' : 'text-[var(--app-code-header-fg)]'}`}
+                        title={wrapLabel}
+                        aria-label={wrapLabel}
+                        aria-pressed={props.codeWrap}
+                    >
+                        <WrapIcon className="h-3.5 w-3.5" />
+                    </button>
+                ) : null}
+                {props.onCopy ? (
+                    <button
+                        type="button"
+                        onClick={props.onCopy}
+                        className="rounded-md p-1 text-[var(--app-code-header-fg)] transition-colors hover:bg-[var(--app-code-copy-hover-bg)] hover:text-[var(--app-fg)]"
+                        title={props.copyLabel}
+                        aria-label={props.copyLabel}
+                    >
+                        {props.copied ? <CheckIcon className="h-3.5 w-3.5" /> : <CopyIcon className="h-3.5 w-3.5" />}
+                    </button>
+                ) : null}
+            </div>
         </div>
     )
 }
@@ -277,6 +306,7 @@ export default function FilePage() {
     const canDownload = fileContentResult?.success === true && Boolean(fileContentResult.content)
 
     const [displayMode, setDisplayMode] = useState<'diff' | 'file'>('diff')
+    const { codeWrap, setCodeWrap } = useCodeWrap()
     const fileScrollRef = useRef<HTMLDivElement>(null)
     const restoredScrollKeyRef = useRef<string | null>(null)
     const fileScrollKey = useMemo(
@@ -487,15 +517,23 @@ export default function FilePage() {
                                         data-hapi-file-source-preview="true"
                                         className="min-w-0 max-w-full overflow-hidden rounded-md bg-[var(--app-code-bg)]"
                                     >
-                                        {canCopyContent ? (
-                                            <FileContentHeader
-                                                label={language ?? 'text'}
-                                                copied={contentCopied}
-                                                copyLabel={t('file.page.copyContent')}
-                                                onCopy={() => copyContent(decodedContent)}
-                                            />
-                                        ) : null}
-                                        <pre className="shiki m-0 overflow-auto bg-[var(--app-code-bg)] p-3 text-xs font-mono">
+                                        <FileContentHeader
+                                            label={language ?? 'text'}
+                                            copied={contentCopied}
+                                            copyLabel={t('file.page.copyContent')}
+                                            onCopy={canCopyContent ? () => copyContent(decodedContent) : undefined}
+                                            codeWrap={codeWrap}
+                                            wrapEnableLabel={t('code.wrap.enable')}
+                                            wrapDisableLabel={t('code.wrap.disable')}
+                                            onToggleWrap={() => setCodeWrap(!codeWrap)}
+                                        />
+                                        <pre
+                                            className={`shiki m-0 overflow-y-auto bg-[var(--app-code-bg)] p-3 text-xs font-mono ${codeWrap ? 'overflow-x-hidden' : 'overflow-x-auto'}`}
+                                            style={{
+                                                whiteSpace: codeWrap ? 'pre-wrap' : 'pre',
+                                                ...(codeWrap ? { wordBreak: 'break-word' as const } : {})
+                                            }}
+                                        >
                                             <code>{highlighted ?? decodedContent}</code>
                                         </pre>
                                     </div>


### PR DESCRIPTION
## Summary

- Add a word-wrap toggle to source-mode file previews.
- Reuse the existing `hapi-code-wrap` preference used by conversation detail code surfaces.
- Preserve the preference across reloads, sessions, tabs, and windows on the same origin.
- Preserve syntax highlighting and horizontal scrolling when wrapping is disabled.
- Add regression coverage for persisted state, toggle behavior, and source rendering.
- No API, data, dependency, or migration changes.

## Problem / Motivation

Source-mode file previews currently render long lines using horizontal scrolling and do not expose the existing word-wrap control. This makes large files difficult to read on narrow screens and makes file previews inconsistent with conversation detail code blocks.

## Validation

- `bun typecheck` — passed.
- `bun run --cwd web test -- src/routes/sessions/file.test.tsx src/components/CodeBlock.test.tsx src/components/assistant-ui/shiki-highlighter.test.tsx src/components/assistant-ui/markdown-text-codeblock.test.tsx src/hooks/useCodeWrap.test.ts` — 5 files, 32 tests passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name file-preview-code-wrap -Suite Root -TestArgs terminal-wrap-fidelity.spec.ts` — 2/2 passed.
- `bun run build` — passed.
- Full Live Playwright verification through the task wrapper — 3/3 passed:
  - Desktop source preview toggle and reload persistence.
  - Mobile classic scrollbar wrapping without horizontal overflow.
  - Mobile overlay scrollbar wrapping without horizontal overflow.
- `git diff --check` — passed.

## Related Issues

Refs #1074

## AI Disclosure

OpenAI Codex assisted with the implementation and validation. Model: GPT-5.6.