### PR TITLE
fix(ios): isolate HapiKit typography spacing test on main actor

### DIFF
--- a/ios/Packages/HapiKit/Tests/HapiUITests/TypographyTests.swift
+++ b/ios/Packages/HapiKit/Tests/HapiUITests/TypographyTests.swift
@@ -19,7 +19,8 @@ struct TypographyTests {
         #expect(large.headingSize(3) > large.bodySize)
     }
 
-    @Test func markdownMarginsAreBetweenBlocksNotStackedPadding() {
+    @Test @MainActor
+    func markdownMarginsAreBetweenBlocksNotStackedPadding() {
         let paragraph = MarkdownBlockNode.paragraph(AttributedString("Body"))
         let heading = MarkdownBlockNode.heading(level: 2, AttributedString("Heading"))
         #expect(MarkdownBlockListView.spacing(before: heading, after: nil) == 0)


### PR DESCRIPTION
## Summary

- Mark the Markdown spacing test as `@MainActor`.
- Keep the fix limited to the test target with no production behavior changes.

## Problem / Motivation

Swift 6 treats `MarkdownBlockListView.spacing(before:after:)` as main-actor isolated because it belongs to a SwiftUI `View`. The synchronous, nonisolated test method therefore fails to compile during the HapiKit package test job.

Annotating the affected test method with `@MainActor` aligns the test with the API's isolation requirements.

## Validation

- `git diff --check` — passed.
- `bun typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name fix-ios-typography-tests -Suite Root terminal-wrap-fidelity.spec.ts` — 2 tests passed.
- `bun run build` — passed.
- `swift test --package-path ios/Packages/HapiKit` — not run locally because the current environment is Windows without Swift/Xcode; macOS CI is required.

## Related Issues

Fixes #1810

## AI Disclosure

OpenAI Codex (GPT-5.6)