### PR TITLE
fix(hub): stop fcmAuth mock.module from poisoning later tests

### DIFF
--- a/hub/src/fcm/fcmService.test.ts
+++ b/hub/src/fcm/fcmService.test.ts
@@ -1,16 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { FcmService, type FcmSendPayload } from './fcmService'
-
-mock.module('./fcmAuth', () => ({
-    getFcmAccessToken: async () => 'test-access-token',
-    loadServiceAccount: () => ({ client_email: 'x', private_key: 'y' })
-}))
+import type { ServiceAccount } from './fcmAuth'
 
 type FakeStore = {
     fcm: {
         getDevicesByNamespace: ReturnType<typeof mock>
         removeDeviceByToken: ReturnType<typeof mock>
     }
+}
+
+const TEST_ACCOUNT: ServiceAccount = { client_email: 'x', private_key: 'y' }
+
+/** Build a service with an injected token getter — no process-wide module mock. */
+function makeService(store: FakeStore): FcmService {
+    return new FcmService(
+        'proj-id',
+        TEST_ACCOUNT,
+        store as never,
+        async () => 'test-access-token'
+    )
 }
 
 function makeStore(devices: Array<{ token: string; platform: 'phone' | 'wear'; deviceId: string; namespace: string }>): FakeStore {
@@ -68,7 +76,7 @@ describe('FcmService.sendToNamespace', () => {
             new Response('{"error":{"status":"UNREGISTERED"}}', { status: 404 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.sent).toBe(0)
@@ -85,7 +93,7 @@ describe('FcmService.sendToNamespace', () => {
             new Response('{"error":{"status":"NOT_FOUND","message":"Requested entity was not found."}}', { status: 404 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.failed).toBe(1)
@@ -109,7 +117,7 @@ describe('FcmService.sendToNamespace', () => {
             }), { status: 404 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.invalidTokens).toEqual(['dead-token'])
@@ -131,7 +139,7 @@ describe('FcmService.sendToNamespace', () => {
             }), { status: 400 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.failed).toBe(1)
@@ -146,7 +154,7 @@ describe('FcmService.sendToNamespace', () => {
             new Response('{"error":{"status":"RESOURCE_EXHAUSTED"}}', { status: 429 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.sent).toBe(0)
@@ -164,7 +172,7 @@ describe('FcmService.sendToNamespace', () => {
             new Response('Service Unavailable', { status: 503 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.failed).toBe(1)
@@ -180,7 +188,7 @@ describe('FcmService.sendToNamespace', () => {
             new Response('{"error":{"status":"UNAUTHENTICATED"}}', { status: 401 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.failed).toBe(1)
@@ -195,7 +203,7 @@ describe('FcmService.sendToNamespace', () => {
             throw new Error('ECONNREFUSED')
         }) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.failed).toBe(1)
@@ -211,7 +219,7 @@ describe('FcmService.sendToNamespace', () => {
             throw new DOMException('The operation was aborted.', 'AbortError')
         }) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.failed).toBe(1)
@@ -226,7 +234,7 @@ describe('FcmService.sendToNamespace', () => {
             new Response('{"name":"projects/proj-id/messages/0:1234567890"}', { status: 200 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.sent).toBe(1)
@@ -253,7 +261,7 @@ describe('FcmService.sendToNamespace', () => {
             return fn ? fn() : new Response('unknown', { status: 500 })
         }) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('default', makePayload())
 
         expect(result.sent).toBe(1)
@@ -269,7 +277,7 @@ describe('FcmService.sendToNamespace', () => {
         const store = makeStore([])
         globalThis.fetch = mock(async () => new Response('should-not-be-called', { status: 200 })) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         const result = await svc.sendToNamespace('empty-ns', makePayload())
 
         expect(result).toEqual({ sent: 0, failed: 0, invalidTokens: [] })
@@ -293,7 +301,7 @@ describe('FcmService.isHealthy (rolling outcome window)', () => {
         // silently drops the first N notifications while waiting for the
         // failure threshold to trip.
         const store = makeStore([])
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         expect(svc.isHealthy()).toBe(false)
     })
 
@@ -305,7 +313,7 @@ describe('FcmService.isHealthy (rolling outcome window)', () => {
             new Response('{"name":"ok"}', { status: 200 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
         expect(svc.isHealthy()).toBe(false)
         await svc.sendToNamespace('default', makePayload())
         expect(svc.isHealthy()).toBe(true)
@@ -319,7 +327,7 @@ describe('FcmService.isHealthy (rolling outcome window)', () => {
             new Response('Service Unavailable', { status: 503 })
         ) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
 
         // Without any prior success the gate must stay unhealthy regardless
         // of where we are in the failure-threshold count. This is the exact
@@ -342,7 +350,7 @@ describe('FcmService.isHealthy (rolling outcome window)', () => {
             return new Response('Service Unavailable', { status: 503 })
         }) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
 
         // 3 successes establish health
         for (let i = 0; i < 3; i += 1) await svc.sendToNamespace('default', makePayload())
@@ -371,7 +379,7 @@ describe('FcmService.isHealthy (rolling outcome window)', () => {
             return new Response('{"name":"ok"}', { status: 200 })
         }) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
 
         for (let i = 0; i < 5; i += 1) {
             await svc.sendToNamespace('default', makePayload())
@@ -400,7 +408,7 @@ describe('FcmService.isHealthy (rolling outcome window)', () => {
             return new Response('{"error":{"status":"UNREGISTERED"}}', { status: 404 })
         }) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
 
         // First send produces 1 sent + 1 invalid. After this the rotated
         // token is removed from the store, leaving only the good one.
@@ -427,7 +435,7 @@ describe('FcmService.isHealthy (rolling outcome window)', () => {
             throw new Error('ECONNREFUSED')
         }) as unknown as typeof fetch
 
-        const svc = new FcmService('proj-id', { client_email: 'x', private_key: 'y' }, store as never)
+        const svc = makeService(store)
 
         // Establish health with 3 successes
         for (let i = 0; i < 3; i += 1) await svc.sendToNamespace('default', makePayload())

--- a/hub/src/fcm/fcmService.ts
+++ b/hub/src/fcm/fcmService.ts
@@ -74,7 +74,9 @@ export class FcmService {
     constructor(
         private readonly projectId: string,
         private readonly serviceAccount: ServiceAccount,
-        private readonly store: Store
+        private readonly store: Store,
+        /** Injectable for unit tests — avoids process-wide `mock.module('./fcmAuth')`. */
+        private readonly getAccessToken: typeof getFcmAccessToken = getFcmAccessToken
     ) {}
 
     /**
@@ -120,7 +122,7 @@ export class FcmService {
 
         let accessToken: string
         try {
-            accessToken = await getFcmAccessToken(this.serviceAccount)
+            accessToken = await this.getAccessToken(this.serviceAccount)
         } catch (e) {
             // Token-fetch failure (expired service account key, OAuth
             // outage, network) - count one health-failure (not one per


### PR DESCRIPTION
## Summary

`hub/src/fcm/fcmService.test.ts` used a top-level `mock.module('./fcmAuth', …)` whose `loadServiceAccount` stub returned `{ client_email, private_key }` with no `project_id`. Bun keeps that override process-wide, so later files that call the real `loadServiceAccount` (`fcmConfig.test.ts`, `androidPushConfig.test.ts`) saw “no project_id” and failed when run after `fcmService` (full `cd hub && bun test`, or the ordered trio).

Fix: drop the process-wide module mock. `FcmService` now accepts an optional injectable `getAccessToken` (defaults to the real helper); tests pass a stub via a small `makeService` helper. Production call sites unchanged.

## Test plan

- [x] `cd hub && bun test src/fcm/fcmService.test.ts src/fcm/fcmConfig.test.ts src/fcm/androidPushConfig.test.ts` — 28 pass
- [x] `cd hub && bun test src/fcm/` — 52 pass
- [x] `bun run typecheck:hub` — clean
- [x] Full `cd hub && bun test` — FCM trio green; remaining local fails are ambient `FCM_SERVICE_ACCOUNT_PATH` / `HAPI_TITLE_PROVIDER_*` on the operator host (out of scope for #1832)

## Issues

Fixes #1832
