### PR TITLE
fix(web): preserve sidebar viewport across pin updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
             - run: bun install --frozen-lockfile
             - run: bun typecheck
             - run: bunx playwright install --with-deps chromium
-            - run: bun run test:e2e -- terminal-wrap-fidelity.spec.ts composer-copy.spec.ts
+            - run: bun run test:e2e -- terminal-wrap-fidelity.spec.ts composer-copy.spec.ts session-list-scroll.spec.ts
             - run: bun run test
 
     # Serial runner-integration suite: starts real detached runner/session

--- a/e2e/session-list-scroll.spec.ts
+++ b/e2e/session-list-scroll.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test'
+
+for (const nativeAnchoring of [true, false]) {
+    test.describe(`native scroll anchoring: ${nativeAnchoring}`, () => {
+        test.beforeEach(async ({ page }) => {
+            if (!nativeAnchoring) {
+                await page.addInitScript(() => {
+                    const style = document.createElement('style')
+                    style.textContent = '* { overflow-anchor: none !important; }'
+                    document.addEventListener('DOMContentLoaded', () => document.head.append(style))
+                })
+            }
+        })
+
+        test('keeps the visible session in place across background pin and activity changes', async ({ page }) => {
+            await page.goto('/e2e-fixtures/session-list-scroll-fixture.html')
+            const row = page.getByRole('button', { name: /^Session 20 / })
+            await row.waitFor()
+            await row.evaluate(element => element.scrollIntoView({ block: 'center' }))
+            const before = (await row.boundingBox())!.y
+            for (const patch of [
+                { pinned: false, active: true, thinking: true },
+                { thinking: false },
+                { active: false },
+                { globalPinned: true },
+                { globalPinned: false, pinned: true },
+            ]) {
+                await page.evaluate(patch => window.updateSession('session-0', patch), patch)
+                await page.waitForTimeout(350) // Include directory collapse transitions and native anchoring.
+                expect(Math.abs((await row.boundingBox())!.y - before)).toBeLessThan(2)
+            }
+        })
+
+        test('keeps a neighboring row in place when the first visible project moves to pinned', async ({ page }) => {
+            await page.goto('/e2e-fixtures/session-list-scroll-fixture.html')
+            const row = page.getByRole('button', { name: /^Session 20 / })
+            await row.waitFor()
+            await page.locator('[title="/project-19"]').evaluate(element => element.scrollIntoView({ block: 'start' }))
+            const before = (await row.boundingBox())!.y
+            await page.evaluate(() => window.updateSession('session-19', { pinned: false, active: true, thinking: true }))
+            await page.waitForTimeout(350)
+            expect(Math.abs((await row.boundingBox())!.y - before)).toBeLessThan(2)
+        })
+
+        test('does not follow a visible project when unpinning moves it to the bottom', async ({ page }) => {
+            await page.goto('/e2e-fixtures/session-list-scroll-fixture.html')
+            const row = page.getByRole('button', { name: /^Session 20 / })
+            await row.waitFor()
+            await page.locator('[title="/project-19"]').evaluate(element => element.scrollIntoView({ block: 'start' }))
+            const before = (await row.boundingBox())!.y
+            await page.evaluate(() => window.updateSession('session-19', { pinned: false }))
+            await page.waitForTimeout(350)
+            expect(Math.abs((await row.boundingBox())!.y - before)).toBeLessThan(2)
+        })
+
+        test('preserves the viewport when a project automatically collapses after unpinning', async ({ page }) => {
+            await page.goto('/e2e-fixtures/session-list-scroll-fixture.html?mixed')
+            const row = page.getByRole('button', { name: /^Session 20 / })
+            await row.waitFor()
+            await row.evaluate(element => element.scrollIntoView({ block: 'center' }))
+            const before = (await row.boundingBox())!.y
+            await page.evaluate(() => window.updateSession('session-0', { pinned: false }))
+            await page.waitForTimeout(350)
+            expect(Math.abs((await row.boundingBox())!.y - before)).toBeLessThan(2)
+        })
+
+        test('preserves collapsed project headers and respects subsequent user scrolling', async ({ page }) => {
+            await page.goto('/e2e-fixtures/session-list-scroll-fixture.html?collapsed')
+            const header = page.locator('[title="/project-20"]')
+            await header.waitFor()
+            await header.evaluate(element => element.scrollIntoView({ block: 'center' }))
+            const before = (await header.boundingBox())!.y
+            await page.evaluate(() => window.updateSession('session-0', { globalPinned: true }))
+            await page.waitForTimeout(350)
+            expect(Math.abs((await header.boundingBox())!.y - before)).toBeLessThan(2)
+            const scroller = page.locator('.session-list-scrollbar-left')
+            await scroller.evaluate(element => { element.scrollTop = 0 })
+            await page.evaluate(() => window.updateSession('session-1', { globalPinned: true }))
+            await page.waitForTimeout(350)
+            expect(await scroller.evaluate(element => element.scrollTop)).toBe(0)
+        })
+
+    })
+}

--- a/web/e2e-fixtures/session-list-scroll-fixture.html
+++ b/web/e2e-fixtures/session-list-scroll-fixture.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Session list scroll fixture</title></head>
+<body><div id="root"></div><script type="module" src="./session-list-scroll-fixture.tsx"></script></body>
+</html>

--- a/web/e2e-fixtures/session-list-scroll-fixture.tsx
+++ b/web/e2e-fixtures/session-list-scroll-fixture.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { SessionList } from '../src/components/SessionList'
+import { I18nProvider } from '../src/lib/i18n-context'
+import { ToastProvider } from '../src/lib/toast-context'
+import type { SessionSummary } from '../src/types/api'
+import '../src/index.css'
+
+localStorage.setItem('hapi-pin-in-progress-sessions', 'true')
+const initialSessions: SessionSummary[] = Array.from({ length: 40 }, (_, index) => ({
+    id: `session-${index}`, active: false, thinking: false, activeAt: 0,
+    updatedAt: 1000 - index, metadataVersion: 0, agentStateVersion: 0,
+    todosUpdatedAt: 0, todoProgress: null, pendingRequestsCount: 0,
+    pendingRequestKinds: [], pendingRequests: [], backgroundTaskCount: 0,
+    futureScheduledMessageCount: 0, nextScheduledAt: null, model: null, effort: null,
+    pinned: !new URLSearchParams(location.search).has('collapsed'),
+    metadata: { path: `/project-${index}`, name: `Session ${index}`, flavor: 'codex' },
+}))
+
+if (new URLSearchParams(location.search).has('mixed')) {
+    initialSessions.push({ ...initialSessions[0], id: 'companion', pinned: false })
+}
+
+declare global {
+    interface Window {
+        updateSession: (id: string, patch: Partial<SessionSummary>) => void
+    }
+}
+
+function Fixture() {
+    const [sessions, setSessions] = useState(initialSessions)
+    window.updateSession = (id, patch) => setSessions(previous => previous.map(session =>
+        session.id === id ? { ...session, ...patch } : session))
+    return <div style={{ width: 360, height: 600, display: 'flex', flexDirection: 'column' }}>
+        <SessionList sessions={sessions} onSelect={() => {}} onNewSession={() => {}}
+            isLoading={false} renderHeader={false} api={null} />
+    </div>
+}
+
+createRoot(document.getElementById('root')!).render(
+    <React.StrictMode><QueryClientProvider client={new QueryClient()}>
+        <ToastProvider><I18nProvider><Fixture /></I18nProvider></ToastProvider>
+    </QueryClientProvider></React.StrictMode>,
+)

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { SessionListScrollAnchor } from './SessionListScrollAnchor'
 import type { SessionSummary } from '@/types/api'
 import { isWildcardSearch, matchesSearchQuery } from '@hapi/protocol'
 import type { ApiClient } from '@/api/client'
@@ -1034,6 +1035,7 @@ function SessionItem(props: {
             <button
                 type="button"
                 {...longPressHandlers}
+                data-session-scroll-anchor
                 className={`session-list-item group/session-row flex w-full flex-col gap-1 py-2 pl-2.5 pr-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)] select-none rounded-lg ${selected ? 'bg-[var(--app-secondary-bg)]' : ''}`}
                 style={{ WebkitTouchCallout: 'none' }}
                 aria-current={selected ? 'page' : undefined}
@@ -1556,7 +1558,7 @@ export function SessionList(props: {
             ? `${group.displayName} · ${resolveMachineLabel(group.machineId)}`
             : group.displayName
         return (
-            <div key={group.key}>
+            <div key={group.key} data-session-scroll-anchor>
                 <div
                     className="group/project sticky top-0 z-10 flex items-center gap-2 bg-[var(--app-bg)] py-1.5 pl-2 pr-2 text-left rounded-lg transition-colors hover:bg-[var(--app-secondary-bg)] min-w-0 w-full select-none"
                     title={group.directory}
@@ -1610,7 +1612,7 @@ export function SessionList(props: {
             ? `${group.displayName} · ${resolveMachineLabel(group.machineId)}`
             : group.displayName
         return (
-            <div key={group.key}>
+            <div key={group.key} data-session-scroll-anchor>
                 <div
                     className="group/project sticky top-0 z-10 flex items-center gap-2 bg-[var(--app-bg)] py-1.5 pl-2 pr-2 text-left rounded-lg transition-colors hover:bg-[var(--app-secondary-bg)] cursor-pointer min-w-0 w-full select-none"
                     onClick={() => toggleGroup(group.key, isCollapsed)}
@@ -1971,7 +1973,7 @@ export function SessionList(props: {
                 </div>
             ) : null}
             <div ref={scrollContainerRef} className="app-scroll-y session-list-scrollbar-left min-h-0 flex-1">
-            <div className="mx-auto flex w-full max-w-content flex-col gap-1 pl-1.5 pr-2 pb-2">
+            <SessionListScrollAnchor sessions={props.sessions} className="mx-auto flex w-full max-w-content flex-col gap-1 pl-1.5 pr-2 pb-2">
                 {props.sessions.length === 0 && !props.isLoading ? (
                     <SessionsEmptyState
                         onNewSession={props.onNewSession}
@@ -2058,7 +2060,7 @@ export function SessionList(props: {
                 })}
                 {groups.map(renderDirectoryGroup)}
                 {actionOnlyGroups.map(renderActionOnlyGroupHeader)}
-            </div>
+            </SessionListScrollAnchor>
             </div>
             </div>
         </div>

--- a/web/src/components/SessionListScrollAnchor.tsx
+++ b/web/src/components/SessionListScrollAnchor.tsx
@@ -1,0 +1,57 @@
+import { Component, createRef, type ReactNode } from 'react'
+import type { SessionSummary } from '@/types/api'
+
+type Props = { children: ReactNode; className: string; sessions: SessionSummary[] }
+type Snapshot = { scrollTop: number; anchors: { element: HTMLElement; top: number }[] }
+
+/** Read the old DOM at commit time, before rows move between pinned sections. */
+export class SessionListScrollAnchor extends Component<Props, object, Snapshot | null> {
+    private contentRef = createRef<HTMLDivElement>()
+
+    getSnapshotBeforeUpdate(previousProps: Props): Snapshot | null {
+        if (previousProps.sessions === this.props.sessions) return null
+        const content = this.contentRef.current
+        const container = content?.parentElement
+        if (!content || !container || container.scrollTop <= 0) return null
+        const viewport = container.getBoundingClientRect()
+        const anchors: Snapshot['anchors'] = []
+        for (const element of content.querySelectorAll<HTMLElement>('[data-session-scroll-anchor]')) {
+            if (element.closest('.collapsible-panel:not([data-open])')) continue
+            const rect = element.getBoundingClientRect()
+            if (rect.top >= viewport.bottom) break
+            // A project's box can span the whole viewport; only anchor its visible header.
+            const isRow = element.classList.contains('session-list-item')
+            if (rect.height > 0 && rect.bottom > viewport.top && (isRow || rect.top >= viewport.top)) {
+                anchors.push({ element, top: rect.top - viewport.top })
+            }
+        }
+        return { scrollTop: container.scrollTop, anchors }
+    }
+
+    componentDidUpdate(_previousProps: Props, _previousState: object, snapshot: Snapshot | null) {
+        const content = this.contentRef.current
+        const container = content?.parentElement
+        if (!content || !container || !snapshot) return
+        const viewportTop = container.getBoundingClientRect().top
+        // Prefer the least-reordered survivor, not a project that was just sent to
+        // the top/bottom. Compare content offsets so native scroll anchoring cannot
+        // make that moved project look stationary.
+        const candidates = snapshot.anchors
+            .filter(({ element }) => content.contains(element)
+                && !element.closest('.collapsible-panel:not([data-open])'))
+            .map(anchor => ({ ...anchor, rect: anchor.element.getBoundingClientRect() }))
+            .filter(({ rect }) => rect.height > 0)
+            .map(anchor => ({
+                ...anchor,
+                shift: anchor.rect.top - viewportTop + container.scrollTop - anchor.top - snapshot.scrollTop,
+            }))
+            .sort((a, b) => Math.abs(a.shift) - Math.abs(b.shift))
+        const anchor = candidates[0]
+        const scrollTop = anchor ? snapshot.scrollTop + anchor.shift : snapshot.scrollTop
+        if (Math.abs(container.scrollTop - scrollTop) > 0.5) container.scrollTop = scrollTop
+    }
+
+    render() {
+        return <div ref={this.contentRef} className={this.props.className}>{this.props.children}</div>
+    }
+}


### PR DESCRIPTION
Fixes #1775.

Background pin/activity updates can move the session sidebar's visible content when native scroll anchoring is unavailable or suppressed. Preserve the reading position across these updates by capturing visible rows/project boxes before React mutates the DOM, then restoring the least-reordered surviving anchor. If a row moves to another section, use a surviving neighbor; if none survives, retain the previous scroll offset within the browser's bounds. User-driven filtering/collapse updates are not intercepted.

The content-offset comparison avoids following a project that was itself sorted to the top or bottom, even when native browser anchoring has already adjusted the viewport. The scroll container and existing grouping behavior stay intact.

Validation:
- `bun typecheck`
- `bun run test` with isolated HAPI_HOME/TMPDIR and production connection variables unset
- Chromium regression coverage with native anchoring both enabled and disabled: pin/activity transitions, visible-row removal, project reorder/collapse, collapsed headers, and scrolling back to the top. The new spec runs in CI.
- Existing composer-copy and terminal-wrap browser specs.

The baseline fails the disabled-native-anchoring cases (42.5px drift in the visible-project case); the final regression suite passes. This addresses layout-induced viewport drift, without claiming every reported jump was a literal scrollTop reset.
