### PR TITLE
fix(web): clarify round usage metadata labels

### DIFF
--- a/web/src/chat/presentation.test.ts
+++ b/web/src/chat/presentation.test.ts
@@ -14,6 +14,12 @@ describe('formatDuration', () => {
         expect(formatDuration(537_000)).toBe('8m 57s')
     })
 
+    it('rounds fractional seconds across minute and hour boundaries', () => {
+        expect(formatDuration(119_500)).toBe('2m')
+        expect(formatDuration(3_599_500)).toBe('1h')
+        expect(formatDuration(3_601_000)).toBe('1h 1s')
+    })
+
     it('uses hours and omits zero trailing components', () => {
         expect(formatDuration(3_600_000)).toBe('1h')
         expect(formatDuration(3_661_000)).toBe('1h 1m 1s')

--- a/web/src/chat/presentation.test.ts
+++ b/web/src/chat/presentation.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from 'vitest'
-import { getEventPresentation, formatMessageTimestamp, formatOutlineTimestamp, formatResetTime } from './presentation'
+import { getEventPresentation, formatDuration, formatMessageTimestamp, formatOutlineTimestamp, formatResetTime } from './presentation'
+
+describe('formatDuration', () => {
+    it('keeps sub-minute durations at one decimal place', () => {
+        expect(formatDuration(59_900)).toBe('59.9s')
+    })
+
+    it('omits zero seconds for an exact minute', () => {
+        expect(formatDuration(60_000)).toBe('1m')
+    })
+
+    it('keeps non-zero minute and second components', () => {
+        expect(formatDuration(537_000)).toBe('8m 57s')
+    })
+
+    it('uses hours and omits zero trailing components', () => {
+        expect(formatDuration(3_600_000)).toBe('1h')
+        expect(formatDuration(3_661_000)).toBe('1h 1m 1s')
+    })
+})
 
 describe('formatOutlineTimestamp', () => {
     it('shows only the time for same-day messages', () => {

--- a/web/src/chat/presentation.ts
+++ b/web/src/chat/presentation.ts
@@ -94,9 +94,16 @@ function formatLimitType(limitType: string | undefined): string {
 export function formatDuration(ms: number): string {
     const seconds = ms / 1000
     if (seconds < 60) return `${seconds.toFixed(1)}s`
-    const mins = Math.floor(seconds / 60)
-    const secs = Math.round(seconds % 60)
-    return `${mins}m ${secs}s`
+
+    const totalSeconds = Math.round(seconds)
+    const hours = Math.floor(totalSeconds / 3_600)
+    const minutes = Math.floor((totalSeconds % 3_600) / 60)
+    const remainingSeconds = totalSeconds % 60
+    const parts: string[] = []
+    if (hours > 0) parts.push(`${hours}h`)
+    if (minutes > 0) parts.push(`${minutes}m`)
+    if (remainingSeconds > 0) parts.push(`${remainingSeconds}s`)
+    return parts.join(' ')
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/web/src/components/AssistantChat/messages/MessageMetadata.test.ts
+++ b/web/src/components/AssistantChat/messages/MessageMetadata.test.ts
@@ -54,6 +54,11 @@ describe('buildMessageMetadataLabels', () => {
         expect(parts).toContain('Duration: 0.0s')
     })
 
+    it('uses compact units for long legacy durations', () => {
+        expect(buildMessageMetadataLabels({ durationMs: 60_000 })).toContain('Duration: 1m')
+        expect(buildMessageMetadataLabels({ durationMs: 3_600_000 })).toContain('Duration: 1h')
+    })
+
     // Proof of Invariance — single-turn inputs (turnCount omitted, or < 2)
     // must produce byte-identical output to the pre-aggregate footer so
     // existing single-turn cards do not regress visually.
@@ -144,9 +149,24 @@ describe('buildMessageMetadataLabels', () => {
         expect(parts).toEqual([
             'Models: claude-opus-5, claude-haiku-4-5',
             'Tokens: 100.6k (100.1k in · 500 out)',
-            'Cache read: 99.9% of input · API-rate est.: $0.028',
-            'Round: 8.2s · 9 internal turns'
+            'Cached input: 99.9% · Cost: $0.028',
+            'Round: 8.2s · 9 turns'
         ])
+    })
+
+    it('formats long round durations with minutes and hours', () => {
+        const summary = (durationMs: number) => buildMessageMetadataLabels({
+            roundSummary: {
+                modelUsage: {},
+                durationMs,
+                numTurns: 1
+            }
+        })
+
+        expect(summary(59_900)).toContain('Round: 59.9s · 1 turn')
+        expect(summary(60_000)).toContain('Round: 1m · 1 turn')
+        expect(summary(537_000)).toContain('Round: 8m 57s · 1 turn')
+        expect(summary(3_661_000)).toContain('Round: 1h 1m 1s · 1 turn')
     })
 
     it('labels a top-level Codex turn with Round', () => {
@@ -191,7 +211,7 @@ describe('buildMessageMetadataLabels', () => {
         })).toEqual([
             'Models: claude-opus-5, claude-haiku-4-5, claude-empty-5',
             'Tokens: 24 (10 in · 14 out)',
-            'API-rate est.: <$0.0001',
+            'Cost: <$0.0001',
             'Round: 0.0s'
         ])
     })

--- a/web/src/components/AssistantChat/messages/MessageMetadata.tsx
+++ b/web/src/components/AssistantChat/messages/MessageMetadata.tsx
@@ -1,3 +1,4 @@
+import { formatDuration } from '@/chat/presentation'
 import type { RoundModelUsage, RoundSummary, UsageData } from '@/chat/types'
 
 export type MessageMetadataProps = {
@@ -58,21 +59,20 @@ function buildRoundSummaryLabels(summary: RoundSummary, fallbackModel?: string |
 
         const economics: string[] = []
         if (input > 0 && (usage.cache_read_input_tokens ?? 0) > 0) {
-            economics.push(`Cache read: ${formatPercentage(((usage.cache_read_input_tokens ?? 0) / input) * 100)}% of input`)
+            economics.push(`Cached input: ${formatPercentage(((usage.cache_read_input_tokens ?? 0) / input) * 100)}%`)
         }
         if (summary.totalCostUsd !== undefined && summary.totalCostUsd > 0) {
-            economics.push(`API-rate est.: ${formatUsd(summary.totalCostUsd)}`)
+            economics.push(`Cost: ${formatUsd(summary.totalCostUsd)}`)
         }
         if (economics.length > 0) parts.push(economics.join(' · '))
     } else if (summary.totalCostUsd !== undefined && summary.totalCostUsd > 0) {
-        parts.push(`API-rate est.: ${formatUsd(summary.totalCostUsd)}`)
+        parts.push(`Cost: ${formatUsd(summary.totalCostUsd)}`)
     }
 
     const round: string[] = []
-    if (summary.durationMs !== undefined && summary.durationMs >= 0) round.push(`${(summary.durationMs / 1000).toFixed(1)}s`)
+    if (summary.durationMs !== undefined && summary.durationMs >= 0) round.push(formatDuration(summary.durationMs))
     if (summary.numTurns !== undefined && summary.numTurns > 0) {
-        const turnLabel = summary.provider === 'codex' ? 'turn' : 'internal turn'
-        round.push(`${summary.numTurns} ${turnLabel}${summary.numTurns === 1 ? '' : 's'}`)
+        round.push(`${summary.numTurns} turn${summary.numTurns === 1 ? '' : 's'}`)
     }
     if (round.length > 0) parts.push(`Round: ${round.join(' · ')}`)
     return parts
@@ -88,7 +88,7 @@ export function buildMessageMetadataLabels({ durationMs, usage, model, turnCount
     const isAggregated = typeof turnCount === 'number' && turnCount >= 2
 
     if (typeof durationMs === 'number' && durationMs >= 0) {
-        parts.push(`Duration: ${(durationMs / 1000).toFixed(1)}s`)
+        parts.push(`Duration: ${formatDuration(durationMs)}`)
     }
 
     const tier = usage?.service_tier

--- a/web/src/components/ToolCard/trace.test.tsx
+++ b/web/src/components/ToolCard/trace.test.tsx
@@ -325,6 +325,11 @@ describe('TraceSection', () => {
         expect(screen.getByText(/3 calls/)).toBeInTheDocument()
     })
 
+    it('uses compact units for long trace durations', () => {
+        expect(getTraceSummaryText(1, null, 60_000, 'calls')).toBe('1 calls · 1m')
+        expect(getTraceSummaryText(1, null, 3_600_000, 'calls')).toBe('1 calls · 1h')
+    })
+
     it('shows Input section when a child row is expanded', () => {
         const block = makeTaskBlock([makeChild('c1', 'Bash')], 'running')
         const { container } = render(<TraceSection block={block} metadata={null} />)

--- a/web/src/components/ToolCard/trace.tsx
+++ b/web/src/components/ToolCard/trace.tsx
@@ -11,7 +11,7 @@ import { getToolResultViewComponent } from '@/components/ToolCard/views/_results
 import { formatTaskChildLabel, TaskStateIcon } from '@/components/ToolCard/helpers'
 import { CodeBlock } from '@/components/CodeBlock'
 import { MarkdownRenderer } from '@/components/MarkdownRenderer'
-import { getEventPresentation } from '@/chat/presentation'
+import { formatDuration, getEventPresentation } from '@/chat/presentation'
 import { useTranslation } from '@/lib/use-translation'
 import { isSubagentToolName } from '@/chat/subagentTool'
 
@@ -84,8 +84,7 @@ export function getTraceSummaryText(
     }
 
     if (totalDurationMs !== null) {
-        const s = totalDurationMs / 1000
-        parts.push(`${s.toFixed(1)}s`)
+        parts.push(formatDuration(totalDurationMs))
     }
 
     return parts.join(' · ')


### PR DESCRIPTION
## Summary

- Rename round metadata labels to `Cost`, `Cached input`, and `turn`.
- Use a shared duration formatter for round metadata and related Web duration displays.
- Omit zero-valued units, such as displaying `1m` instead of `1m 0s`.
- Add regression coverage for minute, hour, and boundary durations.

## Validation

- `bun typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name rename-cost-label -Suite Root -TestArgs 'terminal-wrap-fidelity.spec.ts'` — 2 passed.
- Related Web tests — 75 passed across 3 files.
- `bun run build` — passed.
- `git diff --check` — passed.

## Related Issues

None

## AI Disclosure

Implemented and validated with OpenAI Codex (GPT-5.6).