### PR TITLE
docs: explain execution-host sleep in remote sessions

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -133,6 +133,16 @@ Only if they have your access token. For additional security:
 
 ## Troubleshooting
 
+### Why does a session stop when its laptop host sleeps?
+
+Remote mode changes where you control the agent, not where it executes. The machine running the CLI or runner must remain awake. If the hub runs elsewhere, the web app may still load while that execution machine is unavailable. Running the hub on a server does not move an existing laptop session to that server.
+
+First verify a small request with the laptop open. If that fails too, check the agent's pending permissions, CLI connection, and network before changing power settings. Terminal disconnection and operating-system sleep are separate problems: preserving a process after an SSH disconnect does not let it execute while its host is asleep.
+
+For a MacBook that must work with the lid closed, use a supported external-display setup or a compatible closed-lid solution. Leaving the lid open with idle sleep managed is another option. Keep an active laptop powered and ventilated. After closing the lid, confirm new command output from the phone before relying on a long run.
+
+This [Apple Silicon MacBook setup guide](https://clamshell.dev/guides/keep-claude-code-running-lid-closed#phone-check) includes a two-minute timestamp check and an optional Clamshell setup. Clamshell is a separate paid app with a trial; HAPI does not require it.
+
 ### "Connection refused" error
 
 - Ensure hub is running: `hapi hub`


### PR DESCRIPTION
A phone can still reach a separately hosted HAPI hub while the laptop running its CLI or runner is asleep. This adds a focused FAQ entry explaining which machine must remain awake, distinguishing terminal-disconnection survival from OS sleep, and suggesting a fresh-output check before relying on a long run. This is adjacent to the session-survival discussion in #1526, not an implementation of that proposal.

Disclosure: I make Clamshell. The entry links to our published Apple Silicon guide and explicitly identifies Clamshell as an optional paid app with a trial. It includes lid-open and supported external-display alternatives. The external link can be removed if you prefer vendor-neutral documentation.

Validation: the approved patch applies cleanly to the current FAQ, and the linked guide and its timestamp-check anchor are live. This is documentation only; full HAPI tests, builds, and physical HAPI-to-Clamshell phone/lid acceptance were not run. No runtime behavior changes.

AI assistance: prepared with OpenAI GPT-6 Astra (gpt-6-astra), with source inspection and patch/link verification. The submitter reviewed and approved the proposed text.
