### PR TITLE
feat(web): rank session list search by field weight and IDF

### DIFF
--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { SessionListScrollAnchor } from './SessionListScrollAnchor'
 import type { SessionSummary } from '@/types/api'
-import { isWildcardSearch, matchesSearchQuery } from '@hapi/protocol'
 import type { ApiClient } from '@/api/client'
+import {
+    buildSessionSearchScoreIndex,
+    compareSessionsBySearchRelevance,
+    rankSessionGroupsBySearchRelevance,
+    sessionMatchesQuery,
+    sortSessionsBySearchRelevance,
+} from '@/lib/sessionListSearch'
 import { useLongPress } from '@/hooks/useLongPress'
 import { usePlatform } from '@/hooks/usePlatform'
 import { useSessionActions } from '@/hooks/mutations/useSessionActions'
@@ -514,30 +520,10 @@ function SessionPreviewArrowIcon(props: { direction: 'up' | 'down'; className?: 
 }
 
 export { getSessionTitle } from '@/lib/sessionTitle'
+export { sessionMatchesQuery } from '@/lib/sessionListSearch'
 
 export function normalizeSearch(value: string | null | undefined): string {
     return (value ?? '').trim().toLowerCase()
-}
-
-export function sessionMatchesQuery(session: SessionSummary, query: string, machineLabel: string): boolean {
-    if (!query) return true
-    const searchableParts = [
-        getSessionTitle(session),
-        getWorktreeSessionLabel(session),
-        session.id,
-        session.metadata?.path,
-        session.metadata?.worktree?.basePath,
-        session.metadata?.worktree?.worktreePath,
-        session.metadata?.name,
-        session.metadata?.summary?.text,
-        session.metadata?.flavor,
-        machineLabel,
-    ]
-        .filter((part): part is string => typeof part === 'string' && part.length > 0)
-    if (isWildcardSearch(query)) {
-        return searchableParts.some((part) => matchesSearchQuery(part, query))
-    }
-    return searchableParts.join('\n').toLowerCase().includes(query)
 }
 
 
@@ -1256,18 +1242,37 @@ export function SessionList(props: {
         () => new Set(allSessions.map(session => formatDateValue(new Date(session.updatedAt)))),
         [allSessions]
     )
+    const hasTextQuery = normalizedQuery.length > 0
+    const timeScopedSessions = useMemo(
+        () => timeRange === null
+            ? allSessions
+            : allSessions.filter(session => sessionMatchesTimeRange(session, timeRange)),
+        [allSessions, timeRange?.start, timeRange?.end] // eslint-disable-line react-hooks/exhaustive-deps
+    )
+    const searchScoreIndex = useMemo(
+        () => hasTextQuery
+            ? buildSessionSearchScoreIndex(timeScopedSessions, normalizedQuery, resolveMachineLabel)
+            : null,
+        [hasTextQuery, timeScopedSessions, normalizedQuery, machineLabelsById] // eslint-disable-line react-hooks/exhaustive-deps
+    )
     const visibleSessions = useMemo(
-        () => isFiltering
-            ? allSessions.filter(session => (
-                sessionMatchesTimeRange(session, timeRange)
-                && sessionMatchesQuery(
-                    session,
-                    normalizedQuery,
-                    resolveMachineLabel(session.metadata?.machineId ?? null)
-                )
-            ))
-            : allSessions,
-        [allSessions, isFiltering, normalizedQuery, timeRange?.start, timeRange?.end, machineLabelsById] // eslint-disable-line react-hooks/exhaustive-deps
+        () => {
+            if (!isFiltering) return allSessions
+            const matched = hasTextQuery && searchScoreIndex
+                ? timeScopedSessions.filter(session => (searchScoreIndex.scores.get(session.id) ?? 0) > 0)
+                : timeScopedSessions.filter(session => (
+                    sessionMatchesQuery(
+                        session,
+                        normalizedQuery,
+                        resolveMachineLabel(session.metadata?.machineId ?? null)
+                    )
+                ))
+            if (hasTextQuery && searchScoreIndex) {
+                return sortSessionsBySearchRelevance(matched, searchScoreIndex)
+            }
+            return matched
+        },
+        [allSessions, hasTextQuery, isFiltering, normalizedQuery, searchScoreIndex, timeScopedSessions, machineLabelsById] // eslint-disable-line react-hooks/exhaustive-deps
     )
     const allGroups = useMemo(
         () => groupSessionsByDirectory(allSessions),
@@ -1320,10 +1325,12 @@ export function SessionList(props: {
         [unreadFilteredSessions, activeMachineFilter]
     )
     const globalPinnedSessions = useMemo(() => {
-        return machineFilteredSessions
-            .filter((session) => Boolean(session.globalPinned))
-            .sort((a, b) => b.updatedAt - a.updatedAt)
-    }, [machineFilteredSessions])
+        const pinned = machineFilteredSessions.filter((session) => Boolean(session.globalPinned))
+        if (searchScoreIndex && hasTextQuery) {
+            return sortSessionsBySearchRelevance(pinned, searchScoreIndex)
+        }
+        return [...pinned].sort((a, b) => b.updatedAt - a.updatedAt)
+    }, [machineFilteredSessions, searchScoreIndex, hasTextQuery])
     const runningSessions = useMemo(() => {
         const buckets: Record<RunningBucketKey, SessionSummary[]> = {
             working: [],
@@ -1350,23 +1357,35 @@ export function SessionList(props: {
             }
         }
         const byRecent = (a: SessionSummary, b: SessionSummary) => b.updatedAt - a.updatedAt
+        const byRelevanceOrRecent = (a: SessionSummary, b: SessionSummary) => {
+            if (searchScoreIndex && hasTextQuery) {
+                return compareSessionsBySearchRelevance(a, b, searchScoreIndex)
+            }
+            return byRecent(a, b)
+        }
         for (const key of Object.keys(buckets) as RunningBucketKey[]) {
-            buckets[key].sort(byRecent)
+            buckets[key].sort(byRelevanceOrRecent)
         }
         return buckets
-    }, [machineFilteredSessions, pinInProgressSessions])
+    }, [machineFilteredSessions, pinInProgressSessions, searchScoreIndex, hasTextQuery])
     const runningSessionTotal = runningSessions.working.length
         + runningSessions.pending.length
     const activeSessionTotal = runningSessions.active.length
     const groups = useMemo(
-        () => groupSessionsByDirectory(
-            machineFilteredSessions.filter((session) => {
-                if (session.globalPinned) return false
-                if (pinInProgressSessions && !session.pinned && isPinnedInProgressSession(session)) return false
-                return true
-            })
-        ),
-        [machineFilteredSessions, pinInProgressSessions]
+        () => {
+            const grouped = groupSessionsByDirectory(
+                machineFilteredSessions.filter((session) => {
+                    if (session.globalPinned) return false
+                    if (pinInProgressSessions && !session.pinned && isPinnedInProgressSession(session)) return false
+                    return true
+                })
+            )
+            if (searchScoreIndex && hasTextQuery) {
+                return rankSessionGroupsBySearchRelevance(grouped, searchScoreIndex)
+            }
+            return grouped
+        },
+        [machineFilteredSessions, pinInProgressSessions, searchScoreIndex, hasTextQuery]
     )
     // Directory groups whose rows all floated to the pinned sections still
     // render an action-only header so copy-path / new-session-in-directory

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1259,7 +1259,7 @@ export function SessionList(props: {
         () => {
             if (!isFiltering) return allSessions
             const matched = hasTextQuery && searchScoreIndex
-                ? timeScopedSessions.filter(session => (searchScoreIndex.scores.get(session.id) ?? 0) > 0)
+                ? timeScopedSessions.filter(session => searchScoreIndex.matchedIds.has(session.id))
                 : timeScopedSessions.filter(session => (
                     sessionMatchesQuery(
                         session,

--- a/web/src/lib/sessionListSearch.test.ts
+++ b/web/src/lib/sessionListSearch.test.ts
@@ -5,7 +5,8 @@ import {
     buildSessionSearchScoreIndex,
     compareSessionsBySearchRelevance,
     idfForDocumentFrequency,
-    searchFieldMatchesQuery,
+    searchFieldHasBoundaryMatch,
+    searchFieldIncludesQuery,
     sessionMatchesQuery,
     sortSessionsBySearchRelevance,
 } from './sessionListSearch'
@@ -33,34 +34,54 @@ function makeSession(overrides: Partial<SessionSummary> & { id: string }): Sessi
     }
 }
 
-describe('searchFieldMatchesQuery', () => {
-    it('matches on alphanumeric boundaries so home does not hit homelab', () => {
-        expect(searchFieldMatchesQuery('homelab', 'home')).toBe(false)
-        expect(searchFieldMatchesQuery('home-lab', 'home')).toBe(true)
-        expect(searchFieldMatchesQuery('Home Assistant', 'home')).toBe(true)
-        expect(searchFieldMatchesQuery('/home/heavygee/coding/hapi', 'home')).toBe(true)
+describe('search field match helpers', () => {
+    it('includes mid-token substrings so as-you-type still works', () => {
+        expect(searchFieldIncludesQuery('homelab', 'home')).toBe(true)
+        expect(searchFieldIncludesQuery('session-search-rank', 'sess')).toBe(true)
+    })
+
+    it('detects boundary affinity separately from inclusion', () => {
+        expect(searchFieldHasBoundaryMatch('homelab', 'home')).toBe(false)
+        expect(searchFieldHasBoundaryMatch('home-lab', 'home')).toBe(true)
+        expect(searchFieldHasBoundaryMatch('Home Assistant', 'home')).toBe(true)
+        expect(searchFieldHasBoundaryMatch('/home/heavygee/coding/hapi', 'home')).toBe(true)
     })
 })
 
 describe('sessionMatchesQuery', () => {
-    it('keeps path and title searchable including OS home prefixes', () => {
+    it('keeps path searchable including OS home prefixes', () => {
         const underHome = makeSession({
             id: 'meta',
             metadata: { path: '/home/heavygee/coding/hapi', name: 'meta HAPI triage' },
         })
         expect(sessionMatchesQuery(underHome, 'home', 'oos')).toBe(true)
         expect(sessionMatchesQuery(underHome, 'hapi', 'oos')).toBe(true)
-        expect(sessionMatchesQuery(underHome, 'homelab', 'oos')).toBe(false)
-        expect(sessionMatchesQuery(underHome, 'home', 'homelab')).toBe(true)
+        expect(sessionMatchesQuery(underHome, 'hap', 'oos')).toBe(true)
     })
 
-    it('does not match machine label homelab for query home', () => {
+    it('still matches machine label substrings for shared callers', () => {
         const session = makeSession({
             id: 'docs',
             metadata: { path: '/work/docs', name: 'Peer docs' },
         })
-        expect(sessionMatchesQuery(session, 'home', 'homelab')).toBe(false)
-        expect(sessionMatchesQuery(session, 'homelab', 'homelab')).toBe(true)
+        expect(sessionMatchesQuery(session, 'home', 'homelab')).toBe(true)
+        expect(sessionMatchesQuery(session, 'lab', 'homelab')).toBe(true)
+    })
+
+    it('matches wildcards against individual path parts, not a joined blob', () => {
+        const session = makeSession({
+            id: 'wt',
+            metadata: {
+                path: '/home/heavygee/coding/hapi',
+                worktree: {
+                    basePath: '/home/heavygee/coding/hapi',
+                    branch: 'feat/x',
+                    name: 'x',
+                    worktreePath: '/home/heavygee/coding/hapi-worktrees/x',
+                },
+            },
+        })
+        expect(sessionMatchesQuery(session, '*coding/hapi', 'oos')).toBe(true)
     })
 })
 
@@ -70,20 +91,20 @@ describe('session search relevance ranking', () => {
     })
 
     it('down-weights terms that match most of the corpus (IDF)', () => {
-        // Term matching all docs ≈ log(1+N/(1+N)) small; rare term larger.
         const common = idfForDocumentFrequency(100, 100)
         const rare = idfForDocumentFrequency(100, 1)
         expect(rare).toBeGreaterThan(common)
         expect(common).toBeGreaterThan(0)
     })
 
-    it('ranks Home Assistant above recent path-only /home/ matches for query Home', () => {
+    it('ranks Home Assistant above recent path-only /home/ and mid-token homelab matches', () => {
         const homeAssistant = makeSession({
             id: 'd755080b',
             updatedAt: 100,
             metadata: {
                 path: '/home/heavygee/coding/home-assistant',
                 name: 'Home Assistant',
+                machineId: 'oos',
             },
         })
         const recentMeta = makeSession({
@@ -92,30 +113,33 @@ describe('session search relevance ranking', () => {
             metadata: {
                 path: '/home/heavygee/coding/hapi',
                 name: 'meta HAPI triage/problems',
+                machineId: 'oos',
             },
         })
-        const olderPeer = makeSession({
-            id: 'peer-jobs',
-            updatedAt: 8_000,
+        const homeLabHost = makeSession({
+            id: 'on-homelab',
+            updatedAt: 9_500,
             metadata: {
-                path: '/home/heavygee/coding/hapi/worktrees/jobs',
-                name: 'Peer: session-attached jobs',
+                path: '/work/docs',
+                name: 'Peer docs',
+                machineId: 'homelab-machine',
             },
         })
 
-        const corpus = [recentMeta, olderPeer, homeAssistant]
-        const index = buildSessionSearchScoreIndex(corpus, 'Home', () => 'oos')
+        const corpus = [recentMeta, homeLabHost, homeAssistant]
+        const index = buildSessionSearchScoreIndex(corpus, 'Home', (machineId) =>
+            machineId === 'homelab-machine' ? 'homelab' : 'oos'
+        )
 
-        expect(index.scores.get(homeAssistant.id) ?? 0).toBeGreaterThan(index.scores.get(recentMeta.id) ?? 0)
-        expect(index.scores.get(recentMeta.id) ?? 0).toBeGreaterThan(0)
+        expect(index.matchedIds.has('d755080b')).toBe(true)
+        expect(index.matchedIds.has('meta-triage')).toBe(true)
+        expect(index.matchedIds.has('on-homelab')).toBe(true)
+        expect(index.scores.get('d755080b') ?? 0).toBeGreaterThan(index.scores.get('meta-triage') ?? 0)
+        expect(index.scores.get('d755080b') ?? 0).toBeGreaterThan(index.scores.get('on-homelab') ?? 0)
 
         const ranked = sortSessionsBySearchRelevance(corpus, index)
-        expect(ranked.map((session) => session.id)).toEqual([
-            'd755080b',
-            'meta-triage',
-            'peer-jobs',
-        ])
-        expect(compareSessionsBySearchRelevance(homeAssistant, recentMeta, index)).toBeLessThan(0)
+        expect(ranked[0]?.id).toBe('d755080b')
+        expect(compareSessionsBySearchRelevance(ranked[0]!, ranked[1]!, index)).toBeLessThan(0)
     })
 
     it('lets a distinctive second term dominate when the first term is ubiquitous', () => {
@@ -137,6 +161,7 @@ describe('session search relevance ranking', () => {
         )
         const ranked = sortSessionsBySearchRelevance([onlyHomePath, homeAssistant], index)
         expect(ranked[0]?.id).toBe('ha')
-        expect(index.scores.has('path-only')).toBe(false)
+        expect(index.matchedIds.has('path-only')).toBe(false)
+        expect(index.matchedIds.has('ha')).toBe(true)
     })
 })

--- a/web/src/lib/sessionListSearch.test.ts
+++ b/web/src/lib/sessionListSearch.test.ts
@@ -176,7 +176,7 @@ describe('session search relevance ranking', () => {
             metadata: {
                 path: '/work/x',
                 name: 'unrelated',
-                summary: { text: 'homelab notes', updatedAt: 1 },
+                summary: { text: 'homelab notes' },
                 machineId: 'home-box',
             },
         })

--- a/web/src/lib/sessionListSearch.test.ts
+++ b/web/src/lib/sessionListSearch.test.ts
@@ -164,4 +164,32 @@ describe('session search relevance ranking', () => {
         expect(index.matchedIds.has('path-only')).toBe(false)
         expect(index.matchedIds.has('ha')).toBe(true)
     })
+
+    it('picks the best field by post-bonus contribution, not raw weight', () => {
+        // Machine "Home" (weight 2 × boundary 1.75 = 3.5) must beat a mid-token
+        // title hit like "homelab" (weight 10 × 1 = 10)... wait, 10 > 3.5 so title still wins.
+        // Use summary (weight 3, mid-token) vs machine boundary (2 × 1.75 = 3.5):
+        // raw-weight picker would keep summary (3 > 2) → score 3; post-bonus picks machine → 3.5.
+        const session = makeSession({
+            id: 'boundary-wins',
+            updatedAt: 1,
+            metadata: {
+                path: '/work/x',
+                name: 'unrelated',
+                summary: { text: 'homelab notes', updatedAt: 1 },
+                machineId: 'home-box',
+            },
+        })
+        const index = buildSessionSearchScoreIndex([session], 'home', (id) =>
+            id === 'home-box' ? 'Home' : 'oos'
+        )
+        expect(index.matchedIds.has('boundary-wins')).toBe(true)
+        // Sanity: score should reflect machine boundary contribution (2 * idf * 1.75),
+        // not the weaker mid-token summary contribution (3 * idf * 1).
+        const idfAlone = index.scores.get('boundary-wins') ?? 0
+        expect(idfAlone).toBeGreaterThan(0)
+        // Rebuild with only summary match to compare: strip machine label.
+        const summaryOnly = buildSessionSearchScoreIndex([session], 'home', () => 'oos')
+        expect(summaryOnly.scores.get('boundary-wins') ?? 0).toBeLessThan(idfAlone)
+    })
 })

--- a/web/src/lib/sessionListSearch.test.ts
+++ b/web/src/lib/sessionListSearch.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionSummary } from '@/types/api'
+import {
+    SESSION_SEARCH_FIELD_WEIGHTS,
+    buildSessionSearchScoreIndex,
+    compareSessionsBySearchRelevance,
+    idfForDocumentFrequency,
+    searchFieldMatchesQuery,
+    sessionMatchesQuery,
+    sortSessionsBySearchRelevance,
+} from './sessionListSearch'
+
+function makeSession(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
+    return {
+        active: false,
+        thinking: false,
+        activeAt: 0,
+        updatedAt: 0,
+        metadata: null,
+        metadataVersion: 0,
+        agentStateVersion: 0,
+        todosUpdatedAt: 0,
+        todoProgress: null,
+        pendingRequestsCount: 0,
+        pendingRequestKinds: [],
+        pendingRequests: [],
+        backgroundTaskCount: 0,
+        futureScheduledMessageCount: 0,
+        nextScheduledAt: null,
+        model: null,
+        effort: null,
+        ...overrides,
+    }
+}
+
+describe('searchFieldMatchesQuery', () => {
+    it('matches on alphanumeric boundaries so home does not hit homelab', () => {
+        expect(searchFieldMatchesQuery('homelab', 'home')).toBe(false)
+        expect(searchFieldMatchesQuery('home-lab', 'home')).toBe(true)
+        expect(searchFieldMatchesQuery('Home Assistant', 'home')).toBe(true)
+        expect(searchFieldMatchesQuery('/home/heavygee/coding/hapi', 'home')).toBe(true)
+    })
+})
+
+describe('sessionMatchesQuery', () => {
+    it('keeps path and title searchable including OS home prefixes', () => {
+        const underHome = makeSession({
+            id: 'meta',
+            metadata: { path: '/home/heavygee/coding/hapi', name: 'meta HAPI triage' },
+        })
+        expect(sessionMatchesQuery(underHome, 'home', 'oos')).toBe(true)
+        expect(sessionMatchesQuery(underHome, 'hapi', 'oos')).toBe(true)
+        expect(sessionMatchesQuery(underHome, 'homelab', 'oos')).toBe(false)
+        expect(sessionMatchesQuery(underHome, 'home', 'homelab')).toBe(true)
+    })
+
+    it('does not match machine label homelab for query home', () => {
+        const session = makeSession({
+            id: 'docs',
+            metadata: { path: '/work/docs', name: 'Peer docs' },
+        })
+        expect(sessionMatchesQuery(session, 'home', 'homelab')).toBe(false)
+        expect(sessionMatchesQuery(session, 'homelab', 'homelab')).toBe(true)
+    })
+})
+
+describe('session search relevance ranking', () => {
+    it('gives title hits higher field weight than path hits', () => {
+        expect(SESSION_SEARCH_FIELD_WEIGHTS.title).toBeGreaterThan(SESSION_SEARCH_FIELD_WEIGHTS.path)
+    })
+
+    it('down-weights terms that match most of the corpus (IDF)', () => {
+        // Term matching all docs ≈ log(1+N/(1+N)) small; rare term larger.
+        const common = idfForDocumentFrequency(100, 100)
+        const rare = idfForDocumentFrequency(100, 1)
+        expect(rare).toBeGreaterThan(common)
+        expect(common).toBeGreaterThan(0)
+    })
+
+    it('ranks Home Assistant above recent path-only /home/ matches for query Home', () => {
+        const homeAssistant = makeSession({
+            id: 'd755080b',
+            updatedAt: 100,
+            metadata: {
+                path: '/home/heavygee/coding/home-assistant',
+                name: 'Home Assistant',
+            },
+        })
+        const recentMeta = makeSession({
+            id: 'meta-triage',
+            updatedAt: 9_000,
+            metadata: {
+                path: '/home/heavygee/coding/hapi',
+                name: 'meta HAPI triage/problems',
+            },
+        })
+        const olderPeer = makeSession({
+            id: 'peer-jobs',
+            updatedAt: 8_000,
+            metadata: {
+                path: '/home/heavygee/coding/hapi/worktrees/jobs',
+                name: 'Peer: session-attached jobs',
+            },
+        })
+
+        const corpus = [recentMeta, olderPeer, homeAssistant]
+        const index = buildSessionSearchScoreIndex(corpus, 'Home', () => 'oos')
+
+        expect(index.scores.get(homeAssistant.id) ?? 0).toBeGreaterThan(index.scores.get(recentMeta.id) ?? 0)
+        expect(index.scores.get(recentMeta.id) ?? 0).toBeGreaterThan(0)
+
+        const ranked = sortSessionsBySearchRelevance(corpus, index)
+        expect(ranked.map((session) => session.id)).toEqual([
+            'd755080b',
+            'meta-triage',
+            'peer-jobs',
+        ])
+        expect(compareSessionsBySearchRelevance(homeAssistant, recentMeta, index)).toBeLessThan(0)
+    })
+
+    it('lets a distinctive second term dominate when the first term is ubiquitous', () => {
+        const homeAssistant = makeSession({
+            id: 'ha',
+            updatedAt: 1,
+            metadata: { path: '/home/heavygee/coding/x', name: 'Home Assistant' },
+        })
+        const onlyHomePath = makeSession({
+            id: 'path-only',
+            updatedAt: 99_000,
+            metadata: { path: '/home/heavygee/coding/other', name: 'other work' },
+        })
+
+        const index = buildSessionSearchScoreIndex(
+            [onlyHomePath, homeAssistant],
+            'Home Assistant',
+            () => 'oos'
+        )
+        const ranked = sortSessionsBySearchRelevance([onlyHomePath, homeAssistant], index)
+        expect(ranked[0]?.id).toBe('ha')
+        expect(index.scores.has('path-only')).toBe(false)
+    })
+})

--- a/web/src/lib/sessionListSearch.ts
+++ b/web/src/lib/sessionListSearch.ts
@@ -85,13 +85,18 @@ function bestWeightedHitForTerm(
 ): { weight: number; boundary: boolean } {
     let bestWeight = 0
     let bestBoundary = false
+    let bestContribution = 0
     for (const [field, weight] of Object.entries(SESSION_SEARCH_FIELD_WEIGHTS) as Array<
         [SessionSearchField, number]
     >) {
         const values = fields[field]
         if (!fieldValuesMatchTerm(values, term, wildcard)) continue
         const boundary = wildcard ? true : fieldValuesHaveBoundary(values, term)
-        if (weight > bestWeight || (weight === bestWeight && boundary && !bestBoundary)) {
+        const contribution = weight * (boundary ? SESSION_SEARCH_BOUNDARY_BONUS : 1)
+        // Compare post-bonus contribution so a boundary hit on a lighter field
+        // can beat a mid-token hit on a heavier one when that is the true max.
+        if (contribution > bestContribution) {
+            bestContribution = contribution
             bestWeight = weight
             bestBoundary = boundary
         }

--- a/web/src/lib/sessionListSearch.ts
+++ b/web/src/lib/sessionListSearch.ts
@@ -1,0 +1,237 @@
+import type { SessionSummary } from '@/types/api'
+import { isWildcardSearch, matchesSearchQuery } from '@hapi/protocol'
+import { getSessionTitle } from '@/lib/sessionTitle'
+import { getWorktreeSessionLabel } from '@/lib/sessionWorktreeLabel'
+
+/**
+ * Field weights for session-list metadata search. Higher = more operator-facing.
+ * Path stays searchable (weight 1) so `/home/...` queries still work; ubiquitous
+ * path segments are down-weighted via IDF rather than stripped.
+ */
+export const SESSION_SEARCH_FIELD_WEIGHTS = {
+    title: 10,
+    worktreeLabel: 5,
+    summary: 3,
+    flavor: 2,
+    machine: 2,
+    path: 1,
+    id: 0.5,
+} as const
+
+export type SessionSearchField = keyof typeof SESSION_SEARCH_FIELD_WEIGHTS
+
+export type SessionSearchFields = Record<SessionSearchField, string>
+
+/** Plain-query match on an alphanumeric token boundary (avoids home⊂homelab). */
+export function searchFieldMatchesQuery(value: string, query: string): boolean {
+    if (!query) return true
+    const haystack = value.toLowerCase()
+    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    return new RegExp(`(?:^|[^a-z0-9])${escaped}(?:[^a-z0-9]|$)`).test(haystack)
+}
+
+export function tokenizeSearchQuery(query: string): string[] {
+    return query
+        .trim()
+        .toLowerCase()
+        .split(/\s+/)
+        .filter(Boolean)
+}
+
+export function collectSessionSearchFields(
+    session: SessionSummary,
+    machineLabel: string
+): SessionSearchFields {
+    const pathParts = [
+        session.metadata?.path,
+        session.metadata?.worktree?.basePath,
+        session.metadata?.worktree?.worktreePath,
+    ].filter((part): part is string => typeof part === 'string' && part.length > 0)
+
+    return {
+        title: getSessionTitle(session),
+        worktreeLabel: getWorktreeSessionLabel(session) ?? '',
+        summary: session.metadata?.summary?.text ?? '',
+        flavor: session.metadata?.flavor ?? '',
+        machine: machineLabel,
+        path: pathParts.join('\n'),
+        id: session.id,
+    }
+}
+
+function fieldMatchesTerm(value: string, term: string, wildcard: boolean): boolean {
+    if (!value) return false
+    if (wildcard) return matchesSearchQuery(value, term)
+    return searchFieldMatchesQuery(value, term)
+}
+
+function bestFieldWeightForTerm(fields: SessionSearchFields, term: string, wildcard: boolean): number {
+    let best = 0
+    for (const [field, weight] of Object.entries(SESSION_SEARCH_FIELD_WEIGHTS) as Array<
+        [SessionSearchField, number]
+    >) {
+        if (weight <= best) continue
+        if (fieldMatchesTerm(fields[field], term, wildcard)) {
+            best = weight
+        }
+    }
+    return best
+}
+
+/** Smoothed IDF: rare terms dominate; terms matching most of the corpus ≈ noop. */
+export function idfForDocumentFrequency(documentCount: number, matchingCount: number): number {
+    if (documentCount <= 0) return 0
+    return Math.log(1 + documentCount / (1 + matchingCount))
+}
+
+export function buildSessionSearchIdf(
+    corpus: ReadonlyArray<{ fields: SessionSearchFields }>,
+    terms: readonly string[],
+    wildcard: boolean
+): Map<string, number> {
+    const idfByTerm = new Map<string, number>()
+    const n = corpus.length
+    for (const term of terms) {
+        let df = 0
+        for (const doc of corpus) {
+            if (bestFieldWeightForTerm(doc.fields, term, wildcard) > 0) {
+                df += 1
+            }
+        }
+        idfByTerm.set(term, idfForDocumentFrequency(n, df))
+    }
+    return idfByTerm
+}
+
+export function scoreSessionSearchFields(
+    fields: SessionSearchFields,
+    terms: readonly string[],
+    idfByTerm: ReadonlyMap<string, number>,
+    wildcard: boolean
+): number {
+    if (terms.length === 0) return 0
+    let score = 0
+    let matchedTerms = 0
+    for (const term of terms) {
+        const fieldWeight = bestFieldWeightForTerm(fields, term, wildcard)
+        if (fieldWeight <= 0) continue
+        matchedTerms += 1
+        score += fieldWeight * (idfByTerm.get(term) ?? 0)
+    }
+    // Require every query term to hit somewhere — same as AND for multi-word search.
+    if (matchedTerms < terms.length) return 0
+    return score
+}
+
+export type SessionSearchScoreIndex = {
+    scores: Map<string, number>
+}
+
+/**
+ * Build relevance scores for a corpus. Sessions with score 0 do not match.
+ * Pass the same candidate set you will filter (e.g. time-filtered sessions).
+ */
+export function buildSessionSearchScoreIndex(
+    sessions: readonly SessionSummary[],
+    query: string,
+    resolveMachineLabel: (machineId: string | null) => string
+): SessionSearchScoreIndex {
+    const normalized = query.trim().toLowerCase()
+    const scores = new Map<string, number>()
+    if (!normalized) {
+        return { scores }
+    }
+
+    const wildcard = isWildcardSearch(normalized)
+    const terms = wildcard ? [normalized] : tokenizeSearchQuery(normalized)
+    if (terms.length === 0) {
+        return { scores }
+    }
+
+    const corpus = sessions.map((session) => ({
+        session,
+        fields: collectSessionSearchFields(
+            session,
+            resolveMachineLabel(session.metadata?.machineId ?? null)
+        ),
+    }))
+    const idfByTerm = buildSessionSearchIdf(corpus, terms, wildcard)
+
+    for (const { session, fields } of corpus) {
+        const score = scoreSessionSearchFields(fields, terms, idfByTerm, wildcard)
+        if (score > 0) {
+            scores.set(session.id, score)
+        }
+    }
+    return { scores }
+}
+
+export function sessionMatchesSearchScoreIndex(
+    sessionId: string,
+    index: SessionSearchScoreIndex | null,
+    hasTextQuery: boolean
+): boolean {
+    if (!hasTextQuery) return true
+    if (!index) return true
+    return (index.scores.get(sessionId) ?? 0) > 0
+}
+
+export function compareSessionsBySearchRelevance(
+    a: SessionSummary,
+    b: SessionSummary,
+    index: SessionSearchScoreIndex
+): number {
+    const scoreA = index.scores.get(a.id) ?? 0
+    const scoreB = index.scores.get(b.id) ?? 0
+    if (scoreB !== scoreA) return scoreB - scoreA
+    return b.updatedAt - a.updatedAt
+}
+
+export function sortSessionsBySearchRelevance<T extends SessionSummary>(
+    sessions: readonly T[],
+    index: SessionSearchScoreIndex
+): T[] {
+    return [...sessions].sort((a, b) => compareSessionsBySearchRelevance(a, b, index))
+}
+
+export function rankSessionGroupsBySearchRelevance<T extends {
+    sessions: SessionSummary[]
+    hasPinnedSession: boolean
+    hasActiveSession: boolean
+    latestUpdatedAt: number
+}>(groups: readonly T[], index: SessionSearchScoreIndex): T[] {
+    const ranked = groups.map((group) => ({
+        ...group,
+        sessions: sortSessionsBySearchRelevance(group.sessions, index),
+    }))
+    return ranked.sort((a, b) => {
+        const scoreA = Math.max(0, ...a.sessions.map((session) => index.scores.get(session.id) ?? 0))
+        const scoreB = Math.max(0, ...b.sessions.map((session) => index.scores.get(session.id) ?? 0))
+        if (scoreB !== scoreA) return scoreB - scoreA
+        // Preserve existing tie-breaks when scores are equal (e.g. empty query path unused).
+        if (a.hasPinnedSession !== b.hasPinnedSession) {
+            return a.hasPinnedSession ? -1 : 1
+        }
+        if (a.hasActiveSession !== b.hasActiveSession) {
+            return a.hasActiveSession ? -1 : 1
+        }
+        return b.latestUpdatedAt - a.latestUpdatedAt
+    })
+}
+
+/** Boolean match used by callers that only need include/exclude. */
+export function sessionMatchesQuery(
+    session: SessionSummary,
+    query: string,
+    machineLabel: string
+): boolean {
+    if (!query) return true
+    const fields = collectSessionSearchFields(session, machineLabel)
+    const wildcard = isWildcardSearch(query)
+    if (wildcard) {
+        return Object.values(fields).some((value) => value && matchesSearchQuery(value, query))
+    }
+    const terms = tokenizeSearchQuery(query)
+    if (terms.length === 0) return true
+    return terms.every((term) => bestFieldWeightForTerm(fields, term, false) > 0)
+}

--- a/web/src/lib/sessionListSearch.ts
+++ b/web/src/lib/sessionListSearch.ts
@@ -5,8 +5,7 @@ import { getWorktreeSessionLabel } from '@/lib/sessionWorktreeLabel'
 
 /**
  * Field weights for session-list metadata search. Higher = more operator-facing.
- * Path stays searchable (weight 1) so `/home/...` queries still work; ubiquitous
- * path segments are down-weighted via IDF rather than stripped.
+ * Path stays fully searchable; ubiquitous segments are down-weighted via IDF.
  */
 export const SESSION_SEARCH_FIELD_WEIGHTS = {
     title: 10,
@@ -20,13 +19,23 @@ export const SESSION_SEARCH_FIELD_WEIGHTS = {
 
 export type SessionSearchField = keyof typeof SESSION_SEARCH_FIELD_WEIGHTS
 
-export type SessionSearchFields = Record<SessionSearchField, string>
+/** Extra multiplier when the query sits on an alphanumeric token boundary. */
+export const SESSION_SEARCH_BOUNDARY_BONUS = 1.75
 
-/** Plain-query match on an alphanumeric token boundary (avoids home⊂homelab). */
-export function searchFieldMatchesQuery(value: string, query: string): boolean {
+type FieldValues = Record<SessionSearchField, string[]>
+
+/** Plain substring (case-insensitive). Inclusion gate — do not use as a score. */
+export function searchFieldIncludesQuery(value: string, query: string): boolean {
+    if (!query) return true
+    return value.toLowerCase().includes(query.toLowerCase())
+}
+
+/** True when query sits on an alphanumeric boundary (home matches Home Assistant, not mid-token homelab). */
+export function searchFieldHasBoundaryMatch(value: string, query: string): boolean {
     if (!query) return true
     const haystack = value.toLowerCase()
-    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const needle = query.toLowerCase()
+    const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     return new RegExp(`(?:^|[^a-z0-9])${escaped}(?:[^a-z0-9]|$)`).test(haystack)
 }
 
@@ -41,7 +50,7 @@ export function tokenizeSearchQuery(query: string): string[] {
 export function collectSessionSearchFields(
     session: SessionSummary,
     machineLabel: string
-): SessionSearchFields {
+): FieldValues {
     const pathParts = [
         session.metadata?.path,
         session.metadata?.worktree?.basePath,
@@ -49,43 +58,55 @@ export function collectSessionSearchFields(
     ].filter((part): part is string => typeof part === 'string' && part.length > 0)
 
     return {
-        title: getSessionTitle(session),
-        worktreeLabel: getWorktreeSessionLabel(session) ?? '',
-        summary: session.metadata?.summary?.text ?? '',
-        flavor: session.metadata?.flavor ?? '',
-        machine: machineLabel,
-        path: pathParts.join('\n'),
-        id: session.id,
+        title: [getSessionTitle(session)].filter(Boolean),
+        worktreeLabel: [getWorktreeSessionLabel(session) ?? ''].filter(Boolean),
+        summary: [session.metadata?.summary?.text ?? ''].filter(Boolean),
+        flavor: [session.metadata?.flavor ?? ''].filter(Boolean),
+        machine: [machineLabel].filter(Boolean),
+        path: pathParts,
+        id: [session.id].filter(Boolean),
     }
 }
 
-function fieldMatchesTerm(value: string, term: string, wildcard: boolean): boolean {
-    if (!value) return false
-    if (wildcard) return matchesSearchQuery(value, term)
-    return searchFieldMatchesQuery(value, term)
+function fieldValuesMatchTerm(values: string[], term: string, wildcard: boolean): boolean {
+    if (values.length === 0) return false
+    if (wildcard) return values.some((value) => matchesSearchQuery(value, term))
+    return values.some((value) => searchFieldIncludesQuery(value, term))
 }
 
-function bestFieldWeightForTerm(fields: SessionSearchFields, term: string, wildcard: boolean): number {
-    let best = 0
+function fieldValuesHaveBoundary(values: string[], term: string): boolean {
+    return values.some((value) => searchFieldHasBoundaryMatch(value, term))
+}
+
+function bestWeightedHitForTerm(
+    fields: FieldValues,
+    term: string,
+    wildcard: boolean
+): { weight: number; boundary: boolean } {
+    let bestWeight = 0
+    let bestBoundary = false
     for (const [field, weight] of Object.entries(SESSION_SEARCH_FIELD_WEIGHTS) as Array<
         [SessionSearchField, number]
     >) {
-        if (weight <= best) continue
-        if (fieldMatchesTerm(fields[field], term, wildcard)) {
-            best = weight
+        const values = fields[field]
+        if (!fieldValuesMatchTerm(values, term, wildcard)) continue
+        const boundary = wildcard ? true : fieldValuesHaveBoundary(values, term)
+        if (weight > bestWeight || (weight === bestWeight && boundary && !bestBoundary)) {
+            bestWeight = weight
+            bestBoundary = boundary
         }
     }
-    return best
+    return { weight: bestWeight, boundary: bestBoundary }
 }
 
-/** Smoothed IDF: rare terms dominate; terms matching most of the corpus ≈ noop. */
+/** Smoothed IDF: rare terms dominate; terms matching most of the corpus contribute little. */
 export function idfForDocumentFrequency(documentCount: number, matchingCount: number): number {
     if (documentCount <= 0) return 0
     return Math.log(1 + documentCount / (1 + matchingCount))
 }
 
 export function buildSessionSearchIdf(
-    corpus: ReadonlyArray<{ fields: SessionSearchFields }>,
+    corpus: ReadonlyArray<{ fields: FieldValues }>,
     terms: readonly string[],
     wildcard: boolean
 ): Map<string, number> {
@@ -94,7 +115,7 @@ export function buildSessionSearchIdf(
     for (const term of terms) {
         let df = 0
         for (const doc of corpus) {
-            if (bestFieldWeightForTerm(doc.fields, term, wildcard) > 0) {
+            if (bestWeightedHitForTerm(doc.fields, term, wildcard).weight > 0) {
                 df += 1
             }
         }
@@ -104,48 +125,53 @@ export function buildSessionSearchIdf(
 }
 
 export function scoreSessionSearchFields(
-    fields: SessionSearchFields,
+    fields: FieldValues,
     terms: readonly string[],
     idfByTerm: ReadonlyMap<string, number>,
     wildcard: boolean
-): number {
-    if (terms.length === 0) return 0
+): { matched: boolean; score: number } {
+    if (terms.length === 0) return { matched: true, score: 0 }
     let score = 0
     let matchedTerms = 0
     for (const term of terms) {
-        const fieldWeight = bestFieldWeightForTerm(fields, term, wildcard)
-        if (fieldWeight <= 0) continue
+        const hit = bestWeightedHitForTerm(fields, term, wildcard)
+        if (hit.weight <= 0) continue
         matchedTerms += 1
-        score += fieldWeight * (idfByTerm.get(term) ?? 0)
+        const boundaryFactor = hit.boundary ? SESSION_SEARCH_BOUNDARY_BONUS : 1
+        score += hit.weight * (idfByTerm.get(term) ?? 0) * boundaryFactor
     }
-    // Require every query term to hit somewhere — same as AND for multi-word search.
-    if (matchedTerms < terms.length) return 0
-    return score
+    // AND across terms — every token must hit somewhere.
+    if (matchedTerms < terms.length) return { matched: false, score: 0 }
+    return { matched: true, score }
 }
 
 export type SessionSearchScoreIndex = {
+    /** Relevance scores for matched sessions only. */
     scores: Map<string, number>
+    /** Explicit match set — never infer membership from score > 0. */
+    matchedIds: Set<string>
 }
 
 /**
- * Build relevance scores for a corpus. Sessions with score 0 do not match.
- * Pass the same candidate set you will filter (e.g. time-filtered sessions).
+ * Build relevance scores for a corpus. Pass the candidate set you will filter
+ * (e.g. time-scoped sessions). Empty query → empty index (caller skips ranking).
  */
 export function buildSessionSearchScoreIndex(
     sessions: readonly SessionSummary[],
     query: string,
     resolveMachineLabel: (machineId: string | null) => string
 ): SessionSearchScoreIndex {
-    const normalized = query.trim().toLowerCase()
     const scores = new Map<string, number>()
+    const matchedIds = new Set<string>()
+    const normalized = query.trim().toLowerCase()
     if (!normalized) {
-        return { scores }
+        return { scores, matchedIds }
     }
 
     const wildcard = isWildcardSearch(normalized)
     const terms = wildcard ? [normalized] : tokenizeSearchQuery(normalized)
     if (terms.length === 0) {
-        return { scores }
+        return { scores, matchedIds }
     }
 
     const corpus = sessions.map((session) => ({
@@ -158,22 +184,22 @@ export function buildSessionSearchScoreIndex(
     const idfByTerm = buildSessionSearchIdf(corpus, terms, wildcard)
 
     for (const { session, fields } of corpus) {
-        const score = scoreSessionSearchFields(fields, terms, idfByTerm, wildcard)
-        if (score > 0) {
-            scores.set(session.id, score)
-        }
+        const { matched, score } = scoreSessionSearchFields(fields, terms, idfByTerm, wildcard)
+        if (!matched) continue
+        matchedIds.add(session.id)
+        scores.set(session.id, score)
     }
-    return { scores }
+    return { scores, matchedIds }
 }
 
-export function sessionMatchesSearchScoreIndex(
+export function sessionMatchesSearchIndex(
     sessionId: string,
     index: SessionSearchScoreIndex | null,
     hasTextQuery: boolean
 ): boolean {
     if (!hasTextQuery) return true
     if (!index) return true
-    return (index.scores.get(sessionId) ?? 0) > 0
+    return index.matchedIds.has(sessionId)
 }
 
 export function compareSessionsBySearchRelevance(
@@ -194,6 +220,15 @@ export function sortSessionsBySearchRelevance<T extends SessionSummary>(
     return [...sessions].sort((a, b) => compareSessionsBySearchRelevance(a, b, index))
 }
 
+function maxSessionScore(sessions: readonly SessionSummary[], index: SessionSearchScoreIndex): number {
+    let max = 0
+    for (const session of sessions) {
+        const score = index.scores.get(session.id) ?? 0
+        if (score > max) max = score
+    }
+    return max
+}
+
 export function rankSessionGroupsBySearchRelevance<T extends {
     sessions: SessionSummary[]
     hasPinnedSession: boolean
@@ -205,10 +240,10 @@ export function rankSessionGroupsBySearchRelevance<T extends {
         sessions: sortSessionsBySearchRelevance(group.sessions, index),
     }))
     return ranked.sort((a, b) => {
-        const scoreA = Math.max(0, ...a.sessions.map((session) => index.scores.get(session.id) ?? 0))
-        const scoreB = Math.max(0, ...b.sessions.map((session) => index.scores.get(session.id) ?? 0))
+        const scoreA = maxSessionScore(a.sessions, index)
+        const scoreB = maxSessionScore(b.sessions, index)
         if (scoreB !== scoreA) return scoreB - scoreA
-        // Preserve existing tie-breaks when scores are equal (e.g. empty query path unused).
+        // When scores tie, keep the list's usual pinned/active/recency order.
         if (a.hasPinnedSession !== b.hasPinnedSession) {
             return a.hasPinnedSession ? -1 : 1
         }
@@ -219,7 +254,11 @@ export function rankSessionGroupsBySearchRelevance<T extends {
     })
 }
 
-/** Boolean match used by callers that only need include/exclude. */
+/**
+ * Shared boolean matcher (session list, @-mentions, share picker).
+ * Substring semantics — partial typing must keep working. Boundary affinity is
+ * a ranking bonus in buildSessionSearchScoreIndex, not an exclusion gate.
+ */
 export function sessionMatchesQuery(
     session: SessionSummary,
     query: string,
@@ -227,11 +266,13 @@ export function sessionMatchesQuery(
 ): boolean {
     if (!query) return true
     const fields = collectSessionSearchFields(session, machineLabel)
-    const wildcard = isWildcardSearch(query)
-    if (wildcard) {
-        return Object.values(fields).some((value) => value && matchesSearchQuery(value, query))
+    const values = Object.values(fields).flat()
+    if (isWildcardSearch(query)) {
+        return values.some((value) => matchesSearchQuery(value, query))
     }
     const terms = tokenizeSearchQuery(query)
     if (terms.length === 0) return true
-    return terms.every((term) => bestFieldWeightForTerm(fields, term, false) > 0)
+    return terms.every((term) =>
+        values.some((value) => searchFieldIncludesQuery(value, term))
+    )
 }


### PR DESCRIPTION
## Summary
- Rank session-list metadata search by **field weight × smoothed IDF**, with **recency as tie-break** (was boolean match → recency only).
- Keep paths fully searchable (no OS `/home/` stripping).
- Boundary affinity is a **score bonus** (`×1.75`), not an exclusion gate — substring inclusion preserved for as-you-type, `@`-mentions, and share picker.
- Multi-word queries AND across terms (each token must hit some field).

### Field weights
| Field | Weight |
| title / \`getSessionTitle\` | 10 |
| worktree label | 5 |
| summary | 3 |
| flavor | 2 |
| machine label | 2 |
| path parts | 1 |
| session id | 0.5 |

IDF: \`log(1 + N/(1+df))\` over the time-scoped candidate corpus. Ubiquitous terms (\`home\` in \`/home/…\`) contribute little; distinctive terms dominate.

### Honest limitation
Ranking sorts ~800 equal-looking matches — it does **not** reduce them to a handful. A score cutoff would be a separate deliberate UX choice.

### Notes
- Orthogonal to #1772 (combined filters). Does not touch that PR.
- Fork-stage draft: heavygee/hapi#147. Local Claude cold review Ready YES after boundary-as-bonus fix (substring inclusion restored for shared \`sessionMatchesQuery\` callers).

## Test plan
- [x] \`web\` vitest: \`sessionListSearch\`, \`sessionReference\`, \`sharePickerSessions\`, \`SessionList\`, \`SessionList.machine-filter\`
- [x] Cold review (Claude) — Ready YES
- [ ] Dogfood: type \`Home\` in session list; **Home Assistant** should float above recent \`/home/…\` path-only hits

## Issues
Fixes #1841