### PR TITLE
fix(cli): raise Windows Codex MCP shim-spawn test timeout

### DIFF
--- a/cli/src/codex/utils/codexMcpProxy.test.ts
+++ b/cli/src/codex/utils/codexMcpProxy.test.ts
@@ -98,7 +98,9 @@ describe('codexMcpProxy', () => {
         await prepared.cleanup();
     });
 
-    windowsIt('launches a bare command through a temporary Windows shim', async () => {
+    // Real Windows spawn (cmd shim → node → MCP initialize). Vitest's 5s default
+    // flakes under GHA Defender/cold-start; assertions are about quoting, not latency.
+    windowsIt('launches a bare command through a temporary Windows shim', { timeout: 20_000 }, async () => {
         const directory = await mkdtemp(join(tmpdir(), 'hapi-codex-mcp-shim-test-'));
         const serverPath = join(directory, 'server.js');
         const shimPath = join(directory, 'example-mcp.cmd');
@@ -142,7 +144,7 @@ describe('codexMcpProxy', () => {
                 const timeout = setTimeout(() => {
                     child.kill();
                     reject(new Error('Timed out waiting for the Windows MCP shim response'));
-                }, 5_000);
+                }, 15_000);
                 const finish = (error: Error | null, value?: Record<string, unknown>) => {
                     clearTimeout(timeout);
                     if (error) {


### PR DESCRIPTION
## Summary
- Give the Windows-only Codex MCP shim-spawn unit test an explicit **20s** vitest budget (and a matching 15s handshake wait) so GHA Defender/cold-start cannot flake the default 5s.
- Leaves the global unit-test `testTimeout` unchanged; assertions stay about shim quoting, not latency.

## Test plan
- [ ] Confirm `windows-codex-mcp` (or the job that runs `codexMcpProxy.test.ts` on Windows) is green on this PR
- [ ] Spot-check: on non-Windows, the case remains `it.skip` and the suite still loads
- [x] Diff is test-only under `cli/src/codex/utils/codexMcpProxy.test.ts`

## Issues
Fixes #1823
