### PR TITLE
fix(agy): allow switching existing sessions to newly available models

### DIFF
--- a/cli/src/api/apiMachine.ts
+++ b/cli/src/api/apiMachine.ts
@@ -29,6 +29,7 @@ import { backoff } from '@/utils/time'
 import { getInvokedCwd } from '@/utils/invokedCwd'
 import { RpcHandlerManager } from './rpc/RpcHandlerManager'
 import { registerCommonHandlers } from '../modules/common/registerCommonHandlers'
+import { setAgyCatalogChangeListener } from '../modules/common/agyModels'
 import {
     listOpencodeModelsForCwd,
     type ListOpencodeModelsForCwdRequest,
@@ -121,6 +122,12 @@ export class ApiMachineClient {
         })
 
         registerCommonHandlers(this.rpcHandlerManager, getInvokedCwd())
+
+        // Only the machine daemon answers `<machineId>:listAgyModels`, so it is
+        // the one process that can tell the hub its catalog moved.
+        setAgyCatalogChangeListener(() => {
+            this.socket.emit('machine-agy-models-changed', { machineId: this.machine.id })
+        })
 
         this.rpcHandlerManager.registerHandler<unknown, AgentAvailabilityResponse>(
             RPC_METHODS.AgentAvailability,
@@ -676,6 +683,8 @@ export class ApiMachineClient {
 
     shutdown(): void {
         this.stopKeepAlive()
+        // The listener holds this client, and the socket is about to close.
+        setAgyCatalogChangeListener(null)
         if (this.socket) {
             this.socket.close()
         }

--- a/cli/src/modules/common/agyModels.test.ts
+++ b/cli/src/modules/common/agyModels.test.ts
@@ -245,3 +245,258 @@ describe('listAgyModels live probe', () => {
         expect(result.availableModels?.length).toBeGreaterThan(0)
     })
 })
+
+describe('listAgyModels catalog cache', () => {
+    const LIVE_A = 'gemini-3.6-flash-low\tGemini 3.6 Flash (Low)\n'
+    const LIVE_B = 'gemini-3.8-flash-high\tGemini 3.8 Flash (High)\n'
+    const AUTH_FAILURE = 'Authentication required\n'
+    const CATALOG_A = [{ modelId: 'gemini-3.6-flash-low', name: 'Gemini 3.6 Flash (Low)' }]
+    const CATALOG_B = [{ modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' }]
+
+    function queueProbe() {
+        const child = fakeChild()
+        spawnMock.mockReturnValueOnce(child)
+        return child
+    }
+
+    function finish(child: ReturnType<typeof fakeChild>, output: string) {
+        child.stdout.emit('data', Buffer.from(output))
+        child.emit('exit', 0)
+    }
+
+    async function primeCatalog(output = LIVE_A) {
+        const child = queueProbe()
+        const pending = listAgyModels()
+        await Promise.resolve()
+        finish(child, output)
+        return await pending
+    }
+
+    it('probes agy when nothing is cached yet', async () => {
+        vi.useFakeTimers()
+        const result = await primeCatalog()
+
+        expect(spawnMock).toHaveBeenCalledTimes(1)
+        expect(result.availableModels).toEqual(CATALOG_A)
+    })
+
+    it('answers from the cache without probing again inside the fresh window', async () => {
+        vi.useFakeTimers()
+        await primeCatalog()
+
+        await vi.advanceTimersByTimeAsync(9 * 60_000)
+        const result = await listAgyModels()
+
+        expect(spawnMock).toHaveBeenCalledTimes(1)
+        expect(result.availableModels).toEqual(CATALOG_A)
+    })
+
+    it('answers from the stale catalog immediately and refreshes behind it', async () => {
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+        await vi.advanceTimersByTimeAsync(11 * 60_000)
+
+        const refresh = queueProbe()
+        const stale = await listAgyModels()
+        expect(stale.availableModels).toEqual(CATALOG_A)
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+
+        finish(refresh, LIVE_B)
+        await vi.advanceTimersByTimeAsync(0)
+
+        const refreshed = await listAgyModels()
+        expect(refreshed.availableModels).toEqual(CATALOG_B)
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('runs one probe for callers that arrive together with nothing cached', async () => {
+        vi.useFakeTimers()
+        const child = queueProbe()
+        const first = listAgyModels()
+        const second = listAgyModels()
+        await Promise.resolve()
+        finish(child, LIVE_A)
+
+        const [a, b] = await Promise.all([first, second])
+        expect(spawnMock).toHaveBeenCalledTimes(1)
+        expect(a.availableModels).toEqual(CATALOG_A)
+        expect(b.availableModels).toEqual(CATALOG_A)
+    })
+
+    it('keeps the last known catalog when the background refresh loses auth', async () => {
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+        await vi.advanceTimersByTimeAsync(11 * 60_000)
+
+        const failing = queueProbe()
+        await listAgyModels()
+        finish(failing, AUTH_FAILURE)
+        await vi.advanceTimersByTimeAsync(0)
+
+        const afterFailure = queueProbe()
+        const result = await listAgyModels()
+        expect(result.success).toBe(true)
+        expect(result.availableModels).toEqual(CATALOG_A)
+        finish(afterFailure, AUTH_FAILURE)
+        await vi.advanceTimersByTimeAsync(0)
+    })
+
+    it('stops serving a catalog older than a day and waits for the probe', async () => {
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+        await vi.advanceTimersByTimeAsync(24 * 60 * 60_000 + 1_000)
+
+        const child = queueProbe()
+        const pending = listAgyModels()
+        await Promise.resolve()
+        finish(child, LIVE_B)
+
+        const result = await pending
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+        expect(result.availableModels).toEqual(CATALOG_B)
+    })
+
+    it('probes again on an explicit refresh even while the catalog is fresh', async () => {
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+
+        const child = queueProbe()
+        const pending = listAgyModels({ refresh: true })
+        await Promise.resolve()
+        finish(child, LIVE_B)
+
+        const result = await pending
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+        expect(result.availableModels).toEqual(CATALOG_B)
+    })
+
+    it('falls back to the last known catalog when a forced refresh cannot reach agy', async () => {
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+
+        queueProbe()
+        const pending = listAgyModels({ refresh: true })
+        await vi.advanceTimersByTimeAsync(15_000)
+
+        const result = await pending
+        expect(result.success).toBe(true)
+        expect(result.availableModels).toEqual(CATALOG_A)
+    })
+
+    it('answers from the hardcoded mirror without spawning agy again right after a failed probe', async () => {
+        // Each probe on an unreachable machine costs the full timeout.
+        vi.useFakeTimers()
+        queueProbe()
+        const firstPending = listAgyModels()
+        await vi.advanceTimersByTimeAsync(15_000)
+        const fallback = await firstPending
+        expect(fallback.availableModels?.length).toBeGreaterThan(0)
+
+        const backedOff = await listAgyModels()
+        expect(spawnMock).toHaveBeenCalledTimes(1)
+        expect(backedOff.availableModels?.length).toBeGreaterThan(0)
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        const second = queueProbe()
+        const secondPending = listAgyModels()
+        await Promise.resolve()
+        finish(second, LIVE_B)
+
+        const live = await secondPending
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+        expect(live.availableModels).toEqual(CATALOG_B)
+    })
+
+    it('does not let a forced refresh be answered by the probe that was already running', async () => {
+        // The user signs in while a background revalidation is mid-flight; the
+        // answer they get back has to come from a probe that started after that.
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+        await vi.advanceTimersByTimeAsync(11 * 60_000)
+
+        const stalled = queueProbe()
+        await listAgyModels()
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+
+        const forced = queueProbe()
+        const pending = listAgyModels({ refresh: true })
+        finish(stalled, AUTH_FAILURE)
+        await vi.advanceTimersByTimeAsync(0)
+        finish(forced, LIVE_B)
+
+        const result = await pending
+        expect(spawnMock).toHaveBeenCalledTimes(3)
+        expect(result.availableModels).toEqual(CATALOG_B)
+    })
+
+    it('reports a sign-in failure alongside the catalog it can still serve', async () => {
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+
+        const failing = queueProbe()
+        const pending = listAgyModels({ refresh: true })
+        await Promise.resolve()
+        finish(failing, AUTH_FAILURE)
+
+        const forced = await pending
+        expect(forced.success).toBe(true)
+        expect(forced.availableModels).toEqual(CATALOG_A)
+        expect(forced.error).toContain('Authentication required')
+
+        expect(await listAgyModels()).toMatchObject({ success: true, error: expect.stringContaining('Authentication required') })
+    })
+
+    it('keeps looking for a sign-in that came back, even while the catalog is fresh', async () => {
+        // The user pressed Retry, it failed, then they signed in. Nothing else
+        // would re-probe a catalog that is still inside its fresh window.
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+
+        const failing = queueProbe()
+        const retry = listAgyModels({ refresh: true })
+        await Promise.resolve()
+        finish(failing, AUTH_FAILURE)
+        expect(await retry).toMatchObject({ error: expect.stringContaining('Authentication required') })
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+
+        await listAgyModels()
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        const recovered = queueProbe()
+        const served = await listAgyModels()
+        expect(served.availableModels).toEqual(CATALOG_A)
+        expect(spawnMock).toHaveBeenCalledTimes(3)
+
+        finish(recovered, LIVE_B)
+        await vi.advanceTimersByTimeAsync(0)
+        const afterSignIn = await listAgyModels()
+        expect(afterSignIn.availableModels).toEqual(CATALOG_B)
+        expect(afterSignIn.error).toBeUndefined()
+    })
+
+    it('revalidates instead of trusting an entry the clock has thrown into the future', async () => {
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+
+        vi.setSystemTime(Date.now() - 2 * 24 * 60 * 60_000)
+        const probe = queueProbe()
+        const served = await listAgyModels()
+        expect(served.availableModels).toEqual(CATALOG_A)
+        expect(spawnMock).toHaveBeenCalledTimes(2)
+        finish(probe, LIVE_B)
+        await vi.advanceTimersByTimeAsync(0)
+    })
+
+    it('surfaces the auth failure when there is no catalog to fall back on', async () => {
+        vi.useFakeTimers()
+        const child = queueProbe()
+        const pending = listAgyModels()
+        await Promise.resolve()
+        finish(child, AUTH_FAILURE)
+
+        const result = await pending
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('Authentication required')
+    })
+})

--- a/cli/src/modules/common/agyModels.test.ts
+++ b/cli/src/modules/common/agyModels.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { AGY_MODEL_LABELS, AGY_MODEL_PRESETS } from '@hapi/protocol'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const spawnMock = vi.hoisted(() => vi.fn())
@@ -8,10 +9,17 @@ import {
     _parseAgyModelsJsonForTests,
     _parseAgyModelsOutputForTests,
     _resetAgyModelsCacheForTests,
-    listAgyModels
+    listAgyModels,
+    setAgyCatalogChangeListener
 } from './agyModels'
 
 // Real `agy --output-format=json models` capture, trimmed to four models.
+// The exact listing the hardcoded mirror produces, so a probe can land "no
+// change at all" for a caller that was being served that mirror.
+const MIRROR_LISTING = AGY_MODEL_PRESETS
+    .map((id) => `${id}\t${AGY_MODEL_LABELS[id as keyof typeof AGY_MODEL_LABELS]}`)
+    .join('\n') + '\n'
+
 const JSON_LISTING = JSON.stringify({
     conversation_id: '',
     status: 'SUCCESS',
@@ -473,6 +481,179 @@ describe('listAgyModels catalog cache', () => {
         const afterSignIn = await listAgyModels()
         expect(afterSignIn.availableModels).toEqual(CATALOG_B)
         expect(afterSignIn.error).toBeUndefined()
+    })
+
+    it('announces a background refresh that actually changed the listing', async () => {
+        vi.useFakeTimers()
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await primeCatalog(LIVE_A)
+        expect(changes).toHaveLength(0)
+
+        await vi.advanceTimersByTimeAsync(11 * 60_000)
+        const refresh = queueProbe()
+        expect((await listAgyModels()).availableModels).toEqual(CATALOG_A)
+        finish(refresh, LIVE_B)
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(changes).toHaveLength(1)
+        expect((await listAgyModels()).availableModels).toEqual(CATALOG_B)
+    })
+
+    it('stays quiet when the refresh comes back with the same listing', async () => {
+        vi.useFakeTimers()
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await primeCatalog(LIVE_A)
+        await vi.advanceTimersByTimeAsync(11 * 60_000)
+        const refresh = queueProbe()
+        await listAgyModels()
+        finish(refresh, LIVE_A)
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(changes).toHaveLength(0)
+    })
+
+    it('stays quiet on the very first fetch — whoever asked is already awaiting it', async () => {
+        vi.useFakeTimers()
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await primeCatalog(LIVE_A)
+
+        expect(changes).toHaveLength(0)
+    })
+
+    it('does not announce anything on the read that follows an announced change', async () => {
+        // The announcement makes clients re-read. That read must not start another
+        // probe, or the machine would talk itself round in a circle.
+        vi.useFakeTimers()
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await primeCatalog(LIVE_A)
+        await vi.advanceTimersByTimeAsync(11 * 60_000)
+        const refresh = queueProbe()
+        await listAgyModels()
+        finish(refresh, LIVE_B)
+        await vi.advanceTimersByTimeAsync(0)
+        expect(changes).toHaveLength(1)
+
+        const spawnsBefore = spawnMock.mock.calls.length
+        expect((await listAgyModels()).availableModels).toEqual(CATALOG_B)
+        expect(spawnMock).toHaveBeenCalledTimes(spawnsBefore)
+        expect(changes).toHaveLength(1)
+    })
+
+    it('announces a sign-in that came back even when the listing is identical', async () => {
+        // The response the picker renders is the listing AND the warning beside
+        // it. Recovery clears the warning while leaving the list alone, and an
+        // open picker would otherwise keep accusing a user who already fixed it.
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+
+        const failing = queueProbe()
+        const retry = listAgyModels({ refresh: true })
+        await Promise.resolve()
+        finish(failing, AUTH_FAILURE)
+        expect(await retry).toMatchObject({ error: expect.stringContaining('Authentication required') })
+
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        const recovering = queueProbe()
+        await listAgyModels()
+        finish(recovering, LIVE_A)
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(changes).toHaveLength(1)
+        expect(await listAgyModels()).toMatchObject({ success: true, availableModels: CATALOG_A })
+        expect((await listAgyModels()).error).toBeUndefined()
+    })
+
+    it('announces a sign-in that lapsed even when the listing is identical', async () => {
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await vi.advanceTimersByTimeAsync(11 * 60_000)
+        const failing = queueProbe()
+        await listAgyModels()
+        finish(failing, AUTH_FAILURE)
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(changes).toHaveLength(1)
+        expect((await listAgyModels()).error).toContain('Authentication required')
+    })
+
+    it('does not announce a failure that changes nothing the picker shows', async () => {
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+
+        await vi.advanceTimersByTimeAsync(11 * 60_000)
+        const first = queueProbe()
+        await listAgyModels()
+        finish(first, AUTH_FAILURE)
+        await vi.advanceTimersByTimeAsync(0)
+
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        const second = queueProbe()
+        await listAgyModels()
+        finish(second, AUTH_FAILURE)
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(changes).toHaveLength(0)
+    })
+
+    it('announces the first live listing to everyone who was already being served the mirror', async () => {
+        // One client asked while agy was signed out and got the hardcoded
+        // mirror; nothing is cached. Another client's probe then lands the real
+        // listing. The first client is holding a list that is now wrong, and
+        // only an announcement can tell it.
+        vi.useFakeTimers()
+        queueProbe()
+        const cold = listAgyModels()
+        await vi.advanceTimersByTimeAsync(15_000)
+        expect((await cold).availableModels?.length).toBeGreaterThan(2)
+
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        const recovered = queueProbe()
+        const second = listAgyModels()
+        await Promise.resolve()
+        finish(recovered, LIVE_A)
+        expect((await second).availableModels).toEqual(CATALOG_A)
+
+        expect(changes).toHaveLength(1)
+    })
+
+    it('does not announce a change to an entry that had already stopped being served', async () => {
+        // Past the stale bound the route already answers from the mirror, so
+        // re-landing that same mirror changes nothing anyone could see.
+        vi.useFakeTimers()
+        await primeCatalog(LIVE_A)
+        await vi.advanceTimersByTimeAsync(24 * 60 * 60_000 + 1_000)
+
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        // Built from the presets the fallback uses, so the answer is unchanged.
+        const mirrorProbe = queueProbe()
+        const expired = listAgyModels()
+        await Promise.resolve()
+        finish(mirrorProbe, MIRROR_LISTING)
+        await expired
+
+        expect(changes).toHaveLength(0)
     })
 
     it('revalidates instead of trusting an entry the clock has thrown into the future', async () => {

--- a/cli/src/modules/common/agyModels.test.ts
+++ b/cli/src/modules/common/agyModels.test.ts
@@ -656,6 +656,59 @@ describe('listAgyModels catalog cache', () => {
         expect(changes).toHaveLength(0)
     })
 
+    it('announces a sign-in failure that replaces the fallback listing with an error', async () => {
+        // Nothing has ever been cached, so the route has been answering from the
+        // built-in list. A sign-in failure replaces that with an error — the
+        // picker loses its models — and an open one has to be told.
+        vi.useFakeTimers()
+        queueProbe()
+        const cold = listAgyModels()
+        await vi.advanceTimersByTimeAsync(15_000)
+        expect((await cold).availableModels?.length).toBeGreaterThan(2)
+
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        const failing = queueProbe()
+        const second = listAgyModels()
+        await Promise.resolve()
+        finish(failing, AUTH_FAILURE)
+
+        expect(await second).toMatchObject({ success: false })
+        expect(changes).toHaveLength(1)
+    })
+
+    it('announces a sign-in that came back even when the listing matches the fallback', async () => {
+        // From an uncached auth failure the route answers an error. A listing
+        // that happens to equal the built-in one still turns that error back
+        // into a usable picker.
+        vi.useFakeTimers()
+        queueProbe()
+        const cold = listAgyModels()
+        await vi.advanceTimersByTimeAsync(15_000)
+        await cold
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        const failing = queueProbe()
+        const errored = listAgyModels()
+        await Promise.resolve()
+        finish(failing, AUTH_FAILURE)
+        expect(await errored).toMatchObject({ success: false })
+
+        const changes: number[] = []
+        setAgyCatalogChangeListener(() => changes.push(Date.now()))
+
+        await vi.advanceTimersByTimeAsync(60_000)
+        const recovering = queueProbe()
+        const recovered = listAgyModels()
+        await Promise.resolve()
+        finish(recovering, MIRROR_LISTING)
+
+        expect(await recovered).toMatchObject({ success: true })
+        expect(changes).toHaveLength(1)
+    })
+
     it('revalidates instead of trusting an entry the clock has thrown into the future', async () => {
         vi.useFakeTimers()
         await primeCatalog(LIVE_A)

--- a/cli/src/modules/common/agyModels.ts
+++ b/cli/src/modules/common/agyModels.ts
@@ -15,17 +15,33 @@ const PROBE_TIMEOUT_MS = 15_000
 
 type AgyCatalog = NonNullable<AgyModelsResponse['availableModels']>
 
-interface CacheEntry {
-    expiresAt: number
-    response: ListAgyModelsResponse
+// A probe is a whole agy invocation, so the catalog is served from the last one
+// agy answered. STALE_TTL_MS is the outer bound on that trust: past it the
+// listing stops standing in for the machine even if probes keep failing.
+const FRESH_TTL_MS = 10 * 60_000
+const STALE_TTL_MS = 24 * 60 * 60_000
+
+// Floor between probes after one comes back empty. On a machine where agy hangs
+// on sign-in each attempt costs PROBE_TIMEOUT_MS, and both pickers ask.
+const PROBE_BACKOFF_MS = 60_000
+
+interface CachedCatalog {
+    models: AgyCatalog
+    fetchedAt: number
 }
 
-const CACHE_TTL_MS = 60_000
-const cache: CacheEntry = {
-    expiresAt: 0,
-    response: { success: true, availableModels: [] }
-}
-let inflight: Promise<ListAgyModelsResponse> | null = null
+// Only a live listing lands here, never the hardcoded mirror: the mirror is a
+// stand-in, not something the machine observed, and caching it would pin the
+// picker to it for a whole TTL after a single timeout.
+let cachedCatalog: CachedCatalog | null = null
+
+// Kept for two reasons: it rate-limits retries, and an auth failure has to reach
+// the user even while a cached listing is still being served.
+let lastFailedProbe: { at: number; result: AgyCatalogFetch } | null = null
+
+// The machine daemon owns `machineId:listAgyModels`, so this module runs once
+// per machine — hence no keying.
+let inflight: Promise<AgyCatalogFetch> | null = null
 
 // What one round of asking agy produced. `unavailable` covers every way the
 // listing failed to arrive (spawn failure, timeout, output neither parser
@@ -256,35 +272,22 @@ async function fetchAgyCatalog(): Promise<AgyCatalogFetch> {
     return retryParsed ? { kind: 'live', models: retryParsed } : { kind: 'unavailable' }
 }
 
-function toResponse(fetched: AgyCatalogFetch): ListAgyModelsResponse {
-    if (fetched.kind === 'live') {
-        return { success: true, availableModels: fetched.models }
-    }
-    if (fetched.kind === 'auth-error') {
-        return { success: false, error: fetched.error }
-    }
-    return { success: true, availableModels: buildModelList() }
-}
-
-export async function listAgyModels(): Promise<ListAgyModelsResponse> {
-    if (cache.expiresAt > Date.now() && (cache.response.availableModels?.length ?? 0) > 0) {
-        return cache.response
-    }
-
-    if (inflight) {
-        return inflight
-    }
-
-    inflight = (async () => {
+function startProbe(): Promise<AgyCatalogFetch> {
+    inflight = (async (): Promise<AgyCatalogFetch> => {
         try {
-            const response = toResponse(await fetchAgyCatalog())
-            if (response.success && (response.availableModels?.length ?? 0) > 0) {
-                cache.expiresAt = Date.now() + CACHE_TTL_MS
-                cache.response = response
+            const fetched = await fetchAgyCatalog()
+            if (fetched.kind === 'live') {
+                cachedCatalog = { models: fetched.models, fetchedAt: Date.now() }
+                // agy answered, so whatever went wrong before is over.
+                lastFailedProbe = null
+            } else {
+                lastFailedProbe = { at: Date.now(), result: fetched }
             }
-            return response
+            return fetched
         } catch {
-            return { success: true, availableModels: buildModelList() }
+            const result: AgyCatalogFetch = { kind: 'unavailable' }
+            lastFailedProbe = { at: Date.now(), result }
+            return result
         } finally {
             inflight = null
         }
@@ -293,8 +296,87 @@ export async function listAgyModels(): Promise<ListAgyModelsResponse> {
     return inflight
 }
 
+async function refreshCatalog(force: boolean): Promise<AgyCatalogFetch> {
+    // A probe already running when Retry was pressed predates whatever the user
+    // just fixed in the terminal, so wait it out rather than answer from it.
+    if (force && inflight) {
+        await inflight.catch(() => { })
+    }
+    if (inflight) {
+        return await inflight
+    }
+    if (!force && lastFailedProbe && Date.now() - lastFailedProbe.at < PROBE_BACKOFF_MS) {
+        return lastFailedProbe.result
+    }
+
+    return await startProbe()
+}
+
+// Servable and fresh are asked separately because the clock can step backwards
+// (NTP, suspend/resume): an age we cannot trust is still the last thing agy told
+// us, so it stays servable, but it must never count as fresh or nothing would
+// revalidate it.
+function cachedCatalogAge(): number {
+    return cachedCatalog ? Date.now() - cachedCatalog.fetchedAt : Number.POSITIVE_INFINITY
+}
+
+function isCachedCatalogFresh(): boolean {
+    const age = cachedCatalogAge()
+    return age >= 0 && age < FRESH_TTL_MS
+}
+
+function servableCatalog(): ListAgyModelsResponse | null {
+    if (!cachedCatalog || cachedCatalogAge() >= STALE_TTL_MS) {
+        return null
+    }
+
+
+    const response: ListAgyModelsResponse = { success: true, availableModels: cachedCatalog.models }
+    // A sign-in failure rides along with the listing: a picker that looked
+    // healthy would let the user start a session agy cannot run.
+    if (lastFailedProbe?.result.kind === 'auth-error') {
+        response.error = lastFailedProbe.result.error
+    }
+    return response
+}
+
+function toResponse(fetched: AgyCatalogFetch): ListAgyModelsResponse {
+    if (fetched.kind === 'live') {
+        return { success: true, availableModels: fetched.models }
+    }
+
+    // A failed probe is not evidence that the catalog changed.
+    const cached = servableCatalog()
+    if (cached) {
+        return cached
+    }
+    if (fetched.kind === 'auth-error') {
+        return { success: false, error: fetched.error }
+    }
+    return { success: true, availableModels: buildModelList() }
+}
+
+export async function listAgyModels(options?: { refresh?: boolean }): Promise<ListAgyModelsResponse> {
+    // Retry is the user saying the cached answer is wrong, so it costs a probe.
+    if (options?.refresh === true) {
+        return toResponse(await refreshCatalog(true))
+    }
+
+    const cached = servableCatalog()
+    if (cached) {
+        // A warning is itself a reason to look again — the user may have signed
+        // in since, and nothing else revalidates a catalog that is still fresh.
+        if (!isCachedCatalogFresh() || lastFailedProbe) {
+            void refreshCatalog(false).catch(() => { })
+        }
+        return cached
+    }
+
+    return toResponse(await refreshCatalog(false))
+}
+
 export function _resetAgyModelsCacheForTests(): void {
-    cache.expiresAt = 0
-    cache.response = { success: true, availableModels: [] }
+    cachedCatalog = null
+    lastFailedProbe = null
     inflight = null
 }

--- a/cli/src/modules/common/agyModels.ts
+++ b/cli/src/modules/common/agyModels.ts
@@ -13,6 +13,8 @@ const AUTH_REQUIRED_PATTERNS = [
 
 const PROBE_TIMEOUT_MS = 15_000
 
+type AgyCatalog = NonNullable<AgyModelsResponse['availableModels']>
+
 interface CacheEntry {
     expiresAt: number
     response: ListAgyModelsResponse
@@ -24,6 +26,14 @@ const cache: CacheEntry = {
     response: { success: true, availableModels: [] }
 }
 let inflight: Promise<ListAgyModelsResponse> | null = null
+
+// What one round of asking agy produced. `unavailable` covers every way the
+// listing failed to arrive (spawn failure, timeout, output neither parser
+// could read) — none of them say anything about the catalog itself.
+type AgyCatalogFetch =
+    | { kind: 'live'; models: AgyCatalog }
+    | { kind: 'auth-error'; error: string }
+    | { kind: 'unavailable' }
 
 // Hardcoded list — used as a FALLBACK only (when `agy models` can't be reached)
 // and as the source of truth for name→id mapping of known models.
@@ -207,18 +217,18 @@ function probeAgyModels(args: string[]): Promise<AgyModelsProbe> {
 // picker always matches what agy currently offers — no redeploy when agy changes
 // models. The hardcoded mirror is only a fallback (timeout / spawn error /
 // unparseable output). An auth failure is surfaced so the UI can prompt sign-in.
-async function fetchAgyModels(): Promise<ListAgyModelsResponse> {
+async function fetchAgyCatalog(): Promise<AgyCatalogFetch> {
     // `--output-format` is a global flag: it has to come before the subcommand,
     // and agy only accepts the `=` form here. Releases that predate it ignore
     // the flag and print the table, which the text parser still understands.
     const probe = await probeAgyModels(['--output-format=json', 'models'])
     if ('unreachable' in probe) {
-        return { success: true, availableModels: buildModelList() }
+        return { kind: 'unavailable' }
     }
 
     const authError = checkOutputForAuthError(probe.output)
     if (authError) {
-        return { success: false, error: authError }
+        return { kind: 'auth-error', error: authError }
     }
 
     // Prefer the structured listing, then the printed table for agy releases
@@ -226,7 +236,7 @@ async function fetchAgyModels(): Promise<ListAgyModelsResponse> {
     // (format change, partial fetch, etc.).
     const parsed = parseAgyModelsJson(probe.output) ?? parseAgyModelsOutput(probe.output)
     if (parsed) {
-        return { success: true, availableModels: parsed }
+        return { kind: 'live', models: parsed }
     }
 
     // Nothing readable came back. Every agy release checked ignores an unknown
@@ -236,13 +246,24 @@ async function fetchAgyModels(): Promise<ListAgyModelsResponse> {
     // costs a second invocation on builds that produced nothing usable.
     const retry = await probeAgyModels(['models'])
     if ('unreachable' in retry) {
-        return { success: true, availableModels: buildModelList() }
+        return { kind: 'unavailable' }
     }
     const retryAuthError = checkOutputForAuthError(retry.output)
     if (retryAuthError) {
-        return { success: false, error: retryAuthError }
+        return { kind: 'auth-error', error: retryAuthError }
     }
-    return { success: true, availableModels: parseAgyModelsOutput(retry.output) ?? buildModelList() }
+    const retryParsed = parseAgyModelsOutput(retry.output)
+    return retryParsed ? { kind: 'live', models: retryParsed } : { kind: 'unavailable' }
+}
+
+function toResponse(fetched: AgyCatalogFetch): ListAgyModelsResponse {
+    if (fetched.kind === 'live') {
+        return { success: true, availableModels: fetched.models }
+    }
+    if (fetched.kind === 'auth-error') {
+        return { success: false, error: fetched.error }
+    }
+    return { success: true, availableModels: buildModelList() }
 }
 
 export async function listAgyModels(): Promise<ListAgyModelsResponse> {
@@ -256,7 +277,7 @@ export async function listAgyModels(): Promise<ListAgyModelsResponse> {
 
     inflight = (async () => {
         try {
-            const response = await fetchAgyModels()
+            const response = toResponse(await fetchAgyCatalog())
             if (response.success && (response.availableModels?.length ?? 0) > 0) {
                 cache.expiresAt = Date.now() + CACHE_TTL_MS
                 cache.response = response

--- a/cli/src/modules/common/agyModels.ts
+++ b/cli/src/modules/common/agyModels.ts
@@ -371,12 +371,6 @@ function servableCatalog(): ListAgyModelsResponse | null {
     return response
 }
 
-// Everything a client can see goes through here, so keying the announcement on
-// it makes it about what changed on screen rather than what changed in cache.
-function servedAnswerSignature(): string {
-    return JSON.stringify(servableCatalog() ?? { success: true, availableModels: buildModelList() })
-}
-
 function toResponse(fetched: AgyCatalogFetch): ListAgyModelsResponse {
     if (fetched.kind === 'live') {
         return { success: true, availableModels: fetched.models }
@@ -391,6 +385,14 @@ function toResponse(fetched: AgyCatalogFetch): ListAgyModelsResponse {
         return { success: false, error: fetched.error }
     }
     return { success: true, availableModels: buildModelList() }
+}
+
+// Built through toResponse so the announcement is keyed on the answer a plain
+// read would get, not on the cache behind it. Without a servable catalog those
+// two disagree: an uncached sign-in failure is an error response, while the
+// cache still looks like the fallback listing.
+function servedAnswerSignature(): string {
+    return JSON.stringify(toResponse(lastFailedProbe?.result ?? { kind: 'unavailable' }))
 }
 
 export async function listAgyModels(options?: { refresh?: boolean }): Promise<ListAgyModelsResponse> {

--- a/cli/src/modules/common/agyModels.ts
+++ b/cli/src/modules/common/agyModels.ts
@@ -39,6 +39,27 @@ let cachedCatalog: CachedCatalog | null = null
 // the user even while a cached listing is still being served.
 let lastFailedProbe: { at: number; result: AgyCatalogFetch } | null = null
 
+// Registered only by the machine daemon; a session process has no route out.
+let catalogChangeListener: (() => void) | null = null
+
+export function setAgyCatalogChangeListener(listener: (() => void) | null): void {
+    catalogChangeListener = listener
+}
+
+function notifyCatalogChanged(): void {
+    try {
+        catalogChangeListener?.()
+    } catch {
+        // Best effort: failing to announce a new catalog must not fail the probe.
+    }
+}
+
+// Not the same as "nothing is cached": a machine whose agy is signed out has
+// been answering from the mirror all along, so its first real listing is a
+// change somebody needs to hear about. Until anything has been handed out
+// though, a probe landing has nothing to correct.
+let hasServedAnswer = false
+
 // The machine daemon owns `machineId:listAgyModels`, so this module runs once
 // per machine — hence no keying.
 let inflight: Promise<AgyCatalogFetch> | null = null
@@ -273,6 +294,7 @@ async function fetchAgyCatalog(): Promise<AgyCatalogFetch> {
 }
 
 function startProbe(): Promise<AgyCatalogFetch> {
+    const servedBefore = servedAnswerSignature()
     inflight = (async (): Promise<AgyCatalogFetch> => {
         try {
             const fetched = await fetchAgyCatalog()
@@ -290,10 +312,19 @@ function startProbe(): Promise<AgyCatalogFetch> {
             return result
         } finally {
             inflight = null
+            // In the `finally` so a throw is compared the same way as a return.
+            if (hasServedAnswer && servedAnswerSignature() !== servedBefore) {
+                notifyCatalogChanged()
+            }
         }
     })()
 
     return inflight
+}
+
+// Until the backoff lapses, asking again would only return what we already have.
+function probeIsDue(): boolean {
+    return lastFailedProbe === null || Date.now() - lastFailedProbe.at >= PROBE_BACKOFF_MS
 }
 
 async function refreshCatalog(force: boolean): Promise<AgyCatalogFetch> {
@@ -305,7 +336,7 @@ async function refreshCatalog(force: boolean): Promise<AgyCatalogFetch> {
     if (inflight) {
         return await inflight
     }
-    if (!force && lastFailedProbe && Date.now() - lastFailedProbe.at < PROBE_BACKOFF_MS) {
+    if (!force && !probeIsDue() && lastFailedProbe) {
         return lastFailedProbe.result
     }
 
@@ -340,6 +371,12 @@ function servableCatalog(): ListAgyModelsResponse | null {
     return response
 }
 
+// Everything a client can see goes through here, so keying the announcement on
+// it makes it about what changed on screen rather than what changed in cache.
+function servedAnswerSignature(): string {
+    return JSON.stringify(servableCatalog() ?? { success: true, availableModels: buildModelList() })
+}
+
 function toResponse(fetched: AgyCatalogFetch): ListAgyModelsResponse {
     if (fetched.kind === 'live') {
         return { success: true, availableModels: fetched.models }
@@ -357,6 +394,14 @@ function toResponse(fetched: AgyCatalogFetch): ListAgyModelsResponse {
 }
 
 export async function listAgyModels(options?: { refresh?: boolean }): Promise<ListAgyModelsResponse> {
+    const answer = await answerAgyModels(options)
+    // Set on the way out, not on entry: the first caller is awaiting the probe
+    // rather than looking at a stale screen, so it needs no announcement.
+    hasServedAnswer = true
+    return answer
+}
+
+async function answerAgyModels(options?: { refresh?: boolean }): Promise<ListAgyModelsResponse> {
     // Retry is the user saying the cached answer is wrong, so it costs a probe.
     if (options?.refresh === true) {
         return toResponse(await refreshCatalog(true))
@@ -379,4 +424,6 @@ export function _resetAgyModelsCacheForTests(): void {
     cachedCatalog = null
     lastFailedProbe = null
     inflight = null
+    hasServedAnswer = false
+    catalogChangeListener = null
 }

--- a/cli/src/modules/common/handlers/agyModels.ts
+++ b/cli/src/modules/common/handlers/agyModels.ts
@@ -8,13 +8,15 @@ import {
 import { getErrorMessage, rpcError } from '../rpcResponses';
 
 export function registerAgyModelHandlers(rpcHandlerManager: RpcHandlerManager): void {
-    rpcHandlerManager.registerHandler<Record<string, never>, ListAgyModelsResponse>(
+    rpcHandlerManager.registerHandler<{ refresh?: boolean } | null, ListAgyModelsResponse>(
         RPC_METHODS.ListAgyModels,
-        async () => {
+        async (params) => {
             logger.debug('List Agy models request');
 
             try {
-                return await listAgyModels();
+                // A hub that predates the flag sends none, and only an explicit
+                // refresh should cost another agy invocation.
+                return await listAgyModels({ refresh: params?.refresh === true });
             } catch (error) {
                 logger.debug('Failed to list Agy models:', error);
                 return rpcError(getErrorMessage(error, 'Failed to list Agy models'));

--- a/docs/api/client-contract/errors.md
+++ b/docs/api/client-contract/errors.md
@@ -58,6 +58,8 @@ Many endpoints do not answer from hub state — the hub relays the request over 
 
 Practical rule: treat `success: false`, 503 `rpc_target_missing`, and 503 `no_machine_online` as the same user-facing condition — "the computer running this session is not reachable" — with the raw `error` string available in a details view.
 
+One route qualifies that rule. `GET /api/machines/:id/agy-models` keeps serving the last catalog the machine got out of `agy models` while the CLI re-checks in the background, so it can answer `success: true` **and** carry an `error`: the list is usable, and `error` says why it may be stale (typically the machine's agy sign-in has lapsed). Render it beside the catalog rather than instead of it, and offer `?refresh=true` as the way to ask again — a plain repeat is answered from the same cache.
+
 ## Retry guidance
 
 | Class | Retry? |

--- a/docs/api/client-contract/errors.md
+++ b/docs/api/client-contract/errors.md
@@ -60,6 +60,8 @@ Practical rule: treat `success: false`, 503 `rpc_target_missing`, and 503 `no_ma
 
 One route qualifies that rule. `GET /api/machines/:id/agy-models` keeps serving the last catalog the machine got out of `agy models` while the CLI re-checks in the background, so it can answer `success: true` **and** carry an `error`: the list is usable, and `error` says why it may be stale (typically the machine's agy sign-in has lapsed). Render it beside the catalog rather than instead of it, and offer `?refresh=true` as the way to ask again — a plain repeat is answered from the same cache.
 
+When that background re-check lands a different listing, the machine says so over the existing event stream rather than making clients ask: `machine-agy-models-updated` (see [SSE](./sse.md)) carries the `machineId` and nothing else. Refetch that machine's route on it — the answer comes from the machine's cache, so it costs no `agy` run and produces no further event. It is emitted whenever the re-check changes what this route would answer — a different listing, **or** a sign-in warning that appeared or cleared — and not when it changes neither, so a failed re-check that raises a warning does announce. The machine's very first listing is never announced: whoever triggered it is already awaiting it. Requests during that window are answered from the machine's cache and do not launch agy.
+
 ## Retry guidance
 
 | Class | Retry? |

--- a/docs/api/client-contract/rest.md
+++ b/docs/api/client-contract/rest.md
@@ -105,7 +105,7 @@ All respond `{ok: true}`; apply-failures return 409 with a message. Model/effort
 |---|---|
 | `GET /api/sessions/:id/codex-models`, `/opencode-models`, `/cursor-models`, `/grok-models`, `/copilot-models`, `/pi-models` | Active session of the matching flavor; 400 otherwise |
 | `GET /api/sessions/:id/opencode-reasoning-effort-options`, `/grok-reasoning-effort-options` | Same pattern |
-| `GET /api/machines/:id/agy-models`, `/pi-models`, `/codex-models`, `/cursor-models` | Machine-level (pre-spawn pickers) |
+| `GET /api/machines/:id/agy-models`, `/pi-models`, `/codex-models`, `/cursor-models` | Machine-level (pre-spawn pickers). `agy-models` takes `?refresh=true` to skip the machine's cached catalog, and may answer `success: true` with an advisory `error` (see [Errors](./errors.md#rpc-wrapped-endpoints)) |
 | `GET /api/machines/:id/opencode-models?cwd=`, `/grok-models?cwd=`, `/copilot-models?cwd=` | `cwd` query required (400 without) |
 
 ### Machines & spawning

--- a/docs/api/client-contract/sse.md
+++ b/docs/api/client-contract/sse.md
@@ -122,7 +122,7 @@ Hub-side delivery (`SSEManager.shouldSend`):
 | `toast` | every **visible** connection in the namespace, regardless of filter (no `id`, never replayed) |
 | `message-received`, `scheduled-matured` | `all=true` connections + matching `sessionId` connections |
 | `session-added` / `session-updated` / `session-removed` / `session-ended` / `messages-invalidated` / `messages-consumed` / `messages-indeterminate` / `messages-requeued` / `message-cancelled` | `all=true` connections + matching `sessionId` connections |
-| `machine-updated` | `all=true` connections + matching `machineId` connections |
+| `machine-updated`, `machine-agy-models-updated` | `all=true` connections + matching `machineId` connections |
 
 **The global connection must also handle the message-stream events** (`message-received`, `messages-consumed`, `messages-indeterminate`, `messages-requeued`, `message-cancelled`, `scheduled-matured`): while a session connection is down (reconnect gap) or the session isn't open, the global pipe is the only one alive, and it must still keep queued/optimistic bookkeeping correct — mark local messages consumed, remove cancelled rows, and refresh session-list scheduled counts. The session-scoped connection additionally ingests `message-received` into the message window.
 
@@ -130,7 +130,7 @@ The two connections have **no ordering relationship with each other** — the sa
 
 ---
 
-## SyncEvent union (15 types)
+## SyncEvent union (16 types)
 
 Schema: `SyncEventSchema` in `shared/src/schemas.ts` (discriminated on `type`). All events except `connection-changed` carry `namespace?: string`. Ignore unknown event types.
 
@@ -144,6 +144,7 @@ Schema: `SyncEventSchema` in `shared/src/schemas.ts` (discriminated on `type`). 
 | `scheduled-matured` | `sessionId` | A scheduled message became due and was handed to the agent. Refetch list/queue indicators. |
 | `session-ended` | `sessionId`, `reason?: 'completed'\|'terminated'\|'error'\|'handoff'\|'cleared'` | Session lifecycle signal (the `session-updated` flow still carries the state change). |
 | `machine-updated` | `machineId`, `data?: Machine \| MachinePatch \| null` | Full `Machine`: upsert (remove when `active:false`). `null`: machine removed. Patch `{active?, activeAt?, updatedAt?}`: `active:false` ⇒ remove, otherwise refetch machines. `data` absent ⇒ refetch. |
+| `machine-agy-models-updated` | `machineId` | The machine's `agy models` listing changed on a background re-check. Refetch `GET /api/machines/:id/agy-models` for that machine (answered from the machine's cache; it starts no `agy` run and produces no further event). Emitted when the re-check changes what that route would answer — a different listing, or a sign-in warning that appeared or cleared — never for the machine's first listing. |
 | `toast` | `data: {title, body, sessionId, url}` | Show as in-app toast/banner. Only delivered to visible connections (see [Visibility](#visibility)). |
 | `messages-consumed` | `sessionId`, `localIds: string[]`, `invokedAt: number` | The agent consumed queued user messages: stamp `invokedAt`, flip status to `sent`, remove from the queued bar. |
 | `messages-indeterminate` | `sessionId`, `localIds: string[]` | A steer was dispatched but its outcome is unknown. Keep the row uninvoked, show an explicit Retry/Cancel resolution, and do not auto-replay it. |

--- a/hub/src/socket/handlers/cli/machineHandlers.agyModels.test.ts
+++ b/hub/src/socket/handlers/cli/machineHandlers.agyModels.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test'
+import { EventEmitter } from 'node:events'
+import type { StoredMachine } from '../../../store'
+import type { SyncEvent } from '../../../sync/syncEngine'
+import type { CliSocketWithData } from '../../socketTypes'
+import { registerMachineHandlers } from './machineHandlers'
+
+function harness(options: { access: 'ok' | 'denied' }) {
+    const socket = new EventEmitter() as unknown as CliSocketWithData
+    const events: SyncEvent[] = []
+    const accessErrors: Array<{ scope: string; id: string; reason: string }> = []
+
+    registerMachineHandlers(socket, {
+        store: {} as never,
+        resolveMachineAccess: () => (
+            options.access === 'ok'
+                ? { ok: true, value: { namespace: 'alpha' } as StoredMachine }
+                : { ok: false, reason: 'access-denied' }
+        ),
+        emitAccessError: (scope, id, reason) => { accessErrors.push({ scope, id, reason }) },
+        onWebappEvent: (event) => { events.push(event) }
+    })
+
+    return { socket: socket as unknown as EventEmitter, events, accessErrors }
+}
+
+describe('machine-agy-models-changed', () => {
+    it('forwards a catalog announcement for a machine this CLI may speak for', () => {
+        const { socket, events } = harness({ access: 'ok' })
+
+        socket.emit('machine-agy-models-changed', { machineId: 'machine-1' })
+
+        expect(events).toEqual([{ type: 'machine-agy-models-updated', machineId: 'machine-1' }])
+    })
+
+    it('refuses to announce for a machine the CLI has no access to', () => {
+        const { socket, events, accessErrors } = harness({ access: 'denied' })
+
+        socket.emit('machine-agy-models-changed', { machineId: 'someone-elses-machine' })
+
+        expect(events).toEqual([])
+        expect(accessErrors).toEqual([
+            { scope: 'machine', id: 'someone-elses-machine', reason: 'access-denied' }
+        ])
+    })
+
+    it('drops a malformed payload without announcing or erroring', () => {
+        const { socket, events, accessErrors } = harness({ access: 'ok' })
+
+        socket.emit('machine-agy-models-changed', {})
+        socket.emit('machine-agy-models-changed', { machineId: '' })
+        socket.emit('machine-agy-models-changed', null)
+        socket.emit('machine-agy-models-changed', 'machine-1')
+
+        expect(events).toEqual([])
+        expect(accessErrors).toEqual([])
+    })
+})

--- a/hub/src/socket/handlers/cli/machineHandlers.ts
+++ b/hub/src/socket/handlers/cli/machineHandlers.ts
@@ -25,6 +25,10 @@ const machineUpdateMetadataSchema = z.object({
     metadata: z.unknown()
 })
 
+const machineAgyModelsChangedSchema = z.object({
+    machineId: z.string().min(1)
+})
+
 const machineUpdateStateSchema = z.object({
     machineId: z.string(),
     expectedVersion: z.number().int(),
@@ -138,6 +142,20 @@ export function registerMachineHandlers(socket: CliSocketWithData, deps: Machine
             onWebappEvent?.({ type: 'machine-updated', machineId: id })
         }
     }
+
+    socket.on('machine-agy-models-changed', (data: unknown) => {
+        const parsed = machineAgyModelsChangedSchema.safeParse(data)
+        if (!parsed.success) {
+            return
+        }
+        const id = parsed.data.machineId
+        const machineAccess = resolveMachineAccess(id)
+        if (!machineAccess.ok) {
+            emitAccessError('machine', id, machineAccess.reason)
+            return
+        }
+        onWebappEvent?.({ type: 'machine-agy-models-updated', machineId: id })
+    })
 
     socket.on('machine-update-metadata', handleMachineMetadataUpdate)
     socket.on('machine-update-state', handleMachineStateUpdate)

--- a/hub/src/sse/sseManager.test.ts
+++ b/hub/src/sse/sseManager.test.ts
@@ -334,3 +334,42 @@ describe('SSEManager reconnect replay', () => {
         expect(fresh.replay[0]?.event).toMatchObject({ sessionId: 'big-3' })
     })
 })
+
+describe('SSEManager agy catalog announcements', () => {
+    it('reaches the global connection the app always keeps open, and no other namespace', () => {
+        // The app runs one `all` connection plus a session-scoped one
+        // (web/src/lib/appSseSubscriptions.ts), so this is what decides whether
+        // an open in-session picker hears about a new catalog.
+        const manager = new SSEManager(0, new VisibilityTracker())
+        const globalAlpha: SyncEvent[] = []
+        const sessionAlpha: SyncEvent[] = []
+        const machineAlpha: SyncEvent[] = []
+        const globalBeta: SyncEvent[] = []
+
+        manager.subscribe({
+            id: 'alpha-global', namespace: 'alpha', all: true,
+            send: (event) => { globalAlpha.push(event) }, sendHeartbeat: () => {}
+        })
+        manager.subscribe({
+            id: 'alpha-session', namespace: 'alpha', all: false, sessionId: 's1',
+            send: (event) => { sessionAlpha.push(event) }, sendHeartbeat: () => {}
+        })
+        manager.subscribe({
+            id: 'alpha-machine', namespace: 'alpha', all: false, machineId: 'm1',
+            send: (event) => { machineAlpha.push(event) }, sendHeartbeat: () => {}
+        })
+        manager.subscribe({
+            id: 'beta-global', namespace: 'beta', all: true,
+            send: (event) => { globalBeta.push(event) }, sendHeartbeat: () => {}
+        })
+
+        manager.broadcast({ type: 'machine-agy-models-updated', machineId: 'm1', namespace: 'alpha' })
+
+        expect(globalAlpha).toHaveLength(1)
+        expect(machineAlpha).toHaveLength(1)
+        // A session-scoped connection carries no machineId, so it is not the
+        // route: the global connection is.
+        expect(sessionAlpha).toHaveLength(0)
+        expect(globalBeta).toHaveLength(0)
+    })
+})

--- a/hub/src/sync/rpcGateway.ts
+++ b/hub/src/sync/rpcGateway.ts
@@ -503,8 +503,9 @@ export class RpcGateway {
         return await this.sessionRpc(sessionId, RPC_METHODS.ListOpencodeReasoningEffortOptions, {}) as RpcListOpencodeReasoningEffortOptionsResponse
     }
 
-    async listAgyModelsForMachine(machineId: string): Promise<RpcListAgyModelsResponse> {
-        return await this.machineRpc(machineId, RPC_METHODS.ListAgyModels, {}, MODEL_LIST_RPC_TIMEOUT_MS) as RpcListAgyModelsResponse
+    async listAgyModelsForMachine(machineId: string, options?: { refresh?: boolean }): Promise<RpcListAgyModelsResponse> {
+        const params = { refresh: options?.refresh === true }
+        return await this.machineRpc(machineId, RPC_METHODS.ListAgyModels, params, MODEL_LIST_RPC_TIMEOUT_MS) as RpcListAgyModelsResponse
     }
 
     async listPiModelsForMachine(machineId: string): Promise<RpcListPiModelsResponse> {

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -3918,8 +3918,11 @@ export class SyncEngine {
         return await this.rpcGateway.listSkills(sessionId, flavor)
     }
 
-    async listAgyModelsForMachine(machineId: string): Promise<RpcListAgyModelsResponse> {
-        return await this.rpcGateway.listAgyModelsForMachine(machineId)
+    async listAgyModelsForMachine(
+        machineId: string,
+        options?: { refresh?: boolean }
+    ): Promise<RpcListAgyModelsResponse> {
+        return await this.rpcGateway.listAgyModelsForMachine(machineId, options)
     }
 
     async listPiModelsForMachine(machineId: string): Promise<RpcListPiModelsResponse> {

--- a/hub/src/web/routes/machines.test.ts
+++ b/hub/src/web/routes/machines.test.ts
@@ -790,4 +790,25 @@ describe('machines routes', () => {
             expect((await patch(app, { displayName: 'Workstation' })).status).toBe(500)
         })
     })
+
+    it('forwards an explicit agy model refresh to the machine and defaults to the cached catalog', async () => {
+        const machine = createMachine()
+        const calls: Array<{ refresh?: boolean } | undefined> = []
+        const engine = {
+            getMachine: () => machine,
+            getMachineByNamespace: () => machine,
+            listAgyModelsForMachine: (_machineId: string, options?: { refresh?: boolean }) => {
+                calls.push(options)
+                return Promise.resolve({ success: true, availableModels: [] })
+            },
+        } as unknown as Partial<SyncEngine>
+        const app = new Hono<WebAppEnv>()
+        app.use('*', async (c, next) => { c.set('namespace', 'default'); await next() })
+        app.route('/api', createMachinesRoutes(() => engine as SyncEngine))
+
+        expect((await app.request('/api/machines/machine-1/agy-models')).status).toBe(200)
+        expect((await app.request('/api/machines/machine-1/agy-models?refresh=true')).status).toBe(200)
+
+        expect(calls).toEqual([{ refresh: false }, { refresh: true }])
+    })
 })

--- a/hub/src/web/routes/machines.ts
+++ b/hub/src/web/routes/machines.ts
@@ -211,7 +211,9 @@ export function createMachinesRoutes(getSyncEngine: () => SyncEngine | null): Ho
         }
 
         try {
-            const result = await engine.listAgyModelsForMachine(machineId)
+            const result = await engine.listAgyModelsForMachine(machineId, {
+                refresh: c.req.query('refresh') === 'true'
+            })
             return c.json(result)
         } catch (error) {
             return c.json({

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -588,6 +588,14 @@ export const SyncEventSchema = z.discriminatedUnion('type', [
         type: z.literal('machine-updated'),
         data: MachineUpdatedDataSchema.optional()
     }),
+    /**
+     * The machine re-checked `agy models` in the background and the listing
+     * changed. Carries no catalog: clients refetch the machine's agy-models
+     * route, which answers from the machine's cache.
+     */
+    MachineChangedSchema.extend({
+        type: z.literal('machine-agy-models-updated')
+    }),
     SessionEventBaseSchema.extend({
         type: z.literal('toast'),
         data: z.object({

--- a/shared/src/socket.ts
+++ b/shared/src/socket.ts
@@ -281,6 +281,8 @@ export interface ClientToServerEvents {
     'machine-alive': (data: { machineId: string; time: number; health?: unknown }) => void
     'machine-update-metadata': (data: { machineId: string; expectedVersion: number; metadata: unknown }, cb: (answer: MachineUpdateMetadataAck) => void) => void
     'machine-update-state': (data: { machineId: string; expectedVersion: number; runnerState: unknown | null }, cb: (answer: MachineUpdateStateAck) => void) => void
+    /** The machine's `agy models` listing changed on a background re-check. */
+    'machine-agy-models-changed': (data: { machineId: string }) => void
     'rpc-register': (data: { method: string }) => void
     'rpc-unregister': (data: { method: string }) => void
     'terminal:ready': (data: TerminalReadyPayload) => void

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import { usePushNotifications } from '@/hooks/usePushNotifications'
 import { useViewportHeight } from '@/hooks/useViewportHeight'
 import { useVisibilityReporter } from '@/hooks/useVisibilityReporter'
 import { queryKeys } from '@/lib/query-keys'
+import { refreshAllAgyCatalogs } from '@/lib/agyCatalogAnnouncement'
 import { AppContextProvider } from '@/lib/app-context'
 import { clearMessageWindow, rewindMessageWindow, syncTailMessages } from '@/lib/message-window-store'
 import { useAppGoBack } from '@/hooks/useAppGoBack'
@@ -277,7 +278,8 @@ function AppInner() {
             // freshness window on `useSession`, a previously-viewed session that
             // received updates during the SSE gap would otherwise serve stale
             // cached data on remount.  See tiann/hapi#884.
-            queryClient.invalidateQueries({ queryKey: ['session'] })
+            queryClient.invalidateQueries({ queryKey: ['session'] }),
+            refreshAllAgyCatalogs(queryClient)
         ]
         const refreshMessages = (selectedSessionId && api)
             ? syncTailMessages(api, selectedSessionId)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -172,6 +172,20 @@ describe('ApiClient error mapping', () => {
         expect(fetchMock.mock.calls[0]?.[0]).toBe('/health')
     })
 
+    it('asks the machine to re-probe agy only when the caller forces a refresh', async () => {
+        fetchMock.mockImplementation(() => Promise.resolve(
+            new Response(JSON.stringify({ success: true, availableModels: [] }), { status: 200 })
+        ))
+
+        const api = new ApiClient('test-token')
+        await api.getMachineAgyModels('machine-1')
+        await api.getMachineAgyModels('machine-1', { refresh: true })
+
+        expect(fetchMock.mock.calls[0][0]).toContain('/api/machines/machine-1/agy-models')
+        expect(fetchMock.mock.calls[0][0]).not.toContain('refresh')
+        expect(fetchMock.mock.calls[1][0]).toContain('/api/machines/machine-1/agy-models?refresh=true')
+    })
+
     it('lists and imports Pi sessions through the selected machine', async () => {
         fetchMock
             .mockResolvedValueOnce(new Response(JSON.stringify({ success: true, sessions: [], machineId: 'machine-1' }), { status: 200 }))

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -858,9 +858,14 @@ export class ApiClient {
         })
     }
 
-    async getMachineAgyModels(machineId: string): Promise<AgyModelsResponse> {
+    async getMachineAgyModels(
+        machineId: string,
+        options?: { refresh?: boolean }
+    ): Promise<AgyModelsResponse> {
+        // Without `refresh` the machine may answer from its cached catalog.
+        const query = options?.refresh ? '?refresh=true' : ''
         return await this.request<AgyModelsResponse>(
-            `/api/machines/${encodeURIComponent(machineId)}/agy-models`
+            `/api/machines/${encodeURIComponent(machineId)}/agy-models${query}`
         )
     }
 

--- a/web/src/components/AssistantChat/modelOptions.test.ts
+++ b/web/src/components/AssistantChat/modelOptions.test.ts
@@ -14,6 +14,42 @@ describe('getModelOptionsForFlavor', () => {
         expect(options.some((option) => option.value === null)).toBe(false)
     })
 
+    it('offers the machine catalog in an AGY session instead of the built-in mirror', () => {
+        const live = [
+            { value: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)' },
+            { value: 'gemini-3.8-flash-low', label: 'Gemini 3.8 Flash (Low)' }
+        ]
+
+        const options = getModelOptionsForFlavor('agy', 'gemini-3.8-flash-high', live)
+
+        expect(options).toEqual(live)
+        expect(options.some((option) => option.value === null)).toBe(false)
+    })
+
+    it('keeps the running AGY model selectable, and readable, when the machine catalog no longer lists it', () => {
+        const live = [{ value: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)' }]
+
+        const options = getModelOptionsForFlavor('agy', 'gemini-3.5-flash-medium', live)
+
+        expect(options[0]).toEqual({ value: 'gemini-3.5-flash-medium', label: 'Gemini 3.5 Flash (Medium)' })
+        expect(options.some((option) => option.value === 'gemini-3.8-flash-high')).toBe(true)
+    })
+
+    it('falls back to the wire id for a running AGY model nobody has a label for', () => {
+        const options = getModelOptionsForFlavor('agy', 'gemini-9.9-experimental', [
+            { value: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)' }
+        ])
+
+        expect(options[0]).toEqual({ value: 'gemini-9.9-experimental', label: 'gemini-9.9-experimental' })
+    })
+
+    it('falls back to the built-in AGY mirror until the machine catalog arrives', () => {
+        const withoutCatalog = getModelOptionsForFlavor('agy', null, [])
+
+        expect(withoutCatalog).toEqual(getModelOptionsForFlavor('agy', null))
+        expect(withoutCatalog.length).toBeGreaterThan(0)
+    })
+
     it('returns Gemini model options for gemini flavor', () => {
         const options = getModelOptionsForFlavor('gemini')
         expect(options[0]).toEqual({ value: null, label: 'Default' })
@@ -198,6 +234,17 @@ describe('getNextModelForFlavor', () => {
         expect(getNextModelForFlavor('agy', null)).toBe(firstConcrete)
         expect(getNextModelForFlavor('agy', 'auto')).toBe(firstConcrete)
         expect(getNextModelForFlavor('agy', 'agy-custom-model')).toBe(firstConcrete)
+    })
+
+    it('cycles through the machine catalog in an AGY session', () => {
+        const live = [
+            { value: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)' },
+            { value: 'gemini-3.8-flash-low', label: 'Gemini 3.8 Flash (Low)' }
+        ]
+
+        expect(getNextModelForFlavor('agy', null, live)).toBe('gemini-3.8-flash-high')
+        expect(getNextModelForFlavor('agy', 'gemini-3.8-flash-high', live)).toBe('gemini-3.8-flash-low')
+        expect(getNextModelForFlavor('agy', 'gemini-3.8-flash-low', live)).toBe('gemini-3.8-flash-high')
     })
 
     it('cycles Gemini models', () => {

--- a/web/src/components/AssistantChat/modelOptions.ts
+++ b/web/src/components/AssistantChat/modelOptions.ts
@@ -1,3 +1,4 @@
+import { getAgyModelLabel } from '@hapi/protocol'
 import { MODEL_OPTIONS } from '@/components/NewSession/types'
 import { CURSOR_AUTO_MODEL_LABEL } from '@/lib/cursorModelOptions'
 import { getClaudeComposerModelOptions, getNextClaudeComposerModel } from './claudeModelOptions'
@@ -28,7 +29,11 @@ function cursorCatalogCoversCurrentModel(options: ModelOption[], currentModel: s
     return options.some((option) => option.value === baseId)
 }
 
-function withCurrentModelOption(options: ModelOption[], currentModel?: string | null): ModelOption[] {
+function withCurrentModelOption(
+    options: ModelOption[],
+    currentModel?: string | null,
+    resolveLabel?: (modelId: string) => string | null
+): ModelOption[] {
     const normalizedCurrentModel = normalizeCurrentModel(currentModel)
     if (!normalizedCurrentModel || options.some((option) => option.value === normalizedCurrentModel)) {
         return options
@@ -38,7 +43,7 @@ function withCurrentModelOption(options: ModelOption[], currentModel?: string | 
     const autoIndex = nextOptions.findIndex((option) => option.value === null)
     nextOptions.splice(autoIndex >= 0 ? autoIndex + 1 : 0, 0, {
         value: normalizedCurrentModel,
-        label: normalizedCurrentModel
+        label: resolveLabel?.(normalizedCurrentModel) ?? normalizedCurrentModel
     })
     return nextOptions
 }
@@ -76,12 +81,19 @@ function getClaudeModelOptions(currentModel?: string | null, customOptions?: Mod
     return nextOptions
 }
 
-function getAgyModelOptions(currentModel?: string | null): ModelOption[] {
-    const options = MODEL_OPTIONS.agy.filter((m) => m.value !== 'auto').map((m) => ({
-        value: m.value,
-        label: m.label
-    }))
-    return withCurrentModelOption(options, currentModel)
+function getAgyModelOptions(currentModel?: string | null, customOptions?: ModelOption[]): ModelOption[] {
+    // The built-in list stands in until the machine answers. Neither list carries
+    // a null entry: agy has no mid-session "back to default".
+    const machineOptions = (customOptions ?? []).filter((option) => Boolean(option.value))
+    const options = machineOptions.length > 0
+        ? machineOptions
+        : MODEL_OPTIONS.agy.filter((m) => m.value !== 'auto').map((m) => ({
+            value: m.value,
+            label: m.label
+        }))
+    // A session can be running a model the machine no longer lists. It stays
+    // selectable; the lookup only keeps a known preset readable.
+    return withCurrentModelOption(options, currentModel, getAgyModelLabel)
 }
 
 function getGeminiModelOptions(currentModel?: string | null): ModelOption[] {
@@ -107,7 +119,7 @@ export function getModelOptionsForFlavor(
     customOptions?: ModelOption[]
 ): ModelOption[] {
     if (flavor === 'agy') {
-        return getAgyModelOptions(currentModel)
+        return getAgyModelOptions(currentModel, customOptions)
     }
     if (flavor === 'claude') {
         return getClaudeModelOptions(currentModel, customOptions)
@@ -164,7 +176,7 @@ export function getNextModelForFlavor(
     customOptions?: ModelOption[]
 ): string | null {
     if (flavor === 'agy') {
-        const options = getAgyModelOptions(currentModel)
+        const options = getAgyModelOptions(currentModel, customOptions)
         const currentIndex = options.findIndex((option) => option.value === (normalizeCurrentModel(currentModel) ?? null))
         if (currentIndex === -1) {
             return options.find((option) => option.value !== null)?.value ?? null

--- a/web/src/components/NewSession/AgyModelSelector.test.tsx
+++ b/web/src/components/NewSession/AgyModelSelector.test.tsx
@@ -51,6 +51,27 @@ describe('AgyModelSelector', () => {
         expect(onRetry).toHaveBeenCalledTimes(1)
     })
 
+    it('keeps a picked model listed after the catalog stops advertising it', () => {
+        renderSelector({
+            availableModels: [{ modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' }],
+            selectedModel: 'gemini-3.5-flash-medium'
+        })
+
+        const select = screen.getByTestId('agy-model-list') as HTMLSelectElement
+        expect(select.value).toBe('gemini-3.5-flash-medium')
+        expect(screen.getByRole('option', { name: 'Gemini 3.5 Flash (Medium) (no longer listed)' })).toBeInTheDocument()
+        expect(screen.getByRole('option', { name: 'Gemini 3.8 Flash (High)' })).toBeInTheDocument()
+    })
+
+    it('falls back to the wire id for a picked model nobody has a label for', () => {
+        renderSelector({
+            availableModels: [{ modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' }],
+            selectedModel: 'gemini-9.9-experimental'
+        })
+
+        expect(screen.getByRole('option', { name: 'gemini-9.9-experimental (no longer listed)' })).toBeInTheDocument()
+    })
+
     it('says a re-probe is running instead of leaving Retry looking idle', () => {
         // The probe runs agy, so the answer can be tens of seconds away; without
         // this the button is the only thing on screen and nothing about it moves.

--- a/web/src/components/NewSession/AgyModelSelector.test.tsx
+++ b/web/src/components/NewSession/AgyModelSelector.test.tsx
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { I18nProvider } from '@/lib/i18n-context'
 import { AgyModelSelector } from './AgyModelSelector'
 
@@ -35,4 +35,36 @@ describe('AgyModelSelector', () => {
         expect(screen.getByTestId('agy-model-auth-error')).toBeInTheDocument()
     })
 
+    it('keeps the cached catalog usable while saying the machine failed its last sign-in check, with a way to re-probe', () => {
+        const onRetry = vi.fn()
+        renderSelector({
+            warning: 'Authentication required. Please run `agy` in a terminal to sign in with Google.',
+            availableModels: [{ modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' }],
+            onRetry
+        })
+
+        expect(screen.getByTestId('agy-model-list')).toBeInTheDocument()
+        expect(screen.getByTestId('agy-model-stale-warning')).toBeInTheDocument()
+        expect(screen.queryByTestId('agy-model-auth-error')).not.toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        expect(onRetry).toHaveBeenCalledTimes(1)
+    })
+
+    it('says a re-probe is running instead of leaving Retry looking idle', () => {
+        // The probe runs agy, so the answer can be tens of seconds away; without
+        // this the button is the only thing on screen and nothing about it moves.
+        const onRetry = vi.fn()
+        renderSelector({
+            warning: 'Authentication required. Please run `agy` in a terminal to sign in with Google.',
+            availableModels: [{ modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' }],
+            isFetching: true,
+            onRetry
+        })
+
+        const button = screen.getByRole('button', { name: 'Fetching available models…' })
+        expect(button).toBeDisabled()
+        fireEvent.click(button)
+        expect(onRetry).not.toHaveBeenCalled()
+    })
 })

--- a/web/src/components/NewSession/AgyModelSelector.test.tsx
+++ b/web/src/components/NewSession/AgyModelSelector.test.tsx
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { I18nProvider } from '@/lib/i18n-context'
+import { AgyModelSelector } from './AgyModelSelector'
+
+afterEach(cleanup)
+
+function renderSelector(overrides: Partial<Parameters<typeof AgyModelSelector>[0]> = {}) {
+    render(
+        <I18nProvider>
+            <AgyModelSelector
+                machineId="machine-1"
+                isLoading={false}
+                error={null}
+                availableModels={[]}
+                selectedModel={null}
+                onModelChange={() => {}}
+                {...overrides}
+            />
+        </I18nProvider>
+    )
+}
+
+describe('AgyModelSelector', () => {
+    it('says it is fetching models, which is what the wait is actually spent on', () => {
+        renderSelector({ isLoading: true })
+
+        expect(screen.getByText('Fetching available models…')).toBeInTheDocument()
+        expect(screen.queryByText(/authentication/i)).not.toBeInTheDocument()
+    })
+
+    it('still calls out authentication when that is what the machine reported', () => {
+        renderSelector({ error: 'Authentication required. Please run `agy` in a terminal to sign in with Google.' })
+
+        expect(screen.getByTestId('agy-model-auth-error')).toBeInTheDocument()
+    })
+
+})

--- a/web/src/components/NewSession/AgyModelSelector.tsx
+++ b/web/src/components/NewSession/AgyModelSelector.tsx
@@ -5,10 +5,37 @@ export type AgyModelSelectorProps = {
     machineId: string | null
     isLoading: boolean
     error: string | null
+    /** Catalog is usable, but the machine's last sign-in check failed. */
+    warning?: string | null
+    /** A probe is in flight — asking the machine again can take a while. */
+    isFetching?: boolean
     availableModels: AgyModelSummary[]
     selectedModel: string | null
     onModelChange: (modelId: string | null) => void
     onRetry?: () => void
+}
+
+/** Asks the machine to skip its cached catalog. It says so while it runs, because
+ *  the probe is an agy invocation and a click can take tens of seconds. */
+function RetryButton(props: { onRetry?: () => void; isFetching?: boolean }) {
+    const { t } = useTranslation()
+
+    if (!props.onRetry) {
+        return null
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={props.onRetry}
+            disabled={props.isFetching}
+            className="self-start rounded border border-[var(--app-divider)] px-2 py-1 text-xs text-[var(--app-link)] hover:bg-[var(--app-secondary-bg)] disabled:opacity-50"
+        >
+            {props.isFetching
+                ? t('newSession.agyModel.fetchingModels')
+                : t('newSession.agyModel.retry')}
+        </button>
+    )
 }
 
 export function AgyModelSelector(props: AgyModelSelectorProps) {
@@ -38,34 +65,39 @@ export function AgyModelSelector(props: AgyModelSelectorProps) {
                     <div className="text-xs text-[var(--app-hint)]">
                         {t('newSession.agyModel.authHint')}
                     </div>
-                    {props.onRetry ? (
-                        <button
-                            type="button"
-                            onClick={props.onRetry}
-                            className="self-start rounded border border-[var(--app-divider)] px-2 py-1 text-xs text-[var(--app-link)] hover:bg-[var(--app-secondary-bg)]"
-                        >
-                            {t('newSession.agyModel.retry')}
-                        </button>
-                    ) : null}
+                    <RetryButton onRetry={props.onRetry} isFetching={props.isFetching} />
                 </div>
             ) : props.availableModels.length === 0 ? (
                 <div className="text-xs text-[var(--app-hint)]">
                     {t('newSession.agyModel.noModels')}
                 </div>
             ) : (
-                <select
-                    data-testid="agy-model-list"
-                    value={props.selectedModel ?? ''}
-                    onChange={(e) => props.onModelChange(e.target.value || null)}
-                    className="w-full px-3 py-2 text-sm rounded-lg border border-[var(--app-divider)] bg-[var(--app-bg)] text-[var(--app-text)] focus:outline-none focus:ring-2 focus:ring-[var(--app-link)] disabled:opacity-50"
-                >
-                    <option value="">{t('newSession.model.default')}</option>
-                    {props.availableModels.map((model) => (
-                        <option key={model.modelId} value={model.modelId}>
-                            {model.name ?? model.modelId}
-                        </option>
-                    ))}
-                </select>
+                <div className="flex flex-col gap-2">
+                    {props.warning ? (
+                        <div className="flex flex-col gap-1" data-testid="agy-model-stale-warning">
+                            <div className="text-xs text-amber-600">
+                                {t('newSession.agyModel.authRequired')}: {props.warning}
+                            </div>
+                            <div className="text-xs text-[var(--app-hint)]">
+                                {t('newSession.agyModel.authHint')}
+                            </div>
+                            <RetryButton onRetry={props.onRetry} isFetching={props.isFetching} />
+                        </div>
+                    ) : null}
+                    <select
+                        data-testid="agy-model-list"
+                        value={props.selectedModel ?? ''}
+                        onChange={(e) => props.onModelChange(e.target.value || null)}
+                        className="w-full px-3 py-2 text-sm rounded-lg border border-[var(--app-divider)] bg-[var(--app-bg)] text-[var(--app-text)] focus:outline-none focus:ring-2 focus:ring-[var(--app-link)] disabled:opacity-50"
+                    >
+                        <option value="">{t('newSession.model.default')}</option>
+                        {props.availableModels.map((model) => (
+                            <option key={model.modelId} value={model.modelId}>
+                                {model.name ?? model.modelId}
+                            </option>
+                        ))}
+                    </select>
+                </div>
             )}
         </div>
     )

--- a/web/src/components/NewSession/AgyModelSelector.tsx
+++ b/web/src/components/NewSession/AgyModelSelector.tsx
@@ -28,7 +28,7 @@ export function AgyModelSelector(props: AgyModelSelectorProps) {
             {props.isLoading ? (
                 <div className="flex items-center gap-2 text-xs text-[var(--app-hint)]">
                     <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-[var(--app-divider)] border-t-[var(--app-link)]" />
-                    <span>{t('newSession.agyModel.checkingAuth')}</span>
+                    <span>{t('newSession.agyModel.fetchingModels')}</span>
                 </div>
             ) : props.error ? (
                 <div className="flex flex-col gap-2" data-testid="agy-model-auth-error">

--- a/web/src/components/NewSession/AgyModelSelector.tsx
+++ b/web/src/components/NewSession/AgyModelSelector.tsx
@@ -1,3 +1,4 @@
+import { getAgyModelLabel } from '@hapi/protocol'
 import { useTranslation } from '@/lib/use-translation'
 import type { AgyModelSummary } from '@/types/api'
 
@@ -13,6 +14,25 @@ export type AgyModelSelectorProps = {
     selectedModel: string | null
     onModelChange: (modelId: string | null) => void
     onRetry?: () => void
+}
+
+/** The catalog can change under an open form, so a model the user already picked
+ *  stays listed rather than the select falling blank — labelled, because starting
+ *  a session on it is their call but agy is no longer offering it.
+ *
+ *  `withCurrentModelOption` in AssistantChat/modelOptions.ts leaves the
+ *  equivalent entry unlabelled on purpose: there it is the model the session is
+ *  already running, a fact rather than a choice about to be made. */
+function withSelectedModel(
+    models: AgyModelSummary[],
+    selectedModel: string | null,
+    notListedSuffix: string
+): AgyModelSummary[] {
+    if (!selectedModel || models.some((model) => model.modelId === selectedModel)) {
+        return models
+    }
+    const label = getAgyModelLabel(selectedModel) ?? selectedModel
+    return [{ modelId: selectedModel, name: `${label} (${notListedSuffix})` }, ...models]
 }
 
 /** Asks the machine to skip its cached catalog. It says so while it runs, because
@@ -91,7 +111,11 @@ export function AgyModelSelector(props: AgyModelSelectorProps) {
                         className="w-full px-3 py-2 text-sm rounded-lg border border-[var(--app-divider)] bg-[var(--app-bg)] text-[var(--app-text)] focus:outline-none focus:ring-2 focus:ring-[var(--app-link)] disabled:opacity-50"
                     >
                         <option value="">{t('newSession.model.default')}</option>
-                        {props.availableModels.map((model) => (
+                        {withSelectedModel(
+                            props.availableModels,
+                            props.selectedModel,
+                            t('newSession.agyModel.notListed')
+                        ).map((model) => (
                             <option key={model.modelId} value={model.modelId}>
                                 {model.name ?? model.modelId}
                             </option>

--- a/web/src/components/NewSession/index.test.tsx
+++ b/web/src/components/NewSession/index.test.tsx
@@ -603,6 +603,22 @@ describe('NewSession launch preferences', () => {
         await waitFor(() => expect(screen.getByTestId('agy-model')).toHaveTextContent('auto'))
     })
 
+    it('keeps an AGY model the user picked here when the machine catalog changes under the form', async () => {
+        // The machine refreshes its catalog in the background, so the list can
+        // change while the form is open. A model the user chose is theirs to
+        // keep — unlike a restored one, which the two tests above drop.
+        savePreferredAgent('agy')
+        const view = render(<NewSession api={api} machines={[machine]} initialMachineId="machine-1" initialDirectory="C:\repo" onSuccess={mocks.onSuccess} onCancel={() => {}} />)
+
+        fireEvent.click(screen.getByTestId('agy-model'))
+        await waitFor(() => expect(screen.getByTestId('agy-model')).toHaveTextContent('gemini-3.6-flash-low'))
+
+        mocks.agyModels = [{ modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' }]
+        view.rerender(<NewSession api={api} machines={[machine]} initialMachineId="machine-1" initialDirectory="C:\repo" onSuccess={mocks.onSuccess} onCancel={() => {}} />)
+
+        await waitFor(() => expect(screen.getByTestId('agy-model')).toHaveTextContent('gemini-3.6-flash-low'))
+    })
+
     it('falls back to Default when a preferred AGY model is no longer advertised', async () => {
         savePreferredAgent('agy')
         savePreferredLaunchSettings('machine-1', 'agy', { model: 'removed-model', cursorSelectedBase: 'auto', effort: 'auto', modelReasoningEffort: 'default' })

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -1803,6 +1803,8 @@ export function NewSession(props: {
                     machineId={machineId}
                     isLoading={agyModelsState.isLoading}
                     error={agyModelsState.error}
+                    warning={agyModelsState.warning}
+                    isFetching={agyModelsState.isFetching}
                     availableModels={agyModelsState.availableModels}
                     selectedModel={agySelectedModel}
                     onModelChange={setAgySelectedModel}

--- a/web/src/components/NewSession/index.tsx
+++ b/web/src/components/NewSession/index.tsx
@@ -246,6 +246,7 @@ export function NewSession(props: {
         setOpencodeSelectedModel(
             draft.agent === 'opencode' && draft.model !== 'auto' ? draft.model : null
         )
+        agyModelPickedByUserRef.current = false
         setAgySelectedModel(
             draft.agent === 'agy' && draft.model !== 'auto' ? draft.model : null
         )
@@ -310,6 +311,12 @@ export function NewSession(props: {
         enabled: agent === 'codex' && Boolean(machineId)
     })
     const [agySelectedModel, setAgySelectedModel] = useState<string | null>(null)
+    // Whether the AGY model on screen is one the user picked here, as opposed to
+    // one restored from a draft or a saved preference. A restored model that the
+    // machine does not advertise is dropped (it may never have been runnable on
+    // this machine); one the user just picked is kept, because the catalog can
+    // change under an open form while they are looking at it.
+    const agyModelPickedByUserRef = useRef(false)
     const runnerSpawnError = useMemo(
         () => formatRunnerSpawnError(selectedMachine),
         [selectedMachine]
@@ -760,6 +767,7 @@ export function NewSession(props: {
         // (null → no --model → agy uses its own default); we intentionally do NOT
         // auto-pick the first model, so the user's explicit "Default" choice
         // sticks instead of snapping to the first option.
+        agyModelPickedByUserRef.current = false
         setAgySelectedModel(null)
     }, [agent, machineId])
 
@@ -769,6 +777,7 @@ export function NewSession(props: {
             || agyModelsState.isLoading
             || agyModelsState.error
             || agySelectedModel === null
+            || agyModelPickedByUserRef.current
         ) {
             return
         }
@@ -864,6 +873,7 @@ export function NewSession(props: {
         setOpencodeSelectedModel(
             agent === 'opencode' && preferred.model !== 'auto' ? preferred.model : null
         )
+        agyModelPickedByUserRef.current = false
         setAgySelectedModel(
             agent === 'agy' && preferred.model !== 'auto' ? preferred.model : null
         )
@@ -1807,7 +1817,10 @@ export function NewSession(props: {
                     isFetching={agyModelsState.isFetching}
                     availableModels={agyModelsState.availableModels}
                     selectedModel={agySelectedModel}
-                    onModelChange={setAgySelectedModel}
+                    onModelChange={(modelId) => {
+                        agyModelPickedByUserRef.current = modelId !== null
+                        setAgySelectedModel(modelId)
+                    }}
                     onRetry={agyModelsState.refetch}
                 />
             ) : agent === 'opencode' ? (

--- a/web/src/components/SessionChat.test.ts
+++ b/web/src/components/SessionChat.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
     applyGlobalSelectAll,
+    buildAgyComposerModelOptions,
     applyModelChangeWithReasoningRollback,
     buildGoalStateMessages,
     isScratchlistHotkeyBlockedTarget,
@@ -563,5 +564,21 @@ describe('buildGoalStateMessages', () => {
 
         expect(buildGoalStateMessages([futureQueued, matureQueued, invokedScheduled]).map((message) => message.id))
             .toEqual(['invoked'])
+    })
+})
+
+describe('buildAgyComposerModelOptions', () => {
+    it('maps the machine catalog into composer options and keeps the id when agy sent no label', () => {
+        expect(buildAgyComposerModelOptions([
+            { modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' },
+            { modelId: 'gemini-9.9-experimental' }
+        ])).toEqual([
+            { value: 'gemini-3.8-flash-high', label: 'Gemini 3.8 Flash (High)' },
+            { value: 'gemini-9.9-experimental', label: 'gemini-9.9-experimental' }
+        ])
+    })
+
+    it('signals "no catalog yet" rather than an empty picker while the machine is still answering', () => {
+        expect(buildAgyComposerModelOptions([])).toBeUndefined()
     })
 })

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -7,6 +7,7 @@ import { AssistantRuntimeProvider, useAui, useAuiState } from '@assistant-ui/rea
 import { DragDropZone } from '@/components/AssistantChat/DragDropZone'
 import { ApiError, type ApiClient } from '@/api/client'
 import type {
+    AgyModelSummary,
     AttachmentMetadata,
     CodexCollaborationMode,
     CodexModelSummary,
@@ -90,6 +91,7 @@ import { useSessionActions } from '@/hooks/mutations/useSessionActions'
 import { useCodexModels } from '@/hooks/queries/useCodexModels'
 import { useCursorModels } from '@/hooks/queries/useCursorModels'
 import { useCursorModelsForMachine } from '@/hooks/queries/useCursorModelsForMachine'
+import { useAgyModels } from '@/hooks/queries/useAgyModels'
 import {
     mergeCursorCliModelSkus,
     resolveCursorBaseFromWire
@@ -152,6 +154,24 @@ export function resolvePiContextWindow(
         : models?.find((candidate) => candidate.modelId === legacyModelId)
 
     return model?.contextWindow
+}
+
+/**
+ * Composer options for an agy session, from the same machine catalog New Session
+ * reads. `undefined` until the machine answers, so the picker falls back to the
+ * built-in list rather than rendering empty.
+ */
+export function buildAgyComposerModelOptions(
+    availableModels: AgyModelSummary[]
+): Array<{ value: string; label: string }> | undefined {
+    if (availableModels.length === 0) {
+        return undefined
+    }
+
+    return availableModels.map((model) => ({
+        value: model.modelId,
+        label: model.name ?? model.modelId
+    }))
 }
 
 export async function applyModelChangeWithReasoningRollback(args: {
@@ -1075,6 +1095,19 @@ function SessionChatInner(props: SessionChatProps) {
         sessionCliModelSkus,
         props.session.model
     ])
+    const agyModelsState = useAgyModels({
+        api: props.api,
+        machineId: sessionMachineId,
+        enabled: agentFlavor === 'agy' && props.session.active && Boolean(sessionMachineId)
+    })
+    // Options only: the composer has no surface for a catalog warning, so a
+    // machine whose sign-in has lapsed shows its last known list here and New
+    // Session is where that gets explained.
+    const agyModelOptions = useMemo(() => (
+        agentFlavor === 'agy'
+            ? buildAgyComposerModelOptions(agyModelsState.availableModels)
+            : undefined
+    ), [agentFlavor, agyModelsState.availableModels])
     const piModelsState = usePiModels({
         api: props.api,
         sessionId: props.session.id,
@@ -2002,6 +2035,8 @@ function SessionChatInner(props: SessionChatProps) {
                                             ? grokModelOptions
                                         : agentFlavor === 'copilot'
                                             ? copilotModelOptions
+                                        : agentFlavor === 'agy'
+                                            ? agyModelOptions
                                         // Pi gets its provider-qualified model list from the piModels prop;
                                         // feeding piModelOptions here would make the generic Ctrl/Cmd+M
                                         // cycler (getNextModelForFlavor) post a bare modelId string,

--- a/web/src/hooks/queries/useAgyModels.test.tsx
+++ b/web/src/hooks/queries/useAgyModels.test.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import type { ApiClient } from '@/api/client'
 import { useAgyModels } from './useAgyModels'
+import { applyAgyCatalogAnnouncement } from '@/lib/agyCatalogAnnouncement'
 
 function wrapper(queryClient: QueryClient) {
     return ({ children }: PropsWithChildren) => (
@@ -56,5 +57,124 @@ describe('useAgyModels', () => {
         expect(result.current.error).toBeNull()
         expect(result.current.warning).toContain('Authentication required')
         expect(result.current.isFetching).toBe(false)
+    })
+})
+
+describe('useAgyModels catalog invalidation', () => {
+    const OLD = [{ modelId: 'gemini-3.7-flash-high', name: 'Gemini 3.7 Flash (High)' }]
+    const NEW = [{ modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' }]
+
+    it('redraws an open picker onto the newer listing when the machine announces one', async () => {
+        let call = 0
+        const getMachineAgyModels = vi.fn(async () => ({
+            success: true,
+            availableModels: (call += 1) === 1 ? OLD : NEW
+        }))
+        const api = { getMachineAgyModels } as unknown as ApiClient
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+        const { result } = renderHook(() => useAgyModels({
+            api, machineId: 'machine-1', enabled: true
+        }), { wrapper: wrapper(queryClient) })
+        await waitFor(() => expect(result.current.availableModels).toEqual(OLD))
+
+        await act(async () => {
+            await applyAgyCatalogAnnouncement(queryClient, 'machine-1')
+        })
+
+        await waitFor(() => expect(result.current.availableModels).toEqual(NEW))
+        queryClient.clear()
+    })
+
+    it('does not let a reply carrying the superseded listing land on top of the newer one', async () => {
+        // The announcement can arrive while the request that will answer with the
+        // old listing is still in flight.
+        let release: (() => void) | null = null
+        let call = 0
+        const getMachineAgyModels = vi.fn(async () => {
+            call += 1
+            if (call === 2) {
+                await new Promise<void>((resolve) => { release = resolve })
+                return { success: true, availableModels: OLD }
+            }
+            return { success: true, availableModels: call === 1 ? OLD : NEW }
+        })
+        const api = { getMachineAgyModels } as unknown as ApiClient
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+        const { result } = renderHook(() => useAgyModels({
+            api, machineId: 'machine-1', enabled: true
+        }), { wrapper: wrapper(queryClient) })
+        await waitFor(() => expect(result.current.availableModels).toEqual(OLD))
+
+        act(() => { result.current.refetch() })
+        await waitFor(() => expect(getMachineAgyModels).toHaveBeenCalledTimes(2))
+
+        await act(async () => {
+            await applyAgyCatalogAnnouncement(queryClient, 'machine-1')
+        })
+        await waitFor(() => expect(result.current.availableModels).toEqual(NEW))
+
+        await act(async () => {
+            release?.()
+            await new Promise((resolve) => setTimeout(resolve, 50))
+        })
+        expect(result.current.availableModels).toEqual(NEW)
+        queryClient.clear()
+    })
+
+    it('does not let the very first reply win when the announcement beat it', async () => {
+        // `Query.fetch` cancels an in-flight request only when the query already
+        // holds data, so a cold first mount has to be forced a second fetch.
+        let release: (() => void) | null = null
+        let call = 0
+        const getMachineAgyModels = vi.fn(async () => {
+            call += 1
+            if (call === 1) {
+                await new Promise<void>((resolve) => { release = resolve })
+                return { success: true, availableModels: OLD }
+            }
+            return { success: true, availableModels: NEW }
+        })
+        const api = { getMachineAgyModels } as unknown as ApiClient
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+        const { result } = renderHook(() => useAgyModels({
+            api, machineId: 'machine-1', enabled: true
+        }), { wrapper: wrapper(queryClient) })
+        await waitFor(() => expect(getMachineAgyModels).toHaveBeenCalledTimes(1))
+        expect(result.current.availableModels).toEqual([])
+
+        // The announcement lands while that first request is still open.
+        await act(async () => {
+            await applyAgyCatalogAnnouncement(queryClient, 'machine-1')
+        })
+        await act(async () => {
+            release?.()
+            await new Promise((resolve) => setTimeout(resolve, 50))
+        })
+
+        await waitFor(() => expect(result.current.availableModels).toEqual(NEW))
+        queryClient.clear()
+    })
+
+    it('makes one request for two consumers of the same machine, not two', async () => {
+        const getMachineAgyModels = vi.fn(async () => ({ success: true, availableModels: NEW }))
+        const api = { getMachineAgyModels } as unknown as ApiClient
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        const shared = wrapper(queryClient)
+
+        const first = renderHook(() => useAgyModels({ api, machineId: 'machine-1', enabled: true }), { wrapper: shared })
+        const second = renderHook(() => useAgyModels({ api, machineId: 'machine-1', enabled: true }), { wrapper: shared })
+
+        await waitFor(() => expect(first.result.current.availableModels).toHaveLength(1))
+        await waitFor(() => expect(second.result.current.availableModels).toHaveLength(1))
+        expect(getMachineAgyModels).toHaveBeenCalledTimes(1)
+
+        await act(async () => {
+            await applyAgyCatalogAnnouncement(queryClient, 'machine-1')
+        })
+        expect(getMachineAgyModels).toHaveBeenCalledTimes(2)
+        queryClient.clear()
     })
 })

--- a/web/src/hooks/queries/useAgyModels.test.tsx
+++ b/web/src/hooks/queries/useAgyModels.test.tsx
@@ -1,0 +1,60 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ApiClient } from '@/api/client'
+import { useAgyModels } from './useAgyModels'
+
+function wrapper(queryClient: QueryClient) {
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+}
+
+describe('useAgyModels', () => {
+    it('forces a re-probe for the retry that follows, then goes back to the cached catalog', async () => {
+        const getMachineAgyModels = vi.fn(async () => ({
+            success: true,
+            availableModels: [{ modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' }]
+        }))
+        const api = { getMachineAgyModels } as unknown as ApiClient
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+        const { result } = renderHook(() => useAgyModels({
+            api,
+            machineId: 'machine-1',
+            enabled: true
+        }), { wrapper: wrapper(queryClient) })
+
+        await waitFor(() => expect(result.current.availableModels).toHaveLength(1))
+        expect(getMachineAgyModels).toHaveBeenLastCalledWith('machine-1', { refresh: false })
+
+        act(() => { result.current.refetch() })
+        await waitFor(() => expect(getMachineAgyModels).toHaveBeenCalledTimes(2))
+        expect(getMachineAgyModels).toHaveBeenLastCalledWith('machine-1', { refresh: true })
+
+        await queryClient.refetchQueries({ queryKey: ['machine-agy-models', 'machine-1'] })
+        expect(getMachineAgyModels).toHaveBeenLastCalledWith('machine-1', { refresh: false })
+    })
+
+    it('separates a catalog that is merely out of date from one that could not be loaded', async () => {
+        const getMachineAgyModels = vi.fn(async () => ({
+            success: true,
+            availableModels: [{ modelId: 'gemini-3.8-flash-high', name: 'Gemini 3.8 Flash (High)' }],
+            error: 'Authentication required. Please run `agy` in a terminal to sign in with Google.'
+        }))
+        const api = { getMachineAgyModels } as unknown as ApiClient
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+        const { result } = renderHook(() => useAgyModels({
+            api,
+            machineId: 'machine-1',
+            enabled: true
+        }), { wrapper: wrapper(queryClient) })
+
+        await waitFor(() => expect(result.current.availableModels).toHaveLength(1))
+        expect(result.current.error).toBeNull()
+        expect(result.current.warning).toContain('Authentication required')
+        expect(result.current.isFetching).toBe(false)
+    })
+})

--- a/web/src/hooks/queries/useAgyModels.ts
+++ b/web/src/hooks/queries/useAgyModels.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { useRef } from 'react'
 import type { ApiClient } from '@/api/client'
 import type { AgyModelSummary } from '@/types/api'
 import { queryKeys } from '@/lib/query-keys'
@@ -12,23 +13,36 @@ export function useAgyModels(args: {
     currentModelId: string | null
     isLoading: boolean
     error: string | null
+    /**
+     * The machine still has a catalog but its last sign-in check failed, so the
+     * list is usable and out of date at the same time. Separate from `error`,
+     * which means there is nothing to show.
+     */
+    warning: string | null
+    /** A request is in flight, including a Retry over an already-loaded catalog. */
+    isFetching: boolean
     refetch: () => void
 } {
     const { api, machineId } = args
     const enabled = Boolean(args.enabled && api && machineId)
+    // Spent on the very next fetch so mount and focus refetches stay answerable
+    // from the machine's cache; only Retry means that cache is not wanted.
+    const forceRefreshRef = useRef(false)
 
     const query = useQuery({
         queryKey: machineId
             ? queryKeys.machineAgyModels(machineId)
             : ['machine-agy-models', 'unknown'] as const,
         queryFn: async () => {
+            const refresh = forceRefreshRef.current
+            forceRefreshRef.current = false
             if (!api) {
                 throw new Error('API unavailable')
             }
             if (!machineId) {
                 throw new Error('Agy models target unavailable')
             }
-            return await api.getMachineAgyModels(machineId)
+            return await api.getMachineAgyModels(machineId, { refresh })
         },
         enabled,
         staleTime: 60_000,
@@ -46,7 +60,10 @@ export function useAgyModels(args: {
                 : query.error
                     ? 'Failed to load Agy models'
                     : null,
+        warning: query.data?.success === true ? (query.data.error ?? null) : null,
+        isFetching: query.isFetching,
         refetch: () => {
+            forceRefreshRef.current = true
             void query.refetch()
         }
     }

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -21,6 +21,7 @@ import type {
     SyncEvent
 } from '@/types/api'
 import { queryKeys } from '@/lib/query-keys'
+import { applyAgyCatalogAnnouncement } from '@/lib/agyCatalogAnnouncement'
 import { clearMessageWindow, getMessageWindowState, ingestIncomingMessages, markMessagesConsumed, markMessagesIndeterminate, markMessagesRequeued, removeOptimisticMessage, updateMessageStatus } from '@/lib/message-window-store'
 import { applySessionDetailPatch } from '@/lib/sessionPatch'
 
@@ -762,6 +763,10 @@ export function useSSE(options: {
                         queueSessionListInvalidation()
                     }
                 }
+            }
+
+            if (event.type === 'machine-agy-models-updated') {
+                void applyAgyCatalogAnnouncement(queryClient, event.machineId)
             }
 
             if (event.type === 'machine-updated') {

--- a/web/src/lib/agyCatalogAnnouncement.ts
+++ b/web/src/lib/agyCatalogAnnouncement.ts
@@ -1,0 +1,34 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/lib/query-keys'
+
+/**
+ * Re-read one machine's agy catalog after it announced a newer listing.
+ *
+ * Cancelling first is not belt-and-braces: `invalidateQueries` leans on
+ * `Query.fetch`, which cancels an in-flight request only when the query already
+ * holds data, so a picker opening for the first time would instead join the
+ * request already on its way and settle on the listing being superseded.
+ * `cancelQueries` has no such condition, and is a no-op when nothing is in
+ * flight.
+ */
+export async function applyAgyCatalogAnnouncement(
+    queryClient: QueryClient,
+    machineId: string
+): Promise<void> {
+    await refreshAgyCatalogs(queryClient, queryKeys.machineAgyModels(machineId))
+}
+
+/**
+ * Re-read every machine's agy catalog after a reconnect the hub could not replay.
+ * Announcements made during that gap are gone, so this is the only correction
+ * those pickers get — and a picker that mounted mid-gap is exactly the data-less
+ * in-flight case above.
+ */
+export async function refreshAllAgyCatalogs(queryClient: QueryClient): Promise<void> {
+    await refreshAgyCatalogs(queryClient, ['machine-agy-models'])
+}
+
+async function refreshAgyCatalogs(queryClient: QueryClient, queryKey: readonly unknown[]): Promise<void> {
+    await queryClient.cancelQueries({ queryKey })
+    await queryClient.invalidateQueries({ queryKey })
+}

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -372,7 +372,7 @@ export default {
   'newSession.model.loadFailed': 'Failed to load models',
   'newSession.model.selectVariant': 'Select variant',
   'newSession.model.cursorUnavailable': 'No Cursor models yet. Start a Cursor session once, or use Auto.',
-  'newSession.agyModel.checkingAuth': 'Checking Antigravity authentication…',
+  'newSession.agyModel.fetchingModels': 'Fetching available models…',
   'newSession.agyModel.authRequired': 'Authentication required',
   'newSession.agyModel.authHint': 'Please run `agy` in a terminal to sign in with Google.',
   'newSession.agyModel.retry': 'Retry',

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -376,6 +376,7 @@ export default {
   'newSession.agyModel.authRequired': 'Authentication required',
   'newSession.agyModel.authHint': 'Please run `agy` in a terminal to sign in with Google.',
   'newSession.agyModel.retry': 'Retry',
+  'newSession.agyModel.notListed': 'no longer listed',
   'newSession.agyModel.noModels': 'No Antigravity models available',
   'newSession.opencodeModel.loading': 'Discovering OpenCode models…',
   'newSession.opencodeModel.loadFailed': 'Failed to load OpenCode models',


### PR DESCRIPTION
## Problem

Picking agy's model behaves differently depending on which screen I am on.

New Session asks my machine what `agy models` currently lists. The session I already have open offers the built-in list in `shared/src/models.ts` instead. That list is maintained by hand, so the two screens drift apart as agy's own listing moves: today `agy models` gives me Gemini 3.8 Flash and no longer gives me 3.5, while the in-session picker still offers 3.5 and cannot reach 3.8. I can start a new session on a model I cannot switch the current one to.

Pointing the in-session picker at the same catalog is small on its own, but `agy models` is a whole agy invocation: a few seconds on a good day, fifteen when it times out. The answer was only held for a minute, so every session would pay that. And however the list is fetched, a picker I have already opened keeps showing whatever it was handed, so I end up closing and reopening it to find out whether anything changed.

## Solution

**The machine keeps the catalog.** The last listing agy actually returned is answered from directly: fresh for ten minutes, then still answered while a re-check runs behind it, and dropped once it is a day old. A re-check that times out or loses sign-in leaves that listing alone, so a blip no longer empties a working picker.

**A picker that is already open follows the re-check.** When a re-check changes what the route would answer, the machine says so on the stream that already carries machine changes, and the web re-reads that one machine's catalog. The open picker updates without polling or being reopened; sign-in warnings also follow refresh results.

**Retry means retry, and says why it is there.** With the catalog held for ten minutes, Retry would otherwise hand back the answer it was pressed to replace, so it asks the machine to skip its cache. It is now reachable beside a usable list, with the sign-in failure that explains why that list may be out of date, and it says it is working while it runs because it costs an agy invocation.

**A model I picked stays picked.** The catalog can change while the New Session form is open, so a model I chose there stays selected, marked as no longer listed rather than silently dropped. One restored from a draft or a saved preference is still dropped, as before.

The spinner also said "Checking Antigravity authentication…" while nothing at that point checks authentication. It now says "Fetching available models…", the words agy prints while it fetches.

| Before | After |
| --- | --- |
| ![Before: the in-session picker uses the built-in AGY model list](https://github.com/user-attachments/assets/13d59ebf-7f04-45ac-b0a3-5c1a4fe0a1b5) | ![After: the in-session picker uses the machine's live AGY model list](https://github.com/user-attachments/assets/c40d28dc-4fc9-421e-9a6f-8b3216e1ddc3) |

## Tests

`bun run typecheck && bun run test:cli && bun run test:hub && bun run test:web && bun run test:shared && bun run test:relay`, one package at a time because the cli suite's `globalSetup` writes a fixed path under `/tmp`, and each of the eight commits standalone.

The units stop where the module does: they drive the catalog with a faked `agy` and the pickers with a faked catalog. Past that, against a hub and a runner built from this branch:

- With a **real signed-in agy**, the machine route answered in seconds cold and in milliseconds afterwards, and asking again with `?refresh=true` cost a real probe. An already-running agy session offered the live listing in its composer, where on `main` the same session offered the built-in one.
- The live catalog stayed unchanged during testing, so the cases that need the listing to change ran against a **stub `agy` on PATH**, with the rest of the stack unchanged: a composer model list left open redrew in place with no click, `agy` was invoked twice across the whole run and stayed there afterwards, and a model picked on the New Session form before the catalog dropped it stayed selected.
