### PR TITLE
feat(pi): inject hapi_display_image and render inline tool-result images

### DIFF
--- a/cli/src/pi/loop.test.ts
+++ b/cli/src/pi/loop.test.ts
@@ -25,7 +25,7 @@ vi.mock('./piEventConverter', async (importOriginal) => {
     const actual = await importOriginal<typeof import('./piEventConverter')>();
     return {
         ...actual,
-        convertPiEvent: vi.fn(() => []),
+        convertPiEvent: vi.fn(async () => []),
     };
 });
 
@@ -1050,7 +1050,7 @@ describe('sendPiRpcAndWait', () => {
 });
 
 describe('Pi lifecycle timeline', () => {
-    it('synchronizes authoritative get_state streaming and deduplicates compaction/retry timeline events', () => {
+    it('synchronizes authoritative get_state streaming and deduplicates compaction/retry timeline events', async () => {
         let listener: ((event: Record<string, unknown>) => void) | null = null;
         const transport = {
             onEvent: vi.fn((handler: (event: Record<string, unknown>) => void) => { listener = handler; }),
@@ -1075,6 +1075,9 @@ describe('Pi lifecycle timeline', () => {
         emit({ type: 'compaction_end', reason: 'threshold', aborted: false, willRetry: false });
         emit({ type: 'auto_retry_start', attempt: 1, maxAttempts: 3, delayMs: 10, errorMessage: '429' });
         emit({ type: 'auto_retry_end', attempt: 1, success: true });
+        // Lifecycle notices publish through the serialized chat queue; flush the
+        // microtask chain before asserting what the session emitted.
+        await new Promise((resolve) => setTimeout(resolve, 0));
         expect(stateSession.client.sendSessionEvent).toHaveBeenCalledWith({ type: 'message', message: '📦 Compaction started' });
         expect(stateSession.client.sendSessionEvent).toHaveBeenCalledWith({ type: 'message', message: '📦 Compaction completed' });
         expect(stateSession.client.sendSessionEvent).toHaveBeenCalledTimes(8);

--- a/cli/src/pi/loop.ts
+++ b/cli/src/pi/loop.ts
@@ -691,6 +691,12 @@ export function wireTransportEvents(
     };
     const flushAccumulator = (): void => sendMessages(assistantMessageAccumulator.flush());
 
+    // Serializes chat publishing so tool results (which may await image
+    // registration) can never overtake the assistant snapshot of the next
+    // event in the same stdout chunk; JsonLineParser.feed() dispatches a chunk
+    // synchronously line-by-line, so without this chain an assistant
+    // `message_end` arriving after a `tool_execution_end` would publish first.
+    let publishChain: Promise<void> = Promise.resolve();
     transport.onEvent((event) => {
         // Legacy Pi emitted auto_compaction_*; normalize it before every
         // lifecycle consumer so both the maintenance gate and timeline see the
@@ -841,16 +847,26 @@ export function wireTransportEvents(
         } else if (event.type === 'summarization_retry_finished') {
             maintenanceActive.delete('summary');
         }
-        lifecycleTimeline.emit(event, session);
-        sendMessages(assistantMessageAccumulator.handleEvent(event));
+        publishChain = publishChain
+            .then(async () => {
+                // lifecycle notices (retry/compaction) and assistant/chat output
+                // share the same ordered queue so a notice arriving later in the
+                // same stdout chunk cannot overtake earlier assistant or image
+                // messages in the transcript.
+                lifecycleTimeline.emit(event, session);
+                sendMessages(assistantMessageAccumulator.handleEvent(event));
 
-        if (event.type !== 'message_start' && event.type !== 'message_update' && event.type !== 'message_end') {
-            const messages = convertPiEvent(event);
-            for (const message of messages) {
-                const converted = convertAgentMessage(message, session.currentModel);
-                if (converted) session.sendAgentMessage(converted);
-            }
-        }
+                if (event.type !== 'message_start' && event.type !== 'message_update' && event.type !== 'message_end') {
+                    const messages = await convertPiEvent(event);
+                    for (const message of messages) {
+                        const converted = convertAgentMessage(message, session.currentModel);
+                        if (converted) session.sendAgentMessage(converted);
+                    }
+                }
+            })
+            .catch((error) => {
+                logger.debug('[pi] Failed to publish event:', error instanceof Error ? error.message : String(error));
+            });
 
         if (event.type === 'agent_start') {
             session.updateThinkingState(true);

--- a/cli/src/pi/loopPublishOrder.test.ts
+++ b/cli/src/pi/loopPublishOrder.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { wireTransportEvents } from './loop';
+import type { PiTransport } from './piTransport';
+import type { PiSession } from './session';
+
+/** 1x1 red PNG. */
+const ONE_PX_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+function createHarness() {
+    let listener: ((event: Record<string, unknown>) => void) | null = null;
+    const order: string[] = [];
+    const transport = {
+        onEvent: vi.fn((handler: (event: Record<string, unknown>) => void) => { listener = handler; }),
+        send: vi.fn(),
+    } as unknown as PiTransport;
+    const client = {
+        keepAlive: vi.fn(),
+        updateMetadata: vi.fn(),
+        emitMessagesConsumed: vi.fn(),
+        sendSessionEvent: vi.fn(),
+        updateAgentState: vi.fn(),
+        emitSessionReady: vi.fn(),
+        getMetadata: vi.fn(() => null),
+        rpcHandlerManager: { registerHandler: vi.fn() },
+    };
+    const session = {
+        client,
+        path: '/tmp/test',
+        logPath: '/tmp/test.log',
+        startedBy: 'terminal',
+        startingMode: 'local',
+        model: 'deepseek-v4-flash-0731',
+        sendAgentMessage: vi.fn((msg: { type: string }) => { order.push(`agent:${msg.type}`); }),
+        sendSessionEvent: vi.fn((msg: { type: string }) => { order.push(`session:${msg.type}`); }),
+    } as unknown as PiSession;
+
+    wireTransportEvents(transport, session, []);
+
+    return {
+        emit: (event: Record<string, unknown>) => listener?.(event),
+        order,
+        flush: () => new Promise((resolve) => setTimeout(resolve, 0)),
+    };
+}
+
+const FLUSH_MS = 0;
+
+describe('Pi publish ordering (real converters)', () => {
+    it('publishes a tool-execution result before a later retry notice from the same chunk', async () => {
+        const h = createHarness();
+
+        h.emit({
+            type: 'tool_execution_end',
+            toolCallId: 'tc-1',
+            toolName: 'bash',
+            result: { content: [{ type: 'text', text: 'ok' }], details: {} },
+            isError: false,
+        });
+        h.emit({ type: 'auto_retry_start', attempt: 1, maxAttempts: 3, delayMs: 10, errorMessage: '429' });
+
+        await new Promise((resolve) => setTimeout(resolve, FLUSH_MS));
+
+        // The tool result must reach the chat before the lifecycle notice.
+        const resultIdx = h.order.indexOf('agent:tool-call-result');
+        const noticeIdx = h.order.indexOf('session:message');
+        expect(resultIdx).toBeGreaterThanOrEqual(0);
+        expect(noticeIdx).toBeGreaterThan(resultIdx);
+    });
+
+    it('keeps image cards in event order ahead of a compaction notice', async () => {
+        const h = createHarness();
+
+        h.emit({
+            type: 'tool_execution_end',
+            toolCallId: 'tc-2',
+            toolName: 'hapi_display_image',
+            result: {
+                content: [
+                    { type: 'text', text: 'screenshot' },
+                    { type: 'image', data: ONE_PX_PNG, mimeType: 'image/png' },
+                ],
+                details: {},
+            },
+            isError: false,
+        });
+        h.emit({ type: 'compaction_start', reason: 'threshold' });
+
+        await new Promise((resolve) => setTimeout(resolve, FLUSH_MS));
+
+        const resultIdx = h.order.indexOf('agent:tool-call-result');
+        const imageIdx = h.order.indexOf('agent:generated-image');
+        const noticeIdx = h.order.indexOf('session:message');
+        expect(resultIdx).toBeGreaterThanOrEqual(0);
+        expect(imageIdx).toBeGreaterThan(resultIdx);
+        expect(noticeIdx).toBeGreaterThan(imageIdx);
+    });
+});

--- a/cli/src/pi/piEventConverter.test.ts
+++ b/cli/src/pi/piEventConverter.test.ts
@@ -2,63 +2,50 @@ import { describe, it, expect } from 'vitest';
 import { convertPiCompactionUsage, convertPiEvent, convertPiTurnUsage } from './piEventConverter';
 import type { PiAgentEvent } from './types';
 
+// 1x1 red PNG.
+const ONE_PX_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
 describe('convertPiEvent', () => {
-    it('should return empty for message_update with text_delta (accumulated in runPi)', () => {
+    it('should return empty for message_update with text_delta (accumulated in runPi)', async () => {
         // The converter intentionally emits nothing for message_update
         // — runPi accumulates text/thinking deltas and flushes a single
         // snapshot on `message_end`. This avoids the web UI rendering
         // every delta as a separate block (character-by-character column)
         // and the reducer's per-content streamId dedup showing only the
         // last delta as the whole reasoning.
-        const result = convertPiEvent({
+        const result = await convertPiEvent({
             type: 'message_update',
             assistantMessageEvent: { type: 'text_delta', delta: 'hello world' }
         });
         expect(result).toEqual([]);
     });
 
-    it('should return empty for message_update with thinking_delta (accumulated in runPi)', () => {
-        const result = convertPiEvent({
+    it('should return empty for message_update with thinking_delta (accumulated in runPi)', async () => {
+        const result = await convertPiEvent({
             type: 'message_update',
             assistantMessageEvent: { type: 'thinking_delta', delta: 'let me think...' }
         });
         expect(result).toEqual([]);
     });
 
-    it('should return empty for message_update with start sub-type', () => {
+    it('should return empty for message_update with start sub-type', async () => {
         // text_start/thinking_start carry the full partial state and
         // would cause the web UI to render the same text multiple
         // times. The accumulator only listens to deltas.
-        const result = convertPiEvent({
+        const result = await convertPiEvent({
             type: 'message_update',
             assistantMessageEvent: { type: 'start' }
         });
         expect(result).toEqual([]);
     });
 
-    it('should return empty array for message_update with start sub-type', () => {
-        const result = convertPiEvent({
-            type: 'message_update',
-            assistantMessageEvent: { type: 'start' }
-        });
+    it('should return empty array for message_update without assistantMessageEvent', async () => {
+        const result = await convertPiEvent({ type: 'message_update' });
         expect(result).toEqual([]);
     });
 
-    it('should return empty array for message_update with done sub-type', () => {
-        const result = convertPiEvent({
-            type: 'message_update',
-            assistantMessageEvent: { type: 'done', reason: 'stop' }
-        });
-        expect(result).toEqual([]);
-    });
-
-    it('should return empty array for message_update without assistantMessageEvent', () => {
-        const result = convertPiEvent({ type: 'message_update' });
-        expect(result).toEqual([]);
-    });
-
-    it('should convert tool_execution_start to tool_call AgentMessage', () => {
-        const result = convertPiEvent({
+    it('should convert tool_execution_start to tool_call AgentMessage', async () => {
+        const result = await convertPiEvent({
             type: 'tool_execution_start',
             toolCallId: 'tc-1',
             toolName: 'read_file',
@@ -73,8 +60,8 @@ describe('convertPiEvent', () => {
         }]);
     });
 
-    it('maps tool execution progress onto the running tool call id', () => {
-        expect(convertPiEvent({
+    it('maps tool execution progress onto the running tool call id', async () => {
+        expect(await convertPiEvent({
             type: 'tool_execution_update',
             toolCallId: 'tc-1',
             toolName: 'read_file',
@@ -85,8 +72,8 @@ describe('convertPiEvent', () => {
         }]);
     });
 
-    it('should convert tool_execution_end (success) to tool_result AgentMessage', () => {
-        const result = convertPiEvent({
+    it('should convert tool_execution_end (success) to tool_result AgentMessage', async () => {
+        const result = await convertPiEvent({
             type: 'tool_execution_end',
             toolCallId: 'tc-1',
             toolName: 'read_file',
@@ -101,8 +88,8 @@ describe('convertPiEvent', () => {
         }]);
     });
 
-    it('should convert tool_execution_end (error) to failed tool_result AgentMessage', () => {
-        const result = convertPiEvent({
+    it('should convert tool_execution_end (error) to failed tool_result AgentMessage', async () => {
+        const result = await convertPiEvent({
             type: 'tool_execution_end',
             toolCallId: 'tc-1',
             toolName: 'read_file',
@@ -117,17 +104,109 @@ describe('convertPiEvent', () => {
         }]);
     });
 
-    it('drops malformed tool completion events instead of emitting an uncorrelated result', () => {
-        expect(convertPiEvent({
+    it('drops malformed tool completion events instead of emitting an uncorrelated result', async () => {
+        expect(await convertPiEvent({
             type: 'tool_execution_end', toolCallId: 'tc-1', toolName: 'read_file', isError: false,
         } as never)).toEqual([]);
-        expect(convertPiEvent({
+        expect(await convertPiEvent({
             type: 'tool_execution_end', toolName: 'read_file', result: 'ok', isError: false,
         } as never)).toEqual([]);
     });
 
-    it('should defer turn usage and convert only turn completion', () => {
-        const result = convertPiEvent({
+    it('emits a generated-image message for an inline image block next to the text result', async () => {
+        const result = await convertPiEvent({
+            type: 'tool_execution_end',
+            toolCallId: 'tc-1',
+            toolName: 'hapi_display_image',
+            result: {
+                content: [
+                    { type: 'text', text: 'Here is the screenshot.' },
+                    { type: 'image', data: ONE_PX_PNG, mimeType: 'image/png' },
+                ],
+                details: {},
+            },
+            isError: false
+        });
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual({
+            type: 'tool_result',
+            id: 'tc-1',
+            output: 'Here is the screenshot.',
+            status: 'completed',
+        });
+        expect(result[1]).toMatchObject({
+            type: 'generated_image',
+            mimeType: 'image/png',
+            source: { ingress: 'tool_result', toolName: 'hapi_display_image', toolCallId: 'tc-1' },
+        });
+        expect(result[1]).toHaveProperty('imageId');
+        expect(result[1]).toHaveProperty('fileName');
+        ;
+    });
+
+    it('joins multiple text blocks and skips a malformed image block', async () => {
+        const result = await convertPiEvent({
+            type: 'tool_execution_end',
+            toolCallId: 'tc-2',
+            toolName: 'hapi_display_image',
+            result: {
+                content: [
+                    { type: 'text', text: 'a' },
+                    { type: 'image', data: 'not-base64!', mimeType: 'image/png' },
+                    { type: 'text', text: 'b' },
+                ],
+                details: {},
+            },
+            isError: false
+        });
+
+        // Invalid image payload is dropped; the text blocks remain the result.
+        expect(result).toEqual([{
+            type: 'tool_result',
+            id: 'tc-2',
+            output: 'a\nb',
+            status: 'completed',
+        }]);
+    });
+
+    it('keeps a structured result without images as the plain text output', async () => {
+        const result = await convertPiEvent({
+            type: 'tool_execution_end',
+            toolCallId: 'tc-3',
+            toolName: 'bash',
+            result: { content: [{ type: 'text', text: 'ok' }], details: {} },
+            isError: false
+        });
+
+        expect(result).toEqual([{
+            type: 'tool_result',
+            id: 'tc-3',
+            output: 'ok',
+            status: 'completed',
+        }]);
+    });
+
+    it('falls back to the raw result when content is not a block array', async () => {
+        const raw = { some: 'other', shape: true };
+        const result = await convertPiEvent({
+            type: 'tool_execution_end',
+            toolCallId: 'tc-4',
+            toolName: 'bash',
+            result: raw,
+            isError: false
+        });
+
+        expect(result).toEqual([{
+            type: 'tool_result',
+            id: 'tc-4',
+            output: raw,
+            status: 'completed',
+        }]);
+    });
+
+    it('should defer turn usage and convert only turn completion', async () => {
+        const result = await convertPiEvent({
             type: 'turn_end',
             message: {
                 usage: {
@@ -215,8 +294,8 @@ describe('convertPiEvent', () => {
         expect(result).toBeNull();
     });
 
-    it('should convert turn_end with toolUse stopReason', () => {
-        const result = convertPiEvent({
+    it('should convert turn_end with toolUse stopReason', async () => {
+        const result = await convertPiEvent({
             type: 'turn_end',
             message: {
                 usage: { input: 50, output: 100, cacheRead: 0, cacheWrite: 0, totalTokens: 150 },
@@ -232,8 +311,8 @@ describe('convertPiEvent', () => {
         });
     });
 
-    it('should convert turn_end without usage data', () => {
-        const result = convertPiEvent({
+    it('should convert turn_end without usage data', async () => {
+        const result = await convertPiEvent({
             type: 'turn_end'
         });
 
@@ -244,34 +323,33 @@ describe('convertPiEvent', () => {
         });
     });
 
-    it('should return empty array for agent_start', () => {
-        expect(convertPiEvent({ type: 'agent_start' })).toEqual([]);
+    it('should return empty array for agent_start', async () => {
+        expect(await convertPiEvent({ type: 'agent_start' })).toEqual([]);
     });
 
-    it('should return empty array for agent_end', () => {
-        expect(convertPiEvent({ type: 'agent_end', messages: [] })).toEqual([]);
+    it('should return empty array for agent_end', async () => {
+        expect(await convertPiEvent({ type: 'agent_end', messages: [] })).toEqual([]);
     });
 
-    it('should return empty array for response events', () => {
+    it('should return empty array for response events', async () => {
         // Response events use a different type, but we handle gracefully
-        expect(convertPiEvent({ type: 'response', command: 'prompt', success: true } as unknown as PiAgentEvent)).toEqual([]);
+        expect(await convertPiEvent({ type: 'response', command: 'prompt', success: true } as unknown as PiAgentEvent)).toEqual([]);
     });
 
-    it('should return empty array for turn_start', () => {
-        expect(convertPiEvent({ type: 'turn_start' })).toEqual([]);
+    it('should return empty array for turn_start', async () => {
+        expect(await convertPiEvent({ type: 'turn_start' })).toEqual([]);
     });
 
-    it('should return empty array for unknown event types', () => {
-        expect(convertPiEvent({ type: 'something_else' })).toEqual([]);
+    it('should return empty array for unknown event types', async () => {
+        expect(await convertPiEvent({ type: 'something_else' })).toEqual([]);
     });
 
-    it('should not crash on unexpected data structure (safety net)', () => {
+    it('should not crash on unexpected data structure (safety net)', async () => {
         // Simulate a malformed event that somehow passes through
         const weird = Object.create(null);
         weird.type = 'message_update';
         weird.assistantMessageEvent = undefined;
         // Should not throw
-        expect(() => convertPiEvent(weird as unknown as PiAgentEvent)).not.toThrow();
-        expect(convertPiEvent(weird as unknown as PiAgentEvent)).toEqual([]);
+        await expect(convertPiEvent(weird as unknown as PiAgentEvent)).resolves.toEqual([]);
     });
 });

--- a/cli/src/pi/piEventConverter.ts
+++ b/cli/src/pi/piEventConverter.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/ui/logger';
+import { registerGeneratedImageFromAcpBlock } from '@/modules/common/generatedImages';
 import type { AgentMessage } from '@/agent/types';
 import {
     PiToolExecutionEndEventSchema,
@@ -41,8 +42,33 @@ export function convertPiCompactionUsage(estimatedTokensAfter: number | undefine
     };
 }
 
+/**
+ * Splits a structured Pi tool result ({ content: TextContent[] | ImageContent[], ... })
+ * into displayable text and image blocks. Returns null for legacy string results
+ * so callers keep the pass-through behavior.
+ */
+export function splitPiToolResult(result: unknown): { text: string; images: unknown[] } | null {
+    if (!result || typeof result !== 'object' || !Array.isArray((result as { content?: unknown }).content)) {
+        return null;
+    }
+    const text: string[] = [];
+    const images: unknown[] = [];
+    for (const block of (result as { content: unknown[] }).content) {
+        if (!block || typeof block !== 'object') {
+            continue;
+        }
+        const record = block as Record<string, unknown>;
+        if (record.type === 'text' && typeof record.text === 'string') {
+            text.push(record.text);
+        } else if (record.type === 'image') {
+            images.push(block);
+        }
+    }
+    return { text: text.join('\n'), images };
+}
+
 /** Converts validated Pi lifecycle events to HAPI chat messages. */
-export function convertPiEvent(event: PiAgentEvent): AgentMessage[] {
+export async function convertPiEvent(event: PiAgentEvent): Promise<AgentMessage[]> {
     switch (event.type) {
         case 'tool_execution_start': {
             const parsed = PiToolExecutionStartEventSchema.safeParse(event);
@@ -70,12 +96,62 @@ export function convertPiEvent(event: PiAgentEvent): AgentMessage[] {
         case 'tool_execution_end': {
             const parsed = PiToolExecutionEndEventSchema.safeParse(event);
             if (!parsed.success) return [];
-            return [{
+
+            const { toolCallId, result, isError } = parsed.data;
+            if (isError) {
+                return [{
+                    type: 'tool_result',
+                    id: toolCallId,
+                    output: result,
+                    status: 'failed',
+                }];
+            }
+
+            const split = splitPiToolResult(result);
+            if (!split) {
+                return [{
+                    type: 'tool_result',
+                    id: toolCallId,
+                    output: result,
+                    status: 'completed',
+                }];
+            }
+
+            const messages: AgentMessage[] = [{
                 type: 'tool_result',
-                id: parsed.data.toolCallId,
-                output: parsed.data.result,
-                status: parsed.data.isError ? 'failed' : 'completed',
+                id: toolCallId,
+                output: split.text,
+                status: 'completed',
             }];
+
+            // Inline image blocks (e.g. from the hapi_display_image extension or
+            // any tool that hands back ImageContent) land in the chat via the
+            // same generated-image pipeline the ACP backend already uses.
+            for (const block of split.images) {
+                try {
+                    const image = await registerGeneratedImageFromAcpBlock(block);
+                    if (!image) {
+                        continue;
+                    }
+                    messages.push({
+                        type: 'generated_image',
+                        imageId: image.id,
+                        fileName: image.fileName,
+                        mimeType: image.mimeType,
+                        source: {
+                            ingress: 'tool_result',
+                            toolName: parsed.data.toolName,
+                            toolCallId,
+                        },
+                    });
+                } catch (error) {
+                    logger.debug(
+                        '[pi] Failed to register tool-result image:',
+                        error instanceof Error ? error.message : String(error)
+                    );
+                }
+            }
+            return messages;
         }
         case 'turn_end': {
             const turn = event as PiTurnEndEvent;

--- a/cli/src/pi/titleExtension.test.ts
+++ b/cli/src/pi/titleExtension.test.ts
@@ -16,6 +16,29 @@ describe('pi title extension source', () => {
         expect(PI_TITLE_EXTENSION_SOURCE).toContain("import { Type } from '@sinclair/typebox';");
     });
 
+    it('registers the hapi_display_image tool that returns a base64 image block', () => {
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain("name: 'hapi_display_image'");
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain("import('node:fs/promises')");
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain("type: 'image', data: bytes.toString('base64')");
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain('detectImageMime(bytes)');
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain('meta.size > 25 * 1024 * 1024');
+    });
+
+    it('checks stat before reading so oversized or non-regular paths do not allocate', () => {
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain('meta = await stat(filePath)');
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain('if (!meta.isFile())');
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain('meta.size > 25 * 1024 * 1024');
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain('bytes = await readFile(filePath)');
+    });
+
+    it('detects png/jpeg/gif/webp magic bytes for the display tool', () => {
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain("return 'image/png'");
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain("return 'image/jpeg'");
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain("return 'image/gif'");
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain("return 'image/webp'");
+        expect(PI_TITLE_EXTENSION_SOURCE).toContain('return null;');
+    });
+
     it('injects the instruction on every turn, matching the persistent Claude/Codex rule', () => {
         expect(PI_TITLE_EXTENSION_SOURCE).toContain('## Session title');
         expect(PI_TITLE_EXTENSION_SOURCE).toContain('tool once');

--- a/cli/src/pi/titleExtension.ts
+++ b/cli/src/pi/titleExtension.ts
@@ -63,6 +63,60 @@ export default function hapiTitleExtension(pi) {
             return { content: [{ type: 'text', text: 'Session title set: ' + title }], details: {} };
         }
     });
+
+    pi.registerTool({
+        name: 'hapi_display_image',
+        label: 'Display Image',
+        description: "Display a local image file to the human user inline in the current HAPI chat session. Call it when the user asks to view a local image, screenshot, or diagram. The image is shown in the chat; note it also enters the model context, so prefer reading the file for analysis and this tool for presentation.",
+        parameters: Type.Object({
+            path: Type.String({ description: 'Absolute filesystem path of the local image to display (png, jpeg, gif or webp, up to 25 MiB).' })
+        }),
+        async execute(_toolCallId, params) {
+            const filePath = String((params && params.path) || '').trim();
+            if (!filePath) {
+                return { content: [{ type: 'text', text: 'Error: path must be non-empty' }], details: {} };
+            }
+            const { stat, readFile } = await import('node:fs/promises');
+            // Bound resource use before reading: reject non-regular paths (e.g.
+            // /dev/zero) and oversized files up front instead of allocating.
+            let meta;
+            try {
+                meta = await stat(filePath);
+            } catch (error) {
+                const detail = error && error.message ? error.message : String(error);
+                return { content: [{ type: 'text', text: 'Failed to read file: ' + detail }], details: {} };
+            }
+            if (!meta.isFile()) {
+                return { content: [{ type: 'text', text: 'Path is not a regular file' }], details: {} };
+            }
+            if (meta.size > 25 * 1024 * 1024) {
+                return { content: [{ type: 'text', text: 'File exceeds the 25 MiB display limit' }], details: {} };
+            }
+            let bytes;
+            try {
+                bytes = await readFile(filePath);
+            } catch (error) {
+                const detail = error && error.message ? error.message : String(error);
+                return { content: [{ type: 'text', text: 'Failed to read file: ' + detail }], details: {} };
+            }
+            const mimeType = detectImageMime(bytes);
+            if (!mimeType) {
+                return { content: [{ type: 'text', text: 'Unsupported image content (png, jpeg, gif or webp only)' }], details: {} };
+            }
+            return {
+                content: [{ type: 'image', data: bytes.toString('base64'), mimeType: mimeType }],
+                details: {}
+            };
+        }
+    });
+}
+
+function detectImageMime(bytes) {
+    if (bytes.length >= 8 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) return 'image/png';
+    if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg';
+    if (bytes.length >= 6 && bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x38 && (bytes[4] === 0x37 || bytes[4] === 0x39) && bytes[5] === 0x61) return 'image/gif';
+    if (bytes.length >= 12 && bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 && bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50) return 'image/webp';
+    return null;
 }
 `;
 


### PR DESCRIPTION
Closes #1830

## What

Pi sessions get a working image-presentation path, following the existing extension-injection pattern (`pi --mode rpc --extension`, the same file that already registers `hapi_change_title`):

1. **`hapi_display_image` tool injected into Pi sessions** (`cli/src/pi/titleExtension.ts`): reads a local image (png/jpeg/gif/webp, magic-byte detection, 25 MiB cap) and returns it as a Pi `ImageContent` block in the tool result.

2. **Inline tool-result images now reach the chat** (`cli/src/pi/piEventConverter.ts` + `loop.ts`): `tool_execution_end` results are parsed as structured content — text blocks become the tool_result output, `image` blocks flow through `registerGeneratedImageFromAcpBlock` (the exact function the ACP backend already uses, so zero adaptation) into `generated_image` AgentMessages. The image renders as a card in the web chat **independent of whether the model supports vision** — this is the fix for web attachments to a Pi session ending up as `(image omitted: model does not support images)`.

Legacy string results keep the pass-through behavior; malformed/unsupported image payloads are dropped gracefully.

This also unlocks *any* Pi tool returning ImageContent (e.g. a future `pi-mcp-adapter` screenshot server), not just the injected one.

## Scope

- Images only: Pi's `ToolResultContent` is `TextContent | ImageContent` — video/media stay out of scope.
- Images enter the model context (tool result), unlike the Claude MCP `display_image` which is display-only; the tool description says so.

## Tests

- `piEventConverter` (27): inline image block → `generated_image` message, text-block joining, malformed-image drop, structured-result fallbacks, legacy string pass-through. `convertPiEvent` is now async; `loop.ts` consumes it fire-and-forget with error logging.
- `titleExtension`: extension source registers `hapi_display_image` with base64 + magic-byte mime detection.
- `bun run typecheck` green; cli full suite 2672 passed.

## End-to-end verification (isolated hub, real Pi session)

Real Pi session called the injected tool; the image card rendered in the web chat (blob URL, `GET /api/sessions/:id/generated-images/:id` → 200 `image/png`):

![pi display web](https://files.catbox.moe/k71i15.png)

Same flow through the happy-server MCP `display_image` tool on a Claude session, for comparison:

![mcp display web](https://files.catbox.moe/7pj6jn.png)

---

*AI disclosure: this change was implemented with assistance from the AI model `deepseek/deepseek-v4-flash`.*
