### PR TITLE
fix(web): compact recent path labels

### DIFF
--- a/web/src/components/NewSession/DirectorySection.test.tsx
+++ b/web/src/components/NewSession/DirectorySection.test.tsx
@@ -48,7 +48,7 @@ describe('DirectorySection', () => {
             />
         )
 
-        const recentPath = screen.getByRole('button', { name: 'Agent/Hapi' })
+        const recentPath = screen.getByRole('button', { name: path })
         expect(recentPath).toHaveTextContent('Agent/Hapi')
         expect(recentPath).toHaveAttribute('title', path)
 

--- a/web/src/components/NewSession/DirectorySection.test.tsx
+++ b/web/src/components/NewSession/DirectorySection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { DirectorySection } from './DirectorySection'
 
@@ -26,5 +26,33 @@ describe('DirectorySection', () => {
         )
 
         expect(screen.getByRole('button', { name: 'newSession.browse' })).toHaveClass('self-stretch')
+    })
+
+    it('shows the last two path segments while preserving the full path on click', () => {
+        const onPathClick = vi.fn()
+        const path = 'C:\\Users\\Ananovo\\Downloads\\Agent\\Hapi'
+
+        render(
+            <DirectorySection
+                directory=""
+                suggestions={[]}
+                selectedIndex={0}
+                isDisabled={false}
+                recentPaths={[path]}
+                onDirectoryChange={vi.fn()}
+                onDirectoryFocus={vi.fn()}
+                onDirectoryBlur={vi.fn()}
+                onDirectoryKeyDown={vi.fn()}
+                onSuggestionSelect={vi.fn()}
+                onPathClick={onPathClick}
+            />
+        )
+
+        const recentPath = screen.getByRole('button', { name: 'Agent/Hapi' })
+        expect(recentPath).toHaveTextContent('Agent/Hapi')
+        expect(recentPath).toHaveAttribute('title', path)
+
+        fireEvent.click(recentPath)
+        expect(onPathClick).toHaveBeenCalledWith(path)
     })
 })

--- a/web/src/components/NewSession/DirectorySection.tsx
+++ b/web/src/components/NewSession/DirectorySection.tsx
@@ -127,6 +127,7 @@ export function DirectorySection(props: {
                                 disabled={props.isDisabled}
                                 className="rounded bg-[var(--app-subtle-bg)] px-2 py-1 text-xs text-[var(--app-fg)] hover:bg-[var(--app-secondary-bg)] transition-colors truncate max-w-[200px] disabled:opacity-50"
                                 title={path}
+                                aria-label={path}
                             >
                                 {getPathDisplayName(path)}
                             </button>

--- a/web/src/components/NewSession/DirectorySection.tsx
+++ b/web/src/components/NewSession/DirectorySection.tsx
@@ -3,6 +3,7 @@ import type { Suggestion } from '@/hooks/useActiveSuggestions'
 import { Autocomplete } from '@/components/ChatInput/Autocomplete'
 import { FloatingOverlay } from '@/components/ChatInput/FloatingOverlay'
 import { useTranslation } from '@/lib/use-translation'
+import { getPathDisplayName } from '@/utils/path'
 
 
 function CodexImportIcon(props: { className?: string }) {
@@ -127,7 +128,7 @@ export function DirectorySection(props: {
                                 className="rounded bg-[var(--app-subtle-bg)] px-2 py-1 text-xs text-[var(--app-fg)] hover:bg-[var(--app-secondary-bg)] transition-colors truncate max-w-[200px] disabled:opacity-50"
                                 title={path}
                             >
-                                {path}
+                                {getPathDisplayName(path)}
                             </button>
                         ))}
                     </div>

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -50,6 +50,7 @@ import { SessionRowSummary } from '@/components/SessionRowSummary'
 import { Spinner } from '@/components/Spinner'
 import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer'
 import { useToast } from '@/lib/toast-context'
+import { getPathDisplayName } from '@/utils/path'
 
 export { getWorktreeSessionLabel } from '@/lib/sessionWorktreeLabel'
 
@@ -173,14 +174,6 @@ type MachineGroup = {
     hasActiveSession: boolean
     hasPinnedSession: boolean
     latestUpdatedAt: number
-}
-
-function getGroupDisplayName(directory: string): string {
-    if (directory === 'Other') return directory
-    const parts = directory.split(/[\\/]+/).filter(Boolean)
-    if (parts.length === 0) return directory
-    if (parts.length === 1) return parts[0]
-    return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`
 }
 
 export const UNKNOWN_MACHINE_ID = '__unknown__'
@@ -313,7 +306,7 @@ function groupSessionsByDirectory(sessions: SessionSummary[]): SessionGroup[] {
             )
             const hasActiveSession = group.sessions.some(s => s.active)
             const hasPinnedSession = group.sessions.some(s => s.pinned)
-            const displayName = getGroupDisplayName(group.directory)
+            const displayName = getPathDisplayName(group.directory)
 
             return {
                 key,
@@ -1534,7 +1527,7 @@ export function SessionList(props: {
                                             selected={s.id === selectedSessionId}
                                             showDetailedStatus={showDetailedStatus}
                                             inRunningSection
-                                            projectLabel={getGroupDisplayName(s.metadata?.worktree?.basePath ?? s.metadata?.path ?? 'Other')}
+                                            projectLabel={getPathDisplayName(s.metadata?.worktree?.basePath ?? s.metadata?.path ?? 'Other')}
                                             machineLabel={resolveMachineLabel(s.metadata?.machineId ?? null)}
                                             lastSeenVersion={lastSeenVersion}
                                         />
@@ -2027,7 +2020,7 @@ export function SessionList(props: {
                                             selected={s.id === selectedSessionId}
                                             showDetailedStatus={showDetailedStatus}
                                             inRunningSection
-                                            projectLabel={getGroupDisplayName(s.metadata?.worktree?.basePath ?? s.metadata?.path ?? 'Other')}
+                                            projectLabel={getPathDisplayName(s.metadata?.worktree?.basePath ?? s.metadata?.path ?? 'Other')}
                                             machineLabel={resolveMachineLabel(s.metadata?.machineId ?? null)}
                                             lastSeenVersion={lastSeenVersion}
                                         />

--- a/web/src/utils/path.test.ts
+++ b/web/src/utils/path.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { getPathDisplayName } from './path'
+
+describe('getPathDisplayName', () => {
+    it('keeps the final two segments for nested POSIX paths', () => {
+        expect(getPathDisplayName('/home/user/coding/hapi')).toBe('coding/hapi')
+    })
+
+    it('supports Windows path separators', () => {
+        expect(getPathDisplayName('C:\\Users\\Ananovo\\Downloads\\Agent\\Hapi')).toBe('Agent/Hapi')
+    })
+
+    it('keeps short paths and the fallback group unchanged', () => {
+        expect(getPathDisplayName('hapi')).toBe('hapi')
+        expect(getPathDisplayName('Other')).toBe('Other')
+        expect(getPathDisplayName('')).toBe('')
+    })
+})

--- a/web/src/utils/path.ts
+++ b/web/src/utils/path.ts
@@ -23,3 +23,12 @@ export function basename(path: string): string {
     const parts = normalized.split('/').filter(Boolean)
     return parts.length > 0 ? parts[parts.length - 1] : path
 }
+
+/** Format a path like the compact project labels used by the session list. */
+export function getPathDisplayName(path: string): string {
+    if (path === 'Other') return path
+    const parts = path.split(/[\\/]+/).filter(Boolean)
+    if (parts.length === 0) return path
+    if (parts.length === 1) return parts[0]
+    return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`
+}


### PR DESCRIPTION
## Summary

- Show only the final two path segments for recent-directory buttons in the New Session form.
- Preserve the full path in the button title and when selecting a recent path.
- Reuse the same cross-platform formatter in the New Session form and session list.
- Add POSIX and Windows path formatting plus click-preservation regression coverage.

## Validation

- `bun run --cwd web test src/utils/path.test.ts src/components/NewSession/DirectorySection.test.tsx src/components/SessionList.test.ts` — 55 tests passed.
- `bun typecheck` — passed.
- `pwsh -NoProfile -File scripts/Invoke-HapiTaskPlaywright.ps1 -Name investigate-recent-path-display -Suite Root terminal-wrap-fidelity.spec.ts` — 2 tests passed.
- Manual smoke test on the Full test environment — the New Session page displayed `Agent/Hapi`, retained the full path in the button title, and restored the full path to the directory input after clicking.
- `bun run build` — passed.

## Related Issues

None.

## AI Disclosure

Implementation and tests were assisted by OpenAI Codex (GPT-5.6).