### PR TITLE
fix(web): force-dismiss indeterminate queued rows on cancel/edit

### DIFF
--- a/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
@@ -495,7 +495,9 @@ describe('QueuedMessagesBar edit restore', () => {
         expect(mocks.addToast).not.toHaveBeenCalled()
     })
 
-    it('prefills the composer when editing an indeterminate row whose cancel returns busy (#1839)', async () => {
+    it('does not prefill when editing an indeterminate row whose cancel returns busy', async () => {
+        // Hub may still be mid-dispatch (serialized as indeterminate). Prefilling
+        // would invite a duplicate send if the original later lands.
         mocks.messageWindowState = {
             messages: [makeQueuedMessage(null, 'server-message-id', { deliveryState: 'indeterminate' })],
         }
@@ -519,10 +521,13 @@ describe('QueuedMessagesBar edit restore', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Edit queued message' }))
         await resolveCancel({ status: 'busy', localId: 'local-server-message-id' })
 
-        expect(mocks.composerSetText).toHaveBeenCalledWith('Queued request')
-        expect(onEdit).toHaveBeenCalledWith({
-            text: 'Queued request',
-            pendingSchedule: null,
+        expect(mocks.composerSetText).not.toHaveBeenCalled()
+        expect(onEdit).not.toHaveBeenCalled()
+        expect(mocks.addToast).toHaveBeenCalledWith({
+            title: 'queuedMessages.editBusyNotRestored',
+            body: '',
+            sessionId: 'session-1',
+            url: window.location.href,
         })
     })
 

--- a/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.test.tsx
@@ -15,7 +15,7 @@ import {
 import { formatScheduledTime } from '@/lib/scheduledTime'
 import { clearQueuedEditRecovery, getQueuedEditRecovery } from '@/lib/queued-edit-recovery'
 
-type DeferredCancelResult = { status: 'cancelled' | 'invoked' }
+type DeferredCancelResult = { status: 'cancelled' | 'invoked' | 'busy'; localId?: string }
 
 const mocks = vi.hoisted(() => ({
     composerText: '',
@@ -69,7 +69,11 @@ vi.mock('@/lib/toast-context', () => ({
     useToast: () => ({ addToast: mocks.addToast }),
 }))
 
-function makeQueuedMessage(scheduledAt: number | null = null, id = 'server-message-id'): DecryptedMessage {
+function makeQueuedMessage(
+    scheduledAt: number | null = null,
+    id = 'server-message-id',
+    overrides: Partial<DecryptedMessage> = {},
+): DecryptedMessage {
     return {
         id,
         localId: `local-${id}`,
@@ -82,6 +86,7 @@ function makeQueuedMessage(scheduledAt: number | null = null, id = 'server-messa
             role: 'user',
             content: { type: 'text', text: 'Queued request' },
         },
+        ...overrides,
     } as unknown as DecryptedMessage
 }
 
@@ -476,6 +481,48 @@ describe('QueuedMessagesBar edit restore', () => {
             body: '',
             sessionId: 'session-1',
             url: window.location.href,
+        })
+    })
+
+    it('does not prefill when a normal cancel returns busy (steer still may deliver)', async () => {
+        const { onEdit } = renderQueuedMessage()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Edit queued message' }))
+        await resolveCancel({ status: 'busy', localId: 'local-server-message-id' })
+
+        expect(mocks.composerSetText).not.toHaveBeenCalled()
+        expect(onEdit).not.toHaveBeenCalled()
+        expect(mocks.addToast).not.toHaveBeenCalled()
+    })
+
+    it('prefills the composer when editing an indeterminate row whose cancel returns busy (#1839)', async () => {
+        mocks.messageWindowState = {
+            messages: [makeQueuedMessage(null, 'server-message-id', { deliveryState: 'indeterminate' })],
+        }
+        const onEdit = vi.fn()
+        const queryClient = new QueryClient({
+            defaultOptions: { mutations: { retry: false } },
+        })
+        render(
+            <QueryClientProvider client={queryClient}>
+                <QueuedMessagesBar
+                    sessionId="session-1"
+                    api={null}
+                    pendingSchedule={null}
+                    pendingScheduleRevision={0}
+                    onEdit={onEdit}
+                />
+            </QueryClientProvider>
+        )
+
+        expect(screen.getByText('queuedMessages.steerOutcomeUnknown')).toBeTruthy()
+        fireEvent.click(screen.getByRole('button', { name: 'Edit queued message' }))
+        await resolveCancel({ status: 'busy', localId: 'local-server-message-id' })
+
+        expect(mocks.composerSetText).toHaveBeenCalledWith('Queued request')
+        expect(onEdit).toHaveBeenCalledWith({
+            text: 'Queued request',
+            pendingSchedule: null,
         })
     })
 

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -101,7 +101,9 @@ function useQueuedMessages(sessionId: string): DecryptedMessage[] {
     // useSyncExternalStore guarantees a stable reference when the snapshot is
     // unchanged, so [state] as the dependency avoids unnecessary re-sorts.
     return useMemo(() => {
-        return sortQueuedMessages(state.messages.filter(isQueuedForInvocation))
+        return sortQueuedMessages(
+            state.messages.filter((msg) => isQueuedForInvocation(msg) && !msg.queueDismissed)
+        )
     }, [state])
 }
 

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -432,10 +432,12 @@ export function QueuedMessagesBar({
                                 })
                                 // Race guard: if the agent already consumed this message, skip prefill
                                 // and inform the user so they aren't confused by the row disappearing.
-                                // A 'busy' cancel means the row is inside an async steer — it was
-                                // NOT cancelled, so never prefill (the instruction may still be
+                                // A first-time 'busy' cancel means the row is inside an async steer —
+                                // it was NOT cancelled, so never prefill (the instruction may still be
                                 // delivered; prefilling invites a duplicate send).
-                                if (result.status === 'busy') {
+                                // Cancel/Edit on an already-indeterminate row force-dismisses (#1839),
+                                // so fall through and restore the composer like a successful cancel.
+                                if (result.status === 'busy' && msg.deliveryState !== 'indeterminate') {
                                     return
                                 }
                                 if (result.status === 'invoked') {

--- a/web/src/components/AssistantChat/QueuedMessagesBar.tsx
+++ b/web/src/components/AssistantChat/QueuedMessagesBar.tsx
@@ -432,12 +432,21 @@ export function QueuedMessagesBar({
                                 })
                                 // Race guard: if the agent already consumed this message, skip prefill
                                 // and inform the user so they aren't confused by the row disappearing.
-                                // A first-time 'busy' cancel means the row is inside an async steer —
-                                // it was NOT cancelled, so never prefill (the instruction may still be
-                                // delivered; prefilling invites a duplicate send).
-                                // Cancel/Edit on an already-indeterminate row force-dismisses (#1839),
-                                // so fall through and restore the composer like a successful cancel.
-                                if (result.status === 'busy' && msg.deliveryState !== 'indeterminate') {
+                                // A 'busy' cancel means the row is inside an async steer / live
+                                // dispatch — it was NOT cancelled. Never prefill (the instruction
+                                // may still be delivered; prefilling invites a duplicate send).
+                                // Cancel still force-dismisses an already-indeterminate row (#1839);
+                                // Edit clears the stuck chip but waits for a confirmed cancel before
+                                // restoring composer text.
+                                if (result.status === 'busy') {
+                                    if (msg.deliveryState === 'indeterminate' && mountedRef.current) {
+                                        addToast({
+                                            title: t('queuedMessages.editBusyNotRestored'),
+                                            body: '',
+                                            sessionId,
+                                            url: window.location.href,
+                                        })
+                                    }
                                     return
                                 }
                                 if (result.status === 'invoked') {

--- a/web/src/hooks/mutations/useCancelQueuedMessage.test.tsx
+++ b/web/src/hooks/mutations/useCancelQueuedMessage.test.tsx
@@ -102,7 +102,10 @@ describe('useCancelQueuedMessage', () => {
         })
 
         expect(storeMocks.removeOptimisticMessage).toHaveBeenCalledWith('session-1', 'local-1')
-        expect(storeMocks.appendOptimisticMessage).not.toHaveBeenCalled()
+        expect(storeMocks.appendOptimisticMessage).toHaveBeenCalledWith('session-1', expect.objectContaining({
+            deliveryState: 'indeterminate',
+            queueDismissed: true,
+        }))
         expect(storeMocks.markMessagesConsumed).not.toHaveBeenCalled()
     })
 

--- a/web/src/hooks/mutations/useCancelQueuedMessage.test.tsx
+++ b/web/src/hooks/mutations/useCancelQueuedMessage.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import type { ApiClient } from '@/api/client'
+import type { DecryptedMessage } from '@/types/api'
+import { useCancelQueuedMessage } from './useCancelQueuedMessage'
+
+const storeMocks = vi.hoisted(() => ({
+    appendOptimisticMessage: vi.fn(),
+    removeOptimisticMessage: vi.fn(),
+    markMessagesConsumed: vi.fn(),
+}))
+
+vi.mock('@/lib/message-window-store', () => ({
+    appendOptimisticMessage: storeMocks.appendOptimisticMessage,
+    removeOptimisticMessage: storeMocks.removeOptimisticMessage,
+    markMessagesConsumed: storeMocks.markMessagesConsumed,
+}))
+
+vi.mock('@/hooks/usePlatform', () => ({
+    usePlatform: () => ({
+        haptic: { notification: vi.fn() },
+    }),
+}))
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: { mutations: { retry: false } },
+    })
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    }
+}
+
+function makeSnapshot(overrides: Partial<DecryptedMessage> = {}): DecryptedMessage {
+    return {
+        id: 'server-message-id',
+        localId: 'local-1',
+        createdAt: 1000,
+        seq: 1,
+        invokedAt: null,
+        status: 'queued',
+        content: {
+            role: 'user',
+            content: { type: 'text', text: 'Queued request' },
+        },
+        ...overrides,
+    } as unknown as DecryptedMessage
+}
+
+describe('useCancelQueuedMessage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('restores an indeterminate held row when cancel returns busy for a normal queued message', async () => {
+        const api = {
+            cancelMessage: vi.fn().mockResolvedValue({ status: 'busy', localId: 'local-1' }),
+            getQueuedState: vi.fn().mockResolvedValue({ invokedLocalMessages: [], queuedLocalIds: ['local-1'] }),
+        } as unknown as ApiClient
+        const snapshot = makeSnapshot()
+
+        const { result } = renderHook(() => useCancelQueuedMessage(api), { wrapper: createWrapper() })
+
+        await act(async () => {
+            await result.current.mutateAsync({
+                sessionId: 'session-1',
+                messageId: 'server-message-id',
+                localId: 'local-1',
+                snapshot,
+            })
+        })
+
+        expect(storeMocks.removeOptimisticMessage).toHaveBeenCalledWith('session-1', 'local-1')
+        expect(storeMocks.appendOptimisticMessage).toHaveBeenCalledWith('session-1', {
+            ...snapshot,
+            deliveryState: 'indeterminate',
+        })
+    })
+
+    it('force-dismisses an already-indeterminate row when cancel returns busy (#1839)', async () => {
+        const api = {
+            cancelMessage: vi.fn().mockResolvedValue({ status: 'busy', localId: 'local-1' }),
+            getQueuedState: vi.fn().mockResolvedValue({
+                invokedLocalMessages: [],
+                queuedLocalIds: [],
+                indeterminateLocalIds: ['local-1'],
+            }),
+        } as unknown as ApiClient
+        const snapshot = makeSnapshot({ deliveryState: 'indeterminate' })
+
+        const { result } = renderHook(() => useCancelQueuedMessage(api), { wrapper: createWrapper() })
+
+        await act(async () => {
+            await result.current.mutateAsync({
+                sessionId: 'session-1',
+                messageId: 'server-message-id',
+                localId: 'local-1',
+                snapshot,
+            })
+        })
+
+        expect(storeMocks.removeOptimisticMessage).toHaveBeenCalledWith('session-1', 'local-1')
+        expect(storeMocks.appendOptimisticMessage).not.toHaveBeenCalled()
+        expect(storeMocks.markMessagesConsumed).not.toHaveBeenCalled()
+    })
+
+    it('upgrades force-dismiss busy to invoked when getQueuedState reports consumed', async () => {
+        const api = {
+            cancelMessage: vi.fn().mockResolvedValue({ status: 'busy', localId: 'local-1' }),
+            getQueuedState: vi.fn().mockResolvedValue({
+                invokedLocalMessages: [{ localId: 'local-1', invokedAt: 42 }],
+                queuedLocalIds: [],
+            }),
+        } as unknown as ApiClient
+        const snapshot = makeSnapshot({ deliveryState: 'indeterminate' })
+
+        const { result } = renderHook(() => useCancelQueuedMessage(api), { wrapper: createWrapper() })
+
+        let cancelResult: unknown
+        await act(async () => {
+            cancelResult = await result.current.mutateAsync({
+                sessionId: 'session-1',
+                messageId: 'server-message-id',
+                localId: 'local-1',
+                snapshot,
+            })
+        })
+
+        expect(cancelResult).toEqual({
+            status: 'invoked',
+            message: expect.objectContaining({
+                id: 'server-message-id',
+                localId: 'local-1',
+                invokedAt: 42,
+            }),
+        })
+        await waitFor(() => {
+            expect(storeMocks.appendOptimisticMessage).toHaveBeenCalledWith('session-1', expect.objectContaining({
+                id: 'server-message-id',
+                localId: 'local-1',
+                status: 'sent',
+                invokedAt: 42,
+            }))
+        })
+        expect(storeMocks.appendOptimisticMessage).toHaveBeenCalledTimes(1)
+    })
+})

--- a/web/src/hooks/mutations/useCancelQueuedMessage.test.tsx
+++ b/web/src/hooks/mutations/useCancelQueuedMessage.test.tsx
@@ -147,6 +147,11 @@ describe('useCancelQueuedMessage', () => {
                 invokedAt: 42,
             }))
         })
-        expect(storeMocks.appendOptimisticMessage).toHaveBeenCalledTimes(1)
+        // Hidden hold restored before getQueuedState, then sent after synthetic invoked.
+        expect(storeMocks.appendOptimisticMessage).toHaveBeenCalledWith('session-1', expect.objectContaining({
+            deliveryState: 'indeterminate',
+            queueDismissed: true,
+        }))
+        expect(storeMocks.appendOptimisticMessage).toHaveBeenCalledTimes(2)
     })
 })

--- a/web/src/hooks/mutations/useCancelQueuedMessage.test.tsx
+++ b/web/src/hooks/mutations/useCancelQueuedMessage.test.tsx
@@ -10,12 +10,14 @@ const storeMocks = vi.hoisted(() => ({
     appendOptimisticMessage: vi.fn(),
     removeOptimisticMessage: vi.fn(),
     markMessagesConsumed: vi.fn(),
+    markMessagesRequeued: vi.fn(),
 }))
 
 vi.mock('@/lib/message-window-store', () => ({
     appendOptimisticMessage: storeMocks.appendOptimisticMessage,
     removeOptimisticMessage: storeMocks.removeOptimisticMessage,
     markMessagesConsumed: storeMocks.markMessagesConsumed,
+    markMessagesRequeued: storeMocks.markMessagesRequeued,
 }))
 
 vi.mock('@/hooks/usePlatform', () => ({
@@ -153,5 +155,34 @@ describe('useCancelQueuedMessage', () => {
             queueDismissed: true,
         }))
         expect(storeMocks.appendOptimisticMessage).toHaveBeenCalledTimes(2)
+    })
+
+    it('clears force-dismiss when getQueuedState reports the row is back in FIFO', async () => {
+        const api = {
+            cancelMessage: vi.fn().mockResolvedValue({ status: 'busy', localId: 'local-1' }),
+            getQueuedState: vi.fn().mockResolvedValue({
+                invokedLocalMessages: [],
+                queuedLocalIds: ['local-1'],
+            }),
+        } as unknown as ApiClient
+        const snapshot = makeSnapshot({ deliveryState: 'indeterminate' })
+
+        const { result } = renderHook(() => useCancelQueuedMessage(api), { wrapper: createWrapper() })
+
+        let cancelResult: unknown
+        await act(async () => {
+            cancelResult = await result.current.mutateAsync({
+                sessionId: 'session-1',
+                messageId: 'server-message-id',
+                localId: 'local-1',
+                snapshot,
+            })
+        })
+
+        expect(cancelResult).toEqual({ status: 'busy', localId: 'local-1' })
+        expect(storeMocks.appendOptimisticMessage).toHaveBeenCalledWith('session-1', expect.objectContaining({
+            queueDismissed: true,
+        }))
+        expect(storeMocks.markMessagesRequeued).toHaveBeenCalledWith('session-1', ['local-1'])
     })
 })

--- a/web/src/hooks/mutations/useCancelQueuedMessage.ts
+++ b/web/src/hooks/mutations/useCancelQueuedMessage.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
 import type { ApiClient } from '@/api/client'
 import type { DecryptedMessage } from '@/types/api'
+import type { CancelMessageResponse } from '@hapi/protocol/schemas'
 import {
     appendOptimisticMessage,
     markMessagesConsumed,
@@ -31,17 +32,48 @@ type CancelQueuedMessageInput = {
  *      have already arrived while the web row was optimistically removed (markMessagesConsumed
  *      no-op on missing row), so no later event will fix the stuck chip.
  *      appendOptimisticMessage with status='sent' shows the message in the thread correctly.
+ *  3c. On success with status='busy': the row is inside an async steer / unknown outcome.
+ *      First-time busy restores a held indeterminate copy so the user can retry or cancel.
+ *      Cancel/Edit on an *already* indeterminate row force-dismisses locally (#1839) —
+ *      re-sticking left Edit/X dead with no in-UI escape.
+ *      If getQueuedState reports the row was already consumed, mutationFn upgrades the
+ *      result to `invoked` so Edit toasts instead of prefilling a duplicate.
  *  4. On error: re-insert the snapshot so the bar comes back; haptic error feedback.
  */
 export function useCancelQueuedMessage(api: ApiClient | null) {
     const { haptic } = usePlatform()
 
     const mutation = useMutation({
-        mutationFn: async (input: CancelQueuedMessageInput) => {
+        mutationFn: async (input: CancelQueuedMessageInput): Promise<CancelMessageResponse> => {
             if (!api) {
                 throw new Error('API unavailable')
             }
-            return api.cancelMessage(input.sessionId, input.messageId)
+            const result = await api.cancelMessage(input.sessionId, input.messageId)
+            // Force-dismiss (#1839): learn whether the steer already landed before
+            // callers (Edit) decide to prefill. Returning synthetic `invoked` keeps
+            // the existing Edit toast path and avoids a duplicate composer send.
+            if (result.status === 'busy' && input.snapshot.deliveryState === 'indeterminate') {
+                try {
+                    const state = await api.getQueuedState(input.sessionId, [input.localId])
+                    const invoked = state.invokedLocalMessages.find((item) => item.localId === input.localId)
+                    if (invoked) {
+                        return {
+                            status: 'invoked',
+                            message: {
+                                id: input.snapshot.id,
+                                seq: input.snapshot.seq ?? null,
+                                localId: input.localId,
+                                content: input.snapshot.content,
+                                createdAt: input.snapshot.createdAt,
+                                invokedAt: invoked.invokedAt,
+                            },
+                        }
+                    }
+                } catch {
+                    // Fall through to busy force-dismiss; SSE / reconnect may still reconcile.
+                }
+            }
+            return result
         },
         onMutate: (input) => {
             // Optimistic: remove from the floating bar immediately.
@@ -49,6 +81,11 @@ export function useCancelQueuedMessage(api: ApiClient | null) {
         },
         onSuccess: async (result, input) => {
             if (result.status === 'busy') {
+                const forceDismiss = input.snapshot.deliveryState === 'indeterminate'
+                if (forceDismiss) {
+                    // Optimistic removal stands — do not re-stick an indeterminate row.
+                    return
+                }
                 // The row is inside an async steer: restore a held copy, not a
                 // normal FIFO row. A concurrent consumed ACK may have arrived
                 // while the optimistic row was absent, so reconcile once.

--- a/web/src/hooks/mutations/useCancelQueuedMessage.ts
+++ b/web/src/hooks/mutations/useCancelQueuedMessage.ts
@@ -34,8 +34,9 @@ type CancelQueuedMessageInput = {
  *      appendOptimisticMessage with status='sent' shows the message in the thread correctly.
  *  3c. On success with status='busy': the row is inside an async steer / unknown outcome.
  *      First-time busy restores a held indeterminate copy so the user can retry or cancel.
- *      Cancel/Edit on an *already* indeterminate row force-dismisses locally (#1839) —
- *      re-sticking left Edit/X dead with no in-UI escape.
+ *      Cancel/Edit on an *already* indeterminate row force-dismisses from the floating bar
+ *      (#1839) via queueDismissed — the row stays in the window so a later messages-consumed
+ *      SSE can still promote it into the thread.
  *      If getQueuedState reports the row was already consumed, mutationFn upgrades the
  *      result to `invoked` so Edit toasts instead of prefilling a duplicate.
  *  4. On error: re-insert the snapshot so the bar comes back; haptic error feedback.
@@ -83,7 +84,14 @@ export function useCancelQueuedMessage(api: ApiClient | null) {
             if (result.status === 'busy') {
                 const forceDismiss = input.snapshot.deliveryState === 'indeterminate'
                 if (forceDismiss) {
-                    // Optimistic removal stands — do not re-stick an indeterminate row.
+                    // Keep a hidden copy so a later messages-consumed SSE can
+                    // still promote the row into the thread (markMessagesConsumed
+                    // is a no-op when the row is fully absent).
+                    appendOptimisticMessage(input.sessionId, {
+                        ...input.snapshot,
+                        deliveryState: 'indeterminate',
+                        queueDismissed: true,
+                    })
                     return
                 }
                 // The row is inside an async steer: restore a held copy, not a

--- a/web/src/hooks/mutations/useCancelQueuedMessage.ts
+++ b/web/src/hooks/mutations/useCancelQueuedMessage.ts
@@ -5,6 +5,7 @@ import type { CancelMessageResponse } from '@hapi/protocol/schemas'
 import {
     appendOptimisticMessage,
     markMessagesConsumed,
+    markMessagesRequeued,
     removeOptimisticMessage,
 } from '@/lib/message-window-store'
 import { usePlatform } from '@/hooks/usePlatform'
@@ -77,6 +78,11 @@ export function useCancelQueuedMessage(api: ApiClient | null) {
                                 invokedAt: invoked.invokedAt,
                             },
                         }
+                    }
+                    // Steer may have failed and returned the row to FIFO while DELETE
+                    // was still in flight. Clear the hidden hold so Edit/Cancel return.
+                    if (state.queuedLocalIds.includes(input.localId)) {
+                        markMessagesRequeued(input.sessionId, [input.localId])
                     }
                 } catch {
                     // Fall through to busy force-dismiss; SSE / reconnect may still reconcile.

--- a/web/src/hooks/mutations/useCancelQueuedMessage.ts
+++ b/web/src/hooks/mutations/useCancelQueuedMessage.ts
@@ -35,8 +35,9 @@ type CancelQueuedMessageInput = {
  *  3c. On success with status='busy': the row is inside an async steer / unknown outcome.
  *      First-time busy restores a held indeterminate copy so the user can retry or cancel.
  *      Cancel/Edit on an *already* indeterminate row force-dismisses from the floating bar
- *      (#1839) via queueDismissed — the row stays in the window so a later messages-consumed
- *      SSE can still promote it into the thread.
+ *      (#1839) via queueDismissed — restored before getQueuedState so a concurrent
+ *      messages-consumed SSE can still mark the row sent, then left alone in onSuccess
+ *      so we do not overwrite that acknowledgement with an uninvoked snapshot.
  *      If getQueuedState reports the row was already consumed, mutationFn upgrades the
  *      result to `invoked` so Edit toasts instead of prefilling a duplicate.
  *  4. On error: re-insert the snapshot so the bar comes back; haptic error feedback.
@@ -54,6 +55,13 @@ export function useCancelQueuedMessage(api: ApiClient | null) {
             // callers (Edit) decide to prefill. Returning synthetic `invoked` keeps
             // the existing Edit toast path and avoids a duplicate composer send.
             if (result.status === 'busy' && input.snapshot.deliveryState === 'indeterminate') {
+                // Restore a hidden hold BEFORE the queued-state lookup so a
+                // messages-consumed SSE during that await can still land.
+                appendOptimisticMessage(input.sessionId, {
+                    ...input.snapshot,
+                    deliveryState: 'indeterminate',
+                    queueDismissed: true,
+                })
                 try {
                     const state = await api.getQueuedState(input.sessionId, [input.localId])
                     const invoked = state.invokedLocalMessages.find((item) => item.localId === input.localId)
@@ -82,16 +90,10 @@ export function useCancelQueuedMessage(api: ApiClient | null) {
         },
         onSuccess: async (result, input) => {
             if (result.status === 'busy') {
-                const forceDismiss = input.snapshot.deliveryState === 'indeterminate'
-                if (forceDismiss) {
-                    // Keep a hidden copy so a later messages-consumed SSE can
-                    // still promote the row into the thread (markMessagesConsumed
-                    // is a no-op when the row is fully absent).
-                    appendOptimisticMessage(input.sessionId, {
-                        ...input.snapshot,
-                        deliveryState: 'indeterminate',
-                        queueDismissed: true,
-                    })
+                if (input.snapshot.deliveryState === 'indeterminate') {
+                    // mutationFn already restored the queueDismissed hold (and may
+                    // have been upgraded by a concurrent messages-consumed SSE).
+                    // Do not overwrite with a fresh uninvoked snapshot.
                     return
                 }
                 // The row is inside an async steer: restore a held copy, not a

--- a/web/src/lib/locales/en.ts
+++ b/web/src/lib/locales/en.ts
@@ -663,6 +663,7 @@ export default {
   'composer.scheduleErrorTooFar': 'Maximum schedule time is 7 days.',
   'queuedMessages.scheduledFor': 'Scheduled for {time}',
   'queuedMessages.editAlreadyInvoked': "Message already sent — it can't be edited",
+  'queuedMessages.editBusyNotRestored': 'Delivery still unresolved — draft not restored (may still be in flight)',
   'queuedMessages.editCurrentDraftKept': 'Queued message cancelled — current draft and schedule were kept.',
   'queuedMessages.steer': 'Deliver into the running turn now',
   'queuedMessages.steerFailed': 'Steer failed — message stays queued',

--- a/web/src/lib/locales/zh-CN.ts
+++ b/web/src/lib/locales/zh-CN.ts
@@ -661,6 +661,7 @@ export default {
   'composer.scheduleErrorTooFar': '最多只能定时 7 天。',
   'queuedMessages.scheduledFor': '定时发送: {time}',
   'queuedMessages.editAlreadyInvoked': '消息已发送，无法编辑',
+  'queuedMessages.editBusyNotRestored': '发送结果仍未确认，未恢复草稿（消息可能仍在发送中）',
   'queuedMessages.editCurrentDraftKept': '队列消息已取消，已保留当前草稿和定时设置。',
   'queuedMessages.steer': '立即插入当前回合',
   'queuedMessages.steerFailed': '插入失败，消息仍在队列中',

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -1300,11 +1300,12 @@ export function markMessagesConsumed(
             const needsStatus = message.status !== 'sent'
             const needsInvokedAt = message.invokedAt === null
             const needsSteered = steered === true && message.steered !== true
-            if (!needsStatus && !needsInvokedAt && !needsSteered) return message
+            const needsClearDismiss = message.queueDismissed === true
+            if (!needsStatus && !needsInvokedAt && !needsSteered && !needsClearDismiss) return message
             changed = true
-            const { deliveryState: _deliveryState, ...withoutDeliveryState } = message
+            const { deliveryState: _deliveryState, queueDismissed: _queueDismissed, ...withoutClientHold } = message
             return {
-                ...withoutDeliveryState,
+                ...withoutClientHold,
                 ...(needsStatus ? { status: 'sent' as MessageStatus } : {}),
                 ...(needsInvokedAt ? { invokedAt } : {}),
                 ...(needsSteered ? { steered: true } : {})

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -1272,11 +1272,19 @@ export function markMessagesRequeued(sessionId: string, localIds: string[]): voi
     updateState(sessionId, (previous) => {
         let changed = false
         const messages = previous.messages.map((message) => {
-            if (!message.localId || !idSet.has(message.localId) || message.deliveryState === undefined) {
+            if (
+                !message.localId
+                || !idSet.has(message.localId)
+                || (message.deliveryState === undefined && message.queueDismissed !== true)
+            ) {
                 return message
             }
             changed = true
-            const { deliveryState: _deliveryState, ...requeued } = message
+            const {
+                deliveryState: _deliveryState,
+                queueDismissed: _queueDismissed,
+                ...requeued
+            } = message
             return requeued
         })
         return changed ? buildState(previous, { messages }) : previous

--- a/web/src/lib/message-window-store.ts
+++ b/web/src/lib/message-window-store.ts
@@ -591,7 +591,20 @@ function applyLatestResponse(
         requestBaseline: Map<string, DecryptedMessage>
     }
 ): InternalState {
-    const retainedResponseMessages = response.messages.filter(shouldRetainWindowMessage)
+    const dismissedIds = new Set(
+        previous.messages
+            .filter((message) => message.queueDismissed)
+            .map((message) => message.id)
+    )
+    const retainedResponseMessages = response.messages
+        .filter(shouldRetainWindowMessage)
+        .map((message) => (
+            dismissedIds.has(message.id)
+            && message.invokedAt === null
+            && message.deliveryState === 'indeterminate'
+                ? { ...message, queueDismissed: true }
+                : message
+        ))
     const concurrentServerRows = previous.messages.filter((message) => (
         !optimisticMessage(message)
         && options.requestBaseline.get(message.id) !== message

--- a/web/src/lib/messages.test.ts
+++ b/web/src/lib/messages.test.ts
@@ -11,6 +11,8 @@ function userMessage(partial: Partial<DecryptedMessage> & { id: string }): Decry
         invokedAt: partial.invokedAt ?? null,
         status: partial.status,
         steered: partial.steered,
+        deliveryState: partial.deliveryState,
+        queueDismissed: partial.queueDismissed,
         content: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
     }
 }
@@ -61,6 +63,26 @@ describe('mergeMessages', () => {
         const merged = mergeMessages(existing, incoming)
         expect(merged).toHaveLength(1)
         expect(merged[0]?.steered).toBe(true)
+    })
+
+    it('preserves queueDismissed across a refetch of an indeterminate row (#1839)', () => {
+        const existing = [userMessage({
+            id: 'server-d',
+            localId: 'local-d',
+            invokedAt: null,
+            deliveryState: 'indeterminate',
+            queueDismissed: true,
+        })]
+        const incoming = [userMessage({
+            id: 'server-d',
+            localId: 'local-d',
+            invokedAt: null,
+            deliveryState: 'indeterminate',
+        })]
+
+        const merged = mergeMessages(existing, incoming)
+        expect(merged).toHaveLength(1)
+        expect(merged[0]?.queueDismissed).toBe(true)
     })
 
     it('normalizes a stuck queued status on an invoked message', () => {

--- a/web/src/lib/messages.ts
+++ b/web/src/lib/messages.ts
@@ -71,13 +71,21 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
         const existing = byId.get(msg.id)
         if (existing) {
             // Preserve client-only signals the incoming (server) copy can't carry:
-            // a late ack timestamp and the live 'steered' marker (not persisted).
+            // a late ack timestamp, the live 'steered' marker (not persisted), and
+            // force-dismiss of an indeterminate queued row (#1839).
             const preserved: Partial<DecryptedMessage> = {}
             if (existing.invokedAt != null && msg.invokedAt == null) {
                 preserved.invokedAt = existing.invokedAt
             }
             if (existing.steered && !msg.steered) {
                 preserved.steered = true
+            }
+            if (
+                existing.queueDismissed
+                && msg.invokedAt === null
+                && msg.deliveryState === 'indeterminate'
+            ) {
+                preserved.queueDismissed = true
             }
             byId.set(msg.id, Object.keys(preserved).length > 0 ? { ...msg, ...preserved } : msg)
         } else {
@@ -100,6 +108,7 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
         const optimisticStatusByLocalId = new Map<string, DecryptedMessage['status']>()
         const optimisticInvokedAtByLocalId = new Map<string, number | null | undefined>()
         const optimisticSteeredByLocalId = new Map<string, boolean>()
+        const optimisticQueueDismissedByLocalId = new Map<string, boolean>()
         for (const msg of merged) {
             if (msg.localId && isOptimisticMessage(msg) && incomingStoredLocalIds.has(msg.localId)) {
                 if (msg.status) {
@@ -111,6 +120,9 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
                 if (msg.steered) {
                     optimisticSteeredByLocalId.set(msg.localId, true)
                 }
+                if (msg.queueDismissed) {
+                    optimisticQueueDismissedByLocalId.set(msg.localId, true)
+                }
             }
         }
         merged = merged.filter((msg) => {
@@ -119,7 +131,12 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
             }
             return !isOptimisticMessage(msg)
         })
-        if (optimisticStatusByLocalId.size > 0 || optimisticInvokedAtByLocalId.size > 0 || optimisticSteeredByLocalId.size > 0) {
+        if (
+            optimisticStatusByLocalId.size > 0
+            || optimisticInvokedAtByLocalId.size > 0
+            || optimisticSteeredByLocalId.size > 0
+            || optimisticQueueDismissedByLocalId.size > 0
+        ) {
             merged = merged.map((msg) => {
                 if (!msg.localId) return msg
                 const update: Partial<DecryptedMessage> = {}
@@ -145,6 +162,14 @@ export function mergeMessages(existing: DecryptedMessage[], incoming: DecryptedM
                 // otherwise the ↳ Steered badge vanishes the moment the echo lands.
                 if (optimisticSteeredByLocalId.has(msg.localId) && !msg.steered) {
                     update.steered = true
+                }
+                if (
+                    optimisticQueueDismissedByLocalId.has(msg.localId)
+                    && msg.invokedAt === null
+                    && msg.deliveryState === 'indeterminate'
+                    && !msg.queueDismissed
+                ) {
+                    update.queueDismissed = true
                 }
                 if (Object.keys(update).length > 0) {
                     return { ...msg, ...update }

--- a/web/src/lib/queued-state-reconciliation.test.ts
+++ b/web/src/lib/queued-state-reconciliation.test.ts
@@ -5,6 +5,7 @@ vi.mock('./message-window-store', () => ({
     getQueuedReconcileCandidateLocalIds: vi.fn(),
     markMessagesConsumed: vi.fn(),
     markMessagesIndeterminate: vi.fn(),
+    markMessagesRequeued: vi.fn(),
     reconcileQueuedLocalIds: vi.fn(),
     syncTailMessages: vi.fn(),
 }))
@@ -13,6 +14,7 @@ import {
     getQueuedReconcileCandidateLocalIds,
     markMessagesConsumed,
     markMessagesIndeterminate,
+    markMessagesRequeued,
     reconcileQueuedLocalIds,
     syncTailMessages,
 } from './message-window-store'
@@ -22,6 +24,7 @@ const mockSyncTailMessages = vi.mocked(syncTailMessages)
 const mockGetCandidates = vi.mocked(getQueuedReconcileCandidateLocalIds)
 const mockMarkMessagesConsumed = vi.mocked(markMessagesConsumed)
 const mockMarkMessagesIndeterminate = vi.mocked(markMessagesIndeterminate)
+const mockMarkMessagesRequeued = vi.mocked(markMessagesRequeued)
 const mockReconcileQueuedLocalIds = vi.mocked(reconcileQueuedLocalIds)
 
 function createMockApi(
@@ -86,6 +89,7 @@ describe('reconcileQueuedStateAfterConnect', () => {
         await reconcileQueuedStateAfterConnect(createMockApi(getQueuedState), 'session-B')
 
         expect(getQueuedState).toHaveBeenCalledWith('session-B', candidateLocalIds)
+        expect(mockMarkMessagesRequeued).toHaveBeenCalledWith('session-B', ['local-2'])
         expect(mockReconcileQueuedLocalIds).toHaveBeenCalledWith(
             'session-B',
             candidateLocalIds,

--- a/web/src/lib/queued-state-reconciliation.ts
+++ b/web/src/lib/queued-state-reconciliation.ts
@@ -3,6 +3,7 @@ import {
     getQueuedReconcileCandidateLocalIds,
     markMessagesConsumed,
     markMessagesIndeterminate,
+    markMessagesRequeued,
     reconcileQueuedLocalIds,
     syncTailMessages,
 } from './message-window-store'
@@ -37,6 +38,9 @@ export async function reconcileQueuedStateAfterConnect(
     for (const [invokedAt, localIds] of invokedByTimestamp) {
         markMessagesConsumed(sessionId, localIds, invokedAt)
     }
+    // Clear force-dismiss holds for rows that returned to ordinary FIFO while
+    // SSE was down (#1839 queueDismissed).
+    markMessagesRequeued(sessionId, queuedLocalIds)
     markMessagesIndeterminate(sessionId, indeterminateLocalIds)
     reconcileQueuedLocalIds(sessionId, candidateLocalIds, [...queuedLocalIds, ...indeterminateLocalIds])
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -128,6 +128,12 @@ export type DecryptedMessage = ProtocolDecryptedMessage & {
     status?: MessageStatus
     originalText?: string
     invokedAt?: number | null
+    /**
+     * Client-only: user force-dismissed an indeterminate queued row while the
+     * hub still reported busy. Hidden from QueuedMessagesBar but retained so a
+     * later messages-consumed SSE can mark it sent in the thread.
+     */
+    queueDismissed?: boolean
 }
 
 export type FileSearchItem = {


### PR DESCRIPTION
## Summary

After Steer / run-now leaves a queued row in `deliveryState: 'indeterminate'` (“Delivery outcome unknown”), Cancel (X) and Edit could no-op forever because `useCancelQueuedMessage` re-appended the row whenever DELETE returned `busy`.

- **Cancel / Edit on an already-indeterminate row:** keep the optimistic removal (force-dismiss). Do not re-stick the held row on `busy`.
- **Edit:** still restore composer text/schedule after force-dismiss.
- **Race:** if `getQueuedState` shows the steer already landed, upgrade `busy` → `invoked` so Edit toasts instead of prefilling a duplicate.
- First-time `busy` (normal queued → indeterminate) is unchanged: restore the held row and do not prefill.

## Test plan

- [x] `bun run --cwd web test -- src/hooks/mutations/useCancelQueuedMessage.test.tsx src/components/AssistantChat/QueuedMessagesBar.test.tsx` (44 passed)
- [x] `bun typecheck`
- [x] Local cold review vs `upstream/main` (fixed Major: Edit prefill after busy→invoked reconcile)
- [ ] Manual: mid-turn queue → Steer → outcome unknown → X dismisses; Edit restores composer

## Issues

Fixes #1839
