### PR TITLE
feat(codex): offer Luna Reserve as a manual model choice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
             - run: bun install --frozen-lockfile
             - run: bun typecheck
             - run: bunx playwright install --with-deps chromium
-            - run: bun run test:e2e -- terminal-wrap-fidelity.spec.ts composer-copy.spec.ts session-list-scroll.spec.ts
+            - run: bun run test:e2e -- terminal-wrap-fidelity.spec.ts composer-copy.spec.ts session-list-scroll.spec.ts luna-reserve.spec.ts
             - run: bun run test
 
     # Serial runner-integration suite: starts real detached runner/session

--- a/cli/README.md
+++ b/cli/README.md
@@ -78,6 +78,23 @@ executions use the existing Runner; additional terminals only detach on exit.
 unavailable. See [Codex shared sessions](../docs/guide/codex-shared-sessions.md)
 for queue semantics, environment isolation, recovery, supported flags and tests.
 
+### Manually select Luna Reserve
+
+In a shared Codex session, the existing Web model menu offers **☾ Luna Reserve**
+only when the current backend authorizes it after ordinary usage is exhausted.
+Selecting it changes that thread to `gpt-reserve`; the native settings notification
+confirms the change. HAPI never automatically enters or leaves Reserve and never
+resubmits a failed turn when switching. Reasoning remains adjustable, and the
+Usage popover shows ordinary and active Reserve allowances separately.
+
+The option is session-scoped, absent from New Session defaults, and unavailable
+on servers without the required usage protocol or accounts without entitlement.
+Usage is read on discovery/menu opening, reconnect, and turn completion/errors;
+there is no idle quota timer or usage-driven session activity update. Open the
+model menu to refresh availability, then select a regular model to leave Reserve.
+An attached official TUI retains its own native behavior; HAPI reflects accepted
+settings from all frontends.
+
 ### Answer local Claude prompts from HAPI
 
 In a local Claude session started by `hapi claude`, main-session `AskUserQuestion`

--- a/cli/src/codex/shared/lunaReserve.test.ts
+++ b/cli/src/codex/shared/lunaReserve.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LunaReserve } from './lunaReserve';
+import type { CodexAppServerClient } from '../codexAppServerClient';
+
+describe('Reserve authorization and usage', () => {
+    it('does not infer eligibility from buckets, percentages, timestamps, or unrelated banners', async () => {
+        let response: unknown = { rateLimits: { limitId: 'codex' } };
+        const request = vi.fn(async () => response);
+        const reserve = new LunaReserve({ request } as unknown as CodexAppServerClient);
+        expect(await reserve.usage('astra')).toBeNull();
+        expect(request.mock.calls).toHaveLength(1);
+        response = { accountId: 'a', ordinaryUsageAllowed: false,
+            rateLimits: { limitId: 'codex', primary: { usedPercent: 100, resetsAt: 0 } },
+            rateLimitsByLimitId: { base_model_inference: { limitName: 'gpt-reserve', secondary: { usedPercent: 'bad' } } },
+            rateLimitUpsell: { banner_type: 'luna_reserve', blocked_model_slug: 'other' }
+        };
+        expect((await reserve.usage('astra'))?.reserveAvailable).toBe(false);
+        expect((await reserve.usage('gpt-reserve'))?.reserve?.secondary?.remainingPercent).toBeNull();
+        response = { accountId: 'a', ordinaryUsageAllowed: null, rateLimits: {}, rateLimitUpsell: { banner_type: 'luna_reserve' } };
+        expect((await reserve.usage('astra'))?.reserveAvailable).toBe(false);
+        response = { ordinaryUsageAllowed: false, rateLimits: {}, rateLimitUpsell: { banner_type: 'luna_reserve' } };
+        expect(await reserve.usage('astra')).toBeNull();
+    });
+
+    it('coalesces simultaneous reads and fails closed after a read error', async () => {
+        const response = { accountId: 'a', ordinaryUsageAllowed: false, rateLimits: {}, rateLimitUpsell: { banner_type: 'luna_reserve' } };
+        const request = vi.fn(async () => response);
+        const reserve = new LunaReserve({ request } as unknown as CodexAppServerClient);
+        const values = await Promise.all([reserve.usage('a'), reserve.usage('a')]);
+        expect(values.every(value => value?.reserveAvailable)).toBe(true);
+        expect(request).toHaveBeenCalledTimes(2);
+        request.mockRejectedValueOnce(new Error('offline'));
+        expect(await reserve.usage('a')).toBeNull();
+    });
+});

--- a/cli/src/codex/shared/lunaReserve.ts
+++ b/cli/src/codex/shared/lunaReserve.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+import type { CodexAccountUsage, CodexUsageWindow } from '@hapi/protocol/apiTypes';
+import type { CodexAppServerClient } from '../codexAppServerClient';
+
+export const LUNA_RESERVE_MODEL = 'gpt-reserve';
+const WindowSchema = z.object({
+    usedPercent: z.unknown().optional(), windowDurationMins: z.unknown().optional(), resetsAt: z.unknown().optional()
+});
+const BucketSchema = z.object({
+    limitId: z.string().nullish(), limitName: z.string().nullish(),
+    primary: WindowSchema.nullish(), secondary: WindowSchema.nullish()
+});
+const UsageSchema = z.object({
+    accountId: z.string().nullish(), ordinaryUsageAllowed: z.boolean().nullish(),
+    rateLimits: BucketSchema, rateLimitsByLimitId: z.record(z.string(), BucketSchema).nullish(),
+    rateLimitUpsell: z.unknown().optional()
+});
+const BannerSchema = z.object({
+    banner_type: z.literal('luna_reserve'), blocked_model_slug: z.string().min(1).nullish()
+});
+
+function window(value: z.infer<typeof WindowSchema> | null | undefined): CodexUsageWindow | null {
+    if (!value) return null;
+    const finite = (n: unknown): n is number => typeof n === 'number' && Number.isFinite(n);
+    return {
+        remainingPercent: finite(value.usedPercent) && value.usedPercent >= 0 && value.usedPercent <= 100 ? 100 - value.usedPercent : null,
+        windowDurationMins: finite(value.windowDurationMins) && value.windowDurationMins > 0 ? value.windowDurationMins : null,
+        resetsAt: finite(value.resetsAt) && value.resetsAt >= 0 && value.resetsAt <= 8.64e12 ? value.resetsAt : null
+    };
+}
+function bucket(value: z.infer<typeof BucketSchema> | null | undefined): CodexAccountUsage['ordinary'] {
+    return { primary: window(value?.primary), secondary: window(value?.secondary) };
+}
+
+/** Reads authorize an explicit model selection only. No timers, settings writes, or turn replay. */
+export class LunaReserve {
+    private pending?: Promise<z.infer<typeof UsageSchema> | null>;
+    constructor(private readonly client: Pick<CodexAppServerClient, 'request'>) {}
+
+    private read(): Promise<z.infer<typeof UsageSchema> | null> {
+        return this.pending ??= (async () => {
+            try {
+                // Older servers require null params. Probe before declaring Reserve capability.
+                const probe = UsageSchema.parse(await this.client.request('account/rateLimits/read', null));
+                if (!('ordinaryUsageAllowed' in probe)) return null;
+                return UsageSchema.parse(await this.client.request('account/rateLimits/read', {
+                    supportsLunaReserve: true, excludeResetCreditDetails: true
+                }));
+            } catch { return null; }
+        })().finally(() => { this.pending = undefined; });
+    }
+
+    async usage(model: string | null | undefined): Promise<CodexAccountUsage | null> {
+        const response = await this.read();
+        if (!response?.accountId) return null;
+        const banner = BannerSchema.safeParse(response.rateLimitUpsell);
+        const reserve = Object.values(response.rateLimitsByLimitId ?? {}).find(value => value.limitName === LUNA_RESERVE_MODEL)
+            ?? (response.rateLimits.limitName === LUNA_RESERVE_MODEL ? response.rateLimits : undefined);
+        const ordinary = response.rateLimitsByLimitId?.codex
+            ?? ((!response.rateLimits.limitId || response.rateLimits.limitId === 'codex') && response.rateLimits.limitName !== LUNA_RESERVE_MODEL ? response.rateLimits : undefined);
+        return {
+            ordinary: bucket(ordinary),
+            reserve: model === LUNA_RESERVE_MODEL ? bucket(reserve) : null,
+            reserveAvailable: response.ordinaryUsageAllowed === false && banner.success
+                && (!banner.data.blocked_model_slug || banner.data.blocked_model_slug === model)
+        };
+    }
+}

--- a/cli/src/codex/shared/projection.test.ts
+++ b/cli/src/codex/shared/projection.test.ts
@@ -38,6 +38,25 @@ describe('shared history projection', () => {
         const events = send.mock.calls.map(([body]) => body).filter(body => body.type === 'token_count');
         expect(events.map(body => body.model)).toEqual(['model-a', 'model-c']);
     });
+    it.each(['', 'Reserve available'])('does not block later events or repeat quota hint reads (%s)', async hint => {
+        const send = vi.fn();
+        const session = { getMetadata: () => ({}), sendAgentMessage: send } as unknown as ApiSessionClient;
+        let release!: (hint: string) => void;
+        const read = vi.fn(() => new Promise<string>(resolve => { release = resolve; }));
+        const projection = new SharedCodexProjection(session, 'thread', async () => {}, undefined, read);
+        const error = { message: 'Quota exhausted', codexErrorInfo: 'usageLimitExceeded' };
+        await projection.notification('error', { threadId: 'thread', turnId: 'turn', error });
+        await projection.notification('turn/completed', { threadId: 'thread', turn: { id: 'turn', status: 'failed', error } });
+        await projection.notification('item/completed', { threadId: 'thread', turnId: 'next', item: { id: 'answer', type: 'agentMessage', text: 'Next answer' } });
+        expect(send).toHaveBeenCalledWith(expect.objectContaining({ message: 'Next answer' }), expect.any(String));
+        expect(read).toHaveBeenCalledTimes(1);
+        release(hint);
+        await Promise.resolve();
+        await projection.notification('error', { threadId: 'thread', turnId: 'turn', error });
+        expect(read).toHaveBeenCalledTimes(1);
+        expect(send.mock.calls.filter(([body]) => body.message === 'Reserve available')).toHaveLength(hint ? 1 : 0);
+    });
+
     it('keeps image-only native inputs visible without embedding data URLs', () => {
         expect(inputText([{ type: 'image', url: 'data:image/png;base64,large' }])).toBe('[Image]');
         expect(inputText([{ type: 'localImage', path: '/tmp/image.png' }])).toBe('[Image: /tmp/image.png]');

--- a/cli/src/codex/shared/projection.ts
+++ b/cli/src/codex/shared/projection.ts
@@ -105,9 +105,11 @@ export class SharedCodexProjection {
             } else if (event.type === 'task_failed') {
                 this.send({ type: 'message', message: `Codex error: ${event.error ?? event.message ?? 'Turn failed'}` }, key);
                 const hintKey = `reserve-hint:${turnId ?? key}`;
-                if (event.codex_error_info === 'usageLimitExceeded' && this.quotaHint && !this.emitted.has(hintKey)) {
-                    const hint = await this.quotaHint();
-                    if (hint) this.send({ type: 'message', message: hint }, hintKey);
+                if (event.codex_error_info === 'usageLimitExceeded' && this.quotaHint && !this.emitted.has(`${hintKey}:requested`)) {
+                    this.emitted.add(`${hintKey}:requested`);
+                    void this.quotaHint().then(hint => {
+                        if (hint) this.send({ type: 'message', message: hint }, hintKey);
+                    }).catch(() => {});
                 }
             }
         }

--- a/cli/src/codex/shared/projection.ts
+++ b/cli/src/codex/shared/projection.ts
@@ -20,7 +20,8 @@ export class SharedCodexProjection {
     private readonly turns = new Map<string, string>();
     private readonly turnModels = new Map<string, string>();
     constructor(private readonly session: ApiSessionClient, readonly threadId: string,
-        private readonly committed: (id: string) => Promise<void>, private readonly parentThreadId?: string) {
+        private readonly committed: (id: string) => Promise<void>, private readonly parentThreadId?: string,
+        private readonly quotaHint?: () => Promise<string>) {
         if (!parentThreadId) for (const [id, turn] of Object.entries(session.getMetadata()?.conversationHistoryTurns ?? {})) this.turns.set(id, turn);
     }
 
@@ -103,6 +104,11 @@ export class SharedCodexProjection {
                 if (image) this.send({ type: 'generated-image', imageId: image.id, fileName: image.fileName, mimeType: image.mimeType }, key);
             } else if (event.type === 'task_failed') {
                 this.send({ type: 'message', message: `Codex error: ${event.error ?? event.message ?? 'Turn failed'}` }, key);
+                const hintKey = `reserve-hint:${turnId ?? key}`;
+                if (event.codex_error_info === 'usageLimitExceeded' && this.quotaHint && !this.emitted.has(hintKey)) {
+                    const hint = await this.quotaHint();
+                    if (hint) this.send({ type: 'message', message: hint }, hintKey);
+                }
             }
         }
         if (item.type === 'collabAgentToolCall') {

--- a/cli/src/codex/shared/root.test.ts
+++ b/cli/src/codex/shared/root.test.ts
@@ -186,6 +186,44 @@ describe('manual Luna Reserve', () => {
         expect((await f.root.applySettings({})).applied.model).toBe('other');
     });
 
+    it('expires delayed and queued selections without dispatching a late mutation', async () => {
+        const f = await fixture();
+        f.native.usage = eligible;
+        let release!: () => void;
+        const delay = new Promise<void>(resolve => { release = resolve; });
+        const original = f.root.client.request.bind(f.root.client);
+        const requests = vi.spyOn(f.root.client, 'request').mockImplementation(async (method, params) => {
+            if (method === 'account/rateLimits/read') await delay;
+            return original(method, params);
+        });
+        vi.useFakeTimers();
+        const first = expect(f.root.applySettings({ model: 'gpt-reserve' })).rejects.toThrow('expired');
+        const queued = expect(f.root.applySettings({ model: 'other' })).rejects.toThrow('expired');
+        await vi.advanceTimersByTimeAsync(28_000);
+        await first; await queued;
+        await vi.advanceTimersByTimeAsync(5_000);
+        release();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(requests.mock.calls.some(([method]) => method === 'thread/settings/update')).toBe(false);
+        expect((await f.root.applySettings({})).applied.model).toBe('mock');
+    });
+
+    it('preserves custom plan instructions when selecting Reserve', async () => {
+        const f = await fixture();
+        f.native.usage = eligible;
+        f.root.acceptSettings({ model: 'mock', effort: 'high', collaborationMode: {
+            mode: 'plan', settings: { model: 'mock', reasoning_effort: 'high', developer_instructions: 'Custom planning rules' }
+        } });
+        const requests = vi.spyOn(f.root.client, 'request');
+        const switching = f.root.applySettings({ model: 'gpt-reserve' });
+        const settings = { model: 'gpt-reserve', effort: 'high', serviceTier: null, collaborationMode: {
+            mode: 'plan', settings: { model: 'gpt-reserve', reasoning_effort: 'high', developer_instructions: 'Custom planning rules' }
+        } };
+        await vi.waitFor(() => expect(requests).toHaveBeenCalledWith('thread/settings/update', { threadId: 'thread', ...settings }));
+        f.native.notify('thread/settings/updated', { threadId: 'thread', threadSettings: settings });
+        expect((await switching).applied.collaborationMode).toBe('plan');
+    });
+
     it('never offers ChatGPT Reserve to a custom-provider thread', async () => {
         const f = await fixture();
         f.native.usage = eligible;

--- a/cli/src/codex/shared/root.test.ts
+++ b/cli/src/codex/shared/root.test.ts
@@ -8,6 +8,12 @@ import { SharedCodexRoot, type RootHost } from './root';
 vi.mock('../codexAppServerClient', () => ({
     CodexAppServerClient: class {
         initialized = false;
+        usage: unknown = { accountId: 'account', ordinaryUsageAllowed: true, rateLimits: { limitId: 'codex' } };
+        async listModels() { return { data: [
+            { id: 'mock', model: 'mock', displayName: 'Mock', isDefault: true },
+            { id: 'gpt-reserve', model: 'gpt-reserve', hidden: true, defaultReasoningEffort: 'medium',
+                supportedReasoningEfforts: [{ reasoningEffort: 'medium' }, { reasoningEffort: 'high' }] }
+        ] }; }
         thread = { id: 'thread', turns: [] as Array<{ id: string; status: string; items: unknown[] }> };
         notify?: (method: string, params: unknown) => void;
         abandoned?: () => void;
@@ -19,6 +25,8 @@ vi.mock('../codexAppServerClient', () => ({
         isInitialized() { return this.initialized; }
         async disconnect() { this.initialized = false; }
         async request(method: string) {
+            if (method === 'account/rateLimits/read') return this.usage;
+            if (method === 'thread/settings/update') return {};
             if (method === 'thread/read' || method === 'thread/resume') return { model: 'mock', thread: this.thread };
             if (method === 'thread/list' || method === 'thread/queue/list') return { data: [] };
             throw new Error(`Unexpected request: ${method}`);
@@ -60,6 +68,7 @@ async function fixture() {
     await root.prepare();
     await root.bind('thread', { model: 'mock', thread: { turns: [] } }, false);
     const native = root.client as unknown as {
+        usage: unknown;
         initialized: boolean;
         thread: { id: string; turns: Array<{ id: string; status: string; items: unknown[] }> };
         notify(method: string, params: unknown): void;
@@ -114,5 +123,76 @@ describe('shared steering availability', () => {
         f.native.thread.turns = [{ id: 'busy', status: 'completed', items: [] }];
         f.reconnect();
         await vi.waitFor(() => expect(f.state().steeringActive).toBe(false));
+    });
+});
+
+describe('manual Luna Reserve', () => {
+    const eligible = {
+        accountId: 'account', ordinaryUsageAllowed: false,
+        rateLimits: { limitId: 'codex', primary: { usedPercent: 100 } },
+        rateLimitUpsell: { banner_type: 'luna_reserve', blocked_model_slug: 'mock' },
+        rateLimitsByLimitId: { reserve_bucket: { limitName: 'gpt-reserve', secondary: { usedPercent: 73 } } }
+    };
+
+    it('offers Reserve only when authorized; reads never change settings, turns, or agent state', async () => {
+        const f = await fixture();
+        const requests = vi.spyOn(f.root.client, 'request');
+        const updates = f.updateState.mock.calls.length;
+        expect((await f.root.listModels()).models?.map(model => model.id)).toEqual(['mock']);
+        f.native.usage = eligible;
+        const result = await f.root.listModels();
+        expect(result.models?.map(model => model.id)).toEqual(['mock', 'gpt-reserve']);
+        expect(result.usage).toMatchObject({ reserveAvailable: true, reserve: null });
+        expect(requests.mock.calls.every(([method]) => method === 'account/rateLimits/read')).toBe(true);
+        expect(f.updateState).toHaveBeenCalledTimes(updates);
+        f.native.usage = { ...eligible, ordinaryUsageAllowed: true };
+        await expect(f.root.applySettings({ model: 'gpt-reserve' })).rejects.toThrow('not available');
+        expect(requests.mock.calls.every(([method]) => method === 'account/rateLimits/read')).toBe(true);
+    });
+
+    it('waits for native confirmation, retains Reserve after recovery, and never replays input', async () => {
+        const f = await fixture();
+        f.native.usage = eligible;
+        const requests = vi.spyOn(f.root.client, 'request');
+        let settled = false;
+        const switching = f.root.applySettings({ model: 'gpt-reserve' }).then(value => { settled = true; return value; });
+        await vi.waitFor(() => expect(requests).toHaveBeenCalledWith('thread/settings/update', expect.objectContaining({ model: 'gpt-reserve' })));
+        expect(settled).toBe(false);
+        f.native.notify('thread/settings/updated', { threadId: 'thread', threadSettings: {
+            model: 'gpt-reserve', effort: 'medium', serviceTier: null,
+            collaborationMode: { mode: 'default', settings: { model: 'gpt-reserve', reasoning_effort: 'medium', developer_instructions: null } }
+        } });
+        expect((await switching).applied.model).toBe('gpt-reserve');
+        expect((await f.root.listModels()).usage?.reserve?.secondary?.remainingPercent).toBe(27);
+        f.native.usage = { ...eligible, ordinaryUsageAllowed: true, rateLimitUpsell: null };
+        expect((await f.root.listModels()).models?.map(model => model.id)).toContain('gpt-reserve');
+        expect(requests.mock.calls.filter(([method]) => method === 'thread/settings/update')).toHaveLength(1);
+        expect(requests.mock.calls.some(([method]) => method.startsWith('turn/') || method.startsWith('thread/queue/'))).toBe(false);
+    });
+
+    it('does not publish rejected settings or let stale eligibility override a native model change', async () => {
+        const f = await fixture();
+        f.native.usage = eligible;
+        const original = f.root.client.request.bind(f.root.client);
+        vi.spyOn(f.root.client, 'request').mockImplementation(async (method, params) => {
+            if (method === 'thread/settings/update') throw new Error('Settings rejected');
+            return original(method, params);
+        });
+        await expect(f.root.applySettings({ model: 'gpt-reserve' })).rejects.toThrow('Settings rejected');
+        expect((await f.root.applySettings({})).applied.model).toBe('mock');
+        const listing = f.root.listModels();
+        f.root.acceptSettings({ model: 'other' });
+        expect((await listing).usage).toBeNull();
+        expect((await f.root.applySettings({})).applied.model).toBe('other');
+    });
+
+    it('never offers ChatGPT Reserve to a custom-provider thread', async () => {
+        const f = await fixture();
+        f.native.usage = eligible;
+        f.root.acceptSettings({ model: 'mock', modelProvider: 'custom' });
+        const requests = vi.spyOn(f.root.client, 'request');
+        expect((await f.root.listModels()).models?.map(model => model.id)).toEqual(['mock']);
+        expect(requests).not.toHaveBeenCalled();
+        await expect(f.root.applySettings({ model: 'gpt-reserve' })).rejects.toThrow('not available');
     });
 });

--- a/cli/src/codex/shared/root.ts
+++ b/cli/src/codex/shared/root.ts
@@ -335,14 +335,20 @@ export class SharedCodexRoot {
         } finally { this.reconnecting = false; this.publishSteering(); }
     }
     applySettings(raw: unknown): Promise<{ applied: RuntimeSettings }> {
-        const pending = this.configWork.catch(() => {}).then(() => this.applySettingsNow(raw)).catch(error => {
+        // Leave 20 seconds for the native request inside the hub's 30-second RPC budget.
+        const dispatchDeadline = Date.now() + 8_000;
+        const pending = this.configWork.catch(() => {}).then(() => this.applySettingsNow(raw, dispatchDeadline));
+        this.configWork = pending;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeout = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error('Settings selection expired; reopen the model menu')), 28_000);
+        });
+        return Promise.race([pending, timeout]).catch(error => {
             if (record(raw).model === LUNA_RESERVE_MODEL) this.notice(`Reserve selection was not confirmed: ${error instanceof Error ? error.message : String(error)}`);
             throw error;
-        });
-        this.configWork = pending;
-        return pending;
+        }).finally(() => clearTimeout(timer));
     }
-    private async applySettingsNow(raw: unknown): Promise<{ applied: RuntimeSettings }> {
+    private async applySettingsNow(raw: unknown, dispatchDeadline: number): Promise<{ applied: RuntimeSettings }> {
         if (this.closed || this.stopping) throw new Error('Codex execution is stopping');
         const config = SettingsSchema.parse(raw);
         if (config.model === LUNA_RESERVE_MODEL && this.settings.model !== LUNA_RESERVE_MODEL) {
@@ -383,9 +389,12 @@ export class SharedCodexRoot {
             ...(permission ? { approvalPolicy: permission.approvalPolicy, sandboxPolicy: permission.sandboxPolicy } : {}),
             ...(config.collaborationMode ? { collaborationMode: { mode: config.collaborationMode, settings: {
                 model: config.model ?? this.settings.model, reasoning_effort: config.modelReasoningEffort ?? this.settings.modelReasoningEffort,
-                developer_instructions: null
+                developer_instructions: record(raw).collaborationMode === undefined
+                    ? string(record(record(this.settingsNative.collaborationMode).settings).developer_instructions) ?? null
+                    : null
             } } } : {})
         };
+        if (Date.now() >= dispatchDeadline) throw new Error('Settings selection expired; reopen the model menu');
         let changed!: () => void;
         let timer: ReturnType<typeof setTimeout> | undefined;
         const accepted = new Promise<void>((resolve, reject) => {

--- a/cli/src/codex/shared/root.ts
+++ b/cli/src/codex/shared/root.ts
@@ -21,6 +21,8 @@ import { getCodexSystemPrompt } from '../utils/systemPrompt';
 import { record, string } from './gateway';
 import { initializeSharedClient, type SharedLaunchOptions } from './launch';
 import { inheritedSandbox, settingsMatch } from './settings';
+import { LunaReserve, LUNA_RESERVE_MODEL } from './lunaReserve';
+import type { CodexModelsResponse } from '@hapi/protocol/apiTypes';
 
 type RuntimeSettings = NonNullable<Parameters<ApiSessionClient['keepAlive']>[2]>;
 export type RootHost = {
@@ -41,6 +43,9 @@ const SettingsSchema = z.object({
 export class SharedCodexRoot {
     readonly client: CodexAppServerClient;
     readonly session: ApiSessionClient;
+    private readonly reserve: LunaReserve;
+    private modelRead?: Promise<CodexModelsResponse>;
+    private configWork: Promise<unknown> = Promise.resolve();
     bridge!: HapiMcpBridge;
     threadId = '';
     private permissions!: SharedCodexPermissions;
@@ -72,6 +77,7 @@ export class SharedCodexRoot {
     constructor(readonly bootstrap: SessionBootstrapResult, private readonly host: RootHost) {
         this.session = bootstrap.session;
         this.client = new CodexAppServerClient({ endpoint: host.endpoint, token: host.token, cwd: bootstrap.workingDirectory });
+        this.reserve = new LunaReserve(this.client);
         this.client.setNotificationHandler((method, params) => {
             if (method === 'serverRequest/resolved') {
                 this.permissions?.resolved(string(record(params).threadId) ?? '', record(params).requestId); return;
@@ -167,7 +173,12 @@ export class SharedCodexRoot {
             (id, input) => this.session.syncNativeQueuedMessage(id, input === null ? null : inputText(input)),
             ids => this.session.setSteerDeliveryState(ids, 'queued'));
         await this.queue.load();
-        this.projection = new SharedCodexProjection(this.session, threadId, id => this.queue.committed(id));
+        this.projection = new SharedCodexProjection(this.session, threadId, id => this.queue.committed(id), undefined, async () => {
+            const usage = this.settingsNative.modelProvider && this.settingsNative.modelProvider !== 'openai'
+                ? null : await this.reserve.usage(this.settings.model);
+            return usage?.reserveAvailable && this.settings.model !== LUNA_RESERVE_MODEL
+                ? 'Luna Reserve is available in the model menu.' : '';
+        });
         this.session.updateMetadata(metadata => ({ ...metadata, codexSessionId: threadId, capabilities: {
             ...metadata.capabilities, concurrentClients: true, terminal: true,
             // In-place rewind needs a native + hub commit barrier. Do not
@@ -323,8 +334,30 @@ export class SharedCodexRoot {
             }
         } finally { this.reconnecting = false; this.publishSteering(); }
     }
-    async applySettings(raw: unknown): Promise<{ applied: RuntimeSettings }> {
+    applySettings(raw: unknown): Promise<{ applied: RuntimeSettings }> {
+        const pending = this.configWork.catch(() => {}).then(() => this.applySettingsNow(raw)).catch(error => {
+            if (record(raw).model === LUNA_RESERVE_MODEL) this.notice(`Reserve selection was not confirmed: ${error instanceof Error ? error.message : String(error)}`);
+            throw error;
+        });
+        this.configWork = pending;
+        return pending;
+    }
+    private async applySettingsNow(raw: unknown): Promise<{ applied: RuntimeSettings }> {
+        if (this.closed || this.stopping) throw new Error('Codex execution is stopping');
         const config = SettingsSchema.parse(raw);
+        if (config.model === LUNA_RESERVE_MODEL && this.settings.model !== LUNA_RESERVE_MODEL) {
+            const revision = this.settingsRevision;
+            // A selection must revalidate entitlement; never reuse the model picker's read.
+            if (this.modelRead) await this.modelRead;
+            const available = await this.listModels();
+            if (this.stopping || this.closed || revision !== this.settingsRevision) throw new Error('Session settings changed; reopen the model menu before switching');
+            const model = available.models?.find(model => model.id === LUNA_RESERVE_MODEL);
+            if (!available.usage?.reserveAvailable || !model) throw new Error('Luna Reserve is not available for this session');
+            const effort = config.modelReasoningEffort ?? this.settings.modelReasoningEffort;
+            config.modelReasoningEffort = effort && model.supportedReasoningEfforts?.includes(effort) ? effort : model.defaultReasoningEffort;
+            if (!model.serviceTiers?.includes('priority')) config.serviceTier = 'standard';
+            config.collaborationMode ??= this.settings.collaborationMode ?? 'default';
+        }
         if (config.permissionMode === 'safe-yolo') throw new Error('safe-yolo is not a native shared permission mode; choose default, read-only, or yolo');
         if (Object.keys(config).length === 0) return { applied: this.settings };
         if (typeof config.modelReasoningEffort === 'string') config.modelReasoningEffort = parseReasoningEffortValue(config.modelReasoningEffort);
@@ -371,6 +404,27 @@ export class SharedCodexRoot {
     async initialSettings(options: SharedLaunchOptions): Promise<void> {
         if (options.collaborationMode) await this.applySettings({ collaborationMode: options.collaborationMode });
     }
+    listModels(): Promise<CodexModelsResponse> {
+        return this.modelRead ??= (async () => {
+            const revision = this.settingsRevision;
+            const usage = this.settingsNative.modelProvider && this.settingsNative.modelProvider !== 'openai'
+                ? null : await this.reserve.usage(this.settings.model);
+            const models = []; let cursor: string | undefined;
+            do {
+                const page = await this.client.listModels({ includeHidden: true, cursor });
+                for (const entry of page.data ?? []) {
+                    const isReserve = (entry.model ?? entry.id) === LUNA_RESERVE_MODEL;
+                    if (isReserve ? !(usage?.reserveAvailable || this.settings.model === LUNA_RESERVE_MODEL) : entry.hidden === true) continue;
+                    const model = normalizeCodexModel(isReserve ? { ...entry, id: LUNA_RESERVE_MODEL, displayName: 'Luna Reserve', isDefault: false } : entry);
+                    if (model) models.push(model);
+                }
+                cursor = page.nextCursor ?? undefined;
+            } while (cursor);
+            // Do not offer eligibility calculated for a model that a concurrent frontend replaced.
+            if (revision !== this.settingsRevision) return { success: true, models: models.filter(model => model.id !== LUNA_RESERVE_MODEL), usage: null };
+            return { success: true, models, usage };
+        })().finally(() => { this.modelRead = undefined; });
+    }
     private registerControls(): void {
         const rpc = { registerHandler: (method: string, handler: (raw: unknown) => Promise<unknown>) => {
             this.session.rpcHandlerManager.registerHandler(method, async (raw: unknown) => {
@@ -379,14 +433,7 @@ export class SharedCodexRoot {
                 try { return await pending; } finally { this.controls.delete(pending); }
             });
         } };
-        rpc.registerHandler(RPC_METHODS.ListCodexModels, async raw => {
-            const models = []; let cursor: string | undefined;
-            do {
-                const response = await this.client.listModels({ includeHidden: record(raw).includeHidden === true, cursor });
-                models.push(...(response.data ?? []).map(normalizeCodexModel).filter(model => model !== null)); cursor = response.nextCursor ?? undefined;
-            } while (cursor);
-            return { success: true, models };
-        });
+        rpc.registerHandler(RPC_METHODS.ListCodexModels, () => this.listModels());
         rpc.registerHandler(RPC_METHODS.Switch, async () => { throw new Error('control_mode_not_applicable'); });
         rpc.registerHandler(RPC_METHODS.HandoffLocal, async () => { throw new Error('control_mode_not_applicable'); });
         rpc.registerHandler(RPC_METHODS.Abort, async () => {

--- a/cli/src/modules/common/codexModels.ts
+++ b/cli/src/modules/common/codexModels.ts
@@ -143,7 +143,7 @@ async function fetchCodexModelsFromAppServer(includeHidden: boolean): Promise<Co
 
         const response = await client.listModels({ includeHidden });
         return Array.isArray(response.data)
-            ? response.data.map(normalizeCodexModel).filter((model): model is CodexModelSummary => model !== null)
+            ? response.data.map(normalizeCodexModel).filter((model): model is CodexModelSummary => model !== null && model.id !== 'gpt-reserve')
             : [];
     } catch (error) {
         throw new Error(getErrorMessage(error, 'Failed to list Codex models'));

--- a/e2e/luna-reserve.spec.ts
+++ b/e2e/luna-reserve.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+
+for (const width of [390, 1280]) {
+    test(`Reserve uses the existing model menu, with no automatic switch (${width}px)`, async ({ page }) => {
+        await page.setViewportSize({ width, height: 844 })
+        await page.goto('/e2e-fixtures/luna-reserve-fixture.html')
+        await page.getByRole('button', { name: 'Settings', exact: true }).click()
+        await expect(page.getByRole('button', { name: /Luna Reserve/ })).toHaveCount(0)
+        await page.keyboard.press('Escape')
+        await page.getByRole('button', { name: 'Toggle eligibility' }).click()
+        await expect(page.getByTestId('model')).toHaveText('gpt-6-astra')
+        await page.getByRole('button', { name: 'Settings', exact: true }).click()
+        await page.getByRole('button', { name: /Luna Reserve/ }).click()
+        await expect(page.getByTestId('model')).toHaveText('gpt-6-astra')
+        await page.getByRole('button', { name: 'Confirm native settings' }).click()
+        await expect(page.getByTestId('model')).toHaveText('☾ Luna Reserve')
+        await expect(page.getByTestId('sends')).toHaveText('0')
+        await page.getByRole('button', { name: 'Codex usage details' }).click()
+        await expect(page.getByText('Ordinary usage', { exact: true })).toBeVisible()
+        await expect(page.getByText(/27% remaining/)).toBeVisible()
+        expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
+    })
+}

--- a/hub/src/sync/permissionModePersistence.test.ts
+++ b/hub/src/sync/permissionModePersistence.test.ts
@@ -159,3 +159,11 @@ describe('permission mode persistence', () => {
     })
 
 })
+
+it('does not persist an unverified Reserve selection on an inactive session', async () => {
+    const engine = createEngine()
+    const session = engine.getOrCreateSession('reserve-inactive', { path: '/tmp/project', host: 'localhost', flavor: 'codex' }, null, 'default')
+    const originalModel = session.model
+    await expect(engine.applySessionConfig(session.id, { model: 'gpt-reserve' })).rejects.toThrow('requires an active Codex session')
+    expect(engine.getSession(session.id)?.model).toBe(originalModel)
+})

--- a/hub/src/sync/syncEngine.ts
+++ b/hub/src/sync/syncEngine.ts
@@ -1945,6 +1945,7 @@ export class SyncEngine {
     ): Promise<void> {
         const session = this.sessionCache.getSession(sessionId)
         if (!session?.active) {
+            if (config.model === 'gpt-reserve') throw new Error('Luna Reserve requires an active Codex session to verify availability')
             // For inactive sessions, update the in-memory cache directly without
             // an RPC call — the CLI is not running yet. The updated value will be
             // passed to the spawned process when the session is resumed.

--- a/shared/src/apiTypes.ts
+++ b/shared/src/apiTypes.ts
@@ -763,7 +763,21 @@ export type CodexModelSummary = {
 export type CodexModelsResponse = {
     success: boolean
     models?: CodexModelSummary[]
+    /** Session-scoped account usage. Read-only; never session activity. */
+    usage?: CodexAccountUsage | null
     error?: string
+}
+
+export type CodexUsageWindow = {
+    remainingPercent: number | null
+    windowDurationMins: number | null
+    resetsAt: number | null
+}
+
+export type CodexAccountUsage = {
+    ordinary: { primary: CodexUsageWindow | null; secondary: CodexUsageWindow | null }
+    reserve: { primary: CodexUsageWindow | null; secondary: CodexUsageWindow | null } | null
+    reserveAvailable: boolean
 }
 
 export type ListCodexModelsResponse = CodexModelsResponse

--- a/web/e2e-fixtures/luna-reserve-fixture.html
+++ b/web/e2e-fixtures/luna-reserve-fixture.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Luna Reserve fixture</title></head>
+<body><div id="root"></div><script type="module" src="./luna-reserve-fixture.tsx"></script></body></html>

--- a/web/e2e-fixtures/luna-reserve-fixture.tsx
+++ b/web/e2e-fixtures/luna-reserve-fixture.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import ReactDOM from 'react-dom/client'
+import { AssistantRuntimeProvider, useExternalStoreRuntime } from '@assistant-ui/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nProvider } from '../src/lib/i18n-context'
+import { HappyComposer } from '../src/components/AssistantChat/HappyComposer'
+import { getSessionModelLabel } from '../src/lib/sessionModelLabel'
+import '../src/index.css'
+
+const queryClient = new QueryClient()
+function Fixture() {
+    const [model, setModel] = useState('gpt-6-astra')
+    const [pending, setPending] = useState<string | null>(null)
+    const [eligible, setEligible] = useState(false)
+    const [reads, setReads] = useState(0)
+    const [sends, setSends] = useState(0)
+    const runtime = useExternalStoreRuntime({ messages: [], isRunning: false, onNew: async () => { setSends(n => n + 1) } })
+    return <AssistantRuntimeProvider runtime={runtime}>
+        <main className="mx-auto flex h-screen max-w-3xl flex-col p-3">
+            <div data-testid="model">{getSessionModelLabel({ model })?.value}</div>
+            <div className="flex-1">
+                <button onClick={() => setEligible(value => !value)}>Toggle eligibility</button>
+                <button onClick={() => { if (pending) setModel(pending); setPending(null) }}>Confirm native settings</button>
+                <output data-testid="reads">{reads}</output><output data-testid="sends">{sends}</output>
+            </div>
+            <HappyComposer sessionId="luna-fixture" agentFlavor="codex" active thinking={false} model={model}
+                modelReasoningEffort="high" onModelReasoningEffortChange={() => {}}
+                onModelChange={value => { if (typeof value === 'string') setPending(value) }}
+                onModelMenuOpen={() => setReads(n => n + 1)}
+                availableModelOptions={[
+                    { value: 'gpt-6-astra', label: 'GPT-6 Astra' },
+                    { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
+                    ...(eligible || model === 'gpt-reserve' ? [{ value: 'gpt-reserve', label: '☾ Luna Reserve' }] : [])
+                ]}
+                codexUsage={{ ordinary: { primary: { remainingPercent: 0, windowDurationMins: 300, resetsAt: null }, secondary: null },
+                    reserveAvailable: eligible,
+                    reserve: model === 'gpt-reserve' ? { primary: null, secondary: { remainingPercent: 27, windowDurationMins: 10080, resetsAt: null } } : null }}
+            />
+        </main>
+    </AssistantRuntimeProvider>
+}
+ReactDOM.createRoot(document.getElementById('root')!).render(<QueryClientProvider client={queryClient}><I18nProvider><Fixture /></I18nProvider></QueryClientProvider>)

--- a/web/src/components/AssistantChat/CodexUsage.test.tsx
+++ b/web/src/components/AssistantChat/CodexUsage.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { I18nProvider } from '@/lib/i18n-context'
+import { CodexUsage } from './CodexUsage'
+import type { CodexAccountUsage } from '@hapi/protocol/apiTypes'
+
+const usage: CodexAccountUsage = {
+    ordinary: { primary: { remainingPercent: 0, windowDurationMins: 300, resetsAt: 1800000000 }, secondary: null },
+    reserve: { primary: null, secondary: { remainingPercent: 27, windowDurationMins: 10080, resetsAt: null } },
+    reserveAvailable: true
+}
+
+describe('Codex usage', () => {
+    it('hides unused Reserve, keeps ordinary limits alongside active Reserve, and displays exhaustion', () => {
+        const view = render(<I18nProvider><CodexUsage usage={usage} model="gpt-6-astra" /></I18nProvider>)
+        fireEvent.click(screen.getByRole('button', { name: 'Codex usage details' }))
+        expect(screen.queryByText('☾ Luna Reserve')).toBeNull()
+        view.rerender(<I18nProvider><CodexUsage usage={usage} model="gpt-reserve" /></I18nProvider>)
+        expect(screen.getByText('☾ Luna Reserve')).toBeTruthy()
+        expect(screen.getByText('Ordinary usage')).toBeTruthy()
+        expect(screen.getByText(/27% remaining/)).toBeTruthy()
+        expect(screen.getByText(/0% remaining/)).toBeTruthy()
+        view.rerender(<I18nProvider><CodexUsage usage={null} model="gpt-reserve" /></I18nProvider>)
+        expect(screen.getAllByText('Unknown')).toHaveLength(2)
+        expect(screen.queryByText(/27% remaining/)).toBeNull()
+    })
+})

--- a/web/src/components/AssistantChat/CodexUsage.tsx
+++ b/web/src/components/AssistantChat/CodexUsage.tsx
@@ -1,0 +1,42 @@
+import * as Popover from '@radix-ui/react-popover'
+import type { CodexAccountUsage } from '@hapi/protocol/apiTypes'
+import { useTranslation } from '@/lib/use-translation'
+
+export function CodexUsage(props: { usage?: CodexAccountUsage | null; model?: string | null }) {
+    const { t } = useTranslation()
+    const inReserve = props.model === 'gpt-reserve'
+    if (!props.usage && !inReserve) return null
+    const buckets = [
+        { label: t('codex.usage.ordinary'), value: props.usage?.ordinary },
+        ...(inReserve ? [{ label: '☾ Luna Reserve', value: props.usage?.reserve }] : [])
+    ]
+    return (
+        <Popover.Root>
+            <Popover.Trigger asChild>
+                <button type="button" className="shrink-0 text-xs text-[var(--app-hint)] hover:text-[var(--app-fg)]" aria-label={t('codex.usage.details')}>
+                    {inReserve ? '☾ Reserve' : t('codex.usage.label')}
+                </button>
+            </Popover.Trigger>
+            <Popover.Portal>
+                <Popover.Content side="top" align="start" sideOffset={8} className="z-50 max-w-[calc(100vw-2rem)] rounded-lg border border-[var(--app-divider)] bg-[var(--app-bg)] p-3 text-xs shadow-lg">
+                    {buckets.map(({ label, value }) => (
+                        <div key={label} className="mb-2 last:mb-0">
+                            <div className="mb-1 font-medium">{label}</div>
+                            {!value?.primary && !value?.secondary ? <div className="text-[var(--app-hint)]">{t('codex.usage.unknown')}</div> : null}
+                            {[value?.primary, value?.secondary].map((window, index) => window ? (
+                                <div key={index} className="text-[var(--app-hint)]">
+                                    {window.windowDurationMins === null ? t('codex.usage.window')
+                                        : window.windowDurationMins % 1440 === 0 ? t('codex.usage.days', { value: window.windowDurationMins / 1440 })
+                                        : window.windowDurationMins % 60 === 0 ? t('codex.usage.hours', { value: window.windowDurationMins / 60 })
+                                        : t('codex.usage.minutes', { value: window.windowDurationMins })}
+                                    {' · '}{window.remainingPercent === null ? t('codex.usage.unknown') : t('codex.usage.remaining', { value: window.remainingPercent })}
+                                    {window.resetsAt !== null ? <div>{t('codex.usage.resets', { value: new Date(window.resetsAt * 1000).toLocaleString() })}</div> : null}
+                                </div>
+                            ) : null)}
+                        </div>
+                    ))}
+                </Popover.Content>
+            </Popover.Portal>
+        </Popover.Root>
+    )
+}

--- a/web/src/components/AssistantChat/HappyComposer.tsx
+++ b/web/src/components/AssistantChat/HappyComposer.tsx
@@ -46,6 +46,7 @@ import { useComposerEnterBehavior } from '@/hooks/useComposerEnterBehavior'
 import { FloatingOverlay } from '@/components/ChatInput/FloatingOverlay'
 import { Autocomplete } from '@/components/ChatInput/Autocomplete'
 import { StatusBar } from '@/components/AssistantChat/StatusBar'
+import type { CodexAccountUsage } from '@hapi/protocol/apiTypes'
 import { ComposerButtons } from '@/components/AssistantChat/ComposerButtons'
 import type { PendingSchedule } from '@/components/AssistantChat/ScheduleTimePicker'
 import { SortableComposerAttachments } from '@/components/AssistantChat/SortableComposerAttachments'
@@ -280,6 +281,8 @@ export function ModelEffortSettingsSection(props: {
 }
 
 export function HappyComposer(props: {
+    codexUsage?: CodexAccountUsage | null
+    onModelMenuOpen?: () => void
     sessionId?: string
     onUploadDraftSnapshot?: (text: string, attachments: AttachmentDraftInput[]) => void
     canRestoreAttachments?: boolean
@@ -1427,6 +1430,7 @@ export function HappyComposer(props: {
     // instead of closing, so model->effort moves between sections directly.
     const handleSettingsToggle = useCallback((section: 'model' | 'effort' | null = null) => {
         haptic('light')
+        if ((!showSettings || section !== settingsSection) && section !== 'effort') props.onModelMenuOpen?.()
         if (showSettings && section !== settingsSection) {
             // Open with a different anchor: switch sections, keep the sheet up.
             setSettingsSection(section)
@@ -1441,7 +1445,7 @@ export function HappyComposer(props: {
         }
         setSettingsSection(section)
         setShowSettings(true)
-    }, [haptic, showSettings, settingsSection])
+    }, [haptic, showSettings, settingsSection, props.onModelMenuOpen])
 
     const clearCursorDrillDown = useCallback(() => {
         setCursorDrillDownBase(null)
@@ -1788,6 +1792,7 @@ export function HappyComposer(props: {
                                             <span className={isSelected ? 'text-[var(--app-link)]' : ''}>
                                                 {option.label}
                                             </span>
+                                            {option.value === 'gpt-reserve' && !isSelected ? <span className="ml-auto text-xs text-[var(--app-hint)]">{t('codex.reserve.available')}</span> : null}
                                         </button>
                                         )
                                     })}
@@ -2161,6 +2166,7 @@ export function HappyComposer(props: {
                     {overlays}
 
                     <StatusBar
+                        codexUsage={props.codexUsage}
                         active={active}
                         thinking={thinking}
                         agentState={agentState}

--- a/web/src/components/AssistantChat/StatusBar.tsx
+++ b/web/src/components/AssistantChat/StatusBar.tsx
@@ -8,6 +8,8 @@ import {
 import type { PermissionModeTone } from '@hapi/protocol'
 import * as Popover from '@radix-ui/react-popover'
 import { useMemo } from 'react'
+import type { CodexAccountUsage } from '@hapi/protocol/apiTypes'
+import { CodexUsage } from './CodexUsage'
 import type { AgentState, CodexCollaborationMode, PermissionMode } from '@/types/api'
 import type { ConversationStatus } from '@/realtime/types'
 import { getContextBudgetTokens } from '@/chat/modelConfig'
@@ -192,6 +194,7 @@ export function shouldShowCodexFastBadge(
 }
 
 export function StatusBar(props: {
+    codexUsage?: CodexAccountUsage | null
     active: boolean
     thinking: boolean
     agentState: AgentState | null | undefined
@@ -302,6 +305,7 @@ export function StatusBar(props: {
                         {connectionStatus.text}
                     </span>
                 </div>
+                {props.agentFlavor === 'codex' ? <CodexUsage usage={props.codexUsage} model={props.model} /> : null}
                 {contextUsageLabel ? (
                     <Popover.Root>
                         <Popover.Trigger asChild>

--- a/web/src/components/AssistantChat/modelOptions.ts
+++ b/web/src/components/AssistantChat/modelOptions.ts
@@ -43,7 +43,7 @@ function withCurrentModelOption(
     const autoIndex = nextOptions.findIndex((option) => option.value === null)
     nextOptions.splice(autoIndex >= 0 ? autoIndex + 1 : 0, 0, {
         value: normalizedCurrentModel,
-        label: resolveLabel?.(normalizedCurrentModel) ?? normalizedCurrentModel
+        label: normalizedCurrentModel === 'gpt-reserve' ? '☾ Luna Reserve' : resolveLabel?.(normalizedCurrentModel) ?? normalizedCurrentModel
     })
     return nextOptions
 }

--- a/web/src/components/SessionChat.test.ts
+++ b/web/src/components/SessionChat.test.ts
@@ -582,3 +582,10 @@ describe('buildAgyComposerModelOptions', () => {
         expect(buildAgyComposerModelOptions([])).toBeUndefined()
     })
 })
+
+it('leaves Reserve effort normalization to the atomic native model switch', () => {
+    expect(shouldClearReasoningEffortForModelChange({
+        agentFlavor: 'codex', previousModelReasoningEffort: 'ultra', model: 'gpt-reserve',
+        codexModels: [{ id: 'gpt-reserve', displayName: 'Luna Reserve', isDefault: false, supportedReasoningEfforts: ['high'] }]
+    })).toBe(false)
+})

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -205,6 +205,8 @@ export function shouldClearReasoningEffortForModelChange(args: {
     codexModels: readonly CodexModelSummary[]
     model: SessionModelSelection
 }): boolean {
+    // Reserve validates and normalizes effort atomically in the shared runtime.
+    if (args.agentFlavor === 'codex' && args.model === 'gpt-reserve') return false
     if (!args.previousModelReasoningEffort) {
         return false
     }
@@ -971,8 +973,13 @@ function SessionChatInner(props: SessionChatProps) {
         api: props.api,
         sessionId: props.session.id,
         machineId: props.session.metadata?.machineId ?? null,
+        sessionScoped: props.session.metadata?.capabilities?.concurrentClients === true,
         enabled: agentFlavor === 'codex' && props.session.active && !controlledByUser
     })
+    useEffect(() => {
+        if (agentFlavor !== 'codex' || !props.session.active || !props.session.metadata?.capabilities?.concurrentClients || props.session.thinking) return
+        void queryClient.refetchQueries({ queryKey: queryKeys.sessionCodexModels(sessionId), exact: true }, { cancelRefetch: false })
+    }, [agentFlavor, sessionId, props.session.active, props.session.thinking, props.session.model, props.session.metadata?.capabilities?.concurrentClients, queryClient])
     const effectiveCodexServiceTier = agentFlavor === 'codex'
         ? getEffectiveCodexServiceTier(
             props.session.serviceTier,
@@ -989,7 +996,7 @@ function SessionChatInner(props: SessionChatProps) {
         for (const codexModel of codexModelsState.models) {
             options.push({
                 value: codexModel.id,
-                label: codexModel.displayName
+                label: codexModel.id === 'gpt-reserve' ? '☾ Luna Reserve' : codexModel.displayName
             })
         }
         return options
@@ -2005,6 +2012,8 @@ function SessionChatInner(props: SessionChatProps) {
                         <HappyComposer
                         key={`composer-${props.session.id}`}
                         sessionId={props.session.id}
+                        codexUsage={codexModelsState.usage}
+                        onModelMenuOpen={agentFlavor === 'codex' ? codexModelsState.refresh : undefined}
                         canRestoreAttachments={props.session.active}
                         onUploadDraftSnapshot={(text, attachments) => {
                             uploadDraftSnapshotRef.current = { text, attachments }

--- a/web/src/hooks/queries/useCodexModels.test.tsx
+++ b/web/src/hooks/queries/useCodexModels.test.tsx
@@ -97,3 +97,22 @@ describe('useCodexModels query scoping', () => {
         ])
     })
 })
+
+describe('shared Codex session catalogs', () => {
+    it('uses the live session account, excludes it from machine caches, and refreshes without polling', async () => {
+        const getMachineCodexModels = vi.fn()
+        const getSessionCodexModels = vi.fn(async (id: string) => ({ success: true, models: [
+            { id: id === 'eligible' ? 'gpt-reserve' : 'gpt-6-astra', displayName: id, isDefault: false }
+        ] }))
+        const api = { getMachineCodexModels, getSessionCodexModels } as unknown as ApiClient
+        const queryClient = createQueryClient()
+        const sharedWrapper = wrapper(queryClient)
+        const first = renderHook(() => useCodexModels({ api, sessionId: 'eligible', machineId: 'm', enabled: true, sessionScoped: true }), { wrapper: sharedWrapper })
+        const second = renderHook(() => useCodexModels({ api, sessionId: 'ordinary', machineId: 'm', enabled: true, sessionScoped: true }), { wrapper: sharedWrapper })
+        await waitFor(() => expect(first.result.current.models[0]?.id).toBe('gpt-reserve'))
+        await waitFor(() => expect(second.result.current.models[0]?.id).toBe('gpt-6-astra'))
+        expect(getMachineCodexModels).not.toHaveBeenCalled()
+        first.result.current.refresh()
+        await waitFor(() => expect(getSessionCodexModels).toHaveBeenCalledTimes(3))
+    })
+})

--- a/web/src/hooks/queries/useCodexModels.ts
+++ b/web/src/hooks/queries/useCodexModels.ts
@@ -3,16 +3,20 @@ import { RPC_TARGET_MISSING_ERROR_CODE } from '@hapi/protocol/rpcMethods'
 import { ApiError, type ApiClient } from '@/api/client'
 import type { CodexModelSummary } from '@/types/api'
 import { queryKeys } from '@/lib/query-keys'
+import type { CodexAccountUsage } from '@hapi/protocol/apiTypes'
 
 export function useCodexModels(args: {
     api: ApiClient | null
     sessionId?: string | null
     machineId?: string | null
     enabled?: boolean
+    sessionScoped?: boolean
 }): {
     models: CodexModelSummary[]
     isLoading: boolean
     error: string | null
+    usage: CodexAccountUsage | null
+    refresh: () => void
 } {
     const { api, sessionId, machineId } = args
     const enabled = Boolean(args.enabled && api && (sessionId || machineId))
@@ -28,17 +32,17 @@ export function useCodexModels(args: {
             }
             throw new Error('Codex models target unavailable')
         },
-        enabled: Boolean(enabled && machineId),
+        enabled: Boolean(enabled && machineId && !args.sessionScoped),
         staleTime: 30_000,
         retry: false,
     })
 
-    // Successful machine discovery stays shared across chats and New Session.
-    // Only an absent machine RPC unlocks the per-session neutral fallback.
+    // Shared runtimes own their account/provider context and conditional Reserve
+    // options. Keep those separate from machine discovery used by New Session.
     const useSessionFallback = Boolean(
         enabled
         && sessionId
-        && (!machineId || (
+        && (args.sessionScoped || !machineId || (
             machineQuery.error instanceof ApiError
             && machineQuery.error.code === RPC_TARGET_MISSING_ERROR_CODE
         ))
@@ -62,6 +66,8 @@ export function useCodexModels(args: {
 
     return {
         models: query.data?.models ?? [],
+        usage: query.data?.usage ?? null,
+        refresh: () => { if (enabled) void query.refetch({ cancelRefetch: false }) },
         isLoading: query.isLoading,
         error: query.data?.success === false
             ? (query.data.error ?? 'Failed to load Codex models')

--- a/web/src/hooks/useSSE.ts
+++ b/web/src/hooks/useSSE.ts
@@ -665,6 +665,8 @@ export function useSSE(options: {
                 const resumed = data && typeof data === 'object'
                     && (data as { resume?: unknown }).resume === 'ok'
                 onConnectRef.current?.({ resumed: Boolean(resumed) })
+                // Account usage is read-only RPC data, not part of the SSE replay log.
+                void queryClient.invalidateQueries({ queryKey: ['session-codex-models'], refetchType: 'active' })
             }
 
             if (event.type === 'toast') {

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -1,4 +1,15 @@
 export default {
+  'codex.reserve.available': 'Available',
+  'codex.usage.label': 'Usage',
+  'codex.usage.details': 'Codex usage details',
+  'codex.usage.ordinary': 'Ordinary usage',
+  'codex.usage.unknown': 'Unknown',
+  'codex.usage.window': 'Usage window',
+  'codex.usage.minutes': '{value} min',
+  'codex.usage.hours': '{value}h',
+  'codex.usage.days': '{value}d',
+  'codex.usage.remaining': '{value}% remaining',
+  'codex.usage.resets': 'Resets {value}',
   // Loading states
   'loading': 'Loading…',
   'authorizing': 'Authorizing…',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -1,4 +1,15 @@
 export default {
+  'codex.reserve.available': '可用',
+  'codex.usage.label': '额度',
+  'codex.usage.details': 'Codex 额度详情',
+  'codex.usage.ordinary': '普通额度',
+  'codex.usage.unknown': '未知',
+  'codex.usage.window': '额度周期',
+  'codex.usage.minutes': '{value} 分钟',
+  'codex.usage.hours': '{value} 小时',
+  'codex.usage.days': '{value} 天',
+  'codex.usage.remaining': '剩余 {value}%',
+  'codex.usage.resets': '{value} 重置',
   // Loading states
   'loading': '加载中…',
   'authorizing': '认证中…',

--- a/web/src/lib/sessionModelLabel.ts
+++ b/web/src/lib/sessionModelLabel.ts
@@ -10,6 +10,7 @@ export type SessionModelLabel = {
 }
 
 function getModelLabel(model: string): string | null {
+    if (model === 'gpt-reserve') return '☾ Luna Reserve'
     return getAgyModelLabel(model) ?? getClaudeModelLabel(model)
 }
 


### PR DESCRIPTION
## Current integration (2026-09-14)

Integrated upstream main `9c4e6dad`, preserving native plan proposal publication/implementation and title fixes while retaining explicit Reserve selection. Combined native-root, usage, and projection regression tests: 33 passed, including delayed native settings confirmation. Root typecheck, all CLI/hub/web/shared/relay suites, fixture generation, and 19 current browser checks passed locally.

Fresh read-only validation through the actual HAPI LunaReserve reader and installed Codex 0.154.0 returned supported=true and reserveAvailable=false. Eligible-account HAPI-menu verification is therefore still blocked by account state: do not treat native inference, mocked eligibility, or successful CI as proof of an exhausted-account Reserve transition. No account limits were deliberately exhausted and no production sessions were changed.

---

Replace automatic Reserve fallback with an explicit choice in the existing Codex model menu. When the current session's backend authorizes Reserve, users can select **☾ Luna Reserve**; the native settings notification confirms the change. HAPI never enters or leaves Reserve automatically and never resubmits a failed turn when switching.

This is a new implementation on current upstream, superseding the reverted approach in #1780. Reserve stays out of New Session defaults and machine-wide model caches. The shared runtime revalidates availability on selection, preserves permission/collaboration settings, normalizes reasoning for the target model, preserves custom collaboration instructions, and rejects stale, expired, or unavailable selections. Settings dispatch is bounded within the hub RPC budget, including queued selections. Native TUI changes remain authoritative.

Account usage is returned with the session model-list RPC, not written into agent state or session activity. The existing composer status row opens a usage popover with ordinary and active Reserve allowances kept separate. Reads occur on menu/discovery, reconnect, and turn completion/errors; there is no idle quota timer. Quota errors remain visible and can add a short model-menu hint asynchronously, once per turn, without blocking subsequent native events.

Validation:
- `bun typecheck && bun run test`: exit 0; 7,506 tests passed, 7 skipped (CLI 2,766; hub 1,252; web 3,050; shared 320; relay 118).
- Native shared runtime integration: 4 tests passed with an isolated mock Responses endpoint.
- Full CI Chromium gate: 18 tests passed. New Chromium coverage at 390px and 1280px for the real composer menu, explicit selection, delayed native confirmation, no message submission, and usage visibility; included in the existing CI browser gate.
- Installed Codex 0.154.0 generated protocol schema and real account-usage read: supported response parsed successfully. The account still has ordinary allowance and no Reserve banner; HAPI menu eligibility is false.

Live native verification (2026-09-12): two isolated ephemeral threads explicitly started as `gpt-reserve`, returned `RESERVE_OK`, reported token usage, and completed without a model-rerouted event. Native Reserve inference succeeds even though this account’s model list omits Reserve and ordinary usage remains allowed. Account usage exposes the separate `base_model_inference` bucket with `limitName=gpt-reserve`.

Validation limits: this does not exercise the HAPI menu under an exhausted/eligible account. Around the second minimal request, ordinary usedPercent stayed at 13 and Reserve stayed at 2, including a delayed reread; a per-request quota/billing increment is therefore not measurable from these snapshots. Entitlement, failure and race paths remain covered with controlled responses; no claim of measured Reserve deduction is made.
