### PR TITLE
fix(codex): emit ready notifications after local turn completion

### DIFF
--- a/cli/src/codex/codexLocalLauncher.test.ts
+++ b/cli/src/codex/codexLocalLauncher.test.ts
@@ -210,6 +210,74 @@ describe('codexLocalLauncher', () => {
         }
     });
 
+    it('notifies once for a live completion after forwarding the final answer, without replay alerts', async () => {
+        const transcriptPath = await writeTranscriptMeta('ready.jsonl', 'ready-session');
+        const event = (payload: Record<string, unknown>) => JSON.stringify({ type: 'event_msg', payload }) + '\n';
+        await appendFile(transcriptPath, event({ type: 'task_complete', turn_id: 'old' }));
+        const { session, sessionEvents, agentMessages } = createSessionStub('default', undefined, tempDir, null, true);
+        const sendReady = vi.spyOn(session, 'sendSessionEvent');
+        let release!: () => void;
+        harness.runBarrier = new Promise<void>((resolve) => { release = resolve; });
+        const running = codexLocalLauncher(session as never);
+        try {
+            await vi.waitFor(() => expect(harness.sessionHookHandlers).toHaveLength(1));
+            harness.sessionHookHandlers[0]('ready-session', { transcript_path: transcriptPath });
+            await wait(300);
+            expect(sessionEvents).not.toContainEqual({ type: 'ready' });
+            sendReady.mockImplementation((message) => {
+                if (message.type === 'ready') {
+                    expect(agentMessages).toContainEqual(expect.objectContaining({ message: 'finished answer' }));
+                }
+                sessionEvents.push(message);
+            });
+            await appendFile(transcriptPath,
+                event({ type: 'task_started', turn_id: 'live' })
+                + event({ type: 'agent_message', message: 'finished answer', phase: 'final_answer' })
+                + event({ type: 'task_complete', turn_id: 'live' }));
+            await vi.waitFor(() => expect(sessionEvents.filter(e => e.type === 'ready')).toHaveLength(1), { timeout: 3000 });
+            await appendFile(transcriptPath, event({ type: 'task_complete', turn_id: 'live' }) + event({ type: 'task_complete', turn_id: 'old' }));
+            await wait(300);
+            expect(sessionEvents.filter(e => e.type === 'ready')).toHaveLength(1);
+        } finally {
+            release();
+            await running;
+        }
+    });
+
+    it.each(['next-turn', 'queued', 'aborted', 'failed', 'shutdown'] as const)(
+        'does not notify while %s prevents an idle completion', async (scenario) => {
+            const transcriptPath = await writeTranscriptMeta('suppressed.jsonl', 'ready-session');
+            const event = (payload: Record<string, unknown>) => JSON.stringify({ type: 'event_msg', payload }) + '\n';
+            const { session, sessionEvents } = createSessionStub('default', undefined, tempDir);
+            if (scenario === 'queued') vi.spyOn(session.queue, 'size').mockReturnValue(1);
+            let release!: () => void;
+            harness.runBarrier = new Promise<void>((resolve) => { release = resolve; });
+            const running = codexLocalLauncher(session as never);
+            try {
+                await vi.waitFor(() => expect(harness.sessionHookHandlers).toHaveLength(1));
+                harness.sessionHookHandlers[0]('ready-session', { transcript_path: transcriptPath });
+                await wait(300);
+                const completion = scenario === 'aborted' ? 'turn_aborted' : scenario === 'failed' ? 'task_failed' : 'task_complete';
+                await appendFile(transcriptPath,
+                    event({ type: completion, turn_id: 'first' })
+                    + (scenario === 'next-turn' ? event({ type: 'task_started', turn_id: 'second' }) : ''));
+                if (scenario === 'shutdown') {
+                    release();
+                    await running;
+                }
+                await wait(300);
+                expect(sessionEvents).not.toContainEqual({ type: 'ready' });
+                if (scenario === 'next-turn') {
+                    await appendFile(transcriptPath, event({ type: 'task_complete', turn_id: 'second' }));
+                    await vi.waitFor(() => expect(sessionEvents).toContainEqual({ type: 'ready' }), { timeout: 3000 });
+                }
+            } finally {
+                release();
+                await running;
+            }
+        }
+    );
+
     it('rebuilds approval and sandbox args from yolo mode', async () => {
         const { session } = createSessionStub('yolo', [
             '--sandbox',

--- a/cli/src/codex/codexLocalLauncher.ts
+++ b/cli/src/codex/codexLocalLauncher.ts
@@ -58,6 +58,14 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
     let scanner: CodexSessionScanner | null = null;
     let hookReady = false;
     let shuttingDown = false;
+    let readyTimer: ReturnType<typeof setTimeout> | null = null;
+    const completedTurns = new Set<string>();
+    const cancelReady = (): void => {
+        if (readyTimer !== null) {
+            clearTimeout(readyTimer);
+            readyTimer = null;
+        }
+    };
     let pendingScannerSetup: Promise<void> | null = null;
     let transcriptLocator: CodexTranscriptLocator | null = null;
     let scannerTranscriptPath: string | null = null;
@@ -315,6 +323,26 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
                     session.setModelReasoningEffort(observedReasoningEffort);
                 }
                 dispatchTranscriptActions(convertTranscriptEvent(event), context);
+                if (event.type === 'event_msg' && event.payload && typeof event.payload === 'object') {
+                    const payload = event.payload as Record<string, unknown>;
+                    if (payload.type === 'task_started' || payload.type === 'user_message'
+                        || payload.type === 'turn_aborted' || payload.type === 'task_failed') {
+                        cancelReady();
+                    } else if (payload.type === 'task_complete' && typeof payload.turn_id === 'string') {
+                        if (completedTurns.has(payload.turn_id)) return;
+                        completedTurns.add(payload.turn_id);
+                        if (context.replayedHistory || shuttingDown) return;
+                        cancelReady();
+                        // Finish forwarding this scan before notifying. A following turn in
+                        // the same batch cancels the alert; replay and shutdown never alert.
+                        readyTimer = setTimeout(() => {
+                            readyTimer = null;
+                            if (!shuttingDown && session.queue.size() === 0) {
+                                session.sendSessionEvent({ type: 'ready' });
+                            }
+                        }, 0);
+                    }
+                }
             }
         });
         if (shuttingDown) {
@@ -448,6 +476,7 @@ export async function codexLocalLauncher(session: CodexSession): Promise<'switch
         return await launcher.run();
     } finally {
         shuttingDown = true;
+        cancelReady();
         session.removeTranscriptPathCallback(handleTranscriptPathCallback);
         hookServer.stop();
         const activeLocator = transcriptLocator;


### PR DESCRIPTION
Local `hapi codex` sessions forward the final answer but never emit the `ready` event used by the hub's completion notifications. This leaves Telegram silent even when the bot is configured and the turn has finished.

Emit `ready` after forwarding a live `task_complete`, once per turn. Defer until the current transcript scan finishes so a following turn in the same batch cancels the notification. Skip replayed history, queued work, and launcher shutdown; aborted or failed turns do not trigger a completion notification.

Validation:
- Local-launcher regression tests: 28 passed, covering final-answer ordering, duplicate completions, history replay, following turns, queued work, abort/failure, and shutdown.
- `bun typecheck` and `bun run build:single-exe` passed.
- A real local Codex turn through the compiled executable produced the answer followed by a `ready` event in the hub.
- Full package tests were attempted with Bun 1.4.0 / Node 26.8.1. CLI: 2,615 passed, two skipped, one skill-discovery failure caused by an existing `/tmp/.git` marker; all 28 skill tests passed with `TMPDIR=/var/tmp`. Shared: 299 passed. Relay: 88 passed. Hub: 1,220 passed, three skipped, two failures in unchanged `fcmConfig` tests (all five pass independently). Web: 2,946 passed, one unchanged `StorageEvent`/`localStorage` failure under Node 26; all 78 tests in that file pass with `NODE_OPTIONS=--no-experimental-webstorage`.
