### PR TITLE
fix(web): simplify session summary setting copy

### DIFF
--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -812,7 +812,7 @@ export default {
   'settings.usage.sessions': '{count} sessions with usage',
   'settings.general.description': 'Language, companion pairing, and general application preferences.',
   'settings.general.sessionSummary.title': 'Session status summaries',
-  'settings.general.sessionSummary.description': 'Choose whether supported agents emit a machine-readable status summary and whether it appears in chat.',
+  'settings.general.sessionSummary.description': 'Choose whether supported agents emit status summaries and whether they appear in chat.',
   'settings.general.sessionSummaryContract': 'Emit status summaries',
   'settings.general.sessionSummaryContract.desc': 'Off by default. When enabled, supported agents are asked to add a trailing AGENT_NOTIFY_SUMMARY line after each turn for notifications and background work records. Applies to new/resumed sessions. (Supported: Claude, Codex, OpenCode, remote Grok; not yet supported: local Grok, Cursor)',
   'settings.general.sessionSummaryInChat': 'Show status summaries in chat',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -811,7 +811,7 @@ export default {
   'settings.usage.sessions': '{count} 个会话有用量记录',
   'settings.general.description': '语言、伴侣应用配对和通用应用偏好。',
   'settings.general.sessionSummary.title': '会话状态摘要',
-  'settings.general.sessionSummary.description': '选择是否让受支持的智能体输出机器可读的状态摘要，以及是否在聊天中显示。',
+  'settings.general.sessionSummary.description': '选择是否让受支持的智能体输出状态摘要，以及是否在聊天中显示。',
   'settings.general.sessionSummaryContract': '输出状态摘要',
   'settings.general.sessionSummaryContract.desc': '默认关闭。开启后会要求受支持的智能体在每轮结束时追加 AGENT_NOTIFY_SUMMARY 行，供通知和后台工作记录使用，对新开/恢复的会话生效。(已支持：Claude、Codex、OpenCode、远程 Grok；暂不支持：本地 Grok、Cursor)',
   'settings.general.sessionSummaryInChat': '在聊天中显示状态摘要',

--- a/web/src/routes/settings/index.test.tsx
+++ b/web/src/routes/settings/index.test.tsx
@@ -254,6 +254,7 @@ describe('responsive settings pages', () => {
         expect(screen.getByRole('checkbox', { name: 'Show status summaries in chat' })).toBeInTheDocument()
         fireEvent.click(screen.getByRole('radio', { name: '简体中文' }))
         expect(localStorage.getItem('hapi-lang')).toBe('zh-CN')
+        expect(screen.getByText('选择是否让受支持的智能体输出状态摘要，以及是否在聊天中显示。')).toBeInTheDocument()
     })
 
     it('explains and keeps summary generation separate from chat display', async () => {
@@ -265,7 +266,7 @@ describe('responsive settings pages', () => {
         renderPage(<SettingsGeneralPage />)
 
         expect(await screen.findByRole('heading', { name: 'Session status summaries' })).toBeInTheDocument()
-        expect(screen.getByText('Choose whether supported agents emit a machine-readable status summary and whether it appears in chat.')).toBeInTheDocument()
+        expect(screen.getByText('Choose whether supported agents emit status summaries and whether they appear in chat.')).toBeInTheDocument()
         expect(await screen.findByRole('checkbox', { name: 'Emit status summaries' })).toBeInTheDocument()
         expect(screen.getByText('Off by default. When enabled, supported agents are asked to add a trailing AGENT_NOTIFY_SUMMARY line after each turn for notifications and background work records. Applies to new/resumed sessions. (Supported: Claude, Codex, OpenCode, remote Grok; not yet supported: local Grok, Cursor)')).toBeInTheDocument()
         expect(screen.queryByRole('heading', { name: 'Chat display', level: 3 })).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary

- Remove the technical “machine-readable” qualifier from the session summary setting description in English and Simplified Chinese.
- Add regression coverage for the updated English and Simplified Chinese copy.
- Preserve AGENT_NOTIFY_SUMMARY behavior and all setting semantics.

## Validation

- `bun run --cwd web test -- src/routes/settings/index.test.tsx` — 13 passed.
- `bun typecheck` — passed.
- `bun run build` — passed.
- `git diff --check` — passed.

## Related Issues

None

## Related PRs

Refs #1760

## AI Disclosure

OpenAI Codex (GPT-5.6).