### PR TITLE
feat(codex): support backend-authorized Luna Reserve fallback

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -211,3 +211,25 @@ bun run build:single-exe
 
 - `../hub/README.md`
 - `../web/README.md`
+
+### Codex Luna Reserve
+
+Remote sessions read Codex's account usage through app-server. Luna Reserve is
+shown only while the task is using the backend-authorized Reserve route; an
+unused Reserve allowance never adds a row or a model option. Ordinary and
+Reserve windows remain separate, and unavailable percentages stay unknown.
+
+HAPI applies the official fallback with `thread/settings/update` and restores
+the task's saved model and reasoning effort after a fresh account read permits
+ordinary usage. It does not replay the blocked turn. Resume first reconciles
+Codex's task settings; the task-local return record uses Codex's
+`CODEX_HOME/tui-luna-reserve/<thread-id>.json` format for TUI handoff.
+
+This requires the newer app-server protocol with `ordinaryUsageAllowed`,
+`supportsLunaReserve`, the hidden Reserve catalog entry, and thread settings
+updates. Verified against official source
+[`ac192cd7937`](https://github.com/openai/codex/tree/ac192cd7937b0d73edc6dffe009940ae53782dd4).
+Codex 0.153.4 does not expose the required usage capability; no minimum released
+version is claimed. Older servers keep their ordinary usage display without
+advertising Reserve activation. Real eligible-account exhaustion, Reserve
+exhaustion, and recovery still require account-level validation.

--- a/cli/src/codex/appServerTypes.ts
+++ b/cli/src/codex/appServerTypes.ts
@@ -32,6 +32,7 @@ export interface InitializeResponse {
 }
 
 export interface ModelListParams {
+    cursor?: string;
     includeHidden?: boolean;
 }
 
@@ -385,4 +386,12 @@ export interface ExperimentalFeatureEnablementSetParams {
 export interface ExperimentalFeatureEnablementSetResponse {
     enablement: Record<string, boolean>;
     [key: string]: unknown;
+}
+
+export interface ThreadSettingsUpdateParams {
+    threadId: string;
+    model: string;
+    effort?: string | null;
+    serviceTier?: string | null;
+    collaborationMode?: CollaborationMode;
 }

--- a/cli/src/codex/codexAppServerClient.test.ts
+++ b/cli/src/codex/codexAppServerClient.test.ts
@@ -62,6 +62,26 @@ describe('CodexAppServerClient process cwd', () => {
         spawnMock.mockReset();
     });
 
+    it('uses null for legacy usage reads and opts in only when Reserve is supported', async () => {
+        const child = fakeChild();
+        child.stdin.write = vi.fn((_data: unknown, callback?: (error?: Error | null) => void) => {
+            callback?.();
+            return true;
+        });
+        spawnMock.mockReturnValue(child);
+        const client = new CodexAppServerClient({ cwd: '/neutral-home' });
+        await client.connect();
+        for (const supported of [false, true]) {
+            const pending = client.readAccountRateLimits(supported);
+            const request = JSON.parse(child.stdin.write.mock.lastCall![0] as string);
+            expect(request.method).toBe('account/rateLimits/read');
+            expect(request.params).toEqual(supported ? { supportsLunaReserve: true } : null);
+            child.stdout.emit('data', Buffer.from(JSON.stringify({ id: request.id, result: { rateLimits: {} } }) + '\n'));
+            await expect(pending).resolves.toEqual({ rateLimits: {} });
+        }
+        await client.disconnect();
+    });
+
     it('passes an explicit neutral cwd to the app-server process', async () => {
         spawnMock.mockReturnValue(fakeChild());
         const client = new CodexAppServerClient({ cwd: '/neutral-home' });

--- a/cli/src/codex/codexAppServerClient.ts
+++ b/cli/src/codex/codexAppServerClient.ts
@@ -4,6 +4,7 @@ import { logger } from '@/ui/logger';
 import { JsonLineParser } from '@/utils/jsonLineParser';
 import { killProcessByChildProcess } from '@/utils/process';
 import type {
+    ThreadSettingsUpdateParams,
     CollaborationModeListResponse,
     InitializeParams,
     InitializeResponse,
@@ -300,6 +301,14 @@ export class CodexAppServerClient extends JsonLineParser {
         return response as ConfigReadResponse;
     }
 
+    async readAccountRateLimits(supportsLunaReserve = false): Promise<unknown> {
+        return this.sendRequest('account/rateLimits/read', supportsLunaReserve ? { supportsLunaReserve: true } : null, { timeoutMs: 30_000 });
+    }
+
+    async updateThreadSettings(params: ThreadSettingsUpdateParams): Promise<void> {
+        await this.sendRequest('thread/settings/update', params, { timeoutMs: 30_000 });
+    }
+
     async listModels(params?: ModelListParams): Promise<ModelListResponse> {
         const response = await this.sendRequest('model/list', params ?? {}, {
             timeoutMs: 30_000
@@ -354,7 +363,7 @@ export class CodexAppServerClient extends JsonLineParser {
         return response as ThreadForkResponse;
     }
 
-    async supportsMethod(method: 'thread/fork' | 'thread/rollback'): Promise<boolean> {
+    async supportsMethod(method: 'thread/fork' | 'thread/rollback' | 'thread/settings/update'): Promise<boolean> {
         try {
             await this.sendRequest(method, { threadId: '__hapi_capability_probe__' }, { timeoutMs: 30_000 });
             return true;

--- a/cli/src/codex/codexLocalLauncher.ts
+++ b/cli/src/codex/codexLocalLauncher.ts
@@ -48,7 +48,7 @@ function extractTurnContextModel(event: CodexSessionEvent): string | null | unde
     const model = (event.payload as Record<string, unknown>).model;
     if (model === null) return null;
     if (typeof model !== 'string' || !model.trim()) return undefined;
-    return model.trim();
+    return model.trim() === 'gpt-reserve' ? 'gpt-5.6-luna' : model.trim();
 }
 
 export async function codexLocalLauncher(session: CodexSession): Promise<'switch' | 'exit'> {
@@ -416,7 +416,7 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
             await codexLocal({
                 path: session.path,
                 sessionId: resumeSessionId,
-                modelReasoningEffort: (session.getModelReasoningEffort() ?? undefined) as ReasoningEffort | undefined,
+                modelReasoningEffort: resumeSessionId ? undefined : (session.getModelReasoningEffort() ?? undefined) as ReasoningEffort | undefined,
                 onSessionFound: handleSessionFound,
                 abort: abortSignal,
                 codexArgs,

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -6,6 +6,9 @@ import { MessageQueue2 } from '@/utils/MessageQueue2';
 import type { EnhancedMode } from './loop';
 
 const harness = vi.hoisted(() => ({
+    appServerConnected: true,
+    abandonTransport: null as (() => void) | null,
+    resumeModel: 'gpt-5.4',
     reserveUsage: null as Record<string, unknown> | null,
     reserveSettingsCalls: [] as Array<Record<string, unknown>>,
     notifications: [] as Array<{ method: string; params: unknown }>,
@@ -109,14 +112,14 @@ vi.mock('./codexAppServerClient', () => {
         private notificationHandler: ((method: string, params: unknown) => void) | null = null;
         private stderrHandler: ((text: string) => void) | null = null;
 
-        async connect(): Promise<void> {}
+        async connect(): Promise<void> { harness.appServerConnected = true; }
 
         isConnected(): boolean {
-            return true;
+            return harness.appServerConnected;
         }
 
         isInitialized(): boolean {
-            return true;
+            return harness.appServerConnected;
         }
 
         async initialize(params: unknown): Promise<{ protocolVersion: number }> {
@@ -137,7 +140,7 @@ vi.mock('./codexAppServerClient', () => {
             harness.dispatchNotification = handler;
         }
 
-        setTransportAbandonedHandler(_handler: (() => void) | null): void {}
+        setTransportAbandonedHandler(handler: (() => void) | null): void { harness.abandonTransport = handler; }
 
         setStderrHandler(handler: ((text: string) => void) | null): void {
             this.stderrHandler = handler;
@@ -202,7 +205,7 @@ vi.mock('./codexAppServerClient', () => {
             if (harness.failResumeThreadIds.includes(id)) {
                 throw new Error('resume failed');
             }
-            return { thread: { id }, model: 'gpt-5.4' };
+            return { thread: { id }, model: harness.resumeModel };
         }
 
         async compactThread(params?: { threadId?: string }): Promise<Record<string, never>> {
@@ -1133,6 +1136,7 @@ import { INDETERMINATE_SYMBOL } from './codexAppServerClient';
 import { RPC_METHODS } from '@hapi/protocol/rpcMethods';
 
 type FakeAgentState = {
+    codexUsage?: import('@hapi/protocol').AgentState['codexUsage'];
     requests: Record<string, unknown>;
     completedRequests: Record<string, unknown>;
 };
@@ -1427,6 +1431,9 @@ describe('codexRemoteLauncher', () => {
         session.queue.close();
     });
     afterEach(() => {
+        harness.appServerConnected = true;
+        harness.abandonTransport = null;
+        harness.resumeModel = 'gpt-5.4';
         harness.reserveUsage = null;
         harness.reserveSettingsCalls = [];
         harness.notifications = [];
@@ -2615,6 +2622,88 @@ describe('codexRemoteLauncher', () => {
         expect(harness.startTurnMessages).toEqual(['first message', 'first message', 'first message', 'first message', 'second message']);
         expect(session.sessionId).toBe('thread-1');
         expect(session.thinking).toBe(false);
+    });
+
+    it('preserves queued model settings when resuming an ordinary thread', async () => {
+        const { session } = createSessionStub(['first'], {
+            ...createMode(), model: 'gpt-5.6', modelReasoningEffort: 'high', serviceTier: 'fast'
+        }, true);
+        session.sessionId = 'thread-old';
+        await codexRemoteLauncher(session as never);
+        expect(harness.startTurnParams[0]).toMatchObject({
+            collaborationMode: { settings: { model: 'gpt-5.6', reasoning_effort: 'high' } },
+            serviceTier: 'priority'
+        });
+    });
+
+    it.each([
+        ['transient', 'Codex thread entered systemError', 2, false],
+        ['context', "Codex ran out of room in the model's context window.", 2, true],
+        ['usage', 'Usage limit exceeded', 1, false]
+    ] as const)('preserves %s failure handling during Reserve', async (_kind, error, attempts, compact) => {
+        harness.resumeModel = 'gpt-reserve';
+        harness.remainingThreadSystemErrors = 1;
+        harness.nextThreadSystemErrorMessage = error;
+        harness.reserveUsage = {
+            accountId: 'account-a', ordinaryUsageAllowed: false,
+            rateLimits: { limitId: 'codex', primary: { usedPercent: 100 } }
+        };
+        const { session } = createSessionStub(['first'], createMode(), true);
+        session.sessionId = 'thread-reserve';
+        await codexRemoteLauncher(session as never);
+        expect(harness.startTurnMessages).toEqual(Array(attempts).fill('first'));
+        expect(harness.compactThreadIds).toEqual(compact ? ['thread-reserve'] : []);
+        expect(harness.startThreadIds).toEqual([]);
+        expect(harness.startTurnParams[0]).toMatchObject({
+            collaborationMode: { settings: { model: 'gpt-reserve' } }
+        });
+    });
+
+    it('reconciles a resumed Reserve task before waiting for the first user message', async () => {
+        harness.resumeModel = 'gpt-reserve';
+        harness.reserveUsage = {
+            accountId: 'account-a', ordinaryUsageAllowed: false,
+            rateLimits: { limitId: 'codex', primary: { usedPercent: 100 } },
+            rateLimitsByLimitId: { base_model_inference: { limitName: 'gpt-reserve', primary: { usedPercent: 20 } } }
+        };
+        const { session, getModel, getAgentState } = createSessionStub([], createMode(), false, false);
+        session.sessionId = 'thread-reserve';
+        const run = codexRemoteLauncher(session as never);
+        try {
+            await vi.waitFor(() => expect(getAgentState().codexUsage?.reserve?.primary?.remainingPercent).toBe(80));
+            expect(getModel()).toBe('gpt-5.6-luna');
+            expect(harness.resumeThreadIds).toEqual(['thread-reserve']);
+            expect(harness.startTurnMessages).toEqual([]);
+        } finally {
+            session.queue.close();
+            await run;
+        }
+    });
+
+    it('reads native settings after transport loss without replaying the interrupted message', async () => {
+        harness.resumeModel = 'gpt-reserve';
+        harness.suppressTurnCompletion = true;
+        harness.reserveUsage = {
+            accountId: 'account-a', ordinaryUsageAllowed: false,
+            rateLimits: { limitId: 'codex', primary: { usedPercent: 100 } }
+        };
+        const { session, getModel, getAgentState } = createSessionStub(['first'], createMode(), false, false);
+        session.sessionId = 'thread-reserve';
+        const run = codexRemoteLauncher(session as never);
+        try {
+            await vi.waitFor(() => expect(harness.startTurnMessages).toEqual(['first']));
+            harness.resumeModel = 'gpt-5.4';
+            harness.reserveUsage.ordinaryUsageAllowed = true;
+            harness.appServerConnected = false;
+            harness.abandonTransport?.();
+            await vi.waitFor(() => expect(harness.resumeThreadIds).toEqual(['thread-reserve', 'thread-reserve']));
+            await vi.waitFor(() => expect(getAgentState().codexUsage?.reserve).toBeNull());
+            expect(getModel()).toBe('gpt-5.4');
+            expect(harness.startTurnMessages).toEqual(['first']);
+        } finally {
+            session.queue.close();
+            await run;
+        }
     });
 
     it('uses accepted Reserve settings for queued turns in the same conversation without replay', async () => {

--- a/cli/src/codex/codexRemoteLauncher.test.ts
+++ b/cli/src/codex/codexRemoteLauncher.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { MessageQueue2 } from '@/utils/MessageQueue2';
 import type { EnhancedMode } from './loop';
 
 const harness = vi.hoisted(() => ({
+    reserveUsage: null as Record<string, unknown> | null,
+    reserveSettingsCalls: [] as Array<Record<string, unknown>>,
     notifications: [] as Array<{ method: string; params: unknown }>,
     dispatchNotification: null as ((method: string, params: unknown) => void) | null,
     registerRequestCalls: [] as string[],
@@ -144,6 +149,25 @@ vi.mock('./codexAppServerClient', () => {
                 throw new Error('collaborationMode/list failed');
             }
             return harness.collaborationModeResponse;
+        }
+
+        async readAccountRateLimits(): Promise<unknown> {
+            if (!harness.reserveUsage) throw new Error('Unsupported');
+            return structuredClone(harness.reserveUsage);
+        }
+
+        async supportsMethod(): Promise<boolean> { return true; }
+
+        async listModels(): Promise<unknown> {
+            return { data: [
+                { id: 'gpt-reserve', hidden: true, defaultReasoningEffort: 'medium' },
+                { id: 'gpt-5.4', hidden: false, defaultReasoningEffort: 'high' }
+            ] };
+        }
+
+        async updateThreadSettings(params: Record<string, unknown>): Promise<void> {
+            harness.reserveSettingsCalls.push(params);
+            this.notificationHandler?.('thread/settings/updated', { threadId: params.threadId, threadSettings: params });
         }
 
         async listSkills(params: unknown): Promise<unknown> {
@@ -1204,6 +1228,10 @@ function createSessionStub(
         setModelReasoningEffort(nextEffort: EnhancedMode['modelReasoningEffort']) {
             currentModelReasoningEffort = nextEffort;
         },
+        getModelReasoningEffort() { return currentModelReasoningEffort; },
+        pushKeepAlive() {},
+        getServiceTier() { return undefined; },
+        setServiceTier() {},
         getCollaborationMode() {
             return currentCollaborationMode;
         },
@@ -1399,6 +1427,8 @@ describe('codexRemoteLauncher', () => {
         session.queue.close();
     });
     afterEach(() => {
+        harness.reserveUsage = null;
+        harness.reserveSettingsCalls = [];
         harness.notifications = [];
         harness.dispatchNotification = null;
         harness.registerRequestCalls = [];
@@ -2585,6 +2615,36 @@ describe('codexRemoteLauncher', () => {
         expect(harness.startTurnMessages).toEqual(['first message', 'first message', 'first message', 'first message', 'second message']);
         expect(session.sessionId).toBe('thread-1');
         expect(session.thinking).toBe(false);
+    });
+
+    it('uses accepted Reserve settings for queued turns in the same conversation without replay', async () => {
+        const home = await mkdtemp(join(tmpdir(), 'hapi-reserve-launcher-'));
+        vi.stubEnv('CODEX_HOME', home);
+        try {
+            harness.reserveUsage = {
+                accountId: 'account-a', ordinaryUsageAllowed: false,
+                rateLimits: { limitId: 'codex', primary: { usedPercent: 100 } },
+                rateLimitsByLimitId: { base_model_inference: { limitName: 'gpt-reserve', primary: { usedPercent: 20 } } },
+                rateLimitUpsell: { banner_type: 'luna_reserve', blocked_model_slug: 'gpt-5.4' }
+            };
+            const { session, getModel, sessionEvents } = createSessionStub(['first', 'second'], createMode(), true);
+            session.sessionId = '01900000-0000-7000-8000-000000000001';
+            await codexRemoteLauncher(session as never);
+            expect(harness.resumeThreadIds).toEqual([session.sessionId]);
+            expect(harness.resumeThreadParams[0]).not.toHaveProperty('model');
+            expect(harness.reserveSettingsCalls).toHaveLength(1);
+            expect(harness.startTurnMessages).toEqual(['first', 'second']);
+            expect(harness.startTurnParams).toHaveLength(2);
+            for (const params of harness.startTurnParams) {
+                expect(params.collaborationMode).toMatchObject({ settings: { model: 'gpt-reserve', reasoning_effort: 'medium' } });
+                expect(params.threadId).toBe(session.sessionId);
+            }
+            expect(getModel()).toBe('gpt-5.6-luna');
+            expect(sessionEvents.filter(event => String(event.message).includes('Luna Reserve'))).toHaveLength(1);
+        } finally {
+            vi.unstubAllEnvs();
+            await rm(home, { recursive: true, force: true });
+        }
     });
 
     it('does not create a new thread when an existing conversation cannot be resumed', async () => {

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -1860,6 +1860,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             }
         };
 
+        let hasThread = false;
         let activeMessage: QueuedMessage | null = null;
         let sameThreadRetryAttempt = 0;
         let sameThreadCompactAttempt = 0;
@@ -1914,6 +1915,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             if (session.thinking) session.onThinkingChange(false);
             recoveryInFlight = false;
             activeMessage = null;
+            hasThread = false;
+            this.lunaReserve?.detach();
+            this.currentThreadId = null;
             this.currentTurnId = null;
             wakeLoop();
         });
@@ -2045,6 +2049,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     experimentalApi: true
                 }
             });
+            await this.lunaReserve?.initialize();
         };
 
         // Returns 'accepted' when the thread contains the steered user message
@@ -2909,7 +2914,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             const error = msgType === 'task_failed' ? asString(msg.error) : null;
             const explicitlyNonRetryable = msgType === 'task_failed'
                 && (msg.retryable === false || isPolicyBlockedCodexFailure(msg, error)
-                    || msg.codex_error_info === 'usageLimitExceeded' || this.lunaReserve?.blocksReplay() === true);
+                    || msg.codex_error_info === 'usageLimitExceeded'
+                    || /usage limit|rate limit|quota/i.test(error ?? ''));
 
             if (deferredThreadStatusFailure && isTerminalEvent && !isThreadStatusFailure) {
                 const sameThread = !eventThreadId || eventThreadId === deferredThreadStatusFailure.threadId;
@@ -3701,7 +3707,6 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             logger.debug(`[Codex] collaborationMode/list failed: ${errorMessage(error)}`);
         }
 
-        let hasThread = false;
         let pending: QueuedMessage | null = null;
         let suppressReadyForAdminCommand = false;
 
@@ -3841,7 +3846,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             }
         };
 
-        const ensureThreadForGoal = async (mode: EnhancedMode): Promise<string | null> => {
+        const ensureThread = async (mode: EnhancedMode): Promise<string | null> => {
             if (this.currentThreadId && this.currentThreadId !== invalidThreadId) {
                 hasThread = true;
                 return this.currentThreadId;
@@ -3877,8 +3882,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     hasThread = true;
                     return threadId;
                 } catch (error) {
-                    logger.warn(`[Codex] Failed to resume app-server thread ${resumeCandidate} for /goal`, error);
-                    sendVisibleStatus(`Goal failed: Codex conversation ${resumeCandidate} could not be resumed`);
+                    logger.warn(`[Codex] Failed to resume app-server thread ${resumeCandidate}`, error);
+                    sendVisibleStatus(`Codex conversation ${resumeCandidate} could not be resumed`);
                     return null;
                 }
             }
@@ -3955,7 +3960,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 return true;
             }
 
-            const threadId = await ensureThreadForGoal(message.mode);
+            const threadId = await ensureThread(message.mode);
             if (!threadId) {
                 return true;
             }
@@ -4032,6 +4037,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 invalidThreadId = null;
                 hasThread = false;
                 session.resetCodexThread();
+                reserve.detach();
                 sendVisibleStatus('Context was reset');
                 return true;
             }
@@ -4066,10 +4072,19 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             return true;
         };
 
+        const reconcileIdleThread = async () => {
+            if (!hasThread && session.queue.size() === 0 && session.sessionId && session.sessionId !== session.sourceSessionId) {
+                await ensureThread(currentMode());
+                await refreshUsage();
+            }
+        };
+        await reconcileIdleThread();
+
         while (!this.shouldExit) {
             logActiveHandles('loop-top');
             if (!appServerClient.isConnected() || !appServerClient.isInitialized()) {
                 await ensureAppServerInitialized();
+                await reconcileIdleThread();
             }
             if (pendingSteerReconciliations.size > 0) {
                 await runSteerReconciliation();
@@ -4221,15 +4236,21 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     }
                 }
 
-                await refreshUsage();
+                const beforeRefresh = currentMode();
+                await reserve.refresh(message.mode, () => !turnInFlight && !this.shouldExit);
+                const afterRefresh = currentMode();
+                const transitioned = beforeRefresh.model !== afterRefresh.model
+                    || beforeRefresh.modelReasoningEffort !== afterRefresh.modelReasoningEffort
+                    || beforeRefresh.serviceTier !== afterRefresh.serviceTier;
                 setTurnInFlight(true);
                 this.conversationHistory.setBusy(true);
                 allowAnonymousTerminalEvent = false;
                 const mode = reserve.turnMode({
                     ...message.mode,
-                    model: session.getModel() ?? message.mode.model,
-                    modelReasoningEffort: session.getModelReasoningEffort() ?? undefined,
-                    serviceTier: session.getServiceTier() ?? message.mode.serviceTier
+                    model: transitioned ? afterRefresh.model : message.mode.model ?? afterRefresh.model,
+                    modelReasoningEffort: transitioned ? afterRefresh.modelReasoningEffort
+                        : message.mode.modelReasoningEffort ?? afterRefresh.modelReasoningEffort,
+                    serviceTier: transitioned ? afterRefresh.serviceTier : message.mode.serviceTier ?? afterRefresh.serviceTier
                 });
                 usageModel = typeof mode.model === 'string' && mode.model.trim()
                     ? mode.model.trim()

--- a/cli/src/codex/codexRemoteLauncher.ts
+++ b/cli/src/codex/codexRemoteLauncher.ts
@@ -18,6 +18,7 @@ import { registerGeneratedImageFromPath } from '@/modules/common/generatedImages
 import { registerAppServerPermissionHandlers } from './utils/appServerPermissionAdapter';
 import {
     buildThreadStartParams,
+    withoutCodexModelOverrides,
     buildTurnStartParams,
     type CodexContextManagementConfig
 } from './utils/appServerConfig';
@@ -32,6 +33,7 @@ import {
     type RemoteLauncherExitReason
 } from '@/modules/common/remote/RemoteLauncherBase';
 import { CodexConversationHistory } from './conversationHistory';
+import { LunaReserve } from './utils/lunaReserve';
 
 
 
@@ -351,6 +353,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             onSwitchToLocal: () => this.handleSwitchFromUi()
         });
     }
+
+    private lunaReserve: LunaReserve | null = null;
+    private usageTimer: ReturnType<typeof setInterval> | null = null;
 
     protected async runMainLoop(): Promise<void> {
         const session = this.session;
@@ -2903,7 +2908,8 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             const isThreadStatusFailure = msgType === 'task_failed' && msg.terminal_source === 'thread_status';
             const error = msgType === 'task_failed' ? asString(msg.error) : null;
             const explicitlyNonRetryable = msgType === 'task_failed'
-                && (msg.retryable === false || isPolicyBlockedCodexFailure(msg, error));
+                && (msg.retryable === false || isPolicyBlockedCodexFailure(msg, error)
+                    || msg.codex_error_info === 'usageLimitExceeded' || this.lunaReserve?.blocksReplay() === true);
 
             if (deferredThreadStatusFailure && isTerminalEvent && !isThreadStatusFailure) {
                 const sameThread = !eventThreadId || eventThreadId === deferredThreadStatusFailure.threadId;
@@ -3484,7 +3490,37 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             }
         };
 
+        const reserve = new LunaReserve(appServerClient, (model, effort, serviceTier) => {
+            session.setModel(model);
+            session.setModelReasoningEffort(effort);
+            if (serviceTier !== undefined) session.setServiceTier(serviceTier);
+            session.pushKeepAlive();
+        }, (codexUsage) => {
+            session.client.updateAgentState(state => ({ ...state, codexUsage }));
+        }, message => session.sendSessionEvent({ type: 'message', message }));
+        this.lunaReserve = reserve;
+        const currentMode = (): EnhancedMode => ({
+            permissionMode: 'default',
+            model: session.getModel() ?? undefined,
+            modelReasoningEffort: session.getModelReasoningEffort() ?? undefined,
+            collaborationMode: session.getCollaborationMode() ?? 'default',
+            serviceTier: session.getServiceTier()
+        });
+        const refreshUsage = () => reserve.refresh(currentMode(), () => !turnInFlight && !this.shouldExit);
+
         appServerClient.setNotificationHandler((method, params) => {
+            if (method === 'account/rateLimits/updated' || method === 'account/updated') {
+                reserve.invalidate();
+                void refreshUsage();
+            }
+            if (method === 'thread/settings/updated') {
+                const record = asRecord(params);
+                const threadId = asString(record?.threadId);
+                if (threadId) reserve.onSettings(threadId, record?.threadSettings);
+            }
+            if (method === 'error' || method === 'turn/completed') {
+                reserve.invalidate();
+            }
             if (method === 'skills/changed') {
                 void refreshNativeSkills(true).catch((error) => {
                     logger.debug(`[Codex] failed to refresh skills: ${errorMessage(error)}`);
@@ -3513,6 +3549,9 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                         logger.debug('[Codex] Failed to handle app-server event:', error instanceof Error ? error.message : String(error));
                     });
                 }
+            }
+            if (method === 'error' || method === 'turn/completed') {
+                void (codexEventQueue ?? Promise.resolve()).then(refreshUsage);
             }
         });
 
@@ -3569,6 +3608,10 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 experimentalApi: true
             }
         });
+
+        await reserve.initialize();
+        this.usageTimer = setInterval(() => { void refreshUsage(); }, 60_000);
+        this.usageTimer.unref();
 
         let contextManagementConfig: CodexContextManagementConfig | undefined;
         try {
@@ -3752,7 +3795,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
             try {
                 const resumeResponse = await appServerClient.resumeThread({
                     threadId: resumeCandidate,
-                    ...threadParams
+                    ...withoutCodexModelOverrides(threadParams)
                 }, {
                     signal: this.abortController.signal
                 });
@@ -3760,6 +3803,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 const resumeThread = resumeRecord ? asRecord(resumeRecord.thread) : null;
                 const threadId = asString(resumeThread?.id) ?? resumeCandidate;
                 applyResolvedModel(resumeRecord?.model);
+                reserve.attach(threadId, resumeResponse);
                 this.currentThreadId = threadId;
                 this.conversationHistory.setThreadId(threadId);
                 void this.conversationHistory.probeCapabilities().catch(() => {});
@@ -3817,7 +3861,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 try {
                     const resumeResponse = await appServerClient.resumeThread({
                         threadId: resumeCandidate,
-                        ...threadParams
+                        ...withoutCodexModelOverrides(threadParams)
                     }, {
                         signal: this.abortController.signal
                     });
@@ -3825,6 +3869,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     const resumeThread = resumeRecord ? asRecord(resumeRecord.thread) : null;
                     const threadId = asString(resumeThread?.id) ?? resumeCandidate;
                     applyResolvedModel(resumeRecord?.model);
+                    reserve.attach(threadId, resumeResponse);
                     this.currentThreadId = threadId;
                     this.conversationHistory.setThreadId(threadId);
                     void this.conversationHistory.probeCapabilities().catch(() => {});
@@ -3856,6 +3901,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                 const thread = threadRecord ? asRecord(threadRecord.thread) : null;
                 const threadId = asString(thread?.id);
                 applyResolvedModel(threadRecord?.model);
+                if (threadId) reserve.attach(threadId, threadResponse);
                 if (!threadId) {
                     throw new Error('app-server thread/start did not return thread.id');
                 }
@@ -4111,13 +4157,13 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                             const response = shouldForkImportedSource
                                 ? await appServerClient.forkThread({
                                     threadId: resumeCandidate,
-                                    ...threadParams
+                                    ...withoutCodexModelOverrides(threadParams)
                                 }, {
                                     signal: this.abortController.signal
                                 })
                                 : await appServerClient.resumeThread({
                                     threadId: resumeCandidate,
-                                    ...threadParams
+                                    ...withoutCodexModelOverrides(threadParams)
                                 }, {
                                     signal: this.abortController.signal
                                 });
@@ -4125,6 +4171,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                             const responseThread = responseRecord ? asRecord(responseRecord.thread) : null;
                             threadId = asString(responseThread?.id) ?? resumeCandidate;
                             applyResolvedModel(responseRecord?.model);
+                            if (threadId) reserve.attach(threadId, response, shouldForkImportedSource ? resumeCandidate : undefined);
                             logger.debug(shouldForkImportedSource
                                 ? `[Codex] Forked imported app-server thread ${resumeCandidate} -> ${threadId}`
                                 : `[Codex] Resumed app-server thread ${threadId}`);
@@ -4150,6 +4197,7 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                         const thread = threadRecord ? asRecord(threadRecord.thread) : null;
                         threadId = asString(thread?.id);
                         applyResolvedModel(threadRecord?.model);
+                        if (threadId) reserve.attach(threadId, threadResponse);
                         if (!threadId) {
                             throw new Error('app-server thread/start did not return thread.id');
                         }
@@ -4173,13 +4221,16 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
                     }
                 }
 
+                await refreshUsage();
                 setTurnInFlight(true);
                 this.conversationHistory.setBusy(true);
                 allowAnonymousTerminalEvent = false;
-                const mode = {
+                const mode = reserve.turnMode({
                     ...message.mode,
-                    model: session.getModel() ?? message.mode.model
-                };
+                    model: session.getModel() ?? message.mode.model,
+                    modelReasoningEffort: session.getModelReasoningEffort() ?? undefined,
+                    serviceTier: session.getServiceTier() ?? message.mode.serviceTier
+                });
                 usageModel = typeof mode.model === 'string' && mode.model.trim()
                     ? mode.model.trim()
                     : null;
@@ -4317,6 +4368,10 @@ class CodexRemoteLauncher extends RemoteLauncherBase {
 
     protected async cleanup(): Promise<void> {
         logger.debug('[codex-remote]: cleanup start');
+        if (this.usageTimer) clearInterval(this.usageTimer);
+        this.usageTimer = null;
+        this.lunaReserve?.dispose();
+        this.lunaReserve = null;
         this.appServerClient.setTransportAbandonedHandler(null);
         this.appServerClient.setStderrHandler(null);
         try {

--- a/cli/src/codex/runCodex.test.ts
+++ b/cli/src/codex/runCodex.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { runCodex } from './runCodex'
 
 const mockCodexSession = vi.hoisted(() => ({
+    getPermissionMode: vi.fn<() => string | undefined>(),
+    getModel: vi.fn<() => string | null | undefined>(),
+    getModelReasoningEffort: vi.fn<() => string | null | undefined>(),
+    getServiceTier: vi.fn<() => string | null | undefined>(),
+    getCollaborationMode: vi.fn<() => string | undefined>(),
     setPermissionMode: vi.fn(),
     setModel: vi.fn(),
     setModelReasoningEffort: vi.fn(),
@@ -122,6 +127,11 @@ describe('runCodex', () => {
         harness.session.onUserMessage.mockReset()
         harness.session.onCancelQueuedMessage.mockReset()
         harness.session.rpcHandlerManager.registerHandler.mockReset()
+        mockCodexSession.getPermissionMode.mockReset()
+        mockCodexSession.getModel.mockReset()
+        mockCodexSession.getModelReasoningEffort.mockReset()
+        mockCodexSession.getServiceTier.mockReset()
+        mockCodexSession.getCollaborationMode.mockReset()
         mockCodexSession.setPermissionMode.mockReset()
         mockCodexSession.setModel.mockReset()
         mockCodexSession.setModelReasoningEffort.mockReset()
@@ -266,6 +276,20 @@ describe('runCodex', () => {
 
         expect(mockCodexSession.setModelReasoningEffort).toHaveBeenNthCalledWith(1, 'max')
         expect(mockCodexSession.setModelReasoningEffort).toHaveBeenNthCalledWith(2, 'extreme')
+    })
+
+    it('preserves native fallback settings when changing another session setting', async () => {
+        await runCodexImpl({ workingDirectory: '/tmp/project', model: 'gpt-5.6', modelReasoningEffort: 'high' })
+        mockCodexSession.getModel.mockReturnValue('gpt-5.6-luna')
+        mockCodexSession.getModelReasoningEffort.mockReturnValue('medium')
+        mockCodexSession.getServiceTier.mockReturnValue('standard')
+        const handler = harness.session.rpcHandlerManager.registerHandler.mock.calls.find(
+            ([method]) => method === RPC_METHODS.SetSessionConfig
+        )?.[1] as (payload: unknown) => Promise<unknown>
+        expect(await handler({ permissionMode: 'yolo' })).toEqual({
+            applied: expect.objectContaining({ modelReasoningEffort: 'medium', serviceTier: 'standard' })
+        })
+        expect(mockCodexSession.setModelReasoningEffort).toHaveBeenLastCalledWith('medium')
     })
 
     it('still persists an explicit reasoning effort reset as null', async () => {

--- a/cli/src/codex/runCodex.ts
+++ b/cli/src/codex/runCodex.ts
@@ -373,6 +373,7 @@ export async function runCodex(opts: {
         if (!payload || typeof payload !== 'object') {
             throw new Error('Invalid session config payload');
         }
+        syncCurrentConfigFromSession();
         const config = payload as { permissionMode?: unknown; model?: unknown; modelReasoningEffort?: unknown; collaborationMode?: unknown; serviceTier?: unknown };
 
         if (config.permissionMode !== undefined) {

--- a/cli/src/codex/utils/appServerConfig.ts
+++ b/cli/src/codex/utils/appServerConfig.ts
@@ -336,3 +336,13 @@ export function buildTurnStartParams(args: {
 
     return params;
 }
+
+/** Resume the actual task settings before reconciling HAPI's queued configuration. */
+export function withoutCodexModelOverrides(params: ThreadStartParams): ThreadStartParams {
+    const { model, serviceTier, ...rest } = params;
+    const config = { ...rest.config };
+    delete config.model;
+    delete config.model_reasoning_effort;
+    delete config.service_tier;
+    return { ...rest, config };
+}

--- a/cli/src/codex/utils/lunaReserve.test.ts
+++ b/cli/src/codex/utils/lunaReserve.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LunaReserve } from './lunaReserve';
+import { withoutCodexModelOverrides } from './appServerConfig';
+import type { EnhancedMode } from '../loop';
+
+const threadId = '01900000-0000-7000-8000-000000000001';
+const mode: EnhancedMode = { permissionMode: 'yolo', collaborationMode: 'plan', model: 'gpt-5.6', modelReasoningEffort: 'high' };
+const dirs: string[] = [];
+afterEach(async () => { await Promise.all(dirs.splice(0).map(dir => rm(dir, { recursive: true, force: true }))); });
+
+async function fixture() {
+    const dir = await mkdtemp(join(tmpdir(), 'hapi-reserve-'));
+    dirs.push(dir);
+    const response = {
+        accountId: 'account-a', ordinaryUsageAllowed: true as boolean | null,
+        rateLimits: { limitId: 'codex', primary: { usedPercent: 40 }, secondary: { usedPercent: 60 }, spendControlReached: false, rateLimitReachedType: null as string | null },
+        rateLimitsByLimitId: {
+            base_model_inference: { limitId: 'base_model_inference', limitName: 'gpt-reserve', primary: { usedPercent: 10 as unknown, resetsAt: 2000000000, windowDurationMins: 123 }, secondary: { usedPercent: 25 } }
+        },
+        rateLimitUpsell: null as unknown
+    };
+    const client = {
+        readAccountRateLimits: vi.fn(async () => structuredClone(response) as unknown),
+        supportsMethod: vi.fn(async () => true),
+        listModels: vi.fn(async () => ({ data: [
+            { id: 'gpt-reserve', hidden: true, defaultReasoningEffort: 'medium', supportedReasoningEfforts: [{ reasoningEffort: 'medium' }] },
+            { id: 'gpt-5.6', hidden: false, defaultReasoningEffort: 'medium', supportedReasoningEfforts: [{ reasoningEffort: 'high' }] }
+        ] })),
+        updateThreadSettings: vi.fn(async () => {})
+    };
+    const sync = vi.fn(); const publish = vi.fn(); const notice = vi.fn();
+    const reserve = new LunaReserve(client, sync, publish, notice, dir);
+    await reserve.initialize();
+    reserve.attach(threadId, { model: 'gpt-5.6', reasoningEffort: 'high', serviceTier: 'priority' });
+    const enter = async () => {
+        response.ordinaryUsageAllowed = false;
+        response.rateLimitUpsell = { banner_type: 'luna_reserve', blocked_model_slug: 'gpt-5.6' };
+        await reserve.refresh(mode, () => true);
+    };
+    const usage = () => publish.mock.lastCall?.[0];
+    return { dir, response, client, reserve, sync, publish, notice, enter, usage };
+}
+
+describe('Luna Reserve authoritative transitions', () => {
+    it('hides an available bucket and does not infer eligibility from exhausted percentages', async () => {
+        const f = await fixture();
+        f.response.rateLimits.primary.usedPercent = 100;
+        f.response.rateLimits.secondary.usedPercent = 100;
+        await f.reserve.refresh(mode, () => true);
+        expect(f.usage().reserve).toBeNull();
+        expect(f.client.updateThreadSettings).not.toHaveBeenCalled();
+        f.response.ordinaryUsageAllowed = false;
+        await f.reserve.refresh(mode, () => true);
+        expect(f.client.updateThreadSettings).not.toHaveBeenCalled();
+    });
+
+    it('activates only after acceptance, separates buckets, preserves return settings, and hides on recovery', async () => {
+        const f = await fixture();
+        await f.enter();
+        expect(f.client.readAccountRateLimits).toHaveBeenLastCalledWith(true);
+        expect(f.client.updateThreadSettings).toHaveBeenCalledWith({ threadId, model: 'gpt-reserve', effort: 'medium', serviceTier: null,
+            collaborationMode: { mode: 'plan', settings: { model: 'gpt-reserve', reasoning_effort: 'medium', developer_instructions: null } } });
+        expect(f.usage().ordinary.secondary.remainingPercent).toBe(40);
+        expect(f.usage().reserve.secondary.remainingPercent).toBe(75);
+        expect(f.usage().reserve.primary).toEqual({ remainingPercent: 90, resetsAt: 2000000000, windowDurationMins: 123 });
+        expect(f.sync).toHaveBeenLastCalledWith('gpt-5.6-luna', 'medium', 'standard');
+        expect(JSON.parse(await readFile(join(f.dir, 'tui-luna-reserve', `${threadId}.json`), 'utf8'))).toEqual({ account_id: 'account-a', model: 'gpt-5.6', effort: 'high' });
+        expect(f.reserve.turnMode(mode)).toMatchObject({ model: 'gpt-reserve', modelReasoningEffort: 'medium', serviceTier: 'standard' });
+        f.response.ordinaryUsageAllowed = true;
+        f.response.rateLimitUpsell = null;
+        await f.reserve.refresh(mode, () => true);
+        expect(f.sync).toHaveBeenLastCalledWith('gpt-5.6', 'high', 'standard');
+        expect(f.usage().reserve).toBeNull();
+        expect(f.notice).toHaveBeenCalledTimes(2);
+    });
+
+    it('retains exhausted Reserve without another switch or retry and treats missing/invalid usage as unknown', async () => {
+        const f = await fixture(); await f.enter();
+        for (const used of [undefined, null, '50', NaN, Infinity, -1, 101, 100]) {
+            f.response.rateLimitsByLimitId.base_model_inference.primary.usedPercent = used;
+            await f.reserve.refresh(mode, () => true);
+            expect(f.usage().reserve.primary.remainingPercent).toBe(used === 100 ? 0 : null);
+        }
+        expect(f.client.updateThreadSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('requires a fresh account-bound recovery read; sparse notifications and unknown banners cannot recover', async () => {
+        const f = await fixture(); await f.enter();
+        f.response.ordinaryUsageAllowed = true;
+        f.response.rateLimitUpsell = { banner_type: 'unknown_future_banner' };
+        await f.reserve.refresh(mode, () => true);
+        f.response.rateLimitUpsell = null;
+        f.response.accountId = 'account-b';
+        await f.reserve.refresh(mode, () => true);
+        expect(f.client.updateThreadSettings).toHaveBeenCalledTimes(1);
+        f.response.accountId = 'account-a';
+        let finish!: (value: unknown) => void;
+        f.client.readAccountRateLimits.mockImplementationOnce(() => new Promise(resolve => { finish = resolve; }));
+        const pending = f.reserve.refresh(mode, () => true);
+        await vi.waitFor(() => expect(finish).toBeTypeOf('function'));
+        f.reserve.invalidate();
+        finish(f.response); await pending;
+        expect(f.client.updateThreadSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('reconciles a resumed Reserve task with the TUI return target and ignores another thread settings', async () => {
+        const f = await fixture(); await f.enter(); f.reserve.dispose();
+        const resumed = new LunaReserve(f.client, f.sync, f.publish, f.notice, f.dir);
+        await resumed.initialize();
+        resumed.attach(threadId, { model: 'gpt-reserve', reasoningEffort: 'medium' });
+        resumed.onSettings('other-thread', { model: 'gpt-5.6', effort: 'high' });
+        expect(resumed.turnMode(mode).model).toBe('gpt-reserve');
+        f.response.ordinaryUsageAllowed = true; f.response.rateLimitUpsell = null;
+        await resumed.refresh(mode, () => true);
+        expect(f.sync).toHaveBeenLastCalledWith('gpt-5.6', 'high', 'standard');
+        expect(f.usage().reserve).toBeNull();
+    });
+
+    it('keeps selection and visibility unchanged on a rejected settings update without looping', async () => {
+        const f = await fixture();
+        f.client.updateThreadSettings.mockRejectedValue(new Error('Method not found'));
+        await f.enter(); await f.reserve.refresh(mode, () => true);
+        expect(f.client.updateThreadSettings).toHaveBeenCalledTimes(1);
+        expect(f.usage().reserve).toBeNull();
+        expect(f.reserve.turnMode(mode).model).toBe('gpt-5.6');
+        expect(f.notice).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not advertise or activate Reserve on an older protocol', async () => {
+        const f = await fixture();
+        f.client.readAccountRateLimits.mockImplementation(async () => ({ rateLimits: f.response.rateLimits, accountId: 'account-a', rateLimitUpsell: { banner_type: 'luna_reserve' } }));
+        const old = new LunaReserve(f.client, f.sync, f.publish, f.notice, f.dir);
+        await old.initialize(); old.attach(threadId, { model: 'gpt-5.6' });
+        await old.refresh(mode, () => true);
+        expect(f.client.readAccountRateLimits).toHaveBeenLastCalledWith(false);
+        expect(f.client.updateThreadSettings).not.toHaveBeenCalled();
+    });
+
+    it('waits until idle and hides state after exit/disposal', async () => {
+        const f = await fixture();
+        f.response.ordinaryUsageAllowed = false; f.response.rateLimitUpsell = { banner_type: 'luna_reserve' };
+        await f.reserve.refresh(mode, () => false);
+        expect(f.client.updateThreadSettings).not.toHaveBeenCalled();
+        await f.enter();
+        f.reserve.onSettings(threadId, { model: 'gpt-5.6', effort: 'high' });
+        expect(f.usage().reserve).toBeNull();
+        f.reserve.dispose();
+        expect(f.usage()).toBeNull();
+    });
+
+    it('omits model overrides on resume while retaining permissions, tools and instructions', () => {
+        expect(withoutCodexModelOverrides({ model: 'stale', serviceTier: 'priority', sandbox: 'workspace-write', config: { model_reasoning_effort: 'high', 'mcp_servers.hapi': {}, developer_instructions: 'hapi' } }))
+            .toEqual({ sandbox: 'workspace-write', config: { 'mcp_servers.hapi': {}, developer_instructions: 'hapi' } });
+    });
+});

--- a/cli/src/codex/utils/lunaReserve.test.ts
+++ b/cli/src/codex/utils/lunaReserve.test.ts
@@ -119,6 +119,23 @@ describe('Luna Reserve authoritative transitions', () => {
         expect(f.usage().reserve).toBeNull();
     });
 
+    it('copies the native fork return target without deleting the parent recovery record', async () => {
+        const f = await fixture(); await f.enter();
+        const forkId = '01900000-0000-7000-8000-000000000002';
+        f.reserve.attach(forkId, { model: 'gpt-reserve', reasoningEffort: 'medium', thread: { forkedFromId: threadId } });
+        await f.reserve.refresh(mode, () => true);
+        const parent = join(f.dir, 'tui-luna-reserve', `${threadId}.json`);
+        const child = join(f.dir, 'tui-luna-reserve', `${forkId}.json`);
+        expect(await readFile(child, 'utf8')).toBe(await readFile(parent, 'utf8'));
+        f.response.ordinaryUsageAllowed = true; f.response.rateLimitUpsell = null;
+        await f.reserve.refresh(mode, () => true);
+        expect(f.client.updateThreadSettings).toHaveBeenLastCalledWith(expect.objectContaining({ threadId: forkId, model: 'gpt-5.6' }));
+        expect(JSON.parse(await readFile(parent, 'utf8')).model).toBe('gpt-5.6');
+        await expect(readFile(child, 'utf8')).rejects.toThrow();
+        f.reserve.detach();
+        expect(f.usage()).toBeNull();
+    });
+
     it('keeps selection and visibility unchanged on a rejected settings update without looping', async () => {
         const f = await fixture();
         f.client.updateThreadSettings.mockRejectedValue(new Error('Method not found'));

--- a/cli/src/codex/utils/lunaReserve.ts
+++ b/cli/src/codex/utils/lunaReserve.ts
@@ -89,6 +89,8 @@ export class LunaReserve {
     ) {}
 
     async initialize(): Promise<void> {
+        this.supported = false;
+        this.models = [];
         try {
             const response = UsageSchema.parse(await this.client.readAccountRateLimits());
             this.snapshot = response;
@@ -110,9 +112,9 @@ export class LunaReserve {
     }
 
     attach(threadId: string, response: unknown, forkedFrom?: string): void {
-        const parsed = z.object({ model: z.string(), reasoningEffort: z.string().nullish(), serviceTier: z.string().nullish() }).safeParse(response);
+        const parsed = z.object({ model: z.string(), reasoningEffort: z.string().nullish(), serviceTier: z.string().nullish(), thread: z.object({ forkedFromId: z.string().nullish() }).optional() }).safeParse(response);
         this.threadId = threadId;
-        this.forkedFrom = forkedFrom ?? null;
+        this.forkedFrom = forkedFrom ?? (parsed.success ? parsed.data.thread?.forkedFromId : null) ?? null;
         this.invalidate();
         this.snapshot = null;
         if (parsed.success) {
@@ -141,6 +143,14 @@ export class LunaReserve {
 
     invalidate(): void {
         this.revision++;
+    }
+
+    detach(): void {
+        this.invalidate();
+        this.threadId = null;
+        this.settings = null;
+        this.snapshot = null;
+        this.publishUsage();
     }
 
     dispose(): void {
@@ -279,12 +289,6 @@ export class LunaReserve {
             }
             this.publishUsage();
         }
-    }
-
-    blocksReplay(): boolean {
-        return this.settings?.model === RESERVE_MODEL
-            || BannerSchema.safeParse(this.snapshot?.rateLimitUpsell).success
-            || this.snapshot?.ordinaryUsageAllowed === false;
     }
 
     turnMode(mode: EnhancedMode): EnhancedMode {

--- a/cli/src/codex/utils/lunaReserve.ts
+++ b/cli/src/codex/utils/lunaReserve.ts
@@ -1,0 +1,297 @@
+import { mkdir, open, rename, rm } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import { logger } from '@/ui/logger';
+import type { AgentState } from '@hapi/protocol';
+import type { CodexAppServerClient } from '../codexAppServerClient';
+import type { EnhancedMode } from '../loop';
+import type { ModelListItem, ThreadSettingsUpdateParams } from '../appServerTypes';
+
+// This quota alias belongs only at the Codex boundary, never in HAPI's model picker.
+const RESERVE_MODEL = 'gpt-reserve';
+const LUNA_MODEL = 'gpt-5.6-luna';
+const WindowSchema = z.object({
+    usedPercent: z.unknown().optional(),
+    windowDurationMins: z.unknown().optional(),
+    resetsAt: z.unknown().optional()
+});
+const BucketSchema = z.object({
+    limitId: z.string().nullish(),
+    limitName: z.string().nullish(),
+    normalModelSlug: z.string().nullish(),
+    primary: WindowSchema.nullish(),
+    secondary: WindowSchema.nullish(),
+    credits: z.object({ hasCredits: z.boolean(), unlimited: z.boolean() }).nullish(),
+    spendControlReached: z.boolean().nullish(),
+    rateLimitReachedType: z.string().nullish()
+});
+const UsageSchema = z.object({
+    accountId: z.string().nullish(),
+    ordinaryUsageAllowed: z.boolean().nullish(),
+    rateLimits: BucketSchema,
+    rateLimitsByLimitId: z.record(z.string(), BucketSchema).nullish(),
+    rateLimitUpsell: z.unknown().optional()
+});
+const BannerSchema = z.object({
+    banner_type: z.literal('luna_reserve'),
+    blocked_model_slug: z.string().min(1).max(256).nullish()
+});
+const ReturnSchema = z.object({
+    account_id: z.string().min(1),
+    model: z.string().min(1).max(256),
+    effort: z.string().nullable()
+});
+const SettingsSchema = z.object({
+    model: z.string().min(1),
+    effort: z.string().nullish(),
+    serviceTier: z.string().nullish()
+});
+type Usage = z.infer<typeof UsageSchema>;
+type Bucket = z.infer<typeof BucketSchema>;
+type Settings = z.infer<typeof SettingsSchema>;
+type ReserveClient = Pick<CodexAppServerClient, 'readAccountRateLimits' | 'listModels' | 'supportsMethod' | 'updateThreadSettings'>;
+
+function usageBucket(bucket?: Bucket | null): NonNullable<AgentState['codexUsage']>['ordinary'] {
+    const window = (value: Bucket['primary']) => {
+        if (!value) return null;
+        const finite = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n);
+        return {
+            remainingPercent: finite(value.usedPercent) && value.usedPercent >= 0 && value.usedPercent <= 100
+                ? 100 - value.usedPercent : null,
+            windowDurationMins: finite(value.windowDurationMins) && value.windowDurationMins > 0 ? value.windowDurationMins : null,
+            resetsAt: finite(value.resetsAt) && value.resetsAt >= 0 ? value.resetsAt : null
+        };
+    };
+    return { primary: window(bucket?.primary), secondary: window(bucket?.secondary) };
+}
+
+/** Account reads authorize transitions; settings accepted by the thread establish activation. */
+export class LunaReserve {
+    private threadId: string | null = null;
+    private settings: Settings | null = null;
+    private settingsRevision = 0;
+    private forkedFrom: string | null = null;
+    private snapshot: Usage | null = null;
+    private models: ModelListItem[] = [];
+    private supported = false;
+    private revision = 0;
+    private disposed = false;
+    private queue: Promise<void> = Promise.resolve();
+
+    constructor(
+        private readonly client: ReserveClient,
+        private readonly sync: (model: string, effort: string | null, serviceTier: string | null | undefined) => void,
+        private readonly publish: (usage: AgentState['codexUsage']) => void,
+        private readonly notice: (message: string) => void,
+        private readonly codexHome = process.env.CODEX_HOME || join(homedir(), '.codex')
+    ) {}
+
+    async initialize(): Promise<void> {
+        try {
+            const response = UsageSchema.parse(await this.client.readAccountRateLimits());
+            this.snapshot = response;
+            // Field presence is a protocol capability, not account eligibility.
+            if ('ordinaryUsageAllowed' in response && await this.client.supportsMethod('thread/settings/update')) {
+                let cursor: string | undefined;
+                do {
+                    const page = await this.client.listModels({ includeHidden: true, ...(cursor ? { cursor } : {}) });
+                    this.models.push(...(page.data ?? []));
+                    cursor = page.nextCursor ?? undefined;
+                } while (cursor);
+                this.supported = this.models.some(model => (model.model ?? model.id) === RESERVE_MODEL);
+            }
+            this.publishUsage();
+        } catch {
+            // Older app-servers and API-key accounts can lack the usage endpoint.
+            this.publish(null);
+        }
+    }
+
+    attach(threadId: string, response: unknown, forkedFrom?: string): void {
+        const parsed = z.object({ model: z.string(), reasoningEffort: z.string().nullish(), serviceTier: z.string().nullish() }).safeParse(response);
+        this.threadId = threadId;
+        this.forkedFrom = forkedFrom ?? null;
+        this.invalidate();
+        this.snapshot = null;
+        if (parsed.success) {
+            this.acceptSettings({ ...parsed.data, effort: parsed.data.reasoningEffort });
+        } else {
+            this.settings = null;
+        }
+        this.publishUsage();
+    }
+
+    onSettings(threadId: string, value: unknown): void {
+        if (threadId !== this.threadId || this.disposed) return;
+        const parsed = SettingsSchema.safeParse(value);
+        if (!parsed.success) return;
+        this.invalidate();
+        this.settingsRevision++;
+        this.acceptSettings(parsed.data);
+        this.publishUsage();
+    }
+
+    private acceptSettings(settings: Settings): void {
+        this.settings = settings;
+        this.sync(settings.model === RESERVE_MODEL ? LUNA_MODEL : settings.model, settings.effort ?? null,
+            settings.serviceTier === 'priority' ? 'fast' : settings.serviceTier === null ? 'standard' : undefined);
+    }
+
+    invalidate(): void {
+        this.revision++;
+    }
+
+    dispose(): void {
+        this.disposed = true;
+        this.invalidate();
+        this.publish(null);
+    }
+
+    private publishUsage(): void {
+        const response = this.snapshot;
+        if (!response || this.disposed) {
+            this.publish(null);
+            return;
+        }
+        // Never substitute a model-specific bucket for ordinary account windows.
+        const ordinary = response.rateLimitsByLimitId?.codex
+            ?? (!response.rateLimits.limitId || response.rateLimits.limitId === 'codex' ? response.rateLimits : null);
+        const reserve = Object.values(response.rateLimitsByLimitId ?? {}).find(bucket => bucket.limitName === RESERVE_MODEL)
+            ?? (response.rateLimits.limitName === RESERVE_MODEL ? response.rateLimits : null);
+        this.publish({
+            ordinary: usageBucket(ordinary),
+            reserve: this.settings?.model === RESERVE_MODEL && response.accountId
+                ? usageBucket(reserve) : null
+        });
+    }
+
+    /** Serialize polling with pre-submission reconciliation; never submit or replay a message here. */
+    refresh(mode: EnhancedMode, canSwitch: () => boolean): Promise<void> {
+        this.queue = this.queue.then(() => this.readAndReconcile(mode, canSwitch));
+        return this.queue;
+    }
+
+    private returnPath(threadId = this.threadId): string | null {
+        if (!z.string().uuid().safeParse(threadId).success) return null;
+        // Shared with the official TUI so local/remote handoff preserves the task's return target.
+        return join(this.codexHome, 'tui-luna-reserve', `${threadId}.json`);
+    }
+
+    private async loadReturn(threadId = this.threadId): Promise<z.infer<typeof ReturnSchema> | null> {
+        const path = this.returnPath(threadId);
+        if (!path) return null;
+        try {
+            const handle = await open(path, 'r');
+            try {
+                if ((await handle.stat()).size > 4096) return null;
+                return ReturnSchema.parse(JSON.parse(await handle.readFile('utf8')));
+            } finally {
+                await handle.close();
+            }
+        } catch { return null; }
+    }
+
+    private async saveReturn(value: z.infer<typeof ReturnSchema>): Promise<void> {
+        const path = this.returnPath();
+        if (!path) throw new Error('Invalid Codex thread ID');
+        await mkdir(join(this.codexHome, 'tui-luna-reserve'), { recursive: true });
+        const temporary = `${path}.${randomUUID()}.tmp`;
+        try {
+            const handle = await open(temporary, 'wx', 0o600);
+            try {
+                await handle.writeFile(JSON.stringify(value));
+                await handle.sync();
+            } finally { await handle.close(); }
+            await rename(temporary, path);
+        } finally { await rm(temporary, { force: true }); }
+    }
+
+    private async readAndReconcile(mode: EnhancedMode, canSwitch: () => boolean): Promise<void> {
+        if (this.disposed) return;
+        const revision = this.revision;
+        let applying = false;
+        try {
+            const response = UsageSchema.parse(await this.client.readAccountRateLimits(this.supported));
+            if (this.disposed || revision !== this.revision) return;
+            this.snapshot = response;
+            this.publishUsage();
+            if (!this.supported || !this.threadId || !this.settings || !response.accountId || !canSwitch()) return;
+            const current = this.settings;
+            const inReserve = current.model === RESERVE_MODEL;
+            let previous = inReserve ? await this.loadReturn() : null;
+            if (inReserve && !previous && this.forkedFrom) {
+                const inherited = await this.loadReturn(this.forkedFrom);
+                if (inherited?.account_id === response.accountId) {
+                    await this.saveReturn(inherited);
+                    previous = inherited;
+                }
+            }
+            const ordinary = response.rateLimits;
+            const recovered = response.ordinaryUsageAllowed != null
+                && (response.ordinaryUsageAllowed || ordinary.credits?.hasCredits || ordinary.credits?.unlimited)
+                && response.rateLimitUpsell == null
+                && ordinary.spendControlReached !== true && ordinary.rateLimitReachedType == null;
+            const banner = BannerSchema.safeParse(response.rateLimitUpsell);
+            const entering = !inReserve && (!mode.model || mode.model === current.model)
+                && response.ordinaryUsageAllowed === false && banner.success
+                && (!banner.data.blocked_model_slug || banner.data.blocked_model_slug === current.model);
+            const targetId = entering ? RESERVE_MODEL
+                : inReserve && recovered && previous?.account_id === response.accountId ? previous.model : null;
+            const target = this.models.find(model => (model.model ?? model.id) === targetId && (entering || model.hidden !== true));
+            if (!target || !targetId || revision !== this.revision || !canSwitch()) return;
+            const desiredEffort = entering ? current.effort : previous?.effort;
+            const effort = target.supportedReasoningEfforts?.some(item => item.reasoningEffort === desiredEffort)
+                ? desiredEffort : target.defaultReasoningEffort;
+            applying = true;
+            if (entering) await this.saveReturn({ account_id: response.accountId, model: current.model, effort: current.effort ?? null });
+            if (this.disposed || revision !== this.revision || !canSwitch()) return;
+            const params: ThreadSettingsUpdateParams = {
+                threadId: this.threadId,
+                model: targetId,
+                effort: effort ?? null,
+                serviceTier: null,
+                ...(mode.collaborationMode ? { collaborationMode: {
+                    mode: mode.collaborationMode,
+                    settings: { model: targetId, reasoning_effort: effort ?? null, developer_instructions: null }
+                } } : {})
+            };
+            const settingsRevision = this.settingsRevision;
+            await this.client.updateThreadSettings(params);
+            if (this.disposed || params.threadId !== this.threadId) return;
+            if (this.settingsRevision !== settingsRevision
+                && (this.settings?.model !== targetId || (this.settings.effort ?? null) !== (effort ?? null))) return;
+            this.acceptSettings({ model: targetId, effort, serviceTier: null });
+            if (!entering) {
+                const path = this.returnPath();
+                if (path) await rm(path, { force: true }).catch(error => logger.debug('[Codex] Failed to remove Reserve return record', error));
+            }
+            this.publishUsage();
+            this.notice(entering
+                ? 'Ordinary Codex usage is exhausted. Switched to GPT-5.6 Luna using Luna Reserve.'
+                : `Ordinary Codex usage is available again. Switched back to ${targetId}.`);
+        } catch (error) {
+            logger.debug('[Codex] Reserve reconciliation unavailable', error);
+            if (applying) {
+                this.supported = false;
+                this.notice('Codex could not apply the Reserve transition. Task settings are unchanged; no message was retried.');
+            }
+            this.publishUsage();
+        }
+    }
+
+    blocksReplay(): boolean {
+        return this.settings?.model === RESERVE_MODEL
+            || BannerSchema.safeParse(this.snapshot?.rateLimitUpsell).success
+            || this.snapshot?.ordinaryUsageAllowed === false;
+    }
+
+    turnMode(mode: EnhancedMode): EnhancedMode {
+        if (this.settings?.model !== RESERVE_MODEL) return mode;
+        const target = this.models.find(model => (model.model ?? model.id) === RESERVE_MODEL);
+        const effort = target?.supportedReasoningEfforts?.some(item => item.reasoningEffort === mode.modelReasoningEffort)
+            ? mode.modelReasoningEffort : this.settings.effort ?? undefined;
+        return { ...mode, model: RESERVE_MODEL, modelReasoningEffort: effort, serviceTier: 'standard' };
+    }
+}

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -192,7 +192,22 @@ export const AgentStateCompletedRequestSchema = z.object({
 
 export type AgentStateCompletedRequest = z.infer<typeof AgentStateCompletedRequestSchema>
 
+const CodexUsageWindowSchema = z.object({
+    remainingPercent: z.number().min(0).max(100).nullable(),
+    windowDurationMins: z.number().positive().nullable(),
+    resetsAt: z.number().nonnegative().nullable()
+})
+
+const CodexUsageBucketSchema = z.object({
+    primary: CodexUsageWindowSchema.nullable(),
+    secondary: CodexUsageWindowSchema.nullable()
+})
+
 export const AgentStateSchema = z.object({
+    codexUsage: z.object({
+        ordinary: CodexUsageBucketSchema,
+        reserve: CodexUsageBucketSchema.nullable()
+    }).nullish(),
     controlledByUser: z.boolean().nullish(),
     // True while the CLI is delivering a queued message into the active turn
     // (Steer). Surfaced so the web can reflect the inject in progress.

--- a/web/src/components/AssistantChat/CodexUsage.test.tsx
+++ b/web/src/components/AssistantChat/CodexUsage.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { expect, it } from 'vitest'
+import { I18nProvider } from '@/lib/i18n-context'
+import { CodexUsage } from './CodexUsage'
+import type { AgentState } from '@/types/api'
+
+it('shows Reserve only while active, with separate ordinary limits and unknown data', () => {
+    const usage: NonNullable<AgentState['codexUsage']> = {
+        ordinary: { primary: null, secondary: { remainingPercent: 40, windowDurationMins: null, resetsAt: null } },
+        reserve: null
+    }
+    const view = () => <I18nProvider><CodexUsage usage={usage} /></I18nProvider>
+    const { rerender } = render(view())
+    fireEvent.click(screen.getByRole('button', { name: 'Codex Usage' }))
+    expect(screen.queryByText(/Luna Reserve/)).toBeNull()
+    expect(screen.getByText('40% remaining')).toBeTruthy()
+    usage.reserve = { primary: { remainingPercent: 0, windowDurationMins: 123, resetsAt: 2000000000 }, secondary: { remainingPercent: null, windowDurationMins: null, resetsAt: null } }
+    rerender(view())
+    expect(screen.getByText('Luna Reserve · GPT-5.6 Luna')).toBeTruthy()
+    expect(screen.getByText('40% remaining')).toBeTruthy()
+    expect(screen.getByText('0% remaining')).toBeTruthy()
+    expect(screen.getByText('Unknown')).toBeTruthy()
+    expect(screen.getByText(/123 min window/)).toBeTruthy()
+    expect(screen.getByText(/Resets/)).toBeTruthy()
+    usage.reserve = null
+    rerender(view())
+    expect(screen.queryByText(/Luna Reserve/)).toBeNull()
+})

--- a/web/src/components/AssistantChat/CodexUsage.tsx
+++ b/web/src/components/AssistantChat/CodexUsage.tsx
@@ -1,0 +1,50 @@
+import * as Popover from '@radix-ui/react-popover'
+import type { AgentState } from '@/types/api'
+import { useTranslation } from '@/lib/use-translation'
+
+type Usage = NonNullable<AgentState['codexUsage']>
+
+export function CodexUsage({ usage }: { usage: Usage }) {
+    const { t } = useTranslation()
+    const bucket = (value: Usage['ordinary']) => {
+        const windows = [value.primary, value.secondary].filter(window => window !== null)
+        if (windows.length === 0) return <div>{t('codexUsage.unknown')}</div>
+        return windows.map((window, index) => (
+            <div key={index}>
+                <span>{window.remainingPercent === null
+                    ? t('codexUsage.unknown')
+                    : t('codexUsage.remaining', { percent: window.remainingPercent })}</span>
+                {window.windowDurationMins !== null ? (
+                    <span> · {t('codexUsage.window', { minutes: window.windowDurationMins })}</span>
+                ) : null}
+                {window.resetsAt !== null ? (
+                    <div className="text-[var(--app-hint)]">
+                        {t('codexUsage.resets', { time: new Date(window.resetsAt * 1000).toLocaleString() })}
+                    </div>
+                ) : null}
+            </div>
+        ))
+    }
+    return (
+        <Popover.Root>
+            <Popover.Trigger asChild>
+                <button type="button" className="shrink-0 rounded-sm text-[10px] text-[var(--app-hint)] focus-visible:outline focus-visible:outline-2" aria-label={t('codexUsage.title')}>
+                    {usage.reserve ? '☾ Luna Reserve' : t('codexUsage.title')}
+                </button>
+            </Popover.Trigger>
+            <Popover.Portal>
+                <Popover.Content side="top" sideOffset={6} collisionPadding={8} className="z-50 max-w-[calc(100vw-1rem)] rounded-md border border-[var(--app-border)] bg-[var(--app-bg)] p-3 text-xs text-[var(--app-fg)] shadow-lg">
+                    <h3 className="mb-2 font-semibold">{t('codexUsage.title')}</h3>
+                    <div>{t('codexUsage.ordinary')}</div>
+                    {bucket(usage.ordinary)}
+                    {usage.reserve ? (
+                        <section className="mt-2 border-t border-[var(--app-border)] pt-2">
+                            <h4 className="font-semibold">Luna Reserve · GPT-5.6 Luna</h4>
+                            {bucket(usage.reserve)}
+                        </section>
+                    ) : null}
+                </Popover.Content>
+            </Popover.Portal>
+        </Popover.Root>
+    )
+}

--- a/web/src/components/AssistantChat/StatusBar.tsx
+++ b/web/src/components/AssistantChat/StatusBar.tsx
@@ -18,6 +18,7 @@ import {
     shouldShowReasoningStatusLabel
 } from '@/lib/codexStatusLabels'
 import { isFastServiceTier } from './codexFastMode'
+import { CodexUsage } from './CodexUsage'
 import { useTranslation } from '@/lib/use-translation'
 import { useSessionHeaderMetadata } from '@/hooks/useSessionHeaderMetadata'
 
@@ -302,6 +303,9 @@ export function StatusBar(props: {
                         {connectionStatus.text}
                     </span>
                 </div>
+                {props.agentFlavor === 'codex' && props.agentState?.codexUsage ? (
+                    <CodexUsage usage={props.agentState.codexUsage} />
+                ) : null}
                 {contextUsageLabel ? (
                     <Popover.Root>
                         <Popover.Trigger asChild>

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -1,4 +1,11 @@
 export default {
+  'codexUsage.title': 'Codex Usage',
+  'codexUsage.ordinary': 'Ordinary usage',
+  'codexUsage.unknown': 'Unknown',
+  'codexUsage.remaining': '{percent}% remaining',
+  'codexUsage.window': '{minutes} min window',
+  'codexUsage.resets': 'Resets {time}',
+
   // Loading states
   'loading': 'Loading…',
   'authorizing': 'Authorizing…',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -1,4 +1,11 @@
 export default {
+  'codexUsage.title': 'Codex 用量',
+  'codexUsage.ordinary': '常规用量',
+  'codexUsage.unknown': '未知',
+  'codexUsage.remaining': '剩余 {percent}%',
+  'codexUsage.window': '{minutes} 分钟窗口',
+  'codexUsage.resets': '重置时间 {time}',
+
   // Loading states
   'loading': '加载中…',
   'authorizing': '认证中…',


### PR DESCRIPTION
When Codex authorizes Luna Reserve after ordinary usage is exhausted, HAPI now updates the same thread's settings and shows its separate allowance. An unused Reserve bucket stays hidden; exiting Reserve hides it again. No Reserve model is added to the picker, and Reserve transitions never replay submitted messages.

The CLI owns the app-server client flow: fresh account reads authorize fallback/recovery, accepted thread settings establish activation, and idle resume/reconnect reconciles native settings before another turn. Explicit queued settings survive ordinary resume; quota failures do not retry, while existing transient/context recovery remains available. Hub/Web receive normalized usage only. The task-local return record follows the official TUI format to preserve the previous model/reasoning settings across handoff and native forks, preserving the parent record. Reserve limits are identified by the backend's limit name, independently of ordinary windows; missing/invalid percentages remain unknown.

Protocol evidence: [official Codex source ac192cd7937](https://github.com/openai/codex/tree/ac192cd7937b0d73edc6dffe009940ae53782dd4), including `backend_banner_fallback.rs`, `chatwidget/backend_banners.rs`, and `v2/account.rs`. Capability opt-in follows protocol discovery. Codex 0.153.4 requires null parameters for the initial usage read and lacks `ordinaryUsageAllowed`; it keeps ordinary usage without activating Reserve.

Validation:
- Full `bun typecheck && bun run test`: exit 0; 6,980 passed, 1 skipped.
- Regression coverage for conditional visibility, separate windows, unknown percentages, recovery/account identity, stale reads, rejected settings, idle resume/reconnect, native forks, explicit queued settings, transient/context recovery during Reserve, and quota failures without replay.
- Real installed Codex 0.153.4: generated protocol schema and successful app-server initialize + account/rateLimits/read with null parameters.

Validation limit: no eligible-account ordinary → Reserve → exhausted/recovered inference run. No minimum released Codex version is claimed; the required capability is present in the pinned upstream source, not the installed 0.153.4 release. UI behavior is covered by jsdom component tests.

Fixes #1779
