### PR TITLE
fix(android): stabilize tool group inspection on API 36

### DIFF
--- a/android/app/src/androidTest/kotlin/app/hapi/companion/feature/chat/InspectionReadersTest.kt
+++ b/android/app/src/androidTest/kotlin/app/hapi/companion/feature/chat/InspectionReadersTest.kt
@@ -75,23 +75,42 @@ class InspectionReadersTest {
         ToolGroupingOptions(hasMoreMessages = false),
     ).filterIsInstance<ToolGroupBlock>().single()
 
+    // LazyColumn initial positioning and scroll-to-item can settle after a
+    // recomposition on API 36; do not race the semantics tree by one frame.
+    private fun waitForDisplayed(tag: String) {
+        try {
+            compose.waitUntil(10_000) {
+                try {
+                    compose.onNodeWithTag(tag).assertIsDisplayed()
+                    true
+                } catch (_: AssertionError) {
+                    false
+                }
+            }
+        } catch (_: Throwable) {
+            throw AssertionError("Timed out waiting for displayed node <$tag>")
+        }
+    }
+
     @Test fun toolBrowserStartsAtLatestButDoesNotFollowUpdatesWhileReading() {
         val inspected = mutableStateOf(Inspected(group(200), false))
         var selected: String? = null
         compose.setContent {
             HapiTheme { ToolGroupBrowser(inspected.value, "/repo", { selected = it }, {}, {}) }
         }
-        compose.onNodeWithTag("inspection-tool-tool-200").assertIsDisplayed()
+        waitForDisplayed("inspection-tool-tool-200")
         compose.onNodeWithTag("inspection-tools").performScrollToIndex(30)
-        compose.onNodeWithTag("inspection-tool-tool-31").assertIsDisplayed()
+        waitForDisplayed("inspection-tool-tool-31")
         compose.runOnIdle { inspected.value = Inspected(group(201), false) }
-        compose.onNodeWithTag("inspection-tool-tool-31").assertIsDisplayed().performClick()
+        waitForDisplayed("inspection-tool-tool-31")
+        compose.onNodeWithTag("inspection-tool-tool-31").performClick()
         compose.runOnIdle { assertEquals("tool-31", selected) }
         compose.onNodeWithTag("inspection-tool-tool-201").assertDoesNotExist()
+        waitForDisplayed("inspection-latest-tool")
         compose.onNodeWithTag("inspection-latest-tool").performClick()
-        compose.onNodeWithTag("inspection-tool-tool-201").assertIsDisplayed()
+        waitForDisplayed("inspection-tool-tool-201")
         compose.runOnIdle { inspected.value = inspected.value.copy(stale = true) }
-        compose.onNodeWithTag("inspection-notice").assertIsDisplayed()
+        waitForDisplayed("inspection-notice")
     }
 
     @Test fun fullContentUsesExactClipboardTextOrAReadableGrantedUri() {

--- a/android/app/src/androidTest/kotlin/app/hapi/companion/feature/chat/InspectionReadersTest.kt
+++ b/android/app/src/androidTest/kotlin/app/hapi/companion/feature/chat/InspectionReadersTest.kt
@@ -87,8 +87,10 @@ class InspectionReadersTest {
                     false
                 }
             }
-        } catch (_: Throwable) {
-            throw AssertionError("Timed out waiting for displayed node <$tag>")
+        } catch (timeout: ComposeTimeoutException) {
+            val failure = AssertionError("Timed out waiting for displayed node <$tag>")
+            failure.initCause(timeout)
+            throw failure
         }
     }
 

--- a/android/app/src/main/kotlin/app/hapi/companion/feature/chat/ChatHost.kt
+++ b/android/app/src/main/kotlin/app/hapi/companion/feature/chat/ChatHost.kt
@@ -225,10 +225,13 @@ internal fun ToolGroupBrowser(
             }
         },
     ) { padding ->
-        ReadingColumn(Modifier.padding(padding)) {
-            Column {
+        ReadingColumn(Modifier.padding(padding).fillMaxSize()) {
+            Column(Modifier.fillMaxSize()) {
                 InspectionNotice(inspected.stale, group.needsOlderHistory)
-                LazyColumn(state = list, modifier = Modifier.fillMaxSize().testTag("inspection-tools")) {
+                LazyColumn(
+                    state = list,
+                    modifier = Modifier.weight(1f).fillMaxWidth().testTag("inspection-tools"),
+                ) {
                     items(group.tools, key = { it.id }, contentType = { "tool-summary" }) { block ->
                         val presentation = remember(block.tool.name, block.tool.input, block.tool.description, basePath, resources) {
                             toolSummaryPresentation(block.tool, basePath, resources)

--- a/android/app/src/main/kotlin/app/hapi/companion/feature/chat/ChatHost.kt
+++ b/android/app/src/main/kotlin/app/hapi/companion/feature/chat/ChatHost.kt
@@ -217,6 +217,9 @@ internal fun ToolGroupBrowser(
     val list = rememberLazyListState(initialFirstVisibleItemIndex = (group.tools.size - 1).coerceAtLeast(0))
     val scope = rememberCoroutineScope()
     val resources = LocalContext.current.resources
+    LaunchedEffect(Unit) {
+        if (group.tools.isNotEmpty()) list.scrollToItem(group.tools.lastIndex)
+    }
     InspectionScaffold(stringResource(R.string.chat_group_tools_many, group.summary.totalTools), back, close,
         actions = {
             IconButton(onClick = { scope.launch { if (group.tools.isNotEmpty()) list.scrollToItem(group.tools.lastIndex) } },


### PR DESCRIPTION
## Summary

- Make the tool-group inspection viewport fill the available Scaffold height.
- Give the inspection `LazyColumn` an explicit weighted height and perform a one-time initial scroll to the latest tool after mount.
- Keep bounded, tag-specific visibility diagnostics in `InspectionReadersTest`.
- Preserve the existing latest-tool initialization, reading-position retention, and explicit Latest tool navigation behavior.

## Problem / Motivation

Fixes #1835.

`InspectionReadersTest.toolBrowserStartsAtLatestButDoesNotFollowUpdatesWhileReading` failed on the API 36 instrumentation matrix because the initial `inspection-tool-tool-200` node never became visible, even after a 10-second bounded wait. API 29 passed on the same revision.

The inspection content was nested inside a width-constrained reading column while the inner `LazyColumn` relied on implicit height measurement and only the initial list-state index to position the viewport. The production fix gives the inspection surface an explicit available height, assigns the list the remaining height, and performs a one-time post-mount scroll to the latest item. The one-time effect is not keyed to list size, so later streaming updates do not move the operator's reading position.

## Validation

- `bun typecheck` — passed.
- `bun run build` — passed before the latest Android-only mount-scroll adjustment; the adjustment is Kotlin-only.
- `pwsh -NoProfile -File .\scripts\Invoke-HapiTaskPlaywright.ps1 -Name android-inspection-readers-api36 -Suite Root terminal-wrap-fidelity.spec.ts` — 2 passed before the production Android-only changes.
- Android Gradle and instrumentation tests were not run locally because this Windows environment lacks JDK 17+, the Android SDK, and a connected emulator/device. The CI API 29/API 36 matrix is required for final validation.
- Baseline API 36 failure: [main CI run #34733839988](https://github.com/tiann/hapi/actions/runs/34733839988).
- The intermediate viewport-only revision still failed at the initial tool node: [run #34743006485](https://github.com/tiann/hapi/actions/runs/34743006485).

## Scope and Risk

Small Android UI layout/lifecycle and instrumentation-test change. No API, storage, migration, or dependency changes.

## Related Issues

Fixes #1835

## AI Disclosure

AI-assisted development using OpenAI GPT-5.6.