### PR TITLE
fix(web): center inactive session notice text

### DIFF
--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -1765,7 +1765,7 @@ function SessionChatInner(props: SessionChatProps) {
             )}
 
             {sessionInactive ? (
-                <div className="mx-auto w-full max-w-content bg-[var(--app-subtle-bg)] p-3 text-sm text-[var(--app-hint)]">
+                <div className="mx-auto w-full max-w-content bg-[var(--app-subtle-bg)] p-3 text-center text-sm text-[var(--app-hint)]">
                     {inactiveCanResume
                         ? t('session.inactive.autoResume')
                         : t('session.inactive.cannotResume')}


### PR DESCRIPTION
## Summary

- Add `text-center` to the existing inactive-session notice in the session detail view.
- Keep the change presentation-only, preserving the existing layout and resume behavior.

## Problem / Motivation

The session detail view previously centered only the notice container, while the text inside remained left-aligned. This made the notice look visually offset on narrow mobile layouts and within the desktop content column. This change only adjusts text alignment and does not alter session state, sending, or resume behavior.

## Validation

- `bun typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name center-inactive-session-notice -Suite Root terminal-wrap-fidelity.spec.ts` — 2/2 passed.
- `bun run --cwd web test -- src/components/SessionChat.test.ts src/components/SessionChat.exit-mode.test.tsx` — 53/53 passed.
- `bun run build` — passed.
- `git diff origin/main...HEAD --check` — passed.
- Isolated Web smoke checks passed: health endpoint returned 200, and the archived session remained inactive with its 13-message history available.

## Related Issues

None

## AI Disclosure

Implementation and validation were assisted by OpenAI Codex (GPT-5.6).