### PR TITLE
fix(cli): identify the Windows runner process through CIM

### DIFF
--- a/cli/src/runner/controlClient.test.ts
+++ b/cli/src/runner/controlClient.test.ts
@@ -56,7 +56,7 @@ describe('runner control client stop-session contract', () => {
     })
 })
 
-describe('stopRunner force-kill gate', () => {
+describe('stopRunner identity gate', () => {
     beforeEach(() => {
         readRunnerStateMock.mockResolvedValue({ pid: 42, httpPort: 3210 })
         isProcessAliveMock.mockReturnValue(true)
@@ -72,21 +72,23 @@ describe('stopRunner force-kill gate', () => {
         vi.clearAllMocks()
     })
 
-    it('force kills a confirmed runner', async () => {
+    it('stops a confirmed runner', async () => {
         identityMock.mockReturnValue('runner')
 
         await stopRunner()
 
+        expect(globalThis.fetch).toHaveBeenCalled()
         expect(killProcessMock).toHaveBeenCalledWith(42, true)
     })
 
     it.each(['foreign', 'unknown', 'dead'] as const)(
-        'does not signal a pid whose identity is %s',
+        'sends neither the http stop nor a signal when the identity is %s',
         async (identity) => {
             identityMock.mockReturnValue(identity)
 
             await stopRunner()
 
+            expect(globalThis.fetch).not.toHaveBeenCalled()
             expect(killProcessMock).not.toHaveBeenCalled()
         }
     )

--- a/cli/src/runner/controlClient.test.ts
+++ b/cli/src/runner/controlClient.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { readRunnerStateMock, isProcessAliveMock } = vi.hoisted(() => ({
+const { readRunnerStateMock, isProcessAliveMock, identityMock, killProcessMock } = vi.hoisted(() => ({
     readRunnerStateMock: vi.fn(),
     isProcessAliveMock: vi.fn(),
+    identityMock: vi.fn(),
+    killProcessMock: vi.fn(),
 }))
 
 vi.mock('@/persistence', () => ({
@@ -13,13 +15,13 @@ vi.mock('@/persistence', () => ({
 
 vi.mock('@/utils/process', () => ({
     isProcessAlive: isProcessAliveMock,
-    isHapiRunnerProcess: vi.fn(() => true),
-    killProcess: vi.fn(),
+    getHapiRunnerProcessIdentity: identityMock,
+    killProcess: killProcessMock,
 }))
 
 vi.mock('@/ui/logger', () => ({ logger: { debug: vi.fn() } }))
 
-import { stopRunnerSession } from './controlClient'
+import { stopRunner, stopRunnerSession } from './controlClient'
 
 describe('runner control client stop-session contract', () => {
     beforeEach(() => {
@@ -52,4 +54,40 @@ describe('runner control client stop-session contract', () => {
 
         await expect(stopRunnerSession('session-1')).resolves.toBe('still_alive')
     })
+})
+
+describe('stopRunner force-kill gate', () => {
+    beforeEach(() => {
+        readRunnerStateMock.mockResolvedValue({ pid: 42, httpPort: 3210 })
+        isProcessAliveMock.mockReturnValue(true)
+        killProcessMock.mockResolvedValue(true)
+        // Graceful HTTP stop always fails here so every case reaches the force-kill decision.
+        vi.stubGlobal('fetch', vi.fn(async () => {
+            throw new Error('connection refused')
+        }))
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        vi.clearAllMocks()
+    })
+
+    it('force kills a confirmed runner', async () => {
+        identityMock.mockReturnValue('runner')
+
+        await stopRunner()
+
+        expect(killProcessMock).toHaveBeenCalledWith(42, true)
+    })
+
+    it.each(['foreign', 'unknown', 'dead'] as const)(
+        'does not signal a pid whose identity is %s',
+        async (identity) => {
+            identityMock.mockReturnValue(identity)
+
+            await stopRunner()
+
+            expect(killProcessMock).not.toHaveBeenCalled()
+        }
+    )
 })

--- a/cli/src/runner/controlClient.ts
+++ b/cli/src/runner/controlClient.ts
@@ -10,7 +10,7 @@ import packageJson from '../../package.json';
 import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { isBunCompiled, projectPath } from '@/projectPath';
-import { isProcessAlive, isHapiRunnerProcess, killProcess } from '@/utils/process';
+import { isProcessAlive, getHapiRunnerProcessIdentity, killProcess } from '@/utils/process';
 import { configuration } from '@/configuration';
 import { hashRunnerCliApiToken, hashRunnerExtraHeaders, isRunnerStateCompatibleWithIdentity } from './runnerIdentity';
 
@@ -146,8 +146,17 @@ export async function checkIfRunnerRunningAndCleanupStaleState(): Promise<boolea
   }
 
   // Verify PID is alive AND belongs to hapi (not a reused PID from another process)
-  if (isHapiRunnerProcess(state.pid)) {
+  const identity = getHapiRunnerProcessIdentity(state.pid);
+  if (identity === 'runner') {
     return true;
+  }
+
+  if (identity === 'unknown') {
+    // The pid is alive but unidentifiable. Reporting it as the runner would let
+    // callers signal a process that may not be ours, and clearing the state would
+    // drop the lock that keeps a second runner from starting. Do neither.
+    logger.debug('[RUNNER RUN] Runner PID could not be identified, leaving state untouched');
+    return false;
   }
 
   logger.debug('[RUNNER RUN] Runner PID not running or not a hapi process, cleaning up state');

--- a/cli/src/runner/controlClient.ts
+++ b/cli/src/runner/controlClient.ts
@@ -309,7 +309,15 @@ export async function stopRunner() {
       logger.debug('HTTP stop failed, will force kill', error);
     }
 
-    // Force kill
+    // Force kill. Only a confirmed runner may be signalled: every caller that
+    // reaches this point derived its decision from a boolean, and a pid we
+    // cannot identify may belong to an unrelated process that reused it.
+    const identity = getHapiRunnerProcessIdentity(state.pid);
+    if (identity !== 'runner') {
+      logger.debug(`Not force killing PID ${state.pid}: identity is ${identity}`);
+      return;
+    }
+
     const killed = await killProcess(state.pid, true);
     if (killed) {
       logger.debug('Force killed runner');

--- a/cli/src/runner/controlClient.ts
+++ b/cli/src/runner/controlClient.ts
@@ -295,6 +295,16 @@ export async function stopRunner() {
       return;
     }
 
+    // Every stop is a signal to the persisted pid and port, so gate the whole
+    // sequence on a confirmed identity. Callers derive their decision from a
+    // boolean, and a pid we cannot identify may belong to an unrelated process
+    // that reused it, whose port may have been reused as well.
+    const identity = getHapiRunnerProcessIdentity(state.pid);
+    if (identity !== 'runner') {
+      logger.debug(`Not stopping PID ${state.pid}: identity is ${identity}`);
+      return;
+    }
+
     logger.debug(`Stopping runner with PID ${state.pid}`);
 
     // Try HTTP graceful stop
@@ -307,15 +317,6 @@ export async function stopRunner() {
       return;
     } catch (error) {
       logger.debug('HTTP stop failed, will force kill', error);
-    }
-
-    // Force kill. Only a confirmed runner may be signalled: every caller that
-    // reaches this point derived its decision from a boolean, and a pid we
-    // cannot identify may belong to an unrelated process that reused it.
-    const identity = getHapiRunnerProcessIdentity(state.pid);
-    if (identity !== 'runner') {
-      logger.debug(`Not force killing PID ${state.pid}: identity is ${identity}`);
-      return;
     }
 
     const killed = await killProcess(state.pid, true);

--- a/cli/src/utils/process.test.ts
+++ b/cli/src/utils/process.test.ts
@@ -104,9 +104,18 @@ describe('getHapiRunnerProcessIdentity on Windows', () => {
     it('falls back to WMIC when CIM reports no command line', () => {
         spawnSyncMock
             .mockReturnValueOnce(completed(''))
-            .mockReturnValueOnce(completed('hapi-local.exe runner start-sync'))
+            .mockReturnValueOnce(completed('CommandLine\r\nhapi-local.exe runner start-sync\r\n'))
 
         expect(getHapiRunnerProcessIdentity(9124)).toBe('runner')
+        expect(spawnSyncMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('reports unknown when WMIC prints only the column header', () => {
+        spawnSyncMock
+            .mockReturnValueOnce(completed(''))
+            .mockReturnValueOnce(completed('CommandLine\r\n\r\n'))
+
+        expect(getHapiRunnerProcessIdentity(8328)).toBe('unknown')
         expect(spawnSyncMock).toHaveBeenCalledTimes(2)
     })
 

--- a/cli/src/utils/process.test.ts
+++ b/cli/src/utils/process.test.ts
@@ -10,7 +10,7 @@ vi.mock('cross-spawn', () => ({
     }
 }))
 
-import { isHapiRunnerProcess } from './process'
+import { getHapiRunnerProcessIdentity } from './process'
 
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
 
@@ -40,7 +40,7 @@ function unavailable(command: string) {
     }
 }
 
-describe('isHapiRunnerProcess on Windows', () => {
+describe('getHapiRunnerProcessIdentity on Windows', () => {
     beforeAll(() => {
         if (!originalPlatformDescriptor?.configurable) {
             throw new Error('process.platform is not configurable in this runtime')
@@ -63,10 +63,10 @@ describe('isHapiRunnerProcess on Windows', () => {
         }
     })
 
-    it('rejects a foreign process when CIM identifies it', () => {
+    it('reports a foreign process when CIM identifies it', () => {
         spawnSyncMock.mockReturnValueOnce(completed('C:\\Windows\\System32\\conhost.exe'))
 
-        expect(isHapiRunnerProcess(8328)).toBe(false)
+        expect(getHapiRunnerProcessIdentity(8328)).toBe('foreign')
         expect(spawnSyncMock).toHaveBeenCalledTimes(1)
         expect(spawnSyncMock).toHaveBeenNthCalledWith(
             1,
@@ -81,10 +81,10 @@ describe('isHapiRunnerProcess on Windows', () => {
         )
     })
 
-    it('accepts the runner when CIM identifies it', () => {
+    it('reports the runner when CIM identifies it', () => {
         spawnSyncMock.mockReturnValueOnce(completed('hapi-local.exe runner start-sync'))
 
-        expect(isHapiRunnerProcess(9124)).toBe(true)
+        expect(getHapiRunnerProcessIdentity(9124)).toBe('runner')
     })
 
     it('falls back to WMIC when PowerShell is unavailable', () => {
@@ -92,7 +92,7 @@ describe('isHapiRunnerProcess on Windows', () => {
             .mockReturnValueOnce(unavailable('powershell'))
             .mockReturnValueOnce(completed('hapi-local.exe runner start-sync'))
 
-        expect(isHapiRunnerProcess(9124)).toBe(true)
+        expect(getHapiRunnerProcessIdentity(9124)).toBe('runner')
         expect(spawnSyncMock).toHaveBeenNthCalledWith(
             2,
             'wmic',
@@ -106,7 +106,7 @@ describe('isHapiRunnerProcess on Windows', () => {
             .mockReturnValueOnce(completed(''))
             .mockReturnValueOnce(completed('hapi-local.exe runner start-sync'))
 
-        expect(isHapiRunnerProcess(9124)).toBe(true)
+        expect(getHapiRunnerProcessIdentity(9124)).toBe('runner')
         expect(spawnSyncMock).toHaveBeenCalledTimes(2)
     })
 
@@ -115,20 +115,20 @@ describe('isHapiRunnerProcess on Windows', () => {
             .mockReturnValueOnce(completed('', 1))
             .mockReturnValueOnce(completed('hapi-local.exe runner start-sync'))
 
-        expect(isHapiRunnerProcess(9124)).toBe(true)
+        expect(getHapiRunnerProcessIdentity(9124)).toBe('runner')
         expect(spawnSyncMock).toHaveBeenCalledTimes(2)
     })
 
-    it('preserves a live runner state when no probe reports a command line', () => {
+    it('reports unknown when no probe reports a command line', () => {
         spawnSyncMock
             .mockReturnValueOnce(completed(''))
             .mockReturnValueOnce(unavailable('wmic'))
 
-        expect(isHapiRunnerProcess(8328)).toBe(true)
+        expect(getHapiRunnerProcessIdentity(8328)).toBe('unknown')
         expect(spawnSyncMock).toHaveBeenCalledTimes(2)
     })
 
-    it('rejects the pid when it exits while the probes run', () => {
+    it('reports dead when the pid exits while the probes run', () => {
         vi.spyOn(process, 'kill')
             .mockReturnValueOnce(true)
             .mockImplementationOnce(() => {
@@ -138,6 +138,45 @@ describe('isHapiRunnerProcess on Windows', () => {
             .mockReturnValueOnce(unavailable('powershell'))
             .mockReturnValueOnce(unavailable('wmic'))
 
-        expect(isHapiRunnerProcess(8328)).toBe(false)
+        expect(getHapiRunnerProcessIdentity(8328)).toBe('dead')
+    })
+
+    it('reports dead without probing when the pid is already gone', () => {
+        vi.spyOn(process, 'kill').mockImplementation(() => {
+            throw new Error('ESRCH')
+        })
+
+        expect(getHapiRunnerProcessIdentity(8328)).toBe('dead')
+        expect(spawnSyncMock).not.toHaveBeenCalled()
+    })
+})
+
+describe('getHapiRunnerProcessIdentity on POSIX', () => {
+    beforeEach(() => {
+        setPlatform('linux')
+        spawnSyncMock.mockReset()
+        vi.spyOn(process, 'kill').mockReturnValue(true)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    afterAll(() => {
+        if (originalPlatformDescriptor) {
+            Object.defineProperty(process, 'platform', originalPlatformDescriptor)
+        }
+    })
+
+    it('reports the runner from the ps command line', () => {
+        spawnSyncMock.mockReturnValueOnce(completed('hapi runner start-sync'))
+
+        expect(getHapiRunnerProcessIdentity(9124)).toBe('runner')
+    })
+
+    it('reports unknown when ps cannot report a command line', () => {
+        spawnSyncMock.mockReturnValueOnce(completed(''))
+
+        expect(getHapiRunnerProcessIdentity(8328)).toBe('unknown')
     })
 })

--- a/cli/src/utils/process.test.ts
+++ b/cli/src/utils/process.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnSyncMock } = vi.hoisted(() => ({
+    spawnSyncMock: vi.fn()
+}))
+
+vi.mock('cross-spawn', () => ({
+    default: {
+        sync: spawnSyncMock
+    }
+}))
+
+import { isHapiRunnerProcess } from './process'
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function setPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', {
+        value,
+        configurable: true
+    })
+}
+
+function completed(stdout: string, status = 0) {
+    return {
+        status,
+        stdout: Buffer.from(stdout),
+        stderr: Buffer.from('')
+    }
+}
+
+function unavailable(command: string) {
+    const error = new Error(`spawnSync ${command} ENOENT`) as NodeJS.ErrnoException
+    error.code = 'ENOENT'
+    return {
+        status: null,
+        stdout: Buffer.from(''),
+        stderr: Buffer.from(''),
+        error
+    }
+}
+
+describe('isHapiRunnerProcess on Windows', () => {
+    beforeAll(() => {
+        if (!originalPlatformDescriptor?.configurable) {
+            throw new Error('process.platform is not configurable in this runtime')
+        }
+    })
+
+    beforeEach(() => {
+        setPlatform('win32')
+        spawnSyncMock.mockReset()
+        vi.spyOn(process, 'kill').mockReturnValue(true)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    afterAll(() => {
+        if (originalPlatformDescriptor) {
+            Object.defineProperty(process, 'platform', originalPlatformDescriptor)
+        }
+    })
+
+    it('rejects a foreign process when CIM identifies it', () => {
+        spawnSyncMock.mockReturnValueOnce(completed('C:\\Windows\\System32\\conhost.exe'))
+
+        expect(isHapiRunnerProcess(8328)).toBe(false)
+        expect(spawnSyncMock).toHaveBeenCalledTimes(1)
+        expect(spawnSyncMock).toHaveBeenNthCalledWith(
+            1,
+            'powershell',
+            [
+                '-NoProfile',
+                '-NonInteractive',
+                '-Command',
+                '(Get-CimInstance Win32_Process -Filter "ProcessId = 8328").CommandLine'
+            ],
+            { stdio: 'pipe', windowsHide: true }
+        )
+    })
+
+    it('accepts the runner when CIM identifies it', () => {
+        spawnSyncMock.mockReturnValueOnce(completed('hapi-local.exe runner start-sync'))
+
+        expect(isHapiRunnerProcess(9124)).toBe(true)
+    })
+
+    it('falls back to WMIC when PowerShell is unavailable', () => {
+        spawnSyncMock
+            .mockReturnValueOnce(unavailable('powershell'))
+            .mockReturnValueOnce(completed('hapi-local.exe runner start-sync'))
+
+        expect(isHapiRunnerProcess(9124)).toBe(true)
+        expect(spawnSyncMock).toHaveBeenNthCalledWith(
+            2,
+            'wmic',
+            ['process', 'where', 'ProcessId=9124', 'get', 'CommandLine'],
+            { stdio: 'pipe', windowsHide: true }
+        )
+    })
+
+    it('falls back to WMIC when CIM reports no command line', () => {
+        spawnSyncMock
+            .mockReturnValueOnce(completed(''))
+            .mockReturnValueOnce(completed('hapi-local.exe runner start-sync'))
+
+        expect(isHapiRunnerProcess(9124)).toBe(true)
+        expect(spawnSyncMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('falls back to WMIC when PowerShell exits non-zero', () => {
+        spawnSyncMock
+            .mockReturnValueOnce(completed('', 1))
+            .mockReturnValueOnce(completed('hapi-local.exe runner start-sync'))
+
+        expect(isHapiRunnerProcess(9124)).toBe(true)
+        expect(spawnSyncMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('preserves a live runner state when no probe reports a command line', () => {
+        spawnSyncMock
+            .mockReturnValueOnce(completed(''))
+            .mockReturnValueOnce(unavailable('wmic'))
+
+        expect(isHapiRunnerProcess(8328)).toBe(true)
+        expect(spawnSyncMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('rejects the pid when it exits while the probes run', () => {
+        vi.spyOn(process, 'kill')
+            .mockReturnValueOnce(true)
+            .mockImplementationOnce(() => {
+                throw new Error('ESRCH')
+            })
+        spawnSyncMock
+            .mockReturnValueOnce(unavailable('powershell'))
+            .mockReturnValueOnce(unavailable('wmic'))
+
+        expect(isHapiRunnerProcess(8328)).toBe(false)
+    })
+})

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -73,19 +73,31 @@ function getWindowsProcessCommandLine(pid: number): string | null {
   return null;
 }
 
-export function isHapiRunnerProcess(pid: number): boolean {
+/**
+ * `unknown` means the process is alive but its command line could not be read.
+ * Callers must not signal or clean up on that answer: the pid may belong to an
+ * unrelated process that reused it, and it may equally be a healthy runner.
+ */
+export type RunnerProcessIdentity = 'runner' | 'foreign' | 'unknown' | 'dead';
+
+export function getHapiRunnerProcessIdentity(pid: number): RunnerProcessIdentity {
   if (!isProcessAlive(pid)) {
-    return false;
+    return 'dead';
   }
-  if (isWindows()) {
-    const commandLine = getWindowsProcessCommandLine(pid);
-    return commandLine === null ? isProcessAlive(pid) : isRunnerCommand(commandLine);
+  const commandLine = isWindows()
+    ? getWindowsProcessCommandLine(pid)
+    : getPosixProcessCommandLine(pid);
+  if (commandLine === null) {
+    return isProcessAlive(pid) ? 'unknown' : 'dead';
   }
+  return isRunnerCommand(commandLine) ? 'runner' : 'foreign';
+}
+
+function getPosixProcessCommandLine(pid: number): string | null {
   const result = spawn.sync('ps', ['-p', String(pid), '-o', 'command='], { stdio: 'pipe' });
-  if (result.error || result.status !== 0) {
-    return isProcessAlive(pid);
-  }
-  return isRunnerCommand(result.stdout?.toString() ?? '');
+  if (result.error || result.status !== 0) return null;
+  const commandLine = result.stdout?.toString() ?? '';
+  return commandLine.trim() ? commandLine : null;
 }
 
 function killProcessWindows(pid: number, force: boolean): boolean {

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -66,11 +66,23 @@ function getWindowsProcessCommandLine(pid: number): string | null {
     'process', 'where', `ProcessId=${pid}`, 'get', 'CommandLine'
   ], { stdio: 'pipe', windowsHide: true });
   if (!wmic.error && wmic.status === 0) {
-    const commandLine = wmic.stdout?.toString() ?? '';
-    if (commandLine.trim()) return commandLine;
+    const commandLine = readWmicCommandLine(wmic.stdout?.toString() ?? '');
+    if (commandLine) return commandLine;
   }
 
   return null;
+}
+
+/**
+ * `wmic ... get CommandLine` prints the `CommandLine` column header even when
+ * the property itself is empty or unreadable, so the raw stdout is never empty
+ * on success. Drop the header before deciding whether a command line was read.
+ */
+function readWmicCommandLine(stdout: string): string | null {
+  const lines = stdout.split(/\r?\n/);
+  const headerIndex = lines.findIndex(line => line.trim() === 'CommandLine');
+  const value = (headerIndex === -1 ? lines : lines.slice(headerIndex + 1)).join('\n');
+  return value.trim() ? value : null;
 }
 
 /**

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -48,19 +48,38 @@ function isRunnerCommand(commandLine: string): boolean {
   return /(?:^|\s)runner(?:\s|$)/.test(commandLine) && /(?:^|\s)start-sync(?:\s|$)/.test(commandLine);
 }
 
+function getWindowsProcessCommandLine(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+
+  const powershell = spawn.sync('powershell', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`
+  ], { stdio: 'pipe', windowsHide: true });
+  if (!powershell.error && powershell.status === 0) {
+    const commandLine = powershell.stdout?.toString() ?? '';
+    if (commandLine.trim()) return commandLine;
+  }
+
+  const wmic = spawn.sync('wmic', [
+    'process', 'where', `ProcessId=${pid}`, 'get', 'CommandLine'
+  ], { stdio: 'pipe', windowsHide: true });
+  if (!wmic.error && wmic.status === 0) {
+    const commandLine = wmic.stdout?.toString() ?? '';
+    if (commandLine.trim()) return commandLine;
+  }
+
+  return null;
+}
+
 export function isHapiRunnerProcess(pid: number): boolean {
   if (!isProcessAlive(pid)) {
     return false;
   }
   if (isWindows()) {
-    const result = spawn.sync('wmic', ['process', 'where', `ProcessId=${pid}`, 'get', 'CommandLine'], { stdio: 'pipe' });
-    if (result.error) {
-      return true;
-    }
-    if (result.status !== 0) {
-      return isProcessAlive(pid);
-    }
-    return isRunnerCommand(result.stdout?.toString() ?? '');
+    const commandLine = getWindowsProcessCommandLine(pid);
+    return commandLine === null ? isProcessAlive(pid) : isRunnerCommand(commandLine);
   }
   const result = spawn.sync('ps', ['-p', String(pid), '-o', 'command='], { stdio: 'pipe' });
   if (result.error || result.status !== 0) {


### PR DESCRIPTION
## Problem

`isHapiRunnerProcess()` verifies that the PID persisted in runner state still belongs to a HAPI runner, so that `runner start` can tell a live runner from a stale record. On Windows it reads the command line through `wmic`, and when that spawn fails it returns `true` for any live PID.

WMIC is not installed on current Windows 11 builds, so that fallback is the only path those machines take and the check answers "is this PID alive?" rather than "is this PID our runner?". After a reboot Windows can hand the stale runner PID to an unrelated process, and `runner start` then accepts that process as the runner and exits without starting one. A process manager that keeps restarting the runner will loop.

Observed on a Windows 11 host: the persisted PID had been reused by `conhost.exe`, no HAPI runner process existed, and the supervised runner exited and restarted every few seconds.

## Solution

Read the command line through PowerShell `Get-CimInstance Win32_Process` first and keep `wmic` as the fallback, which is the order `getProcessStartMarker()` in the same file already uses for its `Win32_Process` lookup. `windowsHide: true` is now set on the WMIC spawn too, matching both probes in that function.

A probe that exits successfully without reporting a command line falls through to the next one instead of deciding. `(Get-CimInstance ...).CommandLine` prints nothing for several distinct states, including a process whose `CommandLine` is not readable, so an empty result is not evidence that the PID is a stranger. When no probe reports a command line the identity stays unknown and the existing live-state preservation applies. That lean matters here because a negative verdict makes the caller clear the runner state file and the runner lock, and the lock is what keeps a second runner from starting.

The change is limited to the Windows command-line probe. The persisted state format, runner identity handoff, Hub API, and the Unix `ps` path are untouched.

## Tests

`bun typecheck && bun run test`

The unit tests mock `cross-spawn`, so they stop at the spawn boundary and cannot show what the probes return on a real host. On a Windows 11 machine running the runner I checked the two probes by hand: `Get-Command wmic` finds nothing, and `powershell -NoProfile -NonInteractive -Command "(Get-CimInstance Win32_Process -Filter 'ProcessId = <runner pid>').CommandLine"` returns the runner's full command line.
