### PR TITLE
fix(web): remember file browser tab preference

### DIFF
--- a/web/src/routes/sessions/files.test.tsx
+++ b/web/src/routes/sessions/files.test.tsx
@@ -8,6 +8,7 @@ import FilesPage from './files'
 const mocks = vi.hoisted(() => ({
     navigate: vi.fn(),
     fileSearch: vi.fn(),
+    sessionId: 'session-1',
     transferComposerDraftThenNavigate: vi.fn(async (
         _source: string,
         _target: string,
@@ -18,15 +19,12 @@ const mocks = vi.hoisted(() => ({
     sessionHeaderProps: null as null | {
         onSessionReopened?: (newSessionId: string) => void | Promise<void>
     },
-    search: {
-        tab: 'directories' as const,
-        query: '感',
-    },
+    search: {} as { tab?: 'changes' | 'directories'; query?: string },
 }))
 
 vi.mock('@tanstack/react-router', () => ({
     useNavigate: () => mocks.navigate,
-    useParams: () => ({ sessionId: 'session-1' }),
+    useParams: () => ({ sessionId: mocks.sessionId }),
     useSearch: () => mocks.search,
 }))
 
@@ -45,7 +43,7 @@ vi.mock('@/hooks/useAppGoBack', () => ({
 vi.mock('@/hooks/queries/useSession', () => ({
     useSession: () => ({
         session: {
-            id: 'session-1',
+            id: mocks.sessionId,
             metadata: { path: '/workspace/project' },
         },
     }),
@@ -107,6 +105,8 @@ function renderFilesPage() {
 describe('FilesPage search navigation', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        mocks.sessionId = 'session-1'
+        mocks.search = { tab: 'directories', query: '感' }
         window.localStorage.clear()
         window.sessionStorage.clear()
     })
@@ -164,10 +164,63 @@ describe('FilesPage search navigation', () => {
     })
 })
 
+describe('FilesPage tab preference', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.sessionId = 'session-1'
+        mocks.sessionHeaderProps = null
+        mocks.search = {}
+        window.localStorage.clear()
+        window.sessionStorage.clear()
+    })
+
+    it('restores the globally remembered tab for a different session', () => {
+        const firstRender = renderFilesPage()
+
+        expect(screen.getByRole('tab', { name: 'Changes' })).toHaveAttribute('aria-selected', 'true')
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Directories' }))
+        expect(window.localStorage.getItem('hapi-files-tab')).toBe('directories')
+        firstRender.unmount()
+
+        mocks.sessionId = 'session-2'
+        renderFilesPage()
+
+        expect(screen.getByRole('tab', { name: 'Directories' })).toHaveAttribute('aria-selected', 'true')
+    })
+
+    it('remembers Changes after the user switches back from Directories', () => {
+        window.localStorage.setItem('hapi-files-tab', 'directories')
+        const firstRender = renderFilesPage()
+
+        expect(screen.getByRole('tab', { name: 'Directories' })).toHaveAttribute('aria-selected', 'true')
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Changes' }))
+        expect(window.localStorage.getItem('hapi-files-tab')).toBe('changes')
+        firstRender.unmount()
+
+        renderFilesPage()
+
+        expect(screen.getByRole('tab', { name: 'Changes' })).toHaveAttribute('aria-selected', 'true')
+    })
+
+    it('uses an explicit route tab before the stored browser preference', () => {
+        window.localStorage.setItem('hapi-files-tab', 'directories')
+        mocks.search = { tab: 'changes' }
+
+        renderFilesPage()
+
+        expect(screen.getByRole('tab', { name: 'Changes' })).toHaveAttribute('aria-selected', 'true')
+        expect(window.localStorage.getItem('hapi-files-tab')).toBe('changes')
+    })
+})
+
 describe('FilesPage reopen draft transfer', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        mocks.sessionId = 'session-1'
         mocks.sessionHeaderProps = null
+        mocks.search = { tab: 'directories', query: '感' }
         window.localStorage.clear()
         window.sessionStorage.clear()
     })

--- a/web/src/routes/sessions/files.tsx
+++ b/web/src/routes/sessions/files.tsx
@@ -64,6 +64,29 @@ function SortIcon() {
 }
 
 const DIRECTORY_SORT_STORAGE_KEY = 'hapi-directory-sort'
+const FILES_TAB_STORAGE_KEY = 'hapi-files-tab'
+
+type FilesTab = 'changes' | 'directories'
+
+function readFilesTab(): FilesTab {
+    try {
+        const value = localStorage.getItem(FILES_TAB_STORAGE_KEY)
+        if (value === 'changes' || value === 'directories') {
+            return value
+        }
+    } catch {
+        // Use the default when storage is unavailable.
+    }
+    return 'changes'
+}
+
+function persistFilesTab(tab: FilesTab): void {
+    try {
+        localStorage.setItem(FILES_TAB_STORAGE_KEY, tab)
+    } catch {
+        // Tab switching still works when storage is unavailable.
+    }
+}
 
 function readDirectorySort(): DirectorySort {
     try {
@@ -318,8 +341,7 @@ export default function FilesPage() {
     const { session } = useSession(api, sessionId)
     const scrollRef = useRef<HTMLDivElement>(null)
 
-    const initialTab = search.tab === 'directories' ? 'directories' : 'changes'
-    const [activeTab, setActiveTab] = useState<'changes' | 'directories'>(initialTab)
+    const [activeTab, setActiveTab] = useState<FilesTab>(() => search.tab ?? readFilesTab())
     const [directorySort, setDirectorySort] = useState<DirectorySort>(readDirectorySort)
     const searchQuery = search.query ?? ''
 
@@ -343,6 +365,13 @@ export default function FilesPage() {
             // Sorting still works when storage is unavailable.
         }
     }, [directorySort])
+
+    useEffect(() => {
+        if (search.tab) {
+            setActiveTab(search.tab)
+            persistFilesTab(search.tab)
+        }
+    }, [search.tab])
 
     useEffect(() => {
         const el = scrollRef.current
@@ -430,8 +459,9 @@ export default function FilesPage() {
         void refetchGit()
     }, [activeTab, queryClient, refetchGit, searchQuery, sessionId])
 
-    const handleTabChange = useCallback((nextTab: 'changes' | 'directories') => {
+    const handleTabChange = useCallback((nextTab: FilesTab) => {
         setActiveTab(nextTab)
+        persistFilesTab(nextTab)
         navigate({
             to: '/sessions/$sessionId/files',
             params: { sessionId },


### PR DESCRIPTION
## Summary

- Persist the selected Changes or Directories tab in browser localStorage.
- Restore the remembered tab when opening the file browser without an explicit route tab.
- Keep explicit route tab values authoritative and synchronize them back to the browser preference.
- Add regression coverage for cross-session persistence, switching back to Changes, and explicit route precedence.

## Problem / Motivation

Opening the session file browser from chat always defaulted to Changes after the page remounted, even when the user had previously selected Directories. This made the file browsing preference feel lost between sessions and navigations.

## Validation

- `bun typecheck` — passed.
- `bun run --cwd web test src/routes/sessions/files.test.tsx src/routes/sessions/file.test.tsx` — passed, 8/8 tests.
- `bun run test:web` — 2,786/2,862 tests passed; 76 existing fixture CRLF/LF canonicalization failures unrelated to this change.
- `pwsh -NoProfile -File .\\scripts\\Invoke-HapiTaskPlaywright.ps1 -Name fix-file-preview-tab-memory -Suite Root terminal-wrap-fidelity.spec.ts` — passed, 2/2.
- Live targeted Playwright validation against the task test environment — passed, 1/1.
- `bun run build` — passed.
- `bun run test` — attempted; stopped during the CLI suite because of 28 Windows/agent-runtime environment failures. Changed Web tests passed separately.

## Related Issues

None

## AI Assistance

Implemented and validated with OpenAI Codex (GPT-5.6).