### PR TITLE
fix(pi): make user model selection sticky — do not revert to startup model on list refresh

### DIFF
--- a/cli/src/pi/loop.test.ts
+++ b/cli/src/pi/loop.test.ts
@@ -844,6 +844,87 @@ describe('wireTransportEvents', () => {
         }
     });
 
+    it('applies startup model only once across repeated get_available_models responses (does not revert user switch on list refresh)', async () => {
+        vi.useFakeTimers();
+        try {
+            session = createMockSession('startup-model');
+            const transport = createMockTransport();
+            wireTransportEvents(transport, session, []);
+
+            // First discovery: applies startup model
+            emitEvent({
+                type: 'response',
+                command: 'get_available_models',
+                success: true,
+                data: { models: [{ id: 'startup-model', provider: 'provider' }, { id: 'user-model', provider: 'provider' }] },
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            expect(transport.send).toHaveBeenCalledTimes(1);
+            expect(transport.send).toHaveBeenCalledWith(expect.objectContaining({
+                type: 'set_model', provider: 'provider', modelId: 'startup-model',
+            }));
+
+            // Simulate user explicitly switching to another model
+            session.explicitModelSelection = true;
+            session.currentModel = 'user-model';
+
+            // Subsequent discovery (e.g. web UI refetch on window focus): must NOT re-apply startup model
+            (transport.send as any).mockClear();
+            emitEvent({
+                type: 'response',
+                command: 'get_available_models',
+                success: true,
+                data: { models: [{ id: 'startup-model', provider: 'provider' }, { id: 'user-model', provider: 'provider' }] },
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            expect(transport.send).not.toHaveBeenCalled();
+            expect(session.currentModel).toBe('user-model');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('does not apply startup model if user already selected a model before first discovery', async () => {
+        vi.useFakeTimers();
+        try {
+            session = createMockSession('startup-model');
+            const transport = createMockTransport();
+            wireTransportEvents(transport, session, []);
+
+            // User selected model before discovery returned
+            session.explicitModelSelection = true;
+            session.currentModel = 'user-picked';
+
+            emitEvent({
+                type: 'response',
+                command: 'get_available_models',
+                success: true,
+                data: { models: [{ id: 'startup-model', provider: 'provider' }] },
+            });
+            await vi.advanceTimersByTimeAsync(0);
+            expect(transport.send).not.toHaveBeenCalled();
+            await expect(session.startupModelSettled).resolves.toBeUndefined();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('marks explicitModelSelection when set_model response arrives', () => {
+        const transport = createMockTransport();
+        wireTransportEvents(transport, session, []);
+        expect(session.explicitModelSelection).toBe(false);
+
+        emitEvent({
+            type: 'response',
+            command: 'set_model',
+            success: true,
+            data: { id: 'new-model', provider: 'p' },
+        });
+
+        expect(session.explicitModelSelection).toBe(true);
+        expect(session.currentModel).toBe('new-model');
+    });
+
     it('handles get_commands response — caches commands', () => {
         const transport = createMockTransport();
         wireTransportEvents(transport, session, []);

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -275,6 +275,9 @@ function handleResponse(
                 if (modelId) {
                     session.currentModel = modelId;
                 }
+                // An accepted set_model is an explicit selection: never let a
+                // late startup-model attempt overwrite it.
+                session.explicitModelSelection = true;
                 if (data.provider && data.provider.length > 0) {
                     session.currentProvider = data.provider;
                 }
@@ -304,15 +307,17 @@ function handleResponse(
                     piAvailableModels: models,
                 }));
 
-                // Apply the requested startup model only after confirming it exists
-                // in Pi's available models and Pi accepts set_model. Commit
-                // currentModel/currentProvider only on success so the hub does not
-                // persist a model Pi rejected or never had. Fire-and-forget the
-                // await so resolving the get_available_models RPC itself is not
-                // blocked (it may be awaited by ListPiModels).
-                if (session.initialModel && transport) {
-                    const match = models.find((m) => m.modelId === session.initialModel)
-                        ?? models.find((m) => `${m.provider}/${m.modelId}` === session.initialModel);
+                // The startup model is a *one-shot* bootstrap. It is applied only on
+                // the first discovery that can act on it, and only while the user has
+                // not picked a model in this session. Re-applying it on every response
+                // made any later model-list refresh (the web picker polls ListPiModels)
+                // silently revert the user's own selection back to the launch model.
+                const startupModel = session.initialModel;
+                // Consume regardless of outcome: the startup model gets exactly one chance.
+                if (startupModel) session.initialModel = null;
+                if (startupModel && transport && !session.explicitModelSelection) {
+                    const match = models.find((m) => m.modelId === startupModel)
+                        ?? models.find((m) => `${m.provider}/${m.modelId}` === startupModel);
                     if (match) {
                         void (async () => {
                             try {
@@ -343,10 +348,13 @@ function handleResponse(
                             session.resolveStartupModelSettled?.();
                         })();
                     } else {
-                        logger.debug(`[pi] Startup model not found in available models: ${session.initialModel}`);
+                        logger.debug(`[pi] Startup model not found in available models: ${startupModel}`);
                         session.resolveStartupModelSettled?.();
                     }
                 } else {
+                    if (startupModel && session.explicitModelSelection) {
+                        logger.debug('[pi] Startup model skipped: session already has an explicit model selection');
+                    }
                     session.resolveStartupModelSettled?.();
                 }
             } else {

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -321,7 +321,15 @@ function handleResponse(
                     if (match) {
                         void (async () => {
                             try {
-                                await session.runRuntimeMutation(async () => {
+                                const applied = await session.runRuntimeMutation(async () => {
+                                    // Re-check under the lease: the gate above ran before
+                                    // any queued user selection was granted the mutation
+                                    // lease. A selection that got there first must win, and
+                                    // applying the launch model over it would silently
+                                    // revert the user's own choice.
+                                    if (session.explicitModelSelection) {
+                                        return false;
+                                    }
                                     await sendPiRpcAndWait(session, transport, {
                                         type: 'set_model',
                                         provider: match.provider,
@@ -330,8 +338,13 @@ function handleResponse(
                                     session.currentModel = match.modelId;
                                     session.currentProvider = match.provider;
                                     persistSelectedPiModel(session);
+                                    return true;
                                 }, { poisonOnError: (error) => error instanceof PiRpcTimeoutError });
-                                logger.debug(`[pi] Startup model applied: ${match.provider}/${match.modelId}`);
+                                if (applied) {
+                                    logger.debug(`[pi] Startup model applied: ${match.provider}/${match.modelId}`);
+                                } else {
+                                    logger.debug('[pi] Startup model skipped: an explicit selection acquired the mutation lease first');
+                                }
                             } catch (error) {
                                 if (error instanceof PiRpcTimeoutError) {
                                     onStartupFailure?.(new Error(`Pi startup model outcome is indeterminate: ${error.message}`));

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1687,6 +1687,60 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
+    it('keeps a queued picker selection when discovery lands while the runtime mutation lock is held', async () => {
+        const running = runPi({ workingDirectory: '/work', model: 'startup-model' });
+        await vi.waitFor(() => expect(harness.onEvent).not.toBeNull());
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-lock-session', sessionFile: '/tmp/pi-lock.jsonl', isStreaming: false },
+        });
+        await completeHistoryInitialization();
+
+        const setConfig = harness.rpcHandlers.get(RPC_METHODS.SetSessionConfig)!;
+
+        // Hold the runtime-mutation lock with an unrelated config change.
+        const effortPromise = setConfig({ effort: 'high' });
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({ type: 'set_thinking_level' })));
+
+        // The user's model pick is only *queued* behind that lock.
+        const modelPromise = setConfig({ model: { provider: 'provider', modelId: 'user-model' } });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(harness.sent.filter((item) => (item as { type?: string }).type === 'set_model')).toHaveLength(0);
+
+        // Startup discovery lands while the lock is still held: the startup
+        // bootstrap is scheduled behind the pending user selection.
+        harness.onEvent!({
+            type: 'response', command: 'get_available_models', success: true,
+            data: { models: [
+                { id: 'startup-model', provider: 'provider' },
+                { id: 'user-model', provider: 'provider' },
+            ] },
+        });
+
+        // Release the lock: the user's selection runs first and the startup
+        // bootstrap must not be applied over it afterwards.
+        const setThinking = harness.sent.find((item) => (item as { type?: string }).type === 'set_thinking_level') as { id: string };
+        harness.onEvent!({ type: 'response', id: setThinking.id, command: 'set_thinking_level', success: true });
+        await expect(effortPromise).resolves.toBeDefined();
+
+        await vi.waitFor(() => expect(harness.sent.filter((item) => (item as { type?: string }).type === 'set_model')).toHaveLength(1));
+        const modelCommand = harness.sent.filter((item) => (item as { type?: string }).type === 'set_model')[0] as { id: string };
+        expect(modelCommand).toMatchObject({ provider: 'provider', modelId: 'user-model' });
+        harness.onEvent!({
+            type: 'response', id: modelCommand.id, command: 'set_model', success: true,
+            data: { id: 'user-model', provider: 'provider' },
+        });
+        await expect(modelPromise).resolves.toBeDefined();
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        const switches = harness.sent.filter((item) => (item as { type?: string }).type === 'set_model');
+        expect(switches).toHaveLength(1);
+        expect(switches[0]).toMatchObject({ provider: 'provider', modelId: 'user-model' });
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
     it('recovers /model from an empty model cache by retrying discovery', async () => {
         const { running, onUserMessage } = await startReadySession();
         // No get_available_models was answered at startup: the cache is empty

--- a/cli/src/pi/runPi.test.ts
+++ b/cli/src/pi/runPi.test.ts
@@ -1570,6 +1570,123 @@ describe('Pi built-in slash commands', () => {
         await running;
     });
 
+    it('does not re-apply the startup model when discovery lands while the web picker switch is in flight', async () => {
+        const running = runPi({ workingDirectory: '/work', model: 'startup-model' });
+        await vi.waitFor(() => expect(harness.onEvent).not.toBeNull());
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-picker-session', sessionFile: '/tmp/pi-picker.jsonl', isStreaming: false },
+        });
+        await completeHistoryInitialization();
+
+        // The user picks a model from the web UI before Pi's first discovery
+        // has been answered, so its set_model is still awaiting confirmation.
+        const setConfig = harness.rpcHandlers.get(RPC_METHODS.SetSessionConfig)!;
+        const configPromise = setConfig({ model: { provider: 'provider', modelId: 'user-model' } });
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'set_model', provider: 'provider', modelId: 'user-model',
+        })));
+
+        // Discovery lands mid-switch: the launch-time model must not be applied
+        // over the in-flight explicit selection.
+        harness.onEvent!({
+            type: 'response', command: 'get_available_models', success: true,
+            data: { models: [
+                { id: 'startup-model', provider: 'provider' },
+                { id: 'user-model', provider: 'provider' },
+            ] },
+        });
+        // Confirm the user's switch, then let the runtime-mutation queue drain:
+        // the startup model would be applied behind this mutation, so a second
+        // set_model appearing here means the launch model came back.
+        const pickerSwitch = harness.sent.find((item) => (item as { type?: string }).type === 'set_model') as { id: string };
+        harness.onEvent!({
+            type: 'response', id: pickerSwitch.id, command: 'set_model', success: true,
+            data: { id: 'user-model', provider: 'provider' },
+        });
+        await expect(configPromise).resolves.toMatchObject({
+            applied: { model: { provider: 'provider', modelId: 'user-model' } },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const switches = harness.sent.filter((item) => (item as { type?: string }).type === 'set_model');
+        expect(switches).toHaveLength(1);
+        expect(switches[0]).toMatchObject({ provider: 'provider', modelId: 'user-model' });
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
+    it('keeps a /model switch when a discovery refresh lands before the switch settles', async () => {
+        const running = runPi({ workingDirectory: '/work', model: 'startup-model' });
+        await vi.waitFor(() => expect(harness.onEvent).not.toBeNull());
+        harness.onEvent!({
+            type: 'response', command: 'get_state', success: true,
+            data: { sessionId: 'pi-slash-model-session', sessionFile: '/tmp/pi-slash-model.jsonl', isStreaming: false },
+        });
+        await completeHistoryInitialization();
+        // Warm the command cache: slash-message handling consults discovered
+        // commands to decide extension-vs-builtin precedence.
+        const getCommands = harness.sent.find((item) => (item as { type?: string }).type === 'get_commands') as { id: string };
+        harness.onEvent!({
+            type: 'response', id: getCommands.id, command: 'get_commands', success: true,
+            data: { commands: [{ name: 'test-extension', description: 'Test extension', source: 'extension' }] },
+        });
+        const onUserMessage = harness.session.onUserMessage.mock.calls.at(-1)![0] as (message: {
+            role: 'user';
+            content: { type: 'text'; text: string };
+        }, localId: string) => void;
+
+        // Startup discovery applies the launch model exactly once.
+        harness.onEvent!({
+            type: 'response', command: 'get_available_models', success: true,
+            data: { models: [
+                { id: 'startup-model', provider: 'provider' },
+                { id: 'user-model', provider: 'provider' },
+            ] },
+        });
+        await vi.waitFor(() => expect(harness.sent).toContainEqual(expect.objectContaining({
+            type: 'set_model', provider: 'provider', modelId: 'startup-model',
+        })));
+        const startupSwitch = harness.sent.find((item) => (item as { type?: string }).type === 'set_model') as { id: string };
+        harness.onEvent!({
+            type: 'response', id: startupSwitch.id, command: 'set_model', success: true,
+            data: { id: 'startup-model', provider: 'provider' },
+        });
+        await vi.waitFor(() => expect(harness.sent.filter((item) => (item as { type?: string }).type === 'set_model')).toHaveLength(1));
+
+        // The user switches with /model; a list refresh lands before Pi confirms.
+        onUserMessage({ role: 'user', content: { type: 'text', text: '/model user-model' } }, 'switch-id');
+        await vi.waitFor(() => expect(harness.sent.filter((item) => (item as { type?: string }).type === 'set_model')).toHaveLength(2));
+        const userSwitch = harness.sent.filter((item) => (item as { type?: string }).type === 'set_model')[1] as { id: string };
+        expect(userSwitch).toMatchObject({ provider: 'provider', modelId: 'user-model' });
+
+        harness.onEvent!({
+            type: 'response', command: 'get_available_models', success: true,
+            data: { models: [
+                { id: 'startup-model', provider: 'provider' },
+                { id: 'user-model', provider: 'provider' },
+            ] },
+        });
+        // Confirm the /model switch, then drain the mutation queue: the refresh
+        // must not queue a startup-model re-application behind it.
+        harness.onEvent!({
+            type: 'response', id: userSwitch.id, command: 'set_model', success: true,
+            data: { id: 'user-model', provider: 'provider' },
+        });
+        await vi.waitFor(() => expect(harness.session.sendSessionEvent).toHaveBeenCalledWith(expect.objectContaining({
+            message: 'Model switched to user-model',
+        })));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const switches = harness.sent.filter((item) => (item as { type?: string }).type === 'set_model');
+        expect(switches).toHaveLength(2);
+        expect(switches[1]).toMatchObject({ provider: 'provider', modelId: 'user-model' });
+
+        harness.onError?.(new Error('finish test'));
+        await running;
+    });
+
     it('recovers /model from an empty model cache by retrying discovery', async () => {
         const { running, onUserMessage } = await startReadySession();
         // No get_available_models was answered at startup: the cache is empty

--- a/cli/src/pi/runPi.ts
+++ b/cli/src/pi/runPi.ts
@@ -786,6 +786,13 @@ export async function runPi(opts: {
 
         try {
             return await piSession.runRuntimeMutation(async () => {
+                // A model change requested through SetSessionConfig (web picker) is an
+                // explicit user selection: record it before the Pi round-trip so a
+                // get_available_models response landing in between cannot re-apply the
+                // launch-time startup model over the user's choice.
+                if (requestedModel) {
+                    piSession.explicitModelSelection = true;
+                }
                 // Forward changes to Pi process — wait for Pi to confirm before
                 // committing to PiSession or reporting applied. The runtime mutation
                 // lock is shared with clone/fork/switch_session so a slow set_model
@@ -977,6 +984,9 @@ export async function runPi(opts: {
                 }
                 try {
                     await piSession.runRuntimeMutation(async () => {
+                        // `/model` is an explicit user selection — same protection as the
+                        // web picker path: a later model-list refresh must not revert it.
+                        piSession.explicitModelSelection = true;
                         await sendPiRpcAndWait(piSession, transport, {
                             type: 'set_model',
                             provider: match.provider,

--- a/cli/src/pi/session.ts
+++ b/cli/src/pi/session.ts
@@ -45,8 +45,18 @@ export class PiSession {
     // Pi's set_model requires provider + modelId; learned from get_state
     currentProvider: string | null = null;
     // Startup model from opts.model — prevents get_state from overwriting it
-    // with Pi's default. Applied once when get_available_models returns.
-    readonly initialModel: string | null;
+    // with Pi's default. Bootstrap-only: consumed (set to null) on the first
+    // get_available_models response that attempts to apply it, so a later
+    // model-list refresh can never re-apply it over the user's own choice.
+    initialModel: string | null;
+    /**
+     * True once this session has an explicit model selection from the user
+     * (web picker → SetSessionConfig, or the `/model` slash command). While set,
+     * the startup model is never (re-)applied — otherwise a model-list refresh
+     * arriving after the switch would silently revert the user's selection to
+     * the launch-time `--model`.
+     */
+    explicitModelSelection = false;
     /**
      * Settles once the startup model attempt has finished (applied, rejected,
      * or absent). Startup effort waits on it so set_thinking_level never races
@@ -126,6 +136,7 @@ export class PiSession {
         // resume before Pi reports its real state.
         this.currentModel = undefined;
         this.initialModel = opts.model?.trim() || null;
+        this.explicitModelSelection = false;
         this.startupModelSettled = new Promise<void>((resolve) => {
             this.resolveStartupModelSettled = resolve;
         });


### PR DESCRIPTION
## Problem

Launching Pi with a startup model (`hapi pi --model <m>`) captures that model as `initialModel`, meant to be applied once Pi's available models are confirmed. But `initialModel` was `readonly` and never cleared, so **every** subsequent `get_available_models` response re-issued `set_model` for the startup model and silently reverted whatever model the user had switched to.

Those responses are not rare: the web model picker polls `ListPiModels` (`/api/sessions/:id/pi-models`), and Pi re-emits the model list on window focus and reconnect. Net effect: switch the model in the web UI, and the next list refresh snaps it back to the launch model.

## Fix

1. `cli/src/pi/session.ts` — make `initialModel` mutable and add `explicitModelSelection`.
2. `cli/src/pi/loop.ts`:
   - the startup model is now consumed (nulled out) on the first discovery that can act on it, so it gets exactly one chance;
   - application is additionally guarded by `!session.explicitModelSelection`;
   - an accepted `set_model` response sets `explicitModelSelection = true`.
3. `cli/src/pi/runPi.ts` — mark `explicitModelSelection = true` on both the web picker (`SetSessionConfig`) and the CLI (`/model`) paths *before* the switch round-trip, so a `get_available_models` response landing in between cannot re-apply the launch model over the user's choice.
4. `cli/src/pi/loop.test.ts` — 3 new unit tests: repeated list refreshes do not revert the user's selection, a selection made before the first discovery is preserved, and a `set_model` response marks the flag.

## Testing

- `cd cli && bun run typecheck` — clean
- `cd cli && bun run test` — 234 files, 2619 tests passed, 2 skipped

## AI assistance

Drafted with an AI coding agent (Vibe Coding); reviewed, tested and verified locally.
