### PR TITLE
feat(web): add opt-in PWA taskbar unread badge

### DIFF
--- a/docs/guide/pwa.md
+++ b/docs/guide/pwa.md
@@ -129,6 +129,10 @@ In addition to Web Push, the hub can send notifications through Firebase Cloud M
 If push notifications don't work in your region (e.g., FCM unavailable), use [Telegram integration](./notifications.md#telegram-setup) instead.
 :::
 
+### Windows taskbar badge
+
+When HAPI is installed as a PWA from Microsoft Edge or Chrome on Windows, users can show the number of sessions with activity newer than the local last-seen watermark on its taskbar icon. The setting is disabled by default because some Edge/Windows configurations render the same host badge as overlapping layers, with one layer offset and clipped by the taskbar. Use Settings > Display > Session list > Taskbar unread badge to opt in or out for this PWA. The badge is updated while the PWA has a current session snapshot; it is not shown for a normal browser tab, and the read state remains local to that browser/PWA profile.
+
 ## Managing Your PWA
 
 ### Check Install Status

--- a/e2e/settings-responsive.spec.ts
+++ b/e2e/settings-responsive.spec.ts
@@ -26,9 +26,16 @@ test.describe('settings responsive layout', () => {
         const desktopNav = page.locator('aside nav')
         await expect(desktopNav).toBeVisible()
         await expect(desktopNav.getByRole('button', { name: 'Display' })).toHaveAttribute('aria-current', 'page')
-        await expect(page.getByRole('heading', { name: 'Display' })).toBeVisible()
+        await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible()
         await expect(page.getByText('Appearance, typography, and session list preferences.')).toBeVisible()
         await expect(page.getByText('Choose a category to adjust HAPI to your workflow.')).toBeHidden()
+
+        const appBadgeToggle = page.getByRole('checkbox', { name: 'Taskbar unread badge' })
+        await expect(appBadgeToggle).not.toBeChecked()
+        await appBadgeToggle.locator('xpath=..').click()
+        await expect(appBadgeToggle).toBeChecked()
+        await page.reload()
+        await expect(page.getByRole('checkbox', { name: 'Taskbar unread badge' })).toBeChecked()
 
         await page.setViewportSize({ width: 390, height: 844 })
         await expect(page.getByText('Choose a category to adjust HAPI to your workflow.')).toBeVisible()

--- a/web/README.md
+++ b/web/README.md
@@ -11,6 +11,7 @@ React Mini App / PWA for monitoring and controlling hapi sessions.
 - Machine list and remote session spawn.
 - File browser and git status/diff views.
 - PWA install prompt and offline banner.
+- Optional unread-session count on the Windows taskbar when installed as an Edge/Chrome PWA (toggleable in Display settings; off by default).
 
 ## Runtime behavior
 

--- a/web/e2e-fixtures/settings-fixture.tsx
+++ b/web/e2e-fixtures/settings-fixture.tsx
@@ -9,6 +9,8 @@ import {
     createRouter,
 } from '@tanstack/react-router'
 import '../src/index.css'
+import type { ApiClient } from '../src/api/client'
+import { AppContextProvider } from '../src/lib/app-context'
 import { I18nProvider } from '../src/lib/i18n-context'
 import SettingsLayout from '../src/routes/settings/layout'
 import SettingsHubPage from '../src/routes/settings'
@@ -55,9 +57,11 @@ const root = document.getElementById('root')
 if (root) {
     ReactDOM.createRoot(root).render(
         <React.StrictMode>
-            <I18nProvider>
-                <RouterProvider router={router} />
-            </I18nProvider>
+            <AppContextProvider value={{ api: {} as ApiClient, token: 'x.eyJucyI6ImRlZmF1bHQifQ.x', baseUrl: window.location.origin }}>
+                <I18nProvider>
+                    <RouterProvider router={router} />
+                </I18nProvider>
+            </AppContextProvider>
         </React.StrictMode>
     )
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { useAuthSource } from '@/hooks/useAuthSource'
 import { useServerUrl } from '@/hooks/useServerUrl'
 import { useSSE } from '@/hooks/useSSE'
+import { useSessions } from '@/hooks/queries/useSessions'
 import { useReconnectingState } from '@/hooks/useReconnectingState'
 import { useSyncingState } from '@/hooks/useSyncingState'
 import { usePushNotifications } from '@/hooks/usePushNotifications'
@@ -22,6 +23,8 @@ import { useTranslation } from '@/lib/use-translation'
 import { VoiceProvider } from '@/lib/voice-context'
 import { requireHubUrlForLogin } from '@/lib/runtime-config'
 import { getAppGlobalSseSubscription, getAppSessionSseSubscription } from '@/lib/appSseSubscriptions'
+import { canUseAppBadging, useAppBadge } from '@/hooks/useAppBadge'
+import { useAppBadgePreference } from '@/hooks/useAppBadgePreference'
 import { reconcileQueuedStateAfterConnect } from '@/lib/queued-state-reconciliation'
 import { LoginPrompt } from '@/components/LoginPrompt'
 import { InstallPrompt } from '@/components/InstallPrompt'
@@ -172,6 +175,20 @@ function AppInner() {
     const isFirstConnectRef = useRef(true)
     const baseUrlRef = useRef(baseUrl)
     const pushPromptedRef = useRef(false)
+    const { appBadgeEnabled: appBadgePreferenceEnabled } = useAppBadgePreference()
+    const appBadgeEnabled = Boolean(api && token && appBadgePreferenceEnabled && canUseAppBadging())
+    const {
+        sessions: appBadgeSessions,
+        isLoading: appBadgeSessionsLoading,
+        error: appBadgeSessionsError,
+    } = useSessions(api, { enabled: appBadgeEnabled })
+    useAppBadge({
+        enabled: appBadgeEnabled,
+        scope: baseUrl,
+        sessions: appBadgeSessions,
+        isLoading: appBadgeSessionsLoading,
+        hasError: Boolean(appBadgeSessionsError),
+    })
     const { isSupported: isPushSupported, permission: pushPermission, requestPermission, subscribe } = usePushNotifications(api)
 
     useEffect(() => {

--- a/web/src/hooks/queries/useSessions.ts
+++ b/web/src/hooks/queries/useSessions.ts
@@ -3,7 +3,11 @@ import type { ApiClient } from '@/api/client'
 import type { SessionSummary } from '@/types/api'
 import { queryKeys } from '@/lib/query-keys'
 
-export function useSessions(api: ApiClient | null): {
+export type UseSessionsOptions = {
+    enabled?: boolean
+}
+
+export function useSessions(api: ApiClient | null, options: UseSessionsOptions = {}): {
     sessions: SessionSummary[]
     isLoading: boolean
     error: string | null
@@ -17,7 +21,7 @@ export function useSessions(api: ApiClient | null): {
             }
             return await api.getSessions()
         },
-        enabled: Boolean(api),
+        enabled: Boolean(api) && (options.enabled ?? true),
     })
 
     return {

--- a/web/src/hooks/useAppBadge.test.ts
+++ b/web/src/hooks/useAppBadge.test.ts
@@ -1,0 +1,181 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SessionSummary } from '@/types/api'
+import { markSessionSeen } from '@/lib/sessionLastSeen'
+import { canUseAppBadging, countUnreadSessions, useAppBadge } from './useAppBadge'
+
+function createSession(id: string, updatedAt: number): SessionSummary {
+    return {
+        id,
+        active: false,
+        thinking: false,
+        activeAt: updatedAt,
+        updatedAt,
+        metadata: null,
+        metadataVersion: 0,
+        agentStateVersion: 0,
+        todosUpdatedAt: 0,
+        todoProgress: null,
+        pendingRequestsCount: 0,
+        pendingRequestKinds: [],
+        pendingRequests: [],
+        backgroundTaskCount: 0,
+        futureScheduledMessageCount: 0,
+        nextScheduledAt: null,
+        model: null,
+        effort: null,
+    }
+}
+
+function setDisplayMode(standalone: boolean): void {
+    vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+        matches: standalone && query === '(display-mode: standalone)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(() => false),
+    }))
+}
+
+function setAppBadgeNavigator() {
+    const setAppBadge = vi.fn().mockResolvedValue(undefined)
+    const clearAppBadge = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { setAppBadge, clearAppBadge } as unknown as Navigator)
+    return { setAppBadge, clearAppBadge }
+}
+
+describe('useAppBadge', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        vi.unstubAllGlobals()
+    })
+
+    it('counts each session with activity newer than its local watermark', () => {
+        expect(countUnreadSessions(
+            [createSession('session-a', 11), createSession('session-b', 20)],
+            { 'session-a': 10, 'session-b': 20 },
+        )).toBe(1)
+    })
+
+    it('sets the native badge to the number of unread sessions in an installed PWA', async () => {
+        setDisplayMode(true)
+        const { setAppBadge, clearAppBadge } = setAppBadgeNavigator()
+        localStorage.setItem('hapi.sessionLastSeen.v1', JSON.stringify({
+            'session-a': 10,
+            'session-b': 20,
+        }))
+
+        renderHook(() => useAppBadge({
+            enabled: true,
+            scope: 'https://hapi.test',
+            sessions: [createSession('session-a', 11), createSession('session-b', 20)],
+            isLoading: false,
+            hasError: false,
+        }))
+
+        await waitFor(() => expect(setAppBadge).toHaveBeenCalledWith(1))
+        expect(clearAppBadge).not.toHaveBeenCalled()
+    })
+
+    it('clears the native badge after the unread session is seen', async () => {
+        setDisplayMode(true)
+        const { setAppBadge, clearAppBadge } = setAppBadgeNavigator()
+        localStorage.setItem('hapi.sessionLastSeen.v1', JSON.stringify({ 'session-a': 10 }))
+
+        renderHook(() => useAppBadge({
+            enabled: true,
+            scope: 'https://hapi.test',
+            sessions: [createSession('session-a', 11)],
+            isLoading: false,
+            hasError: false,
+        }))
+
+        await waitFor(() => expect(setAppBadge).toHaveBeenCalledWith(1))
+        act(() => markSessionSeen('session-a', 11))
+        await waitFor(() => expect(clearAppBadge).toHaveBeenCalledTimes(1))
+    })
+
+    it('seeds the first session snapshot without showing existing sessions as unread', async () => {
+        setDisplayMode(true)
+        const { setAppBadge, clearAppBadge } = setAppBadgeNavigator()
+
+        renderHook(() => useAppBadge({
+            enabled: true,
+            scope: 'https://hapi.test',
+            sessions: [createSession('session-a', 11)],
+            isLoading: false,
+            hasError: false,
+        }))
+
+        await waitFor(() => expect(clearAppBadge).toHaveBeenCalledTimes(1))
+        expect(setAppBadge).not.toHaveBeenCalled()
+    })
+
+    it('clears the badge when the feature is disabled', async () => {
+        setDisplayMode(true)
+        const { setAppBadge, clearAppBadge } = setAppBadgeNavigator()
+        localStorage.setItem('hapi.sessionLastSeen.v1', JSON.stringify({ 'session-a': 10 }))
+
+        const { rerender } = renderHook(
+            (options: { enabled: boolean }) => useAppBadge({
+                enabled: options.enabled,
+                scope: 'https://hapi.test',
+                sessions: [createSession('session-a', 11)],
+                isLoading: false,
+                hasError: false,
+            }),
+            { initialProps: { enabled: true } },
+        )
+
+        await waitFor(() => expect(setAppBadge).toHaveBeenCalledWith(1))
+        rerender({ enabled: false })
+        await waitFor(() => expect(clearAppBadge).toHaveBeenCalledTimes(1))
+    })
+
+    it('does not repeat the native update when the unread count is unchanged', async () => {
+        setDisplayMode(true)
+        const { setAppBadge } = setAppBadgeNavigator()
+        localStorage.setItem('hapi.sessionLastSeen.v1', JSON.stringify({ 'session-a': 10 }))
+
+        const { rerender } = renderHook(
+            (sessions: SessionSummary[]) => useAppBadge({
+                enabled: true,
+                scope: 'https://hapi.test',
+                sessions,
+                isLoading: false,
+                hasError: false,
+            }),
+            { initialProps: [createSession('session-a', 11)] },
+        )
+
+        await waitFor(() => expect(setAppBadge).toHaveBeenCalledWith(1))
+        rerender([createSession('session-a', 11)])
+        await new Promise(resolve => setTimeout(resolve, 0))
+        expect(setAppBadge).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not use app badges for a normal browser tab', async () => {
+        setDisplayMode(false)
+        const { setAppBadge, clearAppBadge } = setAppBadgeNavigator()
+
+        renderHook(() => useAppBadge({
+            enabled: true,
+            scope: 'https://hapi.test',
+            sessions: [createSession('session-a', 11)],
+            isLoading: false,
+            hasError: false,
+        }))
+
+        await new Promise(resolve => setTimeout(resolve, 0))
+        expect(canUseAppBadging()).toBe(false)
+        expect(setAppBadge).not.toHaveBeenCalled()
+        expect(clearAppBadge).not.toHaveBeenCalled()
+    })
+})

--- a/web/src/hooks/useAppBadge.ts
+++ b/web/src/hooks/useAppBadge.ts
@@ -1,0 +1,143 @@
+import { useEffect, useRef } from 'react'
+import type { SessionSummary } from '@/types/api'
+import { sessionIsUnread } from '@/lib/sessionAttention'
+import {
+    getSessionLastSeenSnapshot,
+    initializeSessionLastSeen,
+    useSessionLastSeenVersion,
+} from '@/lib/sessionLastSeen'
+
+type AppBadgeNavigator = Navigator & {
+    setAppBadge?: (contents?: number) => Promise<void>
+    clearAppBadge?: () => Promise<void>
+}
+
+export type UseAppBadgeOptions = {
+    enabled: boolean
+    scope: string
+    sessions: readonly SessionSummary[]
+    isLoading: boolean
+    hasError: boolean
+}
+
+function getAppBadgeNavigator(): AppBadgeNavigator | null {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+        return null
+    }
+
+    if (
+        typeof window.matchMedia !== 'function'
+        || !window.matchMedia('(display-mode: standalone)').matches
+    ) {
+        return null
+    }
+
+    const appBadgeNavigator = navigator as AppBadgeNavigator
+    if (typeof appBadgeNavigator.setAppBadge !== 'function') {
+        return null
+    }
+
+    return appBadgeNavigator
+}
+
+/** True when this context can update the installed PWA's app icon badge. */
+export function canUseAppBadging(): boolean {
+    return getAppBadgeNavigator() !== null
+}
+
+/** Count sessions whose activity is newer than their local watermark. */
+export function countUnreadSessions(
+    sessions: readonly SessionSummary[],
+    lastSeenById: Readonly<Record<string, number>>,
+): number {
+    return sessions.reduce(
+        (count, session) => count + (
+            sessionIsUnread(session, { lastSeenAt: lastSeenById[session.id] ?? 0 })
+                ? 1
+                : 0
+        ),
+        0,
+    )
+}
+
+function requestBadgeUpdate(
+    appBadgeNavigator: AppBadgeNavigator,
+    count: number,
+): Promise<void> | null {
+    try {
+        if (count > 0) {
+            return typeof appBadgeNavigator.setAppBadge === 'function'
+                ? appBadgeNavigator.setAppBadge(count)
+                : null
+        }
+
+        if (typeof appBadgeNavigator.clearAppBadge === 'function') {
+            return appBadgeNavigator.clearAppBadge()
+        }
+
+        return typeof appBadgeNavigator.setAppBadge === 'function'
+            ? appBadgeNavigator.setAppBadge(0)
+            : null
+    } catch (error) {
+        return Promise.reject(error)
+    }
+}
+
+function syncBadge(
+    appBadgeNavigator: AppBadgeNavigator,
+    count: number,
+    lastAppliedCountRef: { current: number | null },
+): void {
+    if (lastAppliedCountRef.current === count) {
+        return
+    }
+
+    const update = requestBadgeUpdate(appBadgeNavigator, count)
+    if (!update) {
+        return
+    }
+
+    lastAppliedCountRef.current = count
+    void update.catch(() => {
+        // Retry after a transient browser/OS failure on the next render.
+        if (lastAppliedCountRef.current === count) {
+            lastAppliedCountRef.current = null
+        }
+    })
+}
+
+export function useAppBadge(options: UseAppBadgeOptions): void {
+    const lastSeenVersion = useSessionLastSeenVersion()
+    const lastAppliedCountRef = useRef<number | null>(null)
+
+    useEffect(() => {
+        const appBadgeNavigator = getAppBadgeNavigator()
+        if (!appBadgeNavigator) {
+            return
+        }
+
+        if (!options.enabled) {
+            syncBadge(appBadgeNavigator, 0, lastAppliedCountRef)
+            return
+        }
+
+        // Keep the previous signal while a temporary refetch is in flight or
+        // failed. The next successful session snapshot will reconcile it.
+        if (options.isLoading || options.hasError) {
+            return
+        }
+
+        // Match the session list's first-load baseline so existing sessions do
+        // not all appear unread when a user installs the PWA for the first time.
+        initializeSessionLastSeen(options.scope, options.sessions)
+        const count = countUnreadSessions(options.sessions, getSessionLastSeenSnapshot())
+        syncBadge(appBadgeNavigator, count, lastAppliedCountRef)
+    }, [
+        lastSeenVersion,
+        options.enabled,
+        options.hasError,
+        options.isLoading,
+        options.scope,
+        options.sessions,
+    ])
+}

--- a/web/src/hooks/useAppBadgePreference.test.ts
+++ b/web/src/hooks/useAppBadgePreference.test.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+    DEFAULT_APP_BADGE_ENABLED,
+    getInitialAppBadgeEnabled,
+    useAppBadgePreference,
+} from './useAppBadgePreference'
+
+const STORAGE_KEY = 'hapi-app-badge-enabled'
+
+describe('useAppBadgePreference helpers', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('defaults to disabled', () => {
+        expect(getInitialAppBadgeEnabled()).toBe(DEFAULT_APP_BADGE_ENABLED)
+        expect(getInitialAppBadgeEnabled()).toBe(false)
+    })
+
+    it('reads the stored enabled value and falls back for other values', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'true')
+        expect(getInitialAppBadgeEnabled()).toBe(true)
+
+        window.localStorage.setItem(STORAGE_KEY, 'invalid')
+        expect(getInitialAppBadgeEnabled()).toBe(false)
+    })
+})
+
+describe('useAppBadgePreference', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('persists changes and synchronizes hook instances in the same tab', () => {
+        const first = renderHook(() => useAppBadgePreference())
+        const second = renderHook(() => useAppBadgePreference())
+
+        act(() => first.result.current.setAppBadgeEnabled(true))
+
+        expect(first.result.current.appBadgeEnabled).toBe(true)
+        expect(second.result.current.appBadgeEnabled).toBe(true)
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true')
+
+        act(() => second.result.current.setAppBadgeEnabled(false))
+
+        expect(first.result.current.appBadgeEnabled).toBe(false)
+        expect(second.result.current.appBadgeEnabled).toBe(false)
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('synchronizes changes from another browsing context', () => {
+        const { result } = renderHook(() => useAppBadgePreference())
+
+        act(() => {
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: STORAGE_KEY,
+                newValue: 'true',
+            }))
+        })
+
+        expect(result.current.appBadgeEnabled).toBe(true)
+    })
+
+    it('ignores storage events for unrelated keys', () => {
+        const { result } = renderHook(() => useAppBadgePreference())
+
+        act(() => {
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: 'hapi-other-setting',
+                newValue: 'false',
+            }))
+        })
+
+        expect(result.current.appBadgeEnabled).toBe(false)
+    })
+})

--- a/web/src/hooks/useAppBadgePreference.ts
+++ b/web/src/hooks/useAppBadgePreference.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const APP_BADGE_ENABLED_STORAGE_KEY = 'hapi-app-badge-enabled'
+export const DEFAULT_APP_BADGE_ENABLED = false
+
+const sameTabListeners = new Set<(enabled: boolean) => void>()
+
+function isBrowser(): boolean {
+    return typeof window !== 'undefined' && typeof document !== 'undefined'
+}
+
+function safeGetItem(key: string): string | null {
+    if (!isBrowser()) {
+        return null
+    }
+    try {
+        return localStorage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
+function safeSetItem(key: string, value: string): void {
+    if (!isBrowser()) {
+        return
+    }
+    try {
+        localStorage.setItem(key, value)
+    } catch {
+        // Ignore storage errors
+    }
+}
+
+function safeRemoveItem(key: string): void {
+    if (!isBrowser()) {
+        return
+    }
+    try {
+        localStorage.removeItem(key)
+    } catch {
+        // Ignore storage errors
+    }
+}
+
+function parseAppBadgeEnabled(raw: string | null): boolean {
+    if (raw === 'true') {
+        return true
+    }
+    return DEFAULT_APP_BADGE_ENABLED
+}
+
+export function getInitialAppBadgeEnabled(): boolean {
+    return parseAppBadgeEnabled(safeGetItem(APP_BADGE_ENABLED_STORAGE_KEY))
+}
+
+export function useAppBadgePreference(): {
+    appBadgeEnabled: boolean
+    setAppBadgeEnabled: (enabled: boolean) => void
+} {
+    const [appBadgeEnabled, setAppBadgeEnabledState] = useState<boolean>(getInitialAppBadgeEnabled)
+
+    useEffect(() => {
+        if (!isBrowser()) {
+            return
+        }
+
+        const onStorage = (event: StorageEvent) => {
+            if (event.key !== APP_BADGE_ENABLED_STORAGE_KEY) {
+                return
+            }
+            setAppBadgeEnabledState(parseAppBadgeEnabled(event.newValue))
+        }
+
+        sameTabListeners.add(setAppBadgeEnabledState)
+        window.addEventListener('storage', onStorage)
+        return () => {
+            sameTabListeners.delete(setAppBadgeEnabledState)
+            window.removeEventListener('storage', onStorage)
+        }
+    }, [])
+
+    const setAppBadgeEnabled = useCallback((enabled: boolean) => {
+        for (const listener of sameTabListeners) {
+            listener(enabled)
+        }
+
+        if (enabled === DEFAULT_APP_BADGE_ENABLED) {
+            safeRemoveItem(APP_BADGE_ENABLED_STORAGE_KEY)
+        } else {
+            safeSetItem(APP_BADGE_ENABLED_STORAGE_KEY, String(enabled))
+        }
+    }, [])
+
+    return { appBadgeEnabled, setAppBadgeEnabled }
+}

--- a/web/src/hooks/useDocumentVisibility.test.ts
+++ b/web/src/hooks/useDocumentVisibility.test.ts
@@ -1,0 +1,37 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useDocumentVisibility } from './useDocumentVisibility'
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+    Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: state,
+    })
+}
+
+afterEach(() => {
+    setVisibilityState('visible')
+})
+
+describe('useDocumentVisibility', () => {
+    it('reads the current document visibility synchronously', () => {
+        setVisibilityState('hidden')
+        const { result } = renderHook(() => useDocumentVisibility())
+
+        expect(result.current).toBe(false)
+    })
+
+    it('tracks visibility changes', () => {
+        setVisibilityState('visible')
+        const { result } = renderHook(() => useDocumentVisibility())
+        expect(result.current).toBe(true)
+
+        setVisibilityState('hidden')
+        act(() => document.dispatchEvent(new Event('visibilitychange')))
+        expect(result.current).toBe(false)
+
+        setVisibilityState('visible')
+        act(() => document.dispatchEvent(new Event('visibilitychange')))
+        expect(result.current).toBe(true)
+    })
+})

--- a/web/src/hooks/useDocumentVisibility.ts
+++ b/web/src/hooks/useDocumentVisibility.ts
@@ -1,0 +1,19 @@
+import { useSyncExternalStore } from 'react'
+
+function subscribe(onChange: () => void): () => void {
+    if (typeof document === 'undefined') {
+        return () => {}
+    }
+
+    document.addEventListener('visibilitychange', onChange)
+    return () => document.removeEventListener('visibilitychange', onChange)
+}
+
+function getSnapshot(): boolean {
+    return typeof document === 'undefined' || document.visibilityState === 'visible'
+}
+
+/** Track whether the current document is visible to the user. */
+export function useDocumentVisibility(): boolean {
+    return useSyncExternalStore(subscribe, getSnapshot, () => true)
+}

--- a/web/src/hooks/useSelectedSessionSeen.test.ts
+++ b/web/src/hooks/useSelectedSessionSeen.test.ts
@@ -1,0 +1,54 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getSessionLastSeenAt } from '@/lib/sessionLastSeen'
+import { useSelectedSessionSeen } from './useSelectedSessionSeen'
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+    Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: state,
+    })
+}
+
+beforeEach(() => {
+    window.localStorage.clear()
+})
+
+afterEach(() => {
+    setVisibilityState('visible')
+})
+
+describe('useSelectedSessionSeen', () => {
+    it('does not mark hidden selected-session updates as seen', () => {
+        setVisibilityState('hidden')
+        const { rerender } = renderHook(
+            ({ updatedAt }) => useSelectedSessionSeen('session-a', updatedAt),
+            { initialProps: { updatedAt: 100 } },
+        )
+
+        rerender({ updatedAt: 200 })
+
+        expect(getSessionLastSeenAt('session-a')).toBe(0)
+    })
+
+    it('marks the latest selected-session update when visibility resumes', () => {
+        setVisibilityState('hidden')
+        const { rerender } = renderHook(
+            ({ updatedAt }) => useSelectedSessionSeen('session-a', updatedAt),
+            { initialProps: { updatedAt: 100 } },
+        )
+
+        rerender({ updatedAt: 200 })
+        setVisibilityState('visible')
+        act(() => document.dispatchEvent(new Event('visibilitychange')))
+
+        expect(getSessionLastSeenAt('session-a')).toBe(200)
+    })
+
+    it('marks selected-session updates immediately while visible', () => {
+        setVisibilityState('visible')
+        renderHook(() => useSelectedSessionSeen('session-a', 300))
+
+        expect(getSessionLastSeenAt('session-a')).toBe(300)
+    })
+})

--- a/web/src/hooks/useSelectedSessionSeen.ts
+++ b/web/src/hooks/useSelectedSessionSeen.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import { markSessionSeen } from '@/lib/sessionLastSeen'
+import { useDocumentVisibility } from './useDocumentVisibility'
+
+/** Mark the selected session read only while the document is visible. */
+export function useSelectedSessionSeen(
+    selectedSessionId: string | null,
+    updatedAt: number | undefined,
+): void {
+    const isDocumentVisible = useDocumentVisibility()
+
+    useEffect(() => {
+        if (!isDocumentVisible || !selectedSessionId || updatedAt === undefined) {
+            return
+        }
+
+        markSessionSeen(selectedSessionId, updatedAt)
+    }, [isDocumentVisible, selectedSessionId, updatedAt])
+}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -852,6 +852,8 @@ export default {
   'settings.display.activeSessionsOnly.desc': 'Hide inactive sessions in the sidebar. The session you have open stays visible.',
   'settings.display.pinInProgressSessions': 'Pin in-progress sessions',
   'settings.display.pinInProgressSessions.desc': 'Move unpinned connected sessions into sections above project folders: running and pending work first, then quiet active sessions (finished executing, still connected). Global pins remain above them. Off keeps everything in directory groups.',
+  'settings.display.appBadge': 'Taskbar unread badge',
+  'settings.display.appBadge.desc': 'Show the number of sessions with new activity on an installed Edge or Chrome PWA. The host browser controls its appearance; this has no effect in a normal browser tab.',
   'settings.display.sessionListStatus': 'Session list status hints',
   'settings.display.sessionListStatus.standard': 'Basic',
   'settings.display.sessionListStatus.detailed': 'Extended',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -851,6 +851,8 @@ export default {
   'settings.display.activeSessionsOnly.desc': '在侧边栏隐藏非活跃会话；当前打开的会话仍会保留显示。',
   'settings.display.pinInProgressSessions': '置顶进行中会话',
   'settings.display.pinInProgressSessions.desc': '将未置顶的已连接会话移到项目文件夹上方的分区：先运行中和待处理，再是安静的活跃会话（已执行完但仍在连接）。全局置顶仍在其上。关闭后全部保留在目录分组中。',
+  'settings.display.appBadge': '任务栏未读角标',
+  'settings.display.appBadge.desc': '在已安装的 Edge 或 Chrome PWA 图标上显示有新活动的会话数。角标样式由宿主浏览器控制；普通浏览器标签页不受影响。',
   'settings.display.sessionListStatus': '会话列表状态提示',
   'settings.display.sessionListStatus.standard': '基础',
   'settings.display.sessionListStatus.detailed': '扩展',

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -51,7 +51,8 @@ import { transferComposerDraftThenNavigate } from '@/lib/composer-draft-transfer
 import { getDraftAttachments } from '@/lib/composer-attachment-drafts'
 import { refreshSessionDetailPreservingActive } from '@/lib/session-detail-optimistic'
 import { inactiveSessionCanResume, resolveCursorReopenGate } from '@/lib/sessionResume'
-import { initializeSessionLastSeen, markSessionSeen } from '@/lib/sessionLastSeen'
+import { initializeSessionLastSeen } from '@/lib/sessionLastSeen'
+import { useSelectedSessionSeen } from '@/hooks/useSelectedSessionSeen'
 import { useSessionBrowserTitle } from '@/hooks/useSessionBrowserTitle'
 import { clearCodexImportedSession } from '@/lib/codexImportedSessions'
 import { getSupersedingSessionId, prepareFollowSupersedingSession, shouldFollowSupersedingSession } from '@/routes/sessions/followSupersedingSession'
@@ -206,12 +207,7 @@ function SessionsPage() {
         initializeSessionLastSeen(baseUrl, sessions)
         setInitializedHub(baseUrl)
     }, [baseUrl, error, isLoading, sessions])
-    useEffect(() => {
-        if (!selectedSessionId || !selectedSession) {
-            return
-        }
-        markSessionSeen(selectedSessionId, selectedSession.updatedAt)
-    }, [selectedSessionId, selectedSession?.updatedAt])
+    useSelectedSessionSeen(selectedSessionId, selectedSession?.updatedAt)
     const isSessionsIndex = pathname === '/sessions' || pathname === '/sessions/'
     const sidebar = useSidebarResize()
     const handleNewSessionInDirectory = useCallback((args: { machineId: string | null; directory: string }) => {

--- a/web/src/routes/settings/display.tsx
+++ b/web/src/routes/settings/display.tsx
@@ -10,6 +10,7 @@ import { usePinInProgressSessions } from '@/hooks/usePinInProgressSessions'
 import { MAX_SESSION_PREVIEW_LIMIT, MIN_SESSION_PREVIEW_LIMIT, normalizeSessionPreviewLimit, useSessionPreviewLimit } from '@/hooks/useSessionPreviewLimit'
 import { useThemeColors, type ThemeColorKeyId } from '@/hooks/useThemeColors'
 import { useSessionHeaderMetadata, type SessionHeaderMetadataKey } from '@/hooks/useSessionHeaderMetadata'
+import { useAppBadgePreference } from '@/hooks/useAppBadgePreference'
 import { SettingsChoiceGroup, SettingsFieldLabel, SettingsPageContent, SettingsRow, SettingsSection, SettingsSwitch } from '@/components/settings/SettingsPrimitives'
 
 function MinusIcon() {
@@ -138,6 +139,7 @@ export default function SettingsDisplayPage() {
     const { sessionListStatusMode, setSessionListStatusMode } = useSessionListStatusMode()
     const { showActiveSessionsOnly, setShowActiveSessionsOnly } = useShowActiveSessionsOnly()
     const { pinInProgressSessions, setPinInProgressSessions } = usePinInProgressSessions()
+    const { appBadgeEnabled, setAppBadgeEnabled } = useAppBadgePreference()
     const { preferences: sessionHeaderMetadata, setPreference: setSessionHeaderMetadata } = useSessionHeaderMetadata()
     const sessionHeaderOptions: ReadonlyArray<{ key: SessionHeaderMetadataKey; labelKey: string }> = [
         { key: 'showLabels', labelKey: 'settings.display.sessionHeader.showLabels' },
@@ -175,6 +177,7 @@ export default function SettingsDisplayPage() {
                 <SessionPreviewLimitControl />
                 <SettingsSwitch label={t('settings.display.activeSessionsOnly')} description={t('settings.display.activeSessionsOnly.desc')} checked={showActiveSessionsOnly} onChange={setShowActiveSessionsOnly} />
                 <SettingsSwitch label={t('settings.display.pinInProgressSessions')} description={t('settings.display.pinInProgressSessions.desc')} checked={pinInProgressSessions} onChange={setPinInProgressSessions} />
+                <SettingsSwitch label={t('settings.display.appBadge')} description={t('settings.display.appBadge.desc')} checked={appBadgeEnabled} onChange={setAppBadgeEnabled} />
                 <SettingsChoiceGroup
                     label={t('settings.display.sessionListStatus')}
                     description={t('settings.display.sessionListStatus.detailedDescription')}

--- a/web/src/routes/settings/index.test.tsx
+++ b/web/src/routes/settings/index.test.tsx
@@ -11,7 +11,7 @@ import SettingsVoicePage from './voice'
 import SettingsVoiceVoicesPage from './voice-voices'
 import SettingsVoiceAdvancedPage from './voice-advanced'
 
-const { context, navigate, setAppearance, setColorTheme, setFontScale, setTerminalFontSize, setComposerEnterBehavior, setCodexExplorationCollapsed, setVoice } = vi.hoisted(() => ({
+const { context, navigate, setAppearance, setColorTheme, setFontScale, setTerminalFontSize, setComposerEnterBehavior, setCodexExplorationCollapsed, setVoice, setAppBadgeEnabled } = vi.hoisted(() => ({
     context: { token: '' },
     navigate: vi.fn(),
     setAppearance: vi.fn(),
@@ -21,6 +21,7 @@ const { context, navigate, setAppearance, setColorTheme, setFontScale, setTermin
     setComposerEnterBehavior: vi.fn(),
     setCodexExplorationCollapsed: vi.fn(),
     setVoice: vi.fn(),
+    setAppBadgeEnabled: vi.fn(),
 }))
 
 const getHubSettings = vi.fn().mockResolvedValue({ sessionSummaryContract: false, sessionSummaryInChat: false })
@@ -83,6 +84,10 @@ vi.mock('@/hooks/useShowActiveSessionsOnly', () => ({
 
 vi.mock('@/hooks/usePinInProgressSessions', () => ({
     usePinInProgressSessions: () => ({ pinInProgressSessions: false, setPinInProgressSessions: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useAppBadgePreference', () => ({
+    useAppBadgePreference: () => ({ appBadgeEnabled: false, setAppBadgeEnabled }),
 }))
 
 vi.mock('@/hooks/useSessionHeaderMetadata', () => ({
@@ -258,6 +263,10 @@ describe('responsive settings pages', () => {
         expect(setColorTheme).toHaveBeenCalledWith('nord')
         expect(screen.getByRole('radio', { name: '120%' })).toBeInTheDocument()
         expect(screen.getByRole('spinbutton', { name: 'Sessions Before Folding' })).toHaveValue(8)
+        const appBadgeToggle = screen.getByRole('checkbox', { name: 'Taskbar unread badge' })
+        expect(appBadgeToggle).not.toBeChecked()
+        fireEvent.click(appBadgeToggle)
+        expect(setAppBadgeEnabled).toHaveBeenCalledWith(true)
         expect(screen.getByRole('checkbox', { name: 'Show field labels' })).toBeChecked()
         expect(screen.getByRole('checkbox', { name: 'Reasoning effort' })).toBeChecked()
         expect(screen.getByRole('checkbox', { name: 'Machine' })).toBeChecked()


### PR DESCRIPTION
## Summary

- Add unread-session counting for installed Edge/Chrome PWAs through the App Badging API.
- Make the taskbar unread badge opt-in and disabled by default.
- Add a local toggle under Settings > Display > Session list.
- Keep selected-session read tracking visibility-aware so minimized PWAs retain unread activity.
- Clear the native app badge when the preference is disabled.
- Add unit, settings, Playwright, and documentation coverage.

## Problem / Motivation

HAPI needs a taskbar signal for new session activity. Manual validation found two related issues.

First, Edge and Windows can render one logical App Badging API state as two overlapping visual layers. In the affected environment, one layer is offset toward the bottom-right and clipped by the taskbar boundary. Calling `navigator.clearAppBadge()` removes both layers together. HAPI has only one runtime App Badging API write path, and the Service Worker notification `badge` resource is unrelated to the taskbar App Badge. This is consistent with a host-level browser/OS rendering issue, similar in class to [Chromium issue 324585422](https://issues.chromium.org/issues/324585422).

Second, when the PWA was minimized, a selected session could receive an SSE update and be marked as seen solely because its `updatedAt` changed, even though the document was hidden. This caused the system notification to appear while the unread badge remained absent. Unselected sessions correctly produced a badge, confirming that the counter and App Badging API path worked.

Selected sessions are now marked as read only while the document is visible. When the PWA becomes visible again, the current selected session is reconciled against its latest activity.

Because the host rendering can be visually undesirable, the badge is opt-in instead of enabled for all users by default.

## User Impact

Users who want the native taskbar count can enable:

Settings > Display > Session list > Taskbar unread badge

The preference is local to the current browser/PWA profile. While the PWA is minimized, new activity in the selected session remains unread and can contribute to the badge count. When the PWA becomes visible again, the selected session is marked as read.

Disabling the setting clears the native badge and disables the badge-specific session query.

## Risk / Rollback

- No dependency, API, database, or migration changes.
- Badge rendering remains controlled by the host browser and operating system.
- The feature is disabled by default.
- The setting is local and can be changed at any time.
- Rollback is limited to reverting this commit.

## Validation

- `bun run typecheck:web` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name investigate-windows-taskbar-badge -Suite Root -TestArgs settings-responsive.spec.ts` — 2 passed, including default-off behavior, opt-in behavior, and persistence after reload.
- `bun run --cwd web test -- src/hooks/useDocumentVisibility.test.ts src/hooks/useSelectedSessionSeen.test.ts src/hooks/useAppBadge.test.ts src/hooks/useAppBadgePreference.test.ts src/lib/sessionLastSeen.test.ts src/lib/sessionAttention.test.ts` — 45 passed.
- `bun run build` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Deployed smoke check — Hub health, authentication, test machine, and Runner verified successfully.

## Related Issues

None

## AI Disclosure

OpenAI Codex (GPT-5.6) assisted with implementation, testing, and validation.