### PR TITLE
feat(web): absolute datetime tooltips on relative ages

### DIFF
--- a/web/src/components/AssistantChat/HappyThread.tsx
+++ b/web/src/components/AssistantChat/HappyThread.tsx
@@ -29,7 +29,7 @@ import { useSessionHeaderMetadata } from '@/hooks/useSessionHeaderMetadata'
 import { useMachines } from '@/hooks/queries/useMachines'
 import { useMachineLabels } from '@/hooks/useMachineLabels'
 import { resolveSessionHeaderMachineLabel } from '@/components/SessionHeader'
-import { formatRelativeTime } from '@/lib/relativeTime'
+import { formatAbsoluteDateTime, formatRelativeTime } from '@/lib/relativeTime'
 import { formatSessionHeaderTimestamp } from '@/lib/sessionHeaderTimestamp'
 import { getShareTurnReasoningLabel, selectShareTurnMetadata } from '@/lib/shareTurnMetadata'
 import { useMinuteTick } from '@/hooks/useMinuteTick'
@@ -516,6 +516,7 @@ export function HappyThread(props: {
         )
         const lastActiveAt = props.session.activeAt || props.session.updatedAt || props.session.createdAt
         const lastActiveLabel = lastActiveAt > 0 ? formatRelativeTime(lastActiveAt, t) : null
+        const lastActiveAbsolute = lastActiveLabel ? formatAbsoluteDateTime(lastActiveAt) : null
         const createdAtLabel = formatSessionHeaderTimestamp(props.session.createdAt, locale)
         const updatedAtLabel = formatSessionHeaderTimestamp(props.session.updatedAt, locale)
         const worktreeBranch = props.session.metadata?.worktree?.branch?.trim() || null
@@ -527,7 +528,7 @@ export function HappyThread(props: {
             machine: machineLabel ? {
                 text: `${headerMetadata.showLabels ? `${t('session.item.machine')}: ` : ''}${machineLabel}`,
             } : undefined,
-            lastActive: lastActiveLabel ? { text: lastActiveLabel } : undefined,
+            lastActive: lastActiveLabel ? { text: lastActiveLabel, title: lastActiveAbsolute } : undefined,
             model: modelLabel ? {
                 text: `${headerMetadata.showLabels ? `${t(modelLabel.key)}: ` : ''}${modelLabel.value}`,
             } : undefined,

--- a/web/src/components/AssistantChat/ShareTurnDialog.tsx
+++ b/web/src/components/AssistantChat/ShareTurnDialog.tsx
@@ -757,12 +757,16 @@ export function ShareTurnDialog(props: ShareTurnDialogProps) {
                                 {props.metadataItems.length > 0 ? (
                                     <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-[var(--app-hint)]">
                                         {props.metadataItems.map((item) => item.key === 'agent' ? (
-                                            <span key={item.key} className="inline-flex items-center gap-1">
+                                            <span key={item.key} className="inline-flex items-center gap-1" title={item.title ?? undefined}>
                                                 <AgentFlavorIcon flavor={item.flavor} className="h-3.5 w-3.5 shrink-0" />
                                                 {item.text}
                                             </span>
                                         ) : (
-                                            <span key={item.key} className={item.key === 'fastMode' ? 'text-[#34C759]' : undefined}>
+                                            <span
+                                                key={item.key}
+                                                className={item.key === 'fastMode' ? 'text-[#34C759]' : undefined}
+                                                title={item.title ?? undefined}
+                                            >
                                                 {item.text}
                                             </span>
                                         ))}

--- a/web/src/components/SessionRowSummary.test.tsx
+++ b/web/src/components/SessionRowSummary.test.tsx
@@ -155,3 +155,29 @@ describe('SessionRowSummary background status', () => {
         expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('New activity')
     })
 })
+
+describe('SessionRowSummary relative age tooltip', () => {
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it('exposes the absolute datetime on the relative age label', () => {
+        const updatedAt = Date.now() - 2 * 60 * 60 * 1000
+        render(
+            <I18nProvider>
+                <SessionRowSummary
+                    session={makeSummary({
+                        active: false,
+                        backgroundTaskCount: 0,
+                        updatedAt,
+                    })}
+                    showDetailedStatus={false}
+                />
+            </I18nProvider>
+        )
+
+        const age = screen.getByTestId('session-row-age')
+        expect(age).toHaveTextContent(/ago|just now/i)
+        expect(age).toHaveAttribute('title', new Date(updatedAt).toLocaleString())
+    })
+})

--- a/web/src/components/SessionRowSummary.tsx
+++ b/web/src/components/SessionRowSummary.tsx
@@ -6,7 +6,7 @@ import { HoverTooltip, SESSION_ROW_TOOLTIP_FOCUS_CLASS, useSessionRowTooltipIds 
 import { getAttentionLabel, SessionAttentionIndicator } from '@/components/SessionAttentionIndicator'
 import { classifySessionAttention } from '@/lib/sessionAttention'
 import { getSessionLastSeenAt, getSessionManualUnreadAt } from '@/lib/sessionLastSeen'
-import { formatRelativeTime } from '@/lib/relativeTime'
+import { formatAbsoluteDateTime, formatRelativeTime } from '@/lib/relativeTime'
 import { formatScheduledTooltipDetail } from '@/lib/scheduledTime'
 import { getCodexImportedAt } from '@/lib/codexImportedSessions'
 import { getSessionTitle } from '@/lib/sessionTitle'
@@ -79,17 +79,24 @@ function formatCodexImportedRelativeTime(
     return formatRelativeTime(value, t)
 }
 
+function getSessionTimeStamp(session: SessionSummary): number | null {
+    const importedAt = session.metadata?.flavor === 'codex'
+        ? getCodexImportedAt(session.metadata?.agentSessionId)
+        : null
+    if (importedAt !== null) return importedAt
+    return Number.isFinite(session.updatedAt) ? session.updatedAt : null
+}
+
 function getSessionTimeLabel(
     session: SessionSummary,
     t: (key: string, params?: Record<string, string | number>) => string
 ): string | null {
-    const importedAt = session.metadata?.flavor === 'codex'
-        ? getCodexImportedAt(session.metadata?.agentSessionId)
-        : null
-    if (importedAt !== null) {
-        return formatCodexImportedRelativeTime(importedAt, t)
+    const stamp = getSessionTimeStamp(session)
+    if (stamp === null) return null
+    if (session.metadata?.flavor === 'codex' && getCodexImportedAt(session.metadata?.agentSessionId) !== null) {
+        return formatCodexImportedRelativeTime(stamp, t)
     }
-    return formatRelativeTime(session.updatedAt, t)
+    return formatRelativeTime(stamp, t)
 }
 
 /**
@@ -162,6 +169,8 @@ export function SessionRowSummary(props: {
     const attentionId = attentionTooltipIdProp ?? ownedIds.attentionId
     const scheduleId = scheduleTooltipIdProp ?? ownedIds.scheduleId
     const timeLabel = getSessionTimeLabel(s, t)
+    const timeStamp = getSessionTimeStamp(s)
+    const timeAbsolute = timeStamp !== null ? formatAbsoluteDateTime(timeStamp) : null
 
     return (
         <div className={`flex w-full min-w-0 flex-col gap-1 ${className ?? ''}`}>
@@ -284,7 +293,13 @@ export function SessionRowSummary(props: {
                         </span>
                     ) : null}
                     {timeLabel ? (
-                        <span className="min-w-0 truncate whitespace-nowrap tabular-nums text-[var(--app-hint)]">{timeLabel}</span>
+                        <span
+                            className="min-w-0 truncate whitespace-nowrap tabular-nums text-[var(--app-hint)]"
+                            title={timeAbsolute ?? undefined}
+                            data-testid="session-row-age"
+                        >
+                            {timeLabel}
+                        </span>
                     ) : null}
                 </div>
             </div>

--- a/web/src/lib/shareTurnMetadata.ts
+++ b/web/src/lib/shareTurnMetadata.ts
@@ -7,6 +7,8 @@ export type ShareTurnMetadataItem = {
     key: ShareTurnMetadataKey
     text: string
     flavor?: string | null
+    /** Absolute datetime for relative `lastActive` (and similar) hover labels. */
+    title?: string | null
 }
 
 export function getShareTurnReasoningLabel(


### PR DESCRIPTION
## Summary
- Session-list relative ages (`2d ago`, `just now`, …) now expose a native `title` tooltip with the locale full datetime via `formatAbsoluteDateTime` (same pattern as the session-header last-active chip).
- Share-turn metadata `lastActive` also carries the absolute stamp for hover.

## Test plan
- [ ] Hover a session-list age label; tooltip shows full local datetime
- [ ] Hover session-header last-active (already worked; still works)
- [ ] `bun run --cwd web test -- src/components/SessionRowSummary.test.tsx`

Fixes #1792