### PR TITLE
fix(hub): seed forked session summaries

### DIFF
--- a/hub/src/sync/conversationHistoryPi.test.ts
+++ b/hub/src/sync/conversationHistoryPi.test.ts
@@ -68,6 +68,7 @@ describe('Pi conversation-history hub integration', () => {
                 machineId: 'machine-1',
                 flavor: 'pi',
                 piSessionId: 'pi-source-native',
+                summary: { text: 'Pi source title', updatedAt: 100 },
                 capabilities: { conversationHistory: { forkCurrent: true, forkAtMessage: true, rewindToMessage: true } },
                 conversationHistoryPoints: { local1: true, local2: true },
                 conversationHistoryEntryIds: { local1: 'entry-1', local2: 'entry-2' },
@@ -125,10 +126,15 @@ describe('Pi conversation-history hub integration', () => {
             expect(capturedChildMetadata).toMatchObject({
                 flavor: 'pi',
                 piSessionId: 'pi-clone-native',
+                summary: { text: 'Fork: Pi source title', updatedAt: expect.any(Number) },
                 conversationHistoryEntryIds: { local1: 'entry-1', local2: 'entry-2', local3: 'entry-3' },
                 conversationHistoryPoints: { local1: true, local2: true, local3: true },
             })
             expect(store.messages.getAllMessages(result.sessionId).map((message) => message.localId)).toContain('local3')
+            expect(engine.getSession(result.sessionId)?.metadata?.summary).toMatchObject({
+                text: 'Fork: Pi source title',
+                updatedAt: expect.any(Number),
+            })
             expect(exactBinds).toEqual([[result.sessionId, 'pi-clone-native', 'piSessionId', true]])
             expect(spawnArgs[3]).toBeUndefined()
             expect(spawnArgs[9]).toBeUndefined()

--- a/hub/src/sync/forkSessionSummary.test.ts
+++ b/hub/src/sync/forkSessionSummary.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test'
+import { buildForkSessionSummary } from './forkSessionSummary'
+
+describe('buildForkSessionSummary', () => {
+    it('prefixes the manual title before the generated summary', () => {
+        expect(buildForkSessionSummary({
+            name: '  Manual title  ',
+            summary: { text: 'Generated title' },
+        }, 123)).toEqual({
+            text: 'Fork: Manual title',
+            updatedAt: 123,
+        })
+    })
+
+    it('uses the generated summary when no manual title exists', () => {
+        expect(buildForkSessionSummary({ summary: { text: 'Generated title' } }, 456)).toEqual({
+            text: 'Fork: Generated title',
+            updatedAt: 456,
+        })
+    })
+
+    it('does not create a synthetic summary for an untitled source session', () => {
+        expect(buildForkSessionSummary({ name: '  ', summary: { text: '   ' } }, 789)).toBeUndefined()
+        expect(buildForkSessionSummary(undefined, 789)).toBeUndefined()
+    })
+})

--- a/hub/src/sync/forkSessionSummary.ts
+++ b/hub/src/sync/forkSessionSummary.ts
@@ -1,0 +1,23 @@
+type ForkSessionTitleSource = {
+    name?: string
+    summary?: { text?: string }
+}
+
+export type ForkSessionSummary = {
+    text: string
+    updatedAt: number
+}
+
+/** Seed a fork's generated/native title without claiming manual-name ownership. */
+export function buildForkSessionSummary(
+    metadata: ForkSessionTitleSource | null | undefined,
+    updatedAt: number = Date.now()
+): ForkSessionSummary | undefined {
+    const sourceTitle = metadata?.name?.trim() || metadata?.summary?.text?.trim()
+    if (!sourceTitle) return undefined
+
+    return {
+        text: `Fork: ${sourceTitle}`,
+        updatedAt
+    }
+}

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -30,6 +30,7 @@ import { MachineCache, type Machine } from './machineCache'
 import { MessageService, type RetryIndeterminateMessageResult } from './messageService'
 import { createTitleSuggestionService, type TitleSuggestionService } from './titleSuggestion'
 import { selectForkTranscriptPrefix } from './forkTranscript'
+import { buildForkSessionSummary } from './forkSessionSummary'
 import {
     RpcGateway,
     RpcTargetMissingError,
@@ -1417,11 +1418,13 @@ export class SyncEngine {
         const copiedLocalIds = new Set(
             prefix.flatMap((message) => (message.localId ? [message.localId] : []))
         )
+        const forkSummary = buildForkSessionSummary(source.metadata)
         const childMetadata: Record<string, unknown> = {
             path: directory,
             host: source.metadata?.host ?? 'unknown',
             machineId,
             flavor,
+            ...(forkSummary ? { summary: forkSummary } : {}),
             forkedFrom: sessionId,
             startedBy: 'runner',
             capabilities: source.metadata?.capabilities,


### PR DESCRIPTION
## Summary

- Seed forked HAPI sessions with a generated/native summary derived from the source session title.
- Prefer the source manual name over its generated summary and prefix it with `Fork:`.
- Leave truly untitled source sessions on the existing path fallback behavior.
- Store the default in `metadata.summary` so a later child-generated title can replace it without claiming manual-name ownership.

## Validation

- `bun run --cwd hub test -- src/sync/forkSessionSummary.test.ts src/sync/conversationHistoryPi.test.ts src/sync/forkTranscript.test.ts src/sync/sessionCache.titleSummary.test.ts src/web/routes/sessions.test.ts` — 81 passed.
- `bun run typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name fork-session-summary -Suite Root terminal-wrap-fidelity.spec.ts` — 2 passed.
- `bun run build` — passed.
- `git diff --check` — passed.
- Full environment readiness smoke — local/public health 200, authenticated `/api/machines` 200, and the task Runner registered active.

## Related Issues

None

## AI Disclosure

Implemented and validated with OpenAI Codex (GPT-5.6).