### PR TITLE
feat(web): file context menu — copy path / copy absolute path / add to composer

### DIFF
--- a/web/src/components/FileActionMenu.test.tsx
+++ b/web/src/components/FileActionMenu.test.tsx
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { I18nProvider } from '@/lib/i18n-context'
+import { FileActionMenu } from '@/components/FileActionMenu'
+
+vi.mock('@/hooks/usePlatform', () => ({
+    usePlatform: () => ({
+        haptic: { notification: vi.fn(), impact: vi.fn() },
+    }),
+}))
+
+function renderMenu(overrides: Partial<React.ComponentProps<typeof FileActionMenu>> = {}) {
+    const defaults: React.ComponentProps<typeof FileActionMenu> = {
+        isOpen: true,
+        onClose: vi.fn(),
+        relativePath: 'src/foo.ts',
+        absolutePath: '/home/me/project/src/foo.ts',
+        anchorPoint: { x: 40, y: 40 },
+        onAddToComposer: vi.fn(),
+    }
+    const props = { ...defaults, ...overrides }
+    return {
+        ...render(
+            <I18nProvider>
+                <FileActionMenu {...props} />
+            </I18nProvider>
+        ),
+        props,
+    }
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+})
+
+afterEach(() => cleanup())
+
+describe('FileActionMenu', () => {
+    it('renders the three file actions', () => {
+        renderMenu()
+
+        expect(screen.getByRole('menuitem', { name: 'Copy path' })).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: 'Copy absolute path' })).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: 'Add to composer' })).toBeInTheDocument()
+    })
+
+    it('renders nothing when closed', () => {
+        renderMenu({ isOpen: false })
+
+        expect(screen.queryByRole('menu')).toBeNull()
+    })
+
+    it('copies the relative path and closes', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        })
+        const onClose = vi.fn()
+        renderMenu({ onClose })
+
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Copy path' }))
+
+        expect(onClose).toHaveBeenCalledTimes(1)
+        await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith('src/foo.ts'))
+    })
+
+    it('copies the absolute path and closes', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        })
+        const onClose = vi.fn()
+        renderMenu({ onClose })
+
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Copy absolute path' }))
+
+        expect(onClose).toHaveBeenCalledTimes(1)
+        await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith('/home/me/project/src/foo.ts'))
+    })
+
+    it('adds the file to the composer and closes', () => {
+        const onAddToComposer = vi.fn()
+        const onClose = vi.fn()
+        renderMenu({ onAddToComposer, onClose })
+
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Add to composer' }))
+
+        expect(onAddToComposer).toHaveBeenCalledTimes(1)
+        expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('closes on Escape', () => {
+        const onClose = vi.fn()
+        renderMenu({ onClose })
+
+        fireEvent.keyDown(document, { key: 'Escape' })
+
+        expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('closes on an outside pointer down', () => {
+        const onClose = vi.fn()
+        renderMenu({ onClose })
+
+        fireEvent.pointerDown(document.body)
+
+        expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('anchors the left edge at the pointer instead of centering on it', () => {
+        const originalInnerWidth = window.innerWidth
+        Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1440 })
+        const menuRect = {
+            bottom: 200,
+            height: 200,
+            left: 0,
+            right: 240,
+            top: 0,
+            width: 240,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        } as DOMRect
+        const getBoundingClientRect = vi
+            .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+            .mockReturnValue(menuRect)
+
+        try {
+            renderMenu({ anchorPoint: { x: 800, y: 300 } })
+
+            expect(screen.getByRole('menu').parentElement).toHaveStyle({ left: '800px' })
+        } finally {
+            getBoundingClientRect.mockRestore()
+            Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth })
+        }
+    })
+})

--- a/web/src/components/FileActionMenu.tsx
+++ b/web/src/components/FileActionMenu.tsx
@@ -1,0 +1,109 @@
+import { useId } from 'react'
+import { safeCopyToClipboard } from '@/lib/clipboard'
+import { usePlatform } from '@/hooks/usePlatform'
+import { useAnchoredMenu, type AnchoredMenuPoint } from '@/hooks/useAnchoredMenu'
+import { useTranslation } from '@/lib/use-translation'
+import { CopyIcon, PlusCircleIcon } from '@/components/icons'
+
+type FileActionMenuProps = {
+    isOpen: boolean
+    onClose: () => void
+    /** Workspace-relative path, e.g. `src/routes/sessions/file.tsx`. */
+    relativePath: string
+    /** Absolute path resolved against the session working directory. */
+    absolutePath: string
+    anchorPoint: AnchoredMenuPoint
+    onAddToComposer: () => void
+    menuId?: string
+}
+
+export function FileActionMenu(props: FileActionMenuProps) {
+    const { t } = useTranslation()
+    const { haptic } = usePlatform()
+    const {
+        isOpen,
+        onClose,
+        relativePath,
+        absolutePath,
+        anchorPoint,
+        onAddToComposer,
+        menuId,
+    } = props
+    const { menuRef, menuStyle } = useAnchoredMenu({ isOpen, onClose, anchorPoint, align: 'start' })
+    const internalId = useId()
+    const resolvedMenuId = menuId ?? `file-action-menu-${internalId}`
+    const headingId = `${resolvedMenuId}-heading`
+
+    const handleCopy = async (value: string) => {
+        onClose()
+        try {
+            await safeCopyToClipboard(value)
+            haptic.notification('success')
+        } catch {
+            haptic.notification('error')
+        }
+    }
+
+    const handleAddToComposer = () => {
+        onClose()
+        onAddToComposer()
+    }
+
+    if (!isOpen) return null
+
+    const itemClassName =
+        'flex w-full items-center gap-3 rounded-md py-2 pl-3 pr-[42px] text-left text-base transition-colors hover:bg-[var(--app-subtle-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-link)]'
+
+    return (
+        <div
+            ref={menuRef}
+            className="fixed z-50 box-border w-max max-w-[calc(100vw-16px)] rounded-lg border border-[var(--app-border)] bg-[var(--app-bg)] p-1 shadow-lg animate-menu-pop"
+            style={menuStyle}
+        >
+            <div
+                id={headingId}
+                className="max-w-[60vw] truncate px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--app-hint)]"
+            >
+                {t('file.menu.title')}
+            </div>
+            <div
+                id={resolvedMenuId}
+                role="menu"
+                aria-labelledby={headingId}
+                className="flex flex-col gap-1"
+            >
+                <button
+                    type="button"
+                    role="menuitem"
+                    className={itemClassName}
+                    title={relativePath}
+                    onClick={() => void handleCopy(relativePath)}
+                >
+                    <CopyIcon className="h-[18px] w-[18px] text-[var(--app-hint)]" />
+                    {t('file.menu.copyPath')}
+                </button>
+
+                <button
+                    type="button"
+                    role="menuitem"
+                    className={itemClassName}
+                    title={absolutePath}
+                    onClick={() => void handleCopy(absolutePath)}
+                >
+                    <CopyIcon className="h-[18px] w-[18px] text-[var(--app-hint)]" />
+                    {t('file.menu.copyAbsolutePath')}
+                </button>
+
+                <button
+                    type="button"
+                    role="menuitem"
+                    className={itemClassName}
+                    onClick={handleAddToComposer}
+                >
+                    <PlusCircleIcon className="h-[18px] w-[18px] text-[var(--app-hint)]" />
+                    {t('file.menu.addToComposer')}
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/web/src/components/SessionActionMenu.tsx
+++ b/web/src/components/SessionActionMenu.tsx
@@ -1,17 +1,10 @@
-import {
-    useCallback,
-    useEffect,
-    useId,
-    useLayoutEffect,
-    useRef,
-    useState,
-    type CSSProperties
-} from 'react'
+import { useId } from 'react'
 import { useTranslation } from '@/lib/use-translation'
 import { HoverTooltip } from '@/components/HoverTooltip'
 import { safeCopyToClipboard } from '@/lib/clipboard'
 import { buildSessionReferenceText } from '@/lib/sessionReference'
 import { usePlatform } from '@/hooks/usePlatform'
+import { useAnchoredMenu } from '@/hooks/useAnchoredMenu'
 import { CopyIcon } from '@/components/icons'
 
 type SessionActionMenuProps = {
@@ -192,12 +185,6 @@ function TrashIcon(props: { className?: string }) {
     )
 }
 
-type MenuPosition = {
-    top: number
-    left: number
-    transformOrigin: string
-}
-
 export function SessionActionMenu(props: SessionActionMenuProps) {
     const { t } = useTranslation()
     const { haptic } = usePlatform()
@@ -223,8 +210,7 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         anchorPoint,
         menuId
     } = props
-    const menuRef = useRef<HTMLDivElement | null>(null)
-    const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null)
+    const { menuRef, menuStyle } = useAnchoredMenu({ isOpen, onClose, anchorPoint })
     const internalId = useId()
     const resolvedMenuId = menuId ?? `session-action-menu-${internalId}`
     const headingId = `${resolvedMenuId}-heading`
@@ -284,91 +270,7 @@ export function SessionActionMenu(props: SessionActionMenuProps) {
         onDelete()
     }
 
-    const updatePosition = useCallback(() => {
-        const menuEl = menuRef.current
-        if (!menuEl) return
-
-        const menuRect = menuEl.getBoundingClientRect()
-        const viewportWidth = window.innerWidth
-        const viewportHeight = window.innerHeight
-        const padding = 8
-        const gap = 8
-
-        const spaceBelow = viewportHeight - anchorPoint.y
-        const spaceAbove = anchorPoint.y
-        const openAbove = spaceBelow < menuRect.height + gap && spaceAbove > spaceBelow
-
-        let top = openAbove ? anchorPoint.y - menuRect.height - gap : anchorPoint.y + gap
-        // Keep the menu centered on the trigger, then clamp it only when it would leave the viewport.
-        let left = anchorPoint.x - menuRect.width / 2
-        const transformOrigin = openAbove ? 'bottom center' : 'top center'
-
-        top = Math.min(Math.max(top, padding), viewportHeight - menuRect.height - padding)
-        left = Math.min(Math.max(left, padding), viewportWidth - menuRect.width - padding)
-
-        setMenuPosition({ top, left, transformOrigin })
-    }, [anchorPoint])
-
-    useLayoutEffect(() => {
-        if (!isOpen) return
-        updatePosition()
-    }, [isOpen, updatePosition])
-
-    useEffect(() => {
-        if (!isOpen) {
-            setMenuPosition(null)
-            return
-        }
-
-        const handlePointerDown = (event: PointerEvent) => {
-            const target = event.target as Node
-            if (menuRef.current?.contains(target)) return
-            onClose()
-        }
-
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                onClose()
-            }
-        }
-
-        const handleReflow = () => {
-            updatePosition()
-        }
-
-        document.addEventListener('pointerdown', handlePointerDown)
-        document.addEventListener('keydown', handleKeyDown)
-        window.addEventListener('resize', handleReflow)
-        window.addEventListener('scroll', handleReflow, true)
-
-        return () => {
-            document.removeEventListener('pointerdown', handlePointerDown)
-            document.removeEventListener('keydown', handleKeyDown)
-            window.removeEventListener('resize', handleReflow)
-            window.removeEventListener('scroll', handleReflow, true)
-        }
-    }, [isOpen, onClose, updatePosition])
-
-    useEffect(() => {
-        if (!isOpen) return
-
-        const frame = window.requestAnimationFrame(() => {
-            const firstItem = menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')
-            firstItem?.focus()
-        })
-
-        return () => window.cancelAnimationFrame(frame)
-    }, [isOpen])
-
     if (!isOpen) return null
-
-    const menuStyle: CSSProperties | undefined = menuPosition
-        ? {
-            top: `max(${menuPosition.top}px, calc(env(safe-area-inset-top) + 8px))`,
-            left: menuPosition.left,
-            transformOrigin: menuPosition.transformOrigin
-        }
-        : undefined
 
     // The left text inset includes the icon and gap; mirror it on the right so
     // the text-to-border distance is symmetric without counting the icon twice.

--- a/web/src/components/SessionFiles/DirectoryTree.test.tsx
+++ b/web/src/components/SessionFiles/DirectoryTree.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { I18nProvider } from '@/lib/i18n-context'
+import { ToastProvider } from '@/lib/toast-context'
+import { DEFAULT_DIRECTORY_SORT } from '@/lib/directory-sort'
+import { DirectoryTree } from '@/components/SessionFiles/DirectoryTree'
+
+const mocks = vi.hoisted(() => ({
+    entries: [
+        { name: 'README.md', type: 'file' as const, size: 12, modified: 1_784_175_060_000 },
+        { name: 'src', type: 'directory' as const },
+    ] as Array<{ name: string; type: 'file' | 'directory'; size?: number; modified?: number }>,
+}))
+
+vi.mock('@/hooks/queries/useSessionDirectory', () => ({
+    useSessionDirectory: () => ({
+        entries: mocks.entries,
+        error: null,
+        isLoading: false,
+        refetch: vi.fn(),
+    }),
+}))
+
+function renderTree(handlers: {
+    onOpenFile?: () => void
+    onRequestFileMenu?: (path: string, point: { x: number; y: number }) => void
+} = {}) {
+    const onOpenFile = handlers.onOpenFile ?? vi.fn()
+    const onRequestFileMenu = handlers.onRequestFileMenu ?? vi.fn()
+
+    render(
+        <I18nProvider>
+            <ToastProvider>
+                <DirectoryTree
+                    api={{} as never}
+                    sessionId="session-1"
+                    rootLabel="project"
+                    onOpenFile={onOpenFile}
+                    onRequestFileMenu={onRequestFileMenu}
+                    sort={DEFAULT_DIRECTORY_SORT}
+                />
+            </ToastProvider>
+        </I18nProvider>
+    )
+
+    return { onOpenFile, onRequestFileMenu }
+}
+
+/** The file name button (a directory row's download button also mentions the name in its aria-label). */
+function fileRow(): HTMLButtonElement {
+    return screen.getByText('README.md').closest('button') as HTMLButtonElement
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    window.sessionStorage.clear()
+})
+
+afterEach(() => cleanup())
+
+describe('DirectoryTree file context menu', () => {
+    it('requests the menu on right-click with the entry path and pointer', () => {
+        const { onRequestFileMenu } = renderTree()
+
+        fireEvent.contextMenu(fileRow(), { clientX: 321, clientY: 123 })
+
+        expect(onRequestFileMenu).toHaveBeenCalledWith('README.md', { x: 321, y: 123 })
+    })
+
+    it('requests the menu on touch long-press and does not open the file on release', () => {
+        vi.useFakeTimers()
+        try {
+            const { onOpenFile, onRequestFileMenu } = renderTree()
+
+            fireEvent.touchStart(fileRow(), { touches: [{ clientX: 44, clientY: 55 }] })
+            act(() => {
+                vi.advanceTimersByTime(600)
+            })
+
+            expect(onRequestFileMenu).toHaveBeenCalledWith('README.md', { x: 44, y: 55 })
+            expect(onOpenFile).not.toHaveBeenCalled()
+
+            fireEvent.touchEnd(fileRow(), { changedTouches: [{ clientX: 44, clientY: 55 }] })
+            expect(onOpenFile).not.toHaveBeenCalled()
+        } finally {
+            vi.useRealTimers()
+        }
+    })
+})

--- a/web/src/components/SessionFiles/DirectoryTree.tsx
+++ b/web/src/components/SessionFiles/DirectoryTree.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ApiClient } from '@/api/client'
 import { FileIcon } from '@/components/FileIcon'
 import { useSessionDirectory } from '@/hooks/queries/useSessionDirectory'
+import { useFileMenuTrigger } from '@/hooks/useFileMenuTrigger'
+import type { AnchoredMenuPoint } from '@/hooks/useAnchoredMenu'
 import { formatDirectoryError } from '@/lib/files-i18n'
 import { useTranslation } from '@/lib/use-translation'
 import { useToast } from '@/lib/toast-context'
@@ -89,6 +91,53 @@ function DirectoryErrorRow(props: { depth: number; message: string }) {
     )
 }
 
+type FileMenuRequestHandler = (path: string, point: AnchoredMenuPoint) => void
+
+function DirectoryFileRow(props: {
+    fileName: string
+    metadata: string | null
+    indent: number
+    isDownloading: boolean
+    downloadDisabled: boolean
+    onOpen: () => void
+    onDownload: () => void
+    onOpenMenu?: (point: AnchoredMenuPoint) => void
+}) {
+    const { t } = useTranslation()
+    const rowHandlers = useFileMenuTrigger({
+        onOpen: props.onOpen,
+        onOpenMenu: props.onOpenMenu,
+    })
+
+    return (
+        <div
+            className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-[var(--app-subtle-bg)] transition-colors"
+            style={{ paddingLeft: props.indent }}
+        >
+            <span className="h-4 w-4" />
+            <FileIcon fileName={props.fileName} size={22} />
+            <button
+                type="button"
+                {...rowHandlers}
+                className="min-w-0 flex-1 text-left"
+            >
+                <div className="truncate font-medium">{props.fileName}</div>
+                {props.metadata ? <div className="truncate text-xs text-[var(--app-hint)]">{props.metadata}</div> : null}
+            </button>
+            <button
+                type="button"
+                onClick={props.onDownload}
+                disabled={props.downloadDisabled}
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--app-hint)] transition-colors hover:bg-[var(--app-secondary-bg)] hover:text-[var(--app-fg)] disabled:cursor-wait disabled:opacity-50"
+                title={t('files.directories.download')}
+                aria-label={t('files.directories.downloadNamed', { name: props.fileName })}
+            >
+                <DownloadIcon className={`h-4 w-4 ${props.isDownloading ? 'animate-pulse' : ''}`} />
+            </button>
+        </div>
+    )
+}
+
 function DirectoryNode(props: {
     api: ApiClient | null
     sessionId: string
@@ -96,6 +145,7 @@ function DirectoryNode(props: {
     label: string
     depth: number
     onOpenFile: (path: string) => void
+    onRequestFileMenu?: FileMenuRequestHandler
     expanded: Set<string>
     onToggle: (path: string) => void
     sort: DirectorySort
@@ -173,6 +223,7 @@ function DirectoryNode(props: {
                                     label={entry.name}
                                     depth={childDepth}
                                     onOpenFile={props.onOpenFile}
+                                    onRequestFileMenu={props.onRequestFileMenu}
                                     expanded={props.expanded}
                                     onToggle={props.onToggle}
                                     sort={props.sort}
@@ -185,28 +236,19 @@ function DirectoryNode(props: {
                             const metadata = formatFileMetadata(entry.size, entry.modified, locale)
                             const isDownloading = downloadingPath === filePath
                             return (
-                                <div
+                                <DirectoryFileRow
                                     key={filePath}
-                                    className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-[var(--app-subtle-bg)] transition-colors"
-                                    style={{ paddingLeft: childIndent }}
-                                >
-                                    <span className="h-4 w-4" />
-                                    <FileIcon fileName={entry.name} size={22} />
-                                    <button type="button" onClick={() => props.onOpenFile(filePath)} className="min-w-0 flex-1 text-left">
-                                        <div className="truncate font-medium">{entry.name}</div>
-                                        {metadata ? <div className="truncate text-xs text-[var(--app-hint)]">{metadata}</div> : null}
-                                    </button>
-                                    <button
-                                        type="button"
-                                        onClick={() => void handleDownload(filePath, entry.name)}
-                                        disabled={Boolean(downloadingPath)}
-                                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--app-hint)] transition-colors hover:bg-[var(--app-secondary-bg)] hover:text-[var(--app-fg)] disabled:cursor-wait disabled:opacity-50"
-                                        title={t('files.directories.download')}
-                                        aria-label={t('files.directories.downloadNamed', { name: entry.name })}
-                                    >
-                                        <DownloadIcon className={`h-4 w-4 ${isDownloading ? 'animate-pulse' : ''}`} />
-                                    </button>
-                                </div>
+                                    fileName={entry.name}
+                                    metadata={metadata}
+                                    indent={childIndent}
+                                    isDownloading={isDownloading}
+                                    downloadDisabled={Boolean(downloadingPath)}
+                                    onOpen={() => props.onOpenFile(filePath)}
+                                    onDownload={() => void handleDownload(filePath, entry.name)}
+                                    onOpenMenu={props.onRequestFileMenu
+                                        ? (point) => props.onRequestFileMenu!(filePath, point)
+                                        : undefined}
+                                />
                             )
                         })}
 
@@ -253,6 +295,7 @@ export function DirectoryTree(props: {
     sessionId: string
     rootLabel: string
     onOpenFile: (path: string) => void
+    onRequestFileMenu?: FileMenuRequestHandler
     sort: DirectorySort
 }) {
     const [expanded, setExpanded] = useState<Set<string>>(() => readExpanded(props.sessionId))
@@ -282,6 +325,7 @@ export function DirectoryTree(props: {
                 label={props.rootLabel}
                 depth={0}
                 onOpenFile={props.onOpenFile}
+                onRequestFileMenu={props.onRequestFileMenu}
                 expanded={expanded}
                 onToggle={handleToggle}
                 sort={props.sort}

--- a/web/src/hooks/useAnchoredMenu.ts
+++ b/web/src/hooks/useAnchoredMenu.ts
@@ -1,0 +1,133 @@
+import {
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+    useState,
+    type CSSProperties,
+    type RefObject,
+} from 'react'
+
+export type AnchoredMenuPoint = { x: number; y: number }
+
+type MenuPosition = {
+    top: number
+    left: number
+    transformOrigin: string
+}
+
+/**
+ * Position and dismissal lifecycle for a pointer-anchored context menu.
+ *
+ * Shared by the session action menu and the file action menu: measures the
+ * menu, opens above/below the pointer as space allows, clamps it inside the
+ * viewport, dismisses on outside pointer-down / Escape, repositions on
+ * resize/scroll, and focuses the first `menuitem` when it opens.
+ */
+export function useAnchoredMenu(options: {
+    isOpen: boolean
+    onClose: () => void
+    anchorPoint: AnchoredMenuPoint
+    /**
+     * Horizontal alignment relative to the anchor. `center` suits a trigger
+     * button (menu centered under it); `start` suits a pointer/context menu
+     * (menu's left edge at the pointer).
+     */
+    align?: 'center' | 'start'
+}): {
+    menuRef: RefObject<HTMLDivElement | null>
+    menuStyle: CSSProperties | undefined
+} {
+    const { isOpen, onClose, anchorPoint, align = 'center' } = options
+    const menuRef = useRef<HTMLDivElement | null>(null)
+    const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null)
+
+    const updatePosition = useCallback(() => {
+        const menuEl = menuRef.current
+        if (!menuEl) return
+
+        const menuRect = menuEl.getBoundingClientRect()
+        const viewportWidth = window.innerWidth
+        const viewportHeight = window.innerHeight
+        const padding = 8
+        const gap = 8
+
+        const spaceBelow = viewportHeight - anchorPoint.y
+        const spaceAbove = anchorPoint.y
+        const openAbove = spaceBelow < menuRect.height + gap && spaceAbove > spaceBelow
+
+        let top = openAbove ? anchorPoint.y - menuRect.height - gap : anchorPoint.y + gap
+        // Center the menu on a trigger button, or start its left edge at a
+        // pointer, then clamp it so it never leaves the viewport.
+        let left = align === 'start' ? anchorPoint.x : anchorPoint.x - menuRect.width / 2
+        const transformOrigin = openAbove
+            ? 'bottom center'
+            : align === 'start' ? 'top left' : 'top center'
+
+        top = Math.min(Math.max(top, padding), viewportHeight - menuRect.height - padding)
+        left = Math.min(Math.max(left, padding), viewportWidth - menuRect.width - padding)
+
+        setMenuPosition({ top, left, transformOrigin })
+    }, [align, anchorPoint])
+
+    useLayoutEffect(() => {
+        if (!isOpen) return
+        updatePosition()
+    }, [isOpen, updatePosition])
+
+    useEffect(() => {
+        if (!isOpen) {
+            setMenuPosition(null)
+            return
+        }
+
+        const handlePointerDown = (event: PointerEvent) => {
+            const target = event.target as Node
+            if (menuRef.current?.contains(target)) return
+            onClose()
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose()
+            }
+        }
+
+        const handleReflow = () => {
+            updatePosition()
+        }
+
+        document.addEventListener('pointerdown', handlePointerDown)
+        document.addEventListener('keydown', handleKeyDown)
+        window.addEventListener('resize', handleReflow)
+        window.addEventListener('scroll', handleReflow, true)
+
+        return () => {
+            document.removeEventListener('pointerdown', handlePointerDown)
+            document.removeEventListener('keydown', handleKeyDown)
+            window.removeEventListener('resize', handleReflow)
+            window.removeEventListener('scroll', handleReflow, true)
+        }
+    }, [isOpen, onClose, updatePosition])
+
+    useEffect(() => {
+        if (!isOpen) return
+
+        const frame = window.requestAnimationFrame(() => {
+            const firstItem = menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')
+            firstItem?.focus()
+        })
+
+        return () => window.cancelAnimationFrame(frame)
+    }, [isOpen])
+
+    const menuStyle: CSSProperties | undefined = menuPosition
+        ? {
+            top: `max(${menuPosition.top}px, calc(env(safe-area-inset-top) + 8px))`,
+            left: menuPosition.left,
+            transformOrigin: menuPosition.transformOrigin,
+        }
+        : undefined
+
+    return { menuRef, menuStyle }
+}

--- a/web/src/hooks/useFileMenuTrigger.ts
+++ b/web/src/hooks/useFileMenuTrigger.ts
@@ -1,0 +1,30 @@
+import { useCallback, type MouseEvent as ReactMouseEvent } from 'react'
+import { useLongPress } from '@/hooks/useLongPress'
+import type { AnchoredMenuPoint } from '@/hooks/useAnchoredMenu'
+
+/**
+ * Open a file's action menu from a row: right-click on desktop (native
+ * `contextmenu`) and long-press on mobile, while keeping tap / Enter as the
+ * normal open action. Returns handlers to spread onto the row (or its primary
+ * button).
+ */
+export function useFileMenuTrigger(options: {
+    onOpen: () => void
+    onOpenMenu?: (point: AnchoredMenuPoint) => void
+}) {
+    const { onOpen, onOpenMenu } = options
+    const longPress = useLongPress({
+        onLongPress: (point) => onOpenMenu?.(point),
+        onClick: onOpen,
+        interaction: 'touch-only-native-click',
+        longPressEnabled: Boolean(onOpenMenu),
+    })
+    const onContextMenu = onOpenMenu
+        ? (event: ReactMouseEvent<HTMLElement>) => {
+            event.preventDefault()
+            onOpenMenu({ x: event.clientX, y: event.clientY })
+        }
+        : undefined
+
+    return { ...longPress, onContextMenu }
+}

--- a/web/src/lib/file-composer.test.ts
+++ b/web/src/lib/file-composer.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { formatFileReference, appendFileReferenceToComposerDraft } from './file-composer'
+import { getDraft, saveDraft } from '@/lib/composer-drafts'
+
+describe('file-composer', () => {
+    beforeEach(() => {
+        window.sessionStorage.clear()
+    })
+
+    it('formats a backticked reference', () => {
+        expect(formatFileReference('src/foo.ts')).toBe('`src/foo.ts`')
+    })
+
+    it('writes a new draft when none exists', () => {
+        appendFileReferenceToComposerDraft('file-composer-empty', 'src/foo.ts')
+        expect(getDraft('file-composer-empty')).toBe('`src/foo.ts`')
+    })
+
+    it('appends on a new line and preserves existing text', () => {
+        saveDraft('file-composer-existing', 'please review')
+        appendFileReferenceToComposerDraft('file-composer-existing', 'src/foo.ts')
+        expect(getDraft('file-composer-existing')).toBe('please review\n`src/foo.ts`')
+    })
+
+    it('trims trailing whitespace before appending', () => {
+        saveDraft('file-composer-trailing', 'please review\n\n')
+        appendFileReferenceToComposerDraft('file-composer-trailing', 'src/foo.ts')
+        expect(getDraft('file-composer-trailing')).toBe('please review\n`src/foo.ts`')
+    })
+})

--- a/web/src/lib/file-composer.ts
+++ b/web/src/lib/file-composer.ts
@@ -1,0 +1,19 @@
+import { getDraft, saveDraft } from '@/lib/composer-drafts'
+
+/** Wrap a workspace-relative path so the agent can spot it in the prompt. */
+export function formatFileReference(relativePath: string): string {
+    return `\`${relativePath}\``
+}
+
+/**
+ * Append a file reference to a session's composer draft.
+ *
+ * The composer is unmounted on the files routes, so callers must persist the
+ * draft here and then navigate back to the chat; `useComposerDraft` restores it
+ * on mount. Existing text is preserved and the reference is added on a new line.
+ */
+export function appendFileReferenceToComposerDraft(sessionId: string, relativePath: string): void {
+    const reference = formatFileReference(relativePath)
+    const existing = getDraft(sessionId).replace(/[ \t\r\n]+$/, '')
+    saveDraft(sessionId, existing.length > 0 ? `${existing}\n${reference}` : reference)
+}

--- a/web/src/lib/file-path.test.ts
+++ b/web/src/lib/file-path.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAbsoluteFilePath } from './file-path'
+
+describe('resolveAbsoluteFilePath', () => {
+    it('joins a relative path onto a POSIX workspace root', () => {
+        expect(resolveAbsoluteFilePath('/home/me/project', 'src/foo.ts')).toBe('/home/me/project/src/foo.ts')
+    })
+
+    it('keeps a single leading separator when the root is "/"', () => {
+        expect(resolveAbsoluteFilePath('/', 'etc/hosts')).toBe('/etc/hosts')
+    })
+
+    it('trims trailing separators from the root', () => {
+        expect(resolveAbsoluteFilePath('/home/me/project/', 'src/foo.ts')).toBe('/home/me/project/src/foo.ts')
+    })
+
+    it('preserves literal backslashes in POSIX relative paths', () => {
+        expect(resolveAbsoluteFilePath('/home/me/project', 'src/file\\name.ts')).toBe('/home/me/project/src/file\\name.ts')
+    })
+
+    it('treats a POSIX root containing a backslash as POSIX', () => {
+        expect(resolveAbsoluteFilePath('/home/me\\project', 'src/foo.ts')).toBe('/home/me\\project/src/foo.ts')
+    })
+
+    it('joins a Windows-looking filename when the workspace is POSIX', () => {
+        expect(resolveAbsoluteFilePath('/project', 'C:\\notes.txt')).toBe('/project/C:\\notes.txt')
+        expect(resolveAbsoluteFilePath('/project', 'C:/notes.txt')).toBe('/project/C:/notes.txt')
+    })
+
+    it('uses backslashes for Windows roots and converts forward slashes', () => {
+        expect(resolveAbsoluteFilePath('C:\\Users\\me\\project', 'src/foo.ts')).toBe('C:\\Users\\me\\project\\src\\foo.ts')
+    })
+
+    it('handles a bare drive root', () => {
+        expect(resolveAbsoluteFilePath('C:', 'src/foo.ts')).toBe('C:\\src\\foo.ts')
+    })
+
+    it('returns the relative path when there is no workspace', () => {
+        expect(resolveAbsoluteFilePath(undefined, 'src/foo.ts')).toBe('src/foo.ts')
+        expect(resolveAbsoluteFilePath(null, 'src/foo.ts')).toBe('src/foo.ts')
+        expect(resolveAbsoluteFilePath('', 'src/foo.ts')).toBe('src/foo.ts')
+    })
+
+    it('does not double-join an already absolute path', () => {
+        expect(resolveAbsoluteFilePath('/root', '/etc/hosts')).toBe('/etc/hosts')
+        expect(resolveAbsoluteFilePath('C:\\root', 'D:\\other\\file.ts')).toBe('D:\\other\\file.ts')
+    })
+
+    it('returns the workspace when the relative path is empty', () => {
+        expect(resolveAbsoluteFilePath('/home/me/project', '')).toBe('/home/me/project')
+    })
+})

--- a/web/src/lib/file-path.ts
+++ b/web/src/lib/file-path.ts
@@ -1,0 +1,38 @@
+const WINDOWS_ABSOLUTE_PATH = /^[A-Za-z]:[\\/]|^\\\\/
+const POSIX_ABSOLUTE_PATH = /^\//
+
+function joinPosix(root: string, relativePath: string): string {
+    if (POSIX_ABSOLUTE_PATH.test(relativePath)) return relativePath
+    // Keep every relative-path character: POSIX filenames may contain
+    // backslashes, so only `/` is a separator here.
+    return `${root.replace(/\/+$/, '')}/${relativePath}`
+}
+
+function joinWindows(root: string, relativePath: string): string {
+    if (WINDOWS_ABSOLUTE_PATH.test(relativePath)) return relativePath
+    const trimmedRoot = root.replace(/[\\/]+$/, '')
+    const base = trimmedRoot === '' ? '\\' : `${trimmedRoot}\\`
+    return `${base}${relativePath.replace(/\//g, '\\')}`
+}
+
+/**
+ * Resolve a workspace-relative path against a session's working directory.
+ *
+ * The platform is decided by the workspace root, not by the shape of the
+ * relative path: on a POSIX workspace a relative entry like `C:\notes.txt` is a
+ * legal filename and must still be joined. Relative paths from git status /
+ * ripgrep always use forward slashes; on Windows we re-join with backslashes.
+ */
+export function resolveAbsoluteFilePath(
+    workspacePath: string | null | undefined,
+    relativePath: string
+): string {
+    if (!relativePath) return workspacePath ?? ''
+
+    const root = workspacePath ?? ''
+    if (!root) return relativePath
+
+    return root.startsWith('/')
+        ? joinPosix(root, relativePath)
+        : joinWindows(root, relativePath)
+}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -518,6 +518,12 @@ export default {
   'files.sort.smallest': 'Smallest first',
   'files.sort.largest': 'Largest first',
 
+  // File context menu
+  'file.menu.title': 'File actions',
+  'file.menu.copyPath': 'Copy path',
+  'file.menu.copyAbsolutePath': 'Copy absolute path',
+  'file.menu.addToComposer': 'Add to composer',
+
   // File page
   'file.page.fallbackName': 'File',
   'file.page.unknownPath': 'Unknown path',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -517,6 +517,12 @@ export default {
   'files.sort.smallest': '最小优先',
   'files.sort.largest': '最大优先',
 
+  // 文件右键菜单
+  'file.menu.title': '文件操作',
+  'file.menu.copyPath': '复制路径',
+  'file.menu.copyAbsolutePath': '复制绝对路径',
+  'file.menu.addToComposer': '添加到对话框',
+
   // File page
   'file.page.fallbackName': '文件',
   'file.page.unknownPath': '未知路径',

--- a/web/src/routes/sessions/files.test.tsx
+++ b/web/src/routes/sessions/files.test.tsx
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { I18nProvider } from '@/lib/i18n-context'
+import { clearDraft, getDraft } from '@/lib/composer-drafts'
 import { encodeBase64 } from '@/lib/utils'
 import FilesPage from './files'
 
@@ -20,6 +21,12 @@ const mocks = vi.hoisted(() => ({
         onSessionReopened?: (newSessionId: string) => void | Promise<void>
     },
     search: {} as { tab?: 'changes' | 'directories'; query?: string },
+    gitStatus: {
+        status: null as null | Record<string, unknown>,
+        error: null as null | string,
+        isLoading: false,
+        refetch: vi.fn(),
+    },
 }))
 
 vi.mock('@tanstack/react-router', () => ({
@@ -50,12 +57,7 @@ vi.mock('@/hooks/queries/useSession', () => ({
 }))
 
 vi.mock('@/hooks/queries/useGitStatusFiles', () => ({
-    useGitStatusFiles: () => ({
-        status: null,
-        error: null,
-        isLoading: false,
-        refetch: vi.fn(),
-    }),
+    useGitStatusFiles: () => mocks.gitStatus,
 }))
 
 vi.mock('@/hooks/queries/useSessionFileSearch', () => ({
@@ -101,6 +103,11 @@ function renderFilesPage() {
         </QueryClientProvider>
     )
 }
+
+// Most tests do not render git rows; only the changes-row suite installs a status.
+beforeEach(() => {
+    mocks.gitStatus = { status: null, error: null, isLoading: false, refetch: vi.fn() }
+})
 
 describe('FilesPage search navigation', () => {
     beforeEach(() => {
@@ -253,5 +260,128 @@ describe('FilesPage reopen draft transfer', () => {
         renderFilesPage()
         const secondScrollRegion = document.querySelector('[data-hapi-session-files-scroll="true"]') as HTMLElement
         expect(secondScrollRegion.scrollTop).toBe(87)
+    })
+})
+
+describe('FilesPage file context menu', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.sessionId = 'session-1'
+        mocks.search = { tab: 'directories', query: '感' }
+        window.localStorage.clear()
+        window.sessionStorage.clear()
+        clearDraft('session-1')
+    })
+
+    it('adds a file to the composer draft and navigates back to the chat', () => {
+        renderFilesPage()
+
+        fireEvent.contextMenu(screen.getByRole('button', { name: /感言\.ts/ }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Add to composer' }))
+
+        expect(getDraft('session-1')).toBe('`src/感言.ts`')
+        expect(mocks.navigate).toHaveBeenCalledWith({
+            to: '/sessions/$sessionId',
+            params: { sessionId: 'session-1' },
+            resetScroll: false,
+        })
+    })
+
+    it('copies the absolute path resolved from the session workspace', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        })
+
+        renderFilesPage()
+
+        fireEvent.contextMenu(screen.getByRole('button', { name: /感言\.ts/ }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Copy absolute path' }))
+
+        await vi.waitFor(() => {
+            expect(writeText).toHaveBeenCalledWith('/workspace/project/src/感言.ts')
+        })
+    })
+})
+
+describe('FilesPage changes-row context menu', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mocks.sessionId = 'session-1'
+        mocks.search = {}
+        mocks.gitStatus = {
+            status: {
+                stagedFiles: [],
+                unstagedFiles: [{
+                    fileName: 'README.md',
+                    filePath: '',
+                    fullPath: 'README.md',
+                    status: 'modified',
+                    isStaged: false,
+                    linesAdded: 2,
+                    linesRemoved: 1,
+                }],
+                branch: 'main',
+                totalStaged: 0,
+                totalUnstaged: 1,
+            },
+            error: null,
+            isLoading: false,
+            refetch: vi.fn(),
+        }
+        window.localStorage.clear()
+        window.sessionStorage.clear()
+        clearDraft('session-1')
+    })
+
+    it('opens the menu on a git change row and adds it to the composer', () => {
+        renderFilesPage()
+
+        fireEvent.contextMenu(screen.getByText('README.md').closest('button')!)
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Add to composer' }))
+
+        expect(getDraft('session-1')).toBe('`README.md`')
+        expect(mocks.navigate).toHaveBeenCalledWith({
+            to: '/sessions/$sessionId',
+            params: { sessionId: 'session-1' },
+            resetScroll: false,
+        })
+    })
+
+    it('copies the absolute path for a git change row', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined)
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        })
+
+        renderFilesPage()
+
+        fireEvent.contextMenu(screen.getByText('README.md').closest('button')!)
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Copy absolute path' }))
+
+        await vi.waitFor(() => {
+            expect(writeText).toHaveBeenCalledWith('/workspace/project/README.md')
+        })
+    })
+
+    it('opens the menu on touch long-press and does not navigate on release', () => {
+        vi.useFakeTimers()
+        try {
+            renderFilesPage()
+            const row = screen.getByText('README.md').closest('button')!
+
+            fireEvent.touchStart(row, { touches: [{ clientX: 120, clientY: 240 }] })
+            act(() => {
+                vi.advanceTimersByTime(600)
+            })
+            expect(screen.getByRole('menuitem', { name: 'Copy path' })).toBeInTheDocument()
+
+            fireEvent.touchEnd(row, { changedTouches: [{ clientX: 120, clientY: 240 }] })
+            expect(mocks.navigate).not.toHaveBeenCalled()
+        } finally {
+            vi.useRealTimers()
+        }
     })
 })

--- a/web/src/routes/sessions/files.tsx
+++ b/web/src/routes/sessions/files.tsx
@@ -4,6 +4,11 @@ import { PRESERVE_SESSION_SIDEBAR_SCROLL } from '@/lib/sessionNavigation'
 import type { FileSearchItem, GitFileStatus } from '@/types/api'
 import { FileIcon } from '@/components/FileIcon'
 import { DirectoryTree } from '@/components/SessionFiles/DirectoryTree'
+import { FileActionMenu } from '@/components/FileActionMenu'
+import { useFileMenuTrigger } from '@/hooks/useFileMenuTrigger'
+import type { AnchoredMenuPoint } from '@/hooks/useAnchoredMenu'
+import { appendFileReferenceToComposerDraft } from '@/lib/file-composer'
+import { resolveAbsoluteFilePath } from '@/lib/file-path'
 import { SessionHeader } from '@/components/SessionHeader'
 import { LoadingState } from '@/components/LoadingState'
 import { useAppContext } from '@/lib/app-context'
@@ -257,15 +262,20 @@ function LineChanges(props: { added: number; removed: number }) {
 function GitFileRow(props: {
     file: GitFileStatus
     onOpen: () => void
+    onOpenMenu: (point: AnchoredMenuPoint) => void
     showDivider: boolean
 }) {
     const { t } = useTranslation()
     const subtitle = getProjectRootLabel(props.file.filePath, t)
+    const rowHandlers = useFileMenuTrigger({
+        onOpen: props.onOpen,
+        onOpenMenu: props.onOpenMenu,
+    })
 
     return (
         <button
             type="button"
-            onClick={props.onOpen}
+            {...rowHandlers}
             className={`flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-[var(--app-subtle-bg)] transition-colors ${props.showDivider ? 'border-b border-[var(--app-divider)]' : ''}`}
         >
             <FileIcon fileName={props.file.fileName} size={22} />
@@ -284,10 +294,15 @@ function GitFileRow(props: {
 function SearchResultRow(props: {
     file: FileSearchItem
     onOpen: () => void
+    onOpenMenu: (point: AnchoredMenuPoint) => void
     showDivider: boolean
 }) {
     const { locale } = useTranslation()
     const metadata = formatFileMetadata(props.file.size, props.file.modified, locale)
+    const rowHandlers = useFileMenuTrigger({
+        onOpen: props.onOpen,
+        onOpenMenu: props.onOpenMenu,
+    })
     const icon = props.file.fileType === 'file'
         ? <FileIcon fileName={props.file.fileName} size={22} />
         : <FolderIcon className="text-[var(--app-link)]" />
@@ -295,7 +310,7 @@ function SearchResultRow(props: {
     return (
         <button
             type="button"
-            onClick={props.onOpen}
+            {...rowHandlers}
             className={`flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-[var(--app-subtle-bg)] transition-colors ${props.showDivider ? 'border-b border-[var(--app-divider)]' : ''}`}
         >
             {icon}
@@ -343,7 +358,14 @@ export default function FilesPage() {
 
     const [activeTab, setActiveTab] = useState<FilesTab>(() => search.tab ?? readFilesTab())
     const [directorySort, setDirectorySort] = useState<DirectorySort>(readDirectorySort)
+    const [fileMenu, setFileMenu] = useState<{ path: string; point: AnchoredMenuPoint } | null>(null)
     const searchQuery = search.query ?? ''
+
+    const openFileMenu = useCallback((path: string, point: AnchoredMenuPoint) => {
+        setFileMenu({ path, point })
+    }, [])
+
+    const closeFileMenu = useCallback(() => setFileMenu(null), [])
 
     const setSearchQuery = useCallback((query: string) => {
         navigate({
@@ -424,6 +446,15 @@ export default function FilesPage() {
             ...PRESERVE_SESSION_SIDEBAR_SCROLL,
         })
     }, [activeTab, navigate, searchQuery, sessionId])
+
+    const handleAddFileToComposer = useCallback((path: string) => {
+        appendFileReferenceToComposerDraft(sessionId, path)
+        navigate({
+            to: '/sessions/$sessionId',
+            params: { sessionId },
+            ...PRESERVE_SESSION_SIDEBAR_SCROLL,
+        })
+    }, [navigate, sessionId])
 
     const branchLabel = getDetachedBranchLabel(gitStatus?.branch, t)
     const showGitErrorBanner = Boolean(gitError)
@@ -640,6 +671,7 @@ export default function FilesPage() {
                                         key={file.fullPath}
                                         file={file}
                                         onOpen={() => handleOpenFile(file.fullPath)}
+                                        onOpenMenu={(point) => openFileMenu(file.fullPath, point)}
                                         showDivider={index < sortedSearchResults.length - 1}
                                     />
                                 ))}
@@ -652,6 +684,7 @@ export default function FilesPage() {
                             sessionId={sessionId}
                             rootLabel={rootLabel}
                             onOpenFile={(path) => handleOpenFile(path)}
+                            onRequestFileMenu={openFileMenu}
                             sort={directorySort}
                         />
                     ) : gitLoading ? (
@@ -668,6 +701,7 @@ export default function FilesPage() {
                                             key={`staged-${file.fullPath}-${index}`}
                                             file={file}
                                             onOpen={() => handleOpenFile(file.fullPath, file.isStaged)}
+                                            onOpenMenu={(point) => openFileMenu(file.fullPath, point)}
                                             showDivider={index < gitStatus.stagedFiles.length - 1 || gitStatus.unstagedFiles.length > 0}
                                         />
                                     ))}
@@ -684,6 +718,7 @@ export default function FilesPage() {
                                             key={`unstaged-${file.fullPath}-${index}`}
                                             file={file}
                                             onOpen={() => handleOpenFile(file.fullPath, file.isStaged)}
+                                            onOpenMenu={(point) => openFileMenu(file.fullPath, point)}
                                             showDivider={index < gitStatus.unstagedFiles.length - 1}
                                         />
                                     ))}
@@ -705,6 +740,17 @@ export default function FilesPage() {
                     )}
                 </div>
             </div>
+
+            <FileActionMenu
+                isOpen={fileMenu !== null}
+                onClose={closeFileMenu}
+                relativePath={fileMenu?.path ?? ''}
+                absolutePath={resolveAbsoluteFilePath(session.metadata?.path, fileMenu?.path ?? '')}
+                anchorPoint={fileMenu?.point ?? { x: 0, y: 0 }}
+                onAddToComposer={() => {
+                    if (fileMenu) handleAddFileToComposer(fileMenu.path)
+                }}
+            />
         </div>
     )
 }


### PR DESCRIPTION
Closes #1807.

## What

Adds a context menu to file entries on the Files page — both the **Changes** rows and the **Directories** tree entries — with three actions:

- **Copy path** — workspace-relative path (e.g. `src/routes/sessions/file.tsx`)
- **Copy absolute path** — resolved against `session.metadata.path`
- **Add to composer** — appends a backticked reference to the session's composer draft and navigates back to the chat

Desktop opens it via right-click, mobile via long-press. It dismisses on Escape / outside pointer-down, repositions on resize/scroll, and focuses the first item.

## Screenshots

Changes tab (right-click on a file row):

![Changes tab context menu](https://files.catbox.moe/d26qun.png)

Directories tab (tree entry):

![Directories tab context menu](https://files.catbox.moe/0k5ukj.png)

After "Add to composer" (draft restored in the chat composer):

![Composer draft](https://files.catbox.moe/c6ivdo.png)

## Implementation notes

- Reuses existing primitives: `useLongPress` (right-click + long-press), `safeCopyToClipboard` + `usePlatform().haptic`, the composer draft store (`getDraft`/`saveDraft`), and the shared `CopyIcon` / `PlusCircleIcon`.
- Extracted the pointer-anchored menu lifecycle out of `SessionActionMenu` into a shared `useAnchoredMenu` hook (positioning, viewport clamping, outside-pointerdown/Escape dismissal, resize/scroll reflow, first-item focus). `SessionActionMenu` now uses it as well (net −104 lines there) and gained an `align: 'center' | 'start'` option so a pointer/context menu anchors its left edge at the cursor instead of centering on it.
- Extracted the per-row trigger boilerplate into `useFileMenuTrigger`.
- "Add to composer" is text-only: it does not read or upload file contents.
- Adds i18n keys for `en` and `zh-CN`.

## Testing

- `bun typecheck` — green
- `bun run test` — hub `1222 pass`, web `2968 pass`. The single web failure (`web/src/components/assistant-ui/markdown-a.test.tsx` → `StorageEvent` rejecting the plain-object `localStorage` shim) pre-exists on `main` and is unrelated to this change.
- New tests: `FileActionMenu.test.tsx` (8), `file-path.test.ts` (9), `file-composer.test.ts` (4), plus 2 integration cases in `files.test.tsx` (context menu → absolute-path copy; add-to-composer → draft + navigation).

## AI disclosure

Per the contributing policy: this change was AI-generated (HAPI wrapping `pi`) with model `deepseek/deepseek-v4-flash`.
