### PR TITLE
fix(cursor): keep ACP wire ids spawn-safe and apply effort (#1818)

### DIFF
--- a/cli/src/cursor/utils/cursorAcpModelsBridge.ts
+++ b/cli/src/cursor/utils/cursorAcpModelsBridge.ts
@@ -3,6 +3,8 @@ import type { CursorModelSummary } from '@hapi/protocol/apiTypes';
 export type CursorModelsSnapshot = {
     availableModels: CursorModelSummary[];
     currentModelId: string | null;
+    /** ACP advertised the parameterized picker (bare bases + fast/thought_level options). */
+    parameterized?: boolean;
 };
 
 let snapshot: CursorModelsSnapshot | null = null;

--- a/cli/src/cursor/utils/cursorAcpModelsSnapshot.test.ts
+++ b/cli/src/cursor/utils/cursorAcpModelsSnapshot.test.ts
@@ -48,7 +48,7 @@ describe('buildCursorModelsSnapshotFromAcp', () => {
         expect(snapshot?.availableModels).toHaveLength(2);
     });
 
-    it('synthesizes Composer fast variants from parameterized model + fast config options', () => {
+    it('keeps parameterized model + fast options as bare bases without synthesizing wires', () => {
         const backend = {
             getSessionModelsMetadata: () => ({
                 availableModels: [{ modelId: 'composer-2.5', name: 'Composer 2.5' }],
@@ -87,10 +87,10 @@ describe('buildCursorModelsSnapshotFromAcp', () => {
 
         const snapshot = buildCursorModelsSnapshotFromAcp(backend, 's1');
 
-        expect(snapshot?.availableModels.map((entry) => entry.modelId).sort()).toEqual([
-            'composer-2.5[fast=false]',
-            'composer-2.5[fast=true]'
-        ]);
-        expect(snapshot?.currentModelId).toBe('composer-2.5[fast=false]');
+        // `composer-2.5[fast=…]` is rejected by Cursor's `--model` whenever the wire
+        // omits another parameter of the model, so only the bare base is advertised.
+        expect(snapshot?.availableModels.map((entry) => entry.modelId)).toEqual(['composer-2.5']);
+        expect(snapshot?.currentModelId).toBe('composer-2.5');
+        expect(snapshot?.parameterized).toBe(true);
     });
 });

--- a/cli/src/cursor/utils/cursorAcpModelsSnapshot.ts
+++ b/cli/src/cursor/utils/cursorAcpModelsSnapshot.ts
@@ -4,6 +4,8 @@ import type { CursorModelSummary } from '@hapi/protocol/apiTypes';
 export type CursorModelsSnapshot = {
     availableModels: CursorModelSummary[];
     currentModelId: string | null;
+    /** ACP advertised the parameterized picker (bare bases + fast/thought_level options). */
+    parameterized?: boolean;
 };
 
 type CursorAcpModelSnapshotBackend = Pick<AcpSdkBackend, 'getSessionModelsMetadata' | 'getConfigOptionByCategory'>
@@ -39,8 +41,16 @@ function mergeModelEntries(
 }
 
 /**
- * Zed-style Cursor catalog: `configOptions` model category lists every wire id;
+ * Zed-style Cursor catalog: `configOptions` model category lists every model id;
  * `availableModels` alone is often one variant per base family.
+ *
+ * Cursor's parameterized picker advertises bare model bases plus separate
+ * `fast` / `thought_level` config options. Cursor rejects every bracket id whose
+ * parameter set is not that model's complete set, and those per-model sets are not
+ * derivable from the options, so no wire ids are ever synthesized here: the
+ * advertised values are kept verbatim (bare bases are accepted by `--model`, with
+ * defaults applied) and the requested parameters are applied over ACP config
+ * options by `applyParameterizedCursorModel`.
  */
 export function buildCursorModelsSnapshotFromAcp(
     backend: CursorAcpModelSnapshotBackend,
@@ -48,38 +58,14 @@ export function buildCursorModelsSnapshotFromAcp(
 ): CursorModelsSnapshot | null {
     const metadata = backend.getSessionModelsMetadata(sessionId);
     const modelOption = findConfigOption(backend, sessionId, 'model');
-    const fastOption = findConfigOption(backend, sessionId, 'fast');
 
     if (!metadata && !modelOption) {
         return null;
     }
 
     const merged = new Map<string, CursorModelSummary>();
-    const parameterizedFastModels: CursorModelSummary[] = [];
 
-    if (modelOption?.options?.length && fastOption?.options?.length) {
-        const fastValues = fastOption.options
-            .map((option) => option.value.trim())
-            .filter((value) => value === 'false' || value === 'true');
-        if (fastValues.length > 0) {
-            for (const option of modelOption.options) {
-                const modelId = option.value.trim();
-                if (!modelId || modelId.includes('[')) {
-                    continue;
-                }
-                for (const fast of fastValues) {
-                    parameterizedFastModels.push({
-                        modelId: `${modelId}[fast=${fast}]`,
-                        name: option.name
-                    });
-                }
-            }
-        }
-    }
-
-    if (parameterizedFastModels.length > 0) {
-        mergeModelEntries(merged, parameterizedFastModels);
-    } else if (modelOption?.options?.length) {
+    if (modelOption?.options?.length) {
         mergeModelEntries(merged, modelOption.options.map((option) => ({
             modelId: option.value,
             name: option.name
@@ -87,26 +73,24 @@ export function buildCursorModelsSnapshotFromAcp(
     }
 
     if (metadata?.availableModels?.length) {
-        mergeModelEntries(
-            merged,
-            parameterizedFastModels.length > 0
-                ? metadata.availableModels.filter((entry) => entry.modelId.includes('['))
-                : metadata.availableModels
-        );
+        mergeModelEntries(merged, metadata.availableModels);
     }
 
     if (merged.size === 0) {
         return null;
     }
 
-    const currentModelId = parameterizedFastModels.length > 0 && modelOption?.currentValue && fastOption?.currentValue
-        ? `${modelOption.currentValue}[fast=${fastOption.currentValue}]`
-        : metadata?.currentModelId
-            ?? modelOption?.currentValue
-            ?? null;
+    const parameterized = Boolean(
+        modelOption?.options?.length
+        && modelOption.options.every((option) => {
+            const value = option.value.trim();
+            return value.length > 0 && !value.includes('[');
+        })
+    );
 
     return {
         availableModels: [...merged.values()],
-        currentModelId
+        currentModelId: metadata?.currentModelId ?? modelOption?.currentValue ?? null,
+        ...(parameterized ? { parameterized: true } : {})
     };
 }

--- a/cli/src/cursor/utils/cursorModeConfig.test.ts
+++ b/cli/src/cursor/utils/cursorModeConfig.test.ts
@@ -330,6 +330,76 @@ describe('applyCursorAcpModel', () => {
         expect(setConfigOption).toHaveBeenNthCalledWith(2, 's1', 'fast', 'true');
     });
 
+    it('applies the requested effort over config options for variant sku requests (#1818)', async () => {
+        const setConfigOption = vi.fn(async () => {});
+        const backend = mockModelBackend({
+            setConfigOption,
+            getSessionModelsMetadata: vi.fn(() => ({
+                availableModels: [{ modelId: 'claude-opus-4-8', name: 'Claude Opus 4.8' }],
+                currentModelId: 'claude-opus-4-8'
+            })),
+            getConfigOptionByCategory: vi.fn((_sessionId: string, category: string) => {
+                if (category === 'model') {
+                    return { id: 'model', category: 'model', options: [{ value: 'claude-opus-4-8' }] };
+                }
+                if (category === 'fast') {
+                    return { id: 'fast', category: 'fast', options: [{ value: 'false' }, { value: 'true' }] };
+                }
+                return undefined;
+            }),
+            getSessionConfigOptions: vi.fn(() => [
+                { id: 'model', category: 'model', options: [{ value: 'claude-opus-4-8' }] },
+                {
+                    id: 'effort',
+                    category: 'thought_level',
+                    currentValue: 'high',
+                    options: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }]
+                },
+                { id: 'fast', category: 'model_config', options: [{ value: 'false' }, { value: 'true' }] }
+            ])
+        });
+
+        await expect(applyCursorAcpModel(backend, 's1', 'claude-opus-4-8-low')).resolves.toMatchObject({
+            applied: true,
+            resolvedWireId: 'claude-opus-4-8[fast=false,effort=low]',
+            requestedWireId: 'claude-opus-4-8-low'
+        });
+        expect(setConfigOption).toHaveBeenNthCalledWith(1, 's1', 'model', 'claude-opus-4-8');
+        expect(setConfigOption).toHaveBeenNthCalledWith(2, 's1', 'fast', 'false');
+        expect(setConfigOption).toHaveBeenNthCalledWith(3, 's1', 'effort', 'low');
+    });
+
+    it('skips parameter axes the selected model does not expose (#1818)', async () => {
+        let selected = 'grok-4.6';
+        const fastOption = { id: 'fast', category: 'fast', options: [{ value: 'false' }, { value: 'true' }] };
+        const modelOption = { id: 'model', category: 'model', options: [{ value: 'gemini-3-flash' }] };
+        const setConfigOption = vi.fn(async (_sessionId: string, id: string, value: string) => {
+            if (id === 'model') {
+                selected = value;
+            }
+        });
+        // Cursor drops fast/thought_level for a model that supports neither.
+        const activeOptions = () => (selected === 'gemini-3-flash' ? [modelOption] : [modelOption, fastOption]);
+        const backend = mockModelBackend({
+            setConfigOption,
+            getSessionModelsMetadata: vi.fn(() => ({
+                availableModels: [{ modelId: 'gemini-3-flash' }],
+                currentModelId: 'gemini-3-flash'
+            })),
+            getConfigOptionByCategory: vi.fn((_sessionId: string, category: string) =>
+                activeOptions().find((option) => option.category === category)
+            ),
+            getSessionConfigOptions: vi.fn(() => activeOptions())
+        });
+
+        await expect(applyCursorAcpModel(backend, 's1', 'gemini-3-flash')).resolves.toMatchObject({
+            applied: true,
+            resolvedWireId: 'gemini-3-flash'
+        });
+        expect(setConfigOption).toHaveBeenCalledTimes(1);
+        expect(setConfigOption).toHaveBeenCalledWith('s1', 'model', 'gemini-3-flash');
+    });
+
     it('does not fall back to base-only model apply when parameterized fast update fails', async () => {
         const setConfigOption = vi.fn()
             .mockResolvedValueOnce(undefined)

--- a/cli/src/cursor/utils/cursorModeConfig.test.ts
+++ b/cli/src/cursor/utils/cursorModeConfig.test.ts
@@ -400,6 +400,91 @@ describe('applyCursorAcpModel', () => {
         expect(setConfigOption).toHaveBeenCalledWith('s1', 'model', 'gemini-3-flash');
     });
 
+    it('maps aliased effort values onto the per-model option id (#1818)', async () => {
+        const modelOption = { id: 'model', category: 'model', options: [{ value: 'gpt-5.5' }] };
+        const backend = mockModelBackend({
+            setConfigOption: vi.fn(async () => {}),
+            getSessionModelsMetadata: vi.fn(() => ({
+                availableModels: [{ modelId: 'gpt-5.5' }],
+                currentModelId: 'gpt-5.5'
+            })),
+            getConfigOptionByCategory: vi.fn((_sessionId: string, category: string) => {
+                if (category === 'model') {
+                    return modelOption;
+                }
+                // gpt-5.5 spells the top effort `extra-high` on the `reasoning` id.
+                if (category === 'reasoning') {
+                    return {
+                        id: 'reasoning',
+                        category: 'thought_level',
+                        currentValue: 'medium',
+                        options: [{ value: 'none' }, { value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'extra-high' }]
+                    };
+                }
+                return undefined;
+            }),
+            getSessionConfigOptions: vi.fn(() => [modelOption, { id: 'reasoning', category: 'thought_level', options: [{ value: 'extra-high' }] }])
+        });
+
+        await expect(applyCursorAcpModel(backend, 's1', 'gpt-5.5-xhigh')).resolves.toMatchObject({
+            applied: true,
+            resolvedWireId: 'gpt-5.5[reasoning=extra-high]'
+        });
+        expect(backend.setConfigOption).toHaveBeenNthCalledWith(1, 's1', 'model', 'gpt-5.5');
+        expect(backend.setConfigOption).toHaveBeenNthCalledWith(2, 's1', 'reasoning', 'extra-high');
+    });
+
+    it('leaves Claude thinking untouched while switching effort (#1818)', async () => {
+        const setConfigOption = vi.fn(async () => {});
+        const options = [
+            { id: 'model', category: 'model', options: [{ value: 'claude-opus-4-8' }] },
+            { id: 'thinking', category: 'thought_level', currentValue: 'true', options: [{ value: 'false' }, { value: 'true' }] },
+            { id: 'effort', category: 'thought_level', currentValue: 'high', options: [{ value: 'low' }, { value: 'high' }, { value: 'xhigh' }] }
+        ];
+        const backend = mockModelBackend({
+            setConfigOption,
+            getSessionModelsMetadata: vi.fn(() => ({ availableModels: [{ modelId: 'claude-opus-4-8' }], currentModelId: 'claude-opus-4-8' })),
+            getConfigOptionByCategory: vi.fn((_sessionId: string, category: string) => {
+                if (category === 'model') {
+                    return options[0];
+                }
+                // Both `thinking` and `effort` are thought_level: category lookup must not
+                // pick the toggle when the requested axis is effort.
+                return category === 'effort' ? options[2] : undefined;
+            }),
+            getSessionConfigOptions: vi.fn(() => options)
+        });
+
+        await expect(applyCursorAcpModel(backend, 's1', 'claude-opus-4-8-xhigh')).resolves.toMatchObject({
+            applied: true,
+            resolvedWireId: 'claude-opus-4-8[effort=xhigh]'
+        });
+        expect(setConfigOption).toHaveBeenCalledTimes(2);
+        expect(setConfigOption).toHaveBeenNthCalledWith(2, 's1', 'effort', 'xhigh');
+    });
+
+    it('applies effort on gemini models through the reasoning_effort option id (#1818)', async () => {
+        const options = [
+            { id: 'model', category: 'model', options: [{ value: 'gemini-3.8-flash' }] },
+            { id: 'reasoning_effort', category: 'thought_level', currentValue: 'high', options: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }] }
+        ];
+        const setConfigOption = vi.fn(async () => {});
+        const backend = mockModelBackend({
+            setConfigOption,
+            getSessionModelsMetadata: vi.fn(() => ({ availableModels: [{ modelId: 'gemini-3.8-flash' }], currentModelId: 'gemini-3.8-flash' })),
+            getConfigOptionByCategory: vi.fn((_sessionId: string, category: string) =>
+                category === 'model' ? options[0] : undefined
+            ),
+            getSessionConfigOptions: vi.fn(() => options)
+        });
+
+        await expect(applyCursorAcpModel(backend, 's1', 'gemini-3.8-flash-high')).resolves.toMatchObject({
+            applied: true,
+            resolvedWireId: 'gemini-3.8-flash[reasoning_effort=high]'
+        });
+        expect(setConfigOption).toHaveBeenNthCalledWith(2, 's1', 'reasoning_effort', 'high');
+    });
+
     it('does not fall back to base-only model apply when parameterized fast update fails', async () => {
         const setConfigOption = vi.fn()
             .mockResolvedValueOnce(undefined)

--- a/cli/src/cursor/utils/cursorModeConfig.test.ts
+++ b/cli/src/cursor/utils/cursorModeConfig.test.ts
@@ -485,6 +485,66 @@ describe('applyCursorAcpModel', () => {
         expect(setConfigOption).toHaveBeenNthCalledWith(2, 's1', 'reasoning_effort', 'high');
     });
 
+    it('resolves the advertised base for a legacy cursor- prefixed sku (#1818)', async () => {
+        const setConfigOption = vi.fn(async () => {});
+        const options = [
+            { id: 'model', category: 'model', options: [{ value: 'grok-4.6' }] },
+            { id: 'effort', category: 'thought_level', currentValue: 'high', options: [{ value: 'low' }, { value: 'high' }] }
+        ];
+        const backend = mockModelBackend({
+            setConfigOption,
+            getSessionModelsMetadata: vi.fn(() => ({ availableModels: [{ modelId: 'grok-4.6' }], currentModelId: 'grok-4.6' })),
+            getConfigOptionByCategory: vi.fn((_sessionId: string, category: string) =>
+                category === 'model' ? options[0] : undefined
+            ),
+            getSessionConfigOptions: vi.fn(() => options)
+        });
+
+        await expect(applyCursorAcpModel(backend, 's1', 'cursor-grok-4.6-high')).resolves.toMatchObject({
+            applied: true,
+            resolvedWireId: 'grok-4.6[effort=high]',
+            requestedWireId: 'cursor-grok-4.6-high'
+        });
+        // The `cursor-` family prefix must map onto the advertised `grok-4.6` base.
+        expect(setConfigOption).toHaveBeenNthCalledWith(1, 's1', 'model', 'grok-4.6');
+        expect(setConfigOption).toHaveBeenNthCalledWith(2, 's1', 'effort', 'high');
+    });
+
+    it('reads the new model effort option after the base switch (#1818)', async () => {
+        // Cursor renames the effort axis across families: gpt-5.5 uses `reasoning`,
+        // claude-opus-4-8 uses `effort`. The apply path must resolve against the
+        // options advertised for the model it just selected, not the previous ones.
+        let selected = 'gpt-5.5';
+        const modelOption = { id: 'model', category: 'model', options: [{ value: 'gpt-5.5' }, { value: 'claude-opus-4-8' }] };
+        const gptOptions = [modelOption, { id: 'reasoning', category: 'thought_level', currentValue: 'medium', options: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }] }];
+        const claudeOptions = [modelOption, { id: 'effort', category: 'thought_level', currentValue: 'high', options: [{ value: 'low' }, { value: 'high' }, { value: 'xhigh' }] }];
+        const activeOptions = () => (selected === 'gpt-5.5' ? gptOptions : claudeOptions);
+        const setConfigOption = vi.fn(async (_sessionId: string, id: string, value: string) => {
+            if (id === 'model') {
+                selected = value;
+            }
+        });
+        const backend = mockModelBackend({
+            setConfigOption,
+            getSessionModelsMetadata: vi.fn(() => ({
+                availableModels: [{ modelId: 'claude-opus-4-8' }],
+                currentModelId: 'claude-opus-4-8'
+            })),
+            getConfigOptionByCategory: vi.fn((_sessionId: string, category: string) =>
+                activeOptions().find((option) => option.category === category)
+            ),
+            getSessionConfigOptions: vi.fn(() => activeOptions())
+        });
+
+        await expect(applyCursorAcpModel(backend, 's1', 'claude-opus-4-8-xhigh')).resolves.toMatchObject({
+            applied: true,
+            resolvedWireId: 'claude-opus-4-8[effort=xhigh]'
+        });
+        expect(setConfigOption).toHaveBeenNthCalledWith(1, 's1', 'model', 'claude-opus-4-8');
+        expect(setConfigOption).toHaveBeenNthCalledWith(2, 's1', 'effort', 'xhigh');
+        expect(setConfigOption).not.toHaveBeenCalledWith('s1', 'reasoning', expect.anything());
+    });
+
     it('does not fall back to base-only model apply when parameterized fast update fails', async () => {
         const setConfigOption = vi.fn()
             .mockResolvedValueOnce(undefined)

--- a/cli/src/cursor/utils/cursorModeConfig.ts
+++ b/cli/src/cursor/utils/cursorModeConfig.ts
@@ -1,5 +1,5 @@
 import type { CursorPermissionMode } from '@hapi/protocol/types';
-import { cursorCliSkuBaseId, cursorModelBaseId, matchCliSkuToAcpWireId, resolveCursorLegacyModelBase } from '@hapi/protocol';
+import { cursorCliSkuBaseId, cursorModelBaseId, cursorModelBaseMatches, matchCliSkuToAcpWireId, parseCursorSkuParamHints, parseCursorWireParams, resolveCursorLegacyModelBase } from '@hapi/protocol';
 import type { AcpSdkBackend } from '@/agent/backends/acp';
 import { logger } from '@/ui/logger';
 
@@ -164,10 +164,69 @@ function fastHintForCursorSkuOrWire(modelId: string): 'false' | 'true' {
     return lower.includes('-fast') ? 'true' : 'false';
 }
 
-function cursorRequestBaseId(modelId: string): string {
-    return modelId.includes('[')
+function cursorRequestBaseId(modelId: string, modelOption?: ConfigOption): string {
+    const raw = modelId.includes('[')
         ? cursorModelBaseId(modelId)
         : cursorCliSkuBaseId(modelId);
+    // CLI skus may carry the legacy `cursor-` family prefix (cursor-grok-4.6-high).
+    const advertised = modelOption?.options?.find((option) => cursorModelBaseMatches(option.value, raw));
+    return advertised?.value ?? raw;
+}
+
+/** CLI sku / ACP wire effort values → Cursor config option values (aliases included). */
+const EFFORT_OPTION_VALUES: Readonly<Record<string, readonly string[]>> = {
+    none: ['none'],
+    low: ['low'],
+    medium: ['medium'],
+    high: ['high'],
+    xhigh: ['xhigh', 'extra-high'],
+    'extra-high': ['extra-high', 'xhigh'],
+    max: ['max']
+};
+
+/** Cursor exposes the effort axis under different ids per model family. */
+const EFFORT_OPTION_IDS = ['effort', 'reasoning', 'reasoning_effort'] as const;
+
+function effortHintForCursorSkuOrWire(modelId: string): string | null {
+    const params = modelId.includes('[')
+        ? parseCursorWireParams(modelId)
+        : parseCursorSkuParamHints(modelId);
+    const hint = params.effort ?? params.reasoning ?? params.reasoning_effort;
+    return hint?.trim() || null;
+}
+
+function resolveOptionValue(option: ConfigOption | undefined, candidates: readonly string[]): string | null {
+    if (!option?.options?.length) {
+        return null;
+    }
+    for (const candidate of candidates) {
+        if (option.options.some((entry) => entry.value === candidate)) {
+            return candidate;
+        }
+    }
+    return null;
+}
+
+/**
+ * Effort config option for the model that is currently selected. Ids are tried first
+ * because `thought_level` also covers Claude's separate `thinking` toggle.
+ */
+function findEffortConfigOption(
+    backend: AcpSdkBackend,
+    sessionId: string,
+    hint: string
+): { option: ConfigOption; value: string } | null {
+    const candidates = EFFORT_OPTION_VALUES[hint] ?? [hint];
+    for (const id of EFFORT_OPTION_IDS) {
+        const option = findConfigOption(backend, sessionId, id);
+        const value = resolveOptionValue(option, candidates);
+        if (option && value) {
+            return { option, value };
+        }
+    }
+    const thoughtLevel = backend.getConfigOptionByCategory?.(sessionId, 'thought_level');
+    const value = resolveOptionValue(thoughtLevel, candidates);
+    return thoughtLevel && value ? { option: thoughtLevel, value } : null;
 }
 
 async function applyParameterizedCursorModel(
@@ -176,28 +235,49 @@ async function applyParameterizedCursorModel(
     requested: string
 ): Promise<ParameterizedCursorModelResult> {
     const modelOption = findConfigOption(backend, sessionId, 'model');
-    const fastOption = findConfigOption(backend, sessionId, 'fast');
-    if (!modelOption || !fastOption || !backend.setConfigOption) {
+    if (!modelOption || !backend.setConfigOption) {
         return 'unsupported';
     }
 
-    const baseModel = cursorRequestBaseId(requested);
+    const baseModel = cursorRequestBaseId(requested, modelOption);
     const fast = fastHintForCursorSkuOrWire(requested);
-    if (!optionHasValue(modelOption, baseModel) || !optionHasValue(fastOption, fast)) {
+    // Parameterized sessions advertise bare bases. A model option holding complete
+    // wires belongs to the non-parameterized path, which applies the wire as-is.
+    if (!optionHasValue(modelOption, baseModel)) {
         return 'unsupported';
     }
 
     try {
         await backend.setConfigOption(sessionId, modelOption.id, baseModel);
-        await backend.setConfigOption(sessionId, fastOption.id, fast);
+
+        // Selecting the base refreshes Cursor's per-model config options. Re-read them so
+        // the parameters are applied against the model that is now active, and skipped
+        // for models that do not expose that axis.
+        const appliedParams: string[] = [];
+        const activeFast = findConfigOption(backend, sessionId, 'fast');
+        if (activeFast && optionHasValue(activeFast, fast)) {
+            await backend.setConfigOption(sessionId, activeFast.id, fast);
+            appliedParams.push(`fast=${fast}`);
+        }
+
+        const effortHint = effortHintForCursorSkuOrWire(requested);
+        const effort = effortHint ? findEffortConfigOption(backend, sessionId, effortHint) : null;
+        if (effort) {
+            await backend.setConfigOption(sessionId, effort.option.id, effort.value);
+            appliedParams.push(`${effort.option.id}=${effort.value}`);
+        }
+
+        // Only parameters that were actually applied belong in the pinned wire; a model
+        // that exposes neither axis stays on its bare base.
+        const resolved = appliedParams.length > 0
+            ? `${baseModel}[${appliedParams.join(',')}]`
+            : baseModel;
+        backend.pinSessionModelWireId(sessionId, resolved);
+        return { applied: true, resolvedWireId: resolved, requestedWireId: requested };
     } catch (error) {
         logger.debug('[cursor-acp] parameterized model config failed', error);
         return 'failed';
     }
-
-    const resolved = `${baseModel}[fast=${fast}]`;
-    backend.pinSessionModelWireId(sessionId, resolved);
-    return { applied: true, resolvedWireId: resolved, requestedWireId: requested };
 }
 
 /**

--- a/cli/src/modules/common/cursorAcpModelProbe.ts
+++ b/cli/src/modules/common/cursorAcpModelProbe.ts
@@ -30,7 +30,8 @@ export async function runCursorAcpModelProbe(cwd?: string): Promise<ListCursorMo
         const response: ListCursorModelsResponse = {
             success: true,
             availableModels: snapshot.availableModels,
-            currentModelId: snapshot.currentModelId
+            currentModelId: snapshot.currentModelId,
+            ...(snapshot.parameterized ? { parameterized: true } : {})
         };
         if (!hasAcpWireCatalog(response)) {
             return { success: false, error: 'Cursor ACP catalog has no wire model ids' };

--- a/cli/src/modules/common/cursorModels.test.ts
+++ b/cli/src/modules/common/cursorModels.test.ts
@@ -273,6 +273,50 @@ describe('listCursorModels', () => {
         expect(spawnMock).not.toHaveBeenCalled()
     })
 
+    test('attaches variant cliModelSkus to parameterized bare base catalogs (#1818)', async () => {
+        vi.mocked(isAgentAcpTransportActive).mockReturnValue(true)
+        const bareCatalog = [
+            { modelId: 'composer-2.5', name: 'Composer 2.5' },
+            { modelId: 'claude-opus-4-8', name: 'Claude Opus 4.8' },
+            { modelId: 'grok-4.6', name: 'Cursor Grok 4.6' }
+        ]
+        setCursorAcpModelsSnapshot({
+            availableModels: bareCatalog,
+            currentModelId: 'composer-2.5',
+            parameterized: true
+        })
+        writeSharedCursorModelsCache({
+            success: true,
+            parameterized: true,
+            availableModels: bareCatalog,
+            currentModelId: 'composer-2.5',
+            cliModelSkus: [
+                { modelId: 'composer-2.5', name: 'Composer 2.5' },
+                { modelId: 'composer-2.5-fast', name: 'Composer 2.5 Fast' },
+                { modelId: 'claude-opus-4-8-low', name: 'Claude Opus 4.8 Low' },
+                { modelId: 'cursor-grok-4.6-high', name: 'Cursor Grok 4.6' }
+            ]
+        })
+
+        const result = await listCursorModels()
+
+        expect(result.availableModels?.map((row) => row.modelId)).toEqual([
+            'composer-2.5',
+            'claude-opus-4-8',
+            'grok-4.6'
+        ])
+        // Parameterized ACP sessions apply fast/effort over config options, so the
+        // spawn-safe variant skus stay attached to their bare base rows — including
+        // CLI skus that keep Cursor's legacy `cursor-` family prefix.
+        expect(result.cliModelSkus?.map((row) => row.modelId)).toEqual([
+            'composer-2.5',
+            'composer-2.5-fast',
+            'claude-opus-4-8-low',
+            'cursor-grok-4.6-high'
+        ])
+        expect(spawnMock).not.toHaveBeenCalled()
+    })
+
     test('enriches live ACP snapshot with fuller shared cliModelSkus while lock is active', async () => {
         vi.mocked(isAgentAcpTransportActive).mockReturnValue(true)
         setCursorAcpModelsSnapshot({

--- a/cli/src/modules/common/cursorModels.ts
+++ b/cli/src/modules/common/cursorModels.ts
@@ -18,6 +18,7 @@ import {
 import {
     cursorCliSkuBaseId,
     cursorModelBaseId,
+    cursorModelBaseMatches,
     isCursorAcpCatalogModelId,
     isCursorAcpWireModelId
 } from '@hapi/protocol';
@@ -31,6 +32,7 @@ export function buildCursorModelsSeedPayload(
         availableModels: CursorModelSummary[];
         currentModelId: string | null;
         cliModelSkus?: readonly CursorModelSummary[];
+        parameterized?: boolean;
     },
     shared?: CursorModelsResponse | null
 ): ListCursorModelsResponse {
@@ -42,6 +44,7 @@ export function buildCursorModelsSeedPayload(
         success: true,
         availableModels: snapshot.availableModels,
         currentModelId: snapshot.currentModelId,
+        ...(snapshot.parameterized ? { parameterized: true } : {}),
         ...(cliModelSkus.length > 0 ? { cliModelSkus } : {})
     };
 }
@@ -68,9 +71,9 @@ function filterCliSkusForWireBases(
     cliSkus: CursorModelSummary[],
     wires: CursorModelSummary[]
 ): CursorModelSummary[] {
-    const wireBases = new Set(
-        wires.map((entry) => cursorModelBaseId(entry.modelId)).filter((base) => base.length > 0)
-    );
+    const wireBases = wires
+        .map((entry) => cursorModelBaseId(entry.modelId))
+        .filter((base) => base.length > 0);
 
     return cliSkus.filter((entry) => {
         const modelId = entry.modelId.trim();
@@ -78,7 +81,8 @@ function filterCliSkusForWireBases(
         if (!modelId || modelId === 'auto' || isCursorAcpWireModelId(modelId)) {
             return false;
         }
-        return wireBases.has(cursorCliSkuBaseId(modelId));
+        const skuBase = cursorCliSkuBaseId(modelId);
+        return wireBases.some((base) => cursorModelBaseMatches(skuBase, base));
     });
 }
 
@@ -87,22 +91,24 @@ function attachCliSkusToResponse(
     cliSkus: readonly CursorModelSummary[]
 ): ListCursorModelsResponse {
     const wires = (response.availableModels ?? []).filter((entry) => isCursorAcpCatalogModelId(entry.modelId));
-    // Suffixed CLI variants (effort/speed) only apply when ACP exposes parameterized
-    // wires for that base. Bare-only catalogs cannot express those variants
-    // (apply path is model + fast at most), so attaching them creates dead picker rows.
-    const parameterizedBases = new Set(
-        wires
+    // Variant skus are only usable when the ACP apply path can express them:
+    // parameterized pickers apply model + fast + thought_level over config options,
+    // and wire catalogs already pair each variant with a base wire. Bare-only
+    // catalogs without the parameterized picker keep base rows only.
+    const applyableBases = (response.parameterized === true
+        ? wires.map((entry) => cursorModelBaseId(entry.modelId))
+        : wires
             .filter((entry) => isCursorAcpWireModelId(entry.modelId))
             .map((entry) => cursorModelBaseId(entry.modelId))
-            .filter((base) => base.length > 0)
-    );
+    ).filter((base) => base.length > 0);
     const filtered = filterCliSkusForWireBases(
         mergeCliModelSkus(response.cliModelSkus ?? [], [...cliSkus]),
         wires
     ).filter((entry) => {
         const modelId = entry.modelId.trim();
         const base = cursorCliSkuBaseId(modelId);
-        return modelId === base || parameterizedBases.has(base);
+        return modelId === base
+            || applyableBases.some((candidate) => cursorModelBaseMatches(base, candidate));
     });
     if (filtered.length === 0) {
         return response.cliModelSkus?.length

--- a/cli/src/modules/common/cursorModelsSharedCache.test.ts
+++ b/cli/src/modules/common/cursorModelsSharedCache.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, describe, expect, test } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -58,5 +58,21 @@ describe('cursorModelsSharedCache', () => {
         writeSharedCursorModelsCache(payload);
 
         expect(readSharedCursorModelsCache()?.cliModelSkus).toEqual(payload.cliModelSkus);
+    });
+
+    test('ignores pre-versioned cache files that carry synthesized wire ids', () => {
+        // v1 files carried `[fast=…]` wires Cursor rejects; a runner must re-probe
+        // instead of serving them forever (listCursorModels trusts the cache).
+        writeFileSync(
+            join(testHapiHome, 'cache', 'cursor-models.json'),
+            JSON.stringify({
+                success: true,
+                availableModels: [{ modelId: 'grok-4.6[fast=false]', name: 'Cursor Grok 4.6' }],
+                currentModelId: 'grok-4.6[fast=false]'
+            }),
+            'utf8'
+        );
+
+        expect(readSharedCursorModelsCache()).toBeNull();
     });
 });

--- a/cli/src/modules/common/cursorModelsSharedCache.test.ts
+++ b/cli/src/modules/common/cursorModelsSharedCache.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, describe, expect, test } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -63,6 +63,7 @@ describe('cursorModelsSharedCache', () => {
     test('ignores pre-versioned cache files that carry synthesized wire ids', () => {
         // v1 files carried `[fast=…]` wires Cursor rejects; a runner must re-probe
         // instead of serving them forever (listCursorModels trusts the cache).
+        mkdirSync(join(testHapiHome, 'cache'), { recursive: true });
         writeFileSync(
             join(testHapiHome, 'cache', 'cursor-models.json'),
             JSON.stringify({

--- a/cli/src/modules/common/cursorModelsSharedCache.ts
+++ b/cli/src/modules/common/cursorModelsSharedCache.ts
@@ -18,6 +18,18 @@ function isUsableModelsResponse(response: CursorModelsResponse | null): response
     );
 }
 
+/**
+ * Bumped when a cached catalog can no longer be trusted. v1 carried synthesized
+ * `[fast=…]` wire ids that Cursor rejects at `session/new`; `listCursorModels`
+ * serves the on-disk cache without re-probing, so stale entries must not be read.
+ */
+const SHARED_CACHE_VERSION = 2;
+
+type SharedCacheEnvelope = {
+    version: number;
+    response: CursorModelsResponse;
+};
+
 /** Cross-process catalog for New Session while an ACP lock blocks `agent --list-models`. */
 export function readSharedCursorModelsCache(): CursorModelsResponse | null {
     const path = getSharedCachePath();
@@ -26,8 +38,12 @@ export function readSharedCursorModelsCache(): CursorModelsResponse | null {
     }
 
     try {
-        const parsed = JSON.parse(readFileSync(path, 'utf8')) as CursorModelsResponse;
-        return isUsableModelsResponse(parsed) ? parsed : null;
+        const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<SharedCacheEnvelope> | null;
+        if (!parsed || parsed.version !== SHARED_CACHE_VERSION) {
+            return null;
+        }
+        const response = parsed.response ?? null;
+        return isUsableModelsResponse(response) ? response : null;
     } catch {
         return null;
     }
@@ -41,7 +57,8 @@ export function writeSharedCursorModelsCache(response: CursorModelsResponse): vo
     const path = getSharedCachePath();
     try {
         mkdirSync(dirname(path), { recursive: true });
-        writeFileSync(path, JSON.stringify(response), 'utf8');
+        const envelope: SharedCacheEnvelope = { version: SHARED_CACHE_VERSION, response };
+        writeFileSync(path, JSON.stringify(envelope), 'utf8');
     } catch {
         // Best effort — in-process cache still works in the session child.
     }

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -863,7 +863,15 @@ export type ListAgyModelsResponse = AgyModelsResponse
 
 export type CursorModelSummary = OpencodeModelSummary
 
-export type CursorModelsResponse = OpencodeModelsResponse
+export type CursorModelsResponse = OpencodeModelsResponse & {
+    /**
+     * True when ACP advertised Cursor's parameterized model picker: bare model bases
+     * plus separate `fast` / `thought_level` config options. The ACP apply path
+     * expresses variant CLI skus through those options, so variant rows stay valid
+     * even when the catalog itself carries no bracket wire ids.
+     */
+    parameterized?: boolean
+}
 
 export type ListCursorModelsResponse = CursorModelsResponse
 

--- a/shared/src/cursorCliSku.test.ts
+++ b/shared/src/cursorCliSku.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
     cursorCliSkuBaseId,
+    cursorModelBaseMatches,
     findBestCliSkuForAcpWire,
     isCursorAcpCatalogModelId,
     isCursorAcpWireModelId,
     isCursorCliSkuVariantId,
     matchCliSkuToAcpWireId,
     parseCursorAvailableModelsFromRejection,
+    parseCursorSkuParamHints,
     remapStaleCursorModelId
 } from './cursorCliSku';
 
@@ -270,6 +272,29 @@ describe('round-trip (regression for #883: "selected but no response")', () => {
         const slow = simulateRoundTrip('composer-2.5').sessionModel;
         const fast = simulateRoundTrip('composer-2.5-fast').sessionModel;
         expect(slow).not.toBe(fast);
+    });
+});
+
+describe('cursorModelBaseMatches', () => {
+    it('matches bases across the legacy cursor- CLI family prefix', () => {
+        expect(cursorModelBaseMatches('cursor-grok-4.6', 'grok-4.6')).toBe(true);
+        expect(cursorModelBaseMatches('grok-4.6', 'cursor-grok-4.6')).toBe(true);
+        expect(cursorModelBaseMatches('cursor-grok-4.5', 'cursor-grok-4.5')).toBe(true);
+        expect(cursorModelBaseMatches('composer-2.5', 'composer-2.5')).toBe(true);
+        expect(cursorModelBaseMatches('grok-4.6', 'grok-4.5')).toBe(false);
+        expect(cursorModelBaseMatches('claude-opus-4-8', 'claude-opus-5')).toBe(false);
+    });
+
+    it('parses parameter hints from CLI sku suffixes', () => {
+        expect(parseCursorSkuParamHints('cursor-grok-4.6-low')).toMatchObject({
+            effort: 'low',
+            fast: 'false'
+        });
+        expect(parseCursorSkuParamHints('gpt-5.5-extra-high-fast')).toMatchObject({
+            reasoning: 'extra-high',
+            fast: 'true'
+        });
+        expect(parseCursorSkuParamHints('composer-2.5')).toMatchObject({ fast: 'false' });
     });
 });
 

--- a/shared/src/cursorCliSku.ts
+++ b/shared/src/cursorCliSku.ts
@@ -20,6 +20,24 @@ export function cursorModelBaseId(modelId: string): string {
     return bracket === -1 ? trimmed : trimmed.slice(0, bracket);
 }
 
+function stripCursorFamilyPrefix(base: string): string {
+    return base.startsWith('cursor-') ? base.slice('cursor-'.length) : base;
+}
+
+/**
+ * Compare an ACP wire base with a CLI sku base. Cursor's CLI keeps a legacy `cursor-`
+ * family prefix for some models (`cursor-grok-4.6-high` vs ACP base `grok-4.6`), so a
+ * plain equality check silently drops those variant rows.
+ */
+export function cursorModelBaseMatches(a: string, b: string): boolean {
+    const left = a.trim();
+    const right = b.trim();
+    if (left === right) {
+        return true;
+    }
+    return stripCursorFamilyPrefix(left) === stripCursorFamilyPrefix(right);
+}
+
 /** Longest-first suffixes from Cursor CLI sku ids (e.g. `gpt-5.5-high-fast` → `gpt-5.5`). */
 const CLI_SKU_SUFFIXES = [
     '-extra-high-fast',
@@ -114,6 +132,14 @@ export function parseCursorWireParams(modelId: string): Record<string, string> {
         params[segment.slice(0, eq).trim()] = segment.slice(eq + 1).trim();
     }
     return params;
+}
+
+/**
+ * Parameter hints carried by a CLI `agent --list-models` sku
+ * (effort/reasoning/thinking/fast suffixes).
+ */
+export function parseCursorSkuParamHints(slug: string): Record<string, string> {
+    return inferSkuParamHints(slug);
 }
 
 function inferSkuParamHints(slug: string): Record<string, string> {

--- a/web/src/lib/cursorCliSkuCatalog.test.ts
+++ b/web/src/lib/cursorCliSkuCatalog.test.ts
@@ -36,4 +36,26 @@ describe('CLI sku variant catalog', () => {
         expect(variantIds).toContain('gpt-5.5-low')
         expect(variantIds.length).toBeGreaterThan(2)
     })
+
+    it('groups legacy cursor-prefixed skus under their ACP base (#1818)', () => {
+        const bareWires = [
+            { modelId: 'grok-4.6', name: 'Cursor Grok 4.6' },
+            { modelId: 'composer-2.5', name: 'Composer 2.5' },
+        ]
+        const catalog = appendCliSkusToCatalog(buildCursorModelCatalog(bareWires), [
+            { modelId: 'cursor-grok-4.6-high', name: 'Cursor Grok 4.6' },
+            { modelId: 'cursor-grok-4.6-high-fast', name: 'Cursor Grok 4.6 Fast' },
+            { modelId: 'composer-2.5-fast', name: 'Composer 2.5 Fast' },
+        ])
+
+        const grokVariants = catalog.variantsByBase.get('grok-4.6') ?? []
+        expect(grokVariants.map((row) => row.wireId)).toContain('cursor-grok-4.6-high')
+        expect(grokVariants.map((row) => row.wireId)).toContain('cursor-grok-4.6-high-fast')
+        expect(catalog.wireToBase.get('cursor-grok-4.6-high')).toBe('grok-4.6')
+        // The unrelated prefix group must not absorb other bases' skus.
+        expect(catalog.variantsByBase.get('composer-2.5')?.map((row) => row.wireId)).toEqual([
+            'composer-2.5',
+            'composer-2.5-fast'
+        ])
+    })
 })

--- a/web/src/lib/cursorModelOptions.ts
+++ b/web/src/lib/cursorModelOptions.ts
@@ -1,5 +1,6 @@
 import {
     cursorCliSkuBaseId,
+    cursorModelBaseMatches,
     findBestCliSkuForAcpWire,
     isCursorAcpCatalogModelId,
     isCursorAcpWireModelId as isSharedCursorAcpWireModelId
@@ -49,6 +50,22 @@ export function cursorModelDedupeKey(modelId: string): string {
 function isDefaultCursorModelId(modelId: string): boolean {
     const normalized = modelId.trim().toLowerCase()
     return normalized === 'auto' || normalized === 'default' || normalized === 'default[]'
+}
+
+/** Existing catalog base for a CLI sku base, tolerating the legacy `cursor-` prefix. */
+function findCatalogBaseKey(
+    catalog: CursorModelCatalog,
+    skuBaseId: string
+): string | null {
+    if (catalog.variantsByBase.has(skuBaseId)) {
+        return skuBaseId
+    }
+    for (const baseKey of catalog.variantsByBase.keys()) {
+        if (cursorModelBaseMatches(skuBaseId, baseKey)) {
+            return baseKey
+        }
+    }
+    return null
 }
 
 function normalizeCurrentModel(model?: string | null): string | null {
@@ -267,8 +284,11 @@ export function appendCliSkusToCatalog(
         }
 
         const baseId = cursorCliSkuBaseId(modelId)
-        const existing = catalog.variantsByBase.get(baseId)
-        if (!existing || existing.length === 0) {
+        // CLI sku bases may carry the legacy `cursor-` family prefix
+        // (`cursor-grok-4.6-high` → ACP base `grok-4.6`).
+        const catalogBaseId = findCatalogBaseKey(catalog, baseId)
+        const existing = catalogBaseId ? catalog.variantsByBase.get(catalogBaseId) : undefined
+        if (!catalogBaseId || !existing || existing.length === 0) {
             continue
         }
 
@@ -281,7 +301,7 @@ export function appendCliSkusToCatalog(
             label: sku.name?.trim() && sku.name !== modelId ? sku.name.trim() : modelId,
             sortKey: modelId
         })
-        catalog.wireToBase.set(modelId, baseId)
+        catalog.wireToBase.set(modelId, catalogBaseId)
     }
 
     return catalog


### PR DESCRIPTION
## Current integration (2026-09-14)

Updated onto upstream main `9c4e6dad`. Full local CLI/hub/web/shared/relay suites, root typecheck, and all 17 current CI browser checks passed. #1819 is being integrated on top of this PR so Auto and parameterized IDs are validated together; merge this PR first.

A fresh isolated real Cursor ACP probe through the combined HAPI helpers accepted `--model auto`, advertised 38 model entries, completed an Auto turn, switched to a concrete model, and resumed with `--model auto`. A separate no-inference probe applied `cursor-grok-4.6-low` and read back `effort=low`. No production HAPI session or runner was used. CI and review must cover the latest head; old passes are not substituted.

---

Fixes #1818.

## Problem

HAPI advertises `_meta.parameterizedModelPicker` on ACP `initialize`, so Cursor answers `session/new` with **bare model bases plus separate `fast` / `thought_level` config options**. `buildCursorModelsSnapshotFromAcp` ignored effort and synthesized every base as `${base}[fast=${fast}]`, while `cursor-agent` rejects any bracketed id whose parameter set is not that model's complete set:

```
ACP process exited (code=1) ... stderr: Cannot use this model: grok-4.6[fast=false].
```

So 74 of the 76 published picker ids could not spawn, including the default `grok-4.6`.

## Fix

**1. Never synthesize wire ids** (`cli/src/cursor/utils/cursorAcpModelsSnapshot.ts`)

The advertised values are kept verbatim. Each model's complete parameter set is Cursor-side knowledge that is not derivable from `configOptions` (e.g. `composer-2.5` takes only `fast`, `claude-opus-4-8` takes `thinking`/`context`/`effort`/`fast`), so "bare base + defaults" is the only id the builder can guarantee is accepted. This is exactly the safe fallback the issue asks for in Expected (3).

**2. Keep variant CLI skus usable** (`parameterized` flag)

Bare-only catalogs used to drop suffixed skus because no bracketed wire existed to justify them. ACP now advertises the parameterized picker, so the flag lets `cliModelSkus` attach to their bare base rows; the ACP apply path expresses those variants through config options.

**3. Apply effort in-session** (`cli/src/cursor/utils/cursorModeConfig.ts`)

`applyParameterizedCursorModel` now resolves the requested effort (`effort=…` on a wire, `-low`/`-high`/`-xhigh` on a CLI sku) onto the option Cursor re-advertises after the base switch, trying ids `effort`, `reasoning`, `reasoning_effort` and the aliases `xhigh`/`extra-high`. Ids are tried before the `thought_level` category because that category also carries Claude's separate `thinking` toggle, which this must not clobber. Effort is skipped for models that do not expose the axis (`composer-2.5`, `gemini-3-flash`, …), and the pinned wire only contains parameters that were actually applied.

**4. CLI sku base matching** (`shared/src/cursorCliSku.ts`, `cli/src/modules/common/cursorModels.ts`, `web/src/lib/cursorModelOptions.ts`)

Cursor's CLI keeps a legacy `cursor-` family prefix for some models (`cursor-grok-4.6-high` vs ACP base `grok-4.6`), so strict base equality dropped those rows in the picker and in the catalog filter. `cursorModelBaseMatches` compares bases tolerating that prefix.

**5. Shared cache version** (`cli/src/modules/common/cursorModelsSharedCache.ts`)

`listCursorModels` serves the on-disk cache without re-probing, so a runner that already cached the rejected synthesized ids would keep publishing them. The cache file is now a versioned envelope; v1 entries are ignored (re-probe).

## Verified (live `cursor-agent 2026.09.10-fd3934a`)

- `buildCursorModelsSnapshotFromAcp` on a real ACP session returns 38 entries, all bare bases, `parameterized: true`, `currentModelId: default`.
- `--model` spawn check over all 36 non-default bases + 12 sampled CLI skus: **48/49 accepted**; the one failure is `gemini-2.5-flash`, which Cursor rejects in *every* form, including the complete wire from its own capability-less catalog (`gemini-2.5-flash[]`) and the bare base — a pre-existing Cursor-side defect noted in the issue, not caused by synthesis.
- In-session apply, re-reading the config options after each switch:
  - `claude-opus-4-8-low` → `effort=low` (`thinking=true`, `context=300k` untouched)
  - `cursor-grok-4.6-xhigh-fast` → `effort=xhigh`, `fast=true`
  - `gpt-5.5-low` → `reasoning=low`, `fast=false`
  - `gemini-3.8-flash-high` → `reasoning_effort=high`
  - `kimi-k3-high` → `reasoning=high`
  - `composer-2.5-fast` → `fast=true` (no effort axis → skipped)
  - `gemini-3-flash` → single `model` write, no parameter writes
- `cursor-`-prefixed sku remap through the new base-only cache: `grok-4.6[fast=false] → grok-4.6`, `grok-4.5[fast=false] → cursor-grok-4.5-medium`, `claude-opus-4-8[fast=false] → claude-opus-4-8-medium`.

## Tests

`bun typecheck` clean; `bun run test` green (cli 234 files, web, hub, shared, relay).

New/updated coverage: bare-base + `parameterized` snapshot, effort apply (including skip-when-absent and re-read-after-switch), cache version envelope rejection, variant sku attachment for parameterized bare catalogs, and legacy-prefix base grouping in the CLI filter and web picker catalog.

## Residual risk

Cursor still owns the accepted parameter sets; HAPI now advertises ids Cursor accepts rather than guessing parameter combinations, so an id that Cursor rejects outright (`gemini-2.5-flash`) surfaces as a Cursor-side error instead of a preflight failure. `--model` remains the only spawn-time selector; no per-parameter spawn flag exists.

