### PR TITLE
fix(ios): make transcript profile result handoff Sendable

### DIFF
--- a/ios/HapiTests/TranscriptFrameProfileTests.swift
+++ b/ios/HapiTests/TranscriptFrameProfileTests.swift
@@ -7,6 +7,38 @@ import XCTest
 @testable import Hapi
 @testable import HapiProtocol
 
+private struct DisplayProbeResult: Sendable {
+    let seconds: Double
+    let callbacks: Int
+    let callbackFPS: Double
+    let intervalP50Ms: Double
+    let intervalP95Ms: Double
+    let intervalP99Ms: Double
+    let maxIntervalMs: Double
+    let intervalsOver25Ms: Int
+    let intervalsOver50Ms: Int
+    let distancePoints: Double
+    let offsetUpdateMaxMs: Double
+    let intervalsMs: [Double]
+
+    var jsonObject: [String: Any] {
+        [
+            "seconds": seconds,
+            "callbacks": callbacks,
+            "callbackFPS": callbackFPS,
+            "intervalP50Ms": intervalP50Ms,
+            "intervalP95Ms": intervalP95Ms,
+            "intervalP99Ms": intervalP99Ms,
+            "maxIntervalMs": maxIntervalMs,
+            "intervalsOver25Ms": intervalsOver25Ms,
+            "intervalsOver50Ms": intervalsOver50Ms,
+            "distancePoints": distancePoints,
+            "offsetUpdateMaxMs": offsetUpdateMaxMs,
+            "intervalsMs": intervalsMs,
+        ]
+    }
+}
+
 /// Opt-in, real-vsync diagnostic. No FPS assertion: host load affects Simulator.
 /// CADisplayLink cadence is NOT compositor-presented FPS; correlate with Instruments.
 @MainActor
@@ -122,7 +154,7 @@ final class TranscriptFrameProfileTests: XCTestCase {
                 }
                 let result = await probe.run()
                 os_signpost(.end, log: log, name: "Transcript Scroll", signpostID: signpost)
-                var record = result
+                var record = result.jsonObject
                 record["scenario"] = scenario
                 record["repetition"] = repetition
                 record["rows"] = 800
@@ -138,7 +170,7 @@ final class TranscriptFrameProfileTests: XCTestCase {
                 attachment.name = label
                 attachment.lifetime = .keepAlways
                 add(attachment)
-                XCTAssertGreaterThan(result["distancePoints"] as? Double ?? 0, 5_000, "Probe must actually scroll")
+                XCTAssertGreaterThan(result.distancePoints, 5_000, "Probe must actually scroll")
             }
         }
     }
@@ -150,7 +182,7 @@ final class TranscriptFrameProfileTests: XCTestCase {
         let speed: Double
         let update: (Double) -> Void
         var link: CADisplayLink?
-        var continuation: CheckedContinuation<[String: Any], Never>?
+        var continuation: CheckedContinuation<DisplayProbeResult, Never>?
         var began: Double?
         var previous: Double?
         var intervals: [Double] = []
@@ -164,7 +196,7 @@ final class TranscriptFrameProfileTests: XCTestCase {
             self.update = update
         }
 
-        func run() async -> [String: Any] {
+        func run() async -> DisplayProbeResult {
             await withCheckedContinuation { continuation in
                 self.continuation = continuation
                 initialOffset = collection.contentOffset.y
@@ -186,17 +218,20 @@ final class TranscriptFrameProfileTests: XCTestCase {
                 self.link = nil
                 let sorted = intervals.sorted()
                 func percentile(_ p: Double) -> Double { sorted[min(sorted.count - 1, Int(Double(sorted.count - 1) * p))] }
-                let result: [String: Any] = [
-                    "seconds": elapsed, "callbacks": intervals.count,
-                    "callbackFPS": Double(intervals.count) / elapsed,
-                    "intervalP50Ms": percentile(0.5), "intervalP95Ms": percentile(0.95),
-                    "intervalP99Ms": percentile(0.99), "maxIntervalMs": sorted.last ?? 0,
-                    "intervalsOver25Ms": intervals.filter { $0 > 25 }.count,
-                    "intervalsOver50Ms": intervals.filter { $0 > 50 }.count,
-                    "distancePoints": collection.contentOffset.y - initialOffset,
-                    "offsetUpdateMaxMs": updateTimes.max() ?? 0,
-                    "intervalsMs": intervals,
-                ]
+                let result = DisplayProbeResult(
+                    seconds: elapsed,
+                    callbacks: intervals.count,
+                    callbackFPS: Double(intervals.count) / elapsed,
+                    intervalP50Ms: percentile(0.5),
+                    intervalP95Ms: percentile(0.95),
+                    intervalP99Ms: percentile(0.99),
+                    maxIntervalMs: sorted.last ?? 0,
+                    intervalsOver25Ms: intervals.filter { $0 > 25 }.count,
+                    intervalsOver50Ms: intervals.filter { $0 > 50 }.count,
+                    distancePoints: Double(collection.contentOffset.y - initialOffset),
+                    offsetUpdateMaxMs: updateTimes.max() ?? 0,
+                    intervalsMs: intervals
+                )
                 continuation?.resume(returning: result)
                 continuation = nil
                 return


### PR DESCRIPTION
## Summary

- Replace the non-`Sendable` continuation result dictionary with a typed `Sendable` value.
- Convert the typed result to the existing JSON object format only after the actor handoff.
- Preserve the profiling output schema and opt-in runtime behavior.

## Problem / Motivation

`DisplayProbe` is `@MainActor`-isolated, but it resumed a `CheckedContinuation<[String: Any], Never>` with a dictionary created on the main actor. Under Swift 6 concurrency checking, `[String: Any]` is not `Sendable`, so the compiler reports a potential data race at `resume(returning:)`.

The fix uses a `Sendable` result structure containing only value-semantic numeric data. JSON conversion remains on the receiving side after the continuation resumes.

The relevant failure is in the transcript regression test step invoked by `ios/scripts/test-transcript.sh`; the standalone app build itself was confirmed to succeed by CI.

## Validation

- `git diff --check` — passed.
- `bun typecheck` — passed.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name fix-ios-transcript-data-race -Suite Root terminal-wrap-fidelity.spec.ts` — 2 tests passed.
- `bun run build` — passed.
- `xcodebuild build -project ios/Hapi.xcodeproj -scheme Hapi -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` — not run locally because the current environment is Windows without Xcode.
- `ios/scripts/test-transcript.sh` — not run locally because the current environment is Windows without Xcode or an iOS Simulator.

## Related Issues

Fixes #1811

## AI Disclosure

OpenAI Codex (GPT-5.6)